### PR TITLE
fix(workflow): Allow clear environment for Alert Rule editor

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -100,6 +100,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                 : []
             }
             disabled={this.state.environments === null}
+            isClearable
           />
           <FormField
             name="query"


### PR DESCRIPTION
Allows user to be able to clear the "Environment" field