### PR TITLE
feat(growth) added hovercard for "Ownership Rules" on the Issue page

### DIFF
--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -15,7 +15,7 @@ import SuggestedOwnerHovercard from 'app/components/group/suggestedOwnerHovercar
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import Hovercard from 'app/components/hovercard';
-import InlineSvg from 'app/components/inlineSvg';
+import {IconInfo} from 'app/icons/iconInfo';
 
 class SuggestedOwners extends React.Component {
   static propTypes = {
@@ -160,11 +160,11 @@ class SuggestedOwners extends React.Component {
       <HelpfulBody>
         <p>
           {t(
-            'Ownership rules allow you to associate file paths and URLs to specific teams or users, so alerts can be routed to the right people.'
+            'Ownership rules allow you to associate file paths and URLs to specific teams or users, so issues can be assigned to the right people.'
           )}
         </p>
         <Button href="https://docs.sentry.io/workflow/issue-owners/" priority="primary">
-          Click to learn more
+          Learn more
         </Button>
       </HelpfulBody>
     );
@@ -210,7 +210,7 @@ class SuggestedOwners extends React.Component {
               <h6>
                 <span>{t('Ownership Rules')}</span>
                 <Hovercard body={this.getHovercardBody()}>
-                  <InlineSvg src="icon-circle-info" size="16px" />
+                  <IconInfo size="xs" />
                 </Hovercard>
               </h6>
             </GuideAnchor>

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -159,8 +159,9 @@ class SuggestedOwners extends React.Component {
     return (
       <HelpfulBody>
         <p>
-          Ownership rules allow you to associate file paths and URLs to specific teams or
-          users, so alerts can be routed to the right people.
+          {t(
+            'Ownership rules allow you to associate file paths and URLs to specific teams or users, so alerts can be routed to the right people.'
+          )}
         </p>
         <Button href="https://docs.sentry.io/workflow/issue-owners/" priority="primary">
           Click to learn more
@@ -208,7 +209,7 @@ class SuggestedOwners extends React.Component {
             <GuideAnchor target="owners">
               <h6>
                 <span>{t('Ownership Rules')}</span>
-                <Hovercard body={this.getHovercardBody()} containerClassName="pill-icon">
+                <Hovercard body={this.getHovercardBody()}>
                   <InlineSvg src="icon-circle-info" size="16px" />
                 </Hovercard>
               </h6>

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from '@emotion/styled';
+import space from 'app/styles/space';
 
 import {assignToUser, assignToActor} from 'app/actionCreators/group';
 import {openCreateOwnershipRule} from 'app/actionCreators/modal';
@@ -12,6 +14,8 @@ import SentryTypes from 'app/sentryTypes';
 import SuggestedOwnerHovercard from 'app/components/group/suggestedOwnerHovercard';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
+import Hovercard from 'app/components/hovercard';
+import InlineSvg from 'app/components/inlineSvg';
 
 class SuggestedOwners extends React.Component {
   static propTypes = {
@@ -151,6 +155,20 @@ class SuggestedOwners extends React.Component {
     return owners;
   }
 
+  getHovercardBody() {
+    return (
+      <HelpfulBody>
+        <p>
+          Ownership rules allow you to associate file paths and URLs to specific teams or
+          users, so alerts can be routed to the right people.
+        </p>
+        <Button href="https://docs.sentry.io/workflow/issue-owners/" priority="primary">
+          Click to learn more
+        </Button>
+      </HelpfulBody>
+    );
+  }
+
   render() {
     const {group, organization, project} = this.props;
     const owners = this.getOwnerList();
@@ -190,6 +208,9 @@ class SuggestedOwners extends React.Component {
             <GuideAnchor target="owners">
               <h6>
                 <span>{t('Ownership Rules')}</span>
+                <Hovercard body={this.getHovercardBody()} containerClassName="pill-icon">
+                  <InlineSvg src="icon-circle-info" size="16px" />
+                </Hovercard>
               </h6>
             </GuideAnchor>
             <Button
@@ -230,3 +251,8 @@ function findMatchedRules(rules, owner) {
     .filter(([_, ruleActors]) => ruleActors.find(actorHasOwner))
     .map(([rule]) => rule);
 }
+
+const HelpfulBody = styled('div')`
+  padding: ${space(1)};
+  text-align: center;
+`;

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
+import {ClassNames} from '@emotion/core';
 import space from 'app/styles/space';
 
 import {assignToUser, assignToActor} from 'app/actionCreators/group';
@@ -155,7 +156,7 @@ class SuggestedOwners extends React.Component {
     return owners;
   }
 
-  getHovercardBody() {
+  getInfoHovercardBody() {
     return (
       <HelpfulBody>
         <p>
@@ -207,12 +208,22 @@ class SuggestedOwners extends React.Component {
         <Access access={['project:write']}>
           <div className="m-b-1">
             <GuideAnchor target="owners">
-              <h6>
+              <OwnerRuleHeading>
                 <span>{t('Ownership Rules')}</span>
-                <Hovercard body={this.getHovercardBody()}>
-                  <IconInfo size="xs" />
-                </Hovercard>
-              </h6>
+                <ClassNames>
+                  {({css}) => (
+                    <Hovercard
+                      containerClassName={css`
+                        display: inline-flex;
+                        padding: 0 !important;
+                      `}
+                      body={this.getInfoHovercardBody()}
+                    >
+                      <IconInfo size="xs" />
+                    </Hovercard>
+                  )}
+                </ClassNames>
+              </OwnerRuleHeading>
             </GuideAnchor>
             <Button
               onClick={() =>
@@ -256,4 +267,9 @@ function findMatchedRules(rules, owner) {
 const HelpfulBody = styled('div')`
   padding: ${space(1)};
   text-align: center;
+`;
+
+const OwnerRuleHeading = styled('h6')`
+  display: flex;
+  align-items: center;
 `;

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -160,7 +160,7 @@ class SuggestedOwners extends React.Component {
       <HelpfulBody>
         <p>
           {t(
-            'Ownership rules allow you to associate file paths and URLs to specific teams or users, so issues can be assigned to the right people.'
+            'Ownership rules allow you to associate file paths and URLs to specific teams or users, so alerts can be routed to the right people.'
           )}
         </p>
         <Button href="https://docs.sentry.io/workflow/issue-owners/" priority="primary">

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -164,7 +164,7 @@ class SuggestedOwners extends React.Component {
           )}
         </p>
         <Button href="https://docs.sentry.io/workflow/issue-owners/" priority="primary">
-          Learn more
+          {t('Learn more')}
         </Button>
       </HelpfulBody>
     );


### PR DESCRIPTION
added hovercard for "Ownership Rules" to help users understand how to create ownership rules

https://getsentry.atlassian.net/browse/GROW-34

Updated UI
![Screen Shot 2020-02-11 at 4 34 07 PM](https://user-images.githubusercontent.com/1111155/74292319-8c6a7000-4cec-11ea-95b8-38c6d1eee7a2.png)
![Screen Shot 2020-02-11 at 4 34 14 PM](https://user-images.githubusercontent.com/1111155/74292321-8eccca00-4cec-11ea-9db4-4083cd79ee94.png)


