### PR TITLE
fix(discover2): Account for the border sizes for the resize handles on the table

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -7,6 +7,7 @@ import space from 'app/styles/space';
 
 export const GRID_HEAD_ROW_HEIGHT = 45;
 export const GRID_BODY_ROW_HEIGHT = 40;
+const GRID_BODY_ROW_BORDER_BOX_HEIGHT = GRID_BODY_ROW_HEIGHT + 1; // add border-bottom height
 export const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
 
 /**
@@ -328,7 +329,7 @@ export const GridResizer = styled('div')<{dataRows: number; isLast?: boolean}>`
   right: ${p => (p.isLast ? '0px' : '-5px')};
   width: ${p => (p.isLast ? '6px' : '9px')};
 
-  height: ${p => GRID_HEAD_ROW_HEIGHT + p.dataRows * GRID_BODY_ROW_HEIGHT}px;
+  height: ${p => GRID_HEAD_ROW_HEIGHT + p.dataRows * GRID_BODY_ROW_BORDER_BOX_HEIGHT}px;
 
   padding-left: 4px;
   padding-right: ${p => (p.isLast ? '0px' : '4px')};


### PR DESCRIPTION
**Before:**

![before](https://user-images.githubusercontent.com/139499/73970152-a837d580-48ea-11ea-81b1-c33063b79449.png)


**After:**

![after](https://user-images.githubusercontent.com/139499/73970167-ad952000-48ea-11ea-98da-eb8133e947be.png)
