### PR TITLE
ref: Cleanup the eventstore.use-nodestore switch

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -94,14 +94,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         snuba_filter = get_filter(request.GET.get("query", None), params)
         snuba_filter.conditions.append(["event.type", "!=", "transaction"])
 
-        snuba_cols = None if full else eventstore.full_columns
-
-        data_fn = partial(
-            eventstore.get_events,
-            additional_columns=snuba_cols,
-            referrer="api.group-events",
-            filter=snuba_filter,
-        )
+        data_fn = partial(eventstore.get_events, referrer="api.group-events", filter=snuba_filter)
 
         serializer = EventSerializer() if full else SimpleEventSerializer()
         return self.paginate(

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -49,11 +49,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             # or user doesn't have access to projects in org
             data_fn = lambda *args, **kwargs: []
         else:
-            cols = None if full else eventstore.full_columns
-
             data_fn = partial(
                 eventstore.get_events,
-                additional_columns=cols,
                 referrer="api.organization-events",
                 filter=eventstore.Filter(
                     start=snuba_args["start"],

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -50,11 +50,8 @@ class ProjectEventsEndpoint(ProjectEndpoint):
 
         full = request.GET.get("full", False)
 
-        cols = None if full else eventstore.full_columns
-
         data_fn = partial(
             eventstore.get_events,
-            additional_columns=cols,
             filter=eventstore.Filter(conditions=conditions, project_ids=[project.id]),
             referrer="api.project-events",
         )

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from django.utils import timezone
 from sentry_relay import meta_with_chunks
 
-from sentry import eventstore, options
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import EventAttachment, EventError, Release, UserReport
 from sentry.search.utils import convert_user_tag_to_query
@@ -167,9 +166,6 @@ class EventSerializer(Serializer):
         return serialize(user_report, user)
 
     def get_attrs(self, item_list, user, is_public=False):
-        if not options.get("eventstore.use-nodestore"):
-            eventstore.bind_nodes(item_list, "data")
-
         crash_files = get_crash_files(item_list)
         results = {}
         for item in item_list:

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -62,7 +62,6 @@ class Filter(object):
 class EventStorage(Service):
     __all__ = (
         "minimal_columns",
-        "full_columns",
         "create_event",
         "get_event_by_id",
         "get_events",
@@ -80,33 +79,8 @@ class EventStorage(Service):
     # avoid duplicated work.
     minimal_columns = [Columns.EVENT_ID, Columns.GROUP_ID, Columns.PROJECT_ID, Columns.TIMESTAMP]
 
-    # A list of all useful columns we can get from snuba.
-    full_columns = minimal_columns + [
-        Columns.CULPRIT,
-        Columns.LOCATION,
-        Columns.MESSAGE,
-        Columns.PLATFORM,
-        Columns.TITLE,
-        Columns.TYPE,
-        Columns.TRANSACTION,
-        # Required to provide snuba-only tags
-        Columns.TAGS_KEY,
-        Columns.TAGS_VALUE,
-        # Required to provide snuba-only 'user' interface
-        Columns.USER_EMAIL,
-        Columns.USER_IP_ADDRESS,
-        Columns.USER_ID,
-        Columns.USER_USERNAME,
-    ]
-
     def get_events(
-        self,
-        filter,
-        additional_columns=None,
-        orderby=None,
-        limit=100,
-        offset=0,
-        referrer="eventstore.get_events",
+        self, filter, orderby=None, limit=100, offset=0, referrer="eventstore.get_events"
     ):
         """
         Fetches a list of events given a set of criteria.

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -211,12 +211,8 @@ class EventStorage(Service):
         It's not necessary to bind a single Event object since data will be lazily
         fetched on any attempt to access a property.
         """
-        # Temporarily make bind_nodes noop to prevent unnecessary additional calls
-        # to nodestore by the event serializer.
-        unfetched_object_list = [i for i in object_list if not getattr(i, node_name)._node_data]
-
         object_node_list = [
-            (i, getattr(i, node_name)) for i in unfetched_object_list if getattr(i, node_name).id
+            (i, getattr(i, node_name)) for i in object_list if getattr(i, node_name).id
         ]
 
         node_ids = [n.id for _, n in object_node_list]

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 import logging
 
-from sentry import options
 from sentry.eventstore.base import EventStorage
 from sentry.snuba.events import Columns
 from sentry.utils import snuba
@@ -57,17 +56,6 @@ class SnubaEventStorage(EventStorage):
         """
         Get events from Snuba, with node data loaded.
         """
-        if not options.get("eventstore.use-nodestore"):
-            return self.__get_events(
-                filter,
-                additional_columns=additional_columns,
-                orderby=orderby,
-                limit=limit,
-                offset=offset,
-                referrer=referrer,
-                should_bind_nodes=False,
-            )
-
         return self.__get_events(
             filter,
             orderby=orderby,
@@ -100,7 +88,6 @@ class SnubaEventStorage(EventStorage):
     def __get_events(
         self,
         filter,
-        additional_columns=None,
         orderby=None,
         limit=DEFAULT_LIMIT,
         offset=DEFAULT_OFFSET,
@@ -108,7 +95,7 @@ class SnubaEventStorage(EventStorage):
         should_bind_nodes=False,
     ):
         assert filter, "You must provide a filter"
-        cols = self.__get_columns(additional_columns)
+        cols = self.__get_columns()
         orderby = orderby or DESC_ORDERING
 
         result = snuba.aliased_query(
@@ -223,13 +210,8 @@ class SnubaEventStorage(EventStorage):
 
         return self.__get_event_id_from_filter(filter=filter, orderby=DESC_ORDERING)
 
-    def __get_columns(self, additional_columns=None):
-        columns = EventStorage.minimal_columns
-
-        if additional_columns:
-            columns = set(columns + additional_columns)
-
-        return [col.value.event_name for col in columns]
+    def __get_columns(self):
+        return [col.value.event_name for col in EventStorage.minimal_columns]
 
     def __get_event_id_from_filter(self, filter=None, orderby=None):
         columns = [Columns.EVENT_ID.value.alias, Columns.PROJECT_ID.value.alias]

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -47,7 +47,6 @@ class SnubaEventStorage(EventStorage):
     def get_events(
         self,
         filter,
-        additional_columns=None,
         orderby=None,
         limit=DEFAULT_LIMIT,
         offset=DEFAULT_OFFSET,

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -5,7 +5,7 @@ from collections import defaultdict, OrderedDict
 
 from django.db import transaction
 
-from sentry import eventstore, eventstream, options
+from sentry import eventstore, eventstream
 from sentry.app import tsdb
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS_MAP
 from sentry.event_manager import generate_culprit
@@ -517,9 +517,6 @@ def unmerge(
             eventstream.end_unmerge(eventstream_state)
 
         return destination_id
-
-    if not options.get("eventstore.use-nodestore"):
-        eventstore.bind_nodes(events, "data")
 
     source_events = []
     destination_events = []

--- a/tests/sentry/eventstore/test_base.py
+++ b/tests/sentry/eventstore/test_base.py
@@ -5,7 +5,7 @@ from sentry.utils.compat import mock
 import pytest
 import six
 
-from sentry import eventstore, nodestore
+from sentry import eventstore
 from sentry.eventstore.models import Event
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
@@ -41,11 +41,6 @@ class EventStorageTest(TestCase):
         self.eventstorage.bind_nodes([event, event2], "data")
         assert event.data._node_data is not None
         assert event.data["user"]["id"] == u"user1"
-
-        # Bind nodes is noop if node data was already fetched
-        with mock.patch.object(nodestore, "get_multi") as mock_get_multi:
-            self.eventstorage.bind_nodes([event, event2])
-            assert mock_get_multi.call_count == 0
 
 
 class ServiceDelegationTest(TestCase, SnubaTestCase):


### PR DESCRIPTION
This is now rolled out in production, we no longer need to keep the
original behavior.

Also removes temporary code to make bind nodes noop since we are only calling this method in one place now.