### PR TITLE
fix(discover2): For count() drilldowns, preserve aggregated fields by converting them to their non-aggregated form

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -406,7 +406,7 @@ export function getExpandedResults(
   nextView.fields.forEach((field: FieldType, index: number) => {
     const column = explodeField(field);
 
-    // Remove aggregates as the expanded results have no aggregates.
+    // Mark aggregated fields to be transformed into its un-aggregated form
     if (column.aggregation || aggregateAliases.includes(column.field)) {
       fieldsToUpdate.push(index);
       return;

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -478,7 +478,14 @@ export function getExpandedResults(
     // otherwise just use exploded.field as a column
 
     if (!exploded.field) {
-      return;
+      // edge case: transform count() into id
+
+      if (exploded.aggregation !== 'count') {
+        fieldsToDelete.push(indexToUpdate);
+        return;
+      }
+
+      exploded.field = 'id';
     }
 
     if (transformedFields.has(exploded.field)) {

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -388,8 +388,8 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
 // the given field can be transformed into another field, or undefined if it'll need to be dropped.
 type AggregateTransformer = (field: string) => string | undefined;
 
-// an array of 2-tuples of which the first tuple is an array of field names or aggregate names
-// to match a given column on, and the second tuple would transform the given column.
+// a map between a field alias to a transform function to convert the aggregated field alias into
+// its un-aggregated form
 const TRANSFORM_AGGREGATES: {[field: string]: AggregateTransformer} = {
   p99: () => 'transaction.duration',
   p95: () => 'transaction.duration',

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -305,11 +305,16 @@ describe('getExpandedResults()', function() {
     environment: ['staging'],
   };
 
-  it('removes aggregate fields from result view', () => {
+  it('transforms aggregated fields', () => {
     const view = new EventView(state);
     const result = getExpandedResults(view, {}, {});
 
-    expect(result.fields).toEqual([{field: 'title'}, {field: 'custom_tag'}]);
+    expect(result.fields).toEqual([
+      {field: 'id', width: 300}, // expect count() to be converted to id
+      {field: 'last_seen', width: 300},
+      {field: 'title'},
+      {field: 'custom_tag'},
+    ]);
     expect(result.query).toEqual('event.type:error');
   });
 

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -311,7 +311,7 @@ describe('getExpandedResults()', function() {
 
     expect(result.fields).toEqual([
       {field: 'id', width: 300}, // expect count() to be converted to id
-      {field: 'last_seen', width: 300},
+      {field: 'timestamp', width: 300},
       {field: 'title'},
       {field: 'custom_tag'},
     ]);
@@ -334,19 +334,20 @@ describe('getExpandedResults()', function() {
 
     expect(result.fields).toEqual([
       {field: 'id', width: 300}, // expect count() to be converted to id
-      {field: 'last_seen', width: 300},
+      {field: 'timestamp', width: 300},
       {field: 'title'},
       {field: 'custom_tag'},
     ]);
 
-    // transform aliased fields
+    // transform aliased fields, & de-duplicate any transforms
 
     view = new EventView({
       ...state,
       fields: [
-        {field: 'last_seen'},
+        {field: 'last_seen'}, // expect this to be transformed to transaction.duration
+        {field: 'latest_event'},
         {field: 'title'},
-        {field: 'avg(transaction.duration)'},
+        {field: 'avg(transaction.duration)'}, // expect this to be dropped
         {field: 'p75()'},
         {field: 'p95()'},
         {field: 'p99()'},
@@ -355,18 +356,23 @@ describe('getExpandedResults()', function() {
         {field: 'p95'},
         {field: 'p99'},
         {field: 'custom_tag'},
+        {field: 'title'}, // not expected to be dropped
         {field: 'unique_count(id)'},
+        // expect these aliases to be dropped
+        {field: 'apdex'},
+        {field: 'impact'},
       ],
     });
 
     result = getExpandedResults(view, {}, {});
 
     expect(result.fields).toEqual([
-      {field: 'last_seen', width: 300},
+      {field: 'timestamp', width: 300},
+      {field: 'id', width: 300},
       {field: 'title'},
       {field: 'transaction.duration', width: 300},
       {field: 'custom_tag'},
-      {field: 'id', width: 300},
+      {field: 'title'},
     ]);
   });
 


### PR DESCRIPTION
For count() drilldowns, preserve aggregated fields by converting them to their non-aggregated form:

- Traditional aggregated columns such as `count_unique(user)` will be converted to `user`.

- Transaction-based columns such as `p75()`, `p95()`, and `p99()` will be converted to `transaction.duration`.

- Transformed columns are de-duplicated. For example, if a table contains `avg(transaction.duration)` `p75()`, `p95()`, and `p99()`, then only `transaction.duration` is added after the transformation.

## TODO

- [x] update tests
- [x] update `last_seen` and others