### PR TITLE
fix(discover2): Remove any aggregates from search conditions when drilling down on count() aggregates

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -5,6 +5,11 @@ import isString from 'lodash/isString';
 import {Location, Query} from 'history';
 import {browserHistory} from 'react-router';
 
+import {
+  tokenizeSearch,
+  stringifyQueryObject,
+  QueryResults,
+} from 'app/utils/tokenizeSearch';
 import {t} from 'app/locale';
 import {Event, Organization, OrganizationSummary} from 'app/types';
 import {Client} from 'app/api';
@@ -424,6 +429,30 @@ export function getExpandedResults(
     nextView = nextView.withDeletedColumn(i, undefined);
   });
 
+  // filter out any aggregates from the search conditions.
+  // otherwise, it'll lead to an invalid query result.
+  const queryWithNoAggregates = Object.entries(tokenizeSearch(nextView.query)).reduce(
+    (acc: QueryResults, [field, value]) => {
+      if (field === 'query') {
+        acc.query = value;
+        return acc;
+      }
+
+      const column = explodeFieldString(field);
+
+      if (column.aggregation) {
+        return acc;
+      }
+
+      acc[field] = value;
+
+      return acc;
+    },
+    {query: []}
+  );
+
+  nextView.query = stringifyQueryObject(queryWithNoAggregates);
+
   // Tokenize conditions and append additional conditions provided + generated.
   Object.keys(additionalConditions).forEach(key => {
     if (key === 'project' || key === 'project.id') {
@@ -432,6 +461,13 @@ export function getExpandedResults(
     }
     if (key === 'environment') {
       nextView.environment = [...nextView.environment, additionalConditions[key]];
+      return;
+    }
+
+    // filter out any aggregates from provided additional conditions.
+    // otherwise, it'll lead to an invalid query result.
+    const column = explodeFieldString(key);
+    if (column.aggregation) {
       return;
     }
 

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -327,6 +327,12 @@ describe('getExpandedResults()', function() {
     expect(result.query).toEqual('event.type:error event.type:csp');
   });
 
+  it('removes any aggregates in either search conditions or extra conditions', () => {
+    const view = new EventView({...state, query: 'event.type:error count(id):<10'});
+    const result = getExpandedResults(view, {'count(id)': '>2'}, {});
+    expect(result.query).toEqual('event.type:error');
+  });
+
   it('applies conditions from dataRow map structure based on fields', () => {
     const view = new EventView(state);
     const result = getExpandedResults(view, {extra: 'condition'}, {title: 'Event title'});


### PR DESCRIPTION
Remove any aggregates from search conditions when drilling down on `count()` aggregates. We do this since aggregated columns are removed from the table, and it can lead to an invalid query state.