### PR TITLE
fix(discover) Include projects in default view redirect

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -89,11 +89,15 @@ class Results extends React.Component<Props, State> {
       return;
     }
     // If the view is not valid, redirect to a known valid state.
-    const {location, organization} = this.props;
+    const {location, organization, selection} = this.props;
     const nextEventView = EventView.fromNewQueryWithLocation(
       DEFAULT_EVENT_VIEW,
       location
     );
+    if (nextEventView.project.length === 0 && selection.projects) {
+      nextEventView.project = selection.projects;
+    }
+
     ReactRouter.browserHistory.replace(
       nextEventView.getResultsViewUrlTarget(organization.slug)
     );


### PR DESCRIPTION
When a project is forced into the global selection, the location may not be updated yet. Including projects from the global selection into our default view redirect ensures that accounts that can only look at a single project get a working result page.