### PR TITLE
fix(workflow): Default filter state on page load is not working as expected

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -34,15 +34,21 @@ type State = {
   incidentList: Incident[];
 };
 
+function getQueryStatus(status: any) {
+  return status === undefined || status === '' ? DEFAULT_QUERY_STATUS : status;
+}
 class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state']> {
   getEndpoints(): [string, string, any][] {
     const {params, location} = this.props;
+    const {query} = location;
+    const status = getQueryStatus(query.status);
+
     return [
       [
         'incidentList',
         `/organizations/${params && params.orgId}/incidents/`,
         {
-          query: location && location.query,
+          query: {...query, status},
         },
       ],
     ];
@@ -132,13 +138,6 @@ class IncidentsListContainer extends React.Component<Props> {
    * Incidents list is currently at the organization level, but the link needs to
    * go down to a specific project scope.
    */
-  componentWillUpdate() {
-    const {params, location, router} = this.props;
-    if (router && location.query.status === undefined) {
-      navigateTo(`/organizations/${params && params.orgId}/alerts/?status=open`, router);
-    }
-  }
-
   handleNavigateToSettings = (e: React.MouseEvent) => {
     const {router, params} = this.props;
     e.preventDefault();
@@ -155,8 +154,7 @@ class IncidentsListContainer extends React.Component<Props> {
     const closedIncidentsQuery = {...query, status: 'closed'};
     const allIncidentsQuery = {...query, status: 'all'};
 
-    const status = query.status === undefined ? DEFAULT_QUERY_STATUS : query.status;
-
+    const status = getQueryStatus(query.status);
     return (
       <DocumentTitle title={`Alerts- ${orgId} - Sentry`}>
         <PageContent>

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -35,7 +35,7 @@ type State = {
 };
 
 function getQueryStatus(status: any) {
-  return status === undefined || status === '' ? DEFAULT_QUERY_STATUS : status;
+  return ['open', 'closed', 'all'].includes(status) ? status : DEFAULT_QUERY_STATUS;
 }
 class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state']> {
   getEndpoints(): [string, string, any][] {

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -132,12 +132,12 @@ class IncidentsListContainer extends React.Component<Props> {
    * Incidents list is currently at the organization level, but the link needs to
    * go down to a specific project scope.
    */
-  // componentWillMount() {
-  //   const {params, location, router} = this.props;
-  //   if (location.query.status === undefined) {
-  //     navigateTo(`/organizations/${params && params.orgId}/alerts/?status=open`, router);
-  //   }
-  // }
+  componentWillUpdate() {
+    const {params, location, router} = this.props;
+    if (router && location.query.status === undefined) {
+      navigateTo(`/organizations/${params && params.orgId}/alerts/?status=open`, router);
+    }
+  }
 
   handleNavigateToSettings = (e: React.MouseEvent) => {
     const {router, params} = this.props;

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -132,6 +132,13 @@ class IncidentsListContainer extends React.Component<Props> {
    * Incidents list is currently at the organization level, but the link needs to
    * go down to a specific project scope.
    */
+  // componentWillMount() {
+  //   const {params, location, router} = this.props;
+  //   if (location.query.status === undefined) {
+  //     navigateTo(`/organizations/${params && params.orgId}/alerts/?status=open`, router);
+  //   }
+  // }
+
   handleNavigateToSettings = (e: React.MouseEvent) => {
     const {router, params} = this.props;
     e.preventDefault();

--- a/tests/js/spec/views/incidents/list/index.spec.jsx
+++ b/tests/js/spec/views/incidents/list/index.spec.jsx
@@ -75,7 +75,7 @@ describe('IncidentsList', function() {
 
     expect(mock).toHaveBeenCalledWith(
       '/organizations/org-slug/incidents/',
-      expect.objectContaining({query: {}})
+      expect.objectContaining({query: {status: 'open'}})
     );
 
     wrapper.setProps({location: {query: {status: 'all'}, search: '?status=all`'}});


### PR DESCRIPTION
On initial page load of the alerts listing, the API call to get the alerts wasn't using the default status of "open". However, because the status variable is set afterwards, the UI showed "open" alerts as the selection. This is bad because the results being shown included all status'.

This fixes that by redirecting the user to ?status=open if it's not set.