### PR TITLE
test: add css inlining coverage

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -70,8 +70,9 @@ hiredis>=0.1.0,<0.2.0
 # not directly used, but pinned for at least semaphore/symbolic
 cffi>=1.11.5,<2.0
 
-# not directly used, but pinned for toronado
+# not directly used, but pinned for toronado because it doesn't pin these
 cssutils==1.0.2
+cssselect==1.0.3
 
 # not directly used, but needed
 setproctitle>=1.1.7,<1.2.0

--- a/tests/sentry/utils/email/tests.py
+++ b/tests/sentry/utils/email/tests.py
@@ -66,6 +66,28 @@ class MessageBuilderTest(TestCase):
             "text/html",
         )
 
+    def test_inline_css(self):
+        msg = MessageBuilder(
+            subject="Test",
+            body="hello world",
+            html_body="<head><style type='text/css'>h1 { color: red; }</style></head><h1>foobar</h1><h2><b>hello world</b></h2>",
+            headers={"X-Test": "foo"},
+        )
+        msg.send(["foo@example.com"])
+
+        assert len(mail.outbox) == 1
+
+        out = mail.outbox[0]
+        assert out.to == ["foo@example.com"]
+        assert out.subject == "Test"
+        assert out.extra_headers["X-Test"] == "foo"
+        assert out.body == "hello world"
+        assert len(out.alternatives) == 1
+        assert out.alternatives[0] == (
+            '<!DOCTYPE html>\n<html><head></head><body><h1 style="color: red">foobar</h1><h2><b>hello world</b></h2></body></html>',
+            "text/html",
+        )
+
     def test_explicit_reply_to(self):
         msg = MessageBuilder(
             subject="Test",


### PR DESCRIPTION
Supersedes https://github.com/getsentry/sentry/pull/16824.

Not blocked by https://github.com/disqus/toronado/pull/27. Turns out, current version just works with Python 3.6+.

Pinning cssselect to 1.0.3 to mirror what we have in getsentry, and because toronado doesn't pin it.