### PR TITLE
feat: Android debug info built in

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from sentry.projectoptions import register
 
 # latest epoch
-LATEST_EPOCH = 4
+LATEST_EPOCH = 5
 
 # grouping related configs
 #
@@ -44,7 +44,7 @@ register(key="sentry:default_loader_version", epoch_defaults={1: "4.x", 2: "5.x"
 # Default symbol sources.  The ios source does not exist by default and
 # will be skipped later.  The microsoft source exists by default and is
 # unlikely to be disabled.
-register(key="sentry:builtin_symbol_sources", epoch_defaults={1: ["ios"], 2: ["ios", "microsoft"]})
+register(key="sentry:builtin_symbol_sources", epoch_defaults={1: ["ios"], 2: ["ios", "microsoft"], 5: ["ios", "microsoft", "android"]})
 
 # Default legacy-browsers filter
 register(key="filters:legacy-browsers", epoch_defaults={1: "0"})


### PR DESCRIPTION
We've added the Android "build in source":

![image](https://user-images.githubusercontent.com/1633368/74385501-b2157900-4dc1-11ea-9425-3f25faf6ed88.png)

Now crashes from Android can use this to symbolicate frames:

![image](https://user-images.githubusercontent.com/1633368/74387188-e2f7ad00-4dc5-11ea-84a9-519eda4ef0b3.png)


This change will make it available by default for **new** projects:

![image](https://user-images.githubusercontent.com/1633368/74385541-c8233980-4dc1-11ea-8f9f-d7de2bdf2b9f.png)

