### PR TITLE
fix(integration-directory): show all plugins

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -238,29 +238,30 @@ class OrganizationIntegrations extends AsyncComponent<
   };
 
   renderPlugin = (plugin: PluginWithProjectList) => {
-    //find the integration installations for that provider
-    if (plugin.projectList.length) {
-      const legacyIds = [
-        'jira',
-        'bitbucket',
-        'github',
-        'slack',
-        'pagerduty',
-        'clubhouse',
-        'vsts',
-      ];
-      const isLegacy = legacyIds.includes(plugin.id);
-      return (
-        <PluginRow
-          key={`row-plugin-${plugin.id}`}
-          data-test-id="integration-row"
-          plugin={plugin}
-          isLegacy={isLegacy}
-          organization={this.props.organization}
-        />
-      );
+    const legacyIds = [
+      'jira',
+      'bitbucket',
+      'github',
+      'gitlab',
+      'slack',
+      'pagerduty',
+      'clubhouse',
+      'vsts',
+    ];
+    const isLegacy = legacyIds.includes(plugin.id);
+    //hide legacy integrations if we don't have any projects with them
+    if (isLegacy && !plugin.projectList.length) {
+      return null;
     }
-    return null;
+    return (
+      <PluginRow
+        key={`row-plugin-${plugin.id}`}
+        data-test-id="integration-row"
+        plugin={plugin}
+        isLegacy={isLegacy}
+        organization={this.props.organization}
+      />
+    );
   };
 
   //render either an internal or non-internal app


### PR DESCRIPTION
This fixes the bug where only installed plugins would show in the integration directory. Also adds Gitlab to the list of legacy plugins since there is a Gitlab integration.