### PR TITLE
fix(workflow): Do not show "Resolve" dropdown for resolved alerts

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/header.tsx
@@ -43,27 +43,24 @@ export default class DetailsHeader extends React.Component<Props> {
     const statusLabel = incident ? <Status isSmall incident={incident} /> : null;
 
     return (
-      <Access
-        access={['org:write']}
-        renderNoAccessMessage={() =>
-          incident ? <Status isSmall incident={incident} /> : null
+      <Access access={['org:write']}>
+        {({hasAccess}) =>
+          hasAccess && isIncidentOpen ? (
+            <DropdownControl
+              data-test-id="status-dropdown"
+              label={statusLabel}
+              menuWidth="180px"
+              alignRight
+              buttonProps={{size: 'small', disabled: !incident}}
+            >
+              <StyledMenuItem onSelect={onStatusChange}>
+                <ResolveIcon src="icon-circle-check" /> {t('Resolve this incident')}
+              </StyledMenuItem>
+            </DropdownControl>
+          ) : (
+            statusLabel
+          )
         }
-      >
-        {isIncidentOpen ? (
-          <DropdownControl
-            data-test-id="status-dropdown"
-            label={statusLabel}
-            menuWidth="180px"
-            alignRight
-            buttonProps={{size: 'small', disabled: !incident}}
-          >
-            <StyledMenuItem onSelect={onStatusChange}>
-              <ResolveIcon src="icon-circle-check" /> {t('Resolve this incident')}
-            </StyledMenuItem>
-          </DropdownControl>
-        ) : (
-          statusLabel
-        )}
       </Access>
     );
   }

--- a/src/sentry/static/sentry/app/views/alerts/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/header.tsx
@@ -40,6 +40,7 @@ export default class DetailsHeader extends React.Component<Props> {
     const {incident, onStatusChange} = this.props;
 
     const isIncidentOpen = incident && isOpen(incident);
+    const statusLabel = incident ? <Status isSmall incident={incident} /> : null;
 
     return (
       <Access
@@ -48,18 +49,21 @@ export default class DetailsHeader extends React.Component<Props> {
           incident ? <Status isSmall incident={incident} /> : null
         }
       >
-        <DropdownControl
-          data-test-id="status-dropdown"
-          label={incident && <Status isSmall incident={incident} />}
-          menuWidth="180px"
-          alignRight
-          disabled={!isIncidentOpen}
-          buttonProps={{size: 'small', disabled: !incident}}
-        >
-          <StyledMenuItem onSelect={onStatusChange}>
-            <ResolveIcon src="icon-circle-check" /> {t('Resolve this incident')}
-          </StyledMenuItem>
-        </DropdownControl>
+        {isIncidentOpen ? (
+          <DropdownControl
+            data-test-id="status-dropdown"
+            label={statusLabel}
+            menuWidth="180px"
+            alignRight
+            buttonProps={{size: 'small', disabled: !incident}}
+          >
+            <StyledMenuItem onSelect={onStatusChange}>
+              <ResolveIcon src="icon-circle-check" /> {t('Resolve this incident')}
+            </StyledMenuItem>
+          </DropdownControl>
+        ) : (
+          statusLabel
+        )}
       </Access>
     );
   }


### PR DESCRIPTION
I erroroneously thought that `disabled` would accomplish what this does