### PR TITLE
feat: Show plugins in Integration Directory

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -7,10 +7,10 @@ import {RouteComponentProps} from 'react-router/lib/Router';
 import {
   Organization,
   Integration,
-  Plugin,
   SentryApp,
   IntegrationProvider,
   SentryAppInstallation,
+  PluginWithProjectList,
 } from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {RequestOptions} from 'app/api';
@@ -24,6 +24,7 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import MigrationWarnings from 'app/views/organizationIntegrations/migrationWarnings';
 import PermissionAlert from 'app/views/settings/organization/permissionAlert';
 import ProviderRow from 'app/views/organizationIntegrations/integrationProviderRow';
+import PluginRow from 'app/views/organizationIntegrations/integrationPluginRow';
 import IntegrationDirectoryApplicationRow from 'app/views/settings/organizationDeveloperSettings/sentryApplicationRow/integrationDirectoryApplicationRow';
 import SentryApplicationRow from 'app/views/settings/organizationDeveloperSettings/sentryApplicationRow';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
@@ -33,7 +34,7 @@ import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
 import SearchInput from 'app/components/forms/searchInput';
 
-type AppOrProvider = SentryApp | IntegrationProvider;
+type AppOrProviderOrPlugin = SentryApp | IntegrationProvider | PluginWithProjectList;
 
 type Props = RouteComponentProps<{orgId: string}, {}> & {
   organization: Organization;
@@ -43,7 +44,7 @@ type Props = RouteComponentProps<{orgId: string}, {}> & {
 type State = {
   integrations: Integration[];
   newlyInstalledIntegrationId: string;
-  plugins: Plugin[];
+  plugins: PluginWithProjectList[];
   appInstalls: SentryAppInstallation[];
   orgOwnedApps: SentryApp[];
   publishedApps: SentryApp[];
@@ -51,8 +52,17 @@ type State = {
   extraApp?: SentryApp;
 };
 
-function isSentryApp(integration: AppOrProvider): integration is SentryApp {
-  return (integration as SentryApp).uuid !== undefined;
+function isSentryApp(integration: AppOrProviderOrPlugin): integration is SentryApp {
+  return !!(integration as SentryApp).uuid;
+}
+
+function isPlugin(
+  integration: AppOrProviderOrPlugin
+): integration is PluginWithProjectList {
+  if (integration.hasOwnProperty('doc')) {
+    return true;
+  }
+  return false;
 }
 
 class OrganizationIntegrations extends AsyncComponent<
@@ -95,14 +105,13 @@ class OrganizationIntegrations extends AsyncComponent<
 
   getEndpoints(): ([string, string, any] | [string, string])[] {
     const {orgId} = this.props.params;
-    const query = {plugins: ['vsts', 'github', 'bitbucket']};
     const baseEndpoints: ([string, string, any] | [string, string])[] = [
       ['config', `/organizations/${orgId}/config/integrations/`],
       ['integrations', `/organizations/${orgId}/integrations/`],
-      ['plugins', `/organizations/${orgId}/plugins/`, {query}],
       ['orgOwnedApps', `/organizations/${orgId}/sentry-apps/`],
       ['publishedApps', '/sentry-apps/', {query: {status: 'published'}}],
       ['appInstalls', `/organizations/${orgId}/sentry-app-installations/`],
+      ['plugins', `/organizations/${orgId}/plugins/configs/`],
     ];
     /**
      * optional app to load for super users
@@ -195,7 +204,7 @@ class OrganizationIntegrations extends AsyncComponent<
   };
 
   //Returns 0 if uninstalled, 1 if pending, and 2 if installed
-  getInstallValue(integration: AppOrProvider) {
+  getInstallValue(integration: AppOrProviderOrPlugin) {
     const {integrations} = this.state;
     if (isSentryApp(integration)) {
       const install = this.getAppInstall(integration);
@@ -203,11 +212,13 @@ class OrganizationIntegrations extends AsyncComponent<
         return install.status === 'pending' ? 1 : 2;
       }
       return 0;
+    } else if (isPlugin(integration)) {
+      return integration.projectList.length > 0 ? 2 : 0;
     }
     return integrations.find(i => i.provider.key === integration.key) ? 2 : 0;
   }
 
-  sortIntegrations(integrations: AppOrProvider[]) {
+  sortIntegrations(integrations: AppOrProviderOrPlugin[]) {
     return integrations
       .sort((a, b) => a.name.localeCompare(b.name))
       .sort((a, b) => this.getInstallValue(b) - this.getInstallValue(a));
@@ -227,6 +238,31 @@ class OrganizationIntegrations extends AsyncComponent<
         integrations={integrations}
       />
     );
+  };
+
+  renderPlugin = (plugin: PluginWithProjectList) => {
+    //find the integration installations for that provider
+    if (plugin.projectList.length) {
+      const legacyIds = [
+        'jira',
+        'bitbucket',
+        'github',
+        'slack',
+        'pagerduty',
+        'clubhouse',
+        'vsts',
+      ];
+      const legacy = legacyIds.includes(plugin.id);
+      return (
+        <PluginRow
+          key={`row-plugin-${plugin.id}`}
+          data-test-id="integration-row"
+          plugin={plugin}
+          legacy={legacy}
+        />
+      );
+    }
+    return null;
   };
 
   //render either an internal or non-internal app
@@ -260,16 +296,18 @@ class OrganizationIntegrations extends AsyncComponent<
     return null;
   };
 
-  renderIntegration = (integration: AppOrProvider) => {
+  renderIntegration = (integration: AppOrProviderOrPlugin) => {
     if (isSentryApp(integration)) {
       return this.renderSentryApp(integration);
+    } else if (isPlugin(integration)) {
+      return this.renderPlugin(integration);
     }
     return this.renderProvider(integration);
   };
 
   renderBody() {
     const {orgId} = this.props.params;
-    const {reloading, orgOwnedApps, publishedApps, extraApp} = this.state;
+    const {reloading, orgOwnedApps, publishedApps, extraApp, plugins} = this.state;
     const published = publishedApps || [];
     // If we have an extra app in state from query parameter, add it as org owned app
     if (extraApp) {
@@ -290,8 +328,9 @@ class OrganizationIntegrations extends AsyncComponent<
      */
 
     const publicApps = published.concat(orgOwned.filter(a => a.status === 'published'));
+
     const publicIntegrations = this.sortIntegrations(
-      (publicApps as AppOrProvider[]).concat(this.providers)
+      (publicApps as AppOrProviderOrPlugin[]).concat(this.providers).concat(plugins)
     );
 
     const title = t('Integrations');

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -59,10 +59,7 @@ function isSentryApp(integration: AppOrProviderOrPlugin): integration is SentryA
 function isPlugin(
   integration: AppOrProviderOrPlugin
 ): integration is PluginWithProjectList {
-  if (integration.hasOwnProperty('doc')) {
-    return true;
-  }
-  return false;
+  return integration.hasOwnProperty('shortName');
 }
 
 class OrganizationIntegrations extends AsyncComponent<
@@ -252,13 +249,14 @@ class OrganizationIntegrations extends AsyncComponent<
         'clubhouse',
         'vsts',
       ];
-      const legacy = legacyIds.includes(plugin.id);
+      const isLegacy = legacyIds.includes(plugin.id);
       return (
         <PluginRow
           key={`row-plugin-${plugin.id}`}
           data-test-id="integration-row"
           plugin={plugin}
-          legacy={legacy}
+          isLegacy={isLegacy}
+          organization={this.props.organization}
         />
       );
     }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
@@ -1,5 +1,4 @@
 import {withTheme} from 'emotion-theming';
-import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 import Link from 'app/components/links/link';
@@ -7,40 +6,36 @@ import {PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
 import CircleIndicator from 'app/components/circleIndicator';
 import PluginIcon from 'app/plugins/components/pluginIcon';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
-import {PluginWithProjectList} from 'app/types';
+import {PluginWithProjectList, Organization} from 'app/types';
 
 type Props = {
   plugin: PluginWithProjectList;
-  legacy: boolean;
+  isLegacy: boolean;
+  organization: Organization;
 };
 
 export default class PluginRow extends React.Component<Props> {
-  static propTypes = {
-    plugin: PropTypes.object.isRequired,
-  };
-
-  static contextTypes = {
-    organization: SentryTypes.Organization,
-  };
-
   get isEnabled() {
+    // It's possible to only have items in projectList that are disabled configs (enabled=false).
+    // But for the purpose of showing things that are installed, that might be OK.
     return this.props.plugin.projectList.length > 0;
   }
 
   render() {
-    const {plugin, legacy} = this.props;
     const {
+      plugin,
+      isLegacy,
       organization: {slug},
-    } = this.context;
+    } = this.props;
+
     return (
       <PanelItem p={0} flexDirection="column" data-test-id={plugin.id}>
-        <Flex style={{alignItems: 'center', padding: '16px'}}>
+        <FlexContainer>
           <PluginIcon size={36} pluginId={plugin.id} />
-          <div style={{flex: '1', padding: '0 16px'}}>
+          <Container>
             <ProviderName to={`/settings/${slug}/plugins/${plugin.slug}`}>
-              {`${plugin.name} ${legacy ? '(Legacy)' : ''}`}
+              {`${plugin.name} ${isLegacy ? '(Legacy)' : ''}`}
             </ProviderName>
             <ProviderDetails>
               <Status enabled={this.isEnabled} />
@@ -48,8 +43,8 @@ export default class PluginRow extends React.Component<Props> {
                 to={`/settings/${slug}/plugins/${plugin.slug}?tab=configurations`}
               >{`${plugin.projectList.length} Configurations`}</StyledLink>
             </ProviderDetails>
-          </div>
-        </Flex>
+          </Container>
+        </FlexContainer>
       </PanelItem>
     );
   }
@@ -57,6 +52,16 @@ export default class PluginRow extends React.Component<Props> {
 
 const Flex = styled('div')`
   display: flex;
+`;
+
+const FlexContainer = styled(Flex)`
+  align-items: center;
+  padding: ${space(2)};
+`;
+
+const Container = styled('div')`
+  flex: 1;
+  padding: 0 ${space(2)};
 `;
 
 const ProviderName = styled(Link)`

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
@@ -1,0 +1,111 @@
+import {withTheme} from 'emotion-theming';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from '@emotion/styled';
+import Link from 'app/components/links/link';
+import {PanelItem} from 'app/components/panels';
+import {t} from 'app/locale';
+import CircleIndicator from 'app/components/circleIndicator';
+import PluginIcon from 'app/plugins/components/pluginIcon';
+import SentryTypes from 'app/sentryTypes';
+import space from 'app/styles/space';
+import {PluginWithProjectList} from 'app/types';
+
+type Props = {
+  plugin: PluginWithProjectList;
+  legacy: boolean;
+};
+
+export default class PluginRow extends React.Component<Props> {
+  static propTypes = {
+    plugin: PropTypes.object.isRequired,
+  };
+
+  static contextTypes = {
+    organization: SentryTypes.Organization,
+  };
+
+  get isEnabled() {
+    return this.props.plugin.projectList.length > 0;
+  }
+
+  render() {
+    const {plugin, legacy} = this.props;
+    const {
+      organization: {slug},
+    } = this.context;
+    return (
+      <PanelItem p={0} flexDirection="column" data-test-id={plugin.id}>
+        <Flex style={{alignItems: 'center', padding: '16px'}}>
+          <PluginIcon size={36} pluginId={plugin.id} />
+          <div style={{flex: '1', padding: '0 16px'}}>
+            <ProviderName to={`/settings/${slug}/integrations/${plugin.id}`}>
+              {`${plugin.name} ${legacy ? '(Legacy)' : ''}`}
+            </ProviderName>
+            <ProviderDetails>
+              <Status enabled={this.isEnabled} />
+              <StyledLink
+                to={`/settings/${slug}/integrations/${plugin.id}?tab=configurations`}
+              >{`${plugin.projectList.length} Configurations`}</StyledLink>
+            </ProviderDetails>
+          </div>
+        </Flex>
+      </PanelItem>
+    );
+  }
+}
+
+const Flex = styled('div')`
+  display: flex;
+`;
+
+const ProviderName = styled(Link)`
+  font-weight: bold;
+  color: ${props => props.theme.textColor};
+`;
+
+const ProviderDetails = styled(Flex)`
+  align-items: center;
+  margin-top: 6px;
+  font-size: 0.8em;
+`;
+
+type StatusProps = {
+  enabled: boolean;
+  theme?: any; //TS complains if we don't make this optional
+};
+
+const Status = styled(
+  withTheme((props: StatusProps) => {
+    const {enabled, theme, ...p} = props;
+    return (
+      <StatusWrapper>
+        <CircleIndicator
+          enabled={enabled}
+          size={6}
+          color={enabled ? theme.success : theme.gray2}
+        />
+        <div {...p}>{enabled ? t('Installed') : t('Not Installed')}</div>
+      </StatusWrapper>
+    );
+  })
+)`
+  color: ${(p: StatusProps) => (p.enabled ? p.theme.success : p.theme.gray2)};
+  margin-left: ${space(0.5)};
+  margin-right: ${space(0.75)};
+  &:after {
+    content: '|';
+    color: ${p => p.theme.gray1};
+    margin-left: ${space(0.75)};
+    font-weight: normal;
+  }
+`;
+
+const StatusWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledLink = styled(Link)`
+  color: ${p => p.theme.gray2};
+`;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
@@ -39,13 +39,13 @@ export default class PluginRow extends React.Component<Props> {
         <Flex style={{alignItems: 'center', padding: '16px'}}>
           <PluginIcon size={36} pluginId={plugin.id} />
           <div style={{flex: '1', padding: '0 16px'}}>
-            <ProviderName to={`/settings/${slug}/integrations/${plugin.id}`}>
+            <ProviderName to={`/settings/${slug}/plugins/${plugin.slug}`}>
               {`${plugin.name} ${legacy ? '(Legacy)' : ''}`}
             </ProviderName>
             <ProviderDetails>
               <Status enabled={this.isEnabled} />
               <StyledLink
-                to={`/settings/${slug}/integrations/${plugin.id}?tab=configurations`}
+                to={`/settings/${slug}/plugins/${plugin.slug}?tab=configurations`}
               >{`${plugin.projectList.length} Configurations`}</StyledLink>
             </ProviderDetails>
           </div>


### PR DESCRIPTION
## Problem

Need to show legacy plugins connected to existing projects in the Integration Directory.

## Solution
Show plugins in the Integration Directory if they are connected to projects. Plugins that do not have any connections are not shown. If a connected plugin has an equivalent first-class integration, the tag of `(Legacy)` will be added to the title. Covers Jira, Bitbucket, Github, Slack, PagerDuty, Clubhouse, and VSTS.

## UI
<img width="1440" alt="Screen Shot 2020-02-04 at 5 15 56 PM" src="https://user-images.githubusercontent.com/10491193/73802285-08573c00-4772-11ea-91fe-8dfe5df8c0ba.png">
