### PR TITLE
fix(discover2): Validate and generate a yAxis value for the graph API payload

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -25,6 +25,12 @@ export const AGGREGATE_ALIASES = [
   'latest_event',
 ] as const;
 
+// default list of yAxis options
+export const CHART_AXIS_OPTIONS = [
+  {label: 'count(id)', value: 'count(id)'},
+  {label: 'count_unique(users)', value: 'count_unique(user)'},
+];
+
 export const DEFAULT_EVENT_VIEW: Readonly<NewQuery> = {
   id: undefined,
   name: t('All Events'),

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -4,14 +4,15 @@ import cloneDeep from 'lodash/cloneDeep';
 import pick from 'lodash/pick';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
+import uniqBy from 'lodash/uniqBy';
 import moment from 'moment';
 
 import {DEFAULT_PER_PAGE} from 'app/constants';
-import {SavedQuery, NewQuery} from 'app/types';
+import {SavedQuery, NewQuery, SelectValue} from 'app/types';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
 
-import {SPECIAL_FIELDS, FIELD_FORMATTERS} from './data';
+import {SPECIAL_FIELDS, FIELD_FORMATTERS, CHART_AXIS_OPTIONS} from './data';
 import {
   MetaType,
   EventQuery,
@@ -910,6 +911,45 @@ class EventView {
     newEventView.sorts = [sort];
 
     return newEventView;
+  }
+
+  getYAxisOptions(): SelectValue<string>[] {
+    // Make option set and add the default options in.
+    return uniqBy(
+      this.getAggregateFields()
+        // Exclude last_seen and latest_event as they don't produce useful graphs.
+        .filter(
+          (field: Field) => ['last_seen', 'latest_event'].includes(field.field) === false
+        )
+        .map((field: Field) => {
+          return {label: field.field, value: field.field};
+        })
+        .concat(CHART_AXIS_OPTIONS),
+      'value'
+    );
+  }
+
+  getYAxis(): string {
+    const yAxisOptions = this.getYAxisOptions();
+
+    const yAxis = this.yAxis;
+
+    const defaultOption = yAxisOptions[0].value;
+
+    if (!yAxis) {
+      return defaultOption;
+    }
+
+    // ensure current selected yAxis is one of the items in yAxisOptions
+    const result = yAxisOptions.findIndex((option: SelectValue<string>) => {
+      return option.value === yAxis;
+    });
+
+    if (result >= 0) {
+      return yAxis;
+    }
+
+    return defaultOption;
   }
 }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 import styled from '@emotion/styled';
 import * as ReactRouter from 'react-router';
 import {Location} from 'history';
-import uniqBy from 'lodash/uniqBy';
 
-import {Organization, SelectValue} from 'app/types';
+import {Organization} from 'app/types';
 
 import {Panel} from 'app/components/panels';
 import getDynamicText from 'app/utils/getDynamicText';
 import EventsChart from 'app/views/events/eventsChart';
 
 import ChartFooter, {TooltipData} from './chartFooter';
-import EventView, {Field} from './eventView';
+import EventView from './eventView';
 
 const defaultTooltip: TooltipData = {
   values: [],
@@ -32,11 +31,6 @@ type State = {
   tooltipData: TooltipData;
 };
 
-const CHART_AXIS_OPTIONS = [
-  {label: 'count(id)', value: 'count(id)'},
-  {label: 'count_unique(users)', value: 'count_unique(user)'},
-];
-
 export default class ResultsChart extends React.Component<Props, State> {
   state = {
     tooltipData: defaultTooltip,
@@ -49,21 +43,7 @@ export default class ResultsChart extends React.Component<Props, State> {
   render() {
     const {eventView, location, organization, router, total, onAxisChange} = this.props;
 
-    // Make option set and add the default options in.
-    const yAxisOptions: SelectValue<string>[] = uniqBy(
-      eventView
-        .getAggregateFields()
-        // Exclude last_seen and latest_event as they don't produce useful graphs.
-        .filter(
-          (field: Field) => ['last_seen', 'latest_event'].includes(field.field) === false
-        )
-        .map((field: Field) => {
-          return {label: field.field, value: field.field};
-        })
-        .concat(CHART_AXIS_OPTIONS),
-      'value'
-    );
-    const yAxisValue = eventView.yAxis || yAxisOptions[0].value;
+    const yAxisValue = eventView.getYAxis();
 
     return (
       <StyledPanel onMouseLeave={() => this.handleTooltipUpdate(defaultTooltip)}>
@@ -86,7 +66,7 @@ export default class ResultsChart extends React.Component<Props, State> {
           hoverState={this.state.tooltipData}
           total={total}
           yAxisValue={yAxisValue}
-          yAxisOptions={yAxisOptions}
+          yAxisOptions={eventView.getYAxisOptions()}
           onChange={onAxisChange}
         />
       </StyledPanel>

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -1854,6 +1854,34 @@ describe('EventView.getResultsViewUrlTarget()', function() {
   });
 });
 
+describe('EventView.getGlobalSelection', function() {
+  it('return default global selection', function() {
+    const eventView = new EventView({});
+
+    expect(eventView.getGlobalSelection()).toMatchObject({
+      project: [],
+      start: undefined,
+      end: undefined,
+      statsPeriod: undefined,
+      environment: [],
+    });
+  });
+
+  it('returns global selection', function() {
+    const state2 = {
+      project: [42],
+      start: 'start',
+      end: 'end',
+      statsPeriod: '42d',
+      environment: ['prod'],
+    };
+
+    const eventView = new EventView(state2);
+
+    expect(eventView.getGlobalSelection()).toMatchObject(state2);
+  });
+});
+
 describe('isAPIPayloadSimilar', function() {
   const state = {
     id: '1234',
@@ -2101,34 +2129,6 @@ describe('isAPIPayloadSimilar', function() {
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
       expect(results).toBe(true);
-    });
-  });
-
-  describe('getGlobalSelection', function() {
-    it('return default global selection', function() {
-      const eventView = new EventView({});
-
-      expect(eventView.getGlobalSelection()).toMatchObject({
-        project: [],
-        start: undefined,
-        end: undefined,
-        statsPeriod: undefined,
-        environment: [],
-      });
-    });
-
-    it('returns global selection', function() {
-      const state2 = {
-        project: [42],
-        start: 'start',
-        end: 'end',
-        statsPeriod: '42d',
-        environment: ['prod'],
-      };
-
-      const eventView = new EventView(state2);
-
-      expect(eventView.getGlobalSelection()).toMatchObject(state2);
     });
   });
 

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -1882,6 +1882,27 @@ describe('EventView.getGlobalSelection', function() {
   });
 });
 
+describe('EventView.generateBlankQueryStringObject', function() {
+  it('should return blank values', function() {
+    const eventView = new EventView({});
+
+    expect(eventView.generateBlankQueryStringObject()).toEqual({
+      id: undefined,
+      name: undefined,
+      fields: undefined,
+      sorts: undefined,
+      query: undefined,
+      project: undefined,
+      start: undefined,
+      end: undefined,
+      statsPeriod: undefined,
+      environment: undefined,
+      yAxis: undefined,
+      cursor: undefined,
+    });
+  });
+});
+
 describe('isAPIPayloadSimilar', function() {
   const state = {
     id: '1234',
@@ -2132,24 +2153,6 @@ describe('isAPIPayloadSimilar', function() {
     });
   });
 
-  describe('generateBlankQueryStringObject', function() {
-    it('should return blank values', function() {
-      const eventView = new EventView({});
-
-      expect(eventView.generateBlankQueryStringObject()).toEqual({
-        id: undefined,
-        name: undefined,
-        fields: undefined,
-        sorts: undefined,
-        query: undefined,
-        project: undefined,
-        start: undefined,
-        end: undefined,
-        statsPeriod: undefined,
-        environment: undefined,
-        yAxis: undefined,
-        cursor: undefined,
-      });
     });
   });
 });

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -1965,6 +1965,57 @@ describe('EventView.getYAxisOptions', function() {
   });
 });
 
+describe('EventView.getYAxis', function() {
+  const state = {
+    fields: [],
+    sorts: [],
+    query: '',
+    project: [],
+    statsPeriod: '42d',
+    environment: [],
+  };
+
+  it('should return first default yAxis', function() {
+    const thisEventView = new EventView(state);
+
+    expect(thisEventView.getYAxis()).toEqual('count(id)');
+  });
+
+  it('should return valid yAxis', function() {
+    const thisEventView = new EventView({
+      ...state,
+      fields: generateFields([
+        'ignored-field',
+        'count(user)',
+        'last_seen',
+        'latest_event',
+      ]),
+      yAxis: 'count(user)',
+    });
+
+    expect(thisEventView.getYAxis()).toEqual('count(user)');
+  });
+
+  it('should ignore invalid yAxis', function() {
+    const invalid = [
+      'last_seen',
+      'latest_event',
+      'count(user)', // this is not one of the selected fields
+    ];
+
+    for (const option of invalid) {
+      const thisEventView = new EventView({
+        ...state,
+        fields: generateFields(['ignored-field', 'last_seen', 'latest_event']),
+        yAxis: option,
+      });
+
+      // yAxis defaults to the first entry of the default yAxis options
+      expect(thisEventView.getYAxis()).toEqual('count(id)');
+    }
+  });
+});
+
 describe('isAPIPayloadSimilar', function() {
   const state = {
     id: '1234',

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -15,6 +15,9 @@ const FIELDS = [
   {
     field: 'user',
   },
+  {
+    field: 'count(user)',
+  },
 ];
 
 const generateFields = () => {
@@ -200,7 +203,7 @@ describe('EventsV2 > Results', function() {
     const initialData = initializeOrg({
       organization,
       router: {
-        location: {query: {...generateFields(), yAxis: 'count_id'}},
+        location: {query: {...generateFields(), yAxis: 'count(user)'}},
       },
     });
 
@@ -226,6 +229,6 @@ describe('EventsV2 > Results', function() {
     wrapper.update();
 
     const eventsRequest = wrapper.find('EventsChart');
-    expect(eventsRequest.props().yAxis).toEqual('count_id');
+    expect(eventsRequest.props().yAxis).toEqual('count(user)');
   });
 });


### PR DESCRIPTION
The `yAxis` query string was being passed to the `/:org/events-stats/` without some validation against the selected columns (or fields) of the current event view state.

This PR addresses the following bugs:

- An invalid `yAxis` query string value will break the graph. Preferably, we default to the first `yAxis` option.

- A valid `yAxis` query string value can be passed, but is not one of the available `yAxis` options. The first option shown on the `yAxis` dropdown will be `count(id)`; but the graph will not reflect this. We instead ignore the `yAxis` query string value, and default to the first `yAxis` option.