### PR TITLE
feat: Build the detailed integration view for Sentry Apps

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1187,6 +1187,17 @@ function routes() {
               </Route>
             </Route>
 
+            <Route
+              name="Sentry App Details"
+              path="sentry-apps/:providerKey"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "ConfigureIntegration" */ 'app/views/organizationIntegrations/sentryAppDetailedView'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+
             <Redirect from=":projectId/" to="projects/:projectId/" />
             <Redirect from=":projectId/alerts/" to="projects/:projectId/alerts/" />
             <Redirect

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -829,6 +829,19 @@ function routes() {
         </Route>
       </Route>
 
+      <Redirect from="sentry-apps/" to="integrations/" />
+      <Route name="Sentry Apps" path="sentry-apps/">
+        <Route
+          name="Details"
+          path=":appSlug"
+          componentPromise={() =>
+            import(
+              /* webpackChunkName: "ConfigureIntegration" */ 'app/views/organizationIntegrations/sentryAppDetailedView'
+            )
+          }
+          component={errorHandler(LazyLoad)}
+        />
+      </Route>
       <Route name="Integrations" path="integrations/">
         <IndexRoute
           componentPromise={() =>
@@ -1186,17 +1199,6 @@ function routes() {
                 {projectSettingsRoutes}
               </Route>
             </Route>
-
-            <Route
-              name="Sentry App Details"
-              path="sentry-apps/:providerKey"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "ConfigureIntegration" */ 'app/views/organizationIntegrations/sentryAppDetailedView'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
 
             <Redirect from=":projectId/" to="projects/:projectId/" />
             <Redirect from=":projectId/alerts/" to="projects/:projectId/alerts/" />

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -169,8 +169,6 @@ class IntegrationDetailedView extends AsyncComponent<
   };
 
   renderBody() {
-    console.log('props: ', this.props);
-    console.log('state: ', this.state);
     const {configurations, tab} = this.state;
     const information = this.getInformation();
     const {organization} = this.props;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -30,15 +30,13 @@ import {growDown, highlight} from 'app/styles/animations';
 import {sortArray} from 'app/utils';
 
 type State = {
-  configurations: Integration[];
   information: {providers: IntegrationProvider[]};
-  tab: string;
   newlyInstalledIntegrationId: string;
 };
 
 type Props = {
   organization: Organization;
-} & RouteComponentProps<{orgId: string; providerKey: string}, {}>;
+} & RouteComponentProps<{providerKey: string}, {}>;
 
 const defaultFeatureGateComponents = {
   IntegrationFeatures: p =>
@@ -59,36 +57,20 @@ const defaultFeatureGateComponents = {
   },
 } as ReturnType<Hooks['integrations:feature-gates']>;
 
-const tabs = ['information', 'configurations'];
+const tabs = ['information'];
 
 class IntegrationDetailedView extends AsyncComponent<
   Props & AsyncComponent['props'],
   State & AsyncComponent['state']
 > {
-  componentDidMount() {
-    const {location} = this.props;
-    const value =
-      typeof location.query.tab === 'string' ? location.query.tab : 'information';
-
-    // eslint-disable-next-line react/no-did-mount-set-state
-    this.setState({tab: value});
-  }
-
   getInformation() {
     return this.state.information.providers[0];
   }
 
   getEndpoints(): ([string, string, any] | [string, string])[] {
-    const {orgId, providerKey} = this.props.params;
+    const {providerKey} = this.props.params;
     const baseEndpoints: ([string, string, any] | [string, string])[] = [
-      [
-        'information',
-        `/organizations/${orgId}/config/integrations/?provider_key=${providerKey}`,
-      ],
-      [
-        'configurations',
-        `/organizations/${orgId}/integrations/?provider_key=${providerKey}`,
-      ],
+      ['published_apps', `/sentry-apps/?status=published&&providerKey=${providerKey}`],
     ];
 
     return baseEndpoints;
@@ -167,143 +149,147 @@ class IntegrationDetailedView extends AsyncComponent<
   onTabChange = value => {
     this.setState({tab: value});
   };
-
   renderBody() {
     console.log('props: ', this.props);
     console.log('state: ', this.state);
-    const {configurations, tab} = this.state;
-    const information = this.getInformation();
-    const {organization} = this.props;
-
-    const {metadata} = information;
-    const alerts = metadata.aspects.alerts || [];
-
-    if (!information.canAdd && metadata.aspects.externalInstall) {
-      alerts.push({
-        type: 'warning',
-        icon: 'icon-exit',
-        text: metadata.aspects.externalInstall.noticeText,
-      });
-    }
-
-    const buttonProps = {
-      style: {marginLeft: space(1)},
-      size: 'small',
-      priority: 'primary',
-    };
-
-    const AddButton = p =>
-      (information.canAdd && (
-        <AddIntegrationButton
-          provider={information}
-          onAddIntegration={this.onInstall}
-          {...buttonProps}
-          {...p}
-        />
-      )) ||
-      (!information.canAdd && metadata.aspects.externalInstall && (
-        <Button
-          icon="icon-exit"
-          href={metadata.aspects.externalInstall.url}
-          onClick={this.handleExternalInstall}
-          external
-          {...buttonProps}
-          {...p}
-        >
-          {metadata.aspects.externalInstall.buttonText}
-        </Button>
-      ));
-
-    // Prepare the features list
-    const features = metadata.features.map(f => ({
-      featureGate: f.featureGate,
-      description: (
-        <FeatureListItem
-          dangerouslySetInnerHTML={{__html: singleLineRenderer(f.description)}}
-        />
-      ),
-    }));
-
-    const featureListHooks = HookStore.get('integrations:feature-gates');
-    featureListHooks.push(() => defaultFeatureGateComponents);
-
-    const {FeatureList, IntegrationFeatures} = featureListHooks[0]();
-    const featureProps = {organization, features};
-    return (
-      <React.Fragment>
-        <Flex>
-          <PluginIcon size={60} pluginId={information.key} />
-          <TitleContainer>
-            <Title>{information.name}</Title>
-            <Flex>
-              {information.features.length && this.featureTags(information.features)}
-            </Flex>
-          </TitleContainer>
-
-          <IntegrationFeatures {...featureProps}>
-            {({disabled, disabledReason}) => (
-              <div
-                style={{
-                  marginLeft: 'auto',
-                  alignSelf: 'center',
-                }}
-              >
-                {disabled && <DisabledNotice reason={disabledReason} />}
-                <Access organization={organization} access={['org:integrations']}>
-                  {({hasAccess}) => (
-                    <Tooltip
-                      title={t(
-                        'You must be an organization owner, manager or admin to install this.'
-                      )}
-                      disabled={hasAccess}
-                    >
-                      <AddButton
-                        data-test-id="add-button"
-                        disabled={disabled || !hasAccess}
-                        organization={organization}
-                      />
-                    </Tooltip>
-                  )}
-                </Access>
-              </div>
-            )}
-          </IntegrationFeatures>
-        </Flex>
-        <ul className="nav nav-tabs border-bottom" style={{paddingTop: '30px'}}>
-          {tabs.map(tabName => (
-            <li
-              key={tabName}
-              className={tab === tabName ? 'active' : ''}
-              onClick={() => this.onTabChange(tabName)}
-            >
-              <a style={{textTransform: 'capitalize'}}>{tabName}</a>
-            </li>
-          ))}
-        </ul>
-        {tab === 'information' ? (
-          <InformationCard alerts={alerts} information={information}>
-            <FeatureList {...featureProps} provider={information} />
-          </InformationCard>
-        ) : (
-          <div>
-            {configurations.map(integration => (
-              <StyledInstalledIntegration
-                key={integration.id}
-                organization={organization}
-                provider={information}
-                integration={integration}
-                onRemove={this.onRemove}
-                onDisable={this.onDisable}
-                onReinstallIntegration={this.onInstall}
-                data-test-id={integration.id}
-                newlyAdded={integration.id === this.state.newlyInstalledIntegrationId}
-              />
-            ))}
-          </div>
-        )}
-      </React.Fragment>
-    );
+    return <div>DetailedViewState</div>;
   }
+  // renderBody() {
+  //   console.log('props: ', this.props);
+  //   console.log('state: ', this.state);
+  //   const {configurations, tab} = this.state;
+  //   const information = this.getInformation();
+  //   const {organization} = this.props;
+
+  //   const {metadata} = information;
+  //   const alerts = metadata.aspects.alerts || [];
+
+  //   if (!information.canAdd && metadata.aspects.externalInstall) {
+  //     alerts.push({
+  //       type: 'warning',
+  //       icon: 'icon-exit',
+  //       text: metadata.aspects.externalInstall.noticeText,
+  //     });
+  //   }
+
+  //   const buttonProps = {
+  //     style: {marginLeft: space(1)},
+  //     size: 'small',
+  //     priority: 'primary',
+  //   };
+
+  //   const AddButton = p =>
+  //     (information.canAdd && (
+  //       <AddIntegrationButton
+  //         provider={information}
+  //         onAddIntegration={this.onInstall}
+  //         {...buttonProps}
+  //         {...p}
+  //       />
+  //     )) ||
+  //     (!information.canAdd && metadata.aspects.externalInstall && (
+  //       <Button
+  //         icon="icon-exit"
+  //         href={metadata.aspects.externalInstall.url}
+  //         onClick={this.handleExternalInstall}
+  //         external
+  //         {...buttonProps}
+  //         {...p}
+  //       >
+  //         {metadata.aspects.externalInstall.buttonText}
+  //       </Button>
+  //     ));
+
+  //   // Prepare the features list
+  //   const features = metadata.features.map(f => ({
+  //     featureGate: f.featureGate,
+  //     description: (
+  //       <FeatureListItem
+  //         dangerouslySetInnerHTML={{__html: singleLineRenderer(f.description)}}
+  //       />
+  //     ),
+  //   }));
+
+  //   const featureListHooks = HookStore.get('integrations:feature-gates');
+  //   featureListHooks.push(() => defaultFeatureGateComponents);
+
+  //   const {FeatureList, IntegrationFeatures} = featureListHooks[0]();
+  //   const featureProps = {organization, features};
+  //   return (
+  //     <React.Fragment>
+  //       <Flex>
+  //         <PluginIcon size={60} pluginId={information.key} />
+  //         <TitleContainer>
+  //           <Title>{information.name}</Title>
+  //           <Flex>
+  //             {information.features.length && this.featureTags(information.features)}
+  //           </Flex>
+  //         </TitleContainer>
+
+  //         <IntegrationFeatures {...featureProps}>
+  //           {({disabled, disabledReason}) => (
+  //             <div
+  //               style={{
+  //                 marginLeft: 'auto',
+  //                 alignSelf: 'center',
+  //               }}
+  //             >
+  //               {disabled && <DisabledNotice reason={disabledReason} />}
+  //               <Access organization={organization} access={['org:integrations']}>
+  //                 {({hasAccess}) => (
+  //                   <Tooltip
+  //                     title={t(
+  //                       'You must be an organization owner, manager or admin to install this.'
+  //                     )}
+  //                     disabled={hasAccess}
+  //                   >
+  //                     <AddButton
+  //                       data-test-id="add-button"
+  //                       disabled={disabled || !hasAccess}
+  //                       organization={organization}
+  //                     />
+  //                   </Tooltip>
+  //                 )}
+  //               </Access>
+  //             </div>
+  //           )}
+  //         </IntegrationFeatures>
+  //       </Flex>
+  //       <ul className="nav nav-tabs border-bottom" style={{paddingTop: '30px'}}>
+  //         {tabs.map(tabName => (
+  //           <li
+  //             key={tabName}
+  //             className={tab === tabName ? 'active' : ''}
+  //             onClick={() => this.onTabChange(tabName)}
+  //           >
+  //             <a style={{textTransform: 'capitalize'}}>{tabName}</a>
+  //           </li>
+  //         ))}
+  //       </ul>
+  //       {tab === 'information' ? (
+  //         <InformationCard alerts={alerts} information={information}>
+  //           <FeatureList {...featureProps} provider={information} />
+  //         </InformationCard>
+  //       ) : (
+  //         <div>
+  //           {configurations.map(integration => (
+  //             <StyledInstalledIntegration
+  //               key={integration.id}
+  //               organization={organization}
+  //               provider={information}
+  //               integration={integration}
+  //               onRemove={this.onRemove}
+  //               onDisable={this.onDisable}
+  //               onReinstallIntegration={this.onInstall}
+  //               data-test-id={integration.id}
+  //               newlyAdded={integration.id === this.state.newlyInstalledIntegrationId}
+  //             />
+  //           ))}
+  //         </div>
+  //       )}
+  //     </React.Fragment>
+  //   );
+  // }
 }
 
 const Flex = styled('div')`

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -172,6 +172,11 @@ export default class SentryAppDetailsModal extends AsyncComponent<
               <Flex>{features.length && this.featureTags(features)}</Flex>
             </NameContainer>
           </Flex>
+          <ul className="nav nav-tabs border-bottom" style={{paddingTop: '30px'}}>
+            <li className="active">
+              <a>Information</a>
+            </li>
+          </ul>
           <Description dangerouslySetInnerHTML={{__html: marked(overview)}} />
           <FeatureList {...featureProps} provider={{...sentryApp, key: sentryApp.slug}} />
 


### PR DESCRIPTION
## Problem
Show a detailed description and feature listsentry apps to integration directory and remove buttons from the right side of the list.

## Solution
Similar design to first-party detailed view except no tab for configurations
- Create a new route for detailed view.
- Create a new view component `sentryAppDetailedView.tsx`

# UI
*New App view*
<img width="1440" alt="Screen Shot 2020-02-03 at 6 28 38 PM" src="https://user-images.githubusercontent.com/10491193/73708451-43df0100-46b3-11ea-84dc-f82768302c97.png">

*Fresh Install*
<img width="1440" alt="Screen Shot 2020-02-03 at 6 28 53 PM" src="https://user-images.githubusercontent.com/10491193/73708483-5a855800-46b3-11ea-851b-25d1a753f4e7.png">

*Uninstall Popup*
<img width="1440" alt="Screen Shot 2020-02-03 at 6 29 13 PM" src="https://user-images.githubusercontent.com/10491193/73708506-6a04a100-46b3-11ea-94a4-f28b421eb511.png">

*Successful Uninstall*
<img width="1440" alt="Screen Shot 2020-02-03 at 6 29 30 PM" src="https://user-images.githubusercontent.com/10491193/73708526-7b4dad80-46b3-11ea-850e-d9a226fc870f.png">
