### PR TITLE
fix(search): Fix tag resolution

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -663,8 +663,6 @@ def resolve_column(col, dataset):
         return col
     if col in DATASETS[dataset]:
         return DATASETS[dataset][col]
-    if col in DATASET_FIELDS[dataset]:
-        return col
 
     return u"tags[{}]".format(col)
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -69,14 +69,6 @@ DISCOVER_COLUMN_MAP = {
 
 DATASETS = {Dataset.Events: SENTRY_SNUBA_MAP, Dataset.Discover: DISCOVER_COLUMN_MAP}
 
-# Store the internal field names to save work later on.
-# Add `group_id` to the events dataset list as we don't want to publically
-# expose that field, but it is used by eventstore and other internals.
-DATASET_FIELDS = {
-    Dataset.Events: list(SENTRY_SNUBA_MAP.values()),
-    Dataset.Discover: list(DISCOVER_COLUMN_MAP.values()),
-}
-
 
 class SnubaError(Exception):
     pass


### PR DESCRIPTION
Fixes a bug where columns that have the same name as internal Snuba
fields are not correctly resolved into tags.

This came up in issue search with the tag "email". In this case
the query "tags[email]:a@a.com" works, but "email:a@a.com" doesn't.