### PR TITLE
fix(config): remove autocommit option

### DIFF
--- a/docker/sentry.conf.py
+++ b/docker/sentry.conf.py
@@ -66,9 +66,6 @@ if postgres:
                 env('SENTRY_POSTGRES_PORT')
                 or ''
             ),
-            'OPTIONS': {
-                'autocommit': True,
-            },
         },
     }
 


### PR DESCRIPTION
This PR removes the autocommit option from the default sentry.conf.py used by the Docker image.

The autocommit option was deprecated by Django 1.6 and removed in Django 1.8. The change was made in the onpremise repository some months ago: https://github.com/getsentry/onpremise/pull/195 but docker images on docker hub still include it by default.