### PR TITLE
perf(subscriptions): Use cache when fetching `QuerySubscription` in `QuerySubscriptionConsumer`

### DIFF
--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
 
+from datetime import timedelta
 from enum import Enum
 
 from django.db import models
 from django.utils import timezone
 
 from sentry.db.models import FlexibleForeignKey, Model
+from sentry.db.models.manager import BaseManager
 
 
 class QueryAggregations(Enum):
@@ -30,6 +32,10 @@ class QuerySubscription(Model):
     time_window = models.IntegerField()
     resolution = models.IntegerField()
     date_added = models.DateTimeField(default=timezone.now)
+
+    objects = BaseManager(
+        cache_fields=("pk", "subscription_id"), cache_ttl=int(timedelta(hours=1).total_seconds())
+    )
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -140,7 +140,7 @@ class QuerySubscriptionConsumer(object):
             return
 
         try:
-            subscription = QuerySubscription.objects.get(
+            subscription = QuerySubscription.objects.get_from_cache(
                 subscription_id=contents["subscription_id"]
             )
         except QuerySubscription.DoesNotExist:


### PR DESCRIPTION
This will get called every minute for each subscription, and subscriptions will rarely change, so
this makes sense. Afaict, we auto clear the cache on `post_save` and `post_delete` as part of the
manager, so this should be fine regardless.