### PR TITLE
tests(async-csv): Add working tests for backend routes

### DIFF
--- a/tests/sentry/api/endpoints/test_data_export.py
+++ b/tests/sentry/api/endpoints/test_data_export.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+
+import six
+
+from django.core.urlresolvers import reverse
+from django.utils import timezone
+
+from sentry.models import ExportedData
+from sentry.models.exporteddata import ExportStatus
+from sentry.testutils import APITestCase
+
+
+class DataExportTest(APITestCase):
+    endpoint = "sentry-api-0-organization-data-export"
+
+    TEST_DATE_ADDED = timezone.now()
+
+    def test_simple(self):
+        with self.feature("organizations:data-export"):
+            self.user = self.create_user("foo@example.com")
+            self.org = self.create_organization(owner=self.user, name="Toucan Sam")
+            self.login_as(user=self.user)
+
+            data = {"query_type": 2, "query_info": {"environment": "test"}}
+            url = reverse(self.endpoint, kwargs={"organization_slug": self.org.slug})
+
+            response = self.client.post(url, data=data)
+            data_export = ExportedData.objects.get(id=response.data["id"])
+            assert response.status_code == 201
+            assert response.data == {
+                "id": data_export.id,
+                "user": {
+                    "id": six.binary_type(self.user.id),
+                    "email": self.user.email,
+                    "username": self.user.username,
+                },
+                "dateCreated": data_export.date_added,
+                "dateFinished": None,
+                "dateExpired": None,
+                "storageUrl": None,
+                "query": {"type": data["query_type"], "info": data["query_info"]},
+                "status": ExportStatus.Early,
+            }

--- a/tests/sentry/api/endpoints/test_data_export_details.py
+++ b/tests/sentry/api/endpoints/test_data_export_details.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+
+import six
+
+from django.core.urlresolvers import reverse
+from django.utils import timezone
+
+from sentry.models import ExportedData
+from sentry.models.exporteddata import ExportStatus
+from sentry.testutils import APITestCase
+
+
+class DataExportDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-data-export-details"
+
+    TEST_DATE_ADDED = timezone.now()
+
+    def test_simple(self):
+        with self.feature("organizations:data-export"):
+            self.user = self.create_user("foo@example.com")
+            self.org = self.create_organization(owner=self.user, name="Toucan Sam")
+            self.login_as(user=self.user)
+
+            data_export = ExportedData.objects.create(
+                organization=self.org,
+                user=self.user,
+                date_added=self.TEST_DATE_ADDED,
+                query_type=1,
+                query_info={"environment": "test"},
+            )
+            url = reverse(
+                self.endpoint,
+                kwargs={"data_export_id": data_export.id, "organization_slug": self.org.slug},
+            )
+
+            response = self.client.get(url, format="json")
+            assert response.status_code == 200
+            assert response.data == {
+                "id": data_export.id,
+                "user": {
+                    "id": six.binary_type(self.user.id),
+                    "email": self.user.email,
+                    "username": self.user.username,
+                },
+                "dateCreated": self.TEST_DATE_ADDED,
+                "dateFinished": None,
+                "dateExpired": None,
+                "storageUrl": None,
+                "query": {"type": data_export.query_type, "info": data_export.query_info},
+                "status": ExportStatus.Early,
+            }


### PR DESCRIPTION
The PR adds a few tests to ensure proper API route responses.

**test_data_export_details** - GET route to return exportdata info  (`/api/0/organizations/org-slug/data-export/data-export-id/`)
**test_data_export** - POST route to create a new exportdata entry (`/api/0/organizations/org-slug/data-export/`)