### PR TITLE
ref(ecosystem): refactors integrations:feature-gates logic into util function

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/integrationDetailsModal.tsx
@@ -3,14 +3,16 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {trackIntegrationEvent} from 'app/utils/integrationUtil';
+import {
+  trackIntegrationEvent,
+  getIntegrationFeatureGate,
+} from 'app/utils/integrationUtil';
 import {t} from 'app/locale';
 import Access from 'app/components/acl/access';
 import AddIntegrationButton from 'app/views/organizationIntegrations/addIntegrationButton';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
-import HookStore from 'app/stores/hookStore';
 import InlineSvg from 'app/components/inlineSvg';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import SentryTypes from 'app/sentryTypes';
@@ -20,33 +22,10 @@ import marked, {singleLineRenderer} from 'app/utils/marked';
 import space from 'app/styles/space';
 import {IntegrationDetailsModalOptions} from 'app/actionCreators/modal';
 import {Integration} from 'app/types';
-import {Hooks} from 'app/types/hooks';
 
 type Props = {
   closeModal: () => void;
 } & IntegrationDetailsModalOptions;
-
-/**
- * In sentry.io the features list supports rendering plan details. If the hook
- * is not registered for rendering the features list like this simply show the
- * features as a normal list.
- */
-const defaultFeatureGateComponents = {
-  IntegrationFeatures: p =>
-    p.children({
-      disabled: false,
-      disabledReason: null,
-      ungatedFeatures: p.features,
-      gatedFeatureGroups: [],
-    }),
-  FeatureList: p => (
-    <ul>
-      {p.features.map((f, i) => (
-        <li key={i}>{f.description}</li>
-      ))}
-    </ul>
-  ),
-} as ReturnType<Hooks['integrations:feature-gates']>;
 
 class IntegrationDetailsModal extends React.Component<Props> {
   static propTypes = {
@@ -151,10 +130,7 @@ class IntegrationDetailsModal extends React.Component<Props> {
       ),
     }));
 
-    const featureListHooks = HookStore.get('integrations:feature-gates');
-    featureListHooks.push(() => defaultFeatureGateComponents);
-
-    const {FeatureList, IntegrationFeatures} = featureListHooks[0]();
+    const {FeatureList, IntegrationFeatures} = getIntegrationFeatureGate();
     const featureProps = {organization, features};
 
     return (

--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
@@ -11,40 +11,24 @@ import space from 'app/styles/space';
 import {t, tct} from 'app/locale';
 
 import AsyncComponent from 'app/components/asyncComponent';
-import HookStore from 'app/stores/hookStore';
 import marked, {singleLineRenderer} from 'app/utils/marked';
 import InlineSvg from 'app/components/inlineSvg';
 import Tag from 'app/views/settings/components/tag';
 import {toPermissions} from 'app/utils/consolidatedScopes';
 import CircleIndicator from 'app/components/circleIndicator';
 import {SentryAppDetailsModalOptions} from 'app/actionCreators/modal';
-import {Hooks} from 'app/types/hooks';
 import {IntegrationFeature} from 'app/types';
 import {recordInteraction} from 'app/utils/recordSentryAppInteraction';
-import {trackIntegrationEvent} from 'app/utils/integrationUtil';
+import {
+  trackIntegrationEvent,
+  getIntegrationFeatureGate,
+} from 'app/utils/integrationUtil';
 
 type Props = {
   view?: 'integrations_page' | 'external_install';
   closeModal: () => void;
 } & SentryAppDetailsModalOptions &
   AsyncComponent['props'];
-
-const defaultFeatureGateComponents = {
-  IntegrationFeatures: p =>
-    p.children({
-      disabled: false,
-      disabledReason: null,
-      ungatedFeatures: p.features,
-      gatedFeatureGroups: [],
-    }),
-  FeatureList: p => (
-    <ul>
-      {p.features.map((f, i) => (
-        <li key={i}>{f.description}</li>
-      ))}
-    </ul>
-  ),
-} as ReturnType<Hooks['integrations:feature-gates']>;
 
 type State = {
   featureData: IntegrationFeature[];
@@ -188,9 +172,7 @@ export default class SentryAppDetailsModal extends AsyncComponent<Props, State> 
       ),
     }));
 
-    const defaultHook = () => defaultFeatureGateComponents;
-    const featureHook = HookStore.get('integrations:feature-gates')[0] || defaultHook;
-    const {FeatureList, IntegrationFeatures} = featureHook();
+    const {FeatureList, IntegrationFeatures} = getIntegrationFeatureGate();
 
     const overview = sentryApp.overview || '';
     const featureProps = {organization, features};

--- a/src/sentry/static/sentry/app/views/integrationInstallation.tsx
+++ b/src/sentry/static/sentry/app/views/integrationInstallation.tsx
@@ -5,13 +5,15 @@ import styled from '@emotion/styled';
 import {Organization, IntegrationProvider, Integration} from 'app/types';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {t, tct} from 'app/locale';
-import {trackIntegrationEvent} from 'app/utils/integrationUtil';
+import {
+  trackIntegrationEvent,
+  getIntegrationFeatureGate,
+} from 'app/utils/integrationUtil';
 import AddIntegration from 'app/views/organizationIntegrations/addIntegration';
 import Alert from 'app/components/alert';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import Field from 'app/views/settings/components/forms/field';
-import HookStore from 'app/stores/hookStore';
 import NarrowLayout from 'app/components/narrowLayout';
 import SelectControl from 'app/components/forms/selectControl';
 
@@ -134,10 +136,7 @@ export default class IntegrationInstallation extends AsyncView<Props, State> {
       org.slug,
     ]);
 
-    const featureListHooks = HookStore.get('integrations:feature-gates');
-    const FeatureList = featureListHooks.length
-      ? featureListHooks[0]().FeatureList
-      : null;
+    const {FeatureList} = getIntegrationFeatureGate();
 
     return (
       <NarrowLayout>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -6,9 +6,11 @@ import {RouteComponentProps} from 'react-router/lib/Router';
 import {Organization, Integration, IntegrationProvider} from 'app/types';
 import {RequestOptions} from 'app/api';
 import {addErrorMessage} from 'app/actionCreators/indicator';
-import {Hooks} from 'app/types/hooks';
 import {t} from 'app/locale';
-import {trackIntegrationEvent} from 'app/utils/integrationUtil';
+import {
+  trackIntegrationEvent,
+  getIntegrationFeatureGate,
+} from 'app/utils/integrationUtil';
 import AsyncComponent from 'app/components/asyncComponent';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import space from 'app/styles/space';
@@ -24,7 +26,6 @@ import InstalledIntegration, {
   Props as InstalledIntegrationProps,
 } from 'app/views/organizationIntegrations/installedIntegration';
 import marked, {singleLineRenderer} from 'app/utils/marked';
-import HookStore from 'app/stores/hookStore';
 import withOrganization from 'app/utils/withOrganization';
 import {growDown, highlight} from 'app/styles/animations';
 import {sortArray} from 'app/utils';
@@ -39,25 +40,6 @@ type State = {
 type Props = {
   organization: Organization;
 } & RouteComponentProps<{orgId: string; providerKey: string}, {}>;
-
-const defaultFeatureGateComponents = {
-  IntegrationFeatures: p =>
-    p.children({
-      disabled: false,
-      disabledReason: null,
-      ungatedFeatures: p.features,
-      gatedFeatureGroups: [],
-    }),
-  FeatureList: p => {
-    return (
-      <ul>
-        {p.features.map((f, i) => (
-          <li key={i}>{f.description}</li>
-        ))}
-      </ul>
-    );
-  },
-} as ReturnType<Hooks['integrations:feature-gates']>;
 
 const tabs = ['information', 'configurations'];
 
@@ -222,10 +204,7 @@ class IntegrationDetailedView extends AsyncComponent<
       ),
     }));
 
-    const featureListHooks = HookStore.get('integrations:feature-gates');
-    featureListHooks.push(() => defaultFeatureGateComponents);
-
-    const {FeatureList, IntegrationFeatures} = featureListHooks[0]();
+    const {FeatureList, IntegrationFeatures} = getIntegrationFeatureGate();
     const featureProps = {organization, features};
     return (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -14,13 +14,11 @@ import {
   uninstallSentryApp,
 } from 'app/actionCreators/sentryAppInstallations';
 import AsyncComponent from 'app/components/asyncComponent';
-import HookStore from 'app/stores/hookStore';
 import marked, {singleLineRenderer} from 'app/utils/marked';
 import InlineSvg from 'app/components/inlineSvg';
 import Tag from 'app/views/settings/components/tag';
 import {toPermissions} from 'app/utils/consolidatedScopes';
 import CircleIndicator from 'app/components/circleIndicator';
-import {Hooks} from 'app/types/hooks';
 import {
   IntegrationFeature,
   SentryApp,
@@ -28,6 +26,7 @@ import {
   SentryAppInstallation,
 } from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
+import {getIntegrationFeatureGate} from 'app/utils/integrationUtil';
 import {UninstallButton} from '../settings/organizationDeveloperSettings/sentryApplicationRow/installButtons';
 
 type State = {
@@ -38,23 +37,6 @@ type State = {
 type Props = {
   organization: Organization;
 } & RouteComponentProps<{appSlug: string}, {}>;
-
-const defaultFeatureGateComponents = {
-  IntegrationFeatures: p =>
-    p.children({
-      disabled: false,
-      disabledReason: null,
-      ungatedFeatures: p.features,
-      gatedFeatureGroups: [],
-    }),
-  FeatureList: p => (
-    <ul>
-      {p.features.map((f, i) => (
-        <li key={i}>{f.description}</li>
-      ))}
-    </ul>
-  ),
-} as ReturnType<Hooks['integrations:feature-gates']>;
 
 class SentryAppDetailedView extends AsyncComponent<
   Props & AsyncComponent['props'],
@@ -189,9 +171,7 @@ class SentryAppDetailedView extends AsyncComponent<
       ),
     }));
 
-    const defaultHook = () => defaultFeatureGateComponents;
-    const featureHook = HookStore.get('integrations:feature-gates')[0] || defaultHook;
-    const {FeatureList, IntegrationFeatures} = featureHook();
+    const {FeatureList, IntegrationFeatures} = getIntegrationFeatureGate();
 
     const overview = sentryApp.overview || '';
     const featureProps = {organization, features};


### PR DESCRIPTION
We had a lot of duplicated convoluted logic regarding `integrations:feature-gates` that could be encapsulated into a single utility function. The new function `getIntegrationFeatureGate` finds the first value on the hook `integrations:feature-gates` and returns that. If no value can be found, it returns a default value for the component that just lists the features.

Gonna push this on stage to test.