### PR TITLE
feat(integration-directory): adds features and featureDescriptions to plugins

### DIFF
--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -64,6 +64,16 @@ class PluginSerializer(Serializer):
         if obj.description:
             d["description"] = six.text_type(obj.description)
 
+        d["features"] = list(set(f.featureGate.value for f in obj.feature_descriptions))
+
+        d["featureDescriptions"] = [
+            {
+                "description": f.description.strip(),
+                "featureGate": obj.feature_flag_name(f.featureGate.value),
+            }
+            for f in obj.feature_descriptions
+        ]
+
         if obj.resource_links:
             d["resourceLinks"] = [
                 {"title": title, "url": url} for [title, url] in obj.resource_links

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -92,6 +92,9 @@ class IntegrationFeatures(Enum):
     COMMITS = "commits"
     CHAT_UNFURL = "chat-unfurl"
     ALERT_RULE = "alert-rule"
+    # features currently only existing on plugins:
+    DATA_FORWARDING = "data-forwarding"
+    SESSION_REPLAY = "session-replay"
 
 
 class IntegrationProvider(PipelineProvider):

--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -61,6 +61,7 @@ class IPlugin(local, PluggableViewMixin, PluginConfigMixin, PluginStatusMixin):
     author = None
     author_url = None
     resource_links = ()
+    feature_descriptions = []
 
     # Configuration specifics
     conf_key = None

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -56,6 +56,7 @@ class IPlugin2(local, PluginConfigMixin, PluginStatusMixin):
     author = None
     author_url = None
     resource_links = ()
+    feature_descriptions = []
 
     # Configuration specifics
     conf_key = None

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -165,3 +165,13 @@ class PluginConfigMixin(ProviderMixin):
 
     def setup(self, bindings):
         pass
+
+    @staticmethod
+    def feature_flag_name(f):
+        """
+        FeatureDescriptions are set using the IntegrationFeatures constants,
+        however we expose them here as mappings to organization feature flags, thus
+        we prefix them with `integrations`.
+        """
+        if f is not None:
+            return u"integrations-{}".format(f)

--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -10,6 +10,7 @@ from sentry_plugins.base import CorePluginMixin
 from sentry.plugins.bases.data_forwarding import DataForwardingPlugin
 from sentry_plugins.utils import get_secret_field_config
 from sentry.utils import json, metrics
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,15 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
     description = "Forward Sentry events to Amazon SQS."
     conf_key = "amazon-sqs"
     required_field = "queue_url"
+    # TODO(phillip): Probably need a better feature description
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Forward Sentry errors and events to Amazon SQS.
+            """,
+            IntegrationFeatures.DATA_FORWARDING,
+        )
+    ]
 
     def get_config(self, project, **kwargs):
         return [

--- a/src/sentry_plugins/asana/plugin.py
+++ b/src/sentry_plugins/asana/plugin.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from sentry.exceptions import PluginError, PluginIdentityRequired
 from sentry.plugins.bases.issue2 import IssuePlugin2, IssueGroupActionEndpoint
 from sentry.utils.http import absolute_uri
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 from sentry_plugins.base import CorePluginMixin
 from .client import AsanaClient
@@ -24,6 +25,21 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
     conf_key = "asana"
     auth_provider = "asana"
     required_field = "workspace"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Create and link Sentry issue groups directly to an Asana ticket in any of your
+            projects, providing a quick way to jump from a Sentry bug to tracked ticket!
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+        FeatureDescription(
+            """
+            Link Sentry issues to existing Asana tickets
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+    ]
 
     def get_group_urls(self):
         return super(AsanaPlugin, self).get_group_urls() + [

--- a/src/sentry_plugins/asana/plugin.py
+++ b/src/sentry_plugins/asana/plugin.py
@@ -35,7 +35,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
         ),
         FeatureDescription(
             """
-            Link Sentry issues to existing Asana tickets
+            Link Sentry issues to existing Asana tickets.
             """,
             IntegrationFeatures.ISSUE_BASIC,
         ),

--- a/src/sentry_plugins/opsgenie/plugin.py
+++ b/src/sentry_plugins/opsgenie/plugin.py
@@ -10,6 +10,7 @@ from requests import HTTPError
 from sentry import http
 from sentry.plugins.bases import notify
 from sentry.utils import json
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 
 class OpsGenieOptionsForm(notify.NotificationConfigurationForm):
@@ -44,6 +45,14 @@ class OpsGeniePlugin(notify.NotificationPlugin):
     version = sentry.VERSION
     project_conf_form = OpsGenieOptionsForm
     required_field = "api_key"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Configure rule based OpsGenie alerts to automatically be triggered in a specific service
+            """,
+            IntegrationFeatures.ALERT_RULE,
+        )
+    ]
 
     logger = logging.getLogger("sentry.plugins.opsgenie")
 

--- a/src/sentry_plugins/sessionstack/plugin.py
+++ b/src/sentry_plugins/sessionstack/plugin.py
@@ -7,7 +7,7 @@ from sentry.interfaces.contexts import ContextType
 from sentry.plugins.base import Plugin2
 from sentry.plugins.base.configuration import react_plugin_config
 from sentry.exceptions import PluginError
-
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 from sentry_plugins.base import CorePluginMixin
 
 from .client import SessionStackClient, UnauthorizedError, InvalidWebsiteIdError, InvalidApiUrlError
@@ -34,6 +34,15 @@ class SessionStackPlugin(CorePluginMixin, Plugin2):
 
     sessionstack_resource_links = [
         ("Documentation", "http://docs.sessionstack.com/integrations/sentry/")
+    ]
+
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Watch the session replay of your users when they encounter an error in Sentry.
+            """,
+            IntegrationFeatures.SESSION_REPLAY,
+        )
     ]
 
     def get_resource_links(self):

--- a/src/sentry_plugins/sessionstack/plugin.py
+++ b/src/sentry_plugins/sessionstack/plugin.py
@@ -39,7 +39,7 @@ class SessionStackPlugin(CorePluginMixin, Plugin2):
     feature_descriptions = [
         FeatureDescription(
             """
-            Watch the session replay of your users when they encounter an error in Sentry.
+            Watch the SessionStack session replay of a user in a video widget embedded in the Sentry UI for an issue.
             """,
             IntegrationFeatures.SESSION_REPLAY,
         )

--- a/src/sentry_plugins/trello/plugin.py
+++ b/src/sentry_plugins/trello/plugin.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from sentry.utils.http import absolute_uri
 from sentry.plugins.bases.issue2 import IssuePlugin2, IssueGroupActionEndpoint
 from sentry_plugins.base import CorePluginMixin
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 from .client import TrelloApiClient
 
 
@@ -25,6 +26,21 @@ class TrelloPlugin(CorePluginMixin, IssuePlugin2):
     auth_provider = None
     resource_links = [("Trello Setup Instructions", SETUP_URL)] + CorePluginMixin.resource_links
     required_field = "key"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Create and link Sentry issue groups directly to an Trello card in any of your
+            projects, providing a quick way to jump from a Sentry bug to tracked ticket!
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+        FeatureDescription(
+            """
+            Link Sentry issues to existing Trello cards
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+    ]
 
     def get_config(self, project, **kwargs):
         """

--- a/tests/sentry/api/endpoints/test_project_plugins.py
+++ b/tests/sentry/api/endpoints/test_project_plugins.py
@@ -46,3 +46,5 @@ class ProjectPluginsTest(APITestCase):
         assert "slug" in plugin
         assert "type" in plugin
         assert "status" in plugin
+        assert "features" in plugin
+        assert "featureDescriptions" in plugin


### PR DESCRIPTION
This PR adds `features` and `featureDescriptions` to the plugin serializer which are both ultimately derived from the model field `feature_descriptions` which was added to both V1 and V2 plugins. We will use `features` on the top of the detailed plugin view while `featureDescriptions` will go into the content of the information tab which explains what the plugin does.

This field represents the features of a plugin using the same `FeatureDescription` namedtuple that Integrations use. The idea behind this change is to make plugins more similar to integrations so we can leverage the same feature gating logic and UI for plugins as we do with integrations in the new integration directory. This PR adds those fields for 5 plugins: Asana, Trello, Opgsenie, SessionStack, and Amazon SQS.

Please note that there is already a `type` field on the plugin serializer that represents a similar idea. We will continue to use that field on the legacy integrations page. But since there is no description that comes with the `type`, it's inadequate for the work we are doing with the integration directory which necessitates making the plugin views look as similar to integration views as possible.

This PR also adds two new types of integration features: `integrations-data-forwarding` and `integrations-session-replay`. There is currently a feature flag for `projects:data-forwarding` but it making it an integration flag makes more sense here as it is likely we will port over one or more of the data forwarding plugins into a first-party integration. This change will require future changes on the SaaS side of Sentry to properly restrict `integrations-data-forwarding` the same way we restrict `projects:data-forwarding`. 