### PR TITLE
fix(discv2): adjusted margin, bg color and media query

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -75,9 +75,11 @@ export default class ResultsChart extends React.Component<Props, State> {
 }
 
 export const StyledPanel = styled(Panel)`
-  margin: 0;
-
   .echarts-for-react div:first-child {
     width: 100% !important;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    margin: 0;
   }
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -3,7 +3,6 @@ import {Location} from 'history';
 import styled from '@emotion/styled';
 
 import {Client} from 'app/api';
-import space from 'app/styles/space';
 import {Organization, Tag} from 'app/types';
 import withApi from 'app/utils/withApi';
 import withTags from 'app/utils/withTags';

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -143,5 +143,4 @@ export default withApi(withTags(Table));
 const Container = styled('div')`
   min-width: 0;
   overflow: hidden;
-  margin-top: ${space(1.5)};
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -178,6 +178,10 @@ export const StyledHeading = styled(SectionHeading)`
 
 export const TagSection = styled('div')`
   margin: ${space(2)} 0;
+
+  @media (min-width: ${theme.breakpoints[1]}) {
+    margin: 0 0 ${space(2)} 0;
+  }
 `;
 
 const StyledError = styled('div')`

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -173,7 +173,7 @@ class Tags extends React.Component<Props, State> {
 
 // These styled components are used in getsentry for a paywall.
 export const StyledHeading = styled(SectionHeading)`
-  margin: 0 0 ${space(1)} 0;
+  margin: 0 0 ${space(1.5)} 0;
 `;
 
 export const TagSection = styled('div')`

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -173,15 +173,11 @@ class Tags extends React.Component<Props, State> {
 
 // These styled components are used in getsentry for a paywall.
 export const StyledHeading = styled(SectionHeading)`
-  margin: 0 0 ${space(1.5)} 0;
+  margin: 0 0 ${space(1)} 0;
 `;
 
 export const TagSection = styled('div')`
-  margin: ${space(2)} 0;
-
-  @media (min-width: ${theme.breakpoints[1]}) {
-    margin: 0 0 ${space(2)} 0;
-  }
+  margin: ${space(0.5)} 0;
 `;
 
 const StyledError = styled('div')`

--- a/src/sentry/static/sentry/app/views/eventsV2/tagsTable.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tagsTable.tsx
@@ -70,7 +70,7 @@ const StyledTable = styled('table')`
 
 const StyledTr = styled('tr')`
   &:nth-child(2n + 1) td {
-    background: #f4f2f7;
+    background-color: ${p => p.theme.offWhite};
   }
 `;
 


### PR DESCRIPTION
**Before:**
![Screen Shot 2020-02-11 at 11 56 43 AM](https://user-images.githubusercontent.com/4830259/74273635-a5135f80-4cc5-11ea-99f2-dc9ca89b3417.png)
![Screen Shot 2020-02-11 at 2 35 44 PM](https://user-images.githubusercontent.com/4830259/74286002-cda65400-4cdb-11ea-808a-ac156016dc1f.png)

**After:**
![Screen Shot 2020-02-11 at 11 56 01 AM](https://user-images.githubusercontent.com/4830259/74273655-ad6b9a80-4cc5-11ea-9d71-15e70b52f9a5.png)
![Screen Shot 2020-02-11 at 2 34 05 PM](https://user-images.githubusercontent.com/4830259/74286011-d26b0800-4cdb-11ea-8e1a-5dfaee52cf3e.png)

