### PR TITLE
meta: move node version check into a yarn shim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ setup-git:
 
 install-yarn-pkgs:
 	@echo "--> Installing Yarn packages (for development)"
-	@command -v $(YARN) 2>&1 > /dev/null || (echo 'yarn not found. Please install it before proceeding.'; exit 1)
 	# Use NODE_ENV=development so that yarn installs both dependencies + devDependencies
 	NODE_ENV=development $(YARN) install --pure-lockfile
 	# A common problem is with node packages not existing in `node_modules` even though `yarn install`

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,7 @@ setup-git:
 	pre-commit install --install-hooks
 	@echo ""
 
-node-version-check:
-	@test "$$(node -v)" = v"$$(cat .nvmrc)" || (echo 'node version does not match .nvmrc. Recommended to use https://github.com/creationix/nvm'; exit 1)
-
-install-yarn-pkgs: node-version-check
+install-yarn-pkgs:
 	@echo "--> Installing Yarn packages (for development)"
 	@command -v $(YARN) 2>&1 > /dev/null || (echo 'yarn not found. Please install it before proceeding.'; exit 1)
 	# Use NODE_ENV=development so that yarn installs both dependencies + devDependencies
@@ -79,7 +76,7 @@ install-sentry-dev:
 	@echo "--> Installing Sentry (for development)"
 	$(PIP) install -e ".[dev]"
 
-build-js-po: node-version-check
+build-js-po:
 	mkdir -p build
 	SENTRY_EXTRACT_TRANSLATIONS=1 $(WEBPACK)
 
@@ -119,7 +116,7 @@ test-cli:
 	rm -r test_cli
 	@echo ""
 
-test-js: node-version-check
+test-js:
 	@echo "--> Building static assets"
 	@$(WEBPACK) --profile --json > .artifacts/webpack-stats.json
 	@echo "--> Running JavaScript tests"
@@ -153,7 +150,7 @@ test-symbolicator:
 	py.test tests/symbolicator -vv --cov . --cov-report="xml:.artifacts/symbolicator.coverage.xml" --junit-xml=".artifacts/symbolicator.junit.xml"
 	@echo ""
 
-test-acceptance: node-version-check
+test-acceptance:
 	sentry init
 	@echo "--> Building static assets"
 	@$(WEBPACK) --display errors-only
@@ -202,7 +199,7 @@ publish:
 	python setup.py sdist bdist_wheel upload
 
 
-.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale update-transifex build-platform-assets test-cli test-js test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
+.PHONY: develop build reset-db clean setup-git install-yarn-pkgs install-sentry-dev build-js-po locale update-transifex build-platform-assets test-cli test-js test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
 
 
 ############################

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# NOTE: this needs to be synced with the node version in:
+#   - .nvmrc (mainly, the dockerfile and travis's nvm use this)
+#   - package.json (for volta)
+node_version="10.16.3"
+
+if ! command -v node >/dev/null; then
+    cat <<EOF
+You don't seem to have node installed. We want version ${node_version}.
+It's recommended to use https://github.com/volta-cli/volta.
+EOF
+    exit 1
+fi
+
+if [[ "$(/usr/bin/env node -v)" != "v${node_version}" ]]; then
+    cat <<EOF
+Your node version doesn't match ${node_version}.
+It's recommended to use https://github.com/volta-cli/volta.
+EOF
+    exit 1
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)"
+exec "${HERE}/yarn-vendored" "$@"


### PR DESCRIPTION
The `node-version-check` make target always felt a little unwieldy and unnecessarily duplicated to me, so I thought it would be a good idea to define it once and for all in a yarn shim.

Also taking advantage of this to recommend volta instead of nvm. Although, I won't be switching us away from `.nvmrc`, mainly since travis doesn't have volta preinstalled. It's also used by our Dockerfile.
