### PR TITLE
ref(ts): replace RouterProps with RouteComponentProps

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1,8 +1,6 @@
 import {SpanEntry} from 'app/components/events/interfaces/spans/types';
 import {API_ACCESS_SCOPES} from 'app/constants';
 import {Field} from 'app/views/settings/components/forms/type';
-import {Params} from 'react-router/lib/Router';
-import {Location} from 'history';
 
 export type ObjectStatus =
   | 'active'

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -671,11 +671,6 @@ export type SentryAppComponent = {
   };
 };
 
-export type RouterProps = {
-  params: Params;
-  location: Location;
-};
-
 export type ActiveExperiments = {
   TrialUpgradeV2Experiment: 'upgrade' | 'trial' | -1;
 };

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventAttachments/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventAttachments/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import pick from 'lodash/pick';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {Panel, PanelBody} from 'app/components/panels';
 import {t} from 'app/locale';
@@ -11,12 +12,12 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
 import parseApiError from 'app/utils/parseApiError';
-import {RouterProps, EventAttachment, Group} from 'app/types';
+import {EventAttachment, Group} from 'app/types';
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
 
-type Props = RouterProps & {
+type Props = RouteComponentProps<{orgId: string; groupId: string}, {}> & {
   api: Client;
   group: Group;
 };

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {Client} from 'app/api';
 import {fetchSentryAppComponents} from 'app/actionCreators/sentryAppComponents';
@@ -15,12 +16,15 @@ import MutedBox from 'app/components/mutedBox';
 import ResolutionBox from 'app/components/resolutionBox';
 import SentryTypes from 'app/sentryTypes';
 import fetchSentryAppInstallations from 'app/utils/fetchSentryAppInstallations';
-import {Group, Project, Organization, Environment, RouterProps, Event} from 'app/types';
+import {Group, Project, Organization, Environment, Event} from 'app/types';
 
 import {fetchGroupEventAndMarkSeen, getEventEnvironment} from '../utils';
 import GroupEventToolbar from '../eventToolbar';
 
-type Props = RouterProps & {
+type Props = RouteComponentProps<
+  {orgId: string; groupId: string; eventId?: string},
+  {}
+> & {
   api: Client;
   group: Group;
   project: Project;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {fetchOrganizationEnvironments} from 'app/actionCreators/environments';
 import {t} from 'app/locale';
@@ -7,19 +8,15 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import OrganizationEnvironmentsStore from 'app/stores/organizationEnvironmentsStore';
 import {Client} from 'app/api';
-import {
-  GlobalSelection,
-  Organization,
-  Environment,
-  RouterProps,
-  Project,
-  Group,
-} from 'app/types';
+import {GlobalSelection, Organization, Environment, Project, Group} from 'app/types';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 
-type Props = RouterProps & {
+type Props = RouteComponentProps<
+  {orgId: string; groupId: string; eventId?: string},
+  {}
+> & {
   api: Client;
   organization: Organization;
   selection: GlobalSelection;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.tsx
@@ -3,6 +3,7 @@ import groupBy from 'lodash/groupBy';
 import keyBy from 'lodash/keyBy';
 import React from 'react';
 import styled from '@emotion/styled';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {
   Organization,
@@ -11,7 +12,6 @@ import {
   SentryApp,
   IntegrationProvider,
   SentryAppInstallation,
-  RouterProps,
 } from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {RequestOptions} from 'app/api';
@@ -35,7 +35,7 @@ import withOrganization from 'app/utils/withOrganization';
 
 type AppOrProvider = SentryApp | IntegrationProvider;
 
-type Props = RouterProps & {
+type Props = RouteComponentProps<{orgId: string}, {}> & {
   organization: Organization;
   hideHeader: boolean;
 };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -2,6 +2,7 @@ import groupBy from 'lodash/groupBy';
 import keyBy from 'lodash/keyBy';
 import React from 'react';
 import styled from '@emotion/styled';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {
   Organization,
@@ -10,7 +11,6 @@ import {
   SentryApp,
   IntegrationProvider,
   SentryAppInstallation,
-  RouterProps,
 } from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {RequestOptions} from 'app/api';
@@ -35,7 +35,7 @@ import SearchInput from 'app/components/forms/searchInput';
 
 type AppOrProvider = SentryApp | IntegrationProvider;
 
-type Props = RouterProps & {
+type Props = RouteComponentProps<{orgId: string}, {}> & {
   organization: Organization;
   hideHeader: boolean;
 };


### PR DESCRIPTION
A while back I added the type `RouterProps` when I didn't know how to use `RouteComponentProps`. This PR replaces `RouterProps` with `RouteComponentProps`.