### PR TITLE
fix(discover2): Fix resize handle's height

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -7,7 +7,6 @@ import space from 'app/styles/space';
 
 export const GRID_HEAD_ROW_HEIGHT = 45;
 export const GRID_BODY_ROW_HEIGHT = 40;
-const GRID_BODY_ROW_BORDER_BOX_HEIGHT = GRID_BODY_ROW_HEIGHT + 1; // add border-bottom height
 export const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
 
 /**
@@ -330,7 +329,17 @@ export const GridResizer = styled('div')<{dataRows: number; isLast?: boolean}>`
   right: ${p => (p.isLast ? '0px' : '-5px')};
   width: ${p => (p.isLast ? '6px' : '9px')};
 
-  height: ${p => GRID_HEAD_ROW_HEIGHT + p.dataRows * GRID_BODY_ROW_BORDER_BOX_HEIGHT}px;
+  height: ${p => {
+    const numOfRows = p.dataRows;
+    let height = GRID_HEAD_ROW_HEIGHT + numOfRows * GRID_BODY_ROW_HEIGHT;
+
+    if (numOfRows >= 2) {
+      // account for border-bottom height
+      height += numOfRows - 1;
+    }
+
+    return height;
+  }}px;
 
   padding-left: 4px;
   padding-right: ${p => (p.isLast ? '0px' : '4px')};


### PR DESCRIPTION
Don't account the bottom border (which doesn't exist) of the last row as part of the resize handle's height.