### PR TITLE
fix(discover2) Fix next and prev Link headers

### DIFF
--- a/tests/sentry/discover/test_utils.py
+++ b/tests/sentry/discover/test_utils.py
@@ -61,8 +61,8 @@ class TransformAliasesAndQueryTest(SnubaTestCase, TestCase):
         result = transform_aliases_and_query(
             aggregations=[["count", "", "count"]],
             filter_keys={"project_id": [self.project.id]},
-            start=before_now(minutes=5),
-            end=before_now(),
+            start=before_now(minutes=10),
+            end=before_now(minutes=-1),
             groupby=["time"],
             orderby=["time"],
             rollup=3600,

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -832,7 +832,6 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             )
 
         assert response.status_code == 200, response.content
-        print (response["Link"])
         links = parse_link_header(response["Link"])
         for link in links:
             assert "field=issue.id" in link
@@ -841,7 +840,6 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             assert "sort=-count_id" in link
             assert "query=language%3AC%2B%2B" in link
 
-        print (links)
         assert len(response.data["data"]) == 2
         data = response.data["data"]
         assert data[0]["count_id"] == 3


### PR DESCRIPTION
The base API only appends one of the query params for each query key. Add a new
version that adds all the values to ensure that all the fields get passed in.