### PR TITLE
ref(pagerduty): Log successful requests

### DIFF
--- a/src/sentry/integrations/pagerduty/notify_action.py
+++ b/src/sentry/integrations/pagerduty/notify_action.py
@@ -122,6 +122,7 @@ class PagerDutyNotifyServiceAction(EventAction):
                 extra={
                     "status_code": resp.status_code,
                     "project_id": event.project_id,
+                    "event_id": event.event_id,
                     "service_id": service.id,
                 },
             )

--- a/src/sentry/integrations/pagerduty/notify_action.py
+++ b/src/sentry/integrations/pagerduty/notify_action.py
@@ -115,8 +115,8 @@ class PagerDutyNotifyServiceAction(EventAction):
                     },
                 )
 
-            # TODO(meredith): Maybe move this into the ApiClient at some point
-            # but for now just doing it for PD to confirm successful requests
+            # TODO(meredith): Maybe have a generic success log statements for
+            # first-party integrations similar to plugin `notification.dispatched`
             self.logger.info(
                 "rule.success.pagerduty_trigger",
                 extra={


### PR DESCRIPTION
This PR adds logging for successful request sent to PagerDuty. In the future it could be good to add the generic success logging for the other alert rule integrations (basically slack) - but not sure what the volume of that would look like.

**Context:** We can't confirm (on the project level) that notifications are being sent for first party alerting integrations. For plugins we have `notification.dispatched` in addition to the `notification-plugin.notify-failed`. This makes it hard to tell when and if notifications are sent correctly when debugging.

side note: I also added the `service_id` to the logging for the failed requests because the name of the service can change