### PR TITLE
Revert "fix(slack): use log message that doesn't use extra param"

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-import six
 
 from sentry import http
 from sentry.rules.actions.base import EventAction
@@ -119,15 +118,14 @@ class SlackNotifyServiceAction(EventAction):
             resp.raise_for_status()
             resp = resp.json()
             if not resp.get("ok"):
-                logging_data = {
-                    "error": resp.get("error"),
-                    "project_id": event.project_id,
-                    "event_id": event.event_id,
-                }
                 self.logger.info(
-                    "rule.fail.slack_post-pre-message: %s" % six.text_type(logging_data)
+                    "rule.fail.slack_post",
+                    extra={
+                        "error": resp.get("error"),
+                        "project_id": event.project_id,
+                        "event_id": event.event_id,
+                    },
                 )
-                self.logger.info("rule.fail.slack_post", extra=logging_data)
 
         key = u"slack:{}:{}".format(integration_id, channel)
 


### PR DESCRIPTION
Reverts getsentry/sentry#16949

Turns out the issue with logging was something else 