### PR TITLE
fix(workflow): Fix `Filter` field adding spaces

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -111,20 +111,18 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
               'You can apply standard Sentry filter syntax to filter by status, user, etc.'
             )}
           >
-            {({onChange, onBlur, onKeyDown, value}) => {
-              return (
-                <SearchBar
-                  query={value}
-                  disabled={disabled}
-                  useFormWrapper={false}
-                  organization={organization}
-                  onChange={onChange}
-                  onBlur={onBlur}
-                  onKeyDown={onKeyDown}
-                  onSearch={query => onChange(query, {})}
-                />
-              );
-            }}
+            {({onChange, onBlur, onKeyDown, value}) => (
+              <SearchBar
+                defaultQuery={value}
+                disabled={disabled}
+                useFormWrapper={false}
+                organization={organization}
+                onChange={onChange}
+                onBlur={onBlur}
+                onKeyDown={onKeyDown}
+                onSearch={query => onChange(query, {})}
+              />
+            )}
           </FormField>
           <SelectField
             name="timeWindow"


### PR DESCRIPTION
This fixes the `Filter` field - it kept adding spaces after the query as you type. We should use `defaultQuery` instead of `query` prop as we just need to load the initial query value