### PR TITLE
fix(integrations): fixes bug where jira_server would load jira as well

### DIFF
--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -19,7 +19,7 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
         )
 
         if "provider_key" in request.GET:
-            serialized = list(filter(lambda d: d["key"] in request.GET["provider_key"], serialized))
+            serialized = list(filter(lambda d: d["key"] == request.GET["provider_key"], serialized))
 
         if not serialized:
             return Response({"detail": "Providers do not exist"}, status=404)

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -183,3 +183,8 @@ class AliasedIntegrationProvider(ExampleIntegrationProvider):
     key = "aliased"
     integration_key = "example"
     name = "Integration Key Example"
+
+
+class ServerExampleProvider(ExampleIntegrationProvider):
+    key = "example_server"
+    name = "Example Server"

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -186,6 +186,7 @@ def register_extensions():
         ExampleIntegrationProvider,
         AliasedIntegrationProvider,
         ExampleRepositoryProvider,
+        ServerExampleProvider,
     )
     from sentry.integrations.github import GitHubIntegrationProvider
     from sentry.integrations.github_enterprise import GitHubEnterpriseIntegrationProvider
@@ -200,6 +201,7 @@ def register_extensions():
     integrations.register(BitbucketIntegrationProvider)
     integrations.register(ExampleIntegrationProvider)
     integrations.register(AliasedIntegrationProvider)
+    integrations.register(ServerExampleProvider)
     integrations.register(GitHubIntegrationProvider)
     integrations.register(GitHubEnterpriseIntegrationProvider)
     integrations.register(GitlabIntegrationProvider)

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -22,14 +22,14 @@ class OrganizationConfigIntegrationsTest(APITestCase):
         assert provider["name"] == "Example"
         assert provider["setupDialog"]["url"]
 
-
-class OrganizationConfigIntegrationsProviderKeyExistsTest(APITestCase):
-    def test_simple(self):
+    def test_provider_key(self):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")
-        path = u"/api/0/organizations/{}/config/integrations/?provider_key=example".format(org.slug)
+        path = u"/api/0/organizations/{}/config/integrations/?provider_key=example_server".format(
+            org.slug
+        )
         response = self.client.get(path, format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data["providers"]) == 1
-        assert response.data["providers"][0]["name"] == "Example"
+        assert response.data["providers"][0]["name"] == "Example Server"


### PR DESCRIPTION
Previously, if you wanted to get the provider for `jira_server`, it would match `jira` since `"jira_server".starts("jira")` is true. This PR fixes that bug.