### PR TITLE
feat: Internal Sentry Apps should redirect from the Detailed View

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -58,6 +58,19 @@ class SentryAppDetailedView extends AsyncComponent<
     return baseEndpoints;
   }
 
+  onLoadAllEndpointsSuccess() {
+    const {
+      organization,
+      params: {appSlug},
+      router,
+    } = this.props;
+
+    return (
+      this.state.sentryApp.status === 'internal' &&
+      router.push(`/settings/${organization.slug}/developer-settings/${appSlug}/`)
+    );
+  }
+
   featureTags(features: IntegrationFeature[]) {
     return features.map(feature => {
       const feat = feature.featureGate.replace(/integrations/g, '');


### PR DESCRIPTION
## Problem
Since internal integrations cannot be installed, we don’t want users to land on the integration detailed view for internal sentry apps. If the user does land there on the detailed view for an internal sentry app, they should be redirected to: `/settings/:org_slug/developer-settings/:sentry_app_slug/` which is the management page for internal apps.

## Solution
Check if the app has a status of "internal" and then redirect to the proper url.