### PR TITLE
fix(subscriptions): Fix expected format for messages from subscription results

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -129,7 +129,7 @@ class SubscriptionProcessor(object):
 
         aggregation = QueryAggregations(self.alert_rule.aggregation)
         aggregation_name = query_aggregation_to_snuba[aggregation][2]
-        aggregation_value = subscription_update["values"]["data"][aggregation_name]
+        aggregation_value = subscription_update["values"]["data"][0][aggregation_name]
 
         for trigger in self.triggers:
             alert_operator, resolve_operator = self.THRESHOLD_TYPE_OPERATORS[

--- a/src/sentry/snuba/json_schemas.py
+++ b/src/sentry/snuba/json_schemas.py
@@ -17,7 +17,15 @@ SUBSCRIPTION_PAYLOAD_VERSIONS = {
             "values": {
                 "type": "object",
                 "properties": {
-                    "data": {"minProperties": 1, "additionalProperties": {"type": "number"}}
+                    "data": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "minProperties": 1,
+                            "additionalProperties": {"type": "number"},
+                        },
+                    }
                 },
                 "required": ["data"],
             },

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -122,7 +122,7 @@ class ProcessUpdateTest(TestCase):
             ]
             value = randint(0, 100) if value is None else value
             data = {aggregation_type[2]: value}
-        values = {"data": data}
+        values = {"data": [data]}
         return {
             "subscription_id": subscription.subscription_id if subscription else uuid4().hex,
             "values": values,

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -34,7 +34,7 @@ class BaseQuerySubscriptionTest(object):
     def valid_payload(self):
         return {
             "subscription_id": "1234",
-            "values": {"data": {"hello": 50}},
+            "values": {"data": [{"hello": 50}]},
             "timestamp": "2020-01-01T01:23:45.1234",
         }
 

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -118,7 +118,7 @@ class HandleSnubaQueryUpdateTest(TestCase):
             "version": 1,
             "payload": {
                 "subscription_id": self.subscription.subscription_id,
-                "values": {"data": {value_name: self.trigger.alert_threshold + 1}},
+                "values": {"data": [{value_name: self.trigger.alert_threshold + 1}]},
                 "timestamp": "2020-01-01T01:23:45.1234",
             },
         }

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -34,7 +34,7 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
     def valid_payload(self):
         return {
             "subscription_id": self.subscription_id,
-            "values": {"data": {"hello": 50}},
+            "values": {"data": [{"hello": 50}]},
             "timestamp": "2020-01-01T01:23:45.1234",
         }
 


### PR DESCRIPTION
We had a slight mismatch with the update schema from subscriptions, fixing it and also fixing the
json schema which didn't catch differences.