### PR TITLE
fix(release) - Fix permissions caching for releases

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -317,7 +317,8 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         on the projects to which the release is attached?
 
         If the given request has an actor (user or ApiKey), cache the results
-        for a minute on the unique combination of actor,org,release.
+        for a minute on the unique combination of actor,org,release, and project
+        ids.
         """
         actor_id = None
         has_perms = None

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -322,20 +322,19 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         """
         actor_id = None
         has_perms = None
-        projects = self.get_projects(request, organization)
         if getattr(request, "user", None) and request.user.id:
             actor_id = "user:%s" % request.user.id
         if getattr(request, "auth", None) and request.auth.id:
             actor_id = "apikey:%s" % request.auth.id
         if actor_id is not None:
+            project_ids = sorted(set(map(int, request.GET.getlist("project"))))
             key = "release_perms:1:%s" % hash_values(
-                [actor_id, organization.id, release.id]
-                + sorted([project.id for project in projects])
+                [actor_id, organization.id, release.id] + project_ids
             )
             has_perms = cache.get(key)
         if has_perms is None:
             has_perms = ReleaseProject.objects.filter(
-                release=release, project__in=projects
+                release=release, project__in=self.get_projects(request, organization)
             ).exists()
             if actor_id is not None:
                 cache.set(key, has_perms, 60)

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -321,16 +321,20 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         """
         actor_id = None
         has_perms = None
+        projects = self.get_projects(request, organization)
         if getattr(request, "user", None) and request.user.id:
             actor_id = "user:%s" % request.user.id
         if getattr(request, "auth", None) and request.auth.id:
             actor_id = "apikey:%s" % request.auth.id
         if actor_id is not None:
-            key = "release_perms:1:%s" % hash_values([actor_id, organization.id, release.id])
+            key = "release_perms:1:%s" % hash_values(
+                [actor_id, organization.id, release.id]
+                + sorted([project.id for project in projects])
+            )
             has_perms = cache.get(key)
         if has_perms is None:
             has_perms = ReleaseProject.objects.filter(
-                release=release, project__in=self.get_projects(request, organization)
+                release=release, project__in=projects
             ).exists()
             if actor_id is not None:
                 cache.set(key, has_perms, 60)


### PR DESCRIPTION
- This introduces project ids as part of the caching permissions, since
  we don't currently include this, has_perms can return the incorrect
  value if the list of project_ids is changed.
  - eg. first load returns 404, next 60s of loads even with correct
    project_ids will still 404