### PR TITLE
feat: Implement Search for integration directory

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -349,7 +349,12 @@ class OrganizationIntegrations extends AsyncComponent<
     const {reloading, list, displayedList} = this.state;
 
     console.log({list});
-    const fuse = new Fuse(list, {keys: ['slug']});
+    const fuse = new Fuse(list, {
+      threshold: 0.1,
+      location: 0,
+      distance: 100,
+      keys: ['slug', 'key', 'name', 'id'],
+    });
 
     const title = t('Integrations');
     const tags = [
@@ -374,8 +379,11 @@ class OrganizationIntegrations extends AsyncComponent<
           value={this.state.searchInput || ''}
           onChange={({target}) => {
             this.setState({searchInput: target.value}, () => {
+              if (target.value === '') {
+                return this.setState({displayedList: this.state.list});
+              }
               const result = fuse.search(target.value);
-              this.setState({displayedList: result});
+              return this.setState({displayedList: result});
             });
           }}
           placeholder="Find a new integration, or one you already use."

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -89,7 +89,7 @@ class OrganizationIntegrations extends AsyncComponent<
   }
 
   onLoadAllEndpointsSuccess() {
-    const {integrations, publishedApps, orgOwnedApps, extraApp, plugins} = this.state;
+    const {publishedApps, orgOwnedApps, extraApp, plugins} = this.state;
     const published = publishedApps || [];
     // If we have an extra app in state from query parameter, add it as org owned app
     if (extraApp) {
@@ -117,9 +117,13 @@ class OrganizationIntegrations extends AsyncComponent<
 
     const list = this.sortIntegrations(combined);
 
-    this.setState({list, displayedList: list});
+    this.setState({list, displayedList: list}, () => this.setAnalytics());
+  }
 
+  setAnalytics() {
     //count the number of installed apps
+
+    const {integrations, publishedApps} = this.state;
     const integrationsInstalled = new Set();
     //add installed integrations
     integrations.forEach((integration: Integration) => {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -403,6 +403,7 @@ class OrganizationIntegrations extends AsyncComponent<
           value={this.state.searchInput || ''}
           onChange={this.onSearchChange}
           placeholder="Find a new integration, or one you already use."
+          width="100%"
         />
         <TagsContainer>
           {tags.map(tag => (

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -81,6 +81,7 @@ class OrganizationIntegrations extends AsyncComponent<
   };
 
   componentDidMount() {
+    // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({
       list: [],
       displayedList: [],
@@ -348,7 +349,6 @@ class OrganizationIntegrations extends AsyncComponent<
     const {orgId} = this.props.params;
     const {reloading, list, displayedList} = this.state;
 
-    console.log({list});
     const fuse = new Fuse(list, {
       threshold: 0.1,
       location: 0,

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -364,7 +364,7 @@ class OrganizationIntegrations extends AsyncComponent<
 
   renderBody() {
     const {orgId} = this.props.params;
-    const {reloading, list, displayedList} = this.state;
+    const {reloading, displayedList} = this.state;
 
     const title = t('Integrations');
     const tags = [

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -117,10 +117,10 @@ class OrganizationIntegrations extends AsyncComponent<
 
     const list = this.sortIntegrations(combined);
 
-    this.setState({list, displayedList: list}, () => this.setAnalytics());
+    this.setState({list, displayedList: list}, () => this.trackPageViewed());
   }
 
-  setAnalytics() {
+  trackPageViewed() {
     //count the number of installed apps
 
     const {integrations, publishedApps} = this.state;


### PR DESCRIPTION
## Problem
We want the ability to search by name, id, and slug of the available  first-party integrations, sentry apps, plugins.

## Solution
Built front end search using fuzzy matching. It will search by name, slug, and id. Should return results for first-party integrations, sentry apps, plugins. It has live filtering (don’t need to press enter).