### PR TITLE
perf(discover) Register an option to configure the size of the combined tags query 

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -211,3 +211,6 @@ register("eventstore.use-nodestore", default=False, flags=FLAG_PRIORITIZE_DISK)
 
 # Discover2 incremental rollout rate. Tied to feature handlers in getsentry
 register("discover2.rollout-rate", default=0, flags=FLAG_PRIORITIZE_DISK)
+
+# Max number of tags to combine in a single query in Discover2 tags facet.
+register("discover2.max_tags_to_combine", default=3, flags=FLAG_PRIORITIZE_DISK)


### PR DESCRIPTION
We are about to experiment in reducing the number of queries we send to Snuba to build the tags facet. Right now it is one query per tag.
We know that:
1) one query per tag is bad
2) one single query for all tags is probably bad since the size of the arrayJoin is huge.

The optimal size is somewhere in between like querying the most popular promoted tags separately and aggregating the rest in one query. This register the option we will use to experiment on the size of the combined query.