### PR TITLE
fix(subscriptions): Properly translate queries before passing to snuba.

### DIFF
--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -5,6 +5,7 @@ import json
 from django.db import transaction
 
 from sentry.api.event_search import get_filter
+from sentry.snuba.discover import resolve_discover_aliases
 from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription
 from sentry.utils.snuba import _snuba_pool, SnubaError
 
@@ -168,7 +169,9 @@ def _create_in_snuba(project, dataset, query, aggregation, time_window, resoluti
                 # We only care about conditions here. Filter keys only matter for
                 # filtering to project and groups. Projects are handled with an
                 # explicit param, and groups can't be queried here.
-                "conditions": get_filter(query).conditions,
+                "conditions": resolve_discover_aliases(
+                    {"conditions": get_filter(query).conditions}
+                )[0]["conditions"],
                 "aggregations": [query_aggregation_to_snuba[aggregation]],
                 "time_window": int(time_window.total_seconds()),
                 "resolution": int(resolution.total_seconds()),

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -32,6 +32,25 @@ class CreateSnubaSubscriptionTest(TestCase):
         assert subscription.time_window == int(time_window.total_seconds())
         assert subscription.resolution == int(resolution.total_seconds())
 
+    def test_translated_query(self):
+        type = "something"
+        dataset = QueryDatasets.EVENTS
+        query = "event.type:error"
+        aggregation = QueryAggregations.TOTAL
+        time_window = timedelta(minutes=10)
+        resolution = timedelta(minutes=1)
+        subscription = create_snuba_subscription(
+            self.project, type, dataset, query, aggregation, time_window, resolution
+        )
+        assert subscription.project == self.project
+        assert subscription.type == type
+        assert subscription.subscription_id != ""
+        assert subscription.dataset == dataset.value
+        assert subscription.query == query
+        assert subscription.aggregation == aggregation.value
+        assert subscription.time_window == int(time_window.total_seconds())
+        assert subscription.resolution == int(resolution.total_seconds())
+
 
 class UpdateSnubaSubscriptionTest(TestCase):
     def test(self):


### PR DESCRIPTION
We now need to also pass the list of conditions through `resolve_discover_aliases` so that we can
handle all cases. Added a test case that was previously failing, which passes with this fix.