### PR TITLE
feat(ui): Shorten build string in footer

### DIFF
--- a/src/sentry/static/sentry/app/components/footer.tsx
+++ b/src/sentry/static/sentry/app/components/footer.tsx
@@ -6,6 +6,7 @@ import ConfigStore from 'app/stores/configStore';
 import ExternalLink from 'app/components/links/externalLink';
 import Hook from 'app/components/hook';
 import getDynamicText from 'app/utils/getDynamicText';
+import space from 'app/styles/space';
 
 const Footer = () => {
   const config = ConfigStore.getConfig();
@@ -37,12 +38,12 @@ const Footer = () => {
               fixed: 'Acceptance Test',
               value: config.version.current,
             })}
-            {' ('}
-            {getDynamicText({
-              fixed: 'test',
-              value: config.version.build,
-            })}
-            {')'}
+            <Build>
+              {getDynamicText({
+                fixed: 'test',
+                value: config.version.build.substring(0, 7),
+              })}
+            </Build>
           </div>
         )}
         <a href="/" tabIndex={-1} className="icon-sentry-logo" />
@@ -57,6 +58,13 @@ const FooterLink = styled(ExternalLink)`
     outline: none;
     box-shadow: ${p => p.theme.blue} 0 2px 0;
   }
+`;
+
+const Build = styled('span')`
+  font-size: ${p => p.theme.fontSizeRelativeSmall};
+  color: ${p => p.theme.gray1};
+  font-weight: bold;
+  margin-left: ${space(1)};
 `;
 
 export default Footer;


### PR DESCRIPTION
This shortens the build string and makes it a bit more subtle. This only
affects local dev and on prem installs. (This does not display in our
SaaS offering).

![image](https://user-images.githubusercontent.com/79684/73402796-e6a61280-42a2-11ea-92eb-13fe69a8c644.png)
