### PR TITLE
fix(workflow): Change Alert Rules empty text

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/list.tsx
@@ -122,7 +122,7 @@ class IncidentRulesList extends AsyncView<Props, State> {
             })}
 
           {!isLoading && isEmpty && (
-            <EmptyMessage>{t('No Incident rules have been created yet.')}</EmptyMessage>
+            <EmptyMessage>{t('No Alert Rules have been created yet.')}</EmptyMessage>
           )}
         </PanelBody>
       </Panel>


### PR DESCRIPTION
Updates text to read "Alert" instead of "Incident"