### PR TITLE
build(manifest): Fix README file name in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include setup.py README.rst MANIFEST.in LICENSE AUTHORS
+include setup.py README.md MANIFEST.in LICENSE AUTHORS
 recursive-include ./ requirements*.txt
 graft src/sentry
 global-exclude *~


### PR DESCRIPTION
This is a follow up to #16301.