### PR TITLE
ref: Split up all metrics in save_event by event type

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -421,119 +421,127 @@ def _do_save_event(
     """
     Saves an event to the database.
     """
+
     from sentry.event_manager import HashDiscarded, EventManager
     from sentry import quotas
     from sentry.models import ProjectKey
     from sentry.utils.outcomes import Outcome, track_outcome
     from sentry.ingest.outcomes_consumer import mark_signal_sent
 
+    event_type = "none"
+
     if cache_key and data is None:
-        with metrics.timer("tasks.store.do_save_event.get_cache"):
+        with metrics.timer("tasks.store.do_save_event.get_cache") as metric_tags:
             data = default_cache.get(cache_key)
+            if data is not None:
+                metric_tags["event_type"] = event_type = data.get("type") or "none"
 
-    if data is not None:
-        data = CanonicalKeyDict(data)
+    with metrics.global_tags(event_type=event_type):
+        if data is not None:
+            data = CanonicalKeyDict(data)
 
-    if event_id is None and data is not None:
-        event_id = data["event_id"]
+        if event_id is None and data is not None:
+            event_id = data["event_id"]
 
-    # only when we come from reprocessing we get a project_id sent into
-    # the task.
-    if project_id is None:
-        project_id = data.pop("project")
+        # only when we come from reprocessing we get a project_id sent into
+        # the task.
+        if project_id is None:
+            project_id = data.pop("project")
 
-    key_id = None if data is None else data.get("key_id")
-    if key_id is not None:
-        key_id = int(key_id)
-    timestamp = to_datetime(start_time) if start_time is not None else None
+        key_id = None if data is None else data.get("key_id")
+        if key_id is not None:
+            key_id = int(key_id)
+        timestamp = to_datetime(start_time) if start_time is not None else None
 
-    # We only need to delete raw events for events that support
-    # reprocessing.  If the data cannot be found we want to assume
-    # that we need to delete the raw event.
-    if not data or reprocessing.event_supports_reprocessing(data):
-        with metrics.timer("tasks.store.do_save_event.delete_raw_event"):
-            delete_raw_event(project_id, event_id, allow_hint_clear=True)
+        # We only need to delete raw events for events that support
+        # reprocessing.  If the data cannot be found we want to assume
+        # that we need to delete the raw event.
+        if not data or reprocessing.event_supports_reprocessing(data):
+            with metrics.timer("tasks.store.do_save_event.delete_raw_event"):
+                delete_raw_event(project_id, event_id, allow_hint_clear=True)
 
-    # This covers two cases: where data is None because we did not manage
-    # to fetch it from the default cache or the empty dictionary was
-    # stored in the default cache.  The former happens if the event
-    # expired while being on the queue, the second happens on reprocessing
-    # if the raw event was deleted concurrently while we held on to
-    # it.  This causes the node store to delete the data and we end up
-    # fetching an empty dict.  We could in theory not invoke `save_event`
-    # in those cases but it's important that we always clean up the
-    # reprocessing reports correctly or they will screw up the UI.  So
-    # to future proof this correctly we just handle this case here.
-    if not data:
-        metrics.incr(
-            "events.failed", tags={"reason": "cache", "stage": "post"}, skip_internal=False
-        )
-        return
+        # This covers two cases: where data is None because we did not manage
+        # to fetch it from the default cache or the empty dictionary was
+        # stored in the default cache.  The former happens if the event
+        # expired while being on the queue, the second happens on reprocessing
+        # if the raw event was deleted concurrently while we held on to
+        # it.  This causes the node store to delete the data and we end up
+        # fetching an empty dict.  We could in theory not invoke `save_event`
+        # in those cases but it's important that we always clean up the
+        # reprocessing reports correctly or they will screw up the UI.  So
+        # to future proof this correctly we just handle this case here.
+        if not data:
+            metrics.incr(
+                "events.failed", tags={"reason": "cache", "stage": "post"}, skip_internal=False
+            )
+            return
 
-    with configure_scope() as scope:
-        scope.set_tag("project", project_id)
+        with configure_scope() as scope:
+            scope.set_tag("project", project_id)
 
-    event = None
-    try:
-        with metrics.timer("tasks.store.do_save_event.event_manager.save"):
-            manager = EventManager(data)
-            # event.project.organization is populated after this statement.
-            event = manager.save(project_id, assume_normalized=True, cache_key=cache_key)
+        event = None
+        try:
+            with metrics.timer("tasks.store.do_save_event.event_manager.save"):
+                manager = EventManager(data)
+                # event.project.organization is populated after this statement.
+                event = manager.save(project_id, assume_normalized=True, cache_key=cache_key)
 
-        with metrics.timer("tasks.store.do_save_event.track_outcome"):
-            # This is where we can finally say that we have accepted the event.
+            with metrics.timer("tasks.store.do_save_event.track_outcome"):
+                # This is where we can finally say that we have accepted the event.
+                track_outcome(
+                    event.project.organization_id,
+                    event.project.id,
+                    key_id,
+                    Outcome.ACCEPTED,
+                    None,
+                    timestamp,
+                    event_id,
+                )
+
+        except HashDiscarded:
+            project = Project.objects.get_from_cache(id=project_id)
+            reason = FilterStatKeys.DISCARDED_HASH
+            project_key = None
+            try:
+                if key_id is not None:
+                    project_key = ProjectKey.objects.get_from_cache(id=key_id)
+            except ProjectKey.DoesNotExist:
+                pass
+
+            quotas.refund(project, key=project_key, timestamp=start_time)
+            # There is no signal supposed to be sent for this particular
+            # outcome-reason combination. Prevent the outcome consumer from
+            # emitting it for now.
+            #
+            # XXX(markus): Revisit decision about signals once outcomes consumer is stable.
+            mark_signal_sent(project_id, event_id)
             track_outcome(
-                event.project.organization_id,
-                event.project.id,
+                project.organization_id,
+                project_id,
                 key_id,
-                Outcome.ACCEPTED,
-                None,
+                Outcome.FILTERED,
+                reason,
                 timestamp,
                 event_id,
             )
 
-    except HashDiscarded:
-        project = Project.objects.get_from_cache(id=project_id)
-        reason = FilterStatKeys.DISCARDED_HASH
-        project_key = None
-        try:
-            if key_id is not None:
-                project_key = ProjectKey.objects.get_from_cache(id=key_id)
-        except ProjectKey.DoesNotExist:
-            pass
+        finally:
+            if cache_key:
+                with metrics.timer("tasks.store.do_save_event.delete_cache"):
+                    default_cache.delete(cache_key)
 
-        quotas.refund(project, key=project_key, timestamp=start_time)
-        # There is no signal supposed to be sent for this particular
-        # outcome-reason combination. Prevent the outcome consumer from
-        # emitting it for now.
-        #
-        # XXX(markus): Revisit decision about signals once outcomes consumer is stable.
-        mark_signal_sent(project_id, event_id)
-        track_outcome(
-            project.organization_id,
-            project_id,
-            key_id,
-            Outcome.FILTERED,
-            reason,
-            timestamp,
-            event_id,
-        )
+                with metrics.timer("tasks.store.do_save_event.delete_attachment_cache"):
+                    # For the unlikely case that we did not manage to persist the
+                    # event we also delete the key always.
+                    if event is None or features.has(
+                        "organizations:event-attachments", event.project.organization, actor=None
+                    ):
+                        attachment_cache.delete(cache_key)
 
-    finally:
-        if cache_key:
-            with metrics.timer("tasks.store.do_save_event.delete_cache"):
-                default_cache.delete(cache_key)
-
-            with metrics.timer("tasks.store.do_save_event.delete_attachment_cache"):
-                # For the unlikely case that we did not manage to persist the
-                # event we also delete the key always.
-                if event is None or features.has(
-                    "organizations:event-attachments", event.project.organization, actor=None
-                ):
-                    attachment_cache.delete(cache_key)
-
-        if start_time:
-            metrics.timing("events.time-to-process", time() - start_time, instance=data["platform"])
+            if start_time:
+                metrics.timing(
+                    "events.time-to-process", time() - start_time, instance=data["platform"]
+                )
 
 
 @instrumented_task(

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -9,12 +9,36 @@ from contextlib import contextmanager
 from django.conf import settings
 from random import random
 from time import time
-from threading import Thread
+from threading import Thread, local
 from six.moves.queue import Queue
 
 
 metrics_skip_all_internal = getattr(settings, "SENTRY_METRICS_SKIP_ALL_INTERNAL", False)
 metrics_skip_internal_prefixes = tuple(settings.SENTRY_METRICS_SKIP_INTERNAL_PREFIXES)
+
+_GLOBAL_TAGS = local()
+
+
+@contextmanager
+def global_tags(**tags):
+    if not hasattr(_GLOBAL_TAGS, "stack"):
+        stack = _GLOBAL_TAGS.stack = []
+    else:
+        stack = _GLOBAL_TAGS.stack
+
+    stack.append(tags)
+    try:
+        yield
+    finally:
+        stack.pop()
+
+
+def _get_current_global_tags():
+    rv = {}
+    for tags in getattr(_GLOBAL_TAGS, "stack", None) or ():
+        rv.update(tags)
+
+    return rv
 
 
 def get_default_backend():
@@ -100,6 +124,10 @@ def incr(
     skip_internal=True,
     sample_rate=settings.SENTRY_METRICS_SAMPLE_RATE,
 ):
+    current_tags = _get_current_global_tags()
+    if tags is not None:
+        current_tags.update(tags)
+
     should_send_internal = (
         not metrics_skip_all_internal
         and not skip_internal
@@ -108,10 +136,10 @@ def incr(
     )
 
     if should_send_internal:
-        internal.incr(key, instance, tags, amount, sample_rate)
+        internal.incr(key, instance, current_tags, amount, sample_rate)
 
     try:
-        backend.incr(key, instance, tags, amount, sample_rate)
+        backend.incr(key, instance, current_tags, amount, sample_rate)
         if should_send_internal:
             backend.incr("internal_metrics.incr", key, None, 1, sample_rate)
     except Exception:
@@ -120,8 +148,12 @@ def incr(
 
 
 def timing(key, value, instance=None, tags=None, sample_rate=settings.SENTRY_METRICS_SAMPLE_RATE):
+    current_tags = _get_current_global_tags()
+    if tags is not None:
+        current_tags.update(tags)
+
     try:
-        backend.timing(key, value, instance, tags, sample_rate)
+        backend.timing(key, value, instance, current_tags, sample_rate)
     except Exception:
         logger = logging.getLogger("sentry.errors")
         logger.exception("Unable to record backend metric")
@@ -129,12 +161,13 @@ def timing(key, value, instance=None, tags=None, sample_rate=settings.SENTRY_MET
 
 @contextmanager
 def timer(key, instance=None, tags=None, sample_rate=settings.SENTRY_METRICS_SAMPLE_RATE):
-    if tags is None:
-        tags = {}
+    current_tags = _get_current_global_tags()
+    if tags is not None:
+        current_tags.update(tags)
 
     start = time()
     try:
-        yield tags
+        yield current_tags
     except Exception:
         tags["result"] = "failure"
         raise

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -169,12 +169,12 @@ def timer(key, instance=None, tags=None, sample_rate=settings.SENTRY_METRICS_SAM
     try:
         yield current_tags
     except Exception:
-        tags["result"] = "failure"
+        current_tags["result"] = "failure"
         raise
     else:
-        tags["result"] = "success"
+        current_tags["result"] = "success"
     finally:
-        timing(key, time() - start, instance, tags, sample_rate)
+        timing(key, time() - start, instance, current_tags, sample_rate)
 
 
 def wraps(key, instance=None, tags=None):


### PR DESCRIPTION
Introduce helper functions in the metrics module to manage a thread local tags stack. This is useful because otherwise we need to pass around the event type into functions that would only use it for metrics, such as `Release.get_or_create`.

We're slowly rebuilding the Sentry Python SDK here