### PR TITLE
build(tsc): Ignore node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ env:
     - DJANGO_VERSION=">=1.11,<1.12"
     # node's version is pinned by .nvmrc and is autodetected by `nvm install`.
     - NODE_DIR="${HOME}/.nvm/versions/node/v$(< .nvmrc)"
-    - NODE_OPTIONS=--max-old-space-size=4096
 
 before_install:
   - &pip_install pip install --no-cache-dir "pip>=20.0.2"

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -49,9 +49,6 @@ steps:
     docker tag us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA getsentry/sentry:latest
     docker push getsentry/sentry:latest
 timeout: 2400s
-options:
-  # We need more memory for Webpack builds & e2e onpremise tests
-  machineType: 'N1_HIGHCPU_8'
 secrets:
 - kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
   secretEnv:

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -114,11 +114,6 @@ def devserver(reload, watchers, workers, experimental_spa, styleguide, prefix, e
         os.environ["SENTRY_WEBPACK_PROXY_PORT"] = "%s" % proxy_port
         os.environ["SENTRY_BACKEND_PORT"] = "%s" % port
 
-        # webpack and/or typescript is causing memory issues
-        os.environ["NODE_OPTIONS"] = (
-            (os.environ.get("NODE_OPTIONS", "") + " --max-old-space-size=4096")
-        ).lstrip()
-
         # Replace the webpack watcher with the drop-in webpack-dev-server
         webpack_config = next(w for w in daemons if w[0] == "webpack")[1]
         webpack_config[0] = os.path.join(

--- a/src/sentry/utils/distutils/commands/build_assets.py
+++ b/src/sentry/utils/distutils/commands/build_assets.py
@@ -127,10 +127,6 @@ class BuildAssetsCommand(BaseBuildCommand):
         env = dict(os.environ)
         env["SENTRY_STATIC_DIST_PATH"] = self.sentry_static_dist_path
         env["NODE_ENV"] = "production"
-        # TODO: Our JS builds should not require 4GB heap space
-        env["NODE_OPTIONS"] = (
-            (env.get("NODE_OPTIONS", "") + " --max-old-space-size=4096")
-        ).lstrip()
         self._run_yarn_command(["webpack", "--bail"], env=env)
 
     def _write_version_file(self, version_info):

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -57,10 +57,5 @@ def pytest_configure(config):
     )
 
     subprocess.call(
-        ["yarn", "webpack"],
-        env={
-            "NODE_ENV": "development",
-            "PATH": os.environ["PATH"],
-            "NODE_OPTIONS": "--max-old-space-size=4096",
-        },
+        ["yarn", "webpack"], env={"NODE_ENV": "development", "PATH": os.environ["PATH"],},
     )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,5 +36,6 @@
     },
     "plugins": [{"name": "typescript-styled-plugin"}]
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,5 +37,5 @@
     "plugins": [{"name": "typescript-styled-plugin"}]
   },
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "docs-ui/node_modules", "src/sentry/static/sentry/dist", "src/sentry/integration-docs"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -192,6 +192,9 @@ const babelLoaderConfig = {
 
 const tsLoaderConfig = {
   loader: 'ts-loader',
+  options: {
+    transpileOnly: env.NODE_ENV === 'production',
+  },
 };
 
 /**


### PR DESCRIPTION
This should bring down the memory usage and compile times