### PR TITLE
feat: Add parsed version info to release

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -252,21 +252,22 @@ class ReleaseSerializer(Serializer):
 
     def serialize(self, obj, attrs, user, **kwargs):
         def expose_version_info(info):
-            version = None
+            version = {"raw": info["version_raw"]}
             if info["version_parsed"]:
-                version = {
-                    "major": info["version_parsed"]["major"],
-                    "minor": info["version_parsed"]["minor"],
-                    "patch": info["version_parsed"]["patch"],
-                    "pre": info["version_parsed"]["pre"],
-                    "buildCode": info["version_parsed"]["build_code"],
-                }
+                version.update(
+                    {
+                        "major": info["version_parsed"]["major"],
+                        "minor": info["version_parsed"]["minor"],
+                        "patch": info["version_parsed"]["patch"],
+                        "pre": info["version_parsed"]["pre"],
+                        "buildCode": info["version_parsed"]["build_code"],
+                    }
+                )
             return {
                 "package": info["package"],
-                "versionRaw": info["version_raw"],
                 "version": version,
-                "description": version["description"],
-                "buildHash": version["build_hash"],
+                "description": info["description"],
+                "buildHash": info["build_hash"],
             }
 
         d = {

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -251,10 +251,28 @@ class ReleaseSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
+        def expose_version_info(info):
+            version = None
+            if info["version_parsed"]:
+                version = {
+                    "major": info["version_parsed"]["major"],
+                    "minor": info["version_parsed"]["minor"],
+                    "patch": info["version_parsed"]["patch"],
+                    "pre": info["version_parsed"]["pre"],
+                    "buildCode": info["version_parsed"]["build_code"],
+                }
+            return {
+                "package": info["package"],
+                "versionRaw": info["version_raw"],
+                "version": version,
+                "description": version["description"],
+                "buildHash": version["build_hash"],
+            }
+
         d = {
             "version": obj.version,
             "shortVersion": obj.version,
-            "versionInfo": obj.version_info,
+            "versionInfo": expose_version_info(obj.version_info),
             "ref": obj.ref,
             "url": obj.url,
             "dateReleased": obj.date_released,

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -254,7 +254,7 @@ class ReleaseSerializer(Serializer):
         d = {
             "version": obj.version,
             "shortVersion": obj.version,
-            "versionInfo": obj.verison_info,
+            "versionInfo": obj.version_info,
             "ref": obj.ref,
             "url": obj.url,
             "dateReleased": obj.date_released,

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -254,6 +254,7 @@ class ReleaseSerializer(Serializer):
         d = {
             "version": obj.version,
             "shortVersion": obj.version,
+            "versionInfo": obj.verison_info,
             "ref": obj.ref,
             "url": obj.url,
             "dateReleased": obj.date_released,

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -8,6 +8,7 @@ import itertools
 from django.db import models, IntegrityError, transaction
 from django.db.models import F
 from django.utils import timezone
+from django.utils.functional import cached_property
 from time import time
 
 from sentry.app import locks
@@ -20,6 +21,7 @@ from sentry.db.models import (
     sane_repr,
 )
 
+from sentry_relay import parse_release
 from sentry.constants import BAD_RELEASE_CHARS, COMMIT_RANGE_DELIMITER
 from sentry.models import CommitFileChange
 from sentry.signals import issue_resolved, release_commits_updated
@@ -176,6 +178,10 @@ class Release(Model):
             cache.set(cache_key, release, 3600)
 
         return release
+
+    @cached_property
+    def version_info(self):
+        return parse_release(self.version)
 
     @classmethod
     def merge(cls, to_release, from_releases):

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -81,10 +81,51 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         assert result["commitCount"] == 1
         assert result["authors"] == [{"name": "stebe", "email": "stebe@sentry.io"}]
 
+        assert result["version"] == release.version
+        assert result["versionInfo"]["package"] is None
+        assert result["versionInfo"]["version"]["raw"] == release_version
+        assert result["versionInfo"]["buildHash"] == release_version
+        assert result["versionInfo"]["description"] == release_version[:12]
+
         result = serialize(release, user, project=project)
         assert result["newGroups"] == 1
         assert result["firstEvent"] == tagvalue1.first_seen
         assert result["lastEvent"] == tagvalue1.last_seen
+
+    def test_mobile_version(self):
+        user = self.create_user()
+        project = self.create_project()
+        release_version = "foo.bar.BazApp@1.0a+20200101100"
+
+        release = Release.objects.create(
+            organization_id=project.organization_id, version=release_version
+        )
+        release.add_project(project)
+
+        ReleaseProject.objects.filter(release=release, project=project).update(new_groups=1)
+
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=1)),
+                "release": release_version,
+                "environment": "prod",
+            },
+            project_id=project.id,
+        )
+
+        release = Release.objects.get(version=release_version)
+
+        result = serialize(release, user)
+        assert result["version"] == release.version
+        assert result["versionInfo"]["package"] == "foo.bar.BazApp"
+        assert result["versionInfo"]["version"]["raw"] == "1.0a+20200101100"
+        assert result["versionInfo"]["version"]["major"] == 1
+        assert result["versionInfo"]["version"]["minor"] == 0
+        assert result["versionInfo"]["version"]["patch"] == 0
+        assert result["versionInfo"]["version"]["pre"] == "a"
+        assert result["versionInfo"]["version"]["buildCode"] == "20200101100"
+        assert result["versionInfo"]["buildHash"] is None
+        assert result["versionInfo"]["description"] == "1.0.0-a (20200101100)"
 
     def test_no_tag_data(self):
         user = self.create_user()


### PR DESCRIPTION
This adds a parsed version info to the release.  We also want this information to be reflected on the event model but I don't want to do this migration until we're happy with the data.

TODO:

* [x] add tests
* [x] validate API changes with ecosystem team