### PR TITLE
fix(integration-directory): adds trailing slashes to links

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
@@ -34,7 +34,7 @@ export default class PluginRow extends React.Component<Props> {
         <FlexContainer>
           <PluginIcon size={36} pluginId={plugin.id} />
           <Container>
-            <ProviderName to={`/settings/${slug}/plugins/${plugin.slug}`}>
+            <ProviderName to={`/settings/${slug}/plugins/${plugin.slug}/`}>
               {`${plugin.name} ${isLegacy ? '(Legacy)' : ''}`}
             </ProviderName>
             <ProviderDetails>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationProviderRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationProviderRow.tsx
@@ -40,7 +40,7 @@ export default class ProviderRow extends React.Component<Props> {
         <Flex style={{alignItems: 'center', padding: '16px'}}>
           <PluginIcon size={36} pluginId={provider.key} />
           <div style={{flex: '1', padding: '0 16px'}}>
-            <ProviderName to={`/settings/${slug}/integrations/${provider.key}`}>
+            <ProviderName to={`/settings/${slug}/integrations/${provider.key}/`}>
               {provider.name}
             </ProviderName>
             <ProviderDetails>

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/integrationDirectoryApplicationRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/integrationDirectoryApplicationRow.tsx
@@ -91,7 +91,7 @@ export default class SentryApplicationRow extends React.PureComponent<Props> {
                 </SentryAppLink>
               ) : (
                 <SentryAppLink
-                  to={`/settings/${organization.slug}/sentry-apps/${app.slug}`}
+                  to={`/settings/${organization.slug}/sentry-apps/${app.slug}/`}
                 >
                   {app.name}
                 </SentryAppLink>


### PR DESCRIPTION
Sentry always uses trailing slashes in links. We were missing a few cases of that in the integration directory.