### PR TITLE
fix(discover2) Handle case with empty count and results

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -257,7 +257,11 @@ class OrganizationEventsV2Endpoint(OrganizationEventsEndpointBase):
         for result in results:
             for key in ("projectid", "project.id"):
                 if key in result:
-                    result["project.name"] = projects[result[key]]
+                    # Handle bizarre empty case
+                    if result[key] == 0:
+                        result["project.name"] = ""
+                    else:
+                        result["project.name"] = projects[result[key]]
                     if key not in fields:
                         del result[key]
 


### PR DESCRIPTION
There is a case where we get a result with an empty row, e.g. count = 0,
project_id = 0. Since project_id 0 doesn't exist, handle that case to translate
to an empty project name.