### PR TITLE
feat: Detailed integration page for first party integrations

### DIFF
--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -20,6 +20,8 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
 
         if "provider_key" in request.GET:
             serialized = list(filter(lambda d: d["key"] in request.GET["provider_key"], serialized))
-            return Response({"information": serialized[0]})
+
+        if(len(serialized) == 0):
+            return Response({"detail": "Providers do not exist"}, status=404)
 
         return Response({"providers": serialized})

--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -21,7 +21,7 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
         if "provider_key" in request.GET:
             serialized = list(filter(lambda d: d["key"] in request.GET["provider_key"], serialized))
 
-        if(len(serialized) == 0):
+        if not serialized:
             return Response({"detail": "Providers do not exist"}, status=404)
 
         return Response({"providers": serialized})

--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -18,4 +18,7 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
             providers, organization=organization, serializer=IntegrationProviderSerializer()
         )
 
+        if "provider_key" in request.GET:
+            serialized = list(filter(lambda d: d["key"] in request.GET["provider_key"], serialized))
+
         return Response({"providers": serialized})

--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -20,5 +20,6 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
 
         if "provider_key" in request.GET:
             serialized = list(filter(lambda d: d["key"] in request.GET["provider_key"], serialized))
+            return Response({"information": serialized[0]})
 
         return Response({"providers": serialized})

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -839,6 +839,16 @@ function routes() {
           component={errorHandler(LazyLoad)}
         />
         <Route
+          name="Integration Details"
+          path=":providerKey"
+          componentPromise={() =>
+            import(
+              /* webpackChunkName: "ConfigureIntegration" */ 'app/views/organizationIntegrations/integrationDetailedView'
+            )
+          }
+          component={errorHandler(LazyLoad)}
+        />
+        <Route
           name="Configure Integration"
           path=":providerKey/:integrationId/"
           componentPromise={() =>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -428,7 +428,7 @@ InformationCard.propTypes = {
 };
 
 type InformationCardProps = {
-  alerts: AlertType[];
+  alerts: any | AlertType[];
   information: IntegrationProvider;
 };
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, {FunctionComponent} from 'react';
 import styled from '@emotion/styled';
 import keyBy from 'lodash/keyBy';
 import {RouteComponentProps} from 'react-router/lib/Router';
+import PropTypes from 'prop-types';
 
 import {Organization, Integration, IntegrationProvider} from 'app/types';
 import {RequestOptions} from 'app/api';
@@ -16,7 +17,7 @@ import AddIntegrationButton from 'app/views/organizationIntegrations/addIntegrat
 import Access from 'app/components/acl/access';
 import Tag from 'app/views/settings/components/tag';
 import Button from 'app/components/button';
-import Alert from 'app/components/alert';
+import Alert, {Props as AlertProps} from 'app/components/alert';
 import Tooltip from 'app/components/tooltip';
 import InlineSvg from 'app/components/inlineSvg';
 import ExternalLink from 'app/components/links/externalLink';
@@ -69,9 +70,9 @@ class IntegrationDetailedView extends AsyncComponent<
     const {location} = this.props;
     const value =
       typeof location.query.tab === 'string' ? location.query.tab : 'information';
-    this.setState({
-      tab: value,
-    });
+
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({tab: value});
   }
 
   getInformation() {
@@ -169,7 +170,6 @@ class IntegrationDetailedView extends AsyncComponent<
   };
 
   renderBody() {
-    console.log('state: ', this.state);
     const {configurations, tab} = this.state;
     const information = this.getInformation();
     const {organization} = this.props;
@@ -394,7 +394,11 @@ const StyledInstalledIntegration = styled(
   border: 1px solid ${p => p.theme.borderLight};
 `;
 
-const InformationCard = ({children, alerts, information}) => {
+const InformationCard: FunctionComponent<InformationCardProps> = ({
+  children,
+  alerts,
+  information,
+}) => {
   const {metadata} = information;
   const description = marked(metadata.description);
   return (
@@ -417,4 +421,19 @@ const InformationCard = ({children, alerts, information}) => {
     </React.Fragment>
   );
 };
+
+InformationCard.propTypes = {
+  alerts: PropTypes.array,
+  information: PropTypes.object,
+};
+
+type InformationCardProps = {
+  alerts: AlertType[];
+  information: IntegrationProvider;
+};
+
+type AlertType = AlertProps & {
+  text: string;
+};
+
 export default withOrganization(IntegrationDetailedView);

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -1,8 +1,7 @@
-import React, {FunctionComponent} from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import keyBy from 'lodash/keyBy';
 import {RouteComponentProps} from 'react-router/lib/Router';
-import PropTypes from 'prop-types';
 
 import {Organization, Integration, IntegrationProvider} from 'app/types';
 import {RequestOptions} from 'app/api';
@@ -394,11 +393,7 @@ const StyledInstalledIntegration = styled(
   border: 1px solid ${p => p.theme.borderLight};
 `;
 
-const InformationCard: FunctionComponent<InformationCardProps> = ({
-  children,
-  alerts,
-  information,
-}) => {
+const InformationCard = ({children, alerts, information}: InformationCardProps) => {
   const {metadata} = information;
   const description = marked(metadata.description);
   return (
@@ -422,12 +417,8 @@ const InformationCard: FunctionComponent<InformationCardProps> = ({
   );
 };
 
-InformationCard.propTypes = {
-  alerts: PropTypes.array,
-  information: PropTypes.object,
-};
-
 type InformationCardProps = {
+  children: React.ReactNode;
   alerts: any | AlertType[];
   information: IntegrationProvider;
 };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -1,0 +1,328 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {Organization, Integration, IntegrationProvider, RouterProps} from 'app/types';
+import {Hooks} from 'app/types/hooks';
+import {t} from 'app/locale';
+import {trackIntegrationEvent} from 'app/utils/integrationUtil';
+import AsyncComponent from 'app/components/asyncComponent';
+import PluginIcon from 'app/plugins/components/pluginIcon';
+import space from 'app/styles/space';
+import AddIntegrationButton from 'app/views/organizationIntegrations/addIntegrationButton';
+import Access from 'app/components/acl/access';
+import Tag from 'app/views/settings/components/tag';
+import Button from 'app/components/button';
+import Alert from 'app/components/alert';
+import Tooltip from 'app/components/tooltip';
+import InlineSvg from 'app/components/inlineSvg';
+import ExternalLink from 'app/components/links/externalLink';
+import marked, {singleLineRenderer} from 'app/utils/marked';
+import HookStore from 'app/stores/hookStore';
+import withOrganization from 'app/utils/withOrganization';
+
+type State = {
+  configurations: Integration[];
+  provider: {information: IntegrationProvider};
+  tab: string;
+};
+
+type Props = RouterProps & {
+  organization: Organization;
+};
+
+const defaultFeatureGateComponents = {
+  IntegrationFeatures: p =>
+    p.children({
+      disabled: false,
+      disabledReason: null,
+      ungatedFeatures: p.features,
+      gatedFeatureGroups: [],
+    }),
+  FeatureList: p => {
+    console.log({p});
+
+    return (
+      <ul>
+        {p.features.map((f, i) => (
+          <li key={i}>{f.description}</li>
+        ))}
+      </ul>
+    );
+  },
+} as ReturnType<Hooks['integrations:feature-gates']>;
+
+const tabs = ['information', 'configurations'];
+
+class IntegrationDetailedView extends AsyncComponent<
+  Props & AsyncComponent['props'],
+  State & AsyncComponent['state']
+> {
+  componentDidMount() {
+    const {location} = this.props;
+    let value = location?.query?.tab ? (location.query.tab as string) : 'information';
+    this.setState({
+      tab: value,
+    });
+  }
+
+  getEndpoints(): ([string, string, any] | [string, string])[] {
+    const {orgId, providerKey} = this.props.params;
+    const baseEndpoints: ([string, string, any] | [string, string])[] = [
+      [
+        'provider',
+        `/organizations/${orgId}/config/integrations/?provider_key=${providerKey}`,
+      ],
+      [
+        'configurations',
+        `/organizations/${orgId}/integrations/?provider_key=${providerKey}`,
+      ],
+    ];
+
+    return baseEndpoints;
+  }
+
+  featureTags(features: string[]) {
+    return features.map(feature => (
+      <StyledTag key={feature}>{feature.replace(/-/g, ' ')}</StyledTag>
+    ));
+  }
+
+  onAddIntegration = () => {};
+
+  handleExternalInstall = () => {
+    const {organization} = this.props;
+    const {provider} = this.state;
+    trackIntegrationEvent(
+      {
+        eventKey: 'integrations.installation_start',
+        eventName: 'Integrations: Installation Start',
+        integration: provider.information.key,
+        integration_type: 'first_party',
+      },
+      organization
+    );
+  };
+
+  onTabChange = value => {
+    this.setState({tab: value});
+  };
+
+  renderBody() {
+    console.log('state: ', this.state);
+    const {
+      provider: {information},
+      //   configurations,
+      //   tab,
+    } = this.state;
+    const {organization} = this.props;
+
+    const {metadata} = information;
+    const alerts = metadata.aspects.alerts || [];
+
+    if (!information.canAdd && metadata.aspects.externalInstall) {
+      alerts.push({
+        type: 'warning',
+        icon: 'icon-exit',
+        text: metadata.aspects.externalInstall.noticeText,
+      });
+    }
+
+    const buttonProps = {
+      style: {marginLeft: space(1)},
+      size: 'small',
+      priority: 'primary',
+    };
+
+    const AddButton = p =>
+      (information.canAdd && (
+        <AddIntegrationButton
+          provider={information}
+          onAddIntegration={this.onAddIntegration}
+          {...buttonProps}
+          {...p}
+        />
+      )) ||
+      (!information.canAdd && metadata.aspects.externalInstall && (
+        <Button
+          icon="icon-exit"
+          href={metadata.aspects.externalInstall.url}
+          onClick={this.handleExternalInstall}
+          external
+          {...buttonProps}
+          {...p}
+        >
+          {metadata.aspects.externalInstall.buttonText}
+        </Button>
+      ));
+
+    // Prepare the features list
+    const features = metadata.features.map(f => ({
+      featureGate: f.featureGate,
+      description: (
+        <FeatureListItem
+          dangerouslySetInnerHTML={{__html: singleLineRenderer(f.description)}}
+        />
+      ),
+    }));
+
+    const featureListHooks = HookStore.get('integrations:feature-gates');
+    featureListHooks.push(() => defaultFeatureGateComponents);
+
+    const {FeatureList, IntegrationFeatures} = featureListHooks[0]();
+    const featureProps = {organization, features};
+    console.log('props: ', this.props);
+    return (
+      <React.Fragment>
+        <Flex>
+          <PluginIcon size={60} pluginId={information.key} />
+          <TitleContainer>
+            <Title>{information.name}</Title>
+            <Flex>
+              {information.features.length && this.featureTags(information.features)}
+            </Flex>
+          </TitleContainer>
+
+          <IntegrationFeatures {...featureProps}>
+            {({disabled, disabledReason}) => (
+              <div
+                style={{
+                  marginLeft: 'auto',
+                  alignSelf: 'center',
+                }}
+              >
+                {disabled && <DisabledNotice reason={disabledReason} />}
+                <Access organization={organization} access={['org:integrations']}>
+                  {({hasAccess}) => (
+                    <Tooltip
+                      title={t(
+                        'You must be an organization owner, manager or admin to install this.'
+                      )}
+                      disabled={hasAccess}
+                    >
+                      <AddButton
+                        data-test-id="add-button"
+                        disabled={disabled || !hasAccess}
+                        organization={organization}
+                      />
+                    </Tooltip>
+                  )}
+                </Access>
+              </div>
+            )}
+          </IntegrationFeatures>
+        </Flex>
+        <ul className="nav nav-tabs border-bottom" style={{paddingTop: '30px'}}>
+          {tabs.map(tabName => (
+            <li
+              key={tabName}
+              className={this.state.tab === tabName ? 'active' : ''}
+              onClick={() => this.onTabChange(tabName)}
+            >
+              <a style={{textTransform: 'capitalize'}}>{tabName}</a>
+            </li>
+          ))}
+        </ul>
+        {this.state.tab === 'information' ? (
+          <InformationCard alerts={alerts} information={information}>
+            <FeatureList {...featureProps} provider={information} />
+          </InformationCard>
+        ) : (
+          <div>Configs</div>
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+const Flex = styled('div')`
+  display: flex;
+`;
+
+const Title = styled('div')`
+  font-weight: bold;
+  font-size: 1.4em;
+  margin-bottom: ${space(1)};
+`;
+
+const TitleContainer = styled('div')`
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: ${space(2)};
+`;
+
+const StyledTag = styled(Tag)`
+  &:not(:first-child) {
+    margin-left: ${space(0.5)};
+  }
+`;
+
+const Description = styled('div')`
+  font-size: 1.5rem;
+  line-height: 2.1rem;
+  margin-bottom: ${space(2)};
+
+  li {
+    margin-bottom: 6px;
+  }
+`;
+
+const Metadata = styled(Flex)`
+  font-size: 0.9em;
+  margin-bottom: ${space(2)};
+
+  a {
+    margin-left: ${space(1)};
+  }
+`;
+
+const AuthorName = styled('div')`
+  color: ${p => p.theme.gray2};
+  flex: 1;
+`;
+
+const FeatureListItem = styled('span')`
+  line-height: 24px;
+`;
+
+const DisabledNotice = styled(({reason, ...p}: {reason: React.ReactNode}) => (
+  <div
+    style={{
+      flex: 1,
+      alignItems: 'center',
+    }}
+    {...p}
+  >
+    <InlineSvg src="icon-circle-exclamation" size="1.5em" />
+    <div style={{marginLeft: `${space(1)}`}}>{reason}</div>
+  </div>
+))`
+  color: ${p => p.theme.red};
+  font-size: 0.9em;
+`;
+
+const InformationCard = ({children, alerts, information}) => {
+  const {metadata} = information;
+  const description = marked(metadata.description);
+  return (
+    <React.Fragment>
+      <Description dangerouslySetInnerHTML={{__html: description}} />
+      {children}
+      <Metadata>
+        <AuthorName>{t('By %s', information.metadata.author)}</AuthorName>
+        <div>
+          <ExternalLink href={metadata.source_url}>{t('View Source')}</ExternalLink>
+          <ExternalLink href={metadata.issue_url}>{t('Report Issue')}</ExternalLink>
+        </div>
+      </Metadata>
+
+      {alerts.map((alert, i) => (
+        <Alert key={i} type={alert.type} icon={alert.icon}>
+          <span dangerouslySetInnerHTML={{__html: singleLineRenderer(alert.text)}} />
+        </Alert>
+      ))}
+    </React.Fragment>
+  );
+};
+export default withOrganization(IntegrationDetailedView);

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -32,4 +32,4 @@ class OrganizationConfigIntegrationsProviderKeyExistsTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data["providers"]) == 1
-        assert response.data["provider"][0]["name"] == "Example"
+        assert response.data["providers"][0]["name"] == "Example"

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -32,3 +32,4 @@ class OrganizationConfigIntegrationsProviderKeyExistsTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data["providers"]) == 1
+        assert response.data["provider"][0]["name"] == "Example"

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -21,3 +21,14 @@ class OrganizationConfigIntegrationsTest(APITestCase):
         provider = provider[0]
         assert provider["name"] == "Example"
         assert provider["setupDialog"]["url"]
+
+
+class OrganizationConfigIntegrationsProviderKeyExistsTest(APITestCase):
+    def test_simple(self):
+        self.login_as(user=self.user)
+        org = self.create_organization(owner=self.user, name="baz")
+        path = u"/api/0/organizations/{}/config/integrations/?provider_key=example".format(org.slug)
+        response = self.client.get(path, format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["providers"]) == 1


### PR DESCRIPTION
## Problem
Build the detailed integration page for first party integrations (no dependencies).

## Solution
- Added the query param of `provider_key` to relevant api route.
- Added a new route on the client for the Integration Details UI.
- Created a new view component in `app/views/organizationIntegrations/integrationDetailedView.tsx`