### PR TITLE
feat: Show unpublished and internal integrations in directory

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/IntegrationDirectorySentryAppRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/IntegrationDirectorySentryAppRow.tsx
@@ -31,21 +31,18 @@ export default class IntegrationDirectorySentryAppRow extends React.PureComponen
     return this.props.app.status === 'unpublished';
   }
 
+  get isPublished() {
+    return !(this.isInternal || this.isUnpublished);
+  }
+
   renderStatus() {
     const {app} = this.props;
     const status = this.installationStatus;
-    if (this.isInternal || this.isUnpublished) {
-      return (
-        <React.Fragment>
-          <StatusIndicator status={status} />
-          <PublishStatus status={app.status} />
-        </React.Fragment>
-      );
-    }
 
     return (
       <React.Fragment>
         <StatusIndicator status={status} />
+        {!this.isPublished && <PublishStatus status={app.status} />}
       </React.Fragment>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/IntegrationDirectorySentryAppRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/IntegrationDirectorySentryAppRow.tsx
@@ -27,10 +27,6 @@ export default class IntegrationDirectorySentryAppRow extends React.PureComponen
     return this.props.app.status === 'internal';
   }
 
-  get isUnpublished() {
-    return this.props.app.status === 'unpublished';
-  }
-
   get isPublished() {
     return this.props.app.status === 'published';
   }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/IntegrationDirectorySentryAppRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/IntegrationDirectorySentryAppRow.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import {Link} from 'react-router';
 import capitalize from 'lodash/capitalize';
-import omit from 'lodash/omit';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
-import SentryTypes from 'app/sentryTypes';
 import {PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -36,12 +33,11 @@ export default class IntegrationDirectorySentryAppRow extends React.PureComponen
 
   renderStatus() {
     const {app} = this.props;
-    const isInternal = this.isInternal;
     const status = this.installationStatus;
     if (this.isInternal || this.isUnpublished) {
       return (
         <React.Fragment>
-          <StatusIndicator status={status} isInternal={isInternal} />
+          <StatusIndicator status={status} />
           <PublishStatus status={app.status} />
         </React.Fragment>
       );
@@ -49,7 +45,7 @@ export default class IntegrationDirectorySentryAppRow extends React.PureComponen
 
     return (
       <React.Fragment>
-        <StatusIndicator status={status} isInternal={isInternal} />
+        <StatusIndicator status={status} />
       </React.Fragment>
     );
   }
@@ -135,15 +131,13 @@ const color = {
   [PENDING]: 'yellowOrange',
 };
 
-type StatusIndicatorProps = {status: string; theme?: any; isInternal: boolean};
+type StatusIndicatorProps = {status: string; theme?: any};
 
 const StatusIndicator = styled(({status, ...props}: StatusIndicatorProps) => {
-  //need to omit isInternal
-  const propsToPass = omit(props, ['isInternal']);
   return (
     <FlexContainer>
       <CircleIndicator size={6} color={theme[color[status]]} />
-      <div {...propsToPass}>{t(`${status}`)}</div>
+      <div {...props}>{t(`${status}`)}</div>
     </FlexContainer>
   );
 })`

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/IntegrationDirectorySentryAppRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/IntegrationDirectorySentryAppRow.tsx
@@ -26,12 +26,6 @@ type Props = {
 };
 
 export default class IntegrationDirectorySentryAppRow extends React.PureComponent<Props> {
-  static propTypes = {
-    app: SentryTypes.SentryApplication,
-    organization: SentryTypes.Organization.isRequired,
-    install: PropTypes.object,
-  };
-
   get isInternal() {
     return this.props.app.status === 'internal';
   }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/IntegrationDirectorySentryAppRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/IntegrationDirectorySentryAppRow.tsx
@@ -32,7 +32,7 @@ export default class IntegrationDirectorySentryAppRow extends React.PureComponen
   }
 
   get isPublished() {
-    return !(this.isInternal || this.isUnpublished);
+    return this.props.app.status === 'published';
   }
 
   renderStatus() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -25,8 +25,7 @@ import MigrationWarnings from 'app/views/organizationIntegrations/migrationWarni
 import PermissionAlert from 'app/views/settings/organization/permissionAlert';
 import ProviderRow from 'app/views/organizationIntegrations/integrationProviderRow';
 import PluginRow from 'app/views/organizationIntegrations/integrationPluginRow';
-import IntegrationDirectoryApplicationRow from 'app/views/settings/organizationDeveloperSettings/sentryApplicationRow/integrationDirectoryApplicationRow';
-import SentryApplicationRow from 'app/views/settings/organizationDeveloperSettings/sentryApplicationRow';
+import IntegrationDirectorySentryAppRow from 'app/views/organizationIntegrations/IntegrationDirectorySentryAppRow';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
@@ -154,6 +153,8 @@ class OrganizationIntegrations extends AsyncComponent<
       ['publishedApps', '/sentry-apps/', {query: {status: 'published'}}],
       ['appInstalls', `/organizations/${orgId}/sentry-app-installations/`],
       ['plugins', `/organizations/${orgId}/plugins/configs/`],
+      // ['unPublishedApps', '/sentry-apps/', {query: {status: 'unpublished'}}],
+      // ['internalApps', '/sentry-apps/', {query: {status: 'internal'}}],
     ];
     /**
      * optional app to load for super users
@@ -339,32 +340,16 @@ class OrganizationIntegrations extends AsyncComponent<
   //render either an internal or non-internal app
   renderSentryApp = (app: SentryApp) => {
     const {organization} = this.props;
-    if (app.status === 'internal') {
-      return (
-        <SentryApplicationRow
-          key={`sentry-app-row-${app.slug}`}
-          data-test-id="internal-integration-row"
-          onRemoveApp={() => this.handleRemoveInternalSentryApp(app)}
-          organization={organization}
-          install={this.getAppInstall(app)}
-          app={app}
-          isOnIntegrationPage
-        />
-      );
-    }
-    if (app.status === 'published') {
-      return (
-        <IntegrationDirectoryApplicationRow
-          key={`sentry-app-row-${app.slug}`}
-          data-test-id="integration-row"
-          organization={organization}
-          install={this.getAppInstall(app)}
-          app={app}
-          isOnIntegrationPage
-        />
-      );
-    }
-    return null;
+
+    return (
+      <IntegrationDirectorySentryAppRow
+        key={`sentry-app-row-${app.slug}`}
+        data-test-id="integration-row"
+        organization={organization}
+        install={this.getAppInstall(app)}
+        app={app}
+      />
+    );
   };
 
   renderIntegration = (integration: AppOrProviderOrPlugin) => {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -153,8 +153,6 @@ class OrganizationIntegrations extends AsyncComponent<
       ['publishedApps', '/sentry-apps/', {query: {status: 'published'}}],
       ['appInstalls', `/organizations/${orgId}/sentry-app-installations/`],
       ['plugins', `/organizations/${orgId}/plugins/configs/`],
-      // ['unPublishedApps', '/sentry-apps/', {query: {status: 'unpublished'}}],
-      // ['internalApps', '/sentry-apps/', {query: {status: 'internal'}}],
     ];
     /**
      * optional app to load for super users


### PR DESCRIPTION
## Problem
Cannot see unpublished and internal integrations in the new integration directory.

## Solution
We now show unpublished and internal integrations in the new directory. Where we list the number of configurations for first-party integrations, internal and unpublished sentry apps will say “internal” or “unpublished” respectively. The rows in the list should look the same as Sentry Apps other than that.

## UI
<img width="556" alt="Screen Shot 2020-02-10 at 11 08 26 AM" src="https://user-images.githubusercontent.com/10491193/74181213-b2f9af80-4bf5-11ea-89eb-0579e645dd09.png">
<img width="397" alt="Screen Shot 2020-02-10 at 11 08 32 AM" src="https://user-images.githubusercontent.com/10491193/74181222-b55c0980-4bf5-11ea-880d-6fc89d24d74e.png">
