### PR TITLE
feat(alert_rules): Only apply user alert settings to user email actions

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -49,18 +49,15 @@ class EmailActionHandler(ActionHandler):
             AlertRuleTriggerAction.TargetType.USER.value,
             AlertRuleTriggerAction.TargetType.TEAM.value,
         ):
-            alert_settings = self.project.get_member_alert_settings("mail:alert")
-            disabled_users = set(
-                user_id for user_id, setting in alert_settings.items() if setting == 0
-            )
             if self.action.target_type == AlertRuleTriggerAction.TargetType.USER.value:
+                alert_settings = self.project.get_member_alert_settings("mail:alert")
+                disabled_users = set(
+                    user_id for user_id, setting in alert_settings.items() if setting == 0
+                )
                 if target.id not in disabled_users:
                     targets = [(target.id, target.email)]
             elif self.action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
                 targets = target.member_set.values_list("user_id", "user__email")
-                targets = [
-                    (user_id, email) for user_id, email in targets if user_id not in disabled_users
-                ]
         # TODO: We need some sort of verification system to make sure we're not being
         # used as an email relay.
         # elif self.action.target_type == AlertRuleTriggerAction.TargetType.SPECIFIC.value:

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -72,7 +72,9 @@ class EmailActionHandlerGetTargetsTest(TestCase):
             target_identifier=six.text_type(self.team.id),
         )
         handler = EmailActionHandler(action, self.incident, self.project)
-        assert set(handler.get_targets()) == set([(new_user.id, new_user.email)])
+        assert set(handler.get_targets()) == set(
+            [(self.user.id, self.user.email), (new_user.id, new_user.email)]
+        )
 
 
 @freeze_time()


### PR DESCRIPTION
When an alert rule action is set to email to a team we don't want the user's personal settings to
override that. https://app.asana.com/0/1143295291839284/1154511107157496.