### PR TITLE
feat(discover) Add option for discover2 rollout

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -205,3 +205,6 @@ register("outcomes.tsdb-in-consumer-sample-rate", default=0.0)
 # Node data save rate
 register("nodedata.cache-sample-rate", default=0.0, flags=FLAG_PRIORITIZE_DISK)
 register("nodedata.cache-on-save", default=False, flags=FLAG_PRIORITIZE_DISK)
+
+# Discover2 incremental rollout rate. Tied to feature handlers in getsentry
+register("discover2.rollout-rate", default=0, flags=FLAG_PRIORITIZE_DISK)


### PR DESCRIPTION
When we start enabling discover2 for customers we want to do so gradually. This option will be read by the feature handlers in getsentry to incrementally enable discover2 for accounts on matching plans.