### PR TITLE
feat(discover): Make footer stick to bottom of page

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -128,7 +128,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     const {isSidebarVisible} = this.state;
 
     return (
-      <div>
+      <React.Fragment>
         <HeaderBox>
           <DiscoverBreadcrumb
             eventView={eventView}
@@ -184,7 +184,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
             <TagsTable eventView={eventView} event={event} organization={organization} />
           </div>
         </ContentBox>
-      </div>
+      </React.Fragment>
     );
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/index.tsx
@@ -1,18 +1,20 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import {Params} from 'react-router/lib/Router';
-import {Location} from 'history';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from '@emotion/styled';
 
+import {Location} from 'history';
+import {Organization} from 'app/types';
+import {PageContent} from 'app/styles/organization';
 import {t} from 'app/locale';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import NoProjectMessage from 'app/components/noProjectMessage';
-import {Organization} from 'app/types';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import SentryTypes from 'app/sentryTypes';
 import withOrganization from 'app/utils/withOrganization';
-import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 
-import EventView from '../eventView';
 import EventDetailsContent from './content';
+import EventView from '../eventView';
 
 type Props = {
   organization: Organization;
@@ -58,15 +60,17 @@ class EventDetails extends React.Component<Props> {
       <SentryDocumentTitle title={documentTitle} objSlug={organization.slug}>
         <React.Fragment>
           <GlobalSelectionHeader organization={organization} />
-          <NoProjectMessage organization={organization}>
-            <EventDetailsContent
-              organization={organization}
-              location={location}
-              params={params}
-              eventView={eventView}
-              eventSlug={this.getEventSlug()}
-            />
-          </NoProjectMessage>
+          <StyledPageContent>
+            <NoProjectMessage organization={organization}>
+              <EventDetailsContent
+                organization={organization}
+                location={location}
+                params={params}
+                eventView={eventView}
+                eventSlug={this.getEventSlug()}
+              />
+            </NoProjectMessage>
+          </StyledPageContent>
         </React.Fragment>
       </SentryDocumentTitle>
     );
@@ -74,3 +78,7 @@ class EventDetails extends React.Component<Props> {
 }
 
 export default withOrganization(EventDetails);
+
+const StyledPageContent = styled(PageContent)`
+  padding: 0;
+`;

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -1,39 +1,37 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import styled from '@emotion/styled';
-import * as ReactRouter from 'react-router';
 import {Params} from 'react-router/lib/Router';
-import {Location} from 'history';
-import pick from 'lodash/pick';
+import PropTypes from 'prop-types';
+import React from 'react';
+import * as ReactRouter from 'react-router';
 import isEqual from 'lodash/isEqual';
+import pick from 'lodash/pick';
+import styled from '@emotion/styled';
 
+import {Location} from 'history';
+import {Organization, SavedQuery} from 'app/types';
+import {PageContent} from 'app/styles/organization';
 import {t} from 'app/locale';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import SentryTypes from 'app/sentryTypes';
-import {Organization, SavedQuery} from 'app/types';
-import localStorage from 'app/utils/localStorage';
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
-import BetaTag from 'app/components/betaTag';
-import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
-import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import Banner from 'app/components/banner';
+import BetaTag from 'app/components/betaTag';
 import Button from 'app/components/button';
-import Feature from 'app/components/acl/feature';
-import SearchBar from 'app/components/searchBar';
-import NoProjectMessage from 'app/components/noProjectMessage';
-
 import ConfigStore from 'app/stores/configStore';
-import {PageContent} from 'app/styles/organization';
+import Feature from 'app/components/acl/feature';
+import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
+import NoProjectMessage from 'app/components/noProjectMessage';
+import SearchBar from 'app/components/searchBar';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import SentryTypes from 'app/sentryTypes';
+import localStorage from 'app/utils/localStorage';
 import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
 
-import backgroundSpace from '../../../images/spot/background-space.svg';
-
-import EventView from './eventView';
 import {DEFAULT_EVENT_VIEW} from './data';
-import QueryList from './queryList';
 import {getPrebuiltQueries, decodeScalar} from './utils';
+import EventView from './eventView';
+import QueryList from './queryList';
+import backgroundSpace from '../../../images/spot/background-space.svg';
 
 const BANNER_DISMISSED_KEY = 'discover-banner-dismissed';
 
@@ -306,13 +304,19 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
         <SentryDocumentTitle title={t('Discover')} objSlug={organization.slug}>
           <React.Fragment>
             <GlobalSelectionHeader organization={organization} />
-            <NoProjectMessage organization={organization}>{body}</NoProjectMessage>
+            <StyledPageContent>
+              <NoProjectMessage organization={organization}>{body}</NoProjectMessage>
+            </StyledPageContent>
           </React.Fragment>
         </SentryDocumentTitle>
       </Feature>
     );
   }
 }
+
+const StyledPageContent = styled(PageContent)`
+  padding: 0;
+`;
 
 const StyledPageHeader = styled('div')`
   display: flex;


### PR DESCRIPTION
By wrapping the Discover views with `<PageContent>`, we can make the footer stick to the bottom of the window when there is little content and/or while loading.

When loading:

![image](https://user-images.githubusercontent.com/79684/73394069-bbff8e00-4291-11ea-8d0d-d764847c2e8e.png)

![image](https://user-images.githubusercontent.com/79684/73394126-d89bc600-4291-11ea-8891-03c952cc8f94.png)


Old:
![image](https://user-images.githubusercontent.com/79684/73394269-2284ac00-4292-11ea-87fa-81017f9bf5cd.png)

![image](https://user-images.githubusercontent.com/79684/73394221-100a7280-4292-11ea-94b5-a9a9a1b77655.png)
