### PR TITLE
fix(tests): Attempt to fix unstable `test_unmerge` test

### DIFF
--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -169,7 +169,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         }
 
     def test_unmerge(self):
-        now = before_now(seconds=20).replace(microsecond=0, tzinfo=pytz.utc)
+        now = before_now(minutes=5).replace(microsecond=0, tzinfo=pytz.utc)
 
         def time_from_now(offset=0):
             return now + timedelta(seconds=offset)


### PR DESCRIPTION
This test is failing because the merge hasn't finished in snuba by the time we make the query. Either that
or the query might need to be run with FINAL. We can tell this because it receives 
`set([('blue', 2), ('green', 2), ('red', 2)])`, which are the tags  were originally created on this group.

Testing just dropping the date down a bunch. I'm not sure this will help, the other option might be
a brief sleep before we query the tags, or potentially retry a few times?