### PR TITLE
fix(discover) Fix layout when there are no results.

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -212,6 +212,7 @@ export const StyledPageContent = styled(PageContent)`
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     display: grid;
     grid-template-columns: 66% auto;
+    grid-template-rows: 330px auto;
     grid-column-gap: ${space(3)};
   }
 


### PR DESCRIPTION
Fix the sizable gap between the chart and table when there are no results.

#### Before
![Screen Shot 2020-02-03 at 3 03 03 PM](https://user-images.githubusercontent.com/24086/73686881-db822680-4696-11ea-88ba-9b7c2510f969.png)

#### After
![Screen Shot 2020-02-03 at 3 02 40 PM](https://user-images.githubusercontent.com/24086/73686899-e5a42500-4696-11ea-84b1-bc51fc82e73a.png)
