### PR TITLE
meta(devtools): initial direnv configuration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -162,9 +162,22 @@ fi
 
 ### Node ###
 
-# TODO: check the node version. Or, I could just build this into yarn.
-
 info "Checking node..."
+
+node_version="10.16.3"
+
+# It would be nice to enforce that node is installed via volta (and is therefore a shim that will check against
+# the node pin in package.json), but for now, let's just explicitly check the node version.
+
+if ! require node; then
+    die "You don't seem to have node installed. We want version ${node_version}.
+It's recommended to use https://github.com/volta-cli/volta."
+fi
+
+if [ "$(node -v)" != "v${node_version}" ]; then
+    die "Your node version doesn't match ${node_version}.
+It's recommended to use https://github.com/volta-cli/volta."
+fi
 
 if [ ! -x "node_modules/.bin/webpack" ]; then
     info "You don't seem to have yarn packages installed. Let's install them."

--- a/.envrc
+++ b/.envrc
@@ -49,6 +49,7 @@ EOF
 
 init_venv () {
     deactivate 2>/dev/null || true
+    info "Creating a virtualenv for you."
     require python2.7 || die "You'll need to install python2.7, or make it available on your PATH. It's recommended to use pyenv."
     python2.7 -m virtualenv .venv
 }
@@ -83,7 +84,9 @@ done
 
 ### Python ###
 
-# direnv set -u's; unsure if it's a good idea to set +u.
+info "Checking virtualenv..."
+
+# direnv set -u's, so we need to do this.
 VIRTUAL_ENV="${VIRTUAL_ENV:-}"
 
 if [ -n "$VIRTUAL_ENV" ]; then
@@ -109,13 +112,13 @@ python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
 if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
     info "Your .venv is activated, but sentry doesn't seem to be installed. Let's install it."
     make ensure-pinned-pip
-    # TODO: use venv-update to create venv. this assumes virtualenv is installed
-    # which is reasonable if python2.7 is via pyenv. I forget if brew python@2 contains it.
     SENTRY_LIGHT_BUILD=1 make install-sentry-dev
 fi
 
 
 ### pre-commit ###
+
+info "Checking pre-commit..."
 
 # this is cheap, so we'll just do it every time
 ln -sf config/hooks/* .git/hooks
@@ -130,6 +133,8 @@ rm -f .git/hooks/pre-commit.legacy
 
 
 ### devservices ###
+
+info "Checking devservices..."
 
 # XXX: these container names are hardcoded for now
 # NOTE: sentry_symbolicator isn't started up by devservices, and is behind a config flag, so we're not checking for it
@@ -154,12 +159,16 @@ done
 
 # TODO: check the node version. Or, I could just build this into yarn.
 
+info "Checking node..."
+
 if [ ! -x "node_modules/.bin/webpack" ]; then
     info "You don't seem to have yarn packages installed. Let's install them."
     make install-yarn-pkgs
 fi
 
 PATH_add node_modules/.bin
+
+# TODO: first-time webpacking
 
 ### Overrides ###
 

--- a/.envrc
+++ b/.envrc
@@ -74,7 +74,7 @@ done
 ### Python ###
 
 # direnv set -u's; unsure if it's a good idea to set +u.
-VIRTUAL_ENV="${VIRTUAL_ENV-}"
+VIRTUAL_ENV="${VIRTUAL_ENV:-}"
 
 if [ -n "$VIRTUAL_ENV" ]; then
     # we're enforcing that virtualenv be in .venv, since future tooling e.g. venv-update will rely on this.
@@ -120,7 +120,9 @@ rm -f .git/hooks/pre-commit.legacy
 
 ### devservices/database ###
 
-SENTRY_DIRENV_NO_CHECK_DEVSERVICES="${SENTRY_DIRENV_NO_CHECK_DEVSERVICES-}"
+# honestly, this could just be moved to the future "fixall" script
+
+SENTRY_DIRENV_NO_CHECK_DEVSERVICES="${SENTRY_DIRENV_NO_CHECK_DEVSERVICES:-}"
 if [ -z "${SENTRY_DIRENV_NO_CHECK_DEVSERVICES}" ]; then
     info "Checking for devservices containers, this might be a bit slow.
 To disable in the future, please set SENTRY_DIRENV_NO_CHECK_DEVSERVICES=1"

--- a/.envrc
+++ b/.envrc
@@ -1,19 +1,14 @@
 # This is the .envrc for Sentry, for use with direnv.
-# We use it for:
-#   - lightweight (crucial since it's run on every cd to here) state checking and assurance (e.g. activating the venv)
-#   - one-time heavyweight state initialization (such as creating a .venv)
-#       - TODO: heavyweight state assurance, such as syncing venv, should happen in a one-off "fixall" script
-#               and should be recommended by direnv as a catch-all fixer
-#       - Although, this kind of state initialization could be moved to there from here in the future.
-#   - setting useful environment variables
-#
+# It's responsible for enforcing a standard dev environment by checking as much state as possible, and either performing
+# initialization (e.g. activating the venv) or giving recommendations on how to reach the desired state.
+# It also sets useful environment variables.
 # If you'd like to override or do any custom things, this .envrc will source a .envrc-overrides file at the end.
+
 
 bold="$(tput bold)"
 red="$(tput setaf 1)"
 reset="$(tput sgr0)"
 
-# NOTE: do not trap bash's EXIT; it will prevent direnv from performing its final dance(s)
 trap notice ERR
 
 notice () {
@@ -64,6 +59,7 @@ export PIP_DISABLE_PIP_VERSION_CHECK=on
 # increase node's memory limit, required for our webpacking
 export NODE_OPTIONS=--max-old-space-size=4096
 
+
 ### System ###
 
 for pkg in \
@@ -78,6 +74,7 @@ for pkg in \
 Please install homebrew, and run brew bundle."
     fi
 done
+
 
 ### Python ###
 
@@ -104,7 +101,6 @@ source .venv/bin/activate
 python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
     die "For some reason, the virtualenv isn't Python 2.7."
 
-# naive check, but we need to stay fast
 if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
     info "Your .venv is activated, but sentry doesn't seem to be installed. Let's install it."
     make ensure-pinned-pip
@@ -112,6 +108,7 @@ if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
     # which is reasonable if python2.7 is via pyenv. I forget if brew python@2 contains it.
     SENTRY_LIGHT_BUILD=1 make install-sentry-dev
 fi
+
 
 ### pre-commit ###
 
@@ -126,35 +123,32 @@ fi
 # this hotfix is cheap too, so just run it every time
 rm -f .git/hooks/pre-commit.legacy
 
-### devservices/database ###
 
-# honestly, this could just be moved to the future "fixall" script
+### devservices ###
 
-SENTRY_DIRENV_NO_CHECK_DEVSERVICES="${SENTRY_DIRENV_NO_CHECK_DEVSERVICES:-}"
-if [ -z "${SENTRY_DIRENV_NO_CHECK_DEVSERVICES}" ]; then
-    info "Checking for devservices containers, this might be a bit slow.
-To disable in the future, please set SENTRY_DIRENV_NO_CHECK_DEVSERVICES=1"
+# XXX: these container names are hardcoded for now
+# NOTE: sentry_symbolicator isn't started up by devservices, and is behind a config flag, so we're not checking for it
+for container in \
+    sentry_postgres     \
+    sentry_clickhouse   \
+    sentry_snuba        \
+    sentry_redis        ;
+    do
+    docker exec "$container" true || die "The docker container ${container} doesn't seem to be running.
+Please run sentry devservices up."
+done
 
-    # XXX: these container names are hardcoded for now
-    # NOTE: sentry_symbolicator isn't started up by devservices, and is behind a config flag, so we're not checking for it
-    for container in \
-        sentry_postgres     \
-        sentry_clickhouse   \
-        sentry_snuba        \
-        sentry_redis        ;
-        do
-        docker exec "$container" true || die "The docker container ${container} doesn't seem to be running.
-    Please run sentry devservices up."
-    done
-fi
+
+### database ###
 
 # TODO: is there a faster way to state-check the need for sentry reset-db and sentry createuser?
-# This is a little slower than i'd like, so not turning it on for now, not even behind a NO_CHECK flag.
-# docker exec sentry_postgres sh -c "psql -U postgres -h 127.0.0.1 sentry --command 'select * from sentry_useremail'"
+# docker exec sentry_postgres sh -c "psql -U postgres -h 127.0.0.1 sentry --command 'select 1 from sentry_useremail'"
+
 
 ### Node ###
 
-# naive check, but we need to stay fast
+# TODO: check the node version. Or, I could just build this into yarn.
+
 if [ ! -x "node_modules/.bin/webpack" ]; then
     info "You don't seem to have yarn packages installed. Let's install them."
     make install-yarn-pkgs

--- a/.envrc
+++ b/.envrc
@@ -45,8 +45,7 @@ EOF
 
 init_venv () {
     deactivate 2>/dev/null || true
-    python2.7 -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
-        die "You'll need to install python2.7. It's recommended to use pyenv."
+    require python2.7 || die "You'll need to install python2.7, or make it available on your PATH. It's recommended to use pyenv."
     python2.7 -m virtualenv .venv
 }
 

--- a/.envrc
+++ b/.envrc
@@ -4,20 +4,27 @@
 # It also sets useful environment variables.
 # If you'd like to override or do any custom things, this .envrc will source a .envrc-overrides file at the end.
 
+set -e
 
 bold="$(tput bold)"
 red="$(tput setaf 1)"
 reset="$(tput sgr0)"
 
+# XXX: we can't trap bash EXIT, because it'll override direnv's finalizing routines.
+#      consequently, using "exit" anywhere will skip this notice from showing.
+#      so need to use set -e, and return 1.
 trap notice ERR
 
 notice () {
     [ $? -eq 0 ] && return
     cat <<EOF
-${bold}direnv tooling is in an ALPHA state!
+${bold}direnv wasn't able to complete execution.
+You may have been given some recommendations in the error message.
+Follow them, and then you'll need to re-run direnv with "direnv allow".${reset}
+
+direnv tooling is in an ALPHA state!
 If you're having trouble, or have questions, please ask in #discuss-dev-tooling
 and/or reach out to @josh.
-${reset}
 EOF
 }
 
@@ -37,7 +44,7 @@ die () {
 ${red}${bold}direnv FATAL: ${1}
 ${reset}
 EOF
-    exit 1
+    return 1
 }
 
 init_venv () {
@@ -45,8 +52,6 @@ init_venv () {
     require python2.7 || die "You'll need to install python2.7, or make it available on your PATH. It's recommended to use pyenv."
     python2.7 -m virtualenv .venv
 }
-
-set -e
 
 ### Environment ###
 

--- a/.envrc
+++ b/.envrc
@@ -7,10 +7,6 @@
 #       - Although, this kind of state initialization could be moved to there from here in the future.
 #   - setting useful environment variables
 
-export PYTHONDONTWRITEBYTECODE=1
-export PIP_DISABLE_PIP_VERSION_CHECK=on
-export NODE_OPTIONS=--max-old-space-size=4096
-
 bold="$(tput bold)"
 red="$(tput setaf 1)"
 reset="$(tput sgr0)"
@@ -55,6 +51,17 @@ init_venv () {
 }
 
 set -e
+
+### Environment ###
+
+# don't write *.pyc files; using stale python code occasionally causes subtle problems
+export PYTHONDONTWRITEBYTECODE=1
+
+# don't check pypi for a potential new pip version; low-hanging fruit to save a bit of time
+export PIP_DISABLE_PIP_VERSION_CHECK=on
+
+# increase node's memory limit, required for our webpacking
+export NODE_OPTIONS=--max-old-space-size=4096
 
 ### System ###
 

--- a/.envrc
+++ b/.envrc
@@ -151,8 +151,13 @@ done
 
 ### database ###
 
-# TODO: is there a faster way to state-check the need for sentry reset-db and sentry createuser?
-# docker exec sentry_postgres sh -c "psql -U postgres -h 127.0.0.1 sentry --command 'select 1 from sentry_useremail'"
+info "Checking database..."
+
+if ! docker exec sentry_postgres sh \
+    -c "psql -U postgres -h 127.0.0.1 sentry --command 'select 1 from sentry_useremail'" >/dev/null;
+    then
+    die "It doesn't look like you have a database yet - you'll need to run 'make reset-db'."
+fi
 
 
 ### Node ###

--- a/.envrc
+++ b/.envrc
@@ -6,6 +6,8 @@
 #               and should be recommended by direnv as a catch-all fixer
 #       - Although, this kind of state initialization could be moved to there from here in the future.
 #   - setting useful environment variables
+#
+# If you'd like to override or do any custom things, this .envrc will source a .envrc-overrides file at the end.
 
 bold="$(tput bold)"
 red="$(tput setaf 1)"
@@ -159,3 +161,9 @@ if [ ! -x "node_modules/.bin/webpack" ]; then
 fi
 
 PATH_add node_modules/.bin
+
+### Overrides ###
+
+if [ -f .envrc-overrides ]; then
+    source .envrc-overrides
+fi

--- a/.envrc
+++ b/.envrc
@@ -90,6 +90,7 @@ fi
 
 info "Activating virtualenv."
 source .venv/bin/activate
+[ "$(command -v python)" != "${PWD}/.venv/bin/python" ] && die "Failed to activate virtualenv."
 
 python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
     die "For some reason, the virtualenv isn't Python 2.7."

--- a/.envrc
+++ b/.envrc
@@ -9,15 +9,41 @@
 
 export PYTHONDONTWRITEBYTECODE=1
 export PIP_DISABLE_PIP_VERSION_CHECK=on
-
 export NODE_OPTIONS=--max-old-space-size=4096
+
+bold="$(tput bold)"
+red="$(tput setaf 1)"
+reset="$(tput sgr0)"
+
+trap notice EXIT
+
+notice () {
+    [ $? -eq 0 ] && return
+    cat <<EOF
+${bold}direnv tooling is in an ALPHA state!
+If you're having trouble, or have questions, please ask in #discuss-dev-tooling
+and/or reach out to @josh.
+${reset}
+EOF
+}
 
 require () {
     command -v "$1" 2>&1 > /dev/null
 }
 
+info () {
+    cat <<EOF
+${bold}direnv: ${1}
+${reset}
+EOF
+}
+
 die () {
-    >&2 echo "fatal: ${1}"; exit 1
+    >&2 cat <<EOF
+${red}${bold}direnv FATAL: ${1}
+${reset}
+EOF
+    exit 1
 }
 
 init_venv () {
@@ -37,17 +63,17 @@ VIRTUAL_ENV="${VIRTUAL_ENV-}"
 if [ -n "$VIRTUAL_ENV" ]; then
     # we're enforcing that virtualenv be in .venv, since future tooling e.g. venv-update will rely on this.
     if [ "$VIRTUAL_ENV" != "${PWD}/.venv" ]; then
-        echo "You're in a virtualenv, but it's not in the expected location (${PWD}/.venv)"
+        info "You're in a virtualenv, but it's not in the expected location (${PWD}/.venv)"
         init_venv
     fi
 else
     if [ ! -f ".venv/bin/activate" ]; then
-        echo "You don't seem to have a virtualenv."
+        info "You don't seem to have a virtualenv."
         init_venv
     fi
 fi
 
-echo "Activating virtualenv."
+info "Activating virtualenv."
 source .venv/bin/activate
 
 python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
@@ -55,7 +81,7 @@ python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
 
 # naive check, but we need to stay fast
 if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
-    echo "Your .venv is activated, but sentry doesn't seem to be installed. Let's install it."
+    info "Your .venv is activated, but sentry doesn't seem to be installed. Let's install it."
     make ensure-pinned-pip
     # TODO: use venv-update to create venv. this assumes virtualenv is installed
     # which is reasonable if python2.7 is via pyenv. I forget if brew python@2 contains it.
@@ -64,7 +90,7 @@ fi
 
 # naive check, but we need to stay fast
 if [ ! -x "node_modules/.bin/webpack" ]; then
-    echo "You don't seem to have yarn packages installed. Let's install them."
+    info "You don't seem to have yarn packages installed. Let's install them."
     make install-yarn-pkgs
 fi
 

--- a/.envrc
+++ b/.envrc
@@ -53,6 +53,7 @@ source .venv/bin/activate
 python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
     die "For some reason, the virtualenv isn't Python 2.7."
 
+# naive check, but we need to stay fast
 if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
     echo "Your .venv is activated, but sentry doesn't seem to be installed. Let's install it."
     make ensure-pinned-pip
@@ -60,3 +61,11 @@ if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
     # which is reasonable if python2.7 is via pyenv. I forget if brew python@2 contains it.
     SENTRY_LIGHT_BUILD=1 make install-sentry-dev
 fi
+
+# naive check, but we need to stay fast
+if [ ! -x "node_modules/.bin/webpack" ]; then
+    echo "You don't seem to have yarn packages installed. Let's install them."
+    make install-yarn-pkgs
+fi
+
+PATH_add node_modules/.bin

--- a/.envrc
+++ b/.envrc
@@ -1,28 +1,62 @@
+# This is the .envrc for Sentry, for use with direnv.
+# We use it for:
+#   - lightweight (crucial since it's run on every cd to here) state checking and assurance (e.g. activating the venv)
+#   - one-time heavyweight state initialization (such as creating a .venv)
+#       - TODO: heavyweight state assurance, such as syncing venv, should happen in a one-off "fixall" script
+#               and should be recommended by direnv as a catch-all fixer
+#       - Although, this kind of state initialization could be moved to there from here in the future.
+#   - setting useful environment variables
+
 export PYTHONDONTWRITEBYTECODE=1
 export PIP_DISABLE_PIP_VERSION_CHECK=on
 
 export NODE_OPTIONS=--max-old-space-size=4096
 
-die () {
-    >&2 echo "$1"; exit 1
+require () {
+    command -v "$1" 2>&1 > /dev/null
 }
 
-ensure_python27 () {
-    python2.7 -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))"
-    return $?
+die () {
+    >&2 echo "fatal: ${1}"; exit 1
+}
+
+init_venv () {
+    deactivate 2>/dev/null || true
+    python2.7 -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
+        die "You'll need to install python2.7. It's recommended to use pyenv."
+    python2.7 -m virtualenv .venv
 }
 
 set -e
 
-# TODO: enforce that virtualenv is in .venv, since future tooling (venv-update) will rely on this
-if [ -z "${VIRTUAL_ENV-}" ]; then
-    if [ ! -f ".venv/bin/activate" ]; then
-        ensure_python27 || die "You'll need to install python2.7."
-        echo "You don't seem to have a virtualenv, so let's make you one."
-        # TODO: use venv-update to create + sync venv. this assumes virtualenv is installed
-        # which is reasonable if python2.7 is via pyenv. I forget if brew python@2 contains it.
-        python2.7 -m virtualenv .venv
+# TODO: check for system packages, and provide platform-specific (macos for now) advice to install.
+
+# direnv set -u's; unsure if it's a good idea to set +u.
+VIRTUAL_ENV="${VIRTUAL_ENV-}"
+
+if [ -n "$VIRTUAL_ENV" ]; then
+    # we're enforcing that virtualenv be in .venv, since future tooling e.g. venv-update will rely on this.
+    if [ "$VIRTUAL_ENV" != "${PWD}/.venv" ]; then
+        echo "You're in a virtualenv, but it's not in the expected location (${PWD}/.venv)"
+        init_venv
     fi
-    echo "Activating virtualenv."
-    source .venv/bin/activate
+else
+    if [ ! -f ".venv/bin/activate" ]; then
+        echo "You don't seem to have a virtualenv."
+        init_venv
+    fi
+fi
+
+echo "Activating virtualenv."
+source .venv/bin/activate
+
+python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
+    die "For some reason, the virtualenv isn't Python 2.7."
+
+if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
+    echo "Your .venv is activated, but sentry doesn't seem to be installed. Let's install it."
+    make ensure-pinned-pip
+    # TODO: use venv-update to create venv. this assumes virtualenv is installed
+    # which is reasonable if python2.7 is via pyenv. I forget if brew python@2 contains it.
+    SENTRY_LIGHT_BUILD=1 make install-sentry-dev
 fi

--- a/.envrc
+++ b/.envrc
@@ -15,7 +15,8 @@ bold="$(tput bold)"
 red="$(tput setaf 1)"
 reset="$(tput sgr0)"
 
-trap notice EXIT
+# NOTE: do not trap bash's EXIT; it will prevent direnv from performing its final dance(s)
+trap notice ERR
 
 notice () {
     [ $? -eq 0 ] && return

--- a/.envrc
+++ b/.envrc
@@ -105,7 +105,16 @@ fi
 
 ### pre-commit ###
 
-# TODO: pre-commit + git hooks
+# this is cheap, so we'll just do it every time
+ln -sf config/hooks/* .git/hooks
+
+if ! require pre-commit; then
+    info "Looks like you don't have pre-commit installed. Let's install it."
+    make setup-git
+fi
+
+# this hotfix is cheap too, so just run it every time
+rm -f .git/hooks/pre-commit.legacy
 
 ### devservices/database ###
 

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,28 @@
+export PYTHONDONTWRITEBYTECODE=1
+export PIP_DISABLE_PIP_VERSION_CHECK=on
+
+export NODE_OPTIONS=--max-old-space-size=4096
+
+die () {
+    >&2 echo "$1"; exit 1
+}
+
+ensure_python27 () {
+    python2.7 -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))"
+    return $?
+}
+
+set -e
+
+# TODO: enforce that virtualenv is in .venv, since future tooling (venv-update) will rely on this
+if [ -z "${VIRTUAL_ENV-}" ]; then
+    if [ ! -f ".venv/bin/activate" ]; then
+        ensure_python27 || die "You'll need to install python2.7."
+        echo "You don't seem to have a virtualenv, so let's make you one."
+        # TODO: use venv-update to create + sync venv. this assumes virtualenv is installed
+        # which is reasonable if python2.7 is via pyenv. I forget if brew python@2 contains it.
+        python2.7 -m virtualenv .venv
+    fi
+    echo "Activating virtualenv."
+    source .venv/bin/activate
+fi

--- a/.envrc
+++ b/.envrc
@@ -55,7 +55,22 @@ init_venv () {
 
 set -e
 
-# TODO: check for system packages, and provide platform-specific (macos for now) advice to install.
+### System ###
+
+for pkg in \
+    make            \
+    docker          \
+    chromedriver    \
+    pkg-config      \
+    openssl         ;
+    do
+    if ! require "$pkg"; then
+        die "You seem to be missing the system dependency: ${pkg}
+Please install homebrew, and run brew bundle."
+    fi
+done
+
+### Python ###
 
 # direnv set -u's; unsure if it's a good idea to set +u.
 VIRTUAL_ENV="${VIRTUAL_ENV-}"
@@ -87,6 +102,20 @@ if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
     # which is reasonable if python2.7 is via pyenv. I forget if brew python@2 contains it.
     SENTRY_LIGHT_BUILD=1 make install-sentry-dev
 fi
+
+### pre-commit ###
+
+# TODO: pre-commit + git hooks
+
+### devservices ###
+
+# TODO: lightweight state checks and recommendations
+
+### database ###
+
+# TODO: lightweight state checks and recommendations
+
+### Node ###
 
 # naive check, but we need to stay fast
 if [ ! -x "node_modules/.bin/webpack" ]; then

--- a/.envrc
+++ b/.envrc
@@ -107,13 +107,29 @@ fi
 
 # TODO: pre-commit + git hooks
 
-### devservices ###
+### devservices/database ###
 
-# TODO: lightweight state checks and recommendations
+SENTRY_DIRENV_NO_CHECK_DEVSERVICES="${SENTRY_DIRENV_NO_CHECK_DEVSERVICES-}"
+if [ -z "${SENTRY_DIRENV_NO_CHECK_DEVSERVICES}" ]; then
+    info "Checking for devservices containers, this might be a bit slow.
+To disable in the future, please set SENTRY_DIRENV_NO_CHECK_DEVSERVICES=1"
 
-### database ###
+    # XXX: these container names are hardcoded for now
+    # NOTE: sentry_symbolicator isn't started up by devservices, and is behind a config flag, so we're not checking for it
+    for container in \
+        sentry_postgres     \
+        sentry_clickhouse   \
+        sentry_snuba        \
+        sentry_redis        ;
+        do
+        docker exec "$container" true || die "The docker container ${container} doesn't seem to be running.
+    Please run sentry devservices up."
+    done
+fi
 
-# TODO: lightweight state checks and recommendations
+# TODO: is there a faster way to state-check the need for sentry reset-db and sentry createuser?
+# This is a little slower than i'd like, so not turning it on for now, not even behind a NO_CHECK flag.
+# docker exec sentry_postgres sh -c "psql -U postgres -h 127.0.0.1 sentry --command 'select * from sentry_useremail'"
 
 ### Node ###
 

--- a/.envrc
+++ b/.envrc
@@ -50,7 +50,9 @@ EOF
 init_venv () {
     deactivate 2>/dev/null || true
     info "Creating a virtualenv for you."
-    require python2.7 || die "You'll need to install python2.7, or make it available on your PATH. It's recommended to use pyenv."
+    require python2.7 || \
+        die "You'll need to install python2.7, or make it available on your PATH.
+It's recommended to use pyenv - please refer to https://docs.sentry.io/development/contribute/environment"
     python2.7 -m virtualenv .venv
 }
 
@@ -171,7 +173,7 @@ node_version="10.16.3"
 
 if ! require node; then
     die "You don't seem to have node installed. We want version ${node_version}.
-It's recommended to use https://github.com/volta-cli/volta."
+It's recommended to use volta - please refer to https://docs.sentry.io/development/contribute/environment"
 fi
 
 if [ "$(node -v)" != "v${node_version}" ]; then

--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-# This is the .envrc for Sentry, for use with direnv.
+# This is the .envrc for sentry, for use with direnv.
 # It's responsible for enforcing a standard dev environment by checking as much state as possible, and either performing
 # initialization (e.g. activating the venv) or giving recommendations on how to reach the desired state.
 # It also sets useful environment variables.
@@ -8,6 +8,7 @@ set -e
 
 bold="$(tput bold)"
 red="$(tput setaf 1)"
+green="$(tput setaf 2)"
 reset="$(tput sgr0)"
 
 # XXX: we can't trap bash EXIT, because it'll override direnv's finalizing routines.
@@ -18,9 +19,9 @@ trap notice ERR
 notice () {
     [ $? -eq 0 ] && return
     cat <<EOF
-${bold}direnv wasn't able to complete execution.
+${red}${bold}direnv wasn't able to complete execution.
 You may have been given some recommendations in the error message.
-Follow them, and then you'll need to re-run direnv with "direnv allow".${reset}
+Follow them, and then you'll need to redo direnv by running "direnv allow".${reset}
 
 direnv tooling is in an ALPHA state!
 If you're having trouble, or have questions, please ask in #discuss-dev-tooling
@@ -158,7 +159,7 @@ info "Checking database..."
 if ! docker exec sentry_postgres sh \
     -c "psql -U postgres -h 127.0.0.1 sentry --command 'select 1 from sentry_useremail'" >/dev/null;
     then
-    die "It doesn't look like you have a database yet - you'll need to run 'make reset-db'."
+    die "It doesn't look like you have a database for sentry yet - you'll need to run 'make reset-db'."
 fi
 
 
@@ -178,7 +179,7 @@ fi
 
 if [ "$(node -v)" != "v${node_version}" ]; then
     die "Your node version doesn't match ${node_version}.
-It's recommended to use https://github.com/volta-cli/volta."
+It's recommended to use volta - please refer to https://docs.sentry.io/development/contribute/environment"
 fi
 
 if [ ! -x "node_modules/.bin/webpack" ]; then
@@ -188,10 +189,20 @@ fi
 
 PATH_add node_modules/.bin
 
-# TODO: first-time webpacking
 
 ### Overrides ###
 
 if [ -f .envrc-overrides ]; then
     source .envrc-overrides
 fi
+
+cat <<EOF
+${green}${bold}direnv: SUCCESS!
+${reset}
+direnv tooling is in an ALPHA state!
+If you're having trouble, or have questions, please ask in #discuss-dev-tooling
+and/or reach out to @josh.
+
+You can safely ignore the followiing "PS1 cannot be exported" message.
+
+EOF

--- a/.envrc
+++ b/.envrc
@@ -35,8 +35,7 @@ require () {
 
 info () {
     cat <<EOF
-${bold}direnv: ${1}
-${reset}
+${bold}direnv: ${1}${reset}
 EOF
 }
 

--- a/.envrc
+++ b/.envrc
@@ -2,7 +2,7 @@
 # It's responsible for enforcing a standard dev environment by checking as much state as possible, and either performing
 # initialization (e.g. activating the venv) or giving recommendations on how to reach the desired state.
 # It also sets useful environment variables.
-# If you'd like to override or do any custom things, this .envrc will source a .envrc-overrides file at the end.
+# If you'd like to override or set any custom environment variables, this .envrc will read a .env file at the end.
 
 set -e
 
@@ -191,8 +191,9 @@ PATH_add node_modules/.bin
 
 ### Overrides ###
 
-if [ -f .envrc-overrides ]; then
-    source .envrc-overrides
+if [ -f '.env' ]; then
+    info ".env found. Reading it..."
+    dotenv .env
 fi
 
 cat <<EOF

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.envrc-overrides
 .cache/
 .coverage
 .storybook-out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.envrc-overrides
+.env
 .cache/
 .coverage
 .storybook-out/

--- a/Brewfile
+++ b/Brewfile
@@ -9,6 +9,8 @@ brew 'pkgconfig'
 brew 'libxmlsec1'
 brew 'geoip'
 
+brew 'direnv'
+
 tap 'homebrew/cask'
 
 # required for acceptance testing


### PR DESCRIPTION
Here's an initial envrc for direnv, as part of an effort to standardize/enforce the sentry dev environment.

It sets some useful environment variables, and does reasonably quick (time budget TBD) state checking. If initialization is needed to bring up state, like creating `.venv/`, it will do so. Or, in some cases it'll recommend to run certain commands.

