### PR TITLE
fix(plugins): use deprecatedSelectControl for SelectField

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/genericField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/genericField.jsx
@@ -79,7 +79,7 @@ export default class GenericField extends React.Component {
         if (props.has_autocomplete) {
           return <SelectAsyncField deprecatedSelectControl {...props} />;
         }
-        return <SelectField {...props} />;
+        return <SelectField deprecatedSelectControl {...props} />;
       default:
         return null;
     }

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -163,8 +163,7 @@ const SelectControl = props => {
   // Compatibility with old select2 API
   const choicesOrOptions =
     convertFromSelect2Choices(typeof choices === 'function' ? choices(props) : choices) ||
-    options ||
-    [];
+    options;
 
   // Value is expected to be object like the options list, we map it back from
   // the options list

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -163,7 +163,8 @@ const SelectControl = props => {
   // Compatibility with old select2 API
   const choicesOrOptions =
     convertFromSelect2Choices(typeof choices === 'function' ? choices(props) : choices) ||
-    options;
+    options ||
+    [];
 
   // Value is expected to be object like the options list, we map it back from
   // the options list


### PR DESCRIPTION
This PR switches to using `deprecatedSelectControl` for `SelectControl` so we can get the legacy behavior where Trello used to work.

Fixes JAVASCRIPT-21E3