### PR TITLE
ref: remove cached-property, using django's implementation instead

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -84,5 +84,4 @@ urllib3==1.24.2
 uwsgi>2.0.0,<2.1.0
 
 # sentry-plugins specific dependencies
-cached-property
 phabricator>=0.6.0,<1.0

--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -6,7 +6,7 @@ import json
 import requests
 
 from bs4 import BeautifulSoup
-from cached_property import cached_property
+from django.utils.functional import cached_property
 from requests.exceptions import ConnectionError, HTTPError
 
 from sentry.http import build_session


### PR DESCRIPTION
We only use it in that one place in plugins, which is mostly a copypaste of the same file in integrations, except that integrations (and all our other code) uses django's cached property implementation. There _should_ be no functional difference between the two.

It was either to pin cached-property in case upstream decides to one day remove support for Python 2.7, or switch to using django's implementation everywhere for consistency.