### PR TITLE
feat(ui): Add projects to the releases list

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -607,4 +607,4 @@ const BubbleWithMinWidth = styled(DropdownBubble)`
 
 export default DropdownAutoCompleteMenu;
 
-export {AutoCompleteRoot};
+export {AutoCompleteRoot, AutoCompleteItem};

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -607,4 +607,4 @@ const BubbleWithMinWidth = styled(DropdownBubble)`
 
 export default DropdownAutoCompleteMenu;
 
-export {AutoCompleteRoot, AutoCompleteItem};
+export {AutoCompleteRoot};

--- a/src/sentry/static/sentry/app/components/hovercard.jsx
+++ b/src/sentry/static/sentry/app/components/hovercard.jsx
@@ -279,4 +279,5 @@ const HovercardArrow = styled('span')`
   }
 `;
 
+export {Hovercard, Body};
 export default Hovercard;

--- a/src/sentry/static/sentry/app/views/releases/list/layout.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/layout.jsx
@@ -4,21 +4,25 @@ import space from 'app/styles/space';
 
 const Layout = styled('div')`
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr;
+  grid-template-columns: 1.25fr minmax(0, 1fr) 1fr 1fr 1fr;
   grid-column-gap: ${space(1.5)};
   width: 100%;
   align-items: center;
-  grid-template-areas: 'release-name stats new-count last-event';
+  grid-template-areas: 'release-name projects stats new-count last-event';
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    grid-template-columns: 3fr 1fr 1fr;
-    grid-template-areas: 'release-name new-count last-event';
+    grid-template-columns: 2fr minmax(0, 2fr) 1fr;
+    grid-template-areas: 'release-name projects new-count';
   }
 `;
 
 const VersionColumn = styled('div')`
   grid-area: release-name;
   overflow: hidden;
+`;
+const ProjectsColumn = styled('div')`
+  grid-area: projects;
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 const StatsColumn = styled('div')`
   grid-area: stats;
@@ -32,5 +36,9 @@ const CountColumn = styled('div')`
 `;
 const LastEventColumn = styled('div')`
   grid-area: last-event;
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    display: none;
+  }
 `;
-export {Layout, VersionColumn, StatsColumn, CountColumn, LastEventColumn};
+export {Layout, VersionColumn, ProjectsColumn, StatsColumn, CountColumn, LastEventColumn};

--- a/src/sentry/static/sentry/app/views/releases/list/layout.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/layout.jsx
@@ -4,7 +4,7 @@ import space from 'app/styles/space';
 
 const Layout = styled('div')`
   display: grid;
-  grid-template-columns: 1.25fr minmax(0, 1fr) 1fr 1fr 1fr;
+  grid-template-columns: 1.25fr 1fr minmax(0, 1fr) 1fr 1fr;
   grid-column-gap: ${space(1.5)};
   width: 100%;
   align-items: center;

--- a/src/sentry/static/sentry/app/views/releases/list/layout.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/layout.jsx
@@ -8,7 +8,7 @@ const Layout = styled('div')`
   grid-column-gap: ${space(1.5)};
   width: 100%;
   align-items: center;
-  grid-template-areas: 'release-name projects stats new-count last-event';
+  grid-template-areas: 'release-name stats projects new-count last-event';
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: 2fr minmax(0, 2fr) 1fr;

--- a/src/sentry/static/sentry/app/views/releases/list/projectList.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectList.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {tct} from 'app/locale';
+import {tct, t} from 'app/locale';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
 import {Project} from 'app/types';
 import space from 'app/styles/space';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
-import Hovercard from 'app/components/hovercard';
+import Hovercard, {Body as HoverCardBody} from 'app/components/hovercard';
 
 const MAX_PROJECTS_IN_HOVERCARD = 5;
 
@@ -29,6 +29,7 @@ const ProjectList = ({projects, orgId, version, maxLines = 2}: Props) => {
     hiddenProjects = projects.slice(maxLines - 1, projects.length);
   }
 
+  const hoverCardHead = t('Release Projects');
   const hovercardBody = (
     <HovercardContentWrapper>
       <ProjectList
@@ -47,6 +48,7 @@ const ProjectList = ({projects, orgId, version, maxLines = 2}: Props) => {
       ))}
       {hiddenProjects.length > 0 && (
         <StyledHovercard
+          header={hoverCardHead}
           body={hovercardBody}
           show={hiddenProjects.length <= MAX_PROJECTS_IN_HOVERCARD ? undefined : false}
         >
@@ -72,16 +74,19 @@ const StyledProjectBadge = styled(ProjectBadge)`
 const StyledHovercard = styled(Hovercard)`
   width: auto;
   max-width: 295px;
+  ${HoverCardBody} {
+    padding-bottom: 0;
+  }
 `;
 const HovercardContentWrapper = styled('div')`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   flex-wrap: wrap;
+  font-size: ${p => p.theme.fontSizeMedium};
   ${StyledProjectBadge} {
-    margin-left: ${space(1)};
-    margin-right: ${space(1)};
-    margin-bottom: ${space(0.5)};
+    margin-right: ${space(3)};
+    margin-bottom: ${space(2)};
   }
 `;
 export default ProjectList;

--- a/src/sentry/static/sentry/app/views/releases/list/projectList.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectList.tsx
@@ -5,15 +5,19 @@ import {tct} from 'app/locale';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
 import {Project} from 'app/types';
 import space from 'app/styles/space';
-import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
-import {AutoCompleteItem} from 'app/components/dropdownAutoCompleteMenu';
+import GlobalSelectionLink from 'app/components/globalSelectionLink';
+import Hovercard from 'app/components/hovercard';
+
+const MAX_PROJECTS_IN_HOVERCARD = 5;
 
 type Props = {
   projects: Project[];
+  orgId: string;
+  version: string;
   maxLines?: number;
 };
 
-const ProjectList = ({projects, maxLines = 2}: Props) => {
+const ProjectList = ({projects, orgId, version, maxLines = 2}: Props) => {
   let visibleProjects: Project[], hiddenProjects: Project[];
 
   if (projects.length <= maxLines) {
@@ -25,27 +29,35 @@ const ProjectList = ({projects, maxLines = 2}: Props) => {
     hiddenProjects = projects.slice(maxLines - 1, projects.length);
   }
 
+  const hovercardBody = (
+    <HovercardContentWrapper>
+      <ProjectList
+        projects={hiddenProjects}
+        orgId={orgId}
+        version={version}
+        maxLines={MAX_PROJECTS_IN_HOVERCARD}
+      />
+    </HovercardContentWrapper>
+  );
+
   return (
     <React.Fragment>
       {visibleProjects.map(project => (
         <StyledProjectBadge project={project} avatarSize={14} key={project.slug} />
       ))}
       {hiddenProjects.length > 0 && (
-        <StyledDropdownAutoComplete
-          maxHeight={400}
-          items={hiddenProjects.map(p => ({
-            searchKey: p.slug,
-            label: <StyledProjectBadge project={p} avatarSize={14} />,
-          }))}
-          alignMenu="left"
-          searchPlaceholder="Filter projects"
+        <StyledHovercard
+          body={hovercardBody}
+          show={hiddenProjects.length <= MAX_PROJECTS_IN_HOVERCARD ? undefined : false}
         >
-          {() =>
-            tct('and [count] more', {
+          <GlobalSelectionLink
+            to={`/organizations/${orgId}/releases/${encodeURIComponent(version)}/`}
+          >
+            {tct('and [count] more', {
               count: hiddenProjects.length,
-            })
-          }
-        </StyledDropdownAutoComplete>
+            })}
+          </GlobalSelectionLink>
+        </StyledHovercard>
       )}
     </React.Fragment>
   );
@@ -57,14 +69,19 @@ const StyledProjectBadge = styled(ProjectBadge)`
   }
 `;
 
-const StyledDropdownAutoComplete = styled(DropdownAutoComplete)`
-  ${AutoCompleteItem} {
-    &,
-    &:hover {
-      background: transparent;
-      cursor: default;
-    }
+const StyledHovercard = styled(Hovercard)`
+  width: auto;
+  max-width: 295px;
+`;
+const HovercardContentWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  ${StyledProjectBadge} {
+    margin-left: ${space(1)};
+    margin-right: ${space(1)};
+    margin-bottom: ${space(0.5)};
   }
 `;
-
 export default ProjectList;

--- a/src/sentry/static/sentry/app/views/releases/list/projectList.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/projectList.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {tct} from 'app/locale';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
+import {Project} from 'app/types';
+import space from 'app/styles/space';
+import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
+import {AutoCompleteItem} from 'app/components/dropdownAutoCompleteMenu';
+
+type Props = {
+  projects: Project[];
+  maxLines?: number;
+};
+
+const ProjectList = ({projects, maxLines = 2}: Props) => {
+  let visibleProjects: Project[], hiddenProjects: Project[];
+
+  if (projects.length <= maxLines) {
+    visibleProjects = projects;
+    hiddenProjects = [];
+  } else {
+    // because we need one line for `and X more`
+    visibleProjects = projects.slice(0, maxLines - 1);
+    hiddenProjects = projects.slice(maxLines - 1, projects.length);
+  }
+
+  return (
+    <React.Fragment>
+      {visibleProjects.map(project => (
+        <StyledProjectBadge project={project} avatarSize={14} key={project.slug} />
+      ))}
+      {hiddenProjects.length > 0 && (
+        <StyledDropdownAutoComplete
+          maxHeight={400}
+          items={hiddenProjects.map(p => ({
+            searchKey: p.slug,
+            label: <StyledProjectBadge project={p} avatarSize={14} />,
+          }))}
+          alignMenu="left"
+          searchPlaceholder="Filter projects"
+        >
+          {() =>
+            tct('and [count] more', {
+              count: hiddenProjects.length,
+            })
+          }
+        </StyledDropdownAutoComplete>
+      )}
+    </React.Fragment>
+  );
+};
+
+const StyledProjectBadge = styled(ProjectBadge)`
+  &:not(:last-child) {
+    margin-bottom: ${space(0.5)};
+  }
+`;
+
+const StyledDropdownAutoComplete = styled(DropdownAutoComplete)`
+  ${AutoCompleteItem} {
+    &,
+    &:hover {
+      background: transparent;
+      cursor: default;
+    }
+  }
+`;
+
+export default ProjectList;

--- a/src/sentry/static/sentry/app/views/releases/list/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseList.jsx
@@ -57,6 +57,8 @@ const ReleaseList = props => {
                       projects={projects.filter(project =>
                         release.projects.map(p => p.slug).includes(project.slug)
                       )}
+                      orgId={orgId}
+                      version={release.version}
                     />
                   </ProjectsColumn>
                   <CountColumn>

--- a/src/sentry/static/sentry/app/views/releases/list/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseList.jsx
@@ -49,16 +49,16 @@ const ReleaseList = props => {
                     </VersionWrapper>
                     <LatestDeployOrReleaseTime orgId={orgId} release={release} />
                   </VersionColumn>
-                  <ProjectsColumn>
-                    <ProjectList
-                      projects={projects.filter(fullProject =>
-                        release.projects.map(p => p.slug).includes(fullProject.slug)
-                      )}
-                    />
-                  </ProjectsColumn>
                   <StatsColumn>
                     <ReleaseStats release={release} />
                   </StatsColumn>
+                  <ProjectsColumn>
+                    <ProjectList
+                      projects={projects.filter(project =>
+                        release.projects.map(p => p.slug).includes(project.slug)
+                      )}
+                    />
+                  </ProjectsColumn>
                   <CountColumn>
                     <Count className="release-count" value={release.newGroups || 0} />
                   </CountColumn>

--- a/src/sentry/static/sentry/app/views/releases/list/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseList.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
+import uniq from 'lodash/uniq';
+import flatten from 'lodash/flatten';
 
 import {PanelItem} from 'app/components/panels';
 import Count from 'app/components/count';
@@ -9,46 +11,70 @@ import TimeSince from 'app/components/timeSince';
 import Version from 'app/components/version';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
+import Projects from 'app/utils/projects';
 
-import {LastEventColumn, Layout, CountColumn, VersionColumn, StatsColumn} from './layout';
+import {
+  LastEventColumn,
+  Layout,
+  CountColumn,
+  VersionColumn,
+  ProjectsColumn,
+  StatsColumn,
+} from './layout';
 import LatestDeployOrReleaseTime from './latestDeployOrReleaseTime';
+import ProjectList from './projectList';
 
 const ReleaseList = props => {
-  const {orgId} = props;
+  const {orgId, releaseList} = props;
+
+  const projectSlugs = uniq(
+    flatten(releaseList.map(release => release.projects.map(p => p.slug)))
+  );
 
   return (
     <div>
-      {props.releaseList.map(release => {
-        return (
-          <ReleasePanelItem key={release.version}>
-            <Layout>
-              <VersionColumn>
-                <VersionWrapper>
-                  <Version
-                    orgId={orgId}
-                    version={release.version}
-                    preserveGlobalSelection
-                  />
-                </VersionWrapper>
-                <LatestDeployOrReleaseTime orgId={orgId} release={release} />
-              </VersionColumn>
-              <StatsColumn>
-                <ReleaseStats release={release} />
-              </StatsColumn>
-              <CountColumn>
-                <Count className="release-count" value={release.newGroups || 0} />
-              </CountColumn>
-              <LastEventColumn>
-                {release.lastEvent ? (
-                  <TimeSince date={release.lastEvent} />
-                ) : (
-                  <span>—</span>
-                )}
-              </LastEventColumn>
-            </Layout>
-          </ReleasePanelItem>
-        );
-      })}
+      <Projects orgId={orgId} slugs={projectSlugs}>
+        {({projects}) =>
+          releaseList.map(release => {
+            return (
+              <ReleasePanelItem key={release.version}>
+                <Layout>
+                  <VersionColumn>
+                    <VersionWrapper>
+                      <Version
+                        orgId={orgId}
+                        version={release.version}
+                        preserveGlobalSelection
+                      />
+                    </VersionWrapper>
+                    <LatestDeployOrReleaseTime orgId={orgId} release={release} />
+                  </VersionColumn>
+                  <ProjectsColumn>
+                    <ProjectList
+                      projects={projects.filter(fullProject =>
+                        release.projects.map(p => p.slug).includes(fullProject.slug)
+                      )}
+                    />
+                  </ProjectsColumn>
+                  <StatsColumn>
+                    <ReleaseStats release={release} />
+                  </StatsColumn>
+                  <CountColumn>
+                    <Count className="release-count" value={release.newGroups || 0} />
+                  </CountColumn>
+                  <LastEventColumn>
+                    {release.lastEvent ? (
+                      <TimeSince date={release.lastEvent} />
+                    ) : (
+                      <span>—</span>
+                    )}
+                  </LastEventColumn>
+                </Layout>
+              </ReleasePanelItem>
+            );
+          })
+        }
+      </Projects>
     </div>
   );
 };

--- a/src/sentry/static/sentry/app/views/releases/list/releaseListHeader.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseListHeader.jsx
@@ -3,13 +3,21 @@ import React from 'react';
 import {PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
 
-import {LastEventColumn, Layout, CountColumn, VersionColumn, StatsColumn} from './layout';
+import {
+  LastEventColumn,
+  Layout,
+  CountColumn,
+  VersionColumn,
+  ProjectsColumn,
+  StatsColumn,
+} from './layout';
 
 const ReleaseListHeader = () => {
   return (
     <PanelHeader>
       <Layout>
         <VersionColumn>{t('Version')}</VersionColumn>
+        <ProjectsColumn>{t('Project')}</ProjectsColumn>
         <StatsColumn />
         <CountColumn>{t('New Issues')}</CountColumn>
         <LastEventColumn>{t('Last Event')}</LastEventColumn>

--- a/tests/js/spec/views/releases/list/projectList.spec.jsx
+++ b/tests/js/spec/views/releases/list/projectList.spec.jsx
@@ -11,9 +11,12 @@ const projects = [
 ];
 
 describe('ProjectList', () => {
-  it('shows the correct amount of projects and hide the rest', () => {
-    const wrapper = mountWithTheme(<ProjectList maxLines={3} projects={projects} />);
+  it('shows the correct amount of projects and hides the rest', () => {
+    const wrapper = mountWithTheme(
+      <ProjectList maxLines={3} projects={projects} />,
+      TestStubs.routerContext()
+    );
     expect(wrapper.find('StyledProjectBadge').length).toBe(2);
-    expect(wrapper.find('StyledDropdownAutoComplete').text()).toBe('and 3 more');
+    expect(wrapper.find('StyledHovercard').text()).toBe('and 3 more');
   });
 });

--- a/tests/js/spec/views/releases/list/projectList.spec.jsx
+++ b/tests/js/spec/views/releases/list/projectList.spec.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {mountWithTheme} from 'sentry-test/enzyme';
+import ProjectList from 'app/views/releases/list/projectList.tsx';
+
+const projects = [
+  {slug: 'test1'},
+  {slug: 'test2'},
+  {slug: 'test3'},
+  {slug: 'test4'},
+  {slug: 'test5'},
+];
+
+describe('ProjectList', () => {
+  it('shows the correct amount of projects and hide the rest', () => {
+    const wrapper = mountWithTheme(<ProjectList maxLines={3} projects={projects} />);
+    expect(wrapper.find('StyledProjectBadge').length).toBe(2);
+    expect(wrapper.find('StyledDropdownAutoComplete').text()).toBe('and 3 more');
+  });
+});


### PR DESCRIPTION
This PR adds a new 'project' column to the releases list.

If the release belongs to one project, the new column will show that project.
If it belongs to two projects, it will show two projects.
If it belongs to 3 and more projects, it will show the first one + 'and X more'.

If you click on 'and X more' you will get a scrollable, searchable list of all other projects.

![chrome-capture (2)](https://user-images.githubusercontent.com/9060071/73933077-001b1000-48dc-11ea-8cdd-192c29a37845.gif)
