### PR TITLE
fix(discover2): Fix event details pagination

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -54,6 +54,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
                 event=event,
                 query=request.query_params.get("query"),
                 params=params,
+                organization=organization,
                 reference_event=reference,
                 referrer="api.organization-event-details",
             )
@@ -61,10 +62,14 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
             raise ParseError(detail=six.text_type(err))
 
         data = serialize(event)
-        data["nextEventID"] = pagination.next
-        data["previousEventID"] = pagination.previous
-        data["oldestEventID"] = pagination.oldest
-        data["latestEventID"] = pagination.latest
+        data["nextEventID"] = pagination.next.event_id
+        data["nextEventProjectSlug"] = pagination.next.project_slug
+        data["previousEventID"] = pagination.previous.event_id
+        data["previousEventProjectSlug"] = pagination.previous.project_slug
+        data["oldestEventID"] = pagination.oldest.event_id
+        data["oldestEventProjectSlug"] = pagination.oldest.project_slug
+        data["latestEventID"] = pagination.latest.event_id
+        data["latestEventProjectSlug"] = pagination.latest.project_slug
         data["projectSlug"] = project_slug
 
         return Response(data)

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -62,14 +62,10 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
             raise ParseError(detail=six.text_type(err))
 
         data = serialize(event)
-        data["nextEventID"] = pagination.next.event_id
-        data["nextEventProjectSlug"] = pagination.next.project_slug
-        data["previousEventID"] = pagination.previous.event_id
-        data["previousEventProjectSlug"] = pagination.previous.project_slug
-        data["oldestEventID"] = pagination.oldest.event_id
-        data["oldestEventProjectSlug"] = pagination.oldest.project_slug
-        data["latestEventID"] = pagination.latest.event_id
-        data["latestEventProjectSlug"] = pagination.latest.project_slug
+        data["nextEventID"] = pagination.next
+        data["previousEventID"] = pagination.previous
+        data["oldestEventID"] = pagination.oldest
+        data["latestEventID"] = pagination.latest
         data["projectSlug"] = project_slug
 
         return Response(data)

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -460,6 +460,10 @@ def get_pagination_ids(event, query, params, organization, reference_event=None,
             snuba_filter.conditions.extend(ref_conditions)
 
     def into_pagination_record(project_slug_event_id):
+
+        if project_slug_event_id is None:
+            return PaginationRecord(None, None)
+
         project = Project.objects.get(
             id=project_slug_event_id[0], organization=organization, status=ProjectStatus.VISIBLE
         )

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -472,7 +472,7 @@ def get_pagination_ids(event, query, params, organization, reference_event=None,
     project_slugs = {}
     projects = Project.objects.filter(
         id__in=list(project_ids), organization=organization, status=ProjectStatus.VISIBLE
-    ).values()
+    ).values("id", "slug")
 
     for project in projects:
         project_slugs[project["id"]] = project["slug"]

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -48,7 +48,6 @@ ReferenceEvent = namedtuple("ReferenceEvent", ["organization", "slug", "fields",
 ReferenceEvent.__new__.__defaults__ = (None, None)
 
 PaginationResult = namedtuple("PaginationResult", ["next", "previous", "oldest", "latest"])
-PaginationRecord = namedtuple("PaginationRecord", ["project_slug", "event_id"])
 FacetResult = namedtuple("FacetResult", ["key", "value", "count"])
 
 
@@ -480,21 +479,15 @@ def get_pagination_ids(event, query, params, organization, reference_event=None,
 
     def into_pagination_record(project_slug_event_id):
 
-        if project_slug_event_id is None:
-            return PaginationRecord(None, None)
+        if not project_slug_event_id:
+            return None
 
         project_id = int(project_slug_event_id[0])
 
-        return PaginationRecord(
-            project_slug=project_slugs[project_id], event_id=project_slug_event_id[1]
-        )
+        return "{}:{}".format(project_slugs[project_id], project_slug_event_id[1])
 
     for key, value in result.items():
         result[key] = into_pagination_record(value)
-
-    # import pdb
-
-    # pdb.set_trace()
 
     return PaginationResult(**result)
 

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -196,7 +196,9 @@ type SentryEventBase = {
   entries: EntryType[];
 
   previousEventID?: string;
+  previousEventProjectSlug?: string;
   nextEventID?: string;
+  nextEventProjectSlug?: string;
   projectSlug: string;
 
   tags: EventTag[];
@@ -206,7 +208,9 @@ type SentryEventBase = {
   location: string;
 
   oldestEventID: string | null;
+  oldestEventProjectSlug: string | null;
   latestEventID: string | null;
+  latestEventProjectSlug: string | null;
 };
 
 // This type is incomplete

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -196,9 +196,7 @@ type SentryEventBase = {
   entries: EntryType[];
 
   previousEventID?: string;
-  previousEventProjectSlug?: string;
   nextEventID?: string;
-  nextEventProjectSlug?: string;
   projectSlug: string;
 
   tags: EventTag[];
@@ -208,9 +206,7 @@ type SentryEventBase = {
   location: string;
 
   oldestEventID: string | null;
-  oldestEventProjectSlug: string | null;
   latestEventID: string | null;
-  latestEventProjectSlug: string | null;
 };
 
 // This type is incomplete

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/pagination.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/pagination.tsx
@@ -27,21 +27,21 @@ function buildTargets(
   eventView: EventView,
   organization: Organization
 ): LinksType {
-  const urlMap: {[k in keyof LinksType]: string | undefined | null} = {
-    previous: event.previousEventID,
-    next: event.nextEventID,
-    oldest: event.oldestEventID,
-    latest: event.latestEventID,
+  const urlMap: {[k in keyof LinksType]: Array<string | undefined | null>} = {
+    previous: [event.previousEventProjectSlug, event.previousEventID],
+    next: [event.nextEventProjectSlug, event.nextEventID],
+    oldest: [event.oldestEventProjectSlug, event.oldestEventID],
+    latest: [event.latestEventProjectSlug, event.latestEventID],
   };
 
   const links: {[k in keyof LinksType]?: any} = {};
 
-  Object.entries(urlMap).forEach(([key, value]) => {
+  Object.entries(urlMap).forEach(([key, [project_slug, event_id]]) => {
     // If the urlMap has no value we want to skip this link as it is 'disabled';
-    if (!value) {
+    if (!event_id) {
       links[key] = null;
     } else {
-      const eventSlug = `${event.projectSlug}:${value}`;
+      const eventSlug = `${project_slug || event.projectSlug}:${event_id}`;
 
       links[key] = {
         pathname: generateEventDetailsRoute({eventSlug, orgSlug: organization.slug}),

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/pagination.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/pagination.tsx
@@ -27,21 +27,21 @@ function buildTargets(
   eventView: EventView,
   organization: Organization
 ): LinksType {
-  const urlMap: {[k in keyof LinksType]: Array<string | undefined | null>} = {
-    previous: [event.previousEventProjectSlug, event.previousEventID],
-    next: [event.nextEventProjectSlug, event.nextEventID],
-    oldest: [event.oldestEventProjectSlug, event.oldestEventID],
-    latest: [event.latestEventProjectSlug, event.latestEventID],
+  const urlMap: {[k in keyof LinksType]: string | undefined | null} = {
+    previous: event.previousEventID,
+    next: event.nextEventID,
+    oldest: event.oldestEventID,
+    latest: event.latestEventID,
   };
 
   const links: {[k in keyof LinksType]?: any} = {};
 
-  Object.entries(urlMap).forEach(([key, [project_slug, event_id]]) => {
+  Object.entries(urlMap).forEach(([key, projectEventID]) => {
     // If the urlMap has no value we want to skip this link as it is 'disabled';
-    if (!event_id) {
+    if (!projectEventID) {
       links[key] = null;
     } else {
-      const eventSlug = `${project_slug || event.projectSlug}:${event_id}`;
+      const eventSlug = projectEventID;
 
       links[key] = {
         pathname: generateEventDetailsRoute({eventSlug, orgSlug: organization.slug}),

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/pagination.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/pagination.tsx
@@ -36,13 +36,11 @@ function buildTargets(
 
   const links: {[k in keyof LinksType]?: any} = {};
 
-  Object.entries(urlMap).forEach(([key, projectEventID]) => {
+  Object.entries(urlMap).forEach(([key, eventSlug]) => {
     // If the urlMap has no value we want to skip this link as it is 'disabled';
-    if (!projectEventID) {
+    if (!eventSlug) {
       links[key] = null;
     } else {
-      const eventSlug = projectEventID;
-
       links[key] = {
         pathname: generateEventDetailsRoute({eventSlug, orgSlug: organization.slug}),
         query: eventView.generateQueryStringObject(),

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1333,9 +1333,6 @@ class GetPaginationIdsTest(SnubaTestCase, TestCase):
             },
             self.organization,
         )
-        import pdb
-
-        pdb.set_trace()
 
         assert result.previous.event_id == "a" * 32
         assert result.previous.project_slug == self.project.slug

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1305,14 +1305,10 @@ class GetPaginationIdsTest(SnubaTestCase, TestCase):
             {"project_id": [self.project.id], "end": self.min_ago, "start": self.day_ago},
             self.organization,
         )
-        assert result.previous.event_id == "a" * 32
-        assert result.previous.project_slug == self.project.slug
-        assert result.next.event_id == "c" * 32
-        assert result.next.project_slug == self.project.slug
-        assert result.oldest.event_id == "a" * 32
-        assert result.oldest.project_slug == self.project.slug
-        assert result.latest.event_id == "c" * 32
-        assert result.latest.project_slug == self.project.slug
+        assert result.previous == format_project_event(self.project.slug, "a" * 32)
+        assert result.next == format_project_event(self.project.slug, "c" * 32)
+        assert result.oldest == format_project_event(self.project.slug, "a" * 32)
+        assert result.latest == format_project_event(self.project.slug, "c" * 32)
 
     def test_multi_projects(self):
         result = discover.get_pagination_ids(

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1166,6 +1166,10 @@ class CreateReferenceEventConditionsTest(SnubaTestCase, TestCase):
         assert result == [["issue.id", "=", event.group_id]]
 
 
+def format_project_event(project_slug, event_id):
+    return "{}:{}".format(project_slug, event_id)
+
+
 class GetPaginationIdsTest(SnubaTestCase, TestCase):
     def setUp(self):
         super(GetPaginationIdsTest, self).setUp()
@@ -1249,14 +1253,10 @@ class GetPaginationIdsTest(SnubaTestCase, TestCase):
             {"project_id": [self.project.id], "end": self.min_ago, "start": self.day_ago},
             self.organization,
         )
-        assert result.previous.event_id == "a" * 32
-        assert result.previous.project_slug == self.project.slug
-        assert result.next.event_id == "c" * 32
-        assert result.next.project_slug == self.project.slug
-        assert result.oldest.event_id == "a" * 32
-        assert result.oldest.project_slug == self.project.slug
-        assert result.latest.event_id == "c" * 32
-        assert result.latest.project_slug == self.project.slug
+        assert result.previous == format_project_event(self.project.slug, "a" * 32)
+        assert result.next == format_project_event(self.project.slug, "c" * 32)
+        assert result.oldest == format_project_event(self.project.slug, "a" * 32)
+        assert result.latest == format_project_event(self.project.slug, "c" * 32)
 
     def test_reference_event_matching(self):
         # Create an event that won't match the reference

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1228,14 +1228,10 @@ class GetPaginationIdsTest(SnubaTestCase, TestCase):
             {"project_id": [self.project.id], "start": self.min_ago, "end": self.day_ago},
             self.organization,
         )
-        assert result.previous.event_id is None
-        assert result.previous.project_slug is None
-        assert result.next.event_id is None
-        assert result.next.project_slug is None
-        assert result.oldest.event_id is None
-        assert result.oldest.project_slug is None
-        assert result.latest.event_id is None
-        assert result.latest.project_slug is None
+        assert result.previous is None
+        assert result.next is None
+        assert result.oldest is None
+        assert result.latest is None
 
     def test_invalid_conditions(self):
         with pytest.raises(InvalidSearchQuery):

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1281,14 +1281,10 @@ class GetPaginationIdsTest(SnubaTestCase, TestCase):
             self.organization,
             reference_event=reference,
         )
-        assert result.previous.event_id == "a" * 32
-        assert result.previous.project_slug == self.project.slug
-        assert result.next.event_id == "c" * 32
-        assert result.next.project_slug == self.project.slug
-        assert result.oldest.event_id == "a" * 32
-        assert result.oldest.project_slug == self.project.slug
-        assert result.latest.event_id == "c" * 32
-        assert result.latest.project_slug == self.project.slug
+        assert result.previous == format_project_event(self.project.slug, "a" * 32)
+        assert result.next == format_project_event(self.project.slug, "c" * 32)
+        assert result.oldest == format_project_event(self.project.slug, "a" * 32)
+        assert result.latest == format_project_event(self.project.slug, "c" * 32)
 
     def test_date_params_included(self):
         # Create an event that is outside the date range

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1322,14 +1322,10 @@ class GetPaginationIdsTest(SnubaTestCase, TestCase):
             self.organization,
         )
 
-        assert result.previous.event_id == "a" * 32
-        assert result.previous.project_slug == self.project.slug
-        assert result.next.event_id == "e" * 32
-        assert result.next.project_slug == self.project_2.slug
-        assert result.oldest.event_id == "a" * 32
-        assert result.oldest.project_slug == self.project.slug
-        assert result.latest.event_id == "c" * 32
-        assert result.latest.project_slug == self.project.slug
+        assert result.previous == format_project_event(self.project.slug, "a" * 32)
+        assert result.next == format_project_event(self.project_2.slug, "e" * 32)
+        assert result.oldest == format_project_event(self.project.slug, "a" * 32)
+        assert result.latest == format_project_event(self.project.slug, "c" * 32)
 
 
 class GetFacetsTest(SnubaTestCase, TestCase):

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -8,6 +8,10 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.models import Group
 
 
+def format_project_event(project_slug, event_id):
+    return "{}:{}".format(project_slug, event_id)
+
+
 class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(OrganizationEventDetailsEndpointTest, self).setUp()
@@ -64,7 +68,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data["id"] == "a" * 32
         assert response.data["previousEventID"] is None
-        assert response.data["nextEventID"] == "b" * 32
+        assert response.data["nextEventID"] == format_project_event(self.project.slug, "b" * 32)
         assert response.data["projectSlug"] == self.project.slug
 
     def test_simple_out_of_range_pagination(self):
@@ -159,14 +163,10 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == "d" * 32
-        assert response.data["previousEventID"] == "a" * 32
-        assert response.data["previousEventProjectSlug"] == self.project.slug
-        assert response.data["nextEventID"] == "b" * 32
-        assert response.data["nextEventProjectSlug"] == self.project.slug
-        assert response.data["latestEventID"] == "c" * 32
-        assert response.data["latestEventProjectSlug"] == self.project.slug
-        assert response.data["oldestEventID"] == "a" * 32
-        assert response.data["oldestEventProjectSlug"] == self.project.slug
+        assert response.data["previousEventID"] == format_project_event(self.project.slug, "a" * 32)
+        assert response.data["nextEventID"] == format_project_event(self.project.slug, "b" * 32)
+        assert response.data["latestEventID"] == format_project_event(self.project.slug, "c" * 32)
+        assert response.data["oldestEventID"] == format_project_event(self.project.slug, "a" * 32)
 
     def test_no_access_missing_feature(self):
         url = reverse(
@@ -267,10 +267,18 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json", data={"field": ["message", "count()"]})
         assert response.data["eventID"] == "b" * 32
-        assert response.data["nextEventID"] == "c" * 32, "c is newer & matches message"
-        assert response.data["previousEventID"] == "d" * 32, "d is older & matches message"
-        assert response.data["oldestEventID"] == "e" * 32, "e is oldest matching message"
-        assert response.data["latestEventID"] == "1" * 32, "1 is newest matching message"
+        assert response.data["nextEventID"] == format_project_event(
+            self.project.slug, "c" * 32
+        ), "c is newer & matches message"
+        assert response.data["previousEventID"] == format_project_event(
+            self.project.slug, "d" * 32
+        ), "d is older & matches message"
+        assert response.data["oldestEventID"] == format_project_event(
+            self.project.slug, "e" * 32
+        ), "e is oldest matching message"
+        assert response.data["latestEventID"] == format_project_event(
+            self.project.slug, "1" * 32
+        ), "1 is newest matching message"
 
     def test_event_links_with_date_range(self):
         # Create older in and out of range events
@@ -298,10 +306,18 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 url, format="json", data={"field": ["message", "count()"], "statsPeriod": "7d"}
             )
         assert response.data["eventID"] == "b" * 32
-        assert response.data["nextEventID"] == "c" * 32, "c is newer & matches message + range"
-        assert response.data["previousEventID"] == "2" * 32, "d is older & matches message + range"
-        assert response.data["oldestEventID"] == "2" * 32, "3 is outside range, no match"
-        assert response.data["latestEventID"] == "c" * 32, "c is newest matching message"
+        assert response.data["nextEventID"] == format_project_event(
+            self.project.slug, "c" * 32
+        ), "c is newer & matches message + range"
+        assert response.data["previousEventID"] == format_project_event(
+            self.project.slug, "2" * 32
+        ), "d is older & matches message + range"
+        assert response.data["oldestEventID"] == format_project_event(
+            self.project.slug, "2" * 32
+        ), "3 is outside range, no match"
+        assert response.data["latestEventID"] == format_project_event(
+            self.project.slug, "c" * 32
+        ), "c is newest matching message"
 
     def test_event_links_with_tag_fields(self):
         # Create events that overlap with other event messages but
@@ -350,8 +366,12 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["eventID"] == "1" * 32
         assert response.data["previousEventID"] is None, "no matching tags"
         assert response.data["oldestEventID"] is None, "no older matching events"
-        assert response.data["nextEventID"] == "2" * 32, "2 is older and has matching tags "
-        assert response.data["latestEventID"] == "2" * 32, "2 is oldest matching message"
+        assert response.data["nextEventID"] == format_project_event(
+            self.project.slug, "2" * 32
+        ), "2 is older and has matching tags "
+        assert response.data["latestEventID"] == format_project_event(
+            self.project.slug, "2" * 32
+        ), "2 is oldest matching message"
 
     def test_event_links_with_transaction_events(self):
         prototype = {
@@ -388,8 +408,8 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 data={"field": ["important", "count()"], "query": "transaction.duration:>2"},
             )
         assert response.status_code == 200
-        assert response.data["nextEventID"] == "d" * 32
-        assert response.data["previousEventID"] == "f" * 32
+        assert response.data["nextEventID"] == format_project_event(self.project.slug, "d" * 32)
+        assert response.data["previousEventID"] == format_project_event(self.project.slug, "f" * 32)
 
     def test_event_links_with_transaction_events_aggregate_fields(self):
         prototype = {
@@ -429,8 +449,8 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 },
             )
         assert response.status_code == 200
-        assert response.data["nextEventID"] == "d" * 32
-        assert response.data["previousEventID"] == "f" * 32
+        assert response.data["nextEventID"] == format_project_event(self.project.slug, "d" * 32)
+        assert response.data["previousEventID"] == format_project_event(self.project.slug, "f" * 32)
 
     def test_event_links_with_transaction_events_aggregate_conditions(self):
         prototype = {
@@ -470,5 +490,5 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 },
             )
         assert response.status_code == 200
-        assert response.data["nextEventID"] == "d" * 32
-        assert response.data["previousEventID"] == "f" * 32
+        assert response.data["nextEventID"] == format_project_event(self.project.slug, "d" * 32)
+        assert response.data["previousEventID"] == format_project_event(self.project.slug, "f" * 32)


### PR DESCRIPTION
The query builder state can be constructed to display events from multiple projects. When any of these events are viewed, we'll want to properly traverse these events by propagating their project slugs to their respective pagination links.

## TODO

- [x] update `tests/snuba/api/endpoints/test_organization_event_details.py`