### PR TITLE
fix(discover) Fix resizing columns and errant border

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -11,13 +11,15 @@ import {
 } from './styles';
 import {GridColumnHeader} from './types';
 
-export type GridHeadCellProps<Column> = {
-  isColumnDragging: boolean;
-  gridHeadCellButtonProps: {[prop: string]: any};
-  isLast: boolean;
-
+type DefaultProps = {
+  isFirst: boolean;
   isEditing: boolean;
   isDeletable: boolean;
+};
+
+export type GridHeadCellProps<Column> = DefaultProps & {
+  isColumnDragging: boolean;
+  gridHeadCellButtonProps: {[prop: string]: any};
 
   indexColumnOrder: number;
   column: Column;
@@ -35,6 +37,7 @@ export type GridHeadCellProps<Column> = {
     toggleModalEditColumn: (index?: number, column?: Column) => void;
   };
 };
+
 export type GridHeadCellState = {
   isHovering: boolean;
 };
@@ -48,9 +51,10 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
   GridHeadCellProps<Column>,
   GridHeadCellState
 > {
-  static defaultProps = {
+  static defaultProps: DefaultProps = {
     isEditing: false,
     isDeletable: true,
+    isFirst: false,
   };
 
   state = {
@@ -121,10 +125,10 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
   }
 
   render() {
-    const {isEditing, children, column, gridHeadCellButtonProps} = this.props;
+    const {isEditing, isFirst, children, column, gridHeadCellButtonProps} = this.props;
 
     return (
-      <GridHeadCellWrapper>
+      <GridHeadCellWrapper isFirst={isFirst}>
         <GridHeadCellButton
           isDragging={column.isDragging}
           {...gridHeadCellButtonProps}

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -37,7 +37,7 @@ import {
 import GridHeadCell from './gridHeadCell';
 import GridModalEditColumn from './gridModalEditColumn';
 
-import {COL_WIDTH_UNDEFINED, ColResizeMetadata} from './utils';
+import {COL_WIDTH_MINIMUM, COL_WIDTH_UNDEFINED, ColResizeMetadata} from './utils';
 
 type GridEditableProps<DataRow, ColumnKey> = {
   onToggleEdit?: (nextValue: boolean) => void;
@@ -288,7 +288,7 @@ class GridEditable<
     const nextColumnOrder = [...this.props.columnOrder];
     nextColumnOrder[metadata.columnIndex] = {
       ...nextColumnOrder[metadata.columnIndex],
-      width: metadata.columnWidth + widthChange,
+      width: Math.max(metadata.columnWidth + widthChange, 0),
     };
 
     this.setGridTemplateColumns(nextColumnOrder);
@@ -312,10 +312,13 @@ class GridEditable<
     const prependColumns = this.props.grid.prependColumnWidths || [];
     const prepend = prependColumns.join(' ');
     const widths = columnOrder.map(item => {
-      if (item.width !== COL_WIDTH_UNDEFINED) {
+      if (item.width === COL_WIDTH_UNDEFINED) {
+        return `minmax(${COL_WIDTH_MINIMUM}px, auto)`;
+      }
+      if (typeof item.width === 'number' && item.width > COL_WIDTH_MINIMUM) {
         return `${item.width}px`;
       }
-      return 'minmax(50px, auto)';
+      return `${COL_WIDTH_MINIMUM}px`;
     });
 
     grid.style.gridTemplateColumns = `${prepend} ${widths.join(' ')}`;
@@ -425,7 +428,7 @@ class GridEditable<
         columnOrder.map((column, i) => (
           <GridHeadCell
             openModalAddColumnAt={this.openModalAddColumnAt}
-            isLast={columnOrder.length - 1 === i}
+            isFirst={i === 0}
             key={`${i}.${column.key}`}
             isColumnDragging={this.props.isColumnDragging}
             isEditing={isEditing}

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -22,7 +22,6 @@ const Z_INDEX_GRID = 5;
 const Z_INDEX_GRID_RESIZER = 1;
 
 type GridEditableProps = {
-  numColumn?: number;
   isEditable?: boolean;
   isEditing?: boolean;
   isDragging?: boolean;
@@ -107,6 +106,7 @@ export const Grid = styled('table')`
   z-index: ${Z_INDEX_GRID};
   overflow-x: scroll;
 `;
+
 export const GridRow = styled('tr')`
   display: contents;
 
@@ -127,7 +127,7 @@ export const GridHead = styled('thead')`
   display: contents;
 `;
 
-export const GridHeadCell = styled('th')`
+export const GridHeadCell = styled('th')<{isFirst: boolean}>`
   /* By default, a grid item cannot be smaller than the size of its content.
      We override this by setting min-width to be 0. */
   position: relative; /* Used by GridResizer */
@@ -148,7 +148,8 @@ export const GridHeadCell = styled('th')`
   }
 
   &:hover {
-    border-color: ${p => p.theme.borderDark};
+    border-left-color: ${p => (p.isFirst ? 'transparent' : p.theme.borderDark)};
+    border-right-color: ${p => p.theme.borderDark};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/gridEditable/utils.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/utils.tsx
@@ -1,5 +1,7 @@
 // Auto layout width.
 export const COL_WIDTH_UNDEFINED = -1;
+// Set to 90 as the edit/trash icons need this much space.
+export const COL_WIDTH_MINIMUM = 90;
 
 // Store state at the start of "resize" action
 export type ColResizeMetadata = {


### PR DESCRIPTION
* Don't allow columns to be resized smaller than the minimum size we need  to display edit/trash controls.
* Fix borders showing up on the left side of the first cell. There is no  drag handle there.
* Remove unused props.