### PR TITLE
ref(TS): update plugin types for new serializer

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -317,7 +317,7 @@ export type PluginWithProjectList = PluginNoProject & {
     projectSlug: string;
     projectName: string;
     enabled: boolean;
-    configured: string;
+    configured: boolean;
   }>;
 };
 

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -286,7 +286,7 @@ export type Environment = {
 // TODO(ts): This type is incomplete
 export type SavedSearch = {};
 
-export type Plugin = {
+export type PluginNoProject = {
   id: string;
   name: string;
   slug: string;
@@ -300,12 +300,25 @@ export type Plugin = {
   status: string;
   assets: any[]; // TODO(ts)
   doc: string;
-  enabled?: boolean;
   version?: string;
   author?: {name: string; url: string};
   isHidden: boolean;
   description?: string;
   resourceLinks?: Array<{title: string; url: string}>;
+};
+
+export type Plugin = PluginNoProject & {
+  enabled: boolean;
+};
+
+export type PluginWithProjectList = PluginNoProject & {
+  projectList: Array<{
+    projectId: string;
+    projectSlug: string;
+    projectName: string;
+    enabled: boolean;
+    configured: string;
+  }>;
 };
 
 export type GlobalSelection = {


### PR DESCRIPTION
This PR updates the TS plugin types that are needed with the new endpoint that was recently added: https://github.com/getsentry/sentry/pull/16654

The main difference is that we now have `projectList` field with the new endpoint that we will need to use in future pages.