### PR TITLE
fix(search): Fix search message inserted to Snuba

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -111,7 +111,7 @@ class SnubaProtocolEventStream(EventStream):
                     "project_id": event.project_id,
                     # TODO(mitsuhiko): We do not want to send this incorrect
                     # message but this is what snuba needs at the moment.
-                    "message": event.message,
+                    "message": event.search_message,
                     "platform": event.platform,
                     "datetime": event.datetime,
                     "data": event_data,

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -929,6 +929,20 @@ class EventManagerTest(TestCase):
 
         assert event.message == "hello world"
 
+    def test_search_message(self):
+        manager = EventManager(
+            make_event(
+                **{
+                    "message": "test",
+                    "logentry": {"message": "hello world"},
+                    "transaction": "sentry.tasks.process",
+                }
+            )
+        )
+        manager.normalize()
+        event = manager.save(self.project.id)
+        assert event.search_message == "hello world sentry.tasks.process"
+
     def test_stringified_message(self):
         manager = EventManager(make_event(**{"message": 1234}))
         manager.normalize()

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1043,7 +1043,10 @@ class CreateReferenceEventConditionsTest(SnubaTestCase, TestCase):
             self.organization, slug, ["message", "transaction", "unknown-field"]
         )
         result = discover.create_reference_event_conditions(ref)
-        assert result == [["message", "=", "oh no!"], ["transaction", "=", "/issues/{issue_id}"]]
+        assert result == [
+            ["message", "=", "oh no! /issues/{issue_id}"],
+            ["transaction", "=", "/issues/{issue_id}"],
+        ]
 
     def test_geo_field(self):
         event = self.store_event(


### PR DESCRIPTION
We need to ensure that the entire search message string (including
metadata and culprit) is being inserted into the eventstream as we
will use this for search purposes in Snuba, not just the message value
sent by the client.

This property was renamed from event.message to event.search message
in #16557 but we are still referencing the old field in the eventstream.

Events received in the last 5 days (between #16557 and this PR) will not
be searchable by their culprit or metadata properties.

Fixes ISSUE-680

About message vs search_message fields:
- The "search_message" is an internal only field used for search that shouldn't
be returned in our API. In addition to the logentry / message sent by the client,
it also contains information extracted from the culprit and metadata fields which
can be useful for text search. Confusingly it's stored in Snuba as "message" but
not stored in Nodestore.
- The "message" is basically the message the client sends us. It's the message
field returned by our events APIs. It comes from Nodestore data and is not
stored in Snuba.
