### PR TITLE
feat(discover2) Add an upgrade hook to saved query button

### DIFF
--- a/src/sentry/static/sentry/app/stores/hookStore.tsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.tsx
@@ -30,6 +30,7 @@ const validHookNames = new Set<HookName>([
   'feature-disabled:sso-rippling',
   'feature-disabled:sso-saml2',
   'feature-disabled:grid-editable-actions',
+  'feature-disabled:discover-saved-query-create',
   'footer',
   'integrations:feature-gates',
   'member-invite-modal:customization',

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -95,6 +95,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:project-selector-checkbox': FeatureDisabledHook;
   'feature-disabled:custom-symbol-sources': FeatureDisabledHook;
   'feature-disabled:grid-editable-actions': FeatureDisabledHook;
+  'feature-disabled:discover-saved-query-create': FeatureDisabledHook;
 };
 
 /**

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -73,14 +73,7 @@ class ResultsHeader extends React.Component<Props, State> {
           />
         }
       >
-        <SavedQueryButtonGroup
-          location={location}
-          organization={organization}
-          eventView={eventView}
-          savedQuery={savedQuery}
-          savedQueryLoading={loading}
-          disabled
-        />
+        {p.children(p)}
       </Hovercard>
     );
 
@@ -103,13 +96,16 @@ class ResultsHeader extends React.Component<Props, State> {
             hookName="feature-disabled:discover-saved-query-create"
             renderDisabled={renderDisabled}
           >
-            <SavedQueryButtonGroup
-              location={location}
-              organization={organization}
-              eventView={eventView}
-              savedQuery={savedQuery}
-              savedQueryLoading={loading}
-            />
+            {({hasFeature}) => (
+              <SavedQueryButtonGroup
+                location={location}
+                organization={organization}
+                eventView={eventView}
+                savedQuery={savedQuery}
+                savedQueryLoading={loading}
+                disabled={!hasFeature}
+              />
+            )}
           </Feature>
         </Controller>
       </HeaderBox>

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -7,6 +7,9 @@ import {fetchSavedQuery} from 'app/actionCreators/discoverSavedQueries';
 
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
+import Hovercard from 'app/components/hovercard';
+import {t} from 'app/locale';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 
@@ -59,6 +62,28 @@ class ResultsHeader extends React.Component<Props, State> {
     const {organization, location, eventView} = this.props;
     const {savedQuery, loading} = this.state;
 
+    const renderDisabled = p => (
+      <Hovercard
+        body={
+          <FeatureDisabled
+            features={p.features}
+            hideHelpToggle
+            message={t('Discover queries are disabled')}
+            featureName={t('Discover queries')}
+          />
+        }
+      >
+        <SavedQueryButtonGroup
+          location={location}
+          organization={organization}
+          eventView={eventView}
+          savedQuery={savedQuery}
+          savedQueryLoading={loading}
+          disabled
+        />
+      </Hovercard>
+    );
+
     return (
       <HeaderBox>
         <DiscoverBreadcrumb
@@ -72,7 +97,12 @@ class ResultsHeader extends React.Component<Props, State> {
           eventView={eventView}
         />
         <Controller>
-          <Feature organization={organization} features={['discover-query']}>
+          <Feature
+            organization={organization}
+            features={['discover-query']}
+            hookName="feature-disabled:discover-saved-query-create"
+            renderDisabled={renderDisabled}
+          >
             <SavedQueryButtonGroup
               location={location}
               organization={organization}

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -34,6 +34,7 @@ type Props = {
   eventView: EventView;
   savedQuery: SavedQuery | undefined;
   savedQueryLoading: boolean;
+  disabled?: boolean;
 };
 
 type State = {
@@ -97,6 +98,10 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
       event.preventDefault();
       event.stopPropagation();
     }
+  };
+
+  static defaultProps = {
+    disabled: false,
   };
 
   state = {
@@ -176,6 +181,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
   };
 
   renderButtonSaveAs() {
+    const {disabled} = this.props;
     const {isNewQuery, isEditingQuery, queryName} = this.state;
 
     if (!isNewQuery && !isEditingQuery) {
@@ -197,6 +203,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
             {...getActorProps()}
             isOpen={isOpen}
             showChevron={false}
+            disabled={disabled}
           >
             <ButtonSaveIcon
               isNewQuery={isNewQuery}
@@ -215,12 +222,13 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
             value={queryName || ''}
             onBlur={this.onBlurInput}
             onChange={this.onChangeInput}
+            disabled={disabled}
           />
           <Button
             data-test-id="button-save-query"
             onClick={this.handleCreateQuery}
             priority="primary"
-            disabled={!this.state.queryName}
+            disabled={disabled || !this.state.queryName}
             style={{width: '100%'}}
           >
             {t('Save')}
@@ -256,6 +264,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
       <Button
         onClick={this.handleUpdateQuery}
         data-test-id="discover2-savedquery-button-update"
+        disabled={this.props.disabled}
       >
         <ButtonUpdateIcon />
         {t('Update query')}
@@ -275,6 +284,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
         data-test-id="discover2-savedquery-button-delete"
         icon="icon-trash"
         onClick={this.handleDeleteQuery}
+        disabled={this.props.disabled}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -246,7 +246,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
     }
 
     return (
-      <ButtonSaved>
+      <ButtonSaved disabled={this.props.disabled}>
         <ButtonSaveIcon isNewQuery={isNewQuery} src="icon-star-small-filled" size="14" />
         {t('Saved query')}
       </ButtonSaved>

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -11,13 +11,20 @@ const SELECTOR_BUTTON_SAVED = 'ButtonSaved';
 const SELECTOR_BUTTON_UPDATE = '[data-test-id="discover2-savedquery-button-update"]';
 const SELECTOR_BUTTON_DELETE = '[data-test-id="discover2-savedquery-button-delete"]';
 
-function generateWrappedComponent(location, organization, eventView, savedQuery) {
+function generateWrappedComponent(
+  location,
+  organization,
+  eventView,
+  savedQuery,
+  disabled = false
+) {
   return mountWithTheme(
     <SavedQueryButtonGroup
       location={location}
       organization={organization}
       eventView={eventView}
       savedQuery={savedQuery}
+      disabled={disabled}
     />,
     TestStubs.routerContext()
   );
@@ -50,6 +57,19 @@ describe('EventsV2 > SaveQueryButtonGroup', function() {
 
     beforeEach(() => {
       mockUtils.mockClear();
+    });
+
+    it('renders disabled buttons when disabled prop is used', () => {
+      const wrapper = generateWrappedComponent(
+        location,
+        organization,
+        errorsView,
+        undefined,
+        true
+      );
+
+      const buttonSaveAs = wrapper.find(SELECTOR_BUTTON_SAVE_AS);
+      expect(buttonSaveAs.props().disabled).toBe(true);
     });
 
     it('renders the correct set of buttons', () => {


### PR DESCRIPTION
Add a hook for an upgrade prompt around discover saved queries. Instead of hiding the saved query functionality we should show a disabled state and prompt users to upgrade.

The current UX for self-hosted looks like

![Screen Shot 2020-01-27 at 4 56 35 PM](https://user-images.githubusercontent.com/24086/73217701-6a86c000-4126-11ea-85ba-70c90815db06.png)
