### PR TITLE
feat(discover) Display total event count in chart footer

### DIFF
--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -12,12 +12,10 @@ import ReleaseSeries from 'app/components/charts/releaseSeries';
 import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
-import {callIfFunction} from 'app/utils/callIfFunction';
 import {IconWarning} from 'app/icons';
 import theme from 'app/utils/theme';
 
 import EventsRequest from './utils/eventsRequest';
-import YAxisSelector from './yAxisSelector';
 
 class EventsAreaChart extends React.Component {
   static propTypes = {
@@ -103,27 +101,8 @@ class EventsChart extends React.Component {
     utc: PropTypes.bool,
     router: PropTypes.object,
     showLegend: PropTypes.bool,
-    yAxisOptions: PropTypes.array,
-    yAxisValue: PropTypes.string,
-    onYAxisChange: PropTypes.func,
+    yAxis: PropTypes.string,
   };
-
-  handleYAxisChange = value => {
-    const {onYAxisChange} = this.props;
-    callIfFunction(onYAxisChange, value);
-  };
-
-  getYAxisValue() {
-    const {yAxisValue, yAxisOptions} = this.props;
-    if (yAxisValue) {
-      return yAxisValue;
-    }
-    if (yAxisOptions && yAxisOptions.length) {
-      return yAxisOptions[0].value;
-    }
-
-    return undefined;
-  }
 
   render() {
     const {
@@ -137,12 +116,11 @@ class EventsChart extends React.Component {
       projects,
       environments,
       showLegend,
-      yAxisOptions,
+      yAxis,
       ...props
     } = this.props;
     // Include previous only on relative dates (defaults to relative if no start and end)
     const includePrevious = !start && !end;
-    const yAxis = this.getYAxisValue();
 
     return (
       <ChartZoom
@@ -196,13 +174,6 @@ class EventsChart extends React.Component {
                           timeseriesData={timeseriesData}
                           previousTimeseriesData={previousTimeseriesData}
                         />
-                        {yAxisOptions && (
-                          <YAxisSelector
-                            selected={yAxis}
-                            options={yAxisOptions}
-                            onChange={this.handleYAxisChange}
-                          />
-                        )}
                       </React.Fragment>
                     );
                   }}

--- a/src/sentry/static/sentry/app/views/events/yAxisSelector.jsx
+++ b/src/sentry/static/sentry/app/views/events/yAxisSelector.jsx
@@ -5,15 +5,15 @@ import DropdownButton from 'app/components/dropdownButton';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {SectionHeading} from '../eventsV2/styles';
+import {InlineContainer, SectionHeading} from '../eventsV2/styles';
 
 const YAxisSelector = props => {
   const {options, onChange, selected} = props;
   const selectedOption = options.find(opt => selected === opt.value) || options[0];
 
   return (
-    <ChartControls>
-      <StyledLabel>{t('Y-Axis')}</StyledLabel>
+    <InlineContainer>
+      <SectionHeading>{t('Y-Axis')}</SectionHeading>
       <DropdownControl
         menuWidth="auto"
         alignRight
@@ -34,16 +34,9 @@ const YAxisSelector = props => {
           </DropdownItem>
         ))}
       </DropdownControl>
-    </ChartControls>
+    </InlineContainer>
   );
 };
-
-const ChartControls = styled('div')`
-  display: flex;
-  justify-content: flex-end;
-  padding: ${space(1)};
-  border-top: 1px solid ${p => p.theme.borderLight};
-`;
 
 const StyledDropdownButton = styled(DropdownButton)`
   padding: ${space(1)} ${space(2)};
@@ -55,11 +48,6 @@ const StyledDropdownButton = styled(DropdownButton)`
   &:active {
     color: ${p => p.theme.gray4};
   }
-`;
-
-const StyledLabel = styled(SectionHeading)`
-  padding-right: ${space(1)};
-  line-height: 1.2;
 `;
 
 YAxisSelector.propTypes = {

--- a/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import {t} from 'app/locale';
+import {SelectValue} from 'app/types';
+import Count from 'app/components/count';
+import YAxisSelector from 'app/views/events/yAxisSelector';
+
+import {ChartControls, InlineContainer, SectionHeading} from './styles';
+
+type Props = {
+  total: number | null;
+  yAxisValue: string;
+  yAxisOptions: SelectValue<string>[];
+  onChange: (value: string) => void;
+};
+
+export default function ChartFooter({total, yAxisValue, yAxisOptions, onChange}: Props) {
+  return (
+    <ChartControls>
+      <InlineContainer>
+        <SectionHeading>{t('Count')}</SectionHeading>
+        {total === null ? '-' : <Count value={Number(total)} />}
+      </InlineContainer>
+      <YAxisSelector selected={yAxisValue} options={yAxisOptions} onChange={onChange} />
+    </ChartControls>
+  );
+}

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -241,11 +241,7 @@ class Results extends React.Component<Props, State> {
                   <ChartControls>
                     <InlineContainer>
                       <SectionHeading>{t('Count')}</SectionHeading>
-                      {typeof totalValues === 'number' ? (
-                        <Count value={totalValues} />
-                      ) : (
-                        '-'
-                      )}
+                      {totalValues === null ? '-' : <Count value={Number(totalValues)} />}
                     </InlineContainer>
 
                     <YAxisSelector

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {Organization, SavedQuery} from 'app/types';
@@ -10,13 +9,13 @@ import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
 import Hovercard from 'app/components/hovercard';
 import {t} from 'app/locale';
-import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 
 import DiscoverBreadcrumb from './breadcrumb';
 import EventInputName from './eventInputName';
 import EventView from './eventView';
 import SavedQueryButtonGroup from './savedQuery';
+import {HeaderBox, HeaderControls} from './styles';
 
 type Props = {
   api: Client;
@@ -89,7 +88,7 @@ class ResultsHeader extends React.Component<Props, State> {
           organization={organization}
           eventView={eventView}
         />
-        <Controller>
+        <HeaderControls>
           <Feature
             organization={organization}
             features={['discover-query']}
@@ -107,36 +106,10 @@ class ResultsHeader extends React.Component<Props, State> {
               />
             )}
           </Feature>
-        </Controller>
+        </HeaderControls>
       </HeaderBox>
     );
   }
 }
-
-const HeaderBox = styled('div')`
-  padding: ${space(2)} ${space(4)};
-  background-color: ${p => p.theme.white};
-  border-bottom: 1px solid ${p => p.theme.borderDark};
-  grid-row-gap: ${space(2)};
-  margin: 0;
-
-  @media (min-width: ${p => p.theme.breakpoints[1]}) {
-    display: grid;
-    grid-template-rows: 1fr 30px;
-    grid-template-columns: 65% auto;
-    grid-column-gap: ${space(3)};
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints[2]}) {
-    grid-template-columns: auto 325px;
-  }
-`;
-
-const Controller = styled('div')`
-  display: flex;
-  justify-self: end;
-  grid-row: 1/2;
-  grid-column: 2/3;
-`;
 
 export default withApi(ResultsHeader);

--- a/src/sentry/static/sentry/app/views/eventsV2/styles.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/styles.tsx
@@ -9,6 +9,8 @@ export const SectionHeading = styled('h4')`
   color: ${p => p.theme.gray3};
   font-size: ${p => p.theme.fontSizeMedium};
   margin: ${space(1)} 0;
+  padding-right: ${space(1)};
+  line-height: 1.2;
 `;
 
 export const Container = styled('div')`
@@ -27,4 +29,43 @@ export const StyledDateTime = styled(DateTime)`
 
 export const OverflowLink = styled(Link)`
   ${overflowEllipsis};
+`;
+
+export const ChartControls = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  padding: ${space(1)} ${space(3)};
+  border-top: 1px solid ${p => p.theme.borderLight};
+`;
+
+export const HeaderBox = styled('div')`
+  padding: ${space(2)} ${space(4)};
+  background-color: ${p => p.theme.white};
+  border-bottom: 1px solid ${p => p.theme.borderDark};
+  grid-row-gap: ${space(2)};
+  margin: 0;
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    display: grid;
+    grid-template-rows: 1fr 30px;
+    grid-template-columns: 65% auto;
+    grid-column-gap: ${space(3)};
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    grid-template-columns: auto 325px;
+  }
+`;
+
+export const HeaderControls = styled('div')`
+  display: flex;
+  justify-self: end;
+  grid-row: 1/2;
+  grid-column: 2/3;
+`;
+
+export const InlineContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 `;

--- a/tests/js/spec/views/events/eventsAreaChart.spec.jsx
+++ b/tests/js/spec/views/events/eventsAreaChart.spec.jsx
@@ -50,28 +50,4 @@ describe('EventsChart > EventsAreaChart', function() {
     const areaChart = wrapper.find('AreaChart');
     expect(areaChart.props().legend).toHaveProperty('data');
   });
-
-  it('responds to y-axis changes', function() {
-    const options = [
-      {label: 'users', value: 'user_count'},
-      {label: 'events', value: 'event_count'},
-    ];
-    wrapper.setProps({yAxisOptions: options});
-    wrapper.update();
-    const selector = wrapper.find('YAxisSelector');
-    expect(selector).toHaveLength(1);
-
-    // Open the selector
-    selector.find('StyledDropdownButton button').simulate('click');
-
-    // Click one of the options.
-    selector
-      .find('DropdownMenu MenuItem a')
-      .first()
-      .simulate('click');
-    wrapper.update();
-
-    const eventsRequest = wrapper.find('EventsRequest');
-    expect(eventsRequest.props().yAxis).toEqual('user_count');
-  });
 });

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -74,6 +74,12 @@ describe('EventsV2 > Results', function() {
       },
     });
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-meta/',
+      body: {
+        count: 2,
+      },
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/project-slug:deadbeef/',
       method: 'GET',
       body: {
@@ -145,5 +151,43 @@ describe('EventsV2 > Results', function() {
         statsPeriod: '14d',
       },
     });
+  });
+
+  it('renders a y-axis selector', function() {
+    const organization = TestStubs.Organization({
+      features,
+      projects: [TestStubs.Project()],
+    });
+
+    const initialData = initializeOrg({
+      organization,
+      router: {
+        location: {query: {...generateFields(), yAxis: 'count_id'}},
+      },
+    });
+
+    const wrapper = mountWithTheme(
+      <Results
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+      />,
+      initialData.routerContext
+    );
+    const selector = wrapper.find('YAxisSelector');
+    expect(selector).toHaveLength(1);
+
+    // Open the selector
+    selector.find('StyledDropdownButton button').simulate('click');
+
+    // Click one of the options.
+    selector
+      .find('DropdownMenu MenuItem a')
+      .first()
+      .simulate('click');
+    wrapper.update();
+
+    const eventsRequest = wrapper.find('EventsChart');
+    expect(eventsRequest.props().yAxis).toEqual('count_id');
   });
 });

--- a/tests/js/spec/views/eventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/eventsV2/tags.spec.jsx
@@ -22,13 +22,6 @@ describe('Tags', function() {
         },
       ],
     });
-
-    Client.addMockResponse({
-      url: `/organizations/${org.slug}/events-meta/`,
-      body: {
-        count: 2,
-      },
-    });
   });
 
   afterEach(function() {
@@ -48,6 +41,7 @@ describe('Tags', function() {
       <Tags
         eventView={view}
         api={api}
+        totalValues={2}
         organization={org}
         selection={{projects: [], environments: [], datetime: {}}}
         location={{query: {}}}
@@ -85,6 +79,7 @@ describe('Tags', function() {
         eventView={view}
         api={api}
         organization={org}
+        totalValues={2}
         selection={{projects: [], environments: [], datetime: {}}}
         location={initialData.router.location}
       />,


### PR DESCRIPTION
This displays the total number of rows in the chart footer, so that value is visible to users. In a future pull request the tooltip contents will also be moved into the footer.

![Screen Shot 2020-02-05 at 12 13 15 PM](https://user-images.githubusercontent.com/24086/73866790-7273ed80-4813-11ea-8aa8-e843a26a8a27.png)
