### PR TITLE
fix(slack): use log message that doesn't use extra param

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _
+import six
 
 from sentry import http
 from sentry.rules.actions.base import EventAction
@@ -118,14 +119,15 @@ class SlackNotifyServiceAction(EventAction):
             resp.raise_for_status()
             resp = resp.json()
             if not resp.get("ok"):
+                logging_data = {
+                    "error": resp.get("error"),
+                    "project_id": event.project_id,
+                    "event_id": event.event_id,
+                }
                 self.logger.info(
-                    "rule.fail.slack_post",
-                    extra={
-                        "error": resp.get("error"),
-                        "project_id": event.project_id,
-                        "event_id": event.event_id,
-                    },
+                    "rule.fail.slack_post-pre-message: %s" % six.text_type(logging_data)
                 )
+                self.logger.info("rule.fail.slack_post", extra=logging_data)
 
         key = u"slack:{}:{}".format(integration_id, channel)
 


### PR DESCRIPTION
Since adding the `project_id` and `event_id` parameters to the log meessage for `rule.fail.slack_post`, we stopped seeing the log message show up:

<img width="638" alt="Screen Shot 2020-02-11 at 8 56 00 AM" src="https://user-images.githubusercontent.com/8533851/74265395-565ec900-4cb7-11ea-908d-623a802097ba.png">

In the past, I have seen some log messages not show up when they use the `extra` param. I'm not entirely sure why and neither did ops. However, simply embedding the content of the parameters in the string seems to work. I did this in a previous PR: https://github.com/getsentry/sentry/pull/15646/files. 