### PR TITLE
ref(slack): Log event_id and project_id along with error

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -118,7 +118,14 @@ class SlackNotifyServiceAction(EventAction):
             resp.raise_for_status()
             resp = resp.json()
             if not resp.get("ok"):
-                self.logger.info("rule.fail.slack_post", extra={"error": resp.get("error")})
+                self.logger.info(
+                    "rule.fail.slack_post",
+                    extra={
+                        "error": resp.get("error"),
+                        "project_id": event.project_id,
+                        "event_id": event.event_id,
+                    },
+                )
 
         key = u"slack:{}:{}".format(integration_id, channel)
 


### PR DESCRIPTION
Logging just the error message doesn't give enough context to figure out which projects have alert rules failing for what reasons. Adding the `event_id` and `project_id` to give that context.

We can potentially add a more generic approach later on but this will at least help unblock solving some customer issues right now.

