### PR TITLE
feat(sso): Surface Active Directory as a SSO provider

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(
         "console_scripts": ["sentry = sentry.runner:main"],
         "sentry.apps": [
             # TODO: This can be removed once the getsentry tests no longer check for this app
+            "auth_activedirectory = sentry.auth.providers.saml2.activedirectory",
             "auth_auth0 = sentry.auth.providers.saml2.auth0",
             "auth_github = sentry.auth.providers.github",
             "auth_okta = sentry.auth.providers.saml2.okta",

--- a/src/sentry/auth/providers/saml2/activedirectory/__init__.py
+++ b/src/sentry/auth/providers/saml2/activedirectory/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+default_app_config = "sentry.auth.providers.saml2.activedirectory.apps.Config"

--- a/src/sentry/auth/providers/saml2/activedirectory/apps.py
+++ b/src/sentry/auth/providers/saml2/activedirectory/apps.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry.auth.providers.saml2.activedirectory"
+
+    def ready(self):
+        from sentry.auth import register
+
+        from .provider import ActiveDirectorySAML2Provider
+
+        register("active-directory", ActiveDirectorySAML2Provider)

--- a/src/sentry/auth/providers/saml2/activedirectory/provider.py
+++ b/src/sentry/auth/providers/saml2/activedirectory/provider.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, print_function
+
+from sentry.auth.providers.saml2.generic.provider import GenericSAML2Provider
+
+
+class ActiveDirectorySAML2Provider(GenericSAML2Provider):
+    name = "Active Directory"

--- a/src/sentry/auth/providers/saml2/activedirectory/views.py
+++ b/src/sentry/auth/providers/saml2/activedirectory/views.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import, print_function
+
+from sentry.auth.providers.saml2.generic.view import GenericSAML2View
+
+
+class ActiveDirectorySAML2View(GenericSAML2View):
+    '''
+    Active Directory is a subset of our generic SAML2 implementation. However,
+    this may not be obvious to end users. This inheritence class allows us to
+    explicitly surface this option to them.
+    '''

--- a/src/sentry/auth/providers/saml2/activedirectory/views.py
+++ b/src/sentry/auth/providers/saml2/activedirectory/views.py
@@ -4,8 +4,8 @@ from sentry.auth.providers.saml2.generic.view import GenericSAML2View
 
 
 class ActiveDirectorySAML2View(GenericSAML2View):
-    '''
+    """
     Active Directory is a subset of our generic SAML2 implementation. However,
     this may not be obvious to end users. This inheritence class allows us to
     explicitly surface this option to them.
-    '''
+    """

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
@@ -69,7 +69,11 @@ export default class ProviderItem extends React.PureComponent {
         {({hasFeature, features, renderDisabled, renderInstallButton}) => (
           <PanelItem alignItems="center">
             <ProviderInfo>
-              <ProviderLogo className={`provider-logo ${provider.name.toLowerCase()}`} />
+              <ProviderLogo
+                className={`provider-logo ${provider.name
+                  .replace(/\s/g, '')
+                  .toLowerCase()}`}
+              />
               <div>
                 <ProviderName>{provider.name}</ProviderName>
                 <ProviderDescription>

--- a/src/sentry/static/sentry/less/auth.less
+++ b/src/sentry/static/sentry/less/auth.less
@@ -63,7 +63,10 @@ section.org-login {
     background-image: url(../images/logos/logo-rippling.svg);
   }
 
-  &.activedirectory,
+  &.activedirectory {
+    background-image: url(../images/logos/logo-microsoft.svg);
+  }
+
   &.saml2 {
     background-image: url(../images/logos/logo-saml2.svg);
   }

--- a/src/sentry/static/sentry/less/auth.less
+++ b/src/sentry/static/sentry/less/auth.less
@@ -63,6 +63,7 @@ section.org-login {
     background-image: url(../images/logos/logo-rippling.svg);
   }
 
+  &.activedirectory,
   &.saml2 {
     background-image: url(../images/logos/logo-saml2.svg);
   }


### PR DESCRIPTION
Active Directory is a subset of our generic SAML2 implementation. However, this may not be obvious to end users. This PR aims to explicitly surface this option to them.

### Before
![image](https://user-images.githubusercontent.com/1748388/74289752-b455d580-4ce4-11ea-9a3c-a00eba2ca94c.png)

### After 
![image](https://user-images.githubusercontent.com/1748388/74289760-b881f300-4ce4-11ea-8f8d-69f9b4bd8065.png)
