### PR TITLE
fix(discover) Fix incorrect gridEditable layout on mount

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -164,6 +164,7 @@ class GridEditable<
 
   componentDidMount() {
     window.addEventListener('resize', this.redrawGridColumn);
+    this.setGridTemplateColumns(this.props.columnOrder);
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
If GridEditable never receives a prop update it will have an invalid layout of repeat(auto-fill, 1fr) which is ignored in Firefox. By setting the template on mount we always get a well formed table.