### PR TITLE
fix(metrics): ignore prometheus client failure

### DIFF
--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -9,7 +9,10 @@ from .base import MetricsBackend
 
 class StatsdMetricsBackend(MetricsBackend):
     def __init__(self, host="localhost", port=8125, **kwargs):
-        self.client = statsd.StatsClient(host=host, port=port)
+        try:
+            self.client = statsd.StatsClient(host=host, port=port)
+        except:
+            pass
         super(StatsdMetricsBackend, self).__init__(**kwargs)
 
     def _full_key(self, key, instance=None):
@@ -18,7 +21,9 @@ class StatsdMetricsBackend(MetricsBackend):
         return key
 
     def incr(self, key, instance=None, tags=None, amount=1, sample_rate=1):
-        self.client.incr(self._full_key(self._get_key(key)), amount, sample_rate)
+        if self.client:
+            self.client.incr(self._full_key(self._get_key(key)), amount, sample_rate)
 
     def timing(self, key, value, instance=None, tags=None, sample_rate=1):
-        self.client.timing(self._full_key(self._get_key(key)), value, sample_rate)
+        if self.client:
+            self.client.timing(self._full_key(self._get_key(key)), value, sample_rate)


### PR DESCRIPTION
It's not an essential component of sentry. One does notice, when metrics
are not working and can react to it. Currently sentry won't start at all
after a reboot, if e.g. the prometheus server is not up just yet.

This causes a race condition, when using sentry-onpremise in addition to
an prometheus exporter in the same docker-compose.

Sentry won't start at all and will just crash with this message over and
 over again: socket.gaierror: [Errno -2] Name or service not known

> Notice: I know that this is kind of a naive way of dealing with this, but it's a first shot. I'm open to improvements