### PR TITLE
fix(discover) Remove beta tag and add new tag to sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -312,6 +312,7 @@ class Sidebar extends React.Component {
                         label={t('Discover')}
                         to={getDiscoverLandingUrl(organization)}
                         id="discover-v2"
+                        isNew
                       />
                     </Feature>
                   )}

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.jsx
@@ -4,8 +4,11 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {css} from '@emotion/core';
 
+import Tag from 'app/views/settings/components/tag';
 import HookOrDefault from 'app/components/hookOrDefault';
 import Tooltip from 'app/components/tooltip';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
 
 import Link from '../links/link';
 import TextOverflow from '../textOverflow';
@@ -44,6 +47,9 @@ class SidebarItem extends React.Component {
     // Additional badge to display after label
     badge: PropTypes.number,
 
+    // Additional badge letting users know a tab is new.
+    isNew: PropTypes.bool,
+
     // Sidebar is at "top" or "left" of screen
     orientation: PropTypes.oneOf(['top', 'left']),
   };
@@ -68,6 +74,7 @@ class SidebarItem extends React.Component {
       badge,
       active,
       hasPanel,
+      isNew,
       collapsed,
       className,
       orientation,
@@ -100,6 +107,11 @@ class SidebarItem extends React.Component {
               <SidebarItemLabel>
                 <LabelHook id={this.props.id}>
                   <TextOverflow>{label}</TextOverflow>
+                  {isNew && (
+                    <StyledTag priority="beta" size="small">
+                      {t('New')}
+                    </StyledTag>
+                  )}
                 </LabelHook>
               </SidebarItemLabel>
             )}
@@ -253,4 +265,11 @@ const SidebarItemBadge = styled(({collapsed: _, ...props}) => <span {...props} /
   line-height: ${p => p.theme.sidebar.badgeSize};
 
   ${getCollapsedBadgeStyle};
+`;
+
+const StyledTag = styled(Tag)`
+  font-weight: normal;
+  padding: 3px ${space(0.75)};
+  margin-left: ${space(0.5)};
+  border-radius: 20px;
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
@@ -4,7 +4,6 @@ import {Location} from 'history';
 
 import {t} from 'app/locale';
 import {Event, Organization} from 'app/types';
-import BetaTag from 'app/components/betaTag';
 import Link from 'app/components/links/link';
 import InlineSvg from 'app/components/inlineSvg';
 import space from 'app/styles/space';
@@ -74,12 +73,7 @@ class DiscoverBreadcrumb extends React.Component<Props> {
   }
 
   render() {
-    return (
-      <BreadcrumbList>
-        {this.getCrumbs()}
-        <BetaTag />
-      </BreadcrumbList>
-    );
+    return <BreadcrumbList>{this.getCrumbs()}</BreadcrumbList>;
   }
 }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -14,7 +14,6 @@ import {trackAnalyticsEvent} from 'app/utils/analytics';
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Banner from 'app/components/banner';
-import BetaTag from 'app/components/betaTag';
 import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
 import Feature from 'app/components/acl/feature';
@@ -269,10 +268,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     } else {
       body = (
         <PageContent>
-          <StyledPageHeader>
-            {t('Discover')}
-            <BetaTag />
-          </StyledPageHeader>
+          <StyledPageHeader>{t('Discover')}</StyledPageHeader>
           {this.renderBanner()}
           {this.renderActions()}
           <QueryList


### PR DESCRIPTION
Make discover2 more legit by removing the beta tag and adding a new tag to the sidebar.

![Screen Shot 2020-01-31 at 1 53 38 PM](https://user-images.githubusercontent.com/24086/73566168-2dc20e00-4431-11ea-895f-2e8c021e5962.png)
