### PR TITLE
ref(ui) Convert Event Errors to a styled component

### DIFF
--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -7,7 +7,6 @@ import EventErrorItem from 'app/components/events/errorItem';
 import SentryTypes from 'app/sentryTypes';
 import {IconWarning} from 'app/icons';
 import {t, tn} from 'app/locale';
-import theme from 'app/utils/theme';
 import space from 'app/styles/space';
 
 const MAX_ERRORS = 100;
@@ -47,7 +46,7 @@ class EventErrors extends React.Component {
       <Section>
         <Summary>
           <span>
-            <StyledIconWarning color={theme.red} />
+            <StyledIconWarning />
             {tn(
               'There was %s error encountered while processing this event',
               'There were %s errors encountered while processing this event',
@@ -89,10 +88,19 @@ const Section = styled('div')`
       color: ${p => p.theme.gray4};
     }
   }
+
+  /*
+  Remove border on adjacent context summary box.
+  Once that component uses emotion this will be harder.
+  */
+  & + .context-summary {
+    border-top: none;
+  }
 `;
 
 const StyledIconWarning = styled(IconWarning)`
   margin-right: ${space(1)};
+  color: ${p => p.theme.red};
 `;
 
 const Summary = styled('p')`

--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -54,7 +54,9 @@ class EventErrors extends React.Component {
               numErrors
             )}
           </span>
-          <a onClick={this.toggle}>{isOpen ? t('Hide') : t('Show')}</a>
+          <a data-test-id="toggle-event-errors" onClick={this.toggle}>
+            {isOpen ? t('Hide') : t('Show')}
+          </a>
         </Summary>
         <ErrorList style={{display: isOpen ? 'block' : 'none'}}>
           {errors.map((error, errorIdx) => {
@@ -66,7 +68,7 @@ class EventErrors extends React.Component {
   }
 }
 
-// TODO don't use a custom pink
+// TODO(theme) don't use a custom pink
 const customPink = '#e7c0bc';
 
 const Section = styled('div')`
@@ -103,6 +105,7 @@ const Summary = styled('p')`
 
 const ErrorList = styled('ul')`
   border-top: 1px solid ${customPink};
+  border-bottom: 1px solid ${customPink};
   margin: ${space(1)} 0 0;
   padding: ${space(1)} 0 ${space(1)} ${space(3)};
 

--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -76,6 +76,7 @@ const customPink = '#e7c0bc';
 
 const Section = styled('div')`
   border-top: 1px solid ${customPink};
+  border-bottom: 1px solid ${customPink};
   background: ${p => p.theme.redLightest};
   margin-top: -1px;
   padding: ${space(2)} ${space(4)} 1px 40px;
@@ -108,7 +109,6 @@ const Summary = styled('p')`
 
 const ErrorList = styled('ul')`
   border-top: 1px solid ${customPink};
-  border-bottom: 1px solid ${customPink};
   margin: ${space(1)} 0 0;
   padding: ${space(1)} 0 ${space(1)} ${space(3)};
 

--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -54,11 +54,14 @@ class EventErrors extends React.Component {
               numErrors
             )}
           </span>
-          <a data-test-id="toggle-event-errors" onClick={this.toggle}>
+          <a data-test-id="event-error-toggle" onClick={this.toggle}>
             {isOpen ? t('Hide') : t('Show')}
           </a>
         </Summary>
-        <ErrorList style={{display: isOpen ? 'block' : 'none'}}>
+        <ErrorList
+          data-test-id="event-error-details"
+          style={{display: isOpen ? 'block' : 'none'}}
+        >
           {errors.map((error, errorIdx) => {
             return <EventErrorItem key={errorIdx} error={error} />;
           })}

--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import styled from '@emotion/styled';
 import uniqWith from 'lodash/uniqWith';
 import isEqual from 'lodash/isEqual';
 
-import EventDataSection from 'app/components/events/eventDataSection';
 import EventErrorItem from 'app/components/events/errorItem';
 import SentryTypes from 'app/sentryTypes';
+import {IconWarning} from 'app/icons';
 import {t, tn} from 'app/locale';
+import theme from 'app/utils/theme';
+import space from 'app/styles/space';
 
 const MAX_ERRORS = 100;
 
@@ -14,12 +17,9 @@ class EventErrors extends React.Component {
     event: SentryTypes.Event.isRequired,
   };
 
-  constructor(...args) {
-    super(...args);
-    this.state = {
-      isOpen: false,
-    };
-  }
+  state = {
+    isOpen: false,
+  };
 
   shouldComponentUpdate(nextProps, nextState) {
     if (this.state.isOpen !== nextState.isOpen) {
@@ -44,26 +44,78 @@ class EventErrors extends React.Component {
     const numErrors = errors.length;
     const isOpen = this.state.isOpen;
     return (
-      <EventDataSection event={this.props.event} type="errors" className="errors">
-        <span className="icon icon-alert" />
-        <p>
-          <a className="pull-right errors-toggle" onClick={this.toggle}>
-            {isOpen ? t('Hide') : t('Show')}
-          </a>
-          {tn(
-            'There was %s error encountered while processing this event',
-            'There were %s errors encountered while processing this event',
-            numErrors
-          )}
-        </p>
-        <ul style={{display: isOpen ? 'block' : 'none'}}>
+      <Section>
+        <Summary>
+          <span>
+            <StyledIconWarning color={theme.red} />
+            {tn(
+              'There was %s error encountered while processing this event',
+              'There were %s errors encountered while processing this event',
+              numErrors
+            )}
+          </span>
+          <a onClick={this.toggle}>{isOpen ? t('Hide') : t('Show')}</a>
+        </Summary>
+        <ErrorList style={{display: isOpen ? 'block' : 'none'}}>
           {errors.map((error, errorIdx) => {
             return <EventErrorItem key={errorIdx} error={error} />;
           })}
-        </ul>
-      </EventDataSection>
+        </ErrorList>
+      </Section>
     );
   }
 }
+
+// TODO don't use a custom pink
+const customPink = '#e7c0bc';
+
+const Section = styled('div')`
+  border-top: 1px solid ${customPink};
+  background: ${p => p.theme.redLightest};
+  margin-top: -1px;
+  padding: ${space(2)} ${space(4)} 1px 40px;
+  font-size: ${p => p.theme.fontSizeMedium};
+
+  a {
+    font-weight: bold;
+    color: ${p => p.theme.gray3};
+    &:hover {
+      color: ${p => p.theme.gray4};
+    }
+  }
+`;
+
+const StyledIconWarning = styled(IconWarning)`
+  margin-right: ${space(1)};
+`;
+
+const Summary = styled('p')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: ${space(1.5)};
+
+  & > span {
+    display: flex;
+    align-items: center;
+  }
+`;
+
+const ErrorList = styled('ul')`
+  border-top: 1px solid ${customPink};
+  margin: ${space(1)} 0 0;
+  padding: ${space(1)} 0 ${space(1)} ${space(3)};
+
+  li {
+    margin-bottom: ${space(0.75)};
+    word-break: break-word;
+  }
+
+  pre {
+    background: #f9eded;
+    color: #381618;
+    margin: 5px 0 0;
+  }
+`;
 
 export default EventErrors;

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -169,9 +169,6 @@ class EventEntries extends React.Component {
 
     const features = organization ? new Set(organization.features) : new Set();
 
-    const hasContext =
-      event && (!objectIsEmpty(event.user) || !objectIsEmpty(event.contexts));
-
     if (!event) {
       return (
         <div style={{padding: '15px 30px'}}>
@@ -179,6 +176,8 @@ class EventEntries extends React.Component {
         </div>
       );
     }
+    const hasContext = !objectIsEmpty(event.user) || !objectIsEmpty(event.contexts);
+    const hasErrors = !objectIsEmpty(event.errors);
 
     return (
       <div className="entries">
@@ -194,6 +193,7 @@ class EventEntries extends React.Component {
             report={event.userReport}
             orgId={orgId}
             issueId={group.id}
+            includeBorder={!hasErrors}
           />
         )}
         {hasContext && <EventContextSummary event={event} />}
@@ -239,6 +239,6 @@ const StyledEventUserFeedback = styled(EventUserFeedback)`
   box-shadow: none;
   padding: 20px 30px 0 40px;
   border: 0;
-  border-top: 1px solid ${p => p.theme.borderLight};
+  ${p => (p.includeBorder ? `border-top: 1px solid ${p.theme.borderLight};` : '')}
   margin: 0;
 `;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -423,6 +423,7 @@
     // whatever it pleases (e.g. 4k pixels on my 1280 screen)
     max-width: ~'calc(100% - 365px)';
 
+    // Issue status block shown when an issue is not unresolved
     .issue-status {
       background: @white-dark;
 
@@ -988,12 +989,6 @@ div.traceback > ul {
 
     .box-clippable .clip-fade {
       bottom: 0;
-    }
-
-    &.frame-errors {
-    }
-
-    &.system-frame {
     }
 
     h3 {
@@ -1582,84 +1577,6 @@ div.commands {
     &:hover {
       color: rgba(0, 0, 0, 0.9);
     }
-  }
-}
-
-.box.errors {
-  border-top: 1px solid @alert-danger-border-color !important;
-  background: @alert-danger-bg-color;
-  margin-top: -1px !important;
-  padding-top: 15px !important;
-  font-size: 14px;
-  position: relative;
-  .clearfix;
-
-  &.hint {
-    border-top: 1px solid @purple-lightest !important;
-    background: lighten(@purple-lightest, 15%);
-    margin-top: -1px !important;
-    padding-top: 15px !important;
-    font-size: 14px;
-    position: relative;
-  }
-
-  .icon-alert {
-    position: absolute;
-    top: 17px;
-    font-size: 16px;
-    color: @red;
-  }
-
-  .icon-question.event {
-    position: absolute;
-    top: 17px;
-    font-size: 16px;
-    color: black;
-  }
-
-  .box-content {
-    padding: 10px 20px;
-
-    a {
-      font-weight: bold;
-      color: rgba(0, 0, 0, 0.7);
-
-      &:hover {
-        color: rgba(0, 0, 0, 0.9);
-      }
-    }
-
-    p {
-      margin: 0 0 13px;
-      line-height: 1.5;
-      padding-left: 26px;
-
-      .btn {
-        margin-left: 5px;
-      }
-    }
-
-    ul {
-      border-top: 1px solid lighten(@alert-danger-border-color, 4);
-      margin: 10px 0 0;
-      padding: 10px 0 10px 20px;
-
-      li {
-        margin-bottom: 5px;
-        word-break: break-word;
-      }
-    }
-
-    pre {
-      background: #f9eded;
-      color: #381618;
-      margin: 5px 0 0;
-    }
-  }
-
-  & + .box,
-  & + .context-summary {
-    border-top: 1px solid lighten(@alert-danger-border-color, 4);
   }
 }
 

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -144,8 +144,8 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         event = self.create_sample_event(platform="invalid-interfaces")
         self.visit_issue(event.group.id)
 
-        self.browser.click('[data-test-id="toggle-event-errors"]')
-        self.browser.wait_until(".entries > .errors ul")
+        self.browser.click('[data-test-id="event-error-toggle"]')
+        self.browser.wait_until('[data-test-id="event-error-details"]')
         self.browser.snapshot("issue details invalid interfaces")
 
     def test_activity_page(self):

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -144,7 +144,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         event = self.create_sample_event(platform="invalid-interfaces")
         self.visit_issue(event.group.id)
 
-        self.browser.click(".errors-toggle")
+        self.browser.click('[data-test-id="toggle-event-errors"]')
         self.browser.wait_until(".entries > .errors ul")
         self.browser.snapshot("issue details invalid interfaces")
 


### PR DESCRIPTION
We want to use the `EventEntries` component in discover 2 so that when a new interface is added to events it shows up in both issues and discover with only one set of updates.

Unfortunately many parts of issue details are coupled to the specific class hierarchy on that page. This moves event errors away from less and helps make using EventEntries more portable.