### PR TITLE
build: enable light build for install-sentry-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,10 @@ install-yarn-pkgs: node-version-check
 
 install-sentry-dev:
 	@echo "--> Installing Sentry (for development)"
-	$(PIP) install -e ".[dev]"
+	# SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
+	# Webpacked assets are only necessary for devserver (which does it lazily anyways)
+	# and acceptance tests, which webpack automatically if run.
+	SENTRY_LIGHT_BUILD=1 $(PIP) install -e ".[dev]"
 
 build-js-po: node-version-check
 	mkdir -p build


### PR DESCRIPTION
It's not really necessary for pure python development. devserver has lazily webpacked assets as needed, the remaining piece of the puzzle is acceptance tests - props to @billyvg for https://github.com/getsentry/sentry/pull/15028.

This will massively speed up `make install-sentry-dev` as recommended by the post-merge hook, and consequently, `make develop`.

Ideally the default is inversed, since webpacking should only exist because distribution builds need to compile assets, but SENTRY_LIGHT_BUILD is in a lot of places, so meh.