### PR TITLE
feat(UI): Add ability for hovercards to shrink to fit small bodies

### DIFF
--- a/docs-ui/components/hovercard.stories.js
+++ b/docs-ui/components/hovercard.stories.js
@@ -18,6 +18,12 @@ const showOptions = {
   null: null,
 };
 
+const shrinkToFitOptions = {
+  true: true,
+  false: false,
+  null: null,
+};
+
 const tipColorOptions = {
   red: 'red',
   null: null,
@@ -42,6 +48,7 @@ storiesOf('UI|Hovercard', module).add(
         position={select('position', positionOptions, 'top', 'Hovercard positioning')}
         show={select('show', showOptions, null, 'Force show/unshow')}
         tipColor={select('tipColor', tipColorOptions, null, 'Tip color')}
+        shrinkToFit={select('shrinkToFit', shrinkToFitOptions, null, 'Shrink to fit')}
       >
         Hover over me
       </Hovercard>

--- a/docs-ui/components/hovercard.stories.js
+++ b/docs-ui/components/hovercard.stories.js
@@ -15,7 +15,7 @@ const positionOptions = {
 const showOptions = {
   true: true,
   false: false,
-  null: null,
+  undefined: undefined,
 };
 
 const shrinkToFitOptions = {
@@ -46,7 +46,7 @@ storiesOf('UI|Hovercard', module).add(
         header={text('Header', 'Hovercard Header')}
         body={text('Body', 'Hovercard body (can also be a React node)')}
         position={select('position', positionOptions, 'top', 'Hovercard positioning')}
-        show={select('show', showOptions, null, 'Force show/unshow')}
+        show={select('show', showOptions, undefined, 'Force show/unshow')}
         tipColor={select('tipColor', tipColorOptions, null, 'Tip color')}
         shrinkToFit={select('shrinkToFit', shrinkToFitOptions, null, 'Shrink to fit')}
       >

--- a/docs-ui/components/hovercard.stories.js
+++ b/docs-ui/components/hovercard.stories.js
@@ -15,7 +15,7 @@ const positionOptions = {
 const showOptions = {
   true: true,
   false: false,
-  undefined: undefined,
+  [undefined]: undefined, // eslint-disable-line object-shorthand
 };
 
 const shrinkToFitOptions = {
@@ -46,7 +46,7 @@ storiesOf('UI|Hovercard', module).add(
         header={text('Header', 'Hovercard Header')}
         body={text('Body', 'Hovercard body (can also be a React node)')}
         position={select('position', positionOptions, 'top', 'Hovercard positioning')}
-        show={select('show', showOptions, undefined, 'Force show/unshow')}
+        show={select('show', showOptions, [undefined], 'Force show/unshow')}
         tipColor={select('tipColor', tipColorOptions, null, 'Tip color')}
         shrinkToFit={select('shrinkToFit', shrinkToFitOptions, null, 'Shrink to fit')}
       >

--- a/docs-ui/components/hovercard.stories.js
+++ b/docs-ui/components/hovercard.stories.js
@@ -46,7 +46,7 @@ storiesOf('UI|Hovercard', module).add(
         header={text('Header', 'Hovercard Header')}
         body={text('Body', 'Hovercard body (can also be a React node)')}
         position={select('position', positionOptions, 'top', 'Hovercard positioning')}
-        show={select('show', showOptions, [undefined], 'Force show/unshow')}
+        show={select('show', showOptions, undefined, 'Force show/unshow')}
         tipColor={select('tipColor', tipColorOptions, null, 'Tip color')}
         shrinkToFit={select('shrinkToFit', shrinkToFitOptions, null, 'Shrink to fit')}
       >

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -50,6 +50,10 @@ class Hovercard extends React.Component {
      * Color of the arrow tip
      */
     tipColor: PropTypes.string,
+    /**
+     * Should the hovercard shrink to fit its contents if they're narrower than the default?
+     */
+    shrinkToFit: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -101,6 +105,7 @@ class Hovercard extends React.Component {
       position,
       show,
       tipColor,
+      shrinkToFit,
     } = this.props;
 
     // Maintain the hovercard class name for BC with less styles
@@ -148,6 +153,7 @@ class Hovercard extends React.Component {
                   placement={placement}
                   withHeader={!!header}
                   className={cx}
+                  shrinkToFit={shrinkToFit}
                   {...hoverProps}
                 >
                   {header && <Header>{header}</Header>}
@@ -202,7 +208,10 @@ const StyledHovercard = styled('div')`
   background: #fff;
   background-clip: padding-box;
   box-shadow: 0 0 35px 0 rgba(67, 62, 75, 0.2);
-  width: 295px;
+  ${p => {
+    return p.shrinkToFit ? 'max-width: 295px;' : 'width: 295px;';
+  }}
+
 
   /* The hovercard may appear in different contexts, don't inherit fonts */
   font-family: ${p => p.theme.text.family};

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -15,7 +15,7 @@ const VALID_DIRECTIONS = ['top', 'bottom', 'left', 'right'];
 class Hovercard extends React.Component {
   static propTypes = {
     /**
-     * Time in ms until hovercard is hidden
+     * Time in ms until hovercard is shown or hidden
      */
     displayTimeout: PropTypes.number,
     /**
@@ -133,6 +133,7 @@ class Hovercard extends React.Component {
           {({ref}) => (
             <span
               ref={ref}
+              data-test-id="hover-target"
               aria-describedby={this.tooltipId}
               className={containerClassName}
               {...hoverProps}

--- a/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueActions.spec.jsx.snap
@@ -167,6 +167,7 @@ exports[`ExternalIssueActions with no external issues linked renders 1`] = `
                   <span
                     aria-describedby="hovercard-123456"
                     className="css-1gb8k2a"
+                    data-test-id="hover-target"
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >

--- a/tests/js/spec/components/hovercard.spec.jsx
+++ b/tests/js/spec/components/hovercard.spec.jsx
@@ -1,0 +1,287 @@
+import React from 'react';
+import {mount} from 'sentry-test/enzyme';
+import Hovercard from 'app/components/hovercard';
+
+jest.useFakeTimers();
+
+describe('Hovercard', function() {
+  // let wrapper;
+
+  // beforeEach(function() {
+  //   wrapper = mount(
+  //     <Hovercard>
+  //       {/* {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
+  //         return (
+  //           <span {...getRootProps({})}>
+  //             <button {...getActorProps({})}>Open Dropdown</button>
+  //             {isOpen && (
+  //               <ul {...getMenuProps({})}>
+  //                 <li>Dropdown Menu Item 1</li>
+  //               </ul>
+  //             )}
+  //           </span>
+  //         );
+  //       }} */}
+  //       body={<div>
+
+  //       </div>}
+  //     </Hovercard>
+  //   );
+  // });
+
+  it.only('shows on hover', function() {
+    const wrapper = mount(<Hovercard body={
+      <div>
+        This is a hovercard! It has some text on it. Dogs are great and cats are okay, too.
+      </div>
+    }>
+    <span id="hover-target">
+      Hover over me to show the card!
+    </span>
+    </Hovercard>);
+    wrapper.find("span[id='hover-target']").simulate("mouseenter")
+    console.log(wrapper.find("span[id='hover-target']").debug())
+    expect(wrapper.contains("Dogs are great")).toEqual(true);
+  });
+
+  it('hides on mouseout', function() {
+    const wrapper = mount(<Hovercard body={
+      <div>
+        This is a hovercard! It has some text on it. Dogs are great and cats are okay, too.
+      </div>
+    }>
+    <span id="hover-target">
+      Hover over me to show the card!
+    </span>
+    </Hovercard>);
+    wrapper.find("span[id='hover-target']").simulate("mouseover")
+    wrapper.find("span[id='hover-target']").simulate("mouseout")
+    expect(wrapper.contains("Dogs are great")).toEqual(false);
+  });
+
+  describe("shrinkToFit", function() {
+    // it('defaults to set width when shrinkToFit not specified - narrow contents', function() {
+    //   const wrapper = mount(<Hovercard body={
+    //   <div>
+    //     Hi!
+    //   </div>
+    // }><span id="hover-target">
+    //   Hover over me to show the card!
+    // </span></Hovercard>);
+    // wrapper.si
+    // })
+
+    it('defaults to set width when shrinkToFit not specified - wide contents', function() {
+
+    })
+    it('uses set width when shrinkToFit is false - narrow contents', function() {
+
+    })
+    it('uses set width when shrinkToFit is false - wide contents', function() {
+
+    })
+    it('has variable width when shrinkToFit is true - narrow contents', function() {
+
+    })
+    it('has variable width when shrinkToFit is true - wide contents', function() {
+
+    })
+  })
+
+  // it('can toggle dropdown menu with actor', function() {
+  //   wrapper.find('button').simulate('click');
+  //   expect(wrapper.state('isOpen')).toBe(true);
+  //   expect(wrapper.find('ul')).toHaveLength(1);
+  //   wrapper.find('button').simulate('click');
+  //   expect(wrapper.state('isOpen')).toBe(false);
+  //   expect(wrapper.find('ul')).toHaveLength(0);
+  // });
+
+  // it('closes dropdown when clicking on anything in menu', function() {
+  //   wrapper.find('button').simulate('click');
+  //   wrapper.find('li').simulate('click');
+  //   expect(wrapper.state('isOpen')).toBe(false);
+  //   expect(wrapper.find('ul')).toHaveLength(0);
+  // });
+
+  // it('closes dropdown when clicking outside of menu', async function() {
+  //   wrapper.find('button').simulate('click');
+  //   // Simulate click on document
+  //   const evt = document.createEvent('HTMLEvents');
+  //   evt.initEvent('click', false, true);
+  //   document.body.dispatchEvent(evt);
+  //   jest.runAllTimers();
+  //   await Promise.resolve();
+  //   wrapper.update();
+
+  //   expect(wrapper.find('ul')).toHaveLength(0);
+  // });
+
+  // it('closes dropdown when pressing escape', function() {
+  //   wrapper.find('button').simulate('click');
+  //   expect(wrapper.state('isOpen')).toBe(true);
+  //   wrapper.simulate('keyDown', {key: 'Escape'});
+  //   wrapper.find('button').simulate('keyDown', {key: 'Escape'});
+  //   expect(wrapper.state('isOpen')).toBe(false);
+  //   expect(wrapper.find('ul')).toHaveLength(0);
+  // });
+
+  // it('ignores "Escape" key if `closeOnEscape` is false', function() {
+  //   wrapper = mount(
+  //     <DropdownMenu closeOnEscape={false}>
+  //       {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
+  //         return (
+  //           <span {...getRootProps({})}>
+  //             <button {...getActorProps({})}>Open Dropdown</button>
+  //             {isOpen && (
+  //               <ul {...getMenuProps({})}>
+  //                 <li>Dropdown Menu Item 1</li>
+  //               </ul>
+  //             )}
+  //           </span>
+  //         );
+  //       }}
+  //     </DropdownMenu>
+  //   );
+
+  //   wrapper.find('button').simulate('click');
+  //   expect(wrapper.state('isOpen')).toBe(true);
+  //   wrapper.find('button').simulate('keyDown', {key: 'Escape'});
+  //   expect(wrapper.find('ul')).toHaveLength(1);
+  //   expect(wrapper.state('isOpen')).toBe(true);
+  // });
+
+  // it('keeps dropdown open when clicking on anything in menu with `keepMenuOpen` prop', function() {
+  //   wrapper = mount(
+  //     <DropdownMenu keepMenuOpen>
+  //       {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
+  //         return (
+  //           <span {...getRootProps({})}>
+  //             <button {...getActorProps({})}>Open Dropdown</button>
+  //             {isOpen && (
+  //               <ul {...getMenuProps({})}>
+  //                 <li>Dropdown Menu Item 1</li>
+  //               </ul>
+  //             )}
+  //           </span>
+  //         );
+  //       }}
+  //     </DropdownMenu>
+  //   );
+
+  //   wrapper.find('button').simulate('click');
+  //   wrapper.find('li').simulate('click');
+  //   expect(wrapper.state('isOpen')).toBe(true);
+  //   expect(wrapper.find('ul')).toHaveLength(1);
+  // });
+
+  // it('render prop getters all extend props and call original onClick handlers', function() {
+  //   const rootClick = jest.fn();
+  //   const actorClick = jest.fn();
+  //   const menuClick = jest.fn();
+  //   const addSpy = jest.spyOn(document, 'addEventListener');
+  //   const removeSpy = jest.spyOn(document, 'removeEventListener');
+
+  //   wrapper = mount(
+  //     <DropdownMenu keepMenuOpen>
+  //       {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
+  //         return (
+  //           <span
+  //             {...getRootProps({
+  //               className: 'root',
+  //               onClick: rootClick,
+  //             })}
+  //           >
+  //             <button
+  //               {...getActorProps({
+  //                 className: 'actor',
+  //                 onClick: actorClick,
+  //               })}
+  //             >
+  //               Open Dropdown
+  //             </button>
+  //             {isOpen && (
+  //               <ul
+  //                 {...getMenuProps({
+  //                   className: 'menu',
+  //                   onClick: menuClick,
+  //                 })}
+  //               >
+  //                 <li>Dropdown Menu Item 1</li>
+  //               </ul>
+  //             )}
+  //           </span>
+  //         );
+  //       }}
+  //     </DropdownMenu>
+  //   );
+
+  //   expect(wrapper.find('ul')).toHaveLength(0);
+
+  //   wrapper.find('span').simulate('click');
+  //   expect(rootClick).toHaveBeenCalled();
+  //   wrapper.find('button').simulate('click');
+  //   expect(actorClick).toHaveBeenCalled();
+  //   wrapper.find('li').simulate('click');
+  //   expect(menuClick).toHaveBeenCalled();
+
+  //   // breaks in jest22
+  //   // expect(wrapper).toMatchSnapshot();
+  //   expect(wrapper.find('ul')).toHaveLength(1);
+  //   expect(document.addEventListener).toHaveBeenCalled();
+
+  //   wrapper.unmount();
+  //   expect(document.removeEventListener).toHaveBeenCalled();
+
+  //   addSpy.mockRestore();
+  //   removeSpy.mockRestore();
+  // });
+
+  // it('always rendered menus should attach document event listeners only when opened', function() {
+  //   const addSpy = jest.spyOn(document, 'addEventListener');
+  //   const removeSpy = jest.spyOn(document, 'removeEventListener');
+
+  //   wrapper = mount(
+  //     <DropdownMenu alwaysRenderMenu>
+  //       {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
+  //         return (
+  //           <span
+  //             {...getRootProps({
+  //               className: 'root',
+  //             })}
+  //           >
+  //             <button
+  //               {...getActorProps({
+  //                 className: 'actor',
+  //               })}
+  //             >
+  //               Open Dropdown
+  //             </button>
+  //             <ul
+  //               {...getMenuProps({
+  //                 className: 'menu',
+  //               })}
+  //             >
+  //               <li>Dropdown Menu Item 1</li>
+  //             </ul>
+  //           </span>
+  //         );
+  //       }}
+  //     </DropdownMenu>
+  //   );
+
+  //   // Make sure this is only called when menu is open
+  //   expect(document.addEventListener).not.toHaveBeenCalled();
+  //   wrapper.find('button').simulate('click');
+  //   expect(wrapper.state('isOpen')).toBe(true);
+  //   expect(document.addEventListener).toHaveBeenCalled();
+
+  //   expect(document.removeEventListener).not.toHaveBeenCalled();
+  //   wrapper.find('button').simulate('click');
+  //   expect(wrapper.state('isOpen')).toBe(false);
+  //   expect(document.removeEventListener).toHaveBeenCalled();
+
+  //   addSpy.mockRestore();
+  //   removeSpy.mockRestore();
+  // });
+});

--- a/tests/js/spec/components/hovercard.spec.jsx
+++ b/tests/js/spec/components/hovercard.spec.jsx
@@ -1,287 +1,115 @@
 import React from 'react';
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import Hovercard from 'app/components/hovercard';
 
 jest.useFakeTimers();
 
 describe('Hovercard', function() {
-  // let wrapper;
+  const hoverToShowHovercard = wrapper => {
+    wrapper.find("span[data-test-id='hover-target']").simulate('mouseEnter');
+    jest.runAllTimers();
+    wrapper.update();
+  };
 
-  // beforeEach(function() {
-  //   wrapper = mount(
-  //     <Hovercard>
-  //       {/* {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
-  //         return (
-  //           <span {...getRootProps({})}>
-  //             <button {...getActorProps({})}>Open Dropdown</button>
-  //             {isOpen && (
-  //               <ul {...getMenuProps({})}>
-  //                 <li>Dropdown Menu Item 1</li>
-  //               </ul>
-  //             )}
-  //           </span>
-  //         );
-  //       }} */}
-  //       body={<div>
+  const unhoverToHideHovercard = wrapper => {
+    wrapper.find("span[data-test-id='hover-target']").simulate('mouseLeave');
+    jest.runAllTimers();
+    wrapper.update();
+  };
 
-  //       </div>}
-  //     </Hovercard>
-  //   );
-  // });
+  it('shows on mouseenter', function() {
+    const wrapper = mountWithTheme(
+      <Hovercard
+        body={
+          <div id="hovercard-text">
+            This is a hovercard! It has some text on it. Dogs are great and cats are okay,
+            too.
+          </div>
+        }
+      >
+        Hover over me to show the card!
+      </Hovercard>
+    );
 
-  it.only('shows on hover', function() {
-    const wrapper = mount(<Hovercard body={
-      <div>
-        This is a hovercard! It has some text on it. Dogs are great and cats are okay, too.
-      </div>
-    }>
-    <span id="hover-target">
-      Hover over me to show the card!
-    </span>
-    </Hovercard>);
-    wrapper.find("span[id='hover-target']").simulate("mouseenter")
-    console.log(wrapper.find("span[id='hover-target']").debug())
-    expect(wrapper.contains("Dogs are great")).toEqual(true);
+    hoverToShowHovercard(wrapper);
+
+    expect(wrapper.state().visible).toBe(true);
+    expect(
+      wrapper
+        .find("div[id='hovercard-text']")
+        .text()
+        .includes('Dogs are great')
+    ).toEqual(true);
   });
 
-  it('hides on mouseout', function() {
-    const wrapper = mount(<Hovercard body={
-      <div>
-        This is a hovercard! It has some text on it. Dogs are great and cats are okay, too.
-      </div>
-    }>
-    <span id="hover-target">
-      Hover over me to show the card!
-    </span>
-    </Hovercard>);
-    wrapper.find("span[id='hover-target']").simulate("mouseover")
-    wrapper.find("span[id='hover-target']").simulate("mouseout")
-    expect(wrapper.contains("Dogs are great")).toEqual(false);
+  it('hides on mouseleave', function() {
+    const wrapper = mountWithTheme(
+      <Hovercard
+        body={
+          <div>
+            This is a hovercard! It has some text on it. Dogs are great and cats are okay,
+            too.
+          </div>
+        }
+      >
+        <span id="hover-target">Hover over me to show the card!</span>
+      </Hovercard>
+    );
+
+    // ensure that hovercard is visible before mouseLeave event, to prove that
+    // the mouseleave is actually actively *hiding* it (as opposed to it never
+    // having shown up in the first place)
+    hoverToShowHovercard(wrapper);
+    expect(wrapper.state().visible).toBe(true);
+
+    // now mouseleave and check that the hovercard disappears
+    unhoverToHideHovercard(wrapper);
+    expect(wrapper.state().visible).toBe(false);
+    expect(wrapper.contains("div[id='hovercard-text']")).toEqual(false);
   });
 
-  describe("shrinkToFit", function() {
-    // it('defaults to set width when shrinkToFit not specified - narrow contents', function() {
-    //   const wrapper = mount(<Hovercard body={
-    //   <div>
-    //     Hi!
-    //   </div>
-    // }><span id="hover-target">
-    //   Hover over me to show the card!
-    // </span></Hovercard>);
-    // wrapper.si
-    // })
+  // describe('shrinkToFit', function() {
+  //   it('defaults to set width when shrinkToFit not specified - narrow contents', function() {
+  //     const wrapper = mountWithTheme(
+  //       <div>
+  //         <Hovercard body={<div id="short-text">Hi!</div>}>
+  //           I'm the first hover target!
+  //         </Hovercard>
+  //         <Hovercard
+  //           body={
+  //             <div id="long-text">
+  //               This is a bunch of long text which is definitely going to wrap if I keep
+  //               going long enough. This is a test. This is only a test. Had this been a
+  //               real emergency, you'd already be dead.
+  //             </div>
+  //           }
+  //         >
+  //           I'm the second hover target!
+  //         </Hovercard>
+  //       </div>
+  //     );
 
-    it('defaults to set width when shrinkToFit not specified - wide contents', function() {
+  //     wrapper
+  //       .find("span[data-test-id='hover-target']")
+  //       .filterWhere(element => element.text().includes('first'))
+  //       .simulate('mouseEnter');
+  //     jest.runAllTimers();
+  //     wrapper.update();
 
-    })
-    it('uses set width when shrinkToFit is false - narrow contents', function() {
+  //     expect(
+  //       wrapper
+  //         .find("div[id='short-text']")
+  //         .text()
+  //         .includes('Hi')
+  //     ).toEqual(true);
+  //     console.log(wrapper.find("div[id='short-text']").getDOMNode().width);
 
-    })
-    it('uses set width when shrinkToFit is false - wide contents', function() {
+  //   });
 
-    })
-    it('has variable width when shrinkToFit is true - narrow contents', function() {
-
-    })
-    it('has variable width when shrinkToFit is true - wide contents', function() {
-
-    })
-  })
-
-  // it('can toggle dropdown menu with actor', function() {
-  //   wrapper.find('button').simulate('click');
-  //   expect(wrapper.state('isOpen')).toBe(true);
-  //   expect(wrapper.find('ul')).toHaveLength(1);
-  //   wrapper.find('button').simulate('click');
-  //   expect(wrapper.state('isOpen')).toBe(false);
-  //   expect(wrapper.find('ul')).toHaveLength(0);
-  // });
-
-  // it('closes dropdown when clicking on anything in menu', function() {
-  //   wrapper.find('button').simulate('click');
-  //   wrapper.find('li').simulate('click');
-  //   expect(wrapper.state('isOpen')).toBe(false);
-  //   expect(wrapper.find('ul')).toHaveLength(0);
-  // });
-
-  // it('closes dropdown when clicking outside of menu', async function() {
-  //   wrapper.find('button').simulate('click');
-  //   // Simulate click on document
-  //   const evt = document.createEvent('HTMLEvents');
-  //   evt.initEvent('click', false, true);
-  //   document.body.dispatchEvent(evt);
-  //   jest.runAllTimers();
-  //   await Promise.resolve();
-  //   wrapper.update();
-
-  //   expect(wrapper.find('ul')).toHaveLength(0);
-  // });
-
-  // it('closes dropdown when pressing escape', function() {
-  //   wrapper.find('button').simulate('click');
-  //   expect(wrapper.state('isOpen')).toBe(true);
-  //   wrapper.simulate('keyDown', {key: 'Escape'});
-  //   wrapper.find('button').simulate('keyDown', {key: 'Escape'});
-  //   expect(wrapper.state('isOpen')).toBe(false);
-  //   expect(wrapper.find('ul')).toHaveLength(0);
-  // });
-
-  // it('ignores "Escape" key if `closeOnEscape` is false', function() {
-  //   wrapper = mount(
-  //     <DropdownMenu closeOnEscape={false}>
-  //       {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
-  //         return (
-  //           <span {...getRootProps({})}>
-  //             <button {...getActorProps({})}>Open Dropdown</button>
-  //             {isOpen && (
-  //               <ul {...getMenuProps({})}>
-  //                 <li>Dropdown Menu Item 1</li>
-  //               </ul>
-  //             )}
-  //           </span>
-  //         );
-  //       }}
-  //     </DropdownMenu>
-  //   );
-
-  //   wrapper.find('button').simulate('click');
-  //   expect(wrapper.state('isOpen')).toBe(true);
-  //   wrapper.find('button').simulate('keyDown', {key: 'Escape'});
-  //   expect(wrapper.find('ul')).toHaveLength(1);
-  //   expect(wrapper.state('isOpen')).toBe(true);
-  // });
-
-  // it('keeps dropdown open when clicking on anything in menu with `keepMenuOpen` prop', function() {
-  //   wrapper = mount(
-  //     <DropdownMenu keepMenuOpen>
-  //       {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
-  //         return (
-  //           <span {...getRootProps({})}>
-  //             <button {...getActorProps({})}>Open Dropdown</button>
-  //             {isOpen && (
-  //               <ul {...getMenuProps({})}>
-  //                 <li>Dropdown Menu Item 1</li>
-  //               </ul>
-  //             )}
-  //           </span>
-  //         );
-  //       }}
-  //     </DropdownMenu>
-  //   );
-
-  //   wrapper.find('button').simulate('click');
-  //   wrapper.find('li').simulate('click');
-  //   expect(wrapper.state('isOpen')).toBe(true);
-  //   expect(wrapper.find('ul')).toHaveLength(1);
-  // });
-
-  // it('render prop getters all extend props and call original onClick handlers', function() {
-  //   const rootClick = jest.fn();
-  //   const actorClick = jest.fn();
-  //   const menuClick = jest.fn();
-  //   const addSpy = jest.spyOn(document, 'addEventListener');
-  //   const removeSpy = jest.spyOn(document, 'removeEventListener');
-
-  //   wrapper = mount(
-  //     <DropdownMenu keepMenuOpen>
-  //       {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
-  //         return (
-  //           <span
-  //             {...getRootProps({
-  //               className: 'root',
-  //               onClick: rootClick,
-  //             })}
-  //           >
-  //             <button
-  //               {...getActorProps({
-  //                 className: 'actor',
-  //                 onClick: actorClick,
-  //               })}
-  //             >
-  //               Open Dropdown
-  //             </button>
-  //             {isOpen && (
-  //               <ul
-  //                 {...getMenuProps({
-  //                   className: 'menu',
-  //                   onClick: menuClick,
-  //                 })}
-  //               >
-  //                 <li>Dropdown Menu Item 1</li>
-  //               </ul>
-  //             )}
-  //           </span>
-  //         );
-  //       }}
-  //     </DropdownMenu>
-  //   );
-
-  //   expect(wrapper.find('ul')).toHaveLength(0);
-
-  //   wrapper.find('span').simulate('click');
-  //   expect(rootClick).toHaveBeenCalled();
-  //   wrapper.find('button').simulate('click');
-  //   expect(actorClick).toHaveBeenCalled();
-  //   wrapper.find('li').simulate('click');
-  //   expect(menuClick).toHaveBeenCalled();
-
-  //   // breaks in jest22
-  //   // expect(wrapper).toMatchSnapshot();
-  //   expect(wrapper.find('ul')).toHaveLength(1);
-  //   expect(document.addEventListener).toHaveBeenCalled();
-
-  //   wrapper.unmount();
-  //   expect(document.removeEventListener).toHaveBeenCalled();
-
-  //   addSpy.mockRestore();
-  //   removeSpy.mockRestore();
-  // });
-
-  // it('always rendered menus should attach document event listeners only when opened', function() {
-  //   const addSpy = jest.spyOn(document, 'addEventListener');
-  //   const removeSpy = jest.spyOn(document, 'removeEventListener');
-
-  //   wrapper = mount(
-  //     <DropdownMenu alwaysRenderMenu>
-  //       {({getRootProps, getActorProps, getMenuProps, isOpen}) => {
-  //         return (
-  //           <span
-  //             {...getRootProps({
-  //               className: 'root',
-  //             })}
-  //           >
-  //             <button
-  //               {...getActorProps({
-  //                 className: 'actor',
-  //               })}
-  //             >
-  //               Open Dropdown
-  //             </button>
-  //             <ul
-  //               {...getMenuProps({
-  //                 className: 'menu',
-  //               })}
-  //             >
-  //               <li>Dropdown Menu Item 1</li>
-  //             </ul>
-  //           </span>
-  //         );
-  //       }}
-  //     </DropdownMenu>
-  //   );
-
-  //   // Make sure this is only called when menu is open
-  //   expect(document.addEventListener).not.toHaveBeenCalled();
-  //   wrapper.find('button').simulate('click');
-  //   expect(wrapper.state('isOpen')).toBe(true);
-  //   expect(document.addEventListener).toHaveBeenCalled();
-
-  //   expect(document.removeEventListener).not.toHaveBeenCalled();
-  //   wrapper.find('button').simulate('click');
-  //   expect(wrapper.state('isOpen')).toBe(false);
-  //   expect(document.removeEventListener).toHaveBeenCalled();
-
-  //   addSpy.mockRestore();
-  //   removeSpy.mockRestore();
+  //   it('defaults to set width when shrinkToFit not specified - wide contents', function() {});
+  //   it('uses set width when shrinkToFit is false - narrow contents', function() {});
+  //   it('uses set width when shrinkToFit is false - wide contents', function() {});
+  //   it('has variable width when shrinkToFit is true - narrow contents', function() {});
+  //   it('has variable width when shrinkToFit is true - wide contents', function() {});
   // });
 });

--- a/tests/js/spec/components/hovercard.spec.jsx
+++ b/tests/js/spec/components/hovercard.spec.jsx
@@ -67,49 +67,4 @@ describe('Hovercard', function() {
     expect(wrapper.state().visible).toBe(false);
     expect(wrapper.contains("div[id='hovercard-text']")).toEqual(false);
   });
-
-  // describe('shrinkToFit', function() {
-  //   it('defaults to set width when shrinkToFit not specified - narrow contents', function() {
-  //     const wrapper = mountWithTheme(
-  //       <div>
-  //         <Hovercard body={<div id="short-text">Hi!</div>}>
-  //           I'm the first hover target!
-  //         </Hovercard>
-  //         <Hovercard
-  //           body={
-  //             <div id="long-text">
-  //               This is a bunch of long text which is definitely going to wrap if I keep
-  //               going long enough. This is a test. This is only a test. Had this been a
-  //               real emergency, you'd already be dead.
-  //             </div>
-  //           }
-  //         >
-  //           I'm the second hover target!
-  //         </Hovercard>
-  //       </div>
-  //     );
-
-  //     wrapper
-  //       .find("span[data-test-id='hover-target']")
-  //       .filterWhere(element => element.text().includes('first'))
-  //       .simulate('mouseEnter');
-  //     jest.runAllTimers();
-  //     wrapper.update();
-
-  //     expect(
-  //       wrapper
-  //         .find("div[id='short-text']")
-  //         .text()
-  //         .includes('Hi')
-  //     ).toEqual(true);
-  //     console.log(wrapper.find("div[id='short-text']").getDOMNode().width);
-
-  //   });
-
-  //   it('defaults to set width when shrinkToFit not specified - wide contents', function() {});
-  //   it('uses set width when shrinkToFit is false - narrow contents', function() {});
-  //   it('uses set width when shrinkToFit is false - wide contents', function() {});
-  //   it('has variable width when shrinkToFit is true - narrow contents', function() {});
-  //   it('has variable width when shrinkToFit is true - wide contents', function() {});
-  // });
 });

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -1668,6 +1668,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                           >
                             <span
                               aria-describedby="hovercard-123456"
+                              data-test-id="hover-target"
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
                             >
@@ -1794,6 +1795,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                           >
                             <span
                               aria-describedby="hovercard-123456"
+                              data-test-id="hover-target"
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
                             >


### PR DESCRIPTION
Currently, hovercards have a hardcoded width, which means they're way too big if the text inside them is short:

![image](https://user-images.githubusercontent.com/14812505/73319405-26acbd00-41f1-11ea-96dc-ecf955d9573e.png)

This adds a prop, `shrinkToFit`, which, if present, sets a `max-width` rather than a `width` on the hovercard. That way, short contents get an appropriately-narrow card...

![image](https://user-images.githubusercontent.com/14812505/73319499-6f647600-41f1-11ea-9f93-40314c093383.png)

... while longer contents get a card with the same width as before:

![image](https://user-images.githubusercontent.com/14812505/73319546-8dca7180-41f1-11ea-9487-7fe2dd873f35.png)

It's not perfect, in that it doesn't account for all cases of wrapping...

![image](https://user-images.githubusercontent.com/14812505/73319630-d2eea380-41f1-11ea-91bb-32e39ed60c55.png)

... but since the only place this is actually getting used in currently _admin, going to let that one slide for the moment. (Also, that behavior is no different prior to this change, so at worst it's a lack of a win, rather than a loss.)

This PR also adds initial tests for the hovercard component (just testing show/hide behavior), which were created as a first step to testing the actual shrinking behavior. Said shrinking tests proved difficult, however, and the internet offered up numerous sources opining that "testing rendered styles is not what enzyme is for!" so ended up pulling those in favor of just updating the Storybook story for the hovercard, to include the new prop.