### PR TITLE
ref: remove unused AuthApiClient from integrations

### DIFF
--- a/src/sentry/integrations/client.py
+++ b/src/sentry/integrations/client.py
@@ -14,13 +14,7 @@ from sentry.exceptions import InvalidIdentity
 from sentry.http import build_session
 from sentry.utils import metrics
 
-from .exceptions import (
-    ApiHostError,
-    ApiTimeoutError,
-    ApiError,
-    ApiUnauthorized,
-    UnsupportedResponseType,
-)
+from .exceptions import ApiHostError, ApiTimeoutError, ApiError, UnsupportedResponseType
 
 
 class BaseApiResponse(object):
@@ -243,55 +237,6 @@ class ApiClient(object):
 
     def put(self, *args, **kwargs):
         return self.request("PUT", *args, **kwargs)
-
-
-class AuthApiClient(ApiClient):
-    auth = None
-
-    def __init__(self, auth=None, *args, **kwargs):
-        self.auth = auth
-        super(AuthApiClient, self).__init__(*args, **kwargs)
-
-    def has_auth(self):
-        return self.auth and "access_token" in self.auth.tokens
-
-    def exception_means_unauthorized(self, exc):
-        return isinstance(exc, ApiUnauthorized)
-
-    def ensure_auth(self, **kwargs):
-        headers = kwargs["headers"]
-        if "Authorization" not in headers and self.has_auth() and "auth" not in kwargs:
-            kwargs = self.bind_auth(**kwargs)
-        return kwargs
-
-    def bind_auth(self, **kwargs):
-        token = self.auth.tokens["access_token"]
-        kwargs["headers"]["Authorization"] = u"Bearer {}".format(token)
-        return kwargs
-
-    def _request(self, method, path, **kwargs):
-        headers = kwargs.setdefault("headers", {})
-        headers.setdefault("Accept", "application/json, application/xml")
-
-        # TODO(dcramer): we could proactively refresh the token if we knew
-        # about expires
-        kwargs = self.ensure_auth(**kwargs)
-
-        try:
-            return ApiClient._request(self, method, path, **kwargs)
-        except Exception as exc:
-            if not self.exception_means_unauthorized(exc):
-                raise
-            if not self.auth:
-                raise
-
-        # refresh token
-        self.logger.info(
-            "token.refresh", extra={"auth_id": self.auth.id, "provider": self.auth.provider}
-        )
-        self.auth.refresh_token()
-        kwargs = self.bind_auth(**kwargs)
-        return ApiClient._request(self, method, path, **kwargs)
 
 
 class OAuth2RefreshMixin(object):


### PR DESCRIPTION
As far as I can tell it's not used, and is duplicated code (+ tests) from `sentry_plugins.client.AuthApiClient` which is actually used. Good riddance!