### PR TITLE
feat: Bump sentry-relay to 0.5.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ redis>=2.10.3,<2.10.6
 requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
 selenium==3.141.0
-semaphore>=0.4.65,<0.5.0
+sentry-relay>=0.5.0,<0.6.0
 sentry-sdk>=0.13.5
 setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -5,12 +5,12 @@ from django.utils.crypto import constant_time_compare
 from rest_framework.authentication import BasicAuthentication, get_authorization_header
 from rest_framework.exceptions import AuthenticationFailed
 
+from sentry_relay import UnpackError
+
 from sentry.auth.system import SystemToken
 from sentry.models import ApiApplication, ApiKey, ApiToken, ProjectKey, Relay
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
 from sentry.utils.sdk import configure_scope
-
-import semaphore
 
 
 class QuietBasicAuthentication(BasicAuthentication):
@@ -60,7 +60,7 @@ class RelayAuthentication(BasicAuthentication):
             data = relay.public_key_object.unpack(request.body, relay_sig, max_age=60 * 5)
             request.relay = relay
             request.relay_request_data = data
-        except semaphore.UnpackError:
+        except UnpackError:
             raise AuthenticationFailed("Invalid relay signature")
 
         # TODO(mitsuhiko): can we return the relay here?  would be nice if we

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -7,7 +7,7 @@ from functools import partial
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
-from semaphore.consts import SPAN_STATUS_CODE_TO_NAME
+from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
 from sentry.api.event_search import get_json_meta_type
 from sentry.api.helpers.events import get_direct_hit_response

--- a/src/sentry/api/endpoints/relay_register.py
+++ b/src/sentry/api/endpoints/relay_register.py
@@ -16,7 +16,7 @@ from sentry.api.serializers import serialize
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
 
 
-from semaphore import (
+from sentry_relay import (
     create_register_challenge,
     validate_register_response,
     get_register_response_relay_id,

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -12,7 +12,7 @@ from parsimonious.expressions import Optional
 from parsimonious.exceptions import IncompleteParseError, ParseError
 from parsimonious.nodes import Node
 from parsimonious.grammar import Grammar, NodeVisitor
-from semaphore.consts import SPAN_STATUS_NAME_TO_CODE
+from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 
 from sentry import eventstore
 from sentry.models import Project

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -4,7 +4,7 @@ import six
 
 from datetime import datetime
 from django.utils import timezone
-from semaphore import meta_with_chunks
+from sentry_relay import meta_with_chunks
 
 from sentry import eventstore
 from sentry.api.serializers import Serializer, register, serialize

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -837,8 +837,8 @@ SENTRY_FEATURES = {
     "organizations:org-saved-searches": False,
     # Enable access to more advanced (alpha) datascrubbing settings.
     "organizations:datascrubbers-v2": False,
-    # Enable usage of external relays, for use with sentry semaphore. See
-    # https://github.com/getsentry/semaphore.
+    # Enable usage of external relays, for use with Relay. See
+    # https://github.com/getsentry/relay.
     "organizations:relay": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -16,7 +16,7 @@ from django.utils.translation import ugettext_lazy as _
 from sentry.utils.integrationdocs import load_doc
 from sentry.utils.geo import rust_geoip
 
-import semaphore
+import sentry_relay
 
 
 def get_all_languages():
@@ -226,8 +226,8 @@ SENTRY_RULES = (
 # methods as defined by http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html + PATCH
 HTTP_METHODS = ("GET", "POST", "PUT", "OPTIONS", "HEAD", "DELETE", "TRACE", "CONNECT", "PATCH")
 
-# See https://github.com/getsentry/semaphore/blob/master/general/src/protocol/constants.rs
-VALID_PLATFORMS = semaphore.VALID_PLATFORMS
+# See https://github.com/getsentry/relay/blob/master/relay-general/src/protocol/constants.rs
+VALID_PLATFORMS = sentry_relay.VALID_PLATFORMS
 
 OK_PLUGIN_ENABLED = _("The {name} integration has been enabled.")
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -320,7 +320,7 @@ class EventManager(object):
             raise RuntimeError("Already normalized")
         self._normalized = True
 
-        from semaphore.processing import StoreNormalizer
+        from sentry_relay.processing import StoreNormalizer
 
         rust_normalizer = StoreNormalizer(
             project_id=self._project.id if self._project else None,

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -5,8 +5,7 @@ from warnings import warn
 from sentry.utils.strings import truncatechars, strip
 from sentry.utils.safe import get_path
 
-# Note: Detecting eventtypes is implemented in the semaphore Rust
-# library.
+# Note: Detecting eventtypes is implemented in the Relay Rust library.
 
 
 class BaseEvent(object):

--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -93,7 +93,7 @@ class SecurityReport(Interface):
 
     @classmethod
     def to_python(cls, data):
-        # TODO(markus): semaphore does not validate security interfaces yet
+        # TODO(markus): Relay does not validate security interfaces yet
         is_valid, errors = validate_and_default_interface(data, cls.path)
         if not is_valid:
             raise InterfaceValidationError("Invalid interface data")

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from semaphore.processing import StoreNormalizer
+from sentry_relay.processing import StoreNormalizer
 
 from sentry.db.models import NodeData
 from sentry.utils.canonical import CanonicalKeyDict

--- a/src/sentry/models/relay.py
+++ b/src/sentry/models/relay.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from sentry.db.models import Model
 from django.utils.functional import cached_property
 
-import semaphore
+from sentry_relay import PublicKey
 
 
 class Relay(Model):
@@ -25,7 +25,7 @@ class Relay(Model):
 
     @cached_property
     def public_key_object(self):
-        return semaphore.PublicKey.parse(self.public_key)
+        return PublicKey.parse(self.public_key)
 
     def has_org_access(self, org):
         # Internal relays always have access

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -354,7 +354,7 @@ export const fields = {
     help: tct(
       'Advanced JSON-based configuration for datascrubbing. Applied in addition to the settings above. [learn_more:Learn more]',
       {
-        learn_more: <a href="https://getsentry.github.io/semaphore/pii-config/" />,
+        learn_more: <a href="https://getsentry.github.io/relay/pii-config/" />,
       }
     ),
     visible: ({features}) => features.has('datascrubbers-v2'),

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -8,7 +8,7 @@ from time import time
 from django.core.cache import cache
 from django.utils import timezone
 
-from semaphore.processing import StoreNormalizer
+from sentry_relay.processing import StoreNormalizer
 
 from sentry import features, reprocessing
 from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS

--- a/src/sentry/utils/data_filters.py
+++ b/src/sentry/utils/data_filters.py
@@ -13,7 +13,7 @@ from sentry.relay.utils import to_camel_case_name
 
 class FilterStatKeys(object):
     """
-    NOTE: This enum also exists in semaphore, check if alignment is needed when
+    NOTE: This enum also exists in Relay, check if alignment is needed when
     editing this.
     """
 

--- a/src/sentry/utils/geo.py
+++ b/src/sentry/utils/geo.py
@@ -56,7 +56,7 @@ def _init_geoip():
 def _init_geoip_rust():
     global rust_geoip
 
-    from semaphore.processing import GeoIpLookup
+    from sentry_relay.processing import GeoIpLookup
 
     try:
         rust_geoip = GeoIpLookup.from_path(geoip_path_mmdb)

--- a/src/sentry/utils/glob.py
+++ b/src/sentry/utils/glob.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
-import semaphore
+import sentry_relay
 
 
 def glob_match(
     value, pat, doublestar=False, ignorecase=False, path_normalize=False, allow_newline=True
 ):
     """A beefed up version of fnmatch.fnmatch"""
-    return semaphore.is_glob_match(
+    return sentry_relay.is_glob_match(
         value,
         pat,
         double_star=doublestar,

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -13,7 +13,7 @@ from sentry.utils import safe
 from sentry.models.relay import Relay
 from sentry.models import Project
 
-from semaphore.auth import generate_key_pair
+from sentry_relay.auth import generate_key_pair
 
 
 _date_regex = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$")

--- a/tests/sentry/api/endpoints/test_relay_projectids.py
+++ b/tests/sentry/api/endpoints/test_relay_projectids.py
@@ -12,7 +12,7 @@ from sentry.utils import safe
 from sentry.models.relay import Relay
 from sentry.testutils import APITestCase
 
-from semaphore.auth import generate_key_pair
+from sentry_relay.auth import generate_key_pair
 
 
 def _get_all_keys(config):

--- a/tests/sentry/api/endpoints/test_relay_publickeys.py
+++ b/tests/sentry/api/endpoints/test_relay_publickeys.py
@@ -10,7 +10,7 @@ from django.core.urlresolvers import reverse
 from sentry.models import Relay
 from sentry.testutils import APITestCase
 
-from semaphore import generate_key_pair
+from sentry_relay import generate_key_pair
 
 
 class RelayPublicKeysConfigTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -11,7 +11,7 @@ from django.core.urlresolvers import reverse
 from sentry.models import Relay
 from sentry.testutils import APITestCase
 
-from semaphore import generate_key_pair
+from sentry_relay import generate_key_pair
 
 
 class RelayRegisterTest(APITestCase):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -5,7 +5,7 @@ import pytest
 import six
 import unittest
 from datetime import timedelta
-from semaphore.consts import SPAN_STATUS_CODE_TO_NAME
+from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 
 from django.utils import timezone
 from freezegun import freeze_time

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -239,7 +239,7 @@ def test_renormalization(monkeypatch, factories, task_runner, default_project):
         normalize_mock_calls.append(1)
         return old_normalize(*args, **kwargs)
 
-    monkeypatch.setattr("semaphore.processing.StoreNormalizer.normalize_event", normalize)
+    monkeypatch.setattr("sentry_relay.processing.StoreNormalizer.normalize_event", normalize)
 
     with task_runner():
         factories.store_event(

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -230,7 +230,7 @@ class EventTest(TestCase):
 
 @pytest.mark.django_db
 def test_renormalization(monkeypatch, factories, task_runner, default_project):
-    from semaphore.processing import StoreNormalizer
+    from sentry_relay.processing import StoreNormalizer
 
     old_normalize = StoreNormalizer.normalize_event
     normalize_mock_calls = []


### PR DESCRIPTION
This moves from `semaphore` to the newer `sentry-relay` library. Along with the updated package name comes the `parse_release` function. 