### PR TITLE
chore: bump requests_oauthlib to 1.2.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -63,7 +63,7 @@ querystring_parser>=1.2.3,<2.0.0
 rb>=1.7.0,<2.0.0
 redis-py-cluster==1.3.4
 redis>=2.10.3,<2.10.6
-requests-oauthlib==0.3.3
+requests-oauthlib==1.2.0
 requests[security]>=2.20.0,<2.21.0
 selenium==3.141.0
 sentry-relay>=0.5.0,<0.6.0


### PR DESCRIPTION
Prerequisite for https://github.com/getsentry/sentry/pull/16645, since 

```
* social-auth-core==3.2.0
 - requests-oauthlib [required: >=0.6.1, installed: 0.3.3]
```

Will conflict with the 0.3.3 == pin we currently have.

Also, this is required for Python 3. 0.3.3 is so old it fell off the changelog. https://github.com/requests/requests-oauthlib/blob/master/HISTORY.rst#v041-6-june-2014

> Compliance fixes now re-encode body properly as bytes in Python 3.

Doesn't exactly instill confidence that 0.3.3 will work on Python 3.7.

1.0.0 says:

> Removed support for Python 2.6 and Python 3.3. This project now supports Python 2.7, and Python 3.4 and above.

So we'd most likely need at least 1.0.0. But 1.2.0 says:

> This project now depends on OAuthlib 3.0.0 and above. It does not support versions of OAuthlib before 3.0.0.

I have oauthlib 3.1.0 installed, which worked with https://github.com/getsentry/sentry/pull/16645. So might as well bump requests_oauthlib all the way to 1.2.0.

We only use this in two places:

```
src/sentry_plugins/bitbucket/client.py
6:from requests_oauthlib import OAuth1

src/sentry/integrations/jira_server/client.py
7:from requests_oauthlib import OAuth1
```

So @scefali I'm fully relying on tests for the jira integration for correctness.  Looks like most of the OAuth1 changes were in version range 0.4.x and skimming the changelog it seems mostly internal.