### PR TITLE
fix(slack): Look up channel id async to avoid timeouts

### DIFF
--- a/src/sentry/api/endpoints/project_rule_async_task.py
+++ b/src/sentry/api/endpoints/project_rule_async_task.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+from django.conf import settings
+
+from rest_framework.response import Response
+
+from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
+from sentry.api.serializers import serialize
+from sentry.models import Rule, RuleStatus
+
+from sentry.utils import json
+from sentry.utils.redis import redis_clusters
+
+
+def _get_value_from_redis(task_uuid):
+    cluster_key = getattr(settings, "SENTRY_RULE_TASK_REDIS_CLUSTER", "default")
+    client = redis_clusters.get(cluster_key)
+    key = u"slack-channel-task:1:{}".format(task_uuid)
+    value = client.get(key)
+    return json.loads(value)
+
+
+class ProjectRuleTaskEndpoint(ProjectEndpoint):
+    permission_classes = [ProjectSettingPermission]
+
+    def get(self, request, project, task_uuid):
+        """
+        Retrieve the status of the async task
+
+        Return details of the rule if the task is successful
+
+        """
+        result = _get_value_from_redis(task_uuid)
+        status = result["status"]
+        rule_id = result.get("rule_id", None)
+
+        context = {"status": status, "rule": None}
+
+        if rule_id and status == "success":
+            rule = Rule.objects.get(
+                project=project,
+                id=int(rule_id),
+                status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE],
+            )
+            context["rule"] = serialize(rule, request.user)
+
+        return Response(context, status=200)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -54,12 +54,12 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
             data = serializer.validated_data
             kwargs = {
                 "name": data["name"],
-                "environment": data.get("environment", None),
+                "environment": data.get("environment"),
                 "project": project,
                 "action_match": data["actionMatch"],
                 "conditions": data["conditions"],
                 "actions": data["actions"],
-                "frequency": data["frequency"],
+                "frequency": data.get("frequency"),
             }
 
             updated_rule = project_rules.Updater.run(

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from uuid import uuid4
-
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -67,10 +65,11 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
             )
 
             if not updated_rule:
-                uuid = uuid4().hex
-                kwargs.update({"uuid": uuid, "rule_id": rule.id})
+                client = tasks.RedisRuleStatus()
+                kwargs.update({"uuid": client.uuid, "rule_id": rule.id})
                 tasks.find_channel_id_for_rule.apply_async(kwargs=kwargs)
-                context = {"uuid": uuid}
+
+                context = {"uuid": client.uuid}
                 return Response(context, status=202)
 
             self.create_audit_entry(

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -20,7 +20,7 @@ def _get_value_from_redis(task_uuid):
     return json.loads(value)
 
 
-class ProjectRuleTaskEndpoint(ProjectEndpoint):
+class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
     permission_classes = [ProjectSettingPermission]
 
     def get(self, request, project, task_uuid):

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -32,9 +32,10 @@ class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
         """
         result = _get_value_from_redis(task_uuid)
         status = result["status"]
-        rule_id = result.get("rule_id", None)
-        error = result.get("error", None)
+        rule_id = result.get("rule_id")
+        error = result.get("error")
 
+        # if the status is "pending" we don't have a rule yet or error
         context = {"status": status, "rule": None, "error": None}
 
         if rule_id and status == "success":

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from django.conf import settings
 from django.http import Http404
 from rest_framework.response import Response
 
@@ -8,16 +7,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
 from sentry.models import Rule, RuleStatus
 
-from sentry.utils import json
-from sentry.utils.redis import redis_clusters
-
-
-def _get_value_from_redis(task_uuid):
-    cluster_key = getattr(settings, "SENTRY_RULE_TASK_REDIS_CLUSTER", "default")
-    client = redis_clusters.get(cluster_key)
-    key = u"slack-channel-task:1:{}".format(task_uuid)
-    value = client.get(key)
-    return json.loads(value)
+from sentry.integrations.slack import tasks
 
 
 class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
@@ -30,7 +20,9 @@ class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
         Return details of the rule if the task is successful
 
         """
-        result = _get_value_from_redis(task_uuid)
+        client = tasks.RedisRuleStatus(task_uuid)
+        result = client.get_value()
+
         status = result["status"]
         rule_id = result.get("rule_id")
         error = result.get("error")

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -5,9 +5,8 @@ from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
-from sentry.models import Rule, RuleStatus
-
 from sentry.integrations.slack import tasks
+from sentry.models import Rule, RuleStatus
 
 
 class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -57,12 +57,12 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             data = serializer.validated_data
             kwargs = {
                 "name": data["name"],
-                "environment": data.get("environment", None),
+                "environment": data.get("environment"),
                 "project": project,
                 "action_match": data["actionMatch"],
                 "conditions": data["conditions"],
                 "actions": data["actions"],
-                "frequency": data["frequency"],
+                "frequency": data.get("frequency"),
             }
 
             rule = project_rules.Creator.run(

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -64,16 +64,14 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 "frequency": data.get("frequency"),
             }
 
-            rule = project_rules.Creator.run(
-                pending_save=data.get("pending_save", False), request=request, **kwargs
-            )
-
-            if not rule:
+            if data.get("pending_save"):
                 client = tasks.RedisRuleStatus()
                 uuid_context = {"uuid": client.uuid}
                 kwargs.update(uuid_context)
                 tasks.find_channel_id_for_rule.apply_async(kwargs=kwargs)
                 return Response(uuid_context, status=202)
+
+            rule = project_rules.Creator.run(request=request, **kwargs)
 
             self.create_audit_entry(
                 request=request,

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from uuid import uuid4
 
 from rest_framework import status
 from rest_framework.response import Response
@@ -70,11 +69,11 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             )
 
             if not rule:
-                uuid = uuid4().hex
-                kwargs.update({"uuid": uuid})
+                client = tasks.RedisRuleStatus()
+                uuid_context = {"uuid": client.uuid}
+                kwargs.update(uuid_context)
                 tasks.find_channel_id_for_rule.apply_async(kwargs=kwargs)
-                context = {"uuid": uuid}
-                return Response(context, status=202)
+                return Response(uuid_context, status=202)
 
             self.create_audit_entry(
                 request=request,

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -7,11 +7,10 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import RuleSerializer
-from sentry.models import AuditLogEntryEvent, Rule, RuleStatus
-from sentry.signals import alert_rule_created
-
 from sentry.integrations.slack import tasks
 from sentry.mediators import project_rules
+from sentry.models import AuditLogEntryEvent, Rule, RuleStatus
+from sentry.signals import alert_rule_created
 
 
 class ProjectRulesEndpoint(ProjectEndpoint):

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -56,6 +56,8 @@ class RuleNodeField(serializers.Field):
         # Update data from cleaned form values
         data.update(form.cleaned_data)
 
+        if getattr(form, "_pending_save", False) and form._pending_save:
+            data["pending_save"] = True
         return data
 
 
@@ -91,6 +93,20 @@ class RuleSerializer(serializers.Serializer):
         if not value:
             raise serializers.ValidationError(u"Must select an action")
         return value
+
+    def validate(self, attrs):
+        # XXX(meredith): For rules that have the Slack integration as an action
+        # we need to check if the channel_id needs to be looked up via an async task.
+        # If the "pending_save" attribute is set we want to bubble that up to the
+        # project_rule(_details) endpoints by setting it on attrs
+        actions = attrs.get("actions")
+        if actions:
+            for action in actions:
+                if action.pop("pending_save", None):
+                    attrs["pending_save"] = True
+                    break
+
+        return attrs
 
     def save(self, rule):
         rule.project = self.context["project"]

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -56,7 +56,7 @@ class RuleNodeField(serializers.Field):
         # Update data from cleaned form values
         data.update(form.cleaned_data)
 
-        if getattr(form, "_pending_save", False) and form._pending_save:
+        if getattr(form, "_pending_save", False):
             data["pending_save"] = True
         return data
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -202,6 +202,7 @@ from .endpoints.project_releases import ProjectReleasesEndpoint
 from .endpoints.project_releases_token import ProjectReleasesTokenEndpoint
 from .endpoints.project_reprocessing import ProjectReprocessingEndpoint
 from .endpoints.project_rule_details import ProjectRuleDetailsEndpoint
+from .endpoints.project_rule_async_task import ProjectRuleTaskEndpoint
 from .endpoints.project_rules import ProjectRulesEndpoint
 from .endpoints.project_rules_configuration import ProjectRulesConfigurationEndpoint
 from .endpoints.project_search_details import ProjectSearchDetailsEndpoint
@@ -1312,6 +1313,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/$",
                     ProjectRuleDetailsEndpoint.as_view(),
                     name="sentry-api-0-project-rule-details",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rule-async-tasks/(?P<task_uuid>[^\/]+)/$",
+                    ProjectRuleTaskEndpoint.as_view(),
+                    name="sentry-api-0-project-rule-async-tasks",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/searches/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -202,7 +202,7 @@ from .endpoints.project_releases import ProjectReleasesEndpoint
 from .endpoints.project_releases_token import ProjectReleasesTokenEndpoint
 from .endpoints.project_reprocessing import ProjectReprocessingEndpoint
 from .endpoints.project_rule_details import ProjectRuleDetailsEndpoint
-from .endpoints.project_rule_async_task import ProjectRuleTaskEndpoint
+from .endpoints.project_rule_task_details import ProjectRuleTaskDetailsEndpoint
 from .endpoints.project_rules import ProjectRulesEndpoint
 from .endpoints.project_rules_configuration import ProjectRulesConfigurationEndpoint
 from .endpoints.project_search_details import ProjectSearchDetailsEndpoint
@@ -1315,9 +1315,9 @@ urlpatterns = [
                     name="sentry-api-0-project-rule-details",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rule-async-tasks/(?P<task_uuid>[^\/]+)/$",
-                    ProjectRuleTaskEndpoint.as_view(),
-                    name="sentry-api-0-project-rule-async-tasks",
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rule-task/(?P<task_uuid>[^\/]+)/$",
+                    ProjectRuleTaskDetailsEndpoint.as_view(),
+                    name="sentry-api-0-project-rule-task-details",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/searches/$",

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1049,12 +1049,10 @@ def create_alert_rule_trigger_action(
         if target_type != AlertRuleTriggerAction.TargetType.SPECIFIC:
             raise InvalidTriggerActionError("Slack action must specify channel")
 
-        channel_result = get_channel_id(
+        prefix, channel_id, _ = get_channel_id(
             trigger.alert_rule.organization, integration.id, target_identifier
         )
-        if channel_result is not None:
-            channel_id = channel_result[1]
-        else:
+        if channel_id is None:
             raise InvalidTriggerActionError(
                 "Could not find channel %s. Channel may not exist, or Sentry may not "
                 "have been granted permission to access it" % target_identifier
@@ -1101,11 +1099,11 @@ def update_alert_rule_trigger_action(
             from sentry.integrations.slack.utils import get_channel_id
 
             integration = updated_fields.get("integration", trigger_action.integration)
-            channel_id = get_channel_id(
+            prefix, channel_id, _ = get_channel_id(
                 trigger_action.alert_rule_trigger.alert_rule.organization,
                 integration.id,
                 target_identifier,
-            )[1]
+            )
             # Use the channel name for display
             updated_fields["target_display"] = target_identifier
             updated_fields["target_identifier"] = channel_id

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -30,14 +30,24 @@ class SlackNotifyServiceForm(forms.Form):
         self.fields["workspace"].choices = workspace_list
         self.fields["workspace"].widget.choices = self.fields["workspace"].choices
 
+        # XXX(meredith): When this gets set to True, it lets the RuleSerializer
+        # know to only save if and when we have the channel_id. The rule will get saved
+        # in the task (integrations/slack/tasks.py) if the channel_id is found.
+        self._pending_save = False
+
     def clean(self):
         cleaned_data = super(SlackNotifyServiceForm, self).clean()
 
         workspace = cleaned_data.get("workspace")
         channel = cleaned_data.get("channel", "")
 
-        channel_id = self.channel_transformer(workspace, channel)
+        channel_prefix, channel_id, timed_out = self.channel_transformer(workspace, channel)
         channel = strip_channel_name(channel)
+
+        if channel_id is None and timed_out:
+            cleaned_data["channel"] = channel_prefix + channel
+            self._pending_save = True
+            return cleaned_data
 
         if channel_id is None and workspace is not None:
             params = {
@@ -53,7 +63,6 @@ class SlackNotifyServiceForm(forms.Form):
                 params=params,
             )
 
-        channel_prefix, channel_id = channel_id
         cleaned_data["channel"] = channel_prefix + channel
         cleaned_data["channel_id"] = channel_id
 

--- a/src/sentry/integrations/slack/tasks.py
+++ b/src/sentry/integrations/slack/tasks.py
@@ -1,0 +1,111 @@
+from __future__ import absolute_import
+
+import six
+
+from django.conf import settings
+
+from sentry import http
+from sentry.utils import json
+from sentry.tasks.base import instrumented_task
+from sentry.models import Integration, Project, Rule
+
+from sentry.utils.redis import redis_clusters
+
+MEMBER_PREFIX = "@"
+CHANNEL_PREFIX = "#"
+
+LIST_TYPES = [
+    ("channels", "channels", CHANNEL_PREFIX),
+    ("groups", "groups", CHANNEL_PREFIX),
+    ("users", "members", MEMBER_PREFIX),
+]
+
+
+class RedisRuleStatus(object):
+    def __init__(self, uuid):
+        self.uuid = uuid
+
+        cluster_id = getattr(settings, "SENTRY_RULE_TASK_REDIS_CLUSTER", "default")
+        self.client = redis_clusters.get(cluster_id)
+        self._set_value("pending")
+
+    def _get_redis_key(self):
+        return u"slack-channel-task:1:{}".format(self.uuid)
+
+    def _set_value(self, status, rule_id=None):
+        value = self._format_value(status, rule_id)
+        self.client.set(self._get_redis_key(), u"{}".format(value), ex=60 * 60)
+
+    def _format_value(self, status, rule_id):
+        value = {"status": status}
+        if rule_id:
+            value["rule_id"] = six.text_type(rule_id)
+        if status == "failed":
+            # TODO(meredith): set some generic error? or pass in an error?
+            value["error"] = "some error"
+
+        return json.dumps(value)
+
+
+@instrumented_task(name="sentry.integrations.slack.search_channel_id", queue="integrations")
+def find_channel_id_for_rule(serializer, project_id, uuid, rule_id=None):
+    redis_rule_status = RedisRuleStatus(uuid)
+
+    try:
+        project = Project.objects.get(id=project_id)
+    except Project.DoesNotExist:
+        redis_rule_status._set_value("failed")
+        return
+
+    organization = project.organization
+    integration_id = None
+    channel_name = None
+
+    for action in serializer.validated_data["actions"]:
+        if action.get("workspace") and action.get("channel"):
+            integration_id = action["workspace"]
+            # we need to strip the prefix when searching on the channel name
+            channel_name = action["channel"].strip("#@")
+            break
+
+    try:
+        integration = Integration.objects.get(
+            provider="slack", organizations=organization, id=integration_id
+        )
+    except Integration.DoesNotExist:
+        redis_rule_status._set_value("failed")
+        return
+
+    token_payload = {"token": integration.metadata["access_token"]}
+    payload = dict(token_payload, **{"exclude_archived": False, "exclude_members": True})
+
+    session = http.build_session()
+    for list_type, result_name, prefix in LIST_TYPES:
+        cursor = ""
+        while cursor is not None:
+            # XXX(meredith): change limit to 1000 instead of 1
+            items = session.get(
+                "https://slack.com/api/%s.list" % list_type,
+                params=dict(payload, **{"cursor": cursor, "limit": 1}),
+            )
+            items = items.json()
+            if not items.get("ok"):
+                redis_rule_status._set_value("failed")
+                return
+
+            cursor = items.get("response_metadata", {}).get("next_cursor", None)
+            if cursor == "":
+                cursor = None
+
+            item_id = {c["name"]: c["id"] for c in items[result_name]}.get(channel_name)
+            if item_id:
+                if rule_id:
+                    rule = Rule.objects.get(id=rule_id)
+                else:
+                    rule = Rule()
+
+                rule = serializer.save(rule)
+                redis_rule_status._set_value("success", rule.id)
+                return
+    # if we never find the channel name we failed :(
+    redis_rule_status._set_value("failed")

--- a/src/sentry/integrations/slack/tasks.py
+++ b/src/sentry/integrations/slack/tasks.py
@@ -42,8 +42,9 @@ class RedisRuleStatus(object):
         if rule_id:
             value["rule_id"] = six.text_type(rule_id)
         if status == "failed":
-            # TODO(meredith): set some generic error? or pass in an error?
-            value["error"] = "some error"
+            value[
+                "error"
+            ] = "The slack resource does not exist or has not been granted access in that workspace."
 
         return json.dumps(value)
 

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -377,9 +377,8 @@ def get_channel_id(organization, integration_id, name):
 
             items = session.get(
                 "https://slack.com/api/%s.list" % list_type,
-                # TODO(meredith): change this to 1000
                 # Slack limits the response of `<list_type>.list` to 1000 channels
-                params=dict(payload, **{"cursor": cursor, "limit": 1}),
+                params=dict(payload, **{"cursor": cursor, "limit": 1000}),
             )
             items = items.json()
             if not items.get("ok"):

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+import time
 
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
@@ -41,6 +42,7 @@ LEVEL_TO_COLOR = {
 MEMBER_PREFIX = "@"
 CHANNEL_PREFIX = "#"
 strip_channel_chars = "".join([MEMBER_PREFIX, CHANNEL_PREFIX])
+SLACK_DEFAULT_TIMEOUT = 10
 
 
 def format_actor_option(actor):
@@ -336,6 +338,18 @@ def strip_channel_name(name):
 
 
 def get_channel_id(organization, integration_id, name):
+    name = strip_channel_name(name)
+    try:
+        integration = Integration.objects.get(
+            provider="slack", organizations=organization, id=integration_id
+        )
+    except Integration.DoesNotExist:
+        return None
+
+    return get_channel_id_with_timeout(integration, name, SLACK_DEFAULT_TIMEOUT)
+
+
+def get_channel_id_with_timeout(integration, name, timeout):
     """
     Fetches the internal slack id of a channel.
     :param organization: The organization that is using this integration
@@ -346,15 +360,6 @@ def get_channel_id(organization, integration_id, name):
         2. channel_id: string or `None`
         3. timed_out: boolean (whether we hit our self-imposed time limit)
     """
-    import time
-
-    name = strip_channel_name(name)
-    try:
-        integration = Integration.objects.get(
-            provider="slack", organizations=organization, id=integration_id
-        )
-    except Integration.DoesNotExist:
-        return None
 
     token_payload = {"token": integration.metadata["access_token"]}
 
@@ -366,15 +371,11 @@ def get_channel_id(organization, integration_id, name):
     # This means some users are unable to create/update alert rules. To avoid this, we attempt
     # to find the channel id asynchronously if it takes longer than a certain amount of time,
     # which I have set here - arbitrarily - to 10 seconds.
-    timeout = time.time() + 10
+    time_to_quit = time.time() + timeout
     session = http.build_session()
     for list_type, result_name, prefix in LIST_TYPES:
         cursor = ""
-        while cursor is not None:
-
-            if time.time() > timeout:
-                return (prefix, None, True)
-
+        while True:
             items = session.get(
                 "https://slack.com/api/%s.list" % list_type,
                 # Slack limits the response of `<list_type>.list` to 1000 channels
@@ -387,15 +388,16 @@ def get_channel_id(organization, integration_id, name):
                 )
                 return (prefix, None, False)
 
-            cursor = items.get("response_metadata", {}).get("next_cursor", None)
-            # Slack can return "" as the next cursor so must set to None or else we end
-            # up in a loop and getting rate limited
-            if cursor == "":
-                cursor = None
-
             item_id = {c["name"]: c["id"] for c in items[result_name]}.get(name)
             if item_id:
                 return (prefix, item_id, False)
+
+            cursor = items.get("response_metadata", {}).get("next_cursor", None)
+            if time.time() > time_to_quit:
+                return (prefix, None, True)
+
+            if not cursor:
+                break
 
     return (prefix, None, False)
 

--- a/src/sentry/mediators/project_rules/__init__.py
+++ b/src/sentry/mediators/project_rules/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+
+from .creator import Creator  # NOQA
+from .updater import Updater  # NOQA

--- a/src/sentry/mediators/project_rules/creator.py
+++ b/src/sentry/mediators/project_rules/creator.py
@@ -15,7 +15,6 @@ class Creator(Mediator):
     actions = Param(Iterable)
     conditions = Param(Iterable)
     frequency = Param(int)
-    pending_save = Param(bool)
     request = Param("rest_framework.request.Request", required=False)
 
     def call(self):
@@ -23,9 +22,6 @@ class Creator(Mediator):
         return self.rule
 
     def _create_rule(self):
-        if self.pending_save:
-            return None
-
         kwargs = self._get_kwargs()
         rule = Rule.objects.create(**kwargs)
         return rule

--- a/src/sentry/mediators/project_rules/updater.py
+++ b/src/sentry/mediators/project_rules/updater.py
@@ -36,9 +36,9 @@ class Updater(Mediator):
     def _update_name(self):
         self.rule.label = self.name
 
-    @if_param("environment")
     def _update_environment(self):
-        self.rule.envirnoment_id = self.environment
+        # environment can be None so we don't use the if_param decorator
+        self.rule.environment_id = self.environment
 
     @if_param("project")
     def _update_project(self):

--- a/src/sentry/mediators/project_rules/updater.py
+++ b/src/sentry/mediators/project_rules/updater.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import
+
+import six
+
+from collections import Iterable
+from sentry.mediators import Mediator, Param
+from sentry.mediators.param import if_param
+
+
+class Updater(Mediator):
+    rule = Param("sentry.models.Rule")
+    name = Param(six.string_types, required=False)
+    environment = Param(int, required=False)
+    project = Param("sentry.models.Project")
+    action_match = Param(six.string_types, required=False)
+    actions = Param(Iterable, required=False)
+    conditions = Param(Iterable, required=False)
+    frequency = Param(int, required=False)
+    pending_save = Param(bool)
+    request = Param("rest_framework.request.Request", required=False)
+
+    def call(self):
+        if self.pending_save:
+            return None
+        self._update_name()
+        self._update_environment()
+        self._update_project()
+        self._update_actions()
+        self._update_action_match()
+        self._update_conditions()
+        self._update_frequency()
+        self.rule.save()
+        return self.rule
+
+    @if_param("name")
+    def _update_name(self):
+        self.rule.label = self.name
+
+    @if_param("environment")
+    def _update_environment(self):
+        self.rule.envirnoment_id = self.environment
+
+    @if_param("project")
+    def _update_project(self):
+        self.rule.project = self.project
+
+    @if_param("actions")
+    def _update_actions(self):
+        self.rule.data["actions"] = self.actions
+
+    @if_param("action_match")
+    def _update_action_match(self):
+        self.rule.data["action_match"] = self.action_match
+
+    @if_param("conditions")
+    def _update_conditions(self):
+        self.rule.data["conditions"] = self.conditions
+
+    @if_param("frequency")
+    def _update_frequency(self):
+        self.rule.data["frequency"] = self.frequency

--- a/src/sentry/mediators/project_rules/updater.py
+++ b/src/sentry/mediators/project_rules/updater.py
@@ -16,12 +16,9 @@ class Updater(Mediator):
     actions = Param(Iterable, required=False)
     conditions = Param(Iterable, required=False)
     frequency = Param(int, required=False)
-    pending_save = Param(bool)
     request = Param("rest_framework.request.Request", required=False)
 
     def call(self):
-        if self.pending_save:
-            return None
         self._update_name()
         self._update_environment()
         self._update_project()

--- a/tests/sentry/api/endpoints/test_project_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_task_details.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import
+
+import six
+from uuid import uuid4
+
+from django.core.urlresolvers import reverse
+
+from sentry.utils.compat.mock import patch
+from sentry.testutils import APITestCase
+
+
+class ProjectRuleTaskDetailsTest(APITestCase):
+    def setUp(self):
+        self.login_as(user=self.user)
+        team = self.create_team()
+        project1 = self.create_project(teams=[team], name="foo", fire_project_created=True)
+        self.create_project(teams=[team], name="bar", fire_project_created=True)
+        self.rule = project1.rule_set.all()[0]
+        self.uuid = uuid4().hex
+        self.url = reverse(
+            "sentry-api-0-project-rule-task-details",
+            kwargs={
+                "organization_slug": project1.organization.slug,
+                "project_slug": project1.slug,
+                "task_uuid": self.uuid,
+            },
+        )
+
+    @patch("sentry.api.endpoints.project_rule_task_details._get_value_from_redis")
+    def test_status_pending(self, mock_get_from_redis):
+        self.login_as(user=self.user)
+        mock_get_from_redis.return_value = {"status": "pending", "rule_id": None}
+        response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["status"] == "pending"
+        assert response.data["rule"] is None
+
+    @patch("sentry.api.endpoints.project_rule_task_details._get_value_from_redis")
+    def test_status_failed(self, mock_get_from_redis):
+        self.login_as(user=self.user)
+        mock_get_from_redis.return_value = {"status": "failed", "rule_id": None}
+        response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["status"] == "failed"
+        assert response.data["rule"] is None
+
+    @patch("sentry.api.endpoints.project_rule_task_details._get_value_from_redis")
+    def test_status_success(self, mock_get_from_redis):
+        self.login_as(user=self.user)
+        mock_get_from_redis.return_value = {"status": "success", "rule_id": self.rule.id}
+        response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["status"] == "success"
+
+        rule_data = response.data["rule"]
+        # TODO(meredith): shoudl I check every attribute?
+        assert rule_data["id"] == six.text_type(self.rule.id)
+        assert rule_data["name"] == self.rule.label

--- a/tests/sentry/api/endpoints/test_project_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_task_details.py
@@ -29,7 +29,7 @@ class ProjectRuleTaskDetailsTest(APITestCase):
     @patch("sentry.api.endpoints.project_rule_task_details._get_value_from_redis")
     def test_status_pending(self, mock_get_from_redis):
         self.login_as(user=self.user)
-        mock_get_from_redis.return_value = {"status": "pending", "rule_id": None}
+        mock_get_from_redis.return_value = {"status": "pending"}
         response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
@@ -39,12 +39,13 @@ class ProjectRuleTaskDetailsTest(APITestCase):
     @patch("sentry.api.endpoints.project_rule_task_details._get_value_from_redis")
     def test_status_failed(self, mock_get_from_redis):
         self.login_as(user=self.user)
-        mock_get_from_redis.return_value = {"status": "failed", "rule_id": None}
+        mock_get_from_redis.return_value = {"status": "failed", "error": "This failed"}
         response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
         assert response.data["status"] == "failed"
         assert response.data["rule"] is None
+        assert response.data["error"] == "This failed"
 
     @patch("sentry.api.endpoints.project_rule_task_details._get_value_from_redis")
     def test_status_success(self, mock_get_from_redis):

--- a/tests/sentry/api/endpoints/test_project_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_task_details.py
@@ -26,20 +26,20 @@ class ProjectRuleTaskDetailsTest(APITestCase):
             },
         )
 
-    @patch("sentry.api.endpoints.project_rule_task_details._get_value_from_redis")
-    def test_status_pending(self, mock_get_from_redis):
+    @patch("sentry.integrations.slack.tasks.RedisRuleStatus.get_value")
+    def test_status_pending(self, mock_get_value):
         self.login_as(user=self.user)
-        mock_get_from_redis.return_value = {"status": "pending"}
+        mock_get_value.return_value = {"status": "pending"}
         response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
         assert response.data["status"] == "pending"
         assert response.data["rule"] is None
 
-    @patch("sentry.api.endpoints.project_rule_task_details._get_value_from_redis")
-    def test_status_failed(self, mock_get_from_redis):
+    @patch("sentry.integrations.slack.tasks.RedisRuleStatus.get_value")
+    def test_status_failed(self, mock_get_value):
         self.login_as(user=self.user)
-        mock_get_from_redis.return_value = {"status": "failed", "error": "This failed"}
+        mock_get_value.return_value = {"status": "failed", "error": "This failed"}
         response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
@@ -47,10 +47,10 @@ class ProjectRuleTaskDetailsTest(APITestCase):
         assert response.data["rule"] is None
         assert response.data["error"] == "This failed"
 
-    @patch("sentry.api.endpoints.project_rule_task_details._get_value_from_redis")
-    def test_status_success(self, mock_get_from_redis):
+    @patch("sentry.integrations.slack.tasks.RedisRuleStatus.get_value")
+    def test_status_success(self, mock_get_value):
         self.login_as(user=self.user)
-        mock_get_from_redis.return_value = {"status": "success", "rule_id": self.rule.id}
+        mock_get_value.return_value = {"status": "success", "rule_id": self.rule.id}
         response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -58,23 +58,23 @@ class GetChannelIdTest(TestCase):
             body=json.dumps({"ok": "true", result_name: channels}),
         )
 
-    def run_valid_test(self, channel, expected_prefix, expected_id):
-        assert (expected_prefix, expected_id) == get_channel_id(
+    def run_valid_test(self, channel, expected_prefix, expected_id, timed_out):
+        assert (expected_prefix, expected_id, timed_out) == get_channel_id(
             self.organization, self.integration.id, channel
         )
 
     def test_valid_channel_selected(self):
-        self.run_valid_test("#my-channel", CHANNEL_PREFIX, "m-c")
+        self.run_valid_test("#my-channel", CHANNEL_PREFIX, "m-c", False)
 
     def test_valid_private_channel_selected(self):
-        self.run_valid_test("#my-private-channel", CHANNEL_PREFIX, "m-p-c")
+        self.run_valid_test("#my-private-channel", CHANNEL_PREFIX, "m-p-c", False)
 
     def test_valid_member_selected(self):
-        self.run_valid_test("@morty", MEMBER_PREFIX, "m")
+        self.run_valid_test("@morty", MEMBER_PREFIX, "m", False)
 
     def test_invalid_channel_selected(self):
-        assert get_channel_id(self.organization, self.integration.id, "#fake-channel") is None
-        assert get_channel_id(self.organization, self.integration.id, "@fake-user") is None
+        assert get_channel_id(self.organization, self.integration.id, "#fake-channel")[1] is None
+        assert get_channel_id(self.organization, self.integration.id, "@fake-user")[1] is None
 
 
 class BuildIncidentAttachmentTest(TestCase):

--- a/tests/sentry/mediators/project_rules/test_creator.py
+++ b/tests/sentry/mediators/project_rules/test_creator.py
@@ -31,13 +31,7 @@ class TestCreator(TestCase):
                 }
             ],
             frequency=5,
-            pending_save=False,
         )
-
-    def test_pending_save(self):
-        self.creator.pending_save = True
-        result = self.creator.call()
-        assert result is None
 
     def test_creates_rule(self):
         r = self.creator.call()

--- a/tests/sentry/mediators/project_rules/test_creator.py
+++ b/tests/sentry/mediators/project_rules/test_creator.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import
+
+from sentry.mediators.project_rules import Creator
+from sentry.models import Rule
+from sentry.testutils import TestCase
+
+
+class TestCreator(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.org = self.create_organization(name="bloop", owner=self.user)
+        self.project = self.create_project(
+            teams=[self.create_team()], name="foo", fire_project_created=True
+        )
+        self.creator = Creator(
+            name="New Cool Rule",
+            project=self.project,
+            action_match="all",
+            conditions=[
+                {
+                    "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                    "key": "foo",
+                    "match": "eq",
+                    "value": "bar",
+                }
+            ],
+            actions=[
+                {
+                    "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                    "name": "Send a notification (for all legacy integrations)",
+                }
+            ],
+            frequency=5,
+            pending_save=False,
+        )
+
+    def test_pending_save(self):
+        self.creator.pending_save = True
+        result = self.creator.call()
+        assert result is None
+
+    def test_creates_rule(self):
+        r = self.creator.call()
+        rule = Rule.objects.get(id=r.id)
+        assert rule.label == "New Cool Rule"
+        assert rule.project == self.project
+        assert rule.environment_id is None
+        assert rule.data == {
+            "actions": [
+                {
+                    "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                    "name": "Send a notification (for all legacy integrations)",
+                }
+            ],
+            "conditions": [
+                {
+                    "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                    "key": "foo",
+                    "match": "eq",
+                    "value": "bar",
+                }
+            ],
+            "action_match": "all",
+            "frequency": 5,
+        }

--- a/tests/sentry/mediators/project_rules/test_updater.py
+++ b/tests/sentry/mediators/project_rules/test_updater.py
@@ -12,12 +12,7 @@ class TestUpdater(TestCase):
             teams=[self.create_team()], name="foo", fire_project_created=True
         )
         self.rule = self.project.rule_set.all()[0]
-        self.updater = Updater(rule=self.rule, project=self.project, pending_save=False)
-
-    def test_pending_save(self):
-        self.updater.pending_save = True
-        result = self.updater.call()
-        assert result is None
+        self.updater = Updater(rule=self.rule, project=self.project)
 
     def test_update_name(self):
         self.updater.name = "Cool New Rule"

--- a/tests/sentry/mediators/project_rules/test_updater.py
+++ b/tests/sentry/mediators/project_rules/test_updater.py
@@ -1,0 +1,87 @@
+from __future__ import absolute_import
+
+from sentry.mediators.project_rules import Updater
+from sentry.testutils import TestCase
+
+
+class TestUpdater(TestCase):
+    def setUp(self):
+        self.user = self.create_user()
+        self.org = self.create_organization(name="bloop", owner=self.user)
+        self.project = self.create_project(
+            teams=[self.create_team()], name="foo", fire_project_created=True
+        )
+        self.rule = self.project.rule_set.all()[0]
+        self.updater = Updater(rule=self.rule, project=self.project, pending_save=False)
+
+    def test_pending_save(self):
+        self.updater.pending_save = True
+        result = self.updater.call()
+        assert result is None
+
+    def test_update_name(self):
+        self.updater.name = "Cool New Rule"
+        self.updater.call()
+        assert self.rule.label == "Cool New Rule"
+
+    def test_update_environment(self):
+        self.updater.environment = 3
+        self.updater.call()
+        assert self.rule.environment_id == 3
+
+    def test_update_environment_when_none(self):
+        self.rule.environment_id = 3
+        self.rule.save()
+        assert self.rule.environment_id == 3
+        self.updater.call()
+        assert self.rule.environment_id is None
+
+    def test_update_project(self):
+        project2 = self.create_project(organization=self.org)
+        self.updater.project = project2
+        self.updater.call()
+        assert self.rule.project == project2
+
+    def test_update_actions(self):
+        self.updater.actions = [
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                "name": "Send a notification (for all legacy integrations)",
+            }
+        ]
+        self.updater.call()
+        assert self.rule.data["actions"] == [
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                "name": "Send a notification (for all legacy integrations)",
+            }
+        ]
+
+    def test_update_action_match(self):
+        self.updater.action_match = "any"
+        self.updater.call()
+        assert self.rule.data["action_match"] == "any"
+
+    def test_update_conditions(self):
+        self.updater.conditions = [
+            {
+                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                "key": "foo",
+                "match": "eq",
+                "value": "bar",
+            }
+        ]
+        self.updater.call()
+        assert self.rule.data["conditions"] == [
+            {
+                "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                "key": "foo",
+                "match": "eq",
+                "value": "bar",
+            }
+        ]
+
+    def test_update_frequency(self):
+        self.updater.frequency = 5
+        self.updater.call()
+        assert self.rule.data["frequency"] == 5


### PR DESCRIPTION
**Background:**
When a user enters a slack channel when setting up an alert rule, we query the following slack endpoints to convert the name to an ID:

`channels.list` - to get the ID of public channels
`groups.list` - to get the ID of private channels
`users.list` - to get the ID of users

We do this synchronously. If we iterate through all those endpoints and _don't_ find the channel, it means that we either don't have permission for that channel or it doesn't exist.

**Problem:**
For some of our larger accounts, `channels.list` is timing out. (or in theory any of those endpoints, but since we attempt `channels.list` first we know at least that one). This results in them not being able to save an alert rule. If we put a limit of 1000, it doesn’t time out, but we need to paginate through a lot of pages, so, we (Sentry) times out (and users _still_ can't save/update an alert rule)

**Solution:**
* 👍 Add the limit of 1000 in and start paginating - if it takes more than 10 seconds (arbitrarily set by me) than we enqueue a task to do the pagination, store the status of the task (`pending`, `failed`, `success`) in Redis, and have the frontend ping an endpoint for the status until it gets back either `failed` or `success`.

not-so-honorable mentions:
* 👎 increase the timeout on Sentry’s side - this leads to some odd behavior in our infrastructure and we have been advised against it by ops
* 👎 use the `apps.permissions.resources.list` method to get a list of all the channels our app has access to and then query `channels.info for` each of the channels - this takes a very long and we time out before that happens.
* 👎 asked Slack for a better solution - it doesn’t exist


**More Details:**

1. **"pending save":** I needed some way for the `RuleSerializer` to know that even though there were no errors, we don't want to save the rule yet, since we haven't verified the channel id.  Adding `_pending_save` to the `SlackNotifyServiceForm` let's us bubble up that information from the nested `RuleNodeField` to the serializer and the `pending_save` attribute then gets added to the `validated_data`. 

2. **mediators:** I've added an `Creator` and `Updater` for the project rules. This is so that we can take the logic of actually saving the rule out of the serializer. If `pending_save` is `True` then we want to return `None`, otherwise we return the new or updated rule. 

3. **`200` vs `202`:** Currently we return a `200` response when we have successfully created or updated a rule, that will not changed. If we need to run the task then we return a `202` which the frontend explicitly checks for, as well as an uuid that is tied to that specific task status. 

4. **`RedisRuleStatus`:** This stores the status of the task (`pending`, `failed`, or `success`) and initializing it with no uuid will generate an uuid and set the `pending` status. We initialize it before starting the task because it's possible for the frontend to hit the endpoint looking up the status before the task has already started, meaning there is no value set for that uuid in redis. 
