### PR TITLE
feat(discover) Move chart tooltip into the chart footer

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -36,6 +36,7 @@ class ReleaseSeries extends React.Component {
     utc: PropTypes.bool,
     // Array of releases, if empty, component will fetch releases itself
     releases: PropTypes.arrayOf(SentryTypes.Release),
+    tooltip: SentryTypes.EChartsTooltip,
   };
 
   state = {
@@ -74,7 +75,7 @@ class ReleaseSeries extends React.Component {
   }
 
   getReleaseSeries = releases => {
-    const {utc, organization, router} = this.props;
+    const {utc, organization, router, tooltip} = this.props;
 
     return {
       seriesName: 'Releases',
@@ -87,7 +88,7 @@ class ReleaseSeries extends React.Component {
             type: 'solid',
           },
         },
-        tooltip: {
+        tooltip: tooltip || {
           formatter: ({data}) => {
             return `<div>${moment
               .tz(data.value, utc ? 'UTC' : getUserTimezone())

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -287,7 +287,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     }
 
     return {
-      seriesName: 'Previous Period',
+      seriesName: 'Previous',
       data: this.calculateTotalsPerTimestamp(
         previous,
         (_timestamp, _countArray, i) => current[i][0] * 1000
@@ -311,7 +311,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
   transformTimeseriesData(data: EventsStatsData): [Series] {
     return [
       {
-        seriesName: 'Current Period',
+        seriesName: 'Current',
         data: data.map(([timestamp, countsForTimestamp]) => ({
           name: timestamp * 1000,
           value: countsForTimestamp.reduce((acc, {count}) => acc + count, 0),

--- a/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
@@ -1,27 +1,89 @@
 import React from 'react';
+import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
 import {SelectValue} from 'app/types';
-import Count from 'app/components/count';
+import Duration from 'app/components/duration';
 import YAxisSelector from 'app/views/events/yAxisSelector';
+import {getFormattedDate} from 'app/utils/dates';
+import space from 'app/styles/space';
 
+import {decodeColumnOrder} from './utils';
 import {ChartControls, InlineContainer, SectionHeading} from './styles';
+
+type TooltipSeries = {
+  name: string;
+  value: number;
+};
+
+export type TooltipData = {
+  values: TooltipSeries[];
+  timestamp: number;
+};
 
 type Props = {
   total: number | null;
   yAxisValue: string;
   yAxisOptions: SelectValue<string>[];
   onChange: (value: string) => void;
+  hoverState: TooltipData;
 };
 
-export default function ChartFooter({total, yAxisValue, yAxisOptions, onChange}: Props) {
+function formatValue(val: string | number, columnName: string) {
+  // Extract metadata from the columnName so we can format the
+  // value appropriately.
+  const columnData = decodeColumnOrder([{field: columnName}])[0];
+
+  if (val === null || val === undefined) {
+    return <Value>-</Value>;
+  }
+
+  if (columnData.type === 'duration' && typeof val === 'number') {
+    return (
+      <Value>
+        <Duration seconds={val / 1000} fixedDigits={2} abbreviation />
+      </Value>
+    );
+  }
+
+  const formatted = typeof val === 'number' ? val.toLocaleString() : val;
+  return <Value>{formatted}</Value>;
+}
+
+export default function ChartFooter({
+  total,
+  yAxisValue,
+  yAxisOptions,
+  hoverState,
+  onChange,
+}: Props) {
+  const elements: React.ReactNode[] = [];
+  if (hoverState.values.length === 0) {
+    elements.push(<SectionHeading>{t('Total')}</SectionHeading>);
+    elements.push(
+      total === null ? <Value>-</Value> : <Value>{total.toLocaleString()}</Value>
+    );
+  } else {
+    elements.push(<SectionHeading>{t('Time')}</SectionHeading>);
+    elements.push(
+      <Value>{getFormattedDate(hoverState.timestamp, 'MMM D, LTS', {local: true})}</Value>
+    );
+    hoverState.values.forEach(item => {
+      elements.push(<SectionHeading>{item.name}</SectionHeading>);
+      elements.push(formatValue(item.value, yAxisValue));
+    });
+  }
+
   return (
     <ChartControls>
-      <InlineContainer>
-        <SectionHeading>{t('Count')}</SectionHeading>
-        {total === null ? '-' : <Count value={Number(total)} />}
-      </InlineContainer>
+      <InlineContainer>{elements}</InlineContainer>
       <YAxisSelector selected={yAxisValue} options={yAxisOptions} onChange={onChange} />
     </ChartControls>
   );
 }
+
+const Value = styled('span')`
+  color: ${p => p.theme.gray3};
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin-right: ${space(1)};
+`;

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -143,6 +143,8 @@ export const FIELDS = {
   'transaction.duration': 'duration',
   'transaction.op': 'string',
   'transaction.status': 'string',
+  // TODO when these become real functions, we need to revisit how
+  // their types are inferred in decodeColumnOrder()
   apdex: 'number',
   impact: 'number',
   error_rate: 'number',

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -4,13 +4,11 @@ import * as Sentry from '@sentry/browser';
 import * as ReactRouter from 'react-router';
 import {Location} from 'history';
 import omit from 'lodash/omit';
-import uniqBy from 'lodash/uniqBy';
 import isEqual from 'lodash/isEqual';
 
 import {Organization, GlobalSelection} from 'app/types';
 
 import {Client} from 'app/api';
-import {Panel} from 'app/components/panels';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {loadOrganizationTags} from 'app/actionCreators/tags';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
@@ -21,10 +19,8 @@ import {PageContent} from 'app/styles/organization';
 import space from 'app/styles/space';
 
 import SearchBar from 'app/views/events/searchBar';
-import EventsChart from 'app/views/events/eventsChart';
 
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import getDynamicText from 'app/utils/getDynamicText';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
@@ -34,14 +30,9 @@ import {DEFAULT_EVENT_VIEW} from './data';
 import Table from './table';
 import Tags from './tags';
 import ResultsHeader from './resultsHeader';
-import ChartFooter from './chartFooter';
-import EventView, {Field, isAPIPayloadSimilar} from './eventView';
+import ResultsChart from './resultsChart';
+import EventView, {isAPIPayloadSimilar} from './eventView';
 import {generateTitle, fetchTotalCount} from './utils';
-
-const CHART_AXIS_OPTIONS = [
-  {label: 'count(id)', value: 'count(id)'},
-  {label: 'count_unique(users)', value: 'count_unique(user)'},
-];
 
 type Props = {
   api: Client;
@@ -216,22 +207,6 @@ class Results extends React.Component<Props, State> {
     const query = location.query.query || '';
     const title = this.getDocumentTitle();
 
-    // Make option set and add the default options in.
-    const yAxisOptions = uniqBy(
-      eventView
-        .getAggregateFields()
-        // Exclude last_seen and latest_event as they don't produce useful graphs.
-        .filter(
-          (field: Field) => ['last_seen', 'latest_event'].includes(field.field) === false
-        )
-        .map((field: Field) => {
-          return {label: field.field, value: field.field};
-        })
-        .concat(CHART_AXIS_OPTIONS),
-      'value'
-    );
-    const yAxisValue = eventView.yAxis || yAxisOptions[0].value;
-
     return (
       <SentryDocumentTitle title={title} objSlug={organization.slug}>
         <React.Fragment>
@@ -251,28 +226,14 @@ class Results extends React.Component<Props, State> {
                   query={query}
                   onSearch={this.handleSearch}
                 />
-                <StyledPanel>
-                  {getDynamicText({
-                    value: (
-                      <EventsChart
-                        router={router}
-                        query={eventView.getEventsAPIPayload(location).query}
-                        organization={organization}
-                        showLegend
-                        yAxis={yAxisValue}
-                        project={eventView.project as number[]}
-                        environment={eventView.environment as string[]}
-                      />
-                    ),
-                    fixed: 'events chart',
-                  })}
-                  <ChartFooter
-                    total={totalValues}
-                    yAxisValue={yAxisValue}
-                    yAxisOptions={yAxisOptions}
-                    onChange={this.handleYAxisChange}
-                  />
-                </StyledPanel>
+                <ResultsChart
+                  router={router}
+                  organization={organization}
+                  eventView={eventView}
+                  location={location}
+                  onAxisChange={this.handleYAxisChange}
+                  total={totalValues}
+                />
               </Top>
               <Main eventView={eventView}>
                 <Table
@@ -311,12 +272,6 @@ export const StyledPageContent = styled(PageContent)`
 
 export const StyledSearchBar = styled(SearchBar)`
   margin-bottom: ${space(2)};
-`;
-
-export const StyledPanel = styled(Panel)`
-  .echarts-for-react div:first-child {
-    width: 100% !important;
-  }
 `;
 
 export const Top = styled('div')`

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import * as ReactRouter from 'react-router';
+import {Location} from 'history';
+import uniqBy from 'lodash/uniqBy';
+
+import {Organization, SelectValue} from 'app/types';
+
+import {Panel} from 'app/components/panels';
+import getDynamicText from 'app/utils/getDynamicText';
+import EventsChart from 'app/views/events/eventsChart';
+
+import ChartFooter, {TooltipData} from './chartFooter';
+import EventView, {Field} from './eventView';
+
+const defaultTooltip: TooltipData = {
+  values: [],
+  timestamp: 0,
+};
+
+type Props = {
+  router: ReactRouter.InjectedRouter;
+  organization: Organization;
+  eventView: EventView;
+  location: Location;
+
+  total: number | null;
+  onAxisChange: (value: string) => void;
+};
+
+type State = {
+  tooltipData: TooltipData;
+};
+
+const CHART_AXIS_OPTIONS = [
+  {label: 'count(id)', value: 'count(id)'},
+  {label: 'count_unique(users)', value: 'count_unique(user)'},
+];
+
+export default class ResultsChart extends React.Component<Props, State> {
+  state = {
+    tooltipData: defaultTooltip,
+  };
+
+  handleTooltipUpdate = (state: TooltipData) => {
+    this.setState({tooltipData: state});
+  };
+
+  render() {
+    const {eventView, location, organization, router, total, onAxisChange} = this.props;
+
+    // Make option set and add the default options in.
+    const yAxisOptions: SelectValue<string>[] = uniqBy(
+      eventView
+        .getAggregateFields()
+        // Exclude last_seen and latest_event as they don't produce useful graphs.
+        .filter(
+          (field: Field) => ['last_seen', 'latest_event'].includes(field.field) === false
+        )
+        .map((field: Field) => {
+          return {label: field.field, value: field.field};
+        })
+        .concat(CHART_AXIS_OPTIONS),
+      'value'
+    );
+    const yAxisValue = eventView.yAxis || yAxisOptions[0].value;
+
+    return (
+      <StyledPanel onMouseLeave={() => this.handleTooltipUpdate(defaultTooltip)}>
+        {getDynamicText({
+          value: (
+            <EventsChart
+              router={router}
+              query={eventView.getEventsAPIPayload(location).query}
+              organization={organization}
+              showLegend
+              yAxis={yAxisValue}
+              project={eventView.project as number[]}
+              environment={eventView.environment as string[]}
+              onTooltipUpdate={this.handleTooltipUpdate}
+            />
+          ),
+          fixed: 'events chart',
+        })}
+        <ChartFooter
+          hoverState={this.state.tooltipData}
+          total={total}
+          yAxisValue={yAxisValue}
+          yAxisOptions={yAxisOptions}
+          onChange={onAxisChange}
+        />
+      </StyledPanel>
+    );
+  }
+}
+
+export const StyledPanel = styled(Panel)`
+  .echarts-for-react div:first-child {
+    width: 100% !important;
+  }
+`;

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -225,7 +225,19 @@ export function decodeColumnOrder(
       column.field = aggregationField[1] as Field;
     }
     column.key = col.aggregationField;
-    column.type = column.aggregation ? 'number' : FIELDS[column.field];
+
+    // Aggregations on any field make numbers.
+    // Otherwise use the FIELDS data to infer types.
+    if (
+      AGGREGATIONS[column.aggregation] &&
+      AGGREGATIONS[column.aggregation].type === '*'
+    ) {
+      column.type = 'number';
+    } else if (FIELDS[column.aggregation]) {
+      column.type = FIELDS[column.aggregation];
+    } else {
+      column.type = FIELDS[column.field];
+    }
     column.width = col.width;
 
     column.name = column.key;

--- a/tests/js/spec/views/events/utils/eventsRequest.spec.jsx
+++ b/tests/js/spec/views/events/utils/eventsRequest.spec.jsx
@@ -175,7 +175,7 @@ describe('EventsRequest', function() {
             },
           ],
           previousTimeseriesData: {
-            seriesName: 'Previous Period',
+            seriesName: 'Previous',
             data: [
               expect.objectContaining({
                 name: expect.anything(),

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -155,10 +155,9 @@ describe('decodeColumnOrder', function() {
   });
 
   it('can decode aggregate functions with no arguments', function() {
-    const results = decodeColumnOrder([{field: 'count()', width: 123}]);
+    let results = decodeColumnOrder([{field: 'count()', width: 123}]);
 
     expect(Array.isArray(results)).toBeTruthy();
-
     expect(results[0]).toEqual({
       key: 'count()',
       name: 'count()',
@@ -173,6 +172,12 @@ describe('decodeColumnOrder', function() {
       isSortable: true,
       type: 'number',
     });
+
+    results = decodeColumnOrder([{field: 'p75()', width: 123}]);
+    expect(results[0].type).toEqual('duration');
+
+    results = decodeColumnOrder([{field: 'p99()', width: 123}]);
+    expect(results[0].type).toEqual('duration');
   });
 
   it('can decode elements with aggregate functions with arguments', function() {
@@ -189,7 +194,7 @@ describe('decodeColumnOrder', function() {
       eventViewField: {field: 'avg(transaction.duration)'},
       isDragging: false,
       isSortable: true,
-      type: 'number',
+      type: 'duration',
     });
   });
 });


### PR DESCRIPTION
Move tooltips from the bubble into the chart footer where they are more consistently found and formatted.

![graph hover](https://user-images.githubusercontent.com/24086/74048906-1939c480-49a1-11ea-841d-4a951d9ee888.gif)

The legend icons are not aligned well. I tried several incantations of the configuration options to no avail. I think we could get the alignment correct with a custom icon image that had offset bottom padding.
