### PR TITLE
feat(workflow): Change Alert details chart to show time in tooltips

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -122,6 +122,11 @@ class BaseChart extends React.Component {
     // x-axis and tooltips.
     isGroupedByDate: PropTypes.bool,
 
+    /**
+     * Format timestamp with date AND time
+     */
+    showTimeInTooltip: PropTypes.bool,
+
     // Should we render hours on xaxis instead of day?
     shouldXAxisRenderTimeOnly: PropTypes.bool,
 
@@ -198,6 +203,7 @@ class BaseChart extends React.Component {
       graphic,
 
       isGroupedByDate,
+      showTimeInTooltip,
       shouldXAxisRenderTimeOnly,
       previousPeriod,
       utc,
@@ -248,7 +254,10 @@ class BaseChart extends React.Component {
           useUTC: utc,
           color: colors || this.getColorPalette(),
           grid: Grid(grid),
-          tooltip: tooltip !== null ? Tooltip({isGroupedByDate, utc, ...tooltip}) : null,
+          tooltip:
+            tooltip !== null
+              ? Tooltip({showTimeInTooltip, isGroupedByDate, utc, ...tooltip})
+              : null,
           legend: legend ? Legend({...legend}) : null,
           yAxis: yAxisOrCustom,
           xAxis:

--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -4,12 +4,14 @@ import get from 'lodash/get';
 import {getFormattedDate} from 'app/utils/dates';
 import {truncationFormatter} from '../utils';
 
-function defaultFormatAxisLabel(value, isTimestamp, utc) {
+function defaultFormatAxisLabel(value, isTimestamp, utc, showTimeInTooltip) {
   if (!isTimestamp) {
     return value;
   }
 
-  return getFormattedDate(value, 'MMM D, YYYY', {local: !utc});
+  const format = `MMM D, YYYY${showTimeInTooltip ? ' LT' : ''}`;
+
+  return getFormattedDate(value, format, {local: !utc});
 }
 
 function valueFormatter(value) {
@@ -20,7 +22,14 @@ function valueFormatter(value) {
   return value;
 }
 
-function getFormatter({filter, isGroupedByDate, truncate, formatAxisLabel, utc}) {
+function getFormatter({
+  filter,
+  isGroupedByDate,
+  showTimeInTooltip,
+  truncate,
+  formatAxisLabel,
+  utc,
+}) {
   const getFilter = seriesParam => {
     // Series do not necessarily have `data` defined, e.g. releases don't have `data`, but rather
     // has a series using strictly `markLine`s.
@@ -44,7 +53,12 @@ function getFormatter({filter, isGroupedByDate, truncate, formatAxisLabel, utc})
     // Special tooltip if component is a `markPoint`
     if (!isAxisItem && seriesParamsOrParam.componentType === 'markPoint') {
       const timestamp = seriesParamsOrParam.data.coord[0];
-      const label = axisFormatterOrDefault(timestamp, isGroupedByDate, utc);
+      const label = axisFormatterOrDefault(
+        timestamp,
+        isGroupedByDate,
+        utc,
+        showTimeInTooltip
+      );
       return `<div>${label} - ${seriesParamsOrParam.name}</div>
               <div>${truncationFormatter(
                 seriesParamsOrParam.seriesName,
@@ -60,7 +74,8 @@ function getFormatter({filter, isGroupedByDate, truncate, formatAxisLabel, utc})
       : get(seriesParams, '[0].data[0]');
 
     const label =
-      seriesParams.length && axisFormatterOrDefault(timestamp, isGroupedByDate, utc);
+      seriesParams.length &&
+      axisFormatterOrDefault(timestamp, isGroupedByDate, utc, showTimeInTooltip);
 
     return [
       `<div>${truncationFormatter(label, truncate)}</div>`,
@@ -81,6 +96,7 @@ function getFormatter({filter, isGroupedByDate, truncate, formatAxisLabel, utc})
 export default function Tooltip({
   filter,
   isGroupedByDate,
+  showTimeInTooltip,
   formatter,
   truncate,
   utc,
@@ -88,7 +104,15 @@ export default function Tooltip({
   ...props
 } = {}) {
   formatter =
-    formatter || getFormatter({filter, isGroupedByDate, truncate, utc, formatAxisLabel});
+    formatter ||
+    getFormatter({
+      filter,
+      isGroupedByDate,
+      showTimeInTooltip,
+      truncate,
+      utc,
+      formatAxisLabel,
+    });
 
   return {
     show: true,

--- a/src/sentry/static/sentry/app/views/incidents/details/chart.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/details/chart.tsx
@@ -68,6 +68,7 @@ export default class Chart extends React.PureComponent<Props> {
     return (
       <LineChart
         isGroupedByDate
+        showTimeInTooltip
         series={[
           {
             seriesName: t('Events'),


### PR DESCRIPTION
This adds an option to charts that are `isGroupedByDate`, to also show time when formatting timestamps in tooltips