### PR TITLE
feat(integration-directory): add split hack 

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/SplitInstallationIdModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/SplitInstallationIdModal.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 /**
- * This component is a short term hack for Split.
+ * This component is a hack for Split.
  * It will display the installation ID after installation so users can copy it and paste it in Split's website.
  * We also have a link for users to click so they can go to Split's website.
  */

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -27,6 +27,8 @@ import {
 } from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
 import {getIntegrationFeatureGate} from 'app/utils/integrationUtil';
+import SplitInstallationIdModal from 'app/views/organizationIntegrations/SplitInstallationIdModal';
+import {openModal} from 'app/actionCreators/modal';
 import {UninstallButton} from '../settings/organizationDeveloperSettings/sentryApplicationRow/installButtons';
 
 type State = {
@@ -83,7 +85,6 @@ class SentryAppDetailedView extends AsyncComponent<
       const redirectUrl = addQueryParamsToExistingUrl(sentryApp.redirectUrl, queryParams);
       window.location.assign(redirectUrl);
     }
-    // TODO: Add SplitInstallationIdModal
   };
 
   handleInstall = async () => {
@@ -95,6 +96,17 @@ class SentryAppDetailedView extends AsyncComponent<
     if (!sentryApp.redirectUrl) {
       addSuccessMessage(t(`${sentryApp.slug} successfully installed.`));
       this.setState({appInstalls: [install, ...this.state.appInstalls]});
+
+      //hack for split so we can show the install ID to users for them to copy
+      //Will remove once the proper fix is in place
+      if (['split', 'split-dev', 'split-testing'].includes(sentryApp.slug)) {
+        openModal(({closeModal}) => (
+          <SplitInstallationIdModal
+            installationId={install.uuid}
+            closeModal={closeModal}
+          />
+        ));
+      }
     } else {
       this.redirectUser(install);
     }


### PR DESCRIPTION
A while back, we added a hack for Split (https://github.com/getsentry/sentry/pull/14471) so users could copy the installation ID from Sentry into Split. We have not figured out what the permanent solution is so we need to carry over the hack into the new integration directory.