### PR TITLE
feat(plugins): adds required field to plugins

### DIFF
--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -79,6 +79,9 @@ class IPlugin(local, PluggableViewMixin, PluginConfigMixin, PluginStatusMixin):
     # Should this plugin be enabled by default for projects?
     project_default_enabled = False
 
+    # used by queries to determine if the plugin is configured
+    required_field = None
+
     def _get_option_key(self, key):
         return "%s:%s" % (self.get_conf_key(), key)
 

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -71,6 +71,9 @@ class IPlugin2(local, PluginConfigMixin, PluginStatusMixin):
     # Should this plugin be enabled by default for projects?
     project_default_enabled = False
 
+    # used by queries to determine if the plugin is configured
+    required_field = None
+
     def _get_option_key(self, key):
         return "%s:%s" % (self.get_conf_key(), key)
 

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -59,6 +59,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
     timeout = getattr(settings, "SENTRY_WEBHOOK_TIMEOUT", 3)
     logger = logging.getLogger("sentry.plugins.webhooks")
     user_agent = "sentry-webhooks/%s" % version
+    required_field = "urls"
 
     def is_configured(self, project, **kwargs):
         return bool(self.get_option("urls", project))

--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def get_regions():
     public_region_list = boto3.session.Session().get_available_regions("sqs")
-    cn_region_list = boto3.session.Session().get_available_regions("sqs", partition_name='aws-cn')
+    cn_region_list = boto3.session.Session().get_available_regions("sqs", partition_name="aws-cn")
     return public_region_list + cn_region_list
 
 
@@ -23,6 +23,7 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
     slug = "amazon-sqs"
     description = "Forward Sentry events to Amazon SQS."
     conf_key = "amazon-sqs"
+    required_field = "queue_url"
 
     def get_config(self, project, **kwargs):
         return [

--- a/src/sentry_plugins/asana/plugin.py
+++ b/src/sentry_plugins/asana/plugin.py
@@ -23,6 +23,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
     conf_title = title
     conf_key = "asana"
     auth_provider = "asana"
+    required_field = "workspace"
 
     def get_group_urls(self):
         return super(AsanaPlugin, self).get_group_urls() + [

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -40,6 +40,7 @@ class BitbucketPlugin(BitbucketMixin, IssuePlugin2):
     conf_title = BitbucketMixin.title
     conf_key = "bitbucket"
     auth_provider = "bitbucket"
+    required_field = "repo"
 
     def get_group_urls(self):
         return super(BitbucketPlugin, self).get_group_urls() + [

--- a/src/sentry_plugins/clubhouse/plugin.py
+++ b/src/sentry_plugins/clubhouse/plugin.py
@@ -21,6 +21,7 @@ class ClubhousePlugin(CorePluginMixin, IssuePlugin2):
     title = "Clubhouse"
     conf_title = title
     conf_key = "clubhouse"
+    required_field = "token"
 
     issue_fields = frozenset(["id", "title", "url"])
 

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -67,6 +67,7 @@ class GitHubPlugin(GitHubMixin, IssuePlugin2):
     conf_title = title
     conf_key = "github"
     auth_provider = "github"
+    required_field = "repo"
     logger = logging.getLogger("sentry.plugins.github")
 
     def get_group_urls(self):

--- a/src/sentry_plugins/gitlab/plugin.py
+++ b/src/sentry_plugins/gitlab/plugin.py
@@ -16,6 +16,7 @@ class GitLabPlugin(CorePluginMixin, IssuePlugin2):
     title = "GitLab"
     conf_title = title
     conf_key = "gitlab"
+    required_field = "gitlab_url"
 
     def is_configured(self, request, project, **kwargs):
         return bool(

--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -79,6 +79,7 @@ class HerokuPlugin(CorePluginMixin, ReleaseTrackingPlugin):
     title = "Heroku"
     slug = "heroku"
     description = "Integrate Heroku release tracking."
+    required_field = "repository"
 
     def configure(self, project, request):
         return react_plugin_config(self, project, request)

--- a/src/sentry_plugins/jira/plugin.py
+++ b/src/sentry_plugins/jira/plugin.py
@@ -39,6 +39,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
     title = "JIRA"
     conf_title = title
     conf_key = slug
+    required_field = "instance_url"
 
     def get_group_urls(self):
         _patterns = super(JiraPlugin, self).get_group_urls()

--- a/src/sentry_plugins/jira/plugin.py
+++ b/src/sentry_plugins/jira/plugin.py
@@ -39,7 +39,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
     title = "JIRA"
     conf_title = title
     conf_key = slug
-    required_field = "instance_url"
+    required_field = "username"
 
     def get_group_urls(self):
         _patterns = super(JiraPlugin, self).get_group_urls()

--- a/src/sentry_plugins/opsgenie/plugin.py
+++ b/src/sentry_plugins/opsgenie/plugin.py
@@ -43,6 +43,7 @@ class OpsGeniePlugin(notify.NotificationPlugin):
     conf_key = "opsgenie"
     version = sentry.VERSION
     project_conf_form = OpsGenieOptionsForm
+    required_field = "api_key"
 
     logger = logging.getLogger("sentry.plugins.opsgenie")
 

--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -17,6 +17,7 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
     title = "PagerDuty"
     conf_key = slug
     conf_title = title
+    required_field = "service_key"
 
     def error_message_from_json(self, data):
         message = data.get("message", "unknown error")

--- a/src/sentry_plugins/phabricator/plugin.py
+++ b/src/sentry_plugins/phabricator/plugin.py
@@ -33,6 +33,7 @@ class PhabricatorPlugin(CorePluginMixin, IssuePlugin2):
     title = "Phabricator"
     conf_title = "Phabricator"
     conf_key = "phabricator"
+    required_field = "host"
 
     def get_api(self, project):
         return phabricator.Phabricator(

--- a/src/sentry_plugins/pivotal/plugin.py
+++ b/src/sentry_plugins/pivotal/plugin.py
@@ -22,6 +22,7 @@ class PivotalPlugin(CorePluginMixin, IssuePlugin2):
     title = "Pivotal Tracker"
     conf_title = title
     conf_key = "pivotal"
+    required_field = "token"
 
     def get_group_urls(self):
         return super(PivotalPlugin, self).get_group_urls() + [

--- a/src/sentry_plugins/pushover/plugin.py
+++ b/src/sentry_plugins/pushover/plugin.py
@@ -17,6 +17,7 @@ class PushoverPlugin(CorePluginMixin, NotifyPlugin):
     title = "Pushover"
     conf_title = "Pushover"
     conf_key = "pushover"
+    required_field = "apikey"
 
     def is_configured(self, project):
         return all(self.get_option(key, project) for key in ("userkey", "apikey"))

--- a/src/sentry_plugins/redmine/plugin.py
+++ b/src/sentry_plugins/redmine/plugin.py
@@ -23,6 +23,7 @@ class RedminePlugin(IssuePlugin):
     title = _("Redmine")
     conf_title = "Redmine"
     conf_key = "redmine"
+    required_field = "host"
 
     new_issue_form = RedmineNewIssueForm
 

--- a/src/sentry_plugins/segment/plugin.py
+++ b/src/sentry_plugins/segment/plugin.py
@@ -12,6 +12,7 @@ class SegmentPlugin(CorePluginMixin, DataForwardingPlugin):
     slug = "segment"
     description = "Send Sentry events into Segment."
     conf_key = "segment"
+    required_field = "write_key"
 
     endpoint = "https://api.segment.io/v1/track"
 

--- a/src/sentry_plugins/sessionstack/plugin.py
+++ b/src/sentry_plugins/sessionstack/plugin.py
@@ -30,6 +30,7 @@ class SessionStackPlugin(CorePluginMixin, Plugin2):
     slug = "sessionstack"
     conf_title = title
     conf_key = slug
+    required_field = "account_email"
 
     sessionstack_resource_links = [
         ("Documentation", "http://docs.sessionstack.com/integrations/sentry/")

--- a/src/sentry_plugins/slack/plugin.py
+++ b/src/sentry_plugins/slack/plugin.py
@@ -21,6 +21,7 @@ class SlackPlugin(CorePluginMixin, notify.NotificationPlugin):
     slug = "slack"
     description = "Post notifications to a Slack channel."
     conf_key = "slack"
+    required_field = "webhook"
 
     def is_configured(self, project):
         return bool(self.get_option("webhook", project))

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -96,6 +96,7 @@ class SplunkPlugin(CorePluginMixin, Plugin):
     description = "Send Sentry events into Splunk."
     conf_key = "splunk"
     resource_links = [("Splunk Setup Instructions", SETUP_URL)] + CorePluginMixin.resource_links
+    required_field = "instance"
 
     def configure(self, project, request):
         return react_plugin_config(self, project, request)

--- a/src/sentry_plugins/teamwork/plugin.py
+++ b/src/sentry_plugins/teamwork/plugin.py
@@ -62,6 +62,7 @@ class TeamworkPlugin(IssuePlugin):
     title = _("Teamwork")
     description = _("Create Teamwork Tasks.")
     slug = "teamwork"
+    required_field = "url"
 
     conf_title = title
     conf_key = slug

--- a/src/sentry_plugins/trello/plugin.py
+++ b/src/sentry_plugins/trello/plugin.py
@@ -24,6 +24,7 @@ class TrelloPlugin(CorePluginMixin, IssuePlugin2):
     conf_key = "trello"
     auth_provider = None
     resource_links = [("Trello Setup Instructions", SETUP_URL)] + CorePluginMixin.resource_links
+    required_field = "key"
 
     def get_config(self, project, **kwargs):
         """

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -108,6 +108,7 @@ class TwilioPlugin(NotificationPlugin):
     title = _("Twilio (SMS)")
     conf_title = title
     conf_key = "twilio"
+    required_field = "account_sid"
     project_conf_form = TwilioConfigurationForm
 
     def is_configured(self, project, **kwargs):

--- a/src/sentry_plugins/victorops/plugin.py
+++ b/src/sentry_plugins/victorops/plugin.py
@@ -24,6 +24,7 @@ class VictorOpsPlugin(CorePluginMixin, NotifyPlugin):
     title = "VictorOps"
     conf_key = slug
     conf_title = title
+    required_field = "api_key"
 
     def is_configured(self, project, **kwargs):
         return bool(self.get_option("api_key", project))

--- a/src/sentry_plugins/vsts/plugin.py
+++ b/src/sentry_plugins/vsts/plugin.py
@@ -16,6 +16,7 @@ class VstsPlugin(VisualStudioMixin, IssueTrackingPlugin2):
     slug = "vsts"
     conf_key = slug
     auth_provider = "visualstudio"
+    required_field = "instance"
 
     issue_fields = frozenset(["id", "title", "url"])
 


### PR DESCRIPTION
This PR adds the field `required_field` to plugins. This field represents one field that is necessary for a plugin to have in order to be configured. We will use this field to generate a query to determine if a plugin is configured. Note that there might be multiple required fields for a plugin but form validation is set up such that a configuration is not saved unless every required field is set so the existence of one field is enough for the purpose of generating a query.