### PR TITLE
fix: Pagination bug for tag pages

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.jsx
@@ -22,7 +22,6 @@ class GroupTagValues extends React.Component {
   static propTypes = {
     api: PropTypes.object,
     group: SentryTypes.Group.isRequired,
-    query: PropTypes.object,
   };
 
   state = {
@@ -33,19 +32,22 @@ class GroupTagValues extends React.Component {
     pageLinks: '',
   };
 
-  componentWillMount() {
+  componentDidMount() {
     this.fetchData();
   }
 
   componentDidUpdate(prevProps) {
-    const queryHasChanged = !isEqual(prevProps.query, this.props.query);
+    const queryHasChanged = !isEqual(prevProps.location.query, this.props.location.query);
     if (queryHasChanged || prevProps.params.tagKey !== this.props.params.tagKey) {
       this.fetchData();
     }
   }
 
   fetchData = async () => {
-    const {params, query} = this.props;
+    const {
+      params,
+      location: {query},
+    } = this.props;
     this.setState({
       loading: true,
       error: false,

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.jsx
@@ -22,6 +22,9 @@ class GroupTagValues extends React.Component {
   static propTypes = {
     api: PropTypes.object,
     group: SentryTypes.Group.isRequired,
+    location: PropTypes.shape({
+      query: PropTypes.object,
+    }),
   };
 
   state = {

--- a/tests/js/spec/views/organizationGroupDetails/groupTagValues.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupTagValues.spec.jsx
@@ -24,7 +24,7 @@ describe('GroupTagValues', function() {
     const wrapper = mount(
       <GroupTagValues
         group={group}
-        query={{}}
+        location={{query: {}}}
         params={{orgId: 'org-slug', groupId: group.id, tagKey: 'user'}}
       />,
       routerContext


### PR DESCRIPTION
Fixes the pagination on the Tag sorting pages for Issues:
`https://sentry.io/organizations/{org}/issues/{issueId}/tags/{tag}/`

You can check out a broken example over here:
https://sentry.io/organizations/sentry/issues/1113232556/tags/user/