### PR TITLE
fix(workflow): Changing default selection + ordering of alert filter buttons

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -27,7 +27,7 @@ import {Incident} from '../types';
 import SparkLine from './sparkLine';
 import Status from '../status';
 
-const DEFAULT_QUERY_STATUS = '';
+const DEFAULT_QUERY_STATUS = 'open';
 
 type Props = RouteComponentProps<{orgId: string}, {}>;
 
@@ -147,7 +147,7 @@ class IncidentsListContainer extends React.Component<Props> {
 
     const openIncidentsQuery = {...query, status: 'open'};
     const closedIncidentsQuery = {...query, status: 'closed'};
-    const allIncidentsQuery = omit(query, 'status');
+    const allIncidentsQuery = {...query, status: 'all'};
 
     const status = query.status === undefined ? DEFAULT_QUERY_STATUS : query.status;
 
@@ -179,13 +179,6 @@ class IncidentsListContainer extends React.Component<Props> {
 
               <div className="btn-group">
                 <Button
-                  to={{pathname, query: allIncidentsQuery}}
-                  size="small"
-                  className={'btn' + (status === '' ? ' active' : '')}
-                >
-                  {t('All')}
-                </Button>
-                <Button
                   to={{pathname, query: openIncidentsQuery}}
                   size="small"
                   className={'btn' + (status === 'open' ? ' active' : '')}
@@ -198,6 +191,13 @@ class IncidentsListContainer extends React.Component<Props> {
                   className={'btn' + (status === 'closed' ? ' active' : '')}
                 >
                   {t('Resolved')}
+                </Button>
+                <Button
+                  to={{pathname, query: allIncidentsQuery}}
+                  size="small"
+                  className={'btn' + (status === 'all' ? ' active' : '')}
+                >
+                  {t('All')}
                 </Button>
               </div>
             </Actions>

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -2,7 +2,6 @@ import {RouteComponentProps} from 'react-router/lib/Router';
 import DocumentTitle from 'react-document-title';
 import React from 'react';
 import moment from 'moment';
-import omit from 'lodash/omit';
 import styled from '@emotion/styled';
 
 import {PageContent, PageHeader} from 'app/styles/organization';

--- a/tests/js/spec/views/incidents/list/index.spec.jsx
+++ b/tests/js/spec/views/incidents/list/index.spec.jsx
@@ -78,13 +78,13 @@ describe('IncidentsList', function() {
       expect.objectContaining({query: {}})
     );
 
-    wrapper.setProps({location: {query: {status: 'open'}, search: '?status=open`'}});
+    wrapper.setProps({location: {query: {status: 'all'}, search: '?status=all`'}});
 
     expect(
       wrapper
         .find('.btn-group')
         .find('Button')
-        .at(1)
+        .at(2)
         .hasClass('active')
     ).toBe(true);
 
@@ -92,7 +92,7 @@ describe('IncidentsList', function() {
 
     expect(mock).toHaveBeenCalledWith(
       '/organizations/org-slug/incidents/',
-      expect.objectContaining({query: expect.objectContaining({status: 'open'})})
+      expect.objectContaining({query: expect.objectContaining({status: 'all'})})
     );
   });
 });


### PR DESCRIPTION
This PR makes "active" the default, and reorders the buttons to [ Active | Resolved | All], addressing this Asana ticket:
https://app.asana.com/0/1143846759074121/1160422313293185/f