### PR TITLE
fix(logging): prefix user_id to not conflict with other user_ids.

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -162,7 +162,7 @@ class SlackActionEndpoint(Endpoint):
         user_id = data.get("user", {}).get("id")
 
         logging_data["channel_id"] = channel_id
-        logging_data["user_id"] = user_id
+        logging_data["slack_user_id"] = user_id
 
         integration = slack_request.integration
         logging_data["integration_id"] = integration.id


### PR DESCRIPTION
All of these errors were failing to record because we use `user_id` in many places as an integer.