### PR TITLE
fix(mocks): Fix load-mocks

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -215,8 +215,6 @@ def create_sample_time_series(event, release=None):
     if event is None:
         return
 
-    event.bind_node_data()
-
     group = event.group
 
     project = group.project


### PR DESCRIPTION
This method has been removed, We no longer need to manually bind nodes