### PR TITLE
fix: Uninstalling First Party Integration in detailed view updated UI

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -106,7 +106,7 @@ class IntegrationDetailedView extends AsyncComponent<
     const origIntegrations = [...this.state.configurations];
 
     const integrations = this.state.configurations.filter(i => i.id !== integration.id);
-    this.setState({integrations});
+    this.setState({configurations: integrations});
 
     const options: RequestOptions = {
       method: 'DELETE',


### PR DESCRIPTION
## Problem
When deleting a configuration for a first-party app on the integration detailed view, the configuration list does not update so it doesn't seem like anything happened. But if you refresh the page, the configuration is no longer there.

## Solution
Wrong variable got updated onRemove.