### PR TITLE
fix(discover) Fix broken result views for team plan accounts

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -168,6 +168,8 @@ class Sidebar extends React.Component {
       'releases',
       'user-feedback',
       'discover',
+      'discover/queries',
+      'discover/results',
       'releasesv2',
     ].map(route => `/organizations/${this.props.organization.slug}/${route}/`);
 

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -29,6 +29,7 @@ import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import Alert from 'app/components/alert';
 
+import {DEFAULT_EVENT_VIEW} from './data';
 import Table from './table';
 import Tags from './tags';
 import ResultsHeader from './resultsHeader';
@@ -67,6 +68,8 @@ class Results extends React.Component<Props, State> {
   componentDidMount() {
     const {api, organization, selection} = this.props;
     loadOrganizationTags(api, organization.slug, selection);
+
+    this.checkEventView();
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -77,6 +80,23 @@ class Results extends React.Component<Props, State> {
     ) {
       loadOrganizationTags(api, organization.slug, selection);
     }
+    this.checkEventView();
+  }
+
+  checkEventView() {
+    const {eventView} = this.state;
+    if (eventView.isValid()) {
+      return;
+    }
+    // If the view is not valid, redirect to a known valid state.
+    const {location, organization} = this.props;
+    const nextEventView = EventView.fromNewQueryWithLocation(
+      DEFAULT_EVENT_VIEW,
+      location
+    );
+    ReactRouter.browserHistory.replace(
+      nextEventView.getResultsViewUrlTarget(organization.slug)
+    );
   }
 
   handleSearch = (query: string) => {

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {browserHistory} from 'react-router';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import Results from 'app/views/eventsV2/results';
@@ -25,6 +26,7 @@ const generateFields = () => {
 describe('EventsV2 > Results', function() {
   const eventTitle = 'Oh no something bad';
   const features = ['discover-basic'];
+  let eventResultsMock;
 
   beforeEach(function() {
     MockApiClient.addMockResponse({
@@ -52,7 +54,7 @@ describe('EventsV2 > Results', function() {
       url: '/organizations/org-slug/releases/',
       body: [],
     });
-    MockApiClient.addMockResponse({
+    eventResultsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/eventsv2/',
       body: {
         meta: {
@@ -97,6 +99,42 @@ describe('EventsV2 > Results', function() {
 
   afterEach(function() {
     MockApiClient.clearMockResponses();
+  });
+
+  it('loads data when moving from an invalid to valid EventView', function() {
+    const organization = TestStubs.Organization({
+      features,
+      projects: [TestStubs.Project()],
+    });
+
+    // Start off with an invalid view (empty is invalid)
+    const initialData = initializeOrg({
+      organization,
+      router: {
+        location: {query: {}},
+      },
+    });
+
+    const wrapper = mountWithTheme(
+      <Results
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+      />,
+      initialData.routerContext
+    );
+    // No request as eventview was invalid.
+    expect(eventResultsMock).not.toHaveBeenCalled();
+
+    // Should redirect.
+    expect(browserHistory.replace).toHaveBeenCalled();
+
+    // Update location simulating a redirect.
+    wrapper.setProps({location: {query: {...generateFields()}}});
+    wrapper.update();
+
+    // Should load events once
+    expect(eventResultsMock).toHaveBeenCalled();
   });
 
   it('pagination cursor should be cleared when making a search', function() {


### PR DESCRIPTION
The discover sidebar would not properly retain the sidebar state, causing errors related to multiple project selection errors.

Additionally the discover/results/ view would not correctly handle the redirect to the default view. These changes handle the move from an invalid view to a valid one and loads data as expected.