### PR TITLE
feat(integrations-directory) remove feature flag prefixing for plugins

### DIFF
--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -169,9 +169,9 @@ class PluginConfigMixin(ProviderMixin):
     @staticmethod
     def feature_flag_name(f):
         """
-        FeatureDescriptions are set using the IntegrationFeatures constants,
-        however we expose them here as mappings to organization feature flags, thus
-        we prefix them with `integrations`.
+        For the time being, we want the features for plugins to be treated separately than integrations
+        (integration features prefix with integrations-). This is because in Saas Sentry,
+        users can install the Trello and Asana plugins but not Jira even though both utilize issue-commits.
+        By not prefixing, we can avoid making new feature flags for data-forwarding which are restricted.
         """
-        if f is not None:
-            return u"integrations-{}".format(f)
+        return f


### PR DESCRIPTION
This PR removes the `integration-` prefix on plugin features so they do not collide with integration features. This is to ensure that we have consistent behavior on what SaaS users can do with existing plugins on the legacy integrations page:

- Issue commit plugins won't be restricted to free users as they aren't on the legacy integrations page
- Data forwarding plugins will leverage the existing `data-forwarding` feature flag which is restricted on the legacy integrations page

So Amazon SQS will be unavailable on the new integrations page to free users:

![Screen Shot 2020-02-05 at 2 09 26 PM](https://user-images.githubusercontent.com/8533851/73888085-d30a2700-4821-11ea-8bac-0bcc3c12dba2.png)

Eventually, we will want to revert this PR when we figure out how we are going to price integrations for SaaS users.