### PR TITLE
fix(API): Clarify `assignedTo` param docs

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -291,8 +291,10 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         :param string status: the new status for the issue.  Valid values
                               are ``"resolved"``, ``resolvedInNextRelease``,
                               ``"unresolved"``, and ``"ignored"``.
-        :param string assignedTo: the actor id (or username) of the user or team that should be
-                                  assigned to this issue.
+        :param string assignedTo: the user or team that should be assigned to
+                                  this issue. Can be of the form ``"<user_id>"``,
+                                  ``"user:<user_id>"``, ``"<username>"``,
+                                  ``"<user_primary_email>"``, or ``"team:<team_id>"``.
         :param boolean hasSeen: in case this API call is invoked with a user
                                 context this allows changing of the flag
                                 that indicates if the user has seen the

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -249,9 +249,12 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         :param int ignoreDuration: the number of minutes to ignore this issue.
         :param boolean isPublic: sets the issue to public or private.
         :param boolean merge: allows to merge or unmerge different issues.
-        :param string assignedTo: the actor id (or username) of the user or team that should be
-                                  assigned to this issue. Bulk assigning issues
-                                  is limited to groups within a single project.
+        :param string assignedTo: the user or team that should be assigned to
+                                  these issues. Can be of the form ``"<user_id>"``,
+                                  ``"user:<user_id>"``, ``"<username>"``,
+                                  ``"<user_primary_email>"``, or ``"team:<team_id>"``.
+                                  Bulk assigning issues is limited to groups
+                                  within a single project.
         :param boolean hasSeen: in case this API call is invoked with a user
                                 context this allows changing of the flag
                                 that indicates if the user has seen the

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -262,8 +262,10 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         :param int ignoreDuration: the number of minutes to ignore this issue.
         :param boolean isPublic: sets the issue to public or private.
         :param boolean merge: allows to merge or unmerge different issues.
-        :param string assignedTo: the actor id (or username) of the user or team that should be
-                                  assigned to this issue.
+        :param string assignedTo: the user or team that should be assigned to
+                                  this issue. Can be of the form ``"<user_id>"``,
+                                  ``"user:<user_id>"``, ``"<username>"``,
+                                  ``"<user_primary_email>"``, or ``"team:<team_id>"``.
         :param boolean hasSeen: in case this API call is invoked with a user
                                 context this allows changing of the flag
                                 that indicates if the user has seen the

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -14,26 +14,38 @@ class Actor(namedtuple("Actor", "id type")):
         return "%s:%d" % (self.type.__name__.lower(), self.id)
 
     @classmethod
-    def from_actor_id(cls, actor_id):
+    def from_actor_id(cls, actor_identifier):
+        """
+        Returns an Actor tuple corresponding to a User or Team associated with
+        the given identifier.
+
+        Forms `actor_identifier` can take:
+            1231 -> look up User by id
+            "1231" -> look up User by id
+            "user:1231" -> look up User by id
+            "team:1231" -> look up Team by id
+            "maiseythedog" -> look up User by username
+            "maisey@dogsrule.com" -> look up User by primary email
+        """
         # If we have an integer, fall back to assuming it's a User
-        if isinstance(actor_id, six.integer_types):
-            return Actor(actor_id, User)
+        if isinstance(actor_identifier, six.integer_types):
+            return Actor(actor_identifier, User)
 
-        # If the actor_id is a simple integer as a string,
+        # If the actor_identifier is a simple integer as a string,
         # we're also a User
-        if actor_id.isdigit():
-            return Actor(int(actor_id), User)
+        if actor_identifier.isdigit():
+            return Actor(int(actor_identifier), User)
 
-        if actor_id.startswith("user:"):
-            return cls(int(actor_id[5:]), User)
+        if actor_identifier.startswith("user:"):
+            return cls(int(actor_identifier[5:]), User)
 
-        if actor_id.startswith("team:"):
-            return cls(int(actor_id[5:]), Team)
+        if actor_identifier.startswith("team:"):
+            return cls(int(actor_identifier[5:]), Team)
 
         try:
-            return Actor(find_users(actor_id)[0].id, User)
+            return Actor(find_users(actor_identifier)[0].id, User)
         except IndexError:
-            raise serializers.ValidationError("Unable to resolve actor id")
+            raise serializers.ValidationError("Unable to resolve actor identifier")
 
     def resolve(self):
         return self.type.objects.get(id=self.id)

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -14,7 +14,7 @@ class Actor(namedtuple("Actor", "id type")):
         return "%s:%d" % (self.type.__name__.lower(), self.id)
 
     @classmethod
-    def from_actor_id(cls, actor_identifier):
+    def from_actor_identifier(cls, actor_identifier):
         """
         Returns an Actor tuple corresponding to a User or Team associated with
         the given identifier.
@@ -89,6 +89,6 @@ class ActorField(serializers.Field):
             return None
 
         try:
-            return Actor.from_actor_id(data)
+            return Actor.from_actor_identifier(data)
         except Exception:
             raise serializers.ValidationError("Unknown actor input")

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -109,7 +109,7 @@ def build_attachment_text(group, event=None):
 
 
 def build_assigned_text(group, identity, assignee):
-    actor = Actor.from_actor_id(assignee)
+    actor = Actor.from_actor_identifier(assignee)
 
     try:
         assigned_actor = actor.resolve()

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -243,4 +243,4 @@ class GroupAssignee(Model):
     def assigned_actor(self):
         from sentry.api.fields.actor import Actor
 
-        return Actor.from_actor_id(self.assigned_actor_id())
+        return Actor.from_actor_identifier(self.assigned_actor_id())


### PR DESCRIPTION
A user wrote in, complaining that we don't say anywhere that in order to assign an issue to a team [using the API](https://docs.sentry.io/api/events/put-group-details/), you need to precede the team id with `"team:"`. (He eventually figured it out by watching the network tab as our web app did it.)

This fixes that (and generally clarifies what the options for `assignedTo` are).

Also, in the process of figuring out said options, I came across the `Actor.from_actor_id()` method. As it happens, it doesn't just take ids - it will take a username or email also (via the `sentry.utils.auth.find_users()` [function](https://github.com/getsentry/sentry/blob/7ce3ce4a0e1ccd2b37c5d84a8af0edb95650d1c2/src/sentry/utils/auth.py#L162)). So, this subs `identifier` for `id` in the method and parameter names, and adds a docstring laying out the valid inputs.