### PR TITLE
fix(ui): Updated filter thread info logic

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/filterThreadInfo.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/filterThreadInfo.tsx
@@ -10,19 +10,19 @@ import trimFilename from './trimFilename';
 const NOT_FOUND_FRAME = '<unknown>';
 
 type ThreadInfo = {
-  label: string;
+  label?: string;
   filename?: string;
 };
 
 function filterThreadInfo(thread: Thread, event: Event, simplified: boolean): ThreadInfo {
-  const stacktrace = getThreadStacktrace(thread, event, simplified);
-  const threadInfo: ThreadInfo = {
-    label: NOT_FOUND_FRAME,
-  };
+  const stacktrace = getThreadStacktrace(thread, event, false);
+  const threadInfo: ThreadInfo = {};
 
-  if (!stacktrace) {
+  if (!simplified && !stacktrace) {
     return threadInfo;
   }
+
+  threadInfo.label = NOT_FOUND_FRAME;
 
   const relevantFrame: Frame = getRelevantFrame(stacktrace);
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/filterThreadInfo.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/filterThreadInfo.tsx
@@ -14,33 +14,35 @@ type ThreadInfo = {
   filename?: string;
 };
 
-function filterThreadInfo(thread: Thread, event: Event, simplified: boolean): ThreadInfo {
+function filterThreadInfo(thread: Thread, event: Event): ThreadInfo {
   const stacktrace = getThreadStacktrace(thread, event, false);
   const threadInfo: ThreadInfo = {
     label: NOT_FOUND_FRAME,
   };
 
-  if (!simplified && stacktrace) {
-    const relevantFrame: Frame = getRelevantFrame(stacktrace);
+  if (!stacktrace) {
+    return threadInfo;
+  }
 
-    if (relevantFrame.filename) {
-      threadInfo.filename = trimFilename(relevantFrame.filename);
-    }
+  const relevantFrame: Frame = getRelevantFrame(stacktrace);
 
-    if (relevantFrame.function) {
-      threadInfo.label = relevantFrame.function;
-      return threadInfo;
-    }
+  if (relevantFrame.filename) {
+    threadInfo.filename = trimFilename(relevantFrame.filename);
+  }
 
-    if (relevantFrame.package) {
-      threadInfo.label = trimPackage(relevantFrame.package);
-      return threadInfo;
-    }
+  if (relevantFrame.function) {
+    threadInfo.label = relevantFrame.function;
+    return threadInfo;
+  }
 
-    if (relevantFrame.module) {
-      threadInfo.label = relevantFrame.module;
-      return threadInfo;
-    }
+  if (relevantFrame.package) {
+    threadInfo.label = trimPackage(relevantFrame.package);
+    return threadInfo;
+  }
+
+  if (relevantFrame.module) {
+    threadInfo.label = relevantFrame.module;
+    return threadInfo;
   }
 
   return threadInfo;

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/filterThreadInfo.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/filterThreadInfo.tsx
@@ -10,39 +10,37 @@ import trimFilename from './trimFilename';
 const NOT_FOUND_FRAME = '<unknown>';
 
 type ThreadInfo = {
-  label?: string;
+  label: string;
   filename?: string;
 };
 
 function filterThreadInfo(thread: Thread, event: Event, simplified: boolean): ThreadInfo {
   const stacktrace = getThreadStacktrace(thread, event, false);
-  const threadInfo: ThreadInfo = {};
+  const threadInfo: ThreadInfo = {
+    label: NOT_FOUND_FRAME,
+  };
 
-  if (!simplified && !stacktrace) {
-    return threadInfo;
-  }
+  if (!simplified && stacktrace) {
+    const relevantFrame: Frame = getRelevantFrame(stacktrace);
 
-  threadInfo.label = NOT_FOUND_FRAME;
+    if (relevantFrame.filename) {
+      threadInfo.filename = trimFilename(relevantFrame.filename);
+    }
 
-  const relevantFrame: Frame = getRelevantFrame(stacktrace);
+    if (relevantFrame.function) {
+      threadInfo.label = relevantFrame.function;
+      return threadInfo;
+    }
 
-  if (relevantFrame.filename) {
-    threadInfo.filename = trimFilename(relevantFrame.filename);
-  }
+    if (relevantFrame.package) {
+      threadInfo.label = trimPackage(relevantFrame.package);
+      return threadInfo;
+    }
 
-  if (relevantFrame.function) {
-    threadInfo.label = relevantFrame.function;
-    return threadInfo;
-  }
-
-  if (relevantFrame.package) {
-    threadInfo.label = trimPackage(relevantFrame.package);
-    return threadInfo;
-  }
-
-  if (relevantFrame.module) {
-    threadInfo.label = relevantFrame.module;
-    return threadInfo;
+    if (relevantFrame.module) {
+      threadInfo.label = relevantFrame.module;
+      return threadInfo;
+    }
   }
 
   return threadInfo;

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelector.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelector.tsx
@@ -25,7 +25,7 @@ const DROPDOWN_MAX_HEIGHT = 400;
 
 const ThreadsSelector = ({threads, event, activeThread, onChange}: Props) => {
   const getDropDownItem = (thread: Thread) => {
-    const threadInfo = filterThreadInfo(thread, event, false);
+    const threadInfo = filterThreadInfo(thread, event);
 
     const dropDownValue = `#${thread.id}: ${thread.name} ${threadInfo.label} ${threadInfo.filename}`;
     let crashedInfo: undefined | EntryTypeData;
@@ -93,7 +93,7 @@ const ThreadsSelector = ({threads, event, activeThread, onChange}: Props) => {
               ) : (
                 <ThreadsSelectorSelectedOption
                   id={activeThread.id}
-                  details={filterThreadInfo(activeThread, event, true)}
+                  details={filterThreadInfo(activeThread, event)}
                 />
               )}
             </StyledDropdownButton>

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelector.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelector.tsx
@@ -112,7 +112,9 @@ const StyledDropdownButton = styled(DropdownButton)`
   }
   width: 100%;
 
+  min-width: 150px;
+
   @media (min-width: ${props => props.theme.breakpoints[3]}) {
-    width: 420px;
+    max-width: 420px;
   }
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelectorOption.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelectorOption.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 type ThreadInfo = {
-  label?: string;
+  label: string;
   filename?: string;
 };
 
@@ -26,7 +26,7 @@ const ThreadsSelectorOption = ({id, name, details, crashed, crashedInfo}: Props)
     <DetailsWrapper>
       <StyledNameId>{name ? `#${id}: ${name}` : `#${id}`}</StyledNameId>
       <LabelsWrapper>
-        {details.label && <StyledOptionLabel>{details.label}</StyledOptionLabel>}
+        <StyledOptionLabel>{details.label}</StyledOptionLabel>
         {details.filename && (
           <StyledFileNameWrapper>
             {'('}

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelectorOption.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelectorOption.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 type ThreadInfo = {
-  label: string;
+  label?: string;
   filename?: string;
 };
 
@@ -26,7 +26,7 @@ const ThreadsSelectorOption = ({id, name, details, crashed, crashedInfo}: Props)
     <DetailsWrapper>
       <StyledNameId>{name ? `#${id}: ${name}` : `#${id}`}</StyledNameId>
       <LabelsWrapper>
-        <StyledOptionLabel>{details.label}</StyledOptionLabel>
+        {details.label && <StyledOptionLabel>{details.label}</StyledOptionLabel>}
         {details.filename && (
           <StyledFileNameWrapper>
             {'('}

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelectorSelectedOption.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelectorSelectedOption.tsx
@@ -10,14 +10,14 @@ type Props = {
 };
 
 type ThreadInfo = {
-  label?: string;
+  label: string;
   filename?: string;
 };
 
 const ThreadsSelectorSelectedOption = ({id, details}: Props) => (
   <Wrapper>
     <StyledThreadID>{`Thread #${id}:`}</StyledThreadID>
-    {details.label && <StyledOptionLabel>{details.label}</StyledOptionLabel>}
+    <StyledOptionLabel>{details.label}</StyledOptionLabel>
   </Wrapper>
 );
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelectorSelectedOption.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelectorSelectedOption.tsx
@@ -10,21 +10,21 @@ type Props = {
 };
 
 type ThreadInfo = {
-  label: string;
+  label?: string;
   filename?: string;
 };
 
 const ThreadsSelectorSelectedOption = ({id, details}: Props) => (
   <Wrapper>
     <StyledThreadID>{`Thread #${id}:`}</StyledThreadID>
-    <StyledOptionLabel>{details.label}</StyledOptionLabel>
+    {details.label && <StyledOptionLabel>{details.label}</StyledOptionLabel>}
   </Wrapper>
 );
 
 export default ThreadsSelectorSelectedOption;
 
 const Wrapper = styled('div')`
-  grid-template-columns: 110px 1fr;
+  grid-template-columns: auto 1fr;
   display: grid;
 `;
 


### PR DESCRIPTION
**Type:** Fix

**Description:**
In some use cases, the default value of the thread selector was not correct and this was because the third parameter was true when in fact it should be false. Please see:

`const stacktrace = getThreadStacktrace(thread, event, true);` 

This PR fixes this bug.