### PR TITLE
fix(metric_alerts): Fix links to metric alerts

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -103,7 +103,7 @@ class EmailActionHandler(ActionHandler):
         return {
             "link": absolute_uri(
                 reverse(
-                    "sentry-incident",
+                    "sentry-metric-alert",
                     kwargs={
                         "organization_slug": self.incident.organization.slug,
                         "incident_id": self.incident.identifier,
@@ -115,6 +115,7 @@ class EmailActionHandler(ActionHandler):
                     "sentry-alert-rule",
                     kwargs={
                         "organization_slug": self.incident.organization.slug,
+                        "project_slug": self.project.slug,
                         "alert_rule_id": self.action.alert_rule_trigger.alert_rule_id,
                     },
                 )

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -87,7 +87,7 @@ def build_activity_context(activity, user):
         "action": action,
         "link": absolute_uri(
             reverse(
-                "sentry-incident",
+                "sentry-metric-alert",
                 kwargs={
                     "organization_slug": incident.organization.slug,
                     "incident_id": incident.identifier,

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -306,7 +306,7 @@ def build_incident_attachment(incident):
         "title": title,
         "title_link": absolute_uri(
             reverse(
-                "sentry-incident",
+                "sentry-metric-alert",
                 kwargs={
                     "organization_slug": incident.organization.slug,
                     "incident_id": incident.identifier,

--- a/src/sentry/web/frontend/unsubscribe_incident_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_incident_notifications.py
@@ -22,7 +22,7 @@ class UnsubscribeIncidentNotificationsView(UnsubscribeBaseView):
     def build_link(self, instance):
         return absolute_uri(
             reverse(
-                "sentry-incident",
+                "sentry-metric-alert",
                 kwargs={
                     "organization_slug": instance.organization.slug,
                     "incident_id": instance.identifier,

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -662,12 +662,12 @@ urlpatterns += [
         name="sentry-stream",
     ),
     url(
-        r"^organizations/(?P<organization_slug>[\w_-]+)/incidents/(?P<incident_id>\d+)/$",
+        r"^organizations/(?P<organization_slug>[\w_-]+)/alerts/(?P<incident_id>\d+)/$",
         react_page_view,
-        name="sentry-incident",
+        name="sentry-metric-alert",
     ),
     url(
-        r"^settings/(?P<organization_slug>[\w_-]+)/incident-rules/(?P<alert_rule_id>\d+)/$",
+        r"^settings/(?P<organization_slug>[\w_-]+)/projects/(?P<project_slug>[\w_-]+)/alerts-v2/metric-rules/(?P<alert_rule_id>\d+)/$",
         react_page_view,
         name="sentry-alert-rule",
     ),

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -85,7 +85,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
         expected = {
             "link": absolute_uri(
                 reverse(
-                    "sentry-incident",
+                    "sentry-metric-alert",
                     kwargs={
                         "organization_slug": incident.organization.slug,
                         "incident_id": incident.identifier,
@@ -97,6 +97,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
                     "sentry-alert-rule",
                     kwargs={
                         "organization_slug": incident.organization.slug,
+                        "project_slug": self.project.slug,
                         "alert_rule_id": action.alert_rule_trigger.alert_rule_id,
                     },
                 )

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -103,7 +103,7 @@ class TestBuildActivityContext(BaseIncidentActivityTest, TestCase):
             context["link"]
             == absolute_uri(
                 reverse(
-                    "sentry-incident",
+                    "sentry-metric-alert",
                     kwargs={
                         "organization_slug": incident.organization.slug,
                         "incident_id": incident.identifier,

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -88,7 +88,7 @@ class BuildIncidentAttachmentTest(TestCase):
             "title": title,
             "title_link": absolute_uri(
                 reverse(
-                    "sentry-incident",
+                    "sentry-metric-alert",
                     kwargs={
                         "organization_slug": incident.organization.slug,
                         "incident_id": incident.identifier,


### PR DESCRIPTION
We changed these to point to /alerts rather than /incidents a while ago, but didn't update links. Also updated the links to the alert rule details.