### PR TITLE
fix(discover2) Ensure percentages make sense in tag map

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -108,13 +108,18 @@ class Tags extends React.Component<Props, State> {
 
       return segment;
     });
-
+    // Ensure we don't show >100% if there's a slight mismatch between the facets
+    // endpoint and the totals endpoint
+    const maxTotalValues =
+      segments.length === 1
+        ? Math.max(Number(totalValues), segments[0].count)
+        : totalValues;
     return (
       <TagDistributionMeter
         key={tag.key}
         title={tag.key}
         segments={segments}
-        totalValues={Number(totalValues)}
+        totalValues={Number(maxTotalValues)}
         renderLoading={() => <StyledPlaceholder height="16px" />}
         onTagClick={this.onTagClick}
       />

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -111,7 +111,7 @@ class Tags extends React.Component<Props, State> {
     // Ensure we don't show >100% if there's a slight mismatch between the facets
     // endpoint and the totals endpoint
     const maxTotalValues =
-      segments.length === 1
+      segments.length > 0
         ? Math.max(Number(totalValues), segments[0].count)
         : totalValues;
     return (


### PR DESCRIPTION
Since we calculate totals for tag top values and totals differently, make sure
that the percentages never go over 100 in the case where things are slightly off