### PR TITLE
fix(ui): Fix `<NoGroupsHandler>` request with wrong type for `query`

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/noGroupsHandler.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/noGroupsHandler.tsx
@@ -56,7 +56,8 @@ class NoGroupsHandler extends React.Component<Props, State> {
     // If no projects are selected, then we must check every project the user is a
     // member of and make sure there are no first events for all of the projects
     let firstEventQuery = {};
-    const projectsQuery = {per_page: 1, query: {}};
+    const projectsQuery: {per_page: number; query?: string} = {per_page: 1};
+
     if (!selectedProjectIds || !selectedProjectIds.length) {
       firstEventQuery = {is_member: true};
     } else {


### PR DESCRIPTION
This happened in the case where the URL does not have a project selected, the default type of `query` in this case was an object when it should be a string