### PR TITLE
feat(plugins): change names of resource links to match integrations

### DIFF
--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -299,8 +299,8 @@ class IPlugin(local, PluggableViewMixin, PluginConfigMixin, PluginStatusMixin):
         >>> def get_resource_links(self):
         >>>     return [
         >>>         ('Documentation', 'https://docs.sentry.io'),
-        >>>         ('Bug Tracker', 'https://github.com/getsentry/sentry/issues'),
-        >>>         ('Source', 'https://github.com/getsentry/sentry'),
+        >>>         ('Report Issue', 'https://github.com/getsentry/sentry/issues'),
+        >>>         ('View Source', 'https://github.com/getsentry/sentry'),
         >>>     ]
         """
         return self.resource_links

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -296,8 +296,8 @@ class IPlugin2(local, PluginConfigMixin, PluginStatusMixin):
         >>> def get_resource_links(self):
         >>>     return [
         >>>         ('Documentation', 'https://docs.sentry.io'),
-        >>>         ('Bug Tracker', 'https://github.com/getsentry/sentry/issues'),
-        >>>         ('Source', 'https://github.com/getsentry/sentry'),
+        >>>         ('Report Issue', 'https://github.com/getsentry/sentry/issues'),
+        >>>         ('View Source', 'https://github.com/getsentry/sentry'),
         >>>     ]
         """
         return self.resource_links

--- a/src/sentry/plugins/examples/issue_tracking.py
+++ b/src/sentry/plugins/examples/issue_tracking.py
@@ -9,8 +9,8 @@ class ExampleIssueTrackingPlugin(IssuePlugin2):
     version = "0.0.0"
     description = "An example issue tracking plugin"
     resource_links = [
-        ("Bug Tracker", "https://github.com/getsentry/sentry/issues"),
-        ("Source", "https://github.com/getsentry/sentry"),
+        ("Report Issue", "https://github.com/getsentry/sentry/issues"),
+        ("View Source", "https://github.com/getsentry/sentry"),
     ]
 
     slug = "example-issue"

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -43,9 +43,9 @@ class WebHooksPlugin(notify.NotificationPlugin):
     version = sentry.VERSION
     description = "Integrates web hooks."
     resource_links = [
-        ("Bug Tracker", "https://github.com/getsentry/sentry/issues"),
+        ("Report Issue", "https://github.com/getsentry/sentry/issues"),
         (
-            "Source",
+            "View Source",
             "https://github.com/getsentry/sentry/tree/master/src/sentry/plugins/sentry_webhooks",
         ),
     ]

--- a/src/sentry_plugins/base.py
+++ b/src/sentry_plugins/base.py
@@ -21,8 +21,8 @@ class CorePluginMixin(object):
     author_url = "https://github.com/getsentry/sentry"
     version = sentry_plugins.VERSION
     resource_links = [
-        ("Bug Tracker", "https://github.com/getsentry/sentry/issues"),
-        ("Source", "https://github.com/getsentry/sentry/tree/master/src/sentry_plugins"),
+        ("Report Issue", "https://github.com/getsentry/sentry/issues"),
+        ("View Source", "https://github.com/getsentry/sentry/tree/master/src/sentry_plugins"),
     ]
 
     # HACK(dcramer): work around MRO issue with plugin metaclass

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -102,8 +102,11 @@ class TwilioPlugin(NotificationPlugin):
             "Documentation",
             "https://github.com/getsentry/sentry/blob/master/src/sentry_plugins/twilio/Twilio_Instructions.md",
         ),
-        ("Bug Tracker", "https://github.com/getsentry/sentry/issues"),
-        ("Source", "https://github.com/getsentry/sentry/tree/master/src/sentry_plugins/twilio"),
+        ("Report Issue", "https://github.com/getsentry/sentry/issues"),
+        (
+            "View Source",
+            "https://github.com/getsentry/sentry/tree/master/src/sentry_plugins/twilio",
+        ),
         ("Twilio", "https://www.twilio.com/"),
     )
 


### PR DESCRIPTION
First-party integrations show links for the `View Source` and `Report Issue` which is slightly different than what plugins show which is currently `Source` and `Bug Tracker`. These PR switches plugins to using `View Source` and `Report Issue`.

Before:

![Screen Shot 2020-02-11 at 4 46 37 PM](https://user-images.githubusercontent.com/8533851/74292906-16ff9f00-4cee-11ea-937e-1b01a19c6e8b.png)


After:

![Screen Shot 2020-02-11 at 4 46 03 PM](https://user-images.githubusercontent.com/8533851/74292910-1a932600-4cee-11ea-8f72-68fb4afceb0d.png)
