### PR TITLE
fix(discover) - Allow users to query `has:issue.id`

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -776,7 +776,8 @@ def get_filter(query=None, params=None):
                     projects = get_projects(params)
                 condition = ["project_id", "=", projects.get(term.value.value)]
                 kwargs["conditions"].append(condition)
-            elif name == "issue.id":
+            elif name == "issue.id" and term.value.value != "":
+                # A blank term value means that this is a has filter
                 kwargs["group_ids"].extend(to_list(term.value.value))
             elif name in FIELD_ALIASES:
                 converted_filter = convert_aggregate_filter_to_snuba_query(term, True)

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -979,6 +979,11 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_not_has(self):
         assert get_filter("!has:release").conditions == [[["isNull", ["release"]], "=", 1]]
 
+    def test_has_issue_id(self):
+        has_issue_filter = get_filter("has:issue.id")
+        assert has_issue_filter.group_ids == []
+        assert has_issue_filter.conditions == [[["isNull", ["issue.id"]], "!=", 1]]
+
     def test_message_negative(self):
         assert get_filter('!message:"post_process.process_error HTTPError 403"').conditions == [
             [

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -984,6 +984,11 @@ class GetSnubaQueryArgsTest(TestCase):
         assert has_issue_filter.group_ids == []
         assert has_issue_filter.conditions == [[["isNull", ["issue.id"]], "!=", 1]]
 
+    def test_not_has_issue_id(self):
+        has_issue_filter = get_filter("!has:issue.id")
+        assert has_issue_filter.group_ids == []
+        assert has_issue_filter.conditions == [[["isNull", ["issue.id"]], "=", 1]]
+
     def test_message_negative(self):
         assert get_filter('!message:"post_process.process_error HTTPError 403"').conditions == [
             [


### PR DESCRIPTION
- This will treat has.issue.id slightly differently than before, we were
  always adding the values to group_ids, but when the query is has
  instead, the value would be blank (ie. "").