### PR TITLE
perf(tagstore): apply a lower bound to get_groups_user_counts.

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -463,9 +463,9 @@ class Group(Model):
         return "%s - %s" % (self.qualified_short_id.encode("utf-8"), self.title.encode("utf-8"))
 
     def count_users_seen(self):
-        return tagstore.get_groups_user_counts([self.project_id], [self.id], environment_ids=None)[
-            self.id
-        ]
+        return tagstore.get_groups_user_counts(
+            [self.project_id], [self.id], environment_ids=None, start=self.first_seen
+        )[self.id]
 
     @classmethod
     def calculate_score(cls, times_seen, last_seen):

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1091,7 +1091,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
                 data={
                     "fingerprint": ["put-me-in-group-1"],
                     "user": {"id": six.binary_type(i)},
-                    "timestamp": iso_format(self.min_ago - timedelta(seconds=i)),
+                    "timestamp": iso_format(self.min_ago + timedelta(seconds=i)),
                 },
                 project_id=self.project.id,
             )

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -978,7 +978,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
                 data={
                     "fingerprint": ["put-me-in-group-1"],
                     "user": {"id": six.binary_type(i)},
-                    "timestamp": iso_format(self.min_ago - timedelta(seconds=i)),
+                    "timestamp": iso_format(self.min_ago + timedelta(seconds=i)),
                 },
                 project_id=self.project.id,
             )


### PR DESCRIPTION
Instead of searching through all of retention, let's have new issues search for their first seen.

Should be `min(first_seen, retention)` somewhere down the Snuba pipeline.