### PR TITLE
feat(discover) - Add error states to graphs

### DIFF
--- a/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
+++ b/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
@@ -3,19 +3,20 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import HeroIcon from 'app/components/heroIcon';
-import InlineSvg from 'app/components/inlineSvg';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import {IconWarning} from 'app/icons';
+import theme from 'app/utils/theme';
 
 type Props = {
   small?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 const EmptyStateWarning = ({small = false, children}: Props) =>
   small ? (
     <EmptyMessage>
       <SmallMessage>
-        <InlineSvg src="icon-circle-exclamation" width="34px" />
+        <IconWarning color={theme.gray2} size="lg" />
         {children}
       </SmallMessage>
     </EmptyMessage>

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -9,6 +9,8 @@ import FeatureDisabled from 'app/components/acl/featureDisabled';
 import Hovercard from 'app/components/hovercard';
 import InlineSvg from 'app/components/inlineSvg';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import {IconWarning} from 'app/icons';
+import theme from 'app/utils/theme';
 
 import {
   GridColumn,
@@ -30,7 +32,6 @@ import {
   GridBody,
   GridBodyCell,
   GridBodyCellStatus,
-  GridStatusErrorAlert,
   GridResizer,
 } from './styles';
 import GridHeadCell from './gridHeadCell';
@@ -492,14 +493,10 @@ class GridEditable<
   };
 
   renderError() {
-    const {error} = this.props;
-
     return (
       <GridRow>
         <GridBodyCellStatus>
-          <GridStatusErrorAlert type="error" icon="icon-circle-exclamation">
-            {error}
-          </GridStatusErrorAlert>
+          <IconWarning color={theme.gray2} size="lg" />
         </GridBodyCellStatus>
       </GridRow>
     );

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import Alert from 'app/components/alert';
 import InlineSvg from 'app/components/inlineSvg';
 import {Panel, PanelBody} from 'app/components/panels';
 import space from 'app/styles/space';
@@ -315,10 +314,6 @@ export const GridBodyCellStatus = props => (
     <GridStatusFloat>{props.children}</GridStatusFloat>
   </GridStatusWrapper>
 );
-export const GridStatusErrorAlert = styled(Alert)`
-  width: 100%;
-  margin: ${space(2)};
-`;
 
 /**
  * We have a fat GridResizer and we use the ::after pseudo-element to draw

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -13,6 +13,8 @@ import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import {callIfFunction} from 'app/utils/callIfFunction';
+import {IconWarning} from 'app/icons';
+import theme from 'app/utils/theme';
 
 import EventsRequest from './utils/eventsRequest';
 import YAxisSelector from './yAxisSelector';
@@ -166,10 +168,17 @@ class EventsChart extends React.Component {
             includePrevious={includePrevious}
             yAxis={yAxis}
           >
-            {({loading, reloading, timeseriesData, previousTimeseriesData}) => {
+            {({loading, reloading, errored, timeseriesData, previousTimeseriesData}) => {
               return (
                 <ReleaseSeries utc={utc} api={api} projects={projects}>
                   {({releaseSeries}) => {
+                    if (errored) {
+                      return (
+                        <ErrorPanel>
+                          <IconWarning color={theme.gray2} size="lg" />
+                        </ErrorPanel>
+                      );
+                    }
                     if (loading && !reloading) {
                       return <LoadingPanel data-test-id="events-request-loading" />;
                     }
@@ -238,4 +247,18 @@ const TransparentLoadingMask = styled(LoadingMask)`
   ${p => !p.visible && 'display: none;'};
   opacity: 0.4;
   z-index: 1;
+`;
+
+const ErrorPanel = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  flex: 1;
+  flex-shrink: 0;
+  overflow: hidden;
+  height: 200px;
+  position: relative;
+  border-color: transparent;
+  margin-bottom: 0;
 `;

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -18,6 +18,7 @@ import LoadingPanel from '../loadingPanel';
 type RenderProps = {
   loading: boolean;
   reloading: boolean;
+  errored: boolean;
 
   // timeseries data
   timeseriesData?: Series[];
@@ -61,6 +62,7 @@ type EventsRequestProps = DefaultProps & TimeAggregationProps & EventsRequestPar
 
 type EventsRequestState = {
   reloading: boolean;
+  errored: boolean;
   timeseriesData: null | EventsStats;
 };
 
@@ -150,6 +152,11 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     loading: PropTypes.bool,
 
     /**
+     * Whether there was an error retrieving data
+     */
+    errored: PropTypes.bool,
+
+    /**
      * Should loading be shown.
      */
     showLoading: PropTypes.bool,
@@ -177,6 +184,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
 
   state = {
     reloading: !!this.props.loading,
+    errored: false,
     timeseriesData: null,
   };
 
@@ -213,6 +221,9 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
       } else {
         addErrorMessage(t('Error loading chart data'));
       }
+      this.setState({
+        errored: true,
+      });
     }
 
     if (this.unmounting) {
@@ -343,7 +354,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
 
   render() {
     const {children, showLoading, ...props} = this.props;
-    const {timeseriesData, reloading} = this.state;
+    const {timeseriesData, reloading, errored} = this.state;
     // Is "loading" if data is null
     const loading = this.props.loading || timeseriesData === null;
 
@@ -364,6 +375,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     return children({
       loading,
       reloading,
+      errored,
       // timeseries data
       timeseriesData: transformedTimeseriesData,
       allTimeseriesData,

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -12,6 +12,8 @@ import {getInterval} from 'app/components/charts/utils';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingContainer from 'app/components/loading/loadingContainer';
+import {IconWarning} from 'app/icons';
+import theme from 'app/utils/theme';
 
 import EventView from './eventView';
 
@@ -82,12 +84,19 @@ class MiniGraph extends React.Component<Props> {
         environment={environment as string[]}
         includePrevious={false}
       >
-        {({loading, timeseriesData}) => {
+        {({loading, timeseriesData, errored}) => {
+          if (errored) {
+            return (
+              <StyledGraphContainer>
+                <IconWarning color={theme.gray2} size="md" />
+              </StyledGraphContainer>
+            );
+          }
           if (loading) {
             return (
-              <StyledLoadingContainer>
+              <StyledGraphContainer>
                 <LoadingIndicator mini />
-              </StyledLoadingContainer>
+              </StyledGraphContainer>
             );
           }
 
@@ -142,7 +151,7 @@ class MiniGraph extends React.Component<Props> {
   }
 }
 
-const StyledLoadingContainer = styled(props => {
+const StyledGraphContainer = styled(props => {
   return <LoadingContainer {...props} maskBackgroundColor="transparent" />;
 })`
   height: 100px;

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -27,6 +27,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
+import Alert from 'app/components/alert';
 
 import Table from './table';
 import Tags from './tags';
@@ -49,16 +50,18 @@ type Props = {
 
 type State = {
   eventView: EventView;
+  error: string;
 };
 
 class Results extends React.Component<Props, State> {
-  static getDerivedStateFromProps(nextProps: Props): State {
+  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
     const eventView = EventView.fromLocation(nextProps.location);
-    return {eventView};
+    return {eventView, error: prevState.error};
   }
 
   state = {
     eventView: EventView.fromLocation(this.props.location),
+    error: '',
   };
 
   componentDidMount() {
@@ -129,9 +132,24 @@ class Results extends React.Component<Props, State> {
     return <Tags eventView={eventView} organization={organization} location={location} />;
   };
 
+  renderError = error => {
+    if (!error) {
+      return '';
+    }
+    return (
+      <Alert type="error" icon="icon-circle-exclamation">
+        {error}
+      </Alert>
+    );
+  };
+
+  setError = error => {
+    this.setState({error});
+  };
+
   render() {
     const {organization, location, router} = this.props;
-    const {eventView} = this.state;
+    const {eventView, error} = this.state;
     const query = location.query.query || '';
     const title = this.getDocumentTitle();
 
@@ -162,6 +180,7 @@ class Results extends React.Component<Props, State> {
             />
             <StyledPageContent>
               <Top>
+                {this.renderError(error)}
                 <StyledSearchBar
                   organization={organization}
                   projectIds={eventView.project}
@@ -193,6 +212,7 @@ class Results extends React.Component<Props, State> {
                   eventView={eventView}
                   location={location}
                   title={title}
+                  setError={this.setError}
                 />
               </Main>
               <Side eventView={eventView}>{this.renderTagsTable()}</Side>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -21,6 +21,7 @@ type TableProps = {
   eventView: EventView;
   organization: Organization;
   tags: {[key: string]: Tag};
+  setError: (string) => void;
   title: string;
 };
 
@@ -87,7 +88,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
   };
 
   fetchData = () => {
-    const {eventView, organization, location} = this.props;
+    const {eventView, organization, location, setError} = this.props;
     const url = `/organizations/${organization.slug}/eventsv2/`;
 
     const tableFetchID = Symbol('tableFetchID');
@@ -126,6 +127,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
           pageLinks: null,
           tableData: null,
         });
+        setError(err.responseJSON.detail);
       });
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -31,6 +31,7 @@ type State = {
   loading: boolean;
   tags: Tag[];
   totalValues: null | number;
+  error: string;
 };
 
 class Tags extends React.Component<Props, State> {
@@ -45,6 +46,7 @@ class Tags extends React.Component<Props, State> {
     loading: true,
     tags: [],
     totalValues: null,
+    error: '',
   };
 
   componentDidMount() {
@@ -85,6 +87,7 @@ class Tags extends React.Component<Props, State> {
       })
       .catch(err => {
         Sentry.captureException(err);
+        this.setState({loading: false, error: err});
       });
   };
 
@@ -139,15 +142,26 @@ class Tags extends React.Component<Props, State> {
     );
   }
 
+  renderBody = () => {
+    const {loading, error, tags} = this.state;
+    if (loading) {
+      return this.renderPlaceholders();
+    }
+    if (error) {
+      return <EmptyStateWarning small />;
+    }
+    if (tags.length > 0) {
+      return tags.map(tag => this.renderTag(tag));
+    } else {
+      return <EmptyStateWarning small>{t('No tags')}</EmptyStateWarning>;
+    }
+  };
+
   render() {
     return (
       <TagSection>
         <StyledHeading>{t('Event Tag Summary')}</StyledHeading>
-        {this.state.loading && this.renderPlaceholders()}
-        {this.state.tags.length > 0 && this.state.tags.map(tag => this.renderTag(tag))}
-        {!this.state.loading && !this.state.tags.length && (
-          <EmptyStateWarning small>{t('No tags')}</EmptyStateWarning>
-        )}
+        {this.renderBody()}
       </TagSection>
     );
   }


### PR DESCRIPTION
## On the Queries Page:
![image](https://user-images.githubusercontent.com/4205004/73777697-ec46a100-4757-11ea-8aee-c1f6eef436f1.png)
- When a minigraph errors for any reason, show an error icon instead of
  forever loading.

## On the Results Page:
![image](https://user-images.githubusercontent.com/4205004/73777561-b2759a80-4757-11ea-9116-217428efce3c.png)
- When the graph errors, show a warning symbol
- When the facet map errors, show a warning symbol
- Moving the error alert to the top of the page instead, since errors
  apply to the whole page
  - TODO: This alert needs to move from InlineSVG to the new icons since
    it currently has error-circle instead of IconWarning
