### PR TITLE
feat: Should not show `0 configurations`

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
@@ -39,9 +39,11 @@ export default class PluginRow extends React.Component<Props> {
             </ProviderName>
             <ProviderDetails>
               <Status enabled={this.isEnabled} />
-              <StyledLink
-                to={`/settings/${slug}/plugins/${plugin.slug}/?tab=configurations`}
-              >{`${plugin.projectList.length} Configurations`}</StyledLink>
+              {plugin.projectList.length ? (
+                <StyledLink
+                  to={`/settings/${slug}/plugins/${plugin.slug}/?tab=configurations`}
+                >{`${plugin.projectList.length} Configurations`}</StyledLink>
+              ) : null}
             </ProviderDetails>
           </Container>
         </FlexContainer>
@@ -98,12 +100,6 @@ const Status = styled(
   color: ${(p: StatusProps) => (p.enabled ? p.theme.success : p.theme.gray2)};
   margin-left: ${space(0.5)};
   margin-right: ${space(0.75)};
-  &:after {
-    content: '|';
-    color: ${p => p.theme.gray1};
-    margin-left: ${space(0.75)};
-    font-weight: normal;
-  }
 `;
 
 const StatusWrapper = styled('div')`
@@ -113,4 +109,10 @@ const StatusWrapper = styled('div')`
 
 const StyledLink = styled(Link)`
   color: ${p => p.theme.gray2};
+  &:before {
+    content: '|';
+    color: ${p => p.theme.gray1};
+    margin-right: ${space(0.75)};
+    font-weight: normal;
+  }
 `;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationPluginRow.tsx
@@ -42,7 +42,9 @@ export default class PluginRow extends React.Component<Props> {
               {plugin.projectList.length ? (
                 <StyledLink
                   to={`/settings/${slug}/plugins/${plugin.slug}/?tab=configurations`}
-                >{`${plugin.projectList.length} Configurations`}</StyledLink>
+                >{`${plugin.projectList.length} Configuration${
+                  plugin.projectList.length > 1 ? 's' : ''
+                }`}</StyledLink>
               ) : null}
             </ProviderDetails>
           </Container>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationProviderRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationProviderRow.tsx
@@ -45,9 +45,11 @@ export default class ProviderRow extends React.Component<Props> {
             </ProviderName>
             <ProviderDetails>
               <Status enabled={this.isEnabled} />
-              <StyledLink
-                to={`/settings/${slug}/integrations/${provider.key}/?tab=configurations`}
-              >{`${integrations.length} Configurations`}</StyledLink>
+              {integrations.length ? (
+                <StyledLink
+                  to={`/settings/${slug}/integrations/${provider.key}/?tab=configurations`}
+                >{`${integrations.length} Configurations`}</StyledLink>
+              ) : null}
             </ProviderDetails>
           </div>
         </Flex>
@@ -94,12 +96,6 @@ const Status = styled(
   color: ${(p: StatusProps) => (p.enabled ? p.theme.success : p.theme.gray2)};
   margin-left: ${space(0.5)};
   margin-right: ${space(0.75)};
-  &:after {
-    content: '|';
-    color: ${p => p.theme.gray1};
-    margin-left: ${space(0.75)};
-    font-weight: normal;
-  }
 `;
 
 const StatusWrapper = styled('div')`
@@ -109,4 +105,10 @@ const StatusWrapper = styled('div')`
 
 const StyledLink = styled(Link)`
   color: ${p => p.theme.gray2};
+  &:before {
+    content: '|';
+    color: ${p => p.theme.gray1};
+    margin-right: ${space(0.75)};
+    font-weight: normal;
+  }
 `;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationProviderRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationProviderRow.tsx
@@ -48,7 +48,9 @@ export default class ProviderRow extends React.Component<Props> {
               {integrations.length ? (
                 <StyledLink
                   to={`/settings/${slug}/integrations/${provider.key}/?tab=configurations`}
-                >{`${integrations.length} Configurations`}</StyledLink>
+                >{`${integrations.length} Configuration${
+                  integrations.length > 1 ? 's' : ''
+                }`}</StyledLink>
               ) : null}
             </ProviderDetails>
           </div>


### PR DESCRIPTION
If a plugin or first-party integration has 0 configurations, we should not show that text in the row of the list view. Also use non-plural for 1 configuration.

## UI

*Before*
<img width="318" alt="Screen Shot 2020-02-06 at 9 24 44 AM" src="https://user-images.githubusercontent.com/10491193/73987162-56944880-48f4-11ea-8a2d-44591b3d3c51.png">

*After*
<img width="697" alt="Screen Shot 2020-02-06 at 3 21 43 PM" src="https://user-images.githubusercontent.com/10491193/73987195-690e8200-48f4-11ea-99db-aceb857cc700.png">

