### PR TITLE
feat(alerts): Add rule conditions endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+
+
+from sentry import features
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.rules import rules
+from rest_framework import status
+from rest_framework.response import Response
+
+
+class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
+    def get(self, request, organization):
+        """
+        Retrieve the list of rule conditions
+        """
+
+        def info_extractor(rule_cls):
+            context = {"id": rule_cls.id, "label": rule_cls.label}
+            if hasattr(rule_cls, "form_fields"):
+                context["formFields"] = rule_cls.form_fields
+            return context
+
+        if not features.has("organizations:new-project-issue-alert-options", organization):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return Response(
+            [
+                info_extractor(rule_cls)
+                for rule_type, rule_cls in rules
+                if rule_type.startswith("condition/")
+            ]
+        )

--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
+from rest_framework import status
+from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.rules import rules
-from rest_framework import status
-from rest_framework.response import Response
 
 
 class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -166,8 +166,8 @@ from .endpoints.organization_user_issues import OrganizationUserIssuesEndpoint
 from .endpoints.organization_user_issues_search import OrganizationUserIssuesSearchEndpoint
 from .endpoints.organization_user_reports import OrganizationUserReportsEndpoint
 from .endpoints.organization_users import OrganizationUsersEndpoint
-from .endpoints.project_avatar import ProjectAvatarEndpoint
 from .endpoints.project_agnostic_rule_conditions import ProjectAgnosticRuleConditionsEndpoint
+from .endpoints.project_avatar import ProjectAvatarEndpoint
 from .endpoints.project_create_sample import ProjectCreateSampleEndpoint
 from .endpoints.project_details import ProjectDetailsEndpoint
 from .endpoints.project_docs_platform import ProjectDocsPlatformEndpoint

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -167,6 +167,7 @@ from .endpoints.organization_user_issues_search import OrganizationUserIssuesSea
 from .endpoints.organization_user_reports import OrganizationUserReportsEndpoint
 from .endpoints.organization_users import OrganizationUsersEndpoint
 from .endpoints.project_avatar import ProjectAvatarEndpoint
+from .endpoints.project_agnostic_rule_conditions import ProjectAgnosticRuleConditionsEndpoint
 from .endpoints.project_create_sample import ProjectCreateSampleEndpoint
 from .endpoints.project_details import ProjectDetailsEndpoint
 from .endpoints.project_docs_platform import ProjectDocsPlatformEndpoint
@@ -1092,6 +1093,11 @@ urlpatterns = [
         r"^projects/",
         include(
             [
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/rule-conditions/$",
+                    ProjectAgnosticRuleConditionsEndpoint.as_view(),
+                    name="sentry-api-0-project-agnostic-rule-conditions",
+                ),
                 url(r"^$", ProjectIndexEndpoint.as_view(), name="sentry-api-0-projects"),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/$",

--- a/tests/sentry/api/endpoints/test_project_agnostic_rule_configurations.py
+++ b/tests/sentry/api/endpoints/test_project_agnostic_rule_configurations.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+
+
+class ProjectAgnosticRuleConfigurationsTest(APITestCase):
+    def test_simple(self):
+
+        with self.feature("organizations:new-project-issue-alert-options"):
+            self.login_as(user=self.user)
+            org = self.create_organization(owner=self.user, name="baz")
+            url = reverse("sentry-api-0-project-agnostic-rule-conditions", args=[org.slug])
+            response = self.client.get(url, format="json")
+
+            assert response.status_code == 200, response.content
+            assert len(response.data) == 9
+
+    def test_no_access(self):
+        self.login_as(user=self.user)
+        org = self.create_organization(owner=self.user, name="baz")
+        url = reverse("sentry-api-0-project-agnostic-rule-conditions", args=[org.slug])
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 404


### PR DESCRIPTION
New endpoint to support the fetching of rule conditions without providing project ID. 
This endpoint is used during project creation to populate the available rule conditions for alert options.

Part of: https://www.notion.so/sentry/Default-Alert-Options-450bbbc6f83b4ba29350fb9a59cf5746
Related PRs: https://github.com/getsentry/getsentry/pull/3546, https://github.com/getsentry/sentry/pull/16697 (Frontend)
