### PR TITLE
feat(perf-view): Initial landing page

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -22,6 +22,7 @@ import {
   IconGraph,
   IconIssues,
   IconLab,
+  IconLightning,
   IconProject,
   IconReleases,
   IconSettings,
@@ -183,6 +184,7 @@ class Sidebar extends React.Component {
       'discover',
       'discover/queries',
       'discover/results',
+      'performance',
       'releasesv2',
     ].map(route => `/organizations/${this.props.organization.slug}/${route}/`);
 
@@ -381,7 +383,21 @@ class Sidebar extends React.Component {
                       </GuideAnchor>
                     </Feature>
                   )}
-
+                  <Feature features={['performance-view']} organization={organization}>
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={(_id, evt) =>
+                        this.navigateWithGlobalSelection(
+                          `/organizations/${organization.slug}/performance/`,
+                          evt
+                        )
+                      }
+                      icon={<IconLightning size="md" />}
+                      label={t('Performance')}
+                      to={`/organizations/${organization.slug}/performance/`}
+                      id="performance"
+                    />
+                  </Feature>
                   <Feature features={['incidents']} organization={organization}>
                     <SidebarItem
                       {...sidebarItemProps}

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1421,6 +1421,24 @@ function routes() {
             />
           </Route>
           <Route
+            path="/organizations/:orgId/performance/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "PerformanceLanding" */ 'app/views/performance/landing'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
+          <Route
             path="/organizations/:orgId/events/"
             componentPromise={() =>
               import(/* webpackChunkName: "EventsContainer" */ 'app/views/events')

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -15,7 +15,7 @@ import SentryTypes from 'app/sentryTypes';
 
 import LoadingPanel from '../loadingPanel';
 
-type TimeSeriesData = {
+export type TimeSeriesData = {
   // timeseries data
   timeseriesData?: Series[];
   allTimeseriesData?: EventsStatsData;

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/utils.tsx
@@ -1,4 +1,5 @@
 import {EventData} from '../data';
+import EventView from '../eventView';
 
 export function generateEventDetailsRoute({
   eventSlug,
@@ -15,4 +16,24 @@ export function generateEventSlug(eventData: EventData): string {
   const projectSlug = eventData.project || eventData['project.name'];
 
   return `${projectSlug}:${id}`;
+}
+
+export function eventDetailsRouteWithEventView({
+  orgSlug,
+  eventSlug,
+  eventView,
+}: {
+  orgSlug: string;
+  eventSlug: string;
+  eventView: EventView;
+}) {
+  const pathname = generateEventDetailsRoute({
+    orgSlug,
+    eventSlug,
+  });
+
+  return {
+    pathname,
+    query: eventView.generateQueryStringObject(),
+  };
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -342,7 +342,7 @@ class EventView {
     const environment: string[] =
       Array.isArray(newQuery.environment) && newQuery.environment.length > 0
         ? newQuery.environment
-        : collectQueryStringByKey(location.query, 'environment');
+        : collectQueryStringByKey(query, 'environment');
 
     const project: number[] =
       Array.isArray(newQuery.projects) && newQuery.projects.length > 0

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -310,7 +310,7 @@ const StyledPageContent = styled(PageContent)`
   padding: 0;
 `;
 
-const StyledPageHeader = styled('div')`
+export const StyledPageHeader = styled('div')`
   display: flex;
   align-items: center;
   font-size: ${p => p.theme.headerFontSize};

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -185,7 +185,7 @@ class Results extends React.Component<Props, State> {
 
   renderError = error => {
     if (!error) {
-      return '';
+      return null;
     }
     return (
       <Alert type="error" icon="icon-circle-exclamation">

--- a/src/sentry/static/sentry/app/views/eventsV2/sortLink.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/sortLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import {Location} from 'history';
+import {Location, LocationDescriptorObject} from 'history';
 import omit from 'lodash/omit';
 
 import InlineSvg from 'app/components/inlineSvg';
@@ -18,6 +18,7 @@ type Props = {
   location: Location;
   eventView: EventView;
   tableDataMeta?: MetaType; // Will not be defined if data is not loaded
+  getTarget?: () => LocationDescriptorObject | undefined;
 };
 
 class SortLink extends React.Component<Props> {
@@ -38,8 +39,13 @@ class SortLink extends React.Component<Props> {
     return eventView.isFieldSorted(field, tableDataMeta);
   }
 
-  getTarget() {
-    const {location, field, eventView, tableDataMeta} = this.props;
+  getTarget(): LocationDescriptorObject | undefined {
+    const {location, field, eventView, tableDataMeta, getTarget} = this.props;
+
+    if (getTarget && typeof getTarget === 'function') {
+      return getTarget();
+    }
+
     if (!tableDataMeta) {
       return undefined;
     }
@@ -70,12 +76,14 @@ class SortLink extends React.Component<Props> {
   render() {
     const {align, field, tableDataMeta} = this.props;
 
-    if (!isFieldSortable(field, tableDataMeta)) {
+    const target = this.getTarget();
+
+    if (!target || !isFieldSortable(field, tableDataMeta)) {
       return <StyledNonLink align={align}>{field.field}</StyledNonLink>;
     }
 
     return (
-      <StyledLink align={align} to={this.getTarget()}>
+      <StyledLink align={align} to={target}>
         {field.field} {this.renderChevron()}
       </StyledLink>
     );

--- a/src/sentry/static/sentry/app/views/eventsV2/sortLink.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/sortLink.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import {Location, LocationDescriptorObject} from 'history';
+import {LocationDescriptorObject} from 'history';
 import omit from 'lodash/omit';
 
 import InlineSvg from 'app/components/inlineSvg';
@@ -15,21 +14,12 @@ export type Alignments = 'left' | 'right' | undefined;
 type Props = {
   align: Alignments;
   field: Field;
-  location: Location;
   eventView: EventView;
   tableDataMeta?: MetaType; // Will not be defined if data is not loaded
-  getTarget?: () => LocationDescriptorObject | undefined;
+  generateSortLink: () => LocationDescriptorObject | undefined;
 };
 
 class SortLink extends React.Component<Props> {
-  static propTypes = {
-    align: PropTypes.string,
-    field: PropTypes.object.isRequired,
-    location: PropTypes.object.isRequired,
-    eventView: PropTypes.object.isRequired,
-    tableDataMeta: PropTypes.object,
-  };
-
   isCurrentColumnSorted(): Sort | undefined {
     const {eventView, field, tableDataMeta} = this.props;
     if (!tableDataMeta) {
@@ -37,26 +27,6 @@ class SortLink extends React.Component<Props> {
     }
 
     return eventView.isFieldSorted(field, tableDataMeta);
-  }
-
-  getTarget(): LocationDescriptorObject | undefined {
-    const {location, field, eventView, tableDataMeta, getTarget} = this.props;
-
-    if (getTarget && typeof getTarget === 'function') {
-      return getTarget();
-    }
-
-    if (!tableDataMeta) {
-      return undefined;
-    }
-
-    const nextEventView = eventView.sortOnField(field, tableDataMeta);
-    const queryStringObject = nextEventView.generateQueryStringObject();
-
-    return {
-      ...location,
-      query: queryStringObject,
-    };
   }
 
   renderChevron() {
@@ -74,9 +44,9 @@ class SortLink extends React.Component<Props> {
   }
 
   render() {
-    const {align, field, tableDataMeta} = this.props;
+    const {align, field, tableDataMeta, generateSortLink} = this.props;
 
-    const target = this.getTarget();
+    const target = generateSortLink();
 
     if (!target || !isFieldSortable(field, tableDataMeta)) {
       return <StyledNonLink align={align}>{field.field}</StyledNonLink>;
@@ -98,6 +68,15 @@ const StyledLink = styled((props: StyledLinkProps) => {
 })`
   display: block;
   white-space: nowrap;
+  color: inherit;
+
+  &:hover,
+  &:active,
+  &:focus,
+  &:visited {
+    color: inherit;
+  }
+
   ${(p: StyledLinkProps) => (p.align ? `text-align: ${p.align};` : '')}
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/headerCell.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/headerCell.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import {getAggregateAlias} from '../utils';
+import {ColumnValueType} from '../eventQueryParams';
+import {Alignments} from '../sortLink';
+import {TableColumn, TableData, TableDataRow} from './types';
+
+type ChildrenProps = {
+  align: Alignments;
+};
+
+type Props = {
+  children: (props: ChildrenProps) => React.ReactElement;
+  column: TableColumn<keyof TableDataRow>;
+  tableData: TableData | null | undefined;
+};
+
+function HeaderCell(props: Props) {
+  const {children, column, tableData} = props;
+
+  const field = column.eventViewField;
+
+  // establish alignment based on the type
+  const alignedTypes: ColumnValueType[] = ['number', 'duration', 'integer'];
+  let align: Alignments = alignedTypes.includes(column.type) ? 'right' : 'left';
+
+  if (column.type === 'never' || column.type === '*') {
+    // fallback to align the column based on the table metadata
+    const maybeType =
+      tableData && tableData.meta
+        ? tableData.meta[getAggregateAlias(field.field)]
+        : undefined;
+
+    if (maybeType === 'integer' || maybeType === 'number') {
+      align = 'right';
+    }
+  }
+
+  return children({align});
+}
+
+export default HeaderCell;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -28,7 +28,7 @@ import {ColumnValueType} from '../eventQueryParams';
 import DraggableColumns, {
   DRAGGABLE_COLUMN_CLASSNAME_IDENTIFIER,
 } from './draggableColumns';
-import {generateEventDetailsRoute, generateEventSlug} from '../eventDetails/utils';
+import {generateEventSlug, eventDetailsRouteWithEventView} from '../eventDetails/utils';
 
 export type TableViewProps = {
   location: Location;
@@ -220,7 +220,7 @@ class TableView extends React.Component<TableViewProps> {
     dataRow?: any,
     rowIndex?: number
   ): React.ReactNode[] => {
-    const {eventView} = this.props;
+    const {organization, eventView} = this.props;
     const hasAggregates = eventView.getAggregateFields().length > 0;
     if (isHeader) {
       return [
@@ -229,16 +229,14 @@ class TableView extends React.Component<TableViewProps> {
         </HeaderIcon>,
       ];
     }
-    const {organization, location} = this.props;
+
     const eventSlug = generateEventSlug(dataRow);
-    const pathname = generateEventDetailsRoute({
+
+    const target = eventDetailsRouteWithEventView({
       orgSlug: organization.slug,
       eventSlug,
+      eventView,
     });
-    const target = {
-      pathname,
-      query: {...location.query},
-    };
 
     return [
       <Tooltip key={`eventlink${rowIndex}`} title={t('View Details')}>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -13,7 +13,6 @@ import Tooltip from 'app/components/tooltip';
 
 import {
   downloadAsCsv,
-  getAggregateAlias,
   getFieldRenderer,
   getExpandedResults,
   pushEventViewToLocation,
@@ -21,10 +20,10 @@ import {
   MetaType,
 } from '../utils';
 import EventView, {pickRelevantLocationQueryStrings} from '../eventView';
-import SortLink, {Alignments} from '../sortLink';
+import SortLink from '../sortLink';
 import renderTableModalEditColumnFactory from './tableModalEditColumn';
 import {TableColumn, TableData, TableDataRow} from './types';
-import {ColumnValueType} from '../eventQueryParams';
+import HeaderCell from './headerCell';
 import DraggableColumns, {
   DRAGGABLE_COLUMN_CLASSNAME_IDENTIFIER,
 } from './draggableColumns';
@@ -249,32 +248,23 @@ class TableView extends React.Component<TableViewProps> {
 
   _renderGridHeaderCell = (column: TableColumn<keyof TableDataRow>): React.ReactNode => {
     const {eventView, location, tableData} = this.props;
-    const field = column.eventViewField;
-
-    // establish alignment based on the type
-    const alignedTypes: ColumnValueType[] = ['number', 'duration', 'integer'];
-    let align: Alignments = alignedTypes.includes(column.type) ? 'right' : 'left';
-
-    if (column.type === 'never' || column.type === '*') {
-      // fallback to align the column based on the table metadata
-      const maybeType =
-        tableData && tableData.meta
-          ? tableData.meta[getAggregateAlias(field.field)]
-          : undefined;
-
-      if (maybeType === 'integer' || maybeType === 'number') {
-        align = 'right';
-      }
-    }
 
     return (
-      <SortLink
-        align={align}
-        field={field}
-        location={location}
-        eventView={eventView}
-        tableDataMeta={tableData && tableData.meta ? tableData.meta : undefined}
-      />
+      <HeaderCell column={column} tableData={tableData}>
+        {({align}) => {
+          const field = column.eventViewField;
+
+          return (
+            <SortLink
+              align={align}
+              field={field}
+              location={location}
+              eventView={eventView}
+              tableDataMeta={tableData && tableData.meta ? tableData.meta : undefined}
+            />
+          );
+        }}
+      </HeaderCell>
     );
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {Location} from 'history';
+import {Location, LocationDescriptorObject} from 'history';
 
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
@@ -254,13 +254,29 @@ class TableView extends React.Component<TableViewProps> {
         {({align}) => {
           const field = column.eventViewField;
 
+          const tableDataMeta = tableData && tableData.meta ? tableData.meta : undefined;
+
+          function generateSortLink(): LocationDescriptorObject | undefined {
+            if (!tableDataMeta) {
+              return undefined;
+            }
+
+            const nextEventView = eventView.sortOnField(field, tableDataMeta);
+            const queryStringObject = nextEventView.generateQueryStringObject();
+
+            return {
+              ...location,
+              query: queryStringObject,
+            };
+          }
+
           return (
             <SortLink
               align={align}
               field={field}
-              location={location}
               eventView={eventView}
               tableDataMeta={tableData && tableData.meta ? tableData.meta : undefined}
+              generateSortLink={generateSortLink}
             />
           );
         }}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -273,8 +273,6 @@ class TableView extends React.Component<TableViewProps> {
         field={field}
         location={location}
         eventView={eventView}
-        /* TODO(leedongwei): Verbosity is due to error in Prettier, fix after
-           upgrade to v1.19.1 */
         tableDataMeta={tableData && tableData.meta ? tableData.meta : undefined}
       />
     );

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import * as ReactRouter from 'react-router';
+
+import {TimeSeriesData} from 'app/views/events/utils/eventsRequest';
+import AreaChart from 'app/components/charts/areaChart';
+import ChartZoom from 'app/components/charts/chartZoom';
+
+import {HeaderTitle} from './styles';
+
+type Props = {
+  yAxis: string;
+  data: TimeSeriesData;
+  router: ReactRouter.InjectedRouter;
+  statsPeriod: string | undefined;
+  utc: boolean;
+  projects: number[];
+  environments: string[];
+  loading: boolean;
+};
+
+class Chart extends React.Component<Props> {
+  render() {
+    const {
+      data,
+      yAxis,
+      router,
+      statsPeriod,
+      utc,
+      projects,
+      environments,
+      loading,
+    } = this.props;
+    const {timeseriesData} = data;
+
+    if (!timeseriesData || timeseriesData.length <= 0) {
+      return null;
+    }
+
+    timeseriesData[0].seriesName = yAxis;
+
+    const areaChartProps = {
+      seriesOptions: {
+        showSymbol: false,
+      },
+      grid: {
+        left: '24px',
+        right: '48px',
+        top: '24px',
+        bottom: '12px',
+      },
+      utc,
+      isGroupedByDate: true,
+      showTimeInTooltip: true,
+    };
+
+    if (loading) {
+      return (
+        <Container key="loading">
+          <HeaderTitle>{yAxis}</HeaderTitle>
+          <AreaChart series={[]} {...areaChartProps} />
+        </Container>
+      );
+    }
+
+    return (
+      <Container key="loaded">
+        <HeaderTitle>{yAxis}</HeaderTitle>
+        <ChartZoom
+          router={router}
+          period={statsPeriod}
+          utc={utc}
+          projects={projects}
+          environments={environments}
+        >
+          {zoomRenderProps => {
+            return (
+              <AreaChart
+                {...zoomRenderProps}
+                series={timeseriesData}
+                {...areaChartProps}
+              />
+            );
+          }}
+        </ChartZoom>
+      </Container>
+    );
+  }
+}
+
+const Container = styled('div')`
+  min-width: 50%;
+  max-width: 50%;
+  width: 50%;
+`;
+
+export default Chart;

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -73,15 +73,9 @@ class Chart extends React.Component<Props> {
           projects={projects}
           environments={environments}
         >
-          {zoomRenderProps => {
-            return (
-              <AreaChart
-                {...zoomRenderProps}
-                series={timeseriesData}
-                {...areaChartProps}
-              />
-            );
-          }}
+          {zoomRenderProps => (
+            <AreaChart {...zoomRenderProps} series={timeseriesData} {...areaChartProps} />
+          )}
         </ChartZoom>
       </Container>
     );

--- a/src/sentry/static/sentry/app/views/performance/charts/footer.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/footer.tsx
@@ -1,0 +1,8 @@
+type Props = {
+  totals: null | number;
+};
+
+export default function ChartFooter(_props: Props) {
+  // TODO: implement later
+  return null;
+}

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import * as Sentry from '@sentry/browser';
+import {Location} from 'history';
+import * as ReactRouter from 'react-router';
+
+import {Organization} from 'app/types';
+import {Client} from 'app/api';
+import withApi from 'app/utils/withApi';
+import {getInterval} from 'app/components/charts/utils';
+import LoadingPanel from 'app/views/events/loadingPanel';
+import getDynamicText from 'app/utils/getDynamicText';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import {Panel} from 'app/components/panels';
+import EventView from 'app/views/eventsV2/eventView';
+import {fetchTotalCount} from 'app/views/eventsV2/utils';
+import EventsRequest from 'app/views/events/utils/eventsRequest';
+import {getUtcToLocalDateObject} from 'app/utils/dates';
+import {IconWarning} from 'app/icons';
+import theme from 'app/utils/theme';
+
+import Chart from './chart';
+import Footer from './footer';
+
+const YAXIS_OPTIONS = ['apdex()', 'rpm()'];
+
+type Props = {
+  api: Client;
+  eventView: EventView;
+  organization: Organization;
+  location: Location;
+  router: ReactRouter.InjectedRouter;
+};
+
+type State = {
+  totalValues: null | number;
+};
+
+class Container extends React.Component<Props, State> {
+  state: State = {
+    totalValues: null,
+  };
+
+  componentDidMount() {
+    this.mounted = true;
+
+    // TODO: implement later
+    // this.fetchTotalCount();
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
+  mounted: boolean = false;
+
+  async fetchTotalCount() {
+    const {api, organization, location, eventView} = this.props;
+    if (!eventView.isValid() || !this.mounted) {
+      return;
+    }
+
+    try {
+      const totals = await fetchTotalCount(
+        api,
+        organization.slug,
+        eventView.getEventsAPIPayload(location)
+      );
+
+      if (this.mounted) {
+        this.setState({totalValues: totals});
+      }
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+  }
+
+  render() {
+    const {api, organization, location, eventView, router} = this.props;
+
+    // construct request parameters for fetching chart data
+
+    const globalSelection = eventView.getGlobalSelection();
+    const start = globalSelection.start
+      ? getUtcToLocalDateObject(globalSelection.start)
+      : undefined;
+
+    const end = globalSelection.end
+      ? getUtcToLocalDateObject(globalSelection.end)
+      : undefined;
+
+    const {utc} = getParams(location.query);
+
+    return (
+      <Panel>
+        <ChartsContainer>
+          <EventsRequest
+            organization={organization}
+            api={api}
+            period={globalSelection.statsPeriod}
+            project={globalSelection.project}
+            environment={globalSelection.environment}
+            start={start}
+            end={end}
+            interval={getInterval(
+              {
+                start: start || null,
+                end: end || null,
+                period: globalSelection.statsPeriod,
+              },
+              true
+            )}
+            showLoading={false}
+            query={eventView.getEventsAPIPayload(location).query}
+            includePrevious={false}
+            yAxis={YAXIS_OPTIONS}
+          >
+            {({loading, reloading, errored, results}) => {
+              if (errored) {
+                return (
+                  <ErrorPanel>
+                    <IconWarning color={theme.gray2} size="lg" />
+                  </ErrorPanel>
+                );
+              }
+
+              if (!results) {
+                return <LoadingPanel data-test-id="events-request-loading" />;
+              }
+
+              return YAXIS_OPTIONS.map(yAxis => {
+                return (
+                  <React.Fragment key={yAxis}>
+                    {getDynamicText({
+                      value: (
+                        <Chart
+                          loading={loading || reloading}
+                          yAxis={yAxis}
+                          data={results[yAxis]}
+                          router={router}
+                          statsPeriod={globalSelection.statsPeriod}
+                          utc={utc === 'true'}
+                          projects={globalSelection.project}
+                          environments={globalSelection.environment}
+                        />
+                      ),
+                      fixed: 'events chart',
+                    })}
+                  </React.Fragment>
+                );
+              });
+            }}
+          </EventsRequest>
+        </ChartsContainer>
+        <Footer totals={this.state.totalValues} />
+      </Panel>
+    );
+  }
+}
+
+export const ChartsContainer = styled('div')`
+  display: flex;
+`;
+
+const ErrorPanel = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  flex: 1;
+  flex-shrink: 0;
+  overflow: hidden;
+  height: 200px;
+  position: relative;
+  border-color: transparent;
+  margin-bottom: 0;
+`;
+
+export default withApi(Container);

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -128,27 +128,25 @@ class Container extends React.Component<Props, State> {
                 return <LoadingPanel data-test-id="events-request-loading" />;
               }
 
-              return YAXIS_OPTIONS.map(yAxis => {
-                return (
-                  <React.Fragment key={yAxis}>
-                    {getDynamicText({
-                      value: (
-                        <Chart
-                          loading={loading || reloading}
-                          yAxis={yAxis}
-                          data={results[yAxis]}
-                          router={router}
-                          statsPeriod={globalSelection.statsPeriod}
-                          utc={utc === 'true'}
-                          projects={globalSelection.project}
-                          environments={globalSelection.environment}
-                        />
-                      ),
-                      fixed: 'events chart',
-                    })}
-                  </React.Fragment>
-                );
-              });
+              return YAXIS_OPTIONS.map(yAxis => (
+                <React.Fragment key={yAxis}>
+                  {getDynamicText({
+                    value: (
+                      <Chart
+                        loading={loading || reloading}
+                        yAxis={yAxis}
+                        data={results[yAxis]}
+                        router={router}
+                        statsPeriod={globalSelection.statsPeriod}
+                        utc={utc === 'true'}
+                        projects={globalSelection.project}
+                        environments={globalSelection.environment}
+                      />
+                    ),
+                    fixed: 'events chart',
+                  })}
+                </React.Fragment>
+              ));
             }}
           </EventsRequest>
         </ChartsContainer>

--- a/src/sentry/static/sentry/app/views/performance/charts/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/styles.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+import space from 'app/styles/space';
+
+export const HeaderTitle = styled('h4')`
+  margin: 0;
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.gray3};
+
+  padding: ${space(2)};
+`;

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -1,0 +1,50 @@
+import {Location} from 'history';
+
+import {t} from 'app/locale';
+import {NewQuery} from 'app/types';
+
+export const DEFAULT_STATS_PERIOD = '24h';
+
+export const PERFORMANCE_EVENT_VIEW: Readonly<NewQuery> = {
+  id: undefined,
+  name: t('Performance'),
+  query: 'event.type:transaction',
+  projects: [],
+  fields: [
+    'transaction',
+    'project',
+    'rpm()',
+    'error_rate',
+    'p95()',
+    'avg(transaction.duration)',
+    'apdex()',
+    'impact()',
+  ],
+  version: 2,
+};
+
+export function generatePerformanceQuery(location: Location): Readonly<NewQuery> {
+  const extra: {[key: string]: string} = {};
+
+  const {query} = location;
+
+  const hasStartAndEnd = query?.start && query?.end;
+
+  if (!query?.statsPeriod && !hasStartAndEnd) {
+    extra.range = DEFAULT_STATS_PERIOD;
+  }
+
+  if (!query?.sort) {
+    extra.orderby = '-rpm';
+  } else {
+    const sort = query?.sort;
+    extra.orderby =
+      Array.isArray(sort) && sort.length > 0
+        ? sort[sort.length - 1]
+        : typeof sort === 'string'
+        ? sort
+        : '-rpm';
+  }
+
+  return Object.assign({}, PERFORMANCE_EVENT_VIEW, extra);
+}

--- a/src/sentry/static/sentry/app/views/performance/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import {t} from 'app/locale';
+import {Organization} from 'app/types';
+import {PageContent} from 'app/styles/organization';
+import SentryTypes from 'app/sentryTypes';
+import Feature from 'app/components/acl/feature';
+import Alert from 'app/components/alert';
+import withOrganization from 'app/utils/withOrganization';
+
+type Props = {
+  organization: Organization;
+};
+
+class PerformanceContainer extends React.Component<Props> {
+  static propTypes = {
+    organization: SentryTypes.Organization.isRequired,
+  };
+
+  renderNoAccess() {
+    return (
+      <PageContent>
+        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+      </PageContent>
+    );
+  }
+
+  render() {
+    const {organization, children} = this.props;
+
+    return (
+      <Feature
+        features={['performance-view']}
+        organization={organization}
+        renderDisabled={this.renderNoAccess}
+      >
+        {children}
+      </Feature>
+    );
+  }
+}
+
+export default withOrganization(PerformanceContainer);

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import {Location} from 'history';
+import * as ReactRouter from 'react-router';
+
+import {t} from 'app/locale';
+import {Organization} from 'app/types';
+import withOrganization from 'app/utils/withOrganization';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
+import {PageContent} from 'app/styles/organization';
+import NoProjectMessage from 'app/components/noProjectMessage';
+import Alert from 'app/components/alert';
+import EventView from 'app/views/eventsV2/eventView';
+import {getUtcToLocalDateObject} from 'app/utils/dates';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import {StyledPageHeader} from 'app/views/eventsV2/landing';
+
+import {generatePerformanceQuery, DEFAULT_STATS_PERIOD} from './data';
+import Table from './table';
+import Charts from './charts/index';
+
+type Props = {
+  organization: Organization;
+  location: Location;
+  router: ReactRouter.InjectedRouter;
+};
+
+type State = {
+  eventView: EventView;
+  error: string | undefined;
+};
+
+function generatePerformanceEventView(location: Location): EventView {
+  return EventView.fromNewQueryWithLocation(generatePerformanceQuery(location), location);
+}
+
+class PerformanceLanding extends React.Component<Props, State> {
+  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
+    return {...prevState, eventView: generatePerformanceEventView(nextProps.location)};
+  }
+
+  state = {
+    eventView: generatePerformanceEventView(this.props.location),
+    error: undefined,
+  };
+
+  renderError = () => {
+    const {error} = this.state;
+
+    if (!error) {
+      return null;
+    }
+
+    return (
+      <Alert type="error" icon="icon-circle-exclamation">
+        {error}
+      </Alert>
+    );
+  };
+
+  setError = (error: string | undefined) => {
+    this.setState({error});
+  };
+
+  generateGlobalSelection = () => {
+    const {location} = this.props;
+    const {eventView} = this.state;
+
+    const globalSelection = eventView.getGlobalSelection();
+    const start = globalSelection.start
+      ? getUtcToLocalDateObject(globalSelection.start)
+      : undefined;
+
+    const end = globalSelection.end
+      ? getUtcToLocalDateObject(globalSelection.end)
+      : undefined;
+
+    const {utc} = getParams(location.query);
+
+    return {
+      projects: globalSelection.project,
+      environments: globalSelection.environment,
+      datetime: {
+        start,
+        end,
+        period: globalSelection.statsPeriod,
+        utc: utc === 'true',
+      },
+    };
+  };
+
+  allowClearTimeRange = (): boolean => {
+    const {datetime} = this.generateGlobalSelection();
+    const {start, end, period} = datetime;
+
+    if (period === DEFAULT_STATS_PERIOD) {
+      return false;
+    }
+
+    if ((start && end) || typeof period === 'string') {
+      return true;
+    }
+
+    return false;
+  };
+
+  render() {
+    const {organization, location, router} = this.props;
+    const {eventView} = this.state;
+
+    return (
+      <SentryDocumentTitle title={t('Performance')} objSlug={organization.slug}>
+        <React.Fragment>
+          <GlobalSelectionHeader
+            organization={organization}
+            selection={this.generateGlobalSelection()}
+            allowClearTimeRange={this.allowClearTimeRange()}
+          />
+          <PageContent>
+            <NoProjectMessage organization={organization}>
+              <StyledPageHeader>{t('Performance')}</StyledPageHeader>
+              {this.renderError()}
+              <Charts
+                eventView={eventView}
+                organization={organization}
+                location={location}
+                router={router}
+              />
+              <Table
+                eventView={eventView}
+                organization={organization}
+                location={location}
+                setError={this.setError}
+              />
+            </NoProjectMessage>
+          </PageContent>
+        </React.Fragment>
+      </SentryDocumentTitle>
+    );
+  }
+}
+
+export default withOrganization(PerformanceLanding);

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -14,7 +14,7 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Pagination from 'app/components/pagination';
 import Link from 'app/components/links/link';
-import EventView, {isAPIPayloadSimilar, Field} from 'app/views/eventsV2/eventView';
+import EventView, {isAPIPayloadSimilar} from 'app/views/eventsV2/eventView';
 import SortLink from 'app/views/eventsV2/sortLink';
 import {TableData, TableDataRow, TableColumn} from 'app/views/eventsV2/table/types';
 import HeaderCell from 'app/views/eventsV2/table/headerCell';
@@ -222,33 +222,13 @@ class Table extends React.Component<Props, State> {
     });
   };
 
-  generateSortLink = (field: Field, tableDataMeta?: MetaType) => ():
-    | LocationDescriptorObject
-    | undefined => {
-    const {eventView} = this.props;
-
-    if (!tableDataMeta) {
-      return undefined;
-    }
-
-    const nextEventView = eventView.sortOnField(field, tableDataMeta);
-    const queryStringObject = nextEventView.generateQueryStringObject();
-
-    const omitKeys = ['widths', 'query', 'name', 'field'];
-
-    return {
-      ...location,
-      query: omit(queryStringObject, omitKeys),
-    };
-  };
-
   renderHeader = () => {
     const {location, eventView} = this.props;
     const {tableData} = this.state;
 
     const tableDataMeta = tableData && tableData.meta ? tableData.meta : undefined;
 
-    const columnOrder = this.props.eventView.getColumns();
+    const columnOrder = eventView.getColumns();
 
     const lastindex = columnOrder.length - 1;
     return columnOrder.map((column, index) => {
@@ -257,15 +237,30 @@ class Table extends React.Component<Props, State> {
           {({align}) => {
             const field = column.eventViewField;
 
+            function generateSortLink(): LocationDescriptorObject | undefined {
+              if (!tableDataMeta) {
+                return undefined;
+              }
+
+              const nextEventView = eventView.sortOnField(field, tableDataMeta);
+              const queryStringObject = nextEventView.generateQueryStringObject();
+
+              const omitKeys = ['widths', 'query', 'name', 'field'];
+
+              return {
+                ...location,
+                query: omit(queryStringObject, omitKeys),
+              };
+            }
+
             return (
               <HeadCell first={index === 0} last={lastindex === index}>
                 <SortLink
                   align={align}
                   field={field}
-                  location={location}
                   eventView={eventView}
                   tableDataMeta={tableDataMeta}
-                  getTarget={this.generateSortLink(field, tableDataMeta)}
+                  generateSortLink={generateSortLink}
                 />
               </HeadCell>
             );

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -1,0 +1,359 @@
+import React from 'react';
+import {Location, LocationDescriptorObject} from 'history';
+import styled from '@emotion/styled';
+import omit from 'lodash/omit';
+
+import {t} from 'app/locale';
+import {Organization} from 'app/types';
+import {assert} from 'app/types/utils';
+import {Client} from 'app/api';
+import withApi from 'app/utils/withApi';
+import space from 'app/styles/space';
+import {Panel, PanelHeader, PanelItem} from 'app/components/panels';
+import LoadingIndicator from 'app/components/loadingIndicator';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
+import Pagination from 'app/components/pagination';
+import Link from 'app/components/links/link';
+import EventView, {isAPIPayloadSimilar, Field} from 'app/views/eventsV2/eventView';
+import SortLink from 'app/views/eventsV2/sortLink';
+import {TableData, TableDataRow, TableColumn} from 'app/views/eventsV2/table/types';
+import HeaderCell from 'app/views/eventsV2/table/headerCell';
+import {getFieldRenderer, MetaType, getAggregateAlias} from 'app/views/eventsV2/utils';
+import {
+  generateEventSlug,
+  eventDetailsRouteWithEventView,
+} from 'app/views/eventsV2/eventDetails/utils';
+
+type Props = {
+  api: Client;
+  eventView: EventView;
+  organization: Organization;
+  location: Location;
+  setError: (msg: string | undefined) => void;
+};
+
+type State = {
+  isLoading: boolean;
+  tableFetchID: symbol | undefined;
+  error: null | string;
+  pageLinks: null | string;
+  tableData: TableData | null | undefined;
+};
+
+class Table extends React.Component<Props, State> {
+  state: State = {
+    isLoading: true,
+    tableFetchID: undefined,
+    error: null,
+
+    pageLinks: null,
+    tableData: null,
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    // Reload data if we aren't already loading, or if we've moved
+    // from an invalid view state to a valid one.
+    if (
+      (!this.state.isLoading && this.shouldRefetchData(prevProps)) ||
+      (prevProps.eventView.isValid() === false && this.props.eventView.isValid())
+    ) {
+      this.fetchData();
+    }
+  }
+
+  shouldRefetchData = (prevProps: Props): boolean => {
+    const thisAPIPayload = this.props.eventView.getEventsAPIPayload(this.props.location);
+    const otherAPIPayload = prevProps.eventView.getEventsAPIPayload(prevProps.location);
+
+    return !isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
+  };
+
+  fetchData = () => {
+    const {eventView, organization, location, setError} = this.props;
+
+    if (!eventView.isValid()) {
+      return;
+    }
+
+    const url = `/organizations/${organization.slug}/eventsv2/`;
+    const tableFetchID = Symbol('tableFetchID');
+    const apiPayload = eventView.getEventsAPIPayload(location);
+
+    this.setState({isLoading: true, tableFetchID});
+
+    this.props.api
+      .requestPromise(url, {
+        method: 'GET',
+        includeAllArgs: true,
+        query: apiPayload,
+      })
+      .then(([data, _, jqXHR]) => {
+        if (this.state.tableFetchID !== tableFetchID) {
+          // invariant: a different request was initiated after this request
+          return;
+        }
+
+        this.setState(prevState => {
+          return {
+            isLoading: false,
+            tableFetchID: undefined,
+            error: null,
+            pageLinks: jqXHR ? jqXHR.getResponseHeader('Link') : prevState.pageLinks,
+            tableData: data,
+          };
+        });
+      })
+      .catch(err => {
+        this.setState({
+          isLoading: false,
+          tableFetchID: undefined,
+          error: err.responseJSON.detail,
+          pageLinks: null,
+          tableData: null,
+        });
+        setError(err.responseJSON.detail);
+      });
+  };
+
+  renderResults = () => {
+    const {isLoading, tableData} = this.state;
+
+    if (isLoading) {
+      return (
+        <SpanEntireRow>
+          <LoadingIndicator />
+        </SpanEntireRow>
+      );
+    }
+
+    const hasResults =
+      tableData && tableData.data && tableData.meta && tableData.data.length > 0;
+
+    if (!hasResults) {
+      return (
+        <SpanEntireRow>
+          <EmptyStateWarning>
+            <p>{t('No transactions found')}</p>
+          </EmptyStateWarning>
+        </SpanEntireRow>
+      );
+    }
+
+    assert(tableData);
+
+    const columnOrder = this.props.eventView.getColumns();
+
+    const lastIndex = tableData.data.length - 1;
+    return tableData.data.map((row, index) => {
+      assert(tableData.meta);
+
+      const isLastRow = index === lastIndex;
+      return (
+        <React.Fragment key={index}>
+          {this.renderRowItem(row, columnOrder, tableData.meta, isLastRow)}
+        </React.Fragment>
+      );
+    });
+  };
+
+  renderRowItem = (
+    row: TableDataRow,
+    columnOrder: TableColumn<React.ReactText>[],
+    tableMeta: MetaType,
+    isLastRow: boolean
+  ) => {
+    const {organization, location, eventView} = this.props;
+
+    const lastIndex = columnOrder.length - 1;
+    return columnOrder.map((column, index) => {
+      const field = String(column.key);
+      const fieldName = getAggregateAlias(field);
+      const fieldType = tableMeta[fieldName];
+
+      const fieldRenderer = getFieldRenderer(field, tableMeta);
+      let rendered = fieldRenderer(row, {organization, location});
+
+      const isFirstCell = index === 0;
+      const isLastCell = index === lastIndex;
+
+      if (isFirstCell) {
+        // the first column of the row should link to the transaction details view
+        // on Discover
+
+        const eventSlug = generateEventSlug(row);
+
+        const target = eventDetailsRouteWithEventView({
+          orgSlug: organization.slug,
+          eventSlug,
+          eventView,
+        });
+
+        rendered = <Link to={target}>{rendered}</Link>;
+      }
+
+      const isNumeric = ['integer', 'number', 'duration'].includes(fieldType);
+      if (isNumeric) {
+        return (
+          <BodyCell
+            key={column.key}
+            first={isFirstCell}
+            last={isLastCell}
+            hideBottomBorder={isLastRow}
+          >
+            <NumericColumn>{rendered}</NumericColumn>
+          </BodyCell>
+        );
+      }
+
+      return (
+        <BodyCell
+          key={column.key}
+          first={isFirstCell}
+          last={isLastCell}
+          hideBottomBorder={isLastRow}
+        >
+          {rendered}
+        </BodyCell>
+      );
+    });
+  };
+
+  generateSortLink = (field: Field, tableDataMeta?: MetaType) => ():
+    | LocationDescriptorObject
+    | undefined => {
+    const {eventView} = this.props;
+
+    if (!tableDataMeta) {
+      return undefined;
+    }
+
+    const nextEventView = eventView.sortOnField(field, tableDataMeta);
+    const queryStringObject = nextEventView.generateQueryStringObject();
+
+    const omitKeys = ['widths', 'query', 'name', 'field'];
+
+    return {
+      ...location,
+      query: omit(queryStringObject, omitKeys),
+    };
+  };
+
+  renderHeader = () => {
+    const {location, eventView} = this.props;
+    const {tableData} = this.state;
+
+    const tableDataMeta = tableData && tableData.meta ? tableData.meta : undefined;
+
+    const columnOrder = this.props.eventView.getColumns();
+
+    const lastindex = columnOrder.length - 1;
+    return columnOrder.map((column, index) => {
+      return (
+        <HeaderCell column={column} tableData={tableData} key={index}>
+          {({align}) => {
+            const field = column.eventViewField;
+
+            return (
+              <HeadCell first={index === 0} last={lastindex === index}>
+                <SortLink
+                  align={align}
+                  field={field}
+                  location={location}
+                  eventView={eventView}
+                  tableDataMeta={tableDataMeta}
+                  getTarget={this.generateSortLink(field, tableDataMeta)}
+                />
+              </HeadCell>
+            );
+          }}
+        </HeaderCell>
+      );
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <Panel>
+          <TableGrid>
+            {this.renderHeader()}
+            {this.renderResults()}
+          </TableGrid>
+        </Panel>
+        <Pagination pageLinks={this.state.pageLinks} />
+      </div>
+    );
+  }
+}
+
+const TableGrid = styled('div')`
+  display: grid;
+  grid-template-columns: auto repeat(7, minmax(50px, max-content));
+  width: 100%;
+`;
+
+const HeadCell = styled(PanelHeader)<{first?: boolean; last?: boolean}>`
+  background-color: ${p => p.theme.offWhite};
+
+  display: block;
+  text-overflow: ellipsis;
+
+  padding: ${props => {
+    /* top | right | bottom | left */
+
+    if (props.first) {
+      return `${space(2)} ${space(1)} ${space(2)} ${space(2)}`;
+    }
+
+    if (props.last) {
+      return `${space(2)} ${space(2)} ${space(2)} ${space(1)}`;
+    }
+
+    return `${space(2)} ${space(1)} ${space(2)} ${space(1)}`;
+  }};
+`;
+
+const BodyCell = styled(PanelItem)<{
+  first?: boolean;
+  last?: boolean;
+  hideBottomBorder: boolean;
+}>`
+  display: block;
+  text-overflow: ellipsis;
+
+  padding: ${props => {
+    /* top | right | bottom | left */
+
+    if (props.first) {
+      return `${space(2)} ${space(1)} ${space(2)} ${space(2)}`;
+    }
+
+    if (props.last) {
+      return `${space(2)} ${space(2)} ${space(2)} ${space(1)}`;
+    }
+
+    return `${space(2)} ${space(1)} ${space(2)} ${space(1)}`;
+  }};
+
+  ${props => {
+    if (props.hideBottomBorder) {
+      return 'border-bottom: none';
+    }
+
+    return null;
+  }};
+`;
+
+const SpanEntireRow = styled('div')`
+  grid-column: 1 / -1;
+`;
+
+const NumericColumn = styled('div')`
+  text-align: right;
+`;
+
+export default withApi(Table);

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -97,15 +97,13 @@ class Table extends React.Component<Props, State> {
           return;
         }
 
-        this.setState(prevState => {
-          return {
-            isLoading: false,
-            tableFetchID: undefined,
-            error: null,
-            pageLinks: jqXHR ? jqXHR.getResponseHeader('Link') : prevState.pageLinks,
-            tableData: data,
-          };
-        });
+        this.setState(prevState => ({
+          isLoading: false,
+          tableFetchID: undefined,
+          error: null,
+          pageLinks: jqXHR ? jqXHR.getResponseHeader('Link') : prevState.pageLinks,
+          tableData: data,
+        }));
       })
       .catch(err => {
         this.setState({
@@ -231,43 +229,41 @@ class Table extends React.Component<Props, State> {
     const columnOrder = eventView.getColumns();
 
     const lastindex = columnOrder.length - 1;
-    return columnOrder.map((column, index) => {
-      return (
-        <HeaderCell column={column} tableData={tableData} key={index}>
-          {({align}) => {
-            const field = column.eventViewField;
+    return columnOrder.map((column, index) => (
+      <HeaderCell column={column} tableData={tableData} key={index}>
+        {({align}) => {
+          const field = column.eventViewField;
 
-            function generateSortLink(): LocationDescriptorObject | undefined {
-              if (!tableDataMeta) {
-                return undefined;
-              }
-
-              const nextEventView = eventView.sortOnField(field, tableDataMeta);
-              const queryStringObject = nextEventView.generateQueryStringObject();
-
-              const omitKeys = ['widths', 'query', 'name', 'field'];
-
-              return {
-                ...location,
-                query: omit(queryStringObject, omitKeys),
-              };
+          function generateSortLink(): LocationDescriptorObject | undefined {
+            if (!tableDataMeta) {
+              return undefined;
             }
 
-            return (
-              <HeadCell first={index === 0} last={lastindex === index}>
-                <SortLink
-                  align={align}
-                  field={field}
-                  eventView={eventView}
-                  tableDataMeta={tableDataMeta}
-                  generateSortLink={generateSortLink}
-                />
-              </HeadCell>
-            );
-          }}
-        </HeaderCell>
-      );
-    });
+            const nextEventView = eventView.sortOnField(field, tableDataMeta);
+            const queryStringObject = nextEventView.generateQueryStringObject();
+
+            const omitKeys = ['widths', 'query', 'name', 'field'];
+
+            return {
+              ...location,
+              query: omit(queryStringObject, omitKeys),
+            };
+          }
+
+          return (
+            <HeadCell first={index === 0} last={lastindex === index}>
+              <SortLink
+                align={align}
+                field={field}
+                eventView={eventView}
+                tableDataMeta={tableDataMeta}
+                generateSortLink={generateSortLink}
+              />
+            </HeadCell>
+          );
+        }}
+      </HeaderCell>
+    ));
   };
 
   render() {

--- a/tests/js/spec/views/performance/data.spec.jsx
+++ b/tests/js/spec/views/performance/data.spec.jsx
@@ -1,0 +1,61 @@
+import {
+  generatePerformanceQuery,
+  PERFORMANCE_EVENT_VIEW,
+} from 'app/views/performance/data';
+
+describe('generatePerformanceQuery()', function() {
+  it('generates default values', function() {
+    const result = generatePerformanceQuery({});
+
+    expect(result).toEqual({
+      ...PERFORMANCE_EVENT_VIEW,
+
+      orderby: '-rpm',
+      range: '24h',
+    });
+  });
+
+  it('override sort', function() {
+    const result = generatePerformanceQuery({
+      query: {
+        sort: ['-avg_transaction_duration', '-count'],
+      },
+    });
+
+    expect(result).toEqual({
+      ...PERFORMANCE_EVENT_VIEW,
+
+      orderby: '-count',
+      range: '24h',
+    });
+  });
+
+  it('does not override statsPeriod', function() {
+    const result = generatePerformanceQuery({
+      query: {
+        statsPeriod: ['90d', '45d'],
+      },
+    });
+
+    expect(result).toEqual({
+      ...PERFORMANCE_EVENT_VIEW,
+
+      orderby: '-rpm',
+    });
+  });
+
+  it('does not override start & end', function() {
+    const result = generatePerformanceQuery({
+      query: {
+        start: 'start',
+        end: 'end',
+      },
+    });
+
+    expect(result).toEqual({
+      ...PERFORMANCE_EVENT_VIEW,
+
+      orderby: '-rpm',
+    });
+  });
+});


### PR DESCRIPTION
**WORK IN PROGRESS**

This PR adds initial landing page for the Performance View. Work on graphs will be added in a separate PR.

## TODO

- [x] depends on performance view flags https://github.com/getsentry/sentry/pull/16895
- [x] add global selection header
- [x] query transactions from Discover endpoint
- [x] display transactions on table
- [x] create eventview
- [x] table loading state
- [x] page-wide error state
- [x] sortable columns
- [x] reusable sortlink component
- [x] chart graph thing
- [x] the rest of mark's feedback
- [x] `allowClearTimeRange` prop - https://github.com/getsentry/sentry/pull/17311
- [x] fetch with multiple `yAxis` options - https://github.com/getsentry/sentry/pull/17334