### PR TITLE
feat(discover) Enable discover upsell tab

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -268,9 +268,11 @@ class Sidebar extends React.Component {
       sidebarState.events = true;
     }
 
-    // TODO(mark) Once discover2 is on for all accounts if an organization
-    // doesn't have events, or discover-basic sidebarState.discover2 should = true
-    // so that we can show an upsell.
+    // If an organization doesn't have events, or discover-basic
+    // Enable the tab so we can show an upsell state in saas.
+    if (!sidebarState.events) {
+      sidebarState.discover2 = true;
+    }
 
     return sidebarState;
   }


### PR DESCRIPTION
For organizations that do not have discover-basic we want to show an upsell state to help encourage them to upgrade.

I will merge this once discover2 has been enabled for all users.