### PR TITLE
fix: unpin pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ addons:
 env:
   global:
     - NODE_ENV=development
-    # PIP_VERSION causes issues because: https://github.com/pypa/pip/issues/4528
-    # Note: this has to be synced with the pip version in the Makefile.
-    - PYTHON_PIP_VERSION=19.2.3
     - PIP_DISABLE_PIP_VERSION_CHECK=on
     - PIP_QUIET=1
     - SENTRY_LIGHT_BUILD=1
@@ -40,7 +37,7 @@ env:
     - NODE_OPTIONS=--max-old-space-size=4096
 
 before_install:
-  - &pip_install pip install "pip==${PYTHON_PIP_VERSION}"
+  - &pip_install pip install --upgrade pip
 
 script:
   # certain commands require sentry init to be run, but this is only true for

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 PIP := python -m pip --disable-pip-version-check
-# Note: this has to be synced with the pip version in .travis.yml.
-PIP_VERSION := 19.2.3
 WEBPACK := NODE_ENV=production ./bin/yarn webpack
 YARN := ./bin/yarn
 
@@ -52,7 +50,7 @@ ensure-venv:
 	@./scripts/ensure-venv.sh
 
 ensure-pinned-pip:
-	$(PIP) install "pip==$(PIP_VERSION)"
+	$(PIP) install --upgrade pip
 
 setup-git:
 	@echo "--> Installing git hooks"


### PR DESCRIPTION
Apparently, some pip versions want to build symbolic instead of using the wheel at least on macos mojave. I didn't verify this, but https://github.com/getsentry/milksnake/issues/29 is possibly related.

I'm not really sure why I pinned pip [before](https://github.com/getsentry/sentry/pull/14421/files#diff-354f30a63fb0907d4ad57269548329e3R43), probably to follow convention since I think we had pinned pip in other repositories.

There's no reason why we shouldn't be able to install sentry with latest pip, and if pip releases new versions that break sentry installs, we should know about that.
