### PR TITLE
fix(workflow): Fix "Time Window" not being initially set

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -132,6 +132,8 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             choices={Object.entries(TIME_WINDOW_MAP)}
             required
             disabled={disabled}
+            getValue={value => Number(value)}
+            setValue={value => `${value}`}
           />
         </PanelBody>
       </Panel>


### PR DESCRIPTION
I believe this is due to a change in react-select upgrade. The type checks might be more strict now as this works with v1.

/cc @EvanPurkhiser 