### PR TITLE
feat(workflow): Add UI validation to metric alerts

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -319,6 +319,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
   /**
    * Callback for when triggers change
+   *
+   * Re-validate triggers on every change and reset indicators when no errors
    */
   handleChangeTriggers = (
     triggers: Trigger[],
@@ -328,18 +330,12 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     this.setState(state => {
       let triggerErrors = state.triggerErrors;
 
-      // If we have an existing trigger error, we should attempt to
-      // re-validate triggers when triggers has a change
-      //
-      // Otherwise wait until submit to validate triggers
-      // if (Array.from(state.triggerErrors).length > 0) {
       const newTriggerErrors = this.validateTriggers(triggers, triggerIndex, changeObj);
       triggerErrors = newTriggerErrors;
 
       if (Array.from(newTriggerErrors).length === 0) {
         clearIndicators();
       }
-      // }
 
       return {triggers, triggerErrors};
     });

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -12,8 +12,8 @@ import {
 } from 'app/actionCreators/indicator';
 import {createDefaultTrigger} from 'app/views/settings/incidentRules/constants';
 import {defined} from 'app/utils';
-import {t} from 'app/locale';
 import {fetchOrganizationTags} from 'app/actionCreators/tags';
+import {t} from 'app/locale';
 import Access from 'app/components/acl/access';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
@@ -22,11 +22,17 @@ import Form from 'app/views/settings/components/forms/form';
 import RuleNameForm from 'app/views/settings/incidentRules/ruleNameForm';
 import Triggers from 'app/views/settings/incidentRules/triggers';
 import TriggersChart from 'app/views/settings/incidentRules/triggers/chart';
+import hasThresholdValue from 'app/views/settings/incidentRules/utils/hasThresholdValue';
 import recreateRoute from 'app/utils/recreateRoute';
 import withConfig from 'app/utils/withConfig';
 import withProject from 'app/utils/withProject';
 
-import {AlertRuleAggregations, IncidentRule, Trigger} from '../types';
+import {
+  AlertRuleAggregations,
+  AlertRuleThresholdType,
+  IncidentRule,
+  Trigger,
+} from '../types';
 import {addOrUpdateRule} from '../actions';
 import FormModel from '../../components/forms/model';
 import RuleConditionsForm from '../ruleConditionsForm';
@@ -105,6 +111,54 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     router.replace(recreateRoute('', {routes, params, location, stepBack: -2}));
   }
 
+  /**
+   * Checks to see if threshold is valid given target value, and state of
+   * inverted threshold as well as the *other* threshold
+   *
+   * @param type The threshold type to be updated
+   * @param value The new threshold value
+   */
+  isValidTrigger = (
+    triggerIndex: number,
+    trigger: Trigger,
+    errors,
+    changeObj?: Partial<Trigger>
+  ): boolean => {
+    const {alertThreshold, resolveThreshold} = trigger;
+
+    // If value and/or other value is empty
+    // then there are no checks to perform against
+    if (!hasThresholdValue(alertThreshold) || !hasThresholdValue(resolveThreshold)) {
+      return true;
+    }
+
+    // If this is alert threshold and not inverted, it can't be below resolve
+    // If this is alert threshold and inverted, it can't be above resolve
+    // If this is resolve threshold and not inverted, it can't be above resolve
+    // If this is resolve threshold and inverted, it can't be below resolve
+    const isValid =
+      trigger.thresholdType === AlertRuleThresholdType.BELOW
+        ? alertThreshold <= resolveThreshold
+        : alertThreshold >= resolveThreshold;
+
+    const otherErrors = errors.get(triggerIndex) || {};
+    const isResolveChanged = changeObj?.hasOwnProperty('resolveThreshold');
+    if (!isValid) {
+      errors.set(triggerIndex, {
+        ...otherErrors,
+        [isResolveChanged ? 'resolveThreshold' : 'alertThreshold']: isResolveChanged
+          ? trigger.thresholdType === AlertRuleThresholdType.BELOW
+            ? t('Resolution threshold must be greater than alert')
+            : t('Resolution threshold must be less than alert')
+          : trigger.thresholdType === AlertRuleThresholdType.BELOW
+          ? t('Alert threshold must be less than resolution')
+          : t('Alert threshold must be greater than resolution'),
+      });
+    }
+
+    return isValid;
+  };
+
   validateFieldInTrigger({errors, triggerIndex, field, message, isValid}) {
     // If valid, reset error for fieldName
     if (isValid()) {
@@ -137,7 +191,11 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
    *
    * @return Returns true if triggers are valid
    */
-  validateTriggers(triggers = this.state.triggers) {
+  validateTriggers(
+    triggers = this.state.triggers,
+    changedTriggerIndex?: number,
+    changeObj?: Partial<Trigger>
+  ) {
     const triggerErrors = new Map();
 
     const requiredFields = ['label', 'alertThreshold'];
@@ -152,7 +210,42 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
           message: t('Field is required'),
         });
       });
+
+      // Check thresholds
+      this.isValidTrigger(
+        changedTriggerIndex ?? triggerIndex,
+        trigger,
+        triggerErrors,
+        changeObj
+      );
     });
+
+    // If we have 2 triggers, we need to make sure that the critical and warning
+    // alert thresholds are valid (e.g. if critical is above x, warning must be less than x)
+    if (triggers.length === 2) {
+      const criticalTriggerIndex = triggers.findIndex(({label}) => label === 'critical');
+      const warningTriggerIndex = criticalTriggerIndex ^ 1;
+      const criticalTrigger = triggers[criticalTriggerIndex];
+      const warningTrigger = triggers[warningTriggerIndex];
+
+      const hasError =
+        criticalTrigger.thresholdType === AlertRuleThresholdType.ABOVE
+          ? warningTrigger.alertThreshold > criticalTrigger.alertThreshold
+          : warningTrigger.alertThreshold < criticalTrigger.alertThreshold;
+
+      if (hasError) {
+        [criticalTriggerIndex, warningTriggerIndex].forEach(index => {
+          const otherErrors = triggerErrors.get(index) ?? {};
+          triggerErrors.set(index, {
+            ...otherErrors,
+            alertThreshold:
+              criticalTrigger.thresholdType === AlertRuleThresholdType.BELOW
+                ? t('Warning alert threshold must be greater than critical alert')
+                : t('Warning alert threshold must be less than critical alert'),
+          });
+        });
+      }
+    }
 
     return triggerErrors;
   }
@@ -197,14 +290,21 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       const resp = await addOrUpdateRule(this.api, organization.slug, params.projectId, {
         ...rule,
         ...model.getTransformedData(),
-        triggers: this.state.triggers,
+        triggers: this.state.triggers.map(sanitizeTrigger),
       });
       addSuccessMessage(t('Successfully saved alert'));
       if (onSubmitSuccess) {
         onSubmitSuccess(resp, model);
       }
     } catch (err) {
-      addErrorMessage(t('Unable to save alert'));
+      addErrorMessage(
+        t(
+          'Unable to save alert%s',
+          err?.responseJSON?.nonFieldErrors
+            ? `: ${err.responseJSON.nonFieldErrors.join(', ')}`
+            : ''
+        )
+      );
     }
   };
 
@@ -220,7 +320,11 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   /**
    * Callback for when triggers change
    */
-  handleChangeTriggers = (triggers: Trigger[]) => {
+  handleChangeTriggers = (
+    triggers: Trigger[],
+    triggerIndex?: number,
+    changeObj?: Partial<Trigger>
+  ) => {
     this.setState(state => {
       let triggerErrors = state.triggerErrors;
 
@@ -228,14 +332,14 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       // re-validate triggers when triggers has a change
       //
       // Otherwise wait until submit to validate triggers
-      if (Array.from(state.triggerErrors).length > 0) {
-        const newTriggerErrors = this.validateTriggers(triggers);
-        triggerErrors = newTriggerErrors;
+      // if (Array.from(state.triggerErrors).length > 0) {
+      const newTriggerErrors = this.validateTriggers(triggers, triggerIndex, changeObj);
+      triggerErrors = newTriggerErrors;
 
-        if (Array.from(newTriggerErrors).length === 0) {
-          clearIndicators();
-        }
+      if (Array.from(newTriggerErrors).length === 0) {
+        clearIndicators();
       }
+      // }
 
       return {triggers, triggerErrors};
     });
@@ -356,3 +460,15 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
 export {RuleFormContainer};
 export default withConfig(withProject(RuleFormContainer));
+
+/**
+ * We need a default value of empty string for resolveThreshold or else React complains
+ * so we also need to remove it if we do not have a value. Note `0` is a valid value.
+ */
+function sanitizeTrigger({resolveThreshold, ...trigger}: Trigger): Trigger {
+  return {
+    ...trigger,
+    resolveThreshold:
+      defined(resolveThreshold) && resolveThreshold !== '' ? resolveThreshold : null,
+  };
+}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -143,20 +143,32 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
     const otherErrors = errors.get(triggerIndex) || {};
     const isResolveChanged = changeObj?.hasOwnProperty('resolveThreshold');
-    if (!isValid) {
-      errors.set(triggerIndex, {
-        ...otherErrors,
-        [isResolveChanged ? 'resolveThreshold' : 'alertThreshold']: isResolveChanged
-          ? trigger.thresholdType === AlertRuleThresholdType.BELOW
-            ? t('Resolution threshold must be greater than alert')
-            : t('Resolution threshold must be less than alert')
-          : trigger.thresholdType === AlertRuleThresholdType.BELOW
-          ? t('Alert threshold must be less than resolution')
-          : t('Alert threshold must be greater than resolution'),
-      });
+
+    if (isValid) {
+      return true;
     }
 
-    return isValid;
+    // Not valid... let's figure out an error message
+    const isBelow = trigger.thresholdType === AlertRuleThresholdType.BELOW;
+    const thresholdKey = isResolveChanged ? 'resolveThreshold' : 'alertThreshold';
+    let errorMessage;
+
+    if (isResolveChanged) {
+      errorMessage = isBelow
+        ? t('Resolution threshold must be greater than alert')
+        : t('Resolution threshold must be less than alert');
+    } else {
+      errorMessage = isBelow
+        ? t('Alert threshold must be less than resolution')
+        : t('Alert threshold must be greater than resolution');
+    }
+
+    errors.set(triggerIndex, {
+      ...otherErrors,
+      [thresholdKey]: errorMessage,
+    });
+
+    return false;
   };
 
   validateFieldInTrigger({errors, triggerIndex, field, message, isValid}) {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -154,7 +154,12 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
     const position = this.getChartPixelForThreshold(trigger[type]);
     const isInverted = thresholdType === AlertRuleThresholdType.BELOW;
 
-    if (typeof position !== 'number' || !this.state.height || !this.chartRef) {
+    if (
+      typeof position !== 'number' ||
+      isNaN(position) ||
+      !this.state.height ||
+      !this.chartRef
+    ) {
       return [];
     }
 
@@ -211,7 +216,7 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
     ];
   };
 
-  getChartPixelForThreshold = (threshold: number | '') =>
+  getChartPixelForThreshold = (threshold: number | '' | null) =>
     this.chartRef && this.chartRef.convertToPixel({yAxisIndex: 0}, `${threshold}`);
 
   render() {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/index.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {MetricAction} from 'app/types/alerts';
 import {Organization, Project} from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
-import {Trigger} from 'app/views/settings/incidentRules/types';
 import {removeAtArrayIndex} from 'app/utils/removeAtArrayIndex';
 import {replaceAtArrayIndex} from 'app/utils/replaceAtArrayIndex';
 import {t} from 'app/locale';
@@ -13,6 +12,8 @@ import CircleIndicator from 'app/components/circleIndicator';
 import TriggerForm from 'app/views/settings/incidentRules/triggers/form';
 import space from 'app/styles/space';
 import withProjects from 'app/utils/withProjects';
+
+import {Trigger} from '../types';
 
 type DeleteButtonProps = {
   triggerIndex: number;
@@ -52,7 +53,11 @@ type Props = {
   errors: Map<number, {[fieldName: string]: string}>;
 
   onAdd: () => void;
-  onChange: (triggers: Trigger[]) => void;
+  onChange: (
+    triggers: Trigger[],
+    triggerIndex?: number,
+    changeObj?: Partial<Trigger>
+  ) => void;
 };
 
 /**
@@ -66,11 +71,30 @@ class Triggers extends React.Component<Props> {
     onChange(updatedTriggers);
   };
 
-  handleChangeTrigger = (triggerIndex: number, trigger: Trigger) => {
+  handleChangeTrigger = (
+    triggerIndex: number,
+    trigger: Trigger,
+    changeObj: Partial<Trigger>
+  ) => {
     const {triggers, onChange} = this.props;
-    const updatedTriggers = replaceAtArrayIndex(triggers, triggerIndex, trigger);
+    let updatedTriggers = replaceAtArrayIndex(triggers, triggerIndex, trigger);
 
-    onChange(updatedTriggers);
+    // If we have multiple triggers (warning and critical), we need to make sure
+    // the triggers have the same threshold direction
+    if (triggers.length > 1) {
+      const otherIndex = triggerIndex ^ 1;
+      let otherTrigger = triggers[otherIndex];
+      if (trigger.thresholdType !== otherTrigger.thresholdType) {
+        otherTrigger = {
+          ...otherTrigger,
+          thresholdType: trigger.thresholdType,
+        };
+      }
+
+      updatedTriggers = replaceAtArrayIndex(updatedTriggers, otherIndex, otherTrigger);
+    }
+
+    onChange(updatedTriggers, triggerIndex, changeObj);
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/thresholdControl.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/thresholdControl.tsx
@@ -47,7 +47,7 @@ function ThresholdControl({
     );
   };
 
-  const thresholdName = AlertRuleThreshold.INCIDENT === type ? 'alert' : 'resolution';
+  const thresholdName = AlertRuleThreshold.INCIDENT === type ? 'alert' : 'resolve';
 
   return (
     <div {...props}>
@@ -64,10 +64,10 @@ function ThresholdControl({
       />
       <Input
         disabled={disabled}
-        name={`${thresholdName}ThresholdInput`}
+        name={`${thresholdName}Threshold`}
         type="number"
         placeholder="300"
-        value={threshold}
+        value={threshold ?? ''}
         onChange={onChangeThreshold}
       />
     </div>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -19,13 +19,17 @@ export type UnsavedTrigger = {
   label: string;
   thresholdType: AlertRuleThresholdType;
   alertThreshold: number;
-  resolveThreshold: number | '';
+  resolveThreshold: number | '' | null;
   actions: Action[];
 };
 
 export type ThresholdControlValue = {
   thresholdType: AlertRuleThresholdType;
-  threshold: number | '';
+
+  /**
+   * Resolve threshold is optional, so it can be null
+   */
+  threshold: number | '' | null;
 };
 
 export type SavedTrigger = UnsavedTrigger & {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/utils/hasThresholdValue.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/utils/hasThresholdValue.tsx
@@ -1,0 +1,12 @@
+import {defined} from 'app/utils';
+
+/**
+ * A threshold has a value if it is not one of the following:
+ *
+ * '', null, undefined
+ *
+ *
+ */
+export default function hasThresholdValue(value: number | '' | null): value is number {
+  return defined(value) && value !== '';
+}

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -77,13 +77,13 @@ describe('Incident Rules Details', function() {
     // has existing trigger
     expect(
       wrapper
-        .find('input[name="alertThresholdInput"]')
+        .find('input[name="alertThreshold"]')
         .first()
         .prop('value')
     ).toEqual(70);
     expect(
       wrapper
-        .find('input[name="resolutionThresholdInput"]')
+        .find('input[name="resolveThreshold"]')
         .first()
         .prop('value')
     ).toEqual(36);
@@ -94,11 +94,11 @@ describe('Incident Rules Details', function() {
     wrapper.find('button[aria-label="Add Warning Trigger"]').simulate('click');
 
     wrapper
-      .find('input[name="alertThresholdInput"]')
+      .find('input[name="alertThreshold"]')
       .at(1)
       .simulate('change', {target: {value: 13}});
     wrapper
-      .find('input[name="resolutionThresholdInput"]')
+      .find('input[name="resolveThreshold"]')
       .at(1)
       .simulate('change', {target: {value: 12}});
 
@@ -157,13 +157,13 @@ describe('Incident Rules Details', function() {
     // Has correct values
     expect(
       wrapper
-        .find('input[name="alertThresholdInput"]')
+        .find('input[name="alertThreshold"]')
         .at(1)
         .prop('value')
     ).toBe(13);
     expect(
       wrapper
-        .find('input[name="resolutionThresholdInput"]')
+        .find('input[name="resolveThreshold"]')
         .at(1)
         .prop('value')
     ).toBe(12);


### PR DESCRIPTION
This adds UI validation and better UX for metric alerts, including:

* Syncing the threshold types across Critical and Warning triggers
(above/below)
* Displaying error messages from API
* Validating alert/resolve thresholds for a single trigger
* Validating alert thresholds across critical/warning trigger