### PR TITLE
feat(discover) Remove expensive array fields from public API

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -28,8 +28,8 @@ class Columns(Enum):
     TYPE = Column("events.type", "type", "type", "event.type")
     TAGS_KEY = Column("events.tags.key", "tags.key", "tags.key", "tags.key")
     TAGS_VALUE = Column("events.tags.value", "tags.value", "tags.value", "tags.value")
-    TAGS_KEYS = Column("events.tags_key", "tags_key", "tags_key", "tags_key")
-    TAGS_VALUES = Column("events.tags_value", "tags_value", "tags_value", "tags_value")
+    TAGS_KEYS = Column("events.tags_key", "tags_key", None, "tags_key")
+    TAGS_VALUES = Column("events.tags_value", "tags_value", None, "tags_value")
     TRANSACTION = Column("events.transaction", "transaction", "transaction", "transaction")
     USER = Column("events.tags[sentry:user]", "tags[sentry:user]", "user", "user")
     USER_ID = Column("events.user_id", "user_id", "user_id", "user.id")
@@ -155,9 +155,9 @@ class Columns(Enum):
         "exception_frames.stack_level",
         "stack.stack_level",
     )
-    CONTEXTS_KEY = Column("events.contexts.key", "contexts.key", "contexts.key", "contexts.key")
+    CONTEXTS_KEY = Column("events.contexts.key", "contexts.key", None, "contexts.key")
     CONTEXTS_VALUE = Column(
-        "events.contexts.value", "contexts.value", "contexts.value", "contexts.value"
+        "events.contexts.value", "contexts.value", None, "contexts.value"
     )
     # Transactions specific columns
     TRANSACTION_OP = Column(None, None, "transaction_op", "transaction.op")

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -139,12 +139,6 @@ export const FIELDS = {
   'stack.colno': 'number',
   'stack.lineno': 'number',
   'stack.stack_level': 'number',
-  tags: 'string',
-  'tags.key': 'string',
-  'tags.value': 'string',
-  contexts: 'string',
-  'contexts.key': 'string',
-  'contexts.value': 'string',
 
   'transaction.duration': 'duration',
   'transaction.op': 'string',

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -354,7 +354,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         data["contexts"]["trace"]["status"] = "unauthenticated"
         self.store_event(data, project_id=project.id)
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",


### PR DESCRIPTION
We don't want users using these large/expensive array fields in their queries. Instead they should request specific tags.