### PR TITLE
test(symbolicator): Add host.docker.internal to ALLOWED_HOSTS

### DIFF
--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -8,6 +8,7 @@ from six import BytesIO
 
 from django.core.urlresolvers import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 
 from sentry import eventstore
 from sentry.testutils import TransactionTestCase
@@ -17,10 +18,13 @@ from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 from tests.symbolicator import get_fixture_path, insta_snapshot_stacktrace_data
 
 
-class SymbolicatorMinidumpIntegrationTest(TransactionTestCase):
-    # For these tests to run, write `symbolicator.enabled: true` into your
-    # `~/.sentry/config.yml` and run `sentry devservices up`
+# IMPORTANT:
+# For these tests to run, write `symbolicator.enabled: true` into your
+# `~/.sentry/config.yml` and run `sentry devservices up`
 
+
+@override_settings(ALLOWED_HOSTS=["localhost", "testserver", "host.docker.internal"])
+class SymbolicatorMinidumpIntegrationTest(TransactionTestCase):
     @pytest.fixture(autouse=True)
     def initialize(self, live_server):
         self.project.update_option("sentry:builtin_symbol_sources", [])

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -8,6 +8,7 @@ from six import BytesIO
 
 from django.core.urlresolvers import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 
 from sentry import eventstore
 from sentry.testutils import TransactionTestCase
@@ -16,6 +17,12 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.utils import json
 
 from tests.symbolicator import get_fixture_path, insta_snapshot_stacktrace_data
+
+
+# IMPORTANT:
+# For these tests to run, write `symbolicator.enabled: true` into your
+# `~/.sentry/config.yml` and run `sentry devservices up`
+
 
 REAL_RESOLVING_EVENT_DATA = {
     "platform": "cocoa",
@@ -182,6 +189,7 @@ class ResolvingIntegrationTestBase(object):
         insta_snapshot_stacktrace_data(self, event.data)
 
 
+@override_settings(ALLOWED_HOSTS=["localhost", "testserver", "host.docker.internal"])
 class SymbolicatorResolvingIntegrationTest(ResolvingIntegrationTestBase, TransactionTestCase):
     # For these tests to run, write `symbolicator.enabled: true` into your
     # `~/.sentry/config.yml` and run `sentry devservices up`
@@ -194,6 +202,5 @@ class SymbolicatorResolvingIntegrationTest(ResolvingIntegrationTestBase, Transac
         with patch("sentry.auth.system.is_internal_ip", return_value=True), self.options(
             {"system.url-prefix": new_prefix}
         ):
-
             # Run test case:
             yield

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -8,6 +8,7 @@ from six import BytesIO
 
 from django.core.urlresolvers import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 
 from sentry.testutils import TransactionTestCase
 from sentry.models import EventAttachment
@@ -15,6 +16,11 @@ from sentry import eventstore
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 
 from tests.symbolicator import get_fixture_path
+
+
+# IMPORTANT:
+# For these tests to run, write `symbolicator.enabled: true` into your
+# `~/.sentry/config.yml` and run `sentry devservices up`
 
 
 def get_unreal_crash_file():
@@ -25,6 +31,7 @@ def get_unreal_crash_apple_file():
     return get_fixture_path("unreal_crash_apple")
 
 
+@override_settings(ALLOWED_HOSTS=["localhost", "testserver", "host.docker.internal"])
 class SymbolicatorUnrealIntegrationTest(TransactionTestCase):
     # For these tests to run, write `symbolicator.enabled: true` into your
     # `~/.sentry/config.yml` and run `sentry devservices up`


### PR DESCRIPTION
With the upgrade to Django 1.11, allowed hosts are now checked in tests, too. `host.docker.internal` is not allowed by default, but required for symbolicator to retrieve symbols on development machines.

https://docs.djangoproject.com/en/1.11/releases/1.11/#miscellaneous
