### PR TITLE
build(travis): Remove redundant dist build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,14 +172,6 @@ matrix:
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
-    - python: 2.7
-      name: 'Distribution build'
-      env: TEST_SUITE=dist
-      before_install:
-        - *pip_install
-        - find "$NODE_DIR" -type d -empty -delete
-        - nvm install
-
     - <<: *postgres_default
       name: 'Symbolicator Integration'
       env: TEST_SUITE=symbolicator

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ travis-noop:
 .PHONY: travis-test-lint
 travis-test-lint: lint-python lint-js
 
-.PHONY: travis-test-postgres travis-test-acceptance travis-test-snuba travis-test-symbolicator travis-test-js travis-test-cli travis-test-dist
+.PHONY: travis-test-postgres travis-test-acceptance travis-test-snuba travis-test-symbolicator travis-test-js travis-test-cli
 travis-test-postgres: test-python
 travis-test-acceptance: test-acceptance
 travis-test-snuba: test-snuba
@@ -224,15 +224,8 @@ travis-test-symbolicator: test-symbolicator
 travis-test-js: test-js
 travis-test-cli: test-cli
 travis-test-plugins: test-plugins
-travis-test-dist:
-	# NOTE: We quiet down output here to workaround an issue in travis that
-	# causes the build to fail with a EAGAIN when writing a large amount of
-	# data to STDOUT.
-	# See: https://github.com/travis-ci/travis-ci/issues/4704
-	SENTRY_BUILD=$(TRAVIS_COMMIT) SENTRY_LIGHT_BUILD=0 python setup.py -q sdist bdist_wheel
-	@ls -lh dist/
 
-.PHONY: scan-python travis-scan-postgres travis-scan-acceptance travis-scan-snuba travis-scan-symbolicator travis-scan-js travis-scan-cli travis-scan-dist travis-scan-lint
+.PHONY: scan-python travis-scan-postgres travis-scan-acceptance travis-scan-snuba travis-scan-symbolicator travis-scan-js travis-scan-cli travis-scan-lint
 scan-python:
 	@echo "--> Running Python vulnerability scanner"
 	$(PIP) install safety
@@ -245,6 +238,5 @@ travis-scan-snuba: travis-noop
 travis-scan-symbolicator: travis-noop
 travis-scan-js: travis-noop
 travis-scan-cli: travis-noop
-travis-scan-dist: travis-noop
 travis-scan-lint: scan-python
 travis-scan-plugins: travis-noop

--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,6 @@ lint-js:
 	bin/lint --js --parseable
 	@echo ""
 
-publish:
-	python setup.py sdist bdist_wheel upload
-
 
 .PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale update-transifex build-platform-assets test-cli test-js test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
 


### PR DESCRIPTION
Essentially reverts 1a1fa0c95d83a1e8b20c5e43d73ad6c350b56cac. This is now covered by GCB with on-premise builds.