### PR TITLE
perf(discover) Aggregate multiple query tags together into one

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 from copy import deepcopy
 from datetime import timedelta
 
+from sentry import options
 from sentry.api.event_search import (
     get_filter,
     resolve_field_list,
@@ -554,7 +555,19 @@ def get_facets(query, params, limit=10, referrer=None):
     # Get tag counts for our top tags. Fetching them individually
     # allows snuba to leverage promoted tags better and enables us to get
     # the value count we want.
-    for tag_name in top_tags:
+    max_aggregate_tags = options.get("discover2.max_tags_to_combine")
+    individual_tags = []
+    aggregate_tags = []
+    for i, tag in enumerate(top_tags):
+        if tag == "environment":
+            # Add here tags that you want to be individual
+            individual_tags.append(tag)
+        if i >= len(top_tags) - max_aggregate_tags:
+            aggregate_tags.append(tag)
+        else:
+            individual_tags.append(tag)
+
+    for tag_name in individual_tags:
         tag = u"tags[{}]".format(tag_name)
         tag_values = raw_query(
             aggregations=[["count", None, "count"]],
@@ -572,6 +585,29 @@ def get_facets(query, params, limit=10, referrer=None):
         results.extend(
             [
                 FacetResult(tag_name, r[tag], int(r["count"]) * multiplier)
+                for r in tag_values["data"]
+            ]
+        )
+
+    if aggregate_tags:
+        conditions = snuba_args.get("conditions", [])
+        conditions.append(["tags_key", "IN", aggregate_tags])
+        tag_values = raw_query(
+            aggregations=[["count", None, "count"]],
+            conditions=conditions,
+            start=snuba_args.get("start"),
+            end=snuba_args.get("end"),
+            filter_keys=snuba_args.get("filter_keys"),
+            orderby=["tags_key", "-count"],
+            groupby=["tags_key", "tags_value"],
+            dataset=Dataset.Discover,
+            referrer=referrer,
+            sample=sample_rate,
+            limitby=[TOP_VALUES_DEFAULT_LIMIT, "tags_key"],
+        )
+        results.extend(
+            [
+                FacetResult(r["tags_key"], r["tags_value"], int(r["count"]))
                 for r in tag_values["data"]
             ]
         )

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -562,7 +562,7 @@ def get_facets(query, params, limit=10, referrer=None):
         if tag == "environment":
             # Add here tags that you want to be individual
             individual_tags.append(tag)
-        if i >= len(top_tags) - max_aggregate_tags:
+        elif i >= len(top_tags) - max_aggregate_tags:
             aggregate_tags.append(tag)
         else:
             individual_tags.append(tag)

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1389,7 +1389,7 @@ class GetFacetsTest(SnubaTestCase, TestCase):
         result = discover.get_facets("", params)
         keys = {r.key for r in result}
         assert keys == {"environment", "level"}
-        assert {"prod", "staging", None} == {f.value for f in result if f.key == "environment"}
+        assert {None, "prod", "staging"} == {f.value for f in result if f.key == "environment"}
         assert {1} == {f.count for f in result if f.key == "environment"}
 
     def test_query_string(self):


### PR DESCRIPTION
This replaces some of the individual tag queries we use to populate the tag facet with one single aggregated one that groups by tags_key and tags_value.
It seems that running all 9 tags in this query may be worse than running the individual queries because of the humongous size of the arrayJoin result. This would also not take advantage of promoted tags.
This PR uses an option we can use to configure the distribution of tags that will be loaded through individual queries and those that will be aggregated.
