### PR TITLE
feat(discover) Add hooks for upcoming discover2 paywalls

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -295,7 +295,11 @@ class Sidebar extends React.Component {
                   )}
 
                   {discoverVersion === '2' && (
-                    <Feature features={['discover-basic']} organization={organization}>
+                    <Feature
+                      hookName="feature-disabled:discover2-sidebar-item"
+                      features={['discover-basic']}
+                      organization={organization}
+                    >
                       <SidebarItem
                         {...sidebarItemProps}
                         onClick={(_id, evt) =>

--- a/src/sentry/static/sentry/app/stores/hookStore.tsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.tsx
@@ -29,6 +29,8 @@ const validHookNames = new Set<HookName>([
   'feature-disabled:sso-basic',
   'feature-disabled:sso-rippling',
   'feature-disabled:sso-saml2',
+  'feature-disabled:discover2-page',
+  'feature-disabled:discover2-sidebar-item',
   'feature-disabled:grid-editable-actions',
   'footer',
   'integrations:feature-gates',

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -94,6 +94,8 @@ export type FeatureDisabledHooks = {
   'feature-disabled:discover-sidebar-item': FeatureDisabledHook;
   'feature-disabled:project-selector-checkbox': FeatureDisabledHook;
   'feature-disabled:custom-symbol-sources': FeatureDisabledHook;
+  'feature-disabled:discover2-page': FeatureDisabledHook;
+  'feature-disabled:discover2-sidebar-item': FeatureDisabledHook;
   'feature-disabled:grid-editable-actions': FeatureDisabledHook;
 };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -32,6 +32,7 @@ class DiscoverContainer extends React.Component<Props> {
       <Feature
         features={['discover-basic']}
         organization={organization}
+        hookName="feature-disabled:discover2-page"
         renderDisabled={this.renderNoAccess}
       >
         {children}

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -204,7 +204,9 @@ class Results extends React.Component<Props, State> {
   }
 }
 
-const StyledPageContent = styled(PageContent)`
+// These styled components are used in getsentry to create a paywall page.
+// Be careful changing their interfaces.
+export const StyledPageContent = styled(PageContent)`
   margin: 0;
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
@@ -218,26 +220,26 @@ const StyledPageContent = styled(PageContent)`
   }
 `;
 
-const StyledSearchBar = styled(SearchBar)`
+export const StyledSearchBar = styled(SearchBar)`
   margin-bottom: ${space(2)};
 `;
 
-const StyledPanel = styled(Panel)`
+export const StyledPanel = styled(Panel)`
   .echarts-for-react div:first-child {
     width: 100% !important;
   }
 `;
 
-const Top = styled('div')`
+export const Top = styled('div')`
   grid-column: 1/3;
   flex-grow: 0;
 `;
-const Main = styled('div')<{eventView: EventView}>`
+export const Main = styled('div')<{eventView: EventView}>`
   grid-column: 1/2;
   max-width: 100%;
   overflow: hidden;
 `;
-const Side = styled('div')<{eventView: EventView}>`
+export const Side = styled('div')<{eventView: EventView}>`
   grid-column: 2/3;
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -153,11 +153,12 @@ class Tags extends React.Component<Props, State> {
   }
 }
 
-const StyledHeading = styled(SectionHeading)`
+// These styled components are used in getsentry for a paywall.
+export const StyledHeading = styled(SectionHeading)`
   margin: 0 0 ${space(1.5)} 0;
 `;
 
-const TagSection = styled('div')`
+export const TagSection = styled('div')`
   margin: ${space(2)} 0;
 `;
 


### PR DESCRIPTION
Our old plans and free tiers will not have access to discover2 and we want to show them a upgrade prompt similar to events + discover1