### PR TITLE
fix(discover2): Fixes for Discover2 tables with 1 column

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -17,6 +17,7 @@ export type GridHeadCellProps<Column> = {
   isLast: boolean;
 
   isEditing: boolean;
+  isDeletable: boolean;
 
   indexColumnOrder: number;
   column: Column;
@@ -49,6 +50,7 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
 > {
   static defaultProps = {
     isEditing: false,
+    isDeletable: true,
   };
 
   state = {
@@ -79,11 +81,17 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
 
   renderButtonHoverDraggable() {
     const {isHovering} = this.state;
-    const {isEditing, isColumnDragging} = this.props;
+    const {isEditing, isDeletable, isColumnDragging} = this.props;
 
     if (!isEditing || !isHovering || isColumnDragging) {
       return null;
     }
+
+    const deleteButton = isDeletable ? (
+      <GridHeadCellButtonHoverButton onClick={this.deleteColumn}>
+        <InlineSvg src="icon-trash" />
+      </GridHeadCellButtonHoverButton>
+    ) : null;
 
     return (
       <React.Fragment>
@@ -100,9 +108,7 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
             <GridHeadCellButtonHoverButton onClick={this.toggleModal}>
               <InlineSvg src="icon-edit-pencil" />
             </GridHeadCellButtonHoverButton>
-            <GridHeadCellButtonHoverButton onClick={this.deleteColumn}>
-              <InlineSvg src="icon-trash" />
-            </GridHeadCellButtonHoverButton>
+            {deleteButton}
           </div>
 
           <GridHeadCellButtonHoverDraggable

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -444,7 +444,6 @@ class GridEditable<
 
     // Ensure that the last column cannot be removed
     const numColumn = columnOrder.length;
-    const enableEdit = isEditing && numColumn > 1;
 
     const prependColumns = grid.renderPrependColumns
       ? grid.renderPrependColumns(true)
@@ -463,7 +462,8 @@ class GridEditable<
             isLast={columnOrder.length - 1 === i}
             key={`${i}.${column.key}`}
             isColumnDragging={this.props.isColumnDragging}
-            isEditing={enableEdit}
+            isEditing={isEditing}
+            isDeletable={numColumn > 1}
             indexColumnOrder={i}
             column={column}
             gridHeadCellButtonProps={this.props.gridHeadCellButtonProps || {}}


### PR DESCRIPTION
Fixes for Discover2 tables with 1 column:

- re-enable edit hover state whenever table is in edit state
- hide the delete column button

![Kapture 2020-01-28 at 17 12 44](https://user-images.githubusercontent.com/139499/73310720-dcc4d680-41f2-11ea-88cd-cbc39b71d82b.gif)
