### PR TITLE
fix(alerts): Stop raising custom exception when changing status is a no-op.

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_details.py
+++ b/src/sentry/api/endpoints/organization_incident_details.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.incident import DetailedIncidentSerializer
-from sentry.incidents.logic import StatusAlreadyChangedError, update_incident_status
+from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models import IncidentStatus
 
 
@@ -44,18 +44,12 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
         if serializer.is_valid():
             result = serializer.validated_data
             if result["status"] == IncidentStatus.CLOSED:
-                try:
-                    incident = update_incident_status(
-                        incident=incident,
-                        status=result["status"],
-                        user=request.user,
-                        comment=result.get("comment"),
-                    )
-                except StatusAlreadyChangedError:
-                    return Response(
-                        "Status is already set to {}".format(result["status"]), status=400
-                    )
-
+                incident = update_incident_status(
+                    incident=incident,
+                    status=result["status"],
+                    user=request.user,
+                    comment=result.get("comment"),
+                )
                 return Response(
                     serialize(incident, request.user, DetailedIncidentSerializer()), status=200
                 )

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -48,10 +48,6 @@ from sentry.utils.snuba import bulk_raw_query, raw_query, SnubaQueryParams, Snub
 MAX_INITIAL_INCIDENT_PERIOD = timedelta(days=7)
 
 
-class StatusAlreadyChangedError(Exception):
-    pass
-
-
 class AlreadyDeletedError(Exception):
     pass
 
@@ -240,7 +236,7 @@ def update_incident_status(incident, status, user=None, comment=None):
     """
     if incident.status == status.value:
         # If the status isn't actually changing just no-op.
-        raise StatusAlreadyChangedError()
+        return incident
     with transaction.atomic():
         create_incident_activity(
             incident,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -48,7 +48,6 @@ from sentry.incidents.logic import (
     INCIDENT_START_ROLLUP,
     ProjectsNotAssociatedWithAlertRuleError,
     subscribe_to_incident,
-    StatusAlreadyChangedError,
     update_alert_rule,
     update_alert_rule_trigger_action,
     update_alert_rule_trigger,
@@ -157,8 +156,8 @@ class UpdateIncidentStatus(TestCase):
 
     def test_status_already_set(self):
         incident = self.create_incident(status=IncidentStatus.WARNING.value)
-        with self.assertRaises(StatusAlreadyChangedError):
-            update_incident_status(incident, IncidentStatus.WARNING)
+        update_incident_status(incident, IncidentStatus.WARNING)
+        assert incident.status == IncidentStatus.WARNING.value
 
     def run_test(self, incident, status, expected_date_closed, user=None, comment=None):
         prev_status = incident.status


### PR DESCRIPTION
We don't really need this feedback on the UI, and it makes calling the method more painful than
necessary. Just no-op silently if someone attempts to change it to a status that it's already set
to.