### PR TITLE
ref(py3): exceptions.message -> six.text_type

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -253,7 +253,7 @@ class Endpoint(APIView):
         try:
             cursor_result = paginator.get_result(limit=per_page, cursor=input_cursor)
         except BadPaginationError as e:
-            return Response({"detail": e.message}, status=400)
+            return Response({"detail": six.text_type(e)}, status=400)
 
         # map results based on callback
         if on_results:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
+import six
 from rest_framework.exceptions import PermissionDenied, ParseError
-
 from django.core.cache import cache
 
 from sentry.api.base import Endpoint
@@ -244,8 +244,8 @@ class OrganizationEndpoint(Endpoint):
         # from the request
         try:
             start, end = get_date_range_from_params(request.GET, optional=date_filter_optional)
-        except InvalidParams as exc:
-            raise OrganizationEventsError(exc.message)
+        except InvalidParams as e:
+            raise OrganizationEventsError(six.text_type(e))
 
         try:
             projects = self.get_projects(request, organization)
@@ -255,7 +255,7 @@ class OrganizationEndpoint(Endpoint):
         if not projects:
             raise NoProjects
 
-        environments = [e.name for e in self.get_environments(request, organization)]
+        environments = [env.name for env in self.get_environments(request, organization)]
         params = {"start": start, "end": end, "project_id": [p.id for p in projects]}
         if environments:
             params["environment"] = environments

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 from rest_framework.exceptions import PermissionDenied
 
 from sentry.api.bases import OrganizationEndpoint, OrganizationEventsError
@@ -15,8 +16,8 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         query = request.GET.get("query")
         try:
             return get_filter(query, params)
-        except InvalidSearchQuery as exc:
-            raise OrganizationEventsError(exc.message)
+        except InvalidSearchQuery as e:
+            raise OrganizationEventsError(six.text_type(e))
 
     def get_orderby(self, request):
         sort = request.GET.getlist("sort")
@@ -58,8 +59,8 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         query = request.GET.get("query")
         try:
             _filter = get_filter(query, params)
-        except InvalidSearchQuery as exc:
-            raise OrganizationEventsError(exc.message)
+        except InvalidSearchQuery as e:
+            raise OrganizationEventsError(six.text_type(e))
 
         snuba_args = {
             "start": _filter.start,

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
+import six
 from django.http import Http404
 from django.utils.encoding import force_str
 from django.core.signing import BadSignature, SignatureExpired
-
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -62,8 +62,8 @@ class AcceptProjectTransferEndpoint(Endpoint):
 
         try:
             data, project = self.get_validated_data(data, request.user)
-        except InvalidPayload as exc:
-            return Response({"detail": exc.message}, status=400)
+        except InvalidPayload as e:
+            return Response({"detail": six.text_type(e)}, status=400)
 
         organizations = Organization.objects.filter(
             status=OrganizationStatus.ACTIVE,
@@ -93,8 +93,8 @@ class AcceptProjectTransferEndpoint(Endpoint):
 
         try:
             data, project = self.get_validated_data(data, request.user)
-        except InvalidPayload as exc:
-            return Response({"detail": exc.message}, status=400)
+        except InvalidPayload as e:
+            return Response({"detail": six.text_type(e)}, status=400)
 
         transaction_id = data["transaction_id"]
 

--- a/src/sentry/api/endpoints/data_export.py
+++ b/src/sentry/api/endpoints/data_export.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-
+import six
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
 from rest_framework.response import Response
@@ -51,7 +51,7 @@ class DataExportEndpoint(OrganizationEndpoint):
             )
         except ValidationError as e:
             # This will handle invalid JSON requests
-            return Response({"detail": e.message}, status=400)
+            return Response({"detail": six.text_type(e)}, status=400)
 
         compile_data.delay(data_export=data_export)
         return Response(serialize(data_export, request.user), status=201)

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -66,8 +66,8 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         try:
             start, end = get_date_range_from_params(request.GET, optional=True)
-        except InvalidParams as exc:
-            return Response({"detail": exc.message}, status=400)
+        except InvalidParams as e:
+            return Response({"detail": six.text_type(e)}, status=400)
 
         try:
             return self._get_events_snuba(request, group, environments, query, tags, start, end)

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
+import six
 from django.db import IntegrityError, transaction
-
 from rest_framework.response import Response
 
 from sentry import features
@@ -77,8 +77,8 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
                     organization_id=organization_id,
                 )
             )
-        except IntegrationError as exc:
-            return Response({"detail": exc.message}, status=400)
+        except IntegrationError as e:
+            return Response({"detail": six.text_type(e)}, status=400)
 
     # was thinking put for link an existing issue, post for create new issue?
     def put(self, request, group, integration_id):
@@ -108,8 +108,8 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             data = installation.get_issue(external_issue_id, data=request.data)
         except IntegrationFormError as exc:
             return Response(exc.field_errors, status=400)
-        except IntegrationError as exc:
-            return Response({"non_field_errors": [exc.message]}, status=400)
+        except IntegrationError as e:
+            return Response({"non_field_errors": [six.text_type(e)]}, status=400)
 
         defaults = {
             "title": data.get("title"),
@@ -140,8 +140,8 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             installation.after_link_issue(external_issue, data=request.data)
         except IntegrationFormError as exc:
             return Response(exc.field_errors, status=400)
-        except IntegrationError as exc:
-            return Response({"non_field_errors": [exc.message]}, status=400)
+        except IntegrationError as e:
+            return Response({"non_field_errors": [six.text_type(e)]}, status=400)
 
         try:
             with transaction.atomic():
@@ -192,8 +192,8 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             data = installation.create_issue(request.data)
         except IntegrationFormError as exc:
             return Response(exc.field_errors, status=400)
-        except IntegrationError as exc:
-            return Response({"non_field_errors": [exc.message]}, status=400)
+        except IntegrationError as e:
+            return Response({"non_field_errors": [six.text_type(e)]}, status=400)
 
         external_issue_key = installation.make_external_key(data)
         external_issue, created = ExternalIssue.objects.get_or_create(

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -19,8 +19,8 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
         try:
             params = self.get_filter_params(request, organization)
-        except OrganizationEventsError as exc:
-            return Response({"detail": exc.message}, status=400)
+        except OrganizationEventsError as e:
+            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -42,8 +42,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         full = request.GET.get("full", False)
         try:
             snuba_args = self.get_snuba_query_args_legacy(request, organization)
-        except OrganizationEventsError as exc:
-            return Response({"detail": exc.message}, status=400)
+        except OrganizationEventsError as e:
+            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             # return empty result if org doesn't have projects
             # or user doesn't have access to projects in org

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -13,8 +13,8 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
         try:
             params = self.get_filter_params(request, organization)
-        except OrganizationEventsError as exc:
-            return Response({"detail": exc.message}, status=400)
+        except OrganizationEventsError as e:
+            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             return Response({"count": 0})
 

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -166,8 +166,8 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
         try:
             start, end = get_date_range_from_params(request.GET)
-        except InvalidParams as exc:
-            return Response({"detail": exc.message}, status=400)
+        except InvalidParams as e:
+            return Response({"detail": six.text_type(e)}, status=400)
 
         try:
             cursor_result, query_kwargs = self._search(

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from uuid import uuid4
 
+import six
 from django.http import Http404
 
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
@@ -60,6 +61,6 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationEndpoint):
         try:
             installation.update_organization_config(request.data)
         except IntegrationError as e:
-            return self.respond({"detail": e.message}, status=400)
+            return self.respond({"detail": six.text_type(e)}, status=400)
 
         return self.respond(status=200)

--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 from django.http import Http404
 
 from sentry.constants import ObjectStatus
@@ -38,7 +39,7 @@ class OrganizationIntegrationReposEndpoint(OrganizationEndpoint):
             try:
                 repositories = install.get_repositories(request.GET.get("search"))
             except IntegrationError as e:
-                return self.respond({"detail": e.message}, status=400)
+                return self.respond({"detail": six.text_type(e)}, status=400)
 
             context = {"repos": repositories, "searchable": install.repo_search}
             return self.respond(context)

--- a/src/sentry/api/endpoints/organization_monitors.py
+++ b/src/sentry/api/endpoints/organization_monitors.py
@@ -41,8 +41,8 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
             filter_params = self.get_filter_params(request, organization, date_filter_optional=True)
         except NoProjects:
             return self.respond([])
-        except OrganizationEventsError as exc:
-            return self.respond({"detail": exc.message}, status=400)
+        except OrganizationEventsError as e:
+            return self.respond({"detail": six.text_type(e)}, status=400)
 
         queryset = Monitor.objects.filter(
             organization_id=organization.id, project_id__in=filter_params["project_id"]

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 from rest_framework.response import Response
 
 from sentry.api.base import DocSection
@@ -156,8 +157,8 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
             fetch_commits = not commit_list
             try:
                 release.set_refs(refs, request.user, fetch=fetch_commits)
-            except InvalidRepository as exc:
-                return Response({"refs": [exc.message]}, status=400)
+            except InvalidRepository as e:
+                return Response({"refs": [six.text_type(e)]}, status=400)
 
         if not was_released and release.date_released:
             for project in release.projects.all():

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
+import six
 from django.db import IntegrityError, transaction
-
 from rest_framework.response import Response
 
 from sentry.api.bases import NoProjects, OrganizationEventsError
@@ -94,8 +94,8 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
             filter_params = self.get_filter_params(request, organization, date_filter_optional=True)
         except NoProjects:
             return Response([])
-        except OrganizationEventsError as exc:
-            return Response({"detail": exc.message}, status=400)
+        except OrganizationEventsError as e:
+            return Response({"detail": six.text_type(e)}, status=400)
 
         queryset = (
             Release.objects.filter(
@@ -246,8 +246,8 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
                 fetch_commits = not commit_list
                 try:
                     release.set_refs(refs, request.user, fetch=fetch_commits)
-                except InvalidRepository as exc:
-                    return Response({"refs": [exc.message]}, status=400)
+                except InvalidRepository as e:
+                    return Response({"refs": [six.text_type(e)]}, status=400)
 
             if not created and not new_projects:
                 # This is the closest status code that makes sense, and we want

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 from rest_framework.response import Response
 
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
@@ -16,8 +17,8 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
 
         try:
             filter_params = self.get_filter_params(request, organization)
-        except OrganizationEventsError as exc:
-            return Response({"detail": exc.message}, status=400)
+        except OrganizationEventsError as e:
+            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             paginator = SequencePaginator([])
         else:

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 from rest_framework.response import Response
 
 from sentry import tagstore
@@ -11,8 +12,8 @@ class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
         try:
             filter_params = self.get_filter_params(request, organization)
-        except OrganizationEventsError as exc:
-            return Response({"detail": exc.message}, status=400)
+        except OrganizationEventsError as e:
+            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             return Response([])
 

--- a/src/sentry/api/endpoints/organization_user_reports.py
+++ b/src/sentry/api/endpoints/organization_user_reports.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
+import six
 from rest_framework.response import Response
+
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationUserReportsPermission
 from sentry.api.bases import NoProjects, OrganizationEventsError
 from sentry.api.paginator import DateTimePaginator
@@ -35,8 +37,8 @@ class OrganizationUserReportsEndpoint(OrganizationEndpoint):
             filter_params = self.get_filter_params(request, organization, date_filter_optional=True)
         except NoProjects:
             return Response([])
-        except OrganizationEventsError as exc:
-            return Response({"detail": exc.message}, status=400)
+        except OrganizationEventsError as e:
+            return Response({"detail": six.text_type(e)}, status=400)
 
         queryset = UserReport.objects.filter(
             project_id__in=filter_params["project_id"], group__isnull=False

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -224,7 +224,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
             sources = parse_sources(sources_json.strip())
             sources_json = json.dumps(sources) if sources else ""
         except InvalidSourcesError as e:
-            raise serializers.ValidationError(e.message)
+            raise serializers.ValidationError(six.text_type(e))
 
         return sources_json
 
@@ -235,7 +235,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
         try:
             Enhancements.from_config_string(value)
         except InvalidEnhancerConfig as e:
-            raise serializers.ValidationError(e.message)
+            raise serializers.ValidationError(six.text_type(e))
 
         return value
 
@@ -246,7 +246,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
         try:
             FingerprintingRules.from_config_string(value)
         except InvalidFingerprintingConfig as e:
-            raise serializers.ValidationError(e.message)
+            raise serializers.ValidationError(six.text_type(e))
 
         return value
 

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -42,7 +42,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
             context = serialize(plugin, request.user, PluginWithConfigSerializer(project))
         except PluginIdentityRequired as e:
             context = serialize(plugin, request.user, PluginSerializer(project))
-            context["config_error"] = e.message
+            context["config_error"] = six.text_type(e)
             context["auth_url"] = reverse("socialauth_associate", args=[plugin.slug])
 
         return Response(context)

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -146,7 +146,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
                 InvalidIdentity,
                 PluginError,
             ) as e:
-                errors[key] = e.message
+                errors[key] = six.text_type(e)
 
             if not errors.get(key):
                 cleaned[key] = value
@@ -157,7 +157,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
                     project=project, config=cleaned, actor=request.user
                 )
             except (InvalidIdentity, PluginError) as e:
-                errors["__all__"] = e.message
+                errors["__all__"] = six.text_type(e)
 
         if errors:
             return Response({"errors": errors}, status=400)

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 from rest_framework import serializers
 from uuid import uuid4
 
@@ -120,7 +121,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
         try:
             report_instance = save_userreport(project, report)
         except Conflict as e:
-            return self.respond({"detail": e.message}, status=409)
+            return self.respond({"detail": six.text_type(e)}, status=409)
 
         return self.respond(
             serialize(

--- a/src/sentry/api/endpoints/sentry_internal_app_tokens.py
+++ b/src/sentry/api/endpoints/sentry_internal_app_tokens.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 from rest_framework.response import Response
 from rest_framework import status
 
@@ -45,7 +46,7 @@ class SentryInternalAppTokensEndpoint(SentryAppBaseEndpoint):
                 request=request, sentry_app_installation=sentry_app_installation, user=request.user
             )
         except ApiTokenLimitError as e:
-            return Response(e.message, status=status.HTTP_403_FORBIDDEN)
+            return Response(six.text_type(e), status=status.HTTP_403_FORBIDDEN)
 
         # hack so the token is included in the response
         attrs = {"application": None}

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -91,7 +91,9 @@ def build_query_params_from_request(request, organization, projects, environment
                 parse_search_query(query), projects, request.user, environments
             )
         except InvalidSearchQuery as e:
-            raise ValidationError(u"Your search query could not be parsed: {}".format(e.message))
+            raise ValidationError(
+                u"Your search query could not be parsed: {}".format(six.text_type(e))
+            )
 
         validate_search_filter_permissions(organization, search_filters, request.user)
         query_kwargs["search_filters"] = search_filters

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
+import six
 from jsonschema.exceptions import ValidationError as SchemaValidationError
-
 from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
 
@@ -54,7 +54,7 @@ class SchemaField(serializers.Field):
         try:
             validate_ui_element_schema(data)
         except SchemaValidationError as e:
-            raise ValidationError(e.message)
+            raise ValidationError(six.text_type(e))
         return data
 
 

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import six
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
@@ -54,7 +53,7 @@ class SchemaField(serializers.Field):
         try:
             validate_ui_element_schema(data)
         except SchemaValidationError as e:
-            raise ValidationError(six.text_type(e))
+            raise ValidationError(e.message)
         return data
 
 

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 
+import six
 from django.utils import timezone
 
 from sentry.search.utils import parse_datetime_string, InvalidQuery
@@ -73,8 +74,8 @@ def get_date_range_from_params(params, optional=False):
         try:
             start = parse_datetime_string(params["start"])
             end = parse_datetime_string(params["end"])
-        except InvalidQuery as exc:
-            raise InvalidParams(exc.message)
+        except InvalidQuery as e:
+            raise InvalidParams(six.text_type(e))
     elif optional:
         return None, None
 

--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import logging
 import json
 
-import six
 from jsonschema import Draft4Validator
 from jsonschema.exceptions import best_match
 from jsonschema.exceptions import ValidationError as SchemaValidationError
@@ -219,9 +218,7 @@ def check_each_element_for_error(instance):
             validate_component(element)
         except SchemaValidationError as e:
             # catch the validation error and re-write the error so the user knows which element has the issue
-            raise SchemaValidationError(
-                "%s for element of type '%s'" % (six.text_type(e), found_type)
-            )
+            raise SchemaValidationError("%s for element of type '%s'" % (e.message, found_type))
 
 
 def validate_ui_element_schema(instance):

--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -2,9 +2,12 @@ from __future__ import absolute_import
 
 import logging
 import json
+
+import six
 from jsonschema import Draft4Validator
 from jsonschema.exceptions import best_match
 from jsonschema.exceptions import ValidationError as SchemaValidationError
+
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +219,9 @@ def check_each_element_for_error(instance):
             validate_component(element)
         except SchemaValidationError as e:
             # catch the validation error and re-write the error so the user knows which element has the issue
-            raise SchemaValidationError("%s for element of type '%s'" % (e.message, found_type))
+            raise SchemaValidationError(
+                "%s for element of type '%s'" % (six.text_type(e), found_type)
+            )
 
 
 def validate_ui_element_schema(instance):

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -199,7 +199,7 @@ class RedisBackend(Backend):
                     ],
                 )
             except ResponseError as e:
-                if "err(invalid_state):" in e.message:
+                if "err(invalid_state):" in six.text_type(e):
                     six.raise_from(InvalidState("Timeline is not in the ready state."), e)
                 else:
                     raise

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -73,8 +73,8 @@ class DiscoverQuerySerializer(serializers.Serializer):
                 },
                 optional=True,
             )
-        except InvalidParams as exc:
-            raise serializers.ValidationError(exc.message)
+        except InvalidParams as e:
+            raise serializers.ValidationError(six.text_type(e))
 
         if start is None or end is None:
             raise serializers.ValidationError("Either start and end dates or range is required")

--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import logging
 
+import six
+
 from sentry import http
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.http import safe_urlopen, safe_urlread
@@ -50,7 +52,7 @@ def get_user_info(access_token, installation_data):
                 "verify_ssl": installation_data["verify_ssl"],
                 "client_id": installation_data["client_id"],
                 "error_status": e.code,
-                "error_message": e.message,
+                "error_message": six.text_type(e),
             },
         )
         raise e
@@ -100,7 +102,7 @@ class GitlabIdentityProvider(OAuth2Provider):
                 extra={
                     "identity_id": identity.id,
                     "error_status": e.code,
-                    "error_message": e.message,
+                    "error_message": six.text_type(e),
                 },
             )
             payload = {}

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 from six.moves.urllib.parse import urlparse
 from django.utils.translation import ugettext_lazy as _
 from django import forms
@@ -276,7 +277,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
                     "verify_ssl": installation_data["verify_ssl"],
                     "group": installation_data["group"],
                     "include_subgroups": installation_data["include_subgroups"],
-                    "error_message": e.message,
+                    "error_message": six.text_type(e),
                     "error_status": e.code,
                 },
             )

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -475,14 +475,14 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             raise IntegrationError(
                 "Jira returned: Unauthorized. " "Please check your configuration settings."
             )
-        except ApiError as exc:
+        except ApiError as e:
             logger.info(
                 "jira.fetch-issue-create-meta.error",
                 extra={
                     "integration_id": self.model.id,
                     "organization_id": self.organization_id,
                     "jira_project": project_id,
-                    "error": exc.message,
+                    "error": six.text_type(e),
                 },
             )
             raise IntegrationError(
@@ -502,13 +502,13 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         client = self.get_client()
         try:
             jira_projects = client.get_projects_list()
-        except ApiError as exc:
+        except ApiError as e:
             logger.info(
                 "jira.get-create-issue-config.no-projects",
                 extra={
                     "integration_id": self.model.id,
                     "organization_id": self.organization_id,
-                    "error": exc.message,
+                    "error": six.text_type(e),
                 },
             )
             raise IntegrationError(

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 from rest_framework.response import Response
 
 from sentry.api.bases.integration import IntegrationEndpoint
@@ -47,8 +48,8 @@ class JiraSearchEndpoint(IntegrationEndpoint):
                 return Response([])
             try:
                 resp = installation.search_issues(query)
-            except IntegrationError as exc:
-                return Response({"detail": exc.message}, status=400)
+            except IntegrationError as e:
+                return Response({"detail": six.text_type(e)}, status=400)
             return Response(
                 [
                     {"label": "(%s) %s" % (i["key"], i["fields"]["summary"]), "value": i["key"]}

--- a/src/sentry/integrations/pagerduty/notify_action.py
+++ b/src/sentry/integrations/pagerduty/notify_action.py
@@ -3,10 +3,11 @@ Used for notifying a *specific* plugin
 """
 from __future__ import absolute_import
 
+import six
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-from sentry.constants import ObjectStatus
 
+from sentry.constants import ObjectStatus
 from sentry.rules.actions.base import EventAction
 from sentry.models import Integration, OrganizationIntegration, PagerDutyService
 from sentry.integrations.exceptions import ApiError
@@ -109,7 +110,7 @@ class PagerDutyNotifyServiceAction(EventAction):
                 self.logger.info(
                     "rule.fail.pagerduty_trigger",
                     extra={
-                        "error": e.message,
+                        "error": six.text_type(e),
                         "service_name": service.service_name,
                         "service_id": service.id,
                     },

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -48,7 +48,7 @@ class IntegrationPipeline(Pipeline):
                     "provider_key": self.provider.key,
                 },
             )
-            return self.error(e.message)
+            return self.error(six.text_type(e))
 
         response = self._finish_pipeline(data)
         self.provider.post_install(self.integration, self.organization)

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
+
 from time import time
 import logging
 import re
 
+import six
 from django import forms
 from django.utils.translation import ugettext as _
 
@@ -397,7 +399,9 @@ class VstsIntegrationProvider(IntegrationProvider):
             )
         except ApiError as e:
             auth_codes = (400, 401, 403)
-            permission_error = "permission" in e.message or "not authorized" in e.message
+            permission_error = "permission" in six.text_type(
+                e
+            ) or "not authorized" in six.text_type(e)
             if e.code in auth_codes or permission_error:
                 raise IntegrationError(
                     "You do not have sufficient account access to create webhooks "

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -397,7 +397,7 @@ def fetch_sourcemap(url, project=None, release=None, dist=None, allow_scraping=T
                 url[BASE64_PREAMBLE_LENGTH:] + (b"=" * (-(len(url) - BASE64_PREAMBLE_LENGTH) % 4))
             )
         except TypeError as e:
-            raise UnparseableSourcemap({"url": "<base64>", "reason": e.message})
+            raise UnparseableSourcemap({"url": "<base64>", "reason": six.text_type(e)})
     else:
         result = fetch_file(
             url, project=project, release=release, dist=dist, allow_scraping=allow_scraping

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -225,12 +225,12 @@ def parse_sources(config):
     try:
         sources = json.loads(config)
     except BaseException as e:
-        raise InvalidSourcesError(e.message)
+        raise InvalidSourcesError(six.text_type(e))
 
     try:
         jsonschema.validate(sources, SOURCES_SCHEMA)
     except jsonschema.ValidationError as e:
-        raise InvalidSourcesError(e.message)
+        raise InvalidSourcesError(six.text_type(e))
 
     ids = set()
     for source in sources:

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -230,7 +230,7 @@ def parse_sources(config):
     try:
         jsonschema.validate(sources, SOURCES_SCHEMA)
     except jsonschema.ValidationError as e:
-        raise InvalidSourcesError(six.text_type(e))
+        raise InvalidSourcesError(e.message)
 
     ids = set()
     for source in sources:

--- a/src/sentry/management/commands/serve_normalize.py
+++ b/src/sentry/management/commands/serve_normalize.py
@@ -36,7 +36,9 @@ def catch_errors(f):
                 return encode(
                     {
                         "result": None,
-                        "error": force_str(e.message) + " " + force_str(traceback.format_exc()),
+                        "error": force_str(six.text_type(e))
+                        + " "
+                        + force_str(traceback.format_exc()),
                         "metrics": None,
                         "encoding_error": True,
                     }

--- a/src/sentry/management/commands/serve_normalize.py
+++ b/src/sentry/management/commands/serve_normalize.py
@@ -11,6 +11,7 @@ import json
 import resource
 from optparse import make_option
 
+import six
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.encoding import force_str
 
@@ -25,7 +26,7 @@ def catch_errors(f):
         try:
             return f(*args, **kwargs)
         except Exception as e:
-            error = force_str(e.message) + " " + force_str(traceback.format_exc())
+            error = force_str(six.text_type(e)) + " " + force_str(traceback.format_exc())
 
         try:
             return encode({"result": None, "error": error, "metrics": None})

--- a/src/sentry/mediators/external_requests/select_requester.py
+++ b/src/sentry/mediators/external_requests/select_requester.py
@@ -69,7 +69,7 @@ class SelectRequester(Mediator):
                     "install": self.install.uuid,
                     "project": self.project and self.project.slug,
                     "uri": self.uri,
-                    "error_message": e.message,
+                    "error_message": six.text_type(e),
                 },
             )
             response = {}

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -112,7 +112,7 @@ class Creator(Mediator):
             with transaction.atomic():
                 IntegrationFeature.objects.create(sentry_app=self.sentry_app)
         except IntegrityError as e:
-            self.log(sentry_app=self.sentry_app.slug, error_message=e.message)
+            self.log(sentry_app=self.sentry_app.slug, error_message=six.text_type(e))
 
     def audit(self):
         from sentry.utils.audit import create_audit_entry

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -6,8 +6,9 @@ import re
 import warnings
 from collections import namedtuple
 from enum import Enum
-
 from datetime import timedelta
+
+import six
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
@@ -185,8 +186,10 @@ class GroupManager(BaseManager):
             return manager.save(project)
 
         # TODO(jess): this method maybe isn't even used?
-        except HashDiscarded as exc:
-            logger.info("discarded.hash", extra={"project_id": project, "description": exc.message})
+        except HashDiscarded as e:
+            logger.info(
+                "discarded.hash", extra={"project_id": project, "description": six.text_type(e)}
+            )
 
     def from_event_id(self, project, event_id):
         """

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -411,7 +411,11 @@ class Project(Model, PendingDeletionMixin):
         except IntegrityError as e:
             logging.exception(
                 "Error occurred during copy project settings.",
-                extra={"error": e.message, "project_to": self.id, "project_from": project_id},
+                extra={
+                    "error": six.text_type(e),
+                    "project_to": self.id,
+                    "project_from": project_id,
+                },
             )
             return False
         return True

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -84,12 +84,13 @@ def on_delete(instance, actor=None, **kwargs):
         return
 
     # TODO(lb): I'm assuming that this is used by integrations... is it?
-    def handle_exception(exc):
+    def handle_exception(e):
+        import six
         from sentry.exceptions import InvalidIdentity, PluginError
         from sentry.integrations.exceptions import IntegrationError
 
-        if isinstance(exc, (IntegrationError, PluginError, InvalidIdentity)):
-            error = exc.message
+        if isinstance(e, (IntegrationError, PluginError, InvalidIdentity)):
+            error = six.text_type(e)
         else:
             error = "An unknown error occurred"
         if actor is not None:

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -48,7 +48,7 @@ class ConfigValidator(object):
             try:
                 value = self.validate_field(name=key, value=value)
             except (forms.ValidationError, serializers.ValidationError, PluginError) as e:
-                errors[key] = e.message
+                errors[key] = six.text_type(e)
 
             if not errors.get(key):
                 cleaned[key] = value

--- a/src/sentry/plugins/providers/base.py
+++ b/src/sentry/plugins/providers/base.py
@@ -113,9 +113,9 @@ class ProviderMixin(object):
 
         return UserSocialAuth.objects.filter(user=user, provider=self.auth_provider).first()
 
-    def handle_api_error(self, error):
+    def handle_api_error(self, e):
         context = {"error_type": "unknown"}
-        if isinstance(error, InvalidIdentity):
+        if isinstance(e, InvalidIdentity):
             if self.auth_provider is None:
                 context.update(
                     {
@@ -130,12 +130,12 @@ class ProviderMixin(object):
                     }
                 )
             status = 400
-        elif isinstance(error, PluginError):
+        elif isinstance(e, PluginError):
             # TODO(dcramer): we should have a proper validation error
-            context.update({"error_type": "validation", "errors": {"__all__": error.message}})
+            context.update({"error_type": "validation", "errors": {"__all__": six.text_type(e)}})
             status = 400
         else:
             if self.logger:
-                self.logger.exception(six.text_type(error))
+                self.logger.exception(six.text_type(e))
             status = 500
         return Response(context, status=status)

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -73,25 +73,27 @@ class IntegrationRepositoryProvider(object):
         )
         return Response(serialize(repo, request.user), status=201)
 
-    def handle_api_error(self, error):
+    def handle_api_error(self, e):
         context = {"error_type": "unknown"}
 
-        if isinstance(error, IntegrationError):
-            if "503" in error.message:
+        if isinstance(e, IntegrationError):
+            if "503" in six.text_type(e):
                 context.update(
-                    {"error_type": "service unavailable", "errors": {"__all__": error.message}}
+                    {"error_type": "service unavailable", "errors": {"__all__": six.text_type(e)}}
                 )
                 status = 503
             else:
                 # TODO(dcramer): we should have a proper validation error
-                context.update({"error_type": "validation", "errors": {"__all__": error.message}})
+                context.update(
+                    {"error_type": "validation", "errors": {"__all__": six.text_type(e)}}
+                )
                 status = 400
-        elif isinstance(error, Integration.DoesNotExist):
-            context.update({"error_type": "not found", "errors": {"__all__": error.message}})
+        elif isinstance(e, Integration.DoesNotExist):
+            context.update({"error_type": "not found", "errors": {"__all__": six.text_type(e)}})
             status = 404
         else:
             if self.logger:
-                self.logger.exception(six.text_type(error))
+                self.logger.exception(six.text_type(e))
             status = 500
         return Response(context, status=status)
 

--- a/src/sentry/plugins/providers/repository.py
+++ b/src/sentry/plugins/providers/repository.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from logging import getLogger
 
+import six
 from django.core.urlresolvers import reverse
 from django.db import IntegrityError, transaction
 from rest_framework.response import Response
@@ -65,7 +66,7 @@ class RepositoryProvider(ProviderMixin):
             )
         except PluginError as e:
             logger.exception("repo.create-error")
-            return Response({"errors": {"__all__": e.message}}, status=400)
+            return Response({"errors": {"__all__": six.text_type(e)}}, status=400)
 
         try:
             with transaction.atomic():

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -268,7 +268,7 @@ def assemble_artifacts(org_id, version, checksum, chunks, **kwargs):
 
     except AssembleArtifactsError as e:
         set_assemble_status(
-            AssembleTask.ARTIFACTS, org_id, checksum, ChunkFileState.ERROR, detail=e.message
+            AssembleTask.ARTIFACTS, org_id, checksum, ChunkFileState.ERROR, detail=six.text_type(e)
         )
     except BaseException:
         logger.error("failed to assemble release bundle", exc_info=True)

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -132,7 +132,7 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
                 repo_commits = provider.compare_commits(repo, start_sha, end_sha, actor=user)
         except NotImplementedError:
             pass
-        except Exception as exc:
+        except Exception as e:
             logger.info(
                 "fetch_commits.error",
                 extra={
@@ -140,15 +140,15 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
                     "user_id": user_id,
                     "repository": repo.name,
                     "provider": provider.id,
-                    "error": six.text_type(exc),
+                    "error": six.text_type(e),
                     "end_sha": end_sha,
                     "start_sha": start_sha,
                 },
             )
-            if isinstance(exc, InvalidIdentity) and getattr(exc, "identity", None):
-                handle_invalid_identity(identity=exc.identity, commit_failure=True)
-            elif isinstance(exc, (PluginError, InvalidIdentity, IntegrationError)):
-                msg = generate_fetch_commits_error_email(release, exc.message)
+            if isinstance(e, InvalidIdentity) and getattr(e, "identity", None):
+                handle_invalid_identity(identity=e.identity, commit_failure=True)
+            elif isinstance(e, (PluginError, InvalidIdentity, IntegrationError)):
+                msg = generate_fetch_commits_error_email(release, six.text_type(e))
                 msg.send_async(to=[user.email])
             else:
                 msg = generate_fetch_commits_error_email(

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -639,7 +639,7 @@ class StoreView(APIView):
             track_outcome(
                 organization_id, project_id, key.id, Outcome.INVALID, "invalid_transaction"
             )
-            raise APIError(e.message.split("\n", 1)[0])
+            raise APIError(six.text_type(e).split("\n", 1)[0])
 
         data = event_manager.get_data()
         dict_data = dict(data)
@@ -998,7 +998,7 @@ class UnrealView(StoreView):
                 Outcome.INVALID,
                 "process_unreal",
             )
-            raise APIError(e.message.split("\n", 1)[0])
+            raise APIError(six.text_type(e).split("\n", 1)[0])
 
         try:
             unreal_context = unreal.get_context()

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -397,7 +397,7 @@ class APIView(BaseView):
                 value=json.dumps([meta, base64.b64encode(data), project_config.to_dict()]),
             )
         except Exception as e:
-            logger.debug("Cannot publish event to Kafka: {}".format(e.message))
+            logger.debug("Cannot publish event to Kafka: {}".format(six.text_type(e)))
 
     @csrf_exempt
     @never_cache

--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -117,7 +117,7 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
                     },
                 )
                 return False
-            elif e.message.endswith("must contain the parameter MessageGroupId."):
+            elif six.text_type(e).endswith("must contain the parameter MessageGroupId."):
                 metrics_name = "sentry_plugins.amazon_sqs.missing_message_group_id"
                 logger.info(
                     metrics_name,

--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import
 
 import logging
 
+import six
 import boto3
 from botocore.client import ClientError
+
 from sentry_plugins.base import CorePluginMixin
 from sentry.plugins.bases.data_forwarding import DataForwardingPlugin
 from sentry_plugins.utils import get_secret_field_config
@@ -93,7 +95,7 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
 
             client.send_message(**message)
         except ClientError as e:
-            if e.message.startswith("An error occurred (AccessDenied)"):
+            if six.text_type(e).startswith("An error occurred (AccessDenied)"):
                 # If there's an issue with the user's token then we can't do
                 # anything to recover. Just log and continue.
                 metrics_name = "sentry_plugins.amazon_sqs.access_token_invalid"

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import six
+
 from sentry.api.event_search import InvalidSearchQuery, SearchFilter, SearchKey, SearchValue
 from sentry.api.issue_search import (
     convert_actor_value,
@@ -65,7 +67,9 @@ class ParseSearchQueryTest(TestCase):
         with self.assertRaises(InvalidSearchQuery) as cm:
             parse_search_query("is:wrong")
 
-        assert cm.exception.message.startswith('Invalid value for "is" search, valid values are')
+        assert six.text_type(cm.exception).startswith(
+            'Invalid value for "is" search, valid values are'
+        )
 
     def test_numeric_filter(self):
         # test numeric format

--- a/tests/sentry/api/validators/sentry_apps/util.py
+++ b/tests/sentry/api/validators/sentry_apps/util.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import six
 from jsonschema import ValidationError
 
 
@@ -17,7 +16,7 @@ def invalid_schema_with_error_message(message):
         def inner(self, *args, **kwargs):
             with self.assertRaises(ValidationError) as cm:
                 func(self)
-            found_message = six.text_type(cm.exception)
+            found_message = cm.exception.message
             if found_message != message:
                 assert found_message == message
 

--- a/tests/sentry/api/validators/sentry_apps/util.py
+++ b/tests/sentry/api/validators/sentry_apps/util.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import six
 from jsonschema import ValidationError
 
 
@@ -16,8 +17,7 @@ def invalid_schema_with_error_message(message):
         def inner(self, *args, **kwargs):
             with self.assertRaises(ValidationError) as cm:
                 func(self)
-            # assert cm.exception.message == message
-            found_message = cm.exception.message
+            found_message = six.text_type(cm.exception)
             if found_message != message:
                 assert found_message == message
 

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -4,9 +4,10 @@ import json
 import unittest
 from copy import deepcopy
 
+import six
 from exam import fixture, patcher
-from sentry.utils.compat.mock import Mock
 
+from sentry.utils.compat.mock import Mock
 from sentry.snuba.models import QuerySubscription
 from sentry.snuba.query_subscription_consumer import (
     InvalidMessageError,
@@ -128,7 +129,7 @@ class ParseMessageValueTest(BaseQuerySubscriptionTest, unittest.TestCase):
     def test_invalid_version(self):
         with self.assertRaises(InvalidMessageError) as cm:
             self.run_test({"version": 50, "payload": {}})
-        assert cm.exception.message == "Version specified in wrapper has no schema"
+        assert six.text_type(cm.exception) == "Version specified in wrapper has no schema"
 
     def test_valid(self):
         self.run_test({"version": 1, "payload": self.valid_payload})
@@ -162,4 +163,4 @@ class RegisterSubscriberTest(unittest.TestCase):
         assert subscriber_registry["hello"] == callback
         with self.assertRaises(Exception) as cm:
             register_subscriber("hello")(other_callback)
-        assert cm.exception.message == "Handler already registered for hello"
+        assert six.text_type(cm.exception) == "Handler already registered for hello"

--- a/tests/sentry/testutils/helpers/test_faux.py
+++ b/tests/sentry/testutils/helpers/test_faux.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
-from sentry.utils.compat.mock import patch
-
 from unittest import TestCase
+
+import six
+from sentry.utils.compat.mock import patch
 from sentry.testutils.helpers.faux import faux
 
 
@@ -35,7 +36,7 @@ class TestFaux(TestCase):
         try:
             faux(mock).called_with(False)
         except AssertionError as e:
-            assert e.message == "Expected to be called with (False). Received (1)."
+            assert six.text_type(e) == "Expected to be called with (False). Received (1)."
 
     def test_kwargs_contain(self, mock):
         fakefunc(foo=1)
@@ -47,7 +48,7 @@ class TestFaux(TestCase):
         try:
             faux(mock).kwargs_contain("bar")
         except AssertionError as e:
-            assert e.message == "Expected kwargs to contain key 'bar'. Received (foo=1)."
+            assert six.text_type(e) == "Expected kwargs to contain key 'bar'. Received (foo=1)."
 
     def test_kwarg_equals(self, mock):
         fakefunc(foo=1, bar=2)
@@ -59,7 +60,7 @@ class TestFaux(TestCase):
         try:
             faux(mock).kwarg_equals("bar", True)
         except AssertionError as e:
-            assert e.message == "Expected kwargs[bar] to equal True. Received 2."
+            assert six.text_type(e) == "Expected kwargs[bar] to equal True. Received 2."
 
     def test_args_contain(self, mock):
         fakefunc(1, False, None)
@@ -71,7 +72,7 @@ class TestFaux(TestCase):
         try:
             faux(mock).args_contain(True)
         except AssertionError as e:
-            assert e.message == "Expected args to contain True. Received (1, None, False)."
+            assert six.text_type(e) == "Expected args to contain True. Received (1, None, False)."
 
     def test_args_equal(self, mock):
         fakefunc(1, False, None)
@@ -83,4 +84,4 @@ class TestFaux(TestCase):
         try:
             faux(mock).args_equals(["beep"])
         except AssertionError as e:
-            assert e.message == "Expected args to equal (['beep']). Received (1, False)."
+            assert six.text_type(e) == "Expected args to equal (['beep']). Received (1, False)."

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import six
 import pytest
 import thread
 from Queue import Full
@@ -164,7 +163,7 @@ def test_synchronous_executor():
     try:
         future.result()
     except Exception as e:
-        assert six.text_type(e) is mock.sentinel.MESSAGE
+        assert e.message is mock.sentinel.MESSAGE
     else:
         assert False, "expected future to raise"
 

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from sentry.utils.compat import mock
+import six
 import pytest
 import thread
 from Queue import Full
@@ -8,6 +8,7 @@ from concurrent.futures import CancelledError, Future
 from contextlib import contextmanager
 from threading import Event
 
+from sentry.utils.compat import mock
 from sentry.utils.concurrent import (
     FutureSet,
     SynchronousExecutor,
@@ -163,7 +164,7 @@ def test_synchronous_executor():
     try:
         future.result()
     except Exception as e:
-        assert e.message is mock.sentinel.MESSAGE
+        assert six.text_type(e) is mock.sentinel.MESSAGE
     else:
         assert False, "expected future to raise"
 


### PR DESCRIPTION
BaseException.message was deprecated in Python 2.6 and removed in Python 3.x:

	(.venv) joshua.li@tim-apple sentry $ cat lol.py
    e = Exception("hi")
    print(e.message)
    (.venv) joshua.li@tim-apple sentry $ python2 -W all lol.py
    lol.py:2: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
      print(e.message)
    hi
    (.venv) joshua.li@tim-apple sentry $ python3 -W all lol.py
    Traceback (most recent call last):
      File "lol.py", line 2, in <module>
        print(e.message)
    AttributeError: 'Exception' object has no attribute 'message'

This is a best-effort multi-pass fastmod sweep of converting `(99.99% sure it's an exception).message` to `six.text_type(obj)`. There's a good chance I've missed a few, but we'll find out about those when we have python3 tests running.

Also I've done as much renaming as possible to just `e`, for consistency. For example, `exc` -> `e`.
