### PR TITLE
fix(discover2): Issue titles are not sortable

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -219,7 +219,7 @@ export const SPECIAL_FIELDS: SpecialFields = {
     },
   },
   issue: {
-    sortField: 'issue',
+    sortField: null,
     renderFunc: (data, {organization}) => {
       const target = `/organizations/${organization.slug}/issues/${data['issue.id']}/`;
       return (


### PR DESCRIPTION
`issue` titles were added in https://github.com/getsentry/sentry/pull/16822 ; but unfortunately, we cannot sort them today. We prevent sorting on them for now.