### PR TITLE
feat: Re-sort fuzzy search results

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -289,7 +289,9 @@ class OrganizationIntegrations extends AsyncComponent<
         return this.setState({displayedList: this.state.list});
       }
       const result = this.state.fuzzy && this.state.fuzzy.search(target.value);
-      return this.setState({displayedList: result.map(i => i.item)});
+      return this.setState({
+        displayedList: this.sortIntegrations(result.map(i => i.item)),
+      });
     });
   };
   // Rendering


### PR DESCRIPTION
## Problem
The order of the results should not change based off the search filter.

## Solution
Re-sort fuzzy search results before displaying them.