### PR TITLE
fix(discover) Fix vertical scroll on discover results

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -106,6 +106,8 @@ export const Grid = styled('table')`
 
   z-index: ${Z_INDEX_GRID};
   overflow-x: scroll;
+  /* This padding prevents vertical scrollbars from showing up. */
+  padding-bottom: 1px;
 `;
 
 export const GridRow = styled('tr')`


### PR DESCRIPTION
Because we're using overflow-x browsers throw in a free vertical scrollbar. Applying a smidge of padding expands the grid box so that there is no overflow.