### PR TITLE
feat(ui): Adds component for displaying version names in releasesV2

### DIFF
--- a/docs-ui/components/formatters.stories.js
+++ b/docs-ui/components/formatters.stories.js
@@ -2,11 +2,13 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 // import {action} from '@storybook/addon-actions';
 import {withInfo} from '@storybook/addon-info';
+import {text, boolean} from '@storybook/addon-knobs';
 
 import FileSize from 'app/components/fileSize';
 import Duration from 'app/components/duration';
 import DateTime from 'app/components/dateTime';
 import Count from 'app/components/count';
+import Version from 'app/components/versionV2';
 
 storiesOf('Utility|Formatters', module)
   .add(
@@ -100,4 +102,28 @@ storiesOf('Utility|Formatters', module)
         </div>
       </div>
     ))
+  )
+  .add(
+    'Version',
+    withInfo('Formats release version')(() => {
+      const version = text('version', 'foo.bar.Baz@1.0.0+20200101');
+      const orgId = text('orgId', 'sentry');
+      const anchor = boolean('anchor', true);
+      const preserveGlobalSelection = boolean('preserveGlobalSelection', false);
+      const tooltipRawVersion = boolean('tooltipRawVersion', true);
+      const className = text('className', 'asdsad');
+      return (
+        <div>
+          {version} =
+          <Version
+            version={version}
+            orgId={orgId}
+            anchor={anchor}
+            preserveGlobalSelection={preserveGlobalSelection}
+            tooltipRawVersion={tooltipRawVersion}
+            className={className}
+          />
+        </div>
+      );
+    })
   );

--- a/docs-ui/components/tooltip.stories.js
+++ b/docs-ui/components/tooltip.stories.js
@@ -12,68 +12,90 @@ class CustomThing extends React.Component {
   }
 }
 
-storiesOf('UI|Tooltip', module)
-  .add(
-    'Tooltip',
-    withInfo({
-      text: 'Adds a tooltip to any component,',
-      propTablesExclude: [CustomThing, Button, 'Button'],
-    })(() => {
-      const title = text('tooltip', 'Basic tooltip content');
-      const disabled = boolean('Disabled', false);
-      const displayMode = select('Container display mode', ['block', 'inline-block', 'inline']);
-      const position = select(
-        'position',
-        {top: 'top', bottom: 'bottom', left: 'left', right: 'right'},
-        'top'
-      );
+storiesOf('UI|Tooltip', module).add(
+  'Tooltip',
+  withInfo({
+    text: 'Adds a tooltip to any component,',
+    propTablesExclude: [CustomThing, Button, 'Button'],
+  })(() => {
+    const title = text('tooltip', 'Basic tooltip content');
+    const disabled = boolean('Disabled', false);
+    const displayMode = select('Container display mode', [
+      'block',
+      'inline-block',
+      'inline',
+    ]);
+    const position = select(
+      'position',
+      {top: 'top', bottom: 'bottom', left: 'left', right: 'right'},
+      'top'
+    );
+    const isHoverable = boolean('isHoverable', false);
 
-      return (
-        <React.Fragment>
-          <h3>With styled component trigger</h3>
-          <p>
-            <Tooltip title={title} position={position} disabled={disabled} containerDisplayMode={displayMode}>
-              <Button>Styled button</Button>
-            </Tooltip>
-          </p>
+    return (
+      <React.Fragment>
+        <h3>With styled component trigger</h3>
+        <p>
+          <Tooltip
+            title={title}
+            position={position}
+            disabled={disabled}
+            containerDisplayMode={displayMode}
+            isHoverable={isHoverable}
+          >
+            <Button>Styled button</Button>
+          </Tooltip>
+        </p>
 
-          <h3>With class component trigger</h3>
-          <p>
-            <Tooltip title={title} position={position} disabled={disabled}>
-              <CustomThing>Custom React Component</CustomThing>
-            </Tooltip>
-          </p>
+        <h3>With class component trigger</h3>
+        <p>
+          <Tooltip
+            title={title}
+            position={position}
+            disabled={disabled}
+            isHoverable={isHoverable}
+          >
+            <CustomThing>Custom React Component</CustomThing>
+          </Tooltip>
+        </p>
 
-          <h3>With an SVG element trigger</h3>
-          <p>
-            <svg
-              viewBox="0 0 100 100"
-              width="100"
-              height="100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <Tooltip title={title} position={position} disabled={disabled} containerDisplayMode={displayMode}>
-                <circle cx="50" cy="50" r="50" />
-              </Tooltip>
-            </svg>
-          </p>
-
-          <h3>With element title and native html element</h3>
-          <p>
+        <h3>With an SVG element trigger</h3>
+        <p>
+          <svg
+            viewBox="0 0 100 100"
+            width="100"
+            height="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <Tooltip
-              title={
-                <span>
-                  <em>so strong</em>
-                </span>
-              }
-              containerDisplayMode={displayMode}
+              title={title}
               position={position}
               disabled={disabled}
+              containerDisplayMode={displayMode}
+              isHoverable={isHoverable}
             >
-              <button>Native button</button>
+              <circle cx="50" cy="50" r="50" />
             </Tooltip>
-          </p>
-        </React.Fragment>
-      );
-    })
-  );
+          </svg>
+        </p>
+
+        <h3>With element title and native html element</h3>
+        <p>
+          <Tooltip
+            title={
+              <span>
+                <em>so strong</em>
+              </span>
+            }
+            containerDisplayMode={displayMode}
+            position={position}
+            disabled={disabled}
+            isHoverable={isHoverable}
+          >
+            <button>Native button</button>
+          </Tooltip>
+        </p>
+      </React.Fragment>
+    );
+  })
+);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@sentry/apm": "5.11.2",
     "@sentry/browser": "5.11.2",
     "@sentry/integrations": "5.11.1",
+    "@sentry/release-parser": "^0.4.0",
     "@types/classnames": "^2.2.0",
     "@types/clipboard": "^2.0.1",
     "@types/color": "^3.0.0",

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -81,8 +81,8 @@ class Tooltip extends React.Component<Props, State> {
     delay: PropTypes.number,
 
     /**
-     * If true, there is a slight delay before hiding tooltip - good when
-     * user wants to copy something from tooltip to clipboard
+     * If true, user is able to hover tooltip without it disappearing.
+     * (nice if you want to be able to copy tooltip contents to clipboard)
      */
     isHoverable: PropTypes.bool,
   };

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -7,6 +7,8 @@ import styled from '@emotion/styled';
 
 import {domId} from 'app/utils/domId';
 
+const IS_HOVERABLE_DELAY = 50; // used if isHoverable is true (for hiding AND showing)
+
 type Props = {
   children: React.ReactElement;
   disabled?: boolean;
@@ -79,7 +81,8 @@ class Tooltip extends React.Component<Props, State> {
     delay: PropTypes.number,
 
     /**
-     * Time to wait (in milliseconds) before hiding the tooltip
+     * If true, there is a slight delay before hiding tooltip - good when
+     * user wants to copy something from tooltip to clipboard
      */
     isHoverable: PropTypes.bool,
   };
@@ -119,15 +122,15 @@ class Tooltip extends React.Component<Props, State> {
   };
 
   handleOpen = () => {
-    const {delay} = this.props;
+    const {delay, isHoverable} = this.props;
 
     if (this.delayHideTimeout) {
       window.clearTimeout(this.delayHideTimeout);
       this.delayHideTimeout = null;
     }
 
-    if (delay) {
-      this.delayTimeout = window.setTimeout(this.setOpen, delay);
+    if (delay || isHoverable) {
+      this.delayTimeout = window.setTimeout(this.setOpen, delay || IS_HOVERABLE_DELAY);
     } else {
       this.setOpen();
     }
@@ -142,7 +145,7 @@ class Tooltip extends React.Component<Props, State> {
     }
 
     if (isHoverable) {
-      this.delayHideTimeout = window.setTimeout(this.setClose, 50);
+      this.delayHideTimeout = window.setTimeout(this.setClose, IS_HOVERABLE_DELAY);
     } else {
       this.setClose();
     }

--- a/src/sentry/static/sentry/app/components/versionV2.tsx
+++ b/src/sentry/static/sentry/app/components/versionV2.tsx
@@ -1,0 +1,73 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Release} from '@sentry/release-parser';
+
+import GlobalSelectionLink from 'app/components/globalSelectionLink';
+import Link from 'app/components/links/link';
+import Tooltip from 'app/components/tooltip';
+
+type Props = {
+  version: string;
+  orgId: string;
+  anchor?: boolean;
+  /**
+   * Should link to Release preserve user's global selection values
+   */
+  preserveGlobalSelection?: boolean;
+  tooltipRawVersion?: boolean;
+  className?: string;
+};
+
+export const VersionV2 = ({
+  version,
+  orgId,
+  anchor = true,
+  preserveGlobalSelection,
+  tooltipRawVersion,
+  className,
+}: Props) => {
+  const parsedVersion = new Release(version);
+  const LinkComponent = preserveGlobalSelection ? GlobalSelectionLink : Link;
+
+  const renderVersion = () => {
+    if (anchor && orgId) {
+      return (
+        <LinkComponent
+          to={`/organizations/${orgId}/releases-v2/${encodeURIComponent(
+            parsedVersion.raw
+          )}/`}
+          className={className}
+        >
+          <span>{parsedVersion.describe()}</span>
+        </LinkComponent>
+      );
+    }
+
+    return <span className={className}>{parsedVersion.describe()}</span>;
+  };
+
+  return (
+    <Tooltip
+      title={parsedVersion.raw}
+      disabled={!tooltipRawVersion}
+      isHoverable
+      delay={50}
+    >
+      {renderVersion()}
+    </Tooltip>
+  );
+};
+
+VersionV2.propTypes = {
+  version: PropTypes.string.isRequired,
+  orgId: PropTypes.string,
+  anchor: PropTypes.bool,
+  /**
+   * Should link to Release preserve user's global selection values
+   */
+  preserveGlobalSelection: PropTypes.bool,
+  tooltipRawVersion: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export default VersionV2;

--- a/src/sentry/static/sentry/app/components/versionV2.tsx
+++ b/src/sentry/static/sentry/app/components/versionV2.tsx
@@ -47,12 +47,7 @@ export const VersionV2 = ({
   };
 
   return (
-    <Tooltip
-      title={parsedVersion.raw}
-      disabled={!tooltipRawVersion}
-      isHoverable
-      delay={50}
-    >
+    <Tooltip title={parsedVersion.raw} disabled={!tooltipRawVersion} isHoverable>
       {renderVersion()}
     </Tooltip>
   );

--- a/src/sentry/static/sentry/app/components/versionV2.tsx
+++ b/src/sentry/static/sentry/app/components/versionV2.tsx
@@ -18,7 +18,7 @@ type Props = {
   className?: string;
 };
 
-export const VersionV2 = ({
+const VersionV2 = ({
   version,
   orgId,
   anchor = true,

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releasesV2TableRow.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releasesV2TableRow.tsx
@@ -16,7 +16,7 @@ import {ReleasesV2RowData} from 'app/views/releasesV2/list/types';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import HealthStatus from 'app/views/releasesV2/list/healthStatus';
 import LatestDeployOrReleaseTime from 'app/views/releases/list/latestDeployOrReleaseTime';
-import Version from 'app/views/releasesV2/list/version';
+import Version from 'app/components/versionV2';
 
 type Props = ReleasesV2RowData & {
   organizationId: string;
@@ -44,6 +44,7 @@ const ReleasesV2TableRow: React.FC<Props> = ({
             orgId={organizationId}
             version={release.name}
             preserveGlobalSelection
+            tooltipRawVersion
           />
           <LatestDeployOrReleaseTime release={release} />
         </Column>

--- a/tests/js/spec/components/__snapshots__/versionV2.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/versionV2.spec.jsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Version renders 1`] = `
+<VersionV2
+  orgId="sentry"
+  version="foo.bar.Baz@1.0.0+20200101"
+>
+  <Tooltip
+    containerDisplayMode="inline-block"
+    delay={50}
+    disabled={true}
+    isHoverable={true}
+    position="top"
+    title="foo.bar.Baz@1.0.0+20200101"
+  >
+    <Link
+      to="/organizations/sentry/releases-v2/foo.bar.Baz%401.0.0%2B20200101/"
+    >
+      <a
+        href="/organizations/sentry/releases-v2/foo.bar.Baz%401.0.0%2B20200101/"
+      >
+        <span>
+          1.0.0 (20200101)
+        </span>
+      </a>
+    </Link>
+  </Tooltip>
+</VersionV2>
+`;

--- a/tests/js/spec/components/__snapshots__/versionV2.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/versionV2.spec.jsx.snap
@@ -7,7 +7,6 @@ exports[`Version renders 1`] = `
 >
   <Tooltip
     containerDisplayMode="inline-block"
-    delay={50}
     disabled={true}
     isHoverable={true}
     position="top"

--- a/tests/js/spec/components/versionV2.spec.jsx
+++ b/tests/js/spec/components/versionV2.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {mount} from 'sentry-test/enzyme';
+import Version from 'app/components/versionV2';
+
+const VERSION = 'foo.bar.Baz@1.0.0+20200101';
+const ORG_ID = 'sentry';
+
+describe('Version', () => {
+  it('renders', () => {
+    const wrapper = mount(<Version version={VERSION} orgId={ORG_ID} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('shows correct parsed version', () => {
+    // component uses @sentry/release-parser package for parsing versions
+    const wrapper = mount(<Version version={VERSION} orgId={ORG_ID} />);
+
+    expect(wrapper.text()).toBe('1.0.0 (20200101)');
+  });
+
+  it('links to release page', () => {
+    const wrapper = mount(<Version version={VERSION} orgId={ORG_ID} />);
+
+    expect(wrapper.find('Link').prop('to')).toBe(
+      '/organizations/sentry/releases-v2/foo.bar.Baz%401.0.0%2B20200101/'
+    );
+  });
+
+  it('shows raw version in tooltip', () => {
+    const wrapper = mount(<Version version={VERSION} orgId={ORG_ID} tooltipRawVersion />);
+
+    expect(wrapper.find('Tooltip').prop('title')).toBe(VERSION);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,6 +1451,11 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
+"@sentry/release-parser@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-0.4.0.tgz#9b8e868d8ecee8313dc32bdef1478cd06ea7b7fd"
+  integrity sha512-wnXqyFZrOlnsnI8qcY6T2wlEih5zWXwPMcmh6/F9iyyhG/NmcK8zJ67aOZrkT1X7MYN6kssUm8Gfa3DR7aT0Zg==
+
 "@sentry/types@5.11.0":
   version "5.11.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.11.0.tgz#40f0f3174362928e033ddd9725d55e7c5cb7c5b6"


### PR DESCRIPTION
This PR adds a new component for displaying parsed release version names. 
It is a part of health/releasesV2 initiative and will be replacing `app/components/version.tsx` component in the future.

This also modifies the tooltip component to accept a new prop called `isHoverable` - if true, a user is able to hover tooltip without it disappearing (nice if you want to be able to copy tooltip contents to clipboard).