### PR TITLE
feat(plugins): Add ApiClient to Twilio

### DIFF
--- a/src/sentry_plugins/twilio/client.py
+++ b/src/sentry_plugins/twilio/client.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+from sentry_plugins.client import ApiClient
+
+
+class TwilioApiClient(ApiClient):
+    plugin_name = "twilio"
+    allow_redirects = False
+    twilio_sms_endpoint = "https://api.twilio.com/2010-04-01/Accounts/{0}/SMS/Messages.json"
+
+    def __init__(self, account_sid=None, auth_token=None, sms_from=None, sms_to=None):
+        self.account_sid = account_sid
+        self.auth_token = auth_token
+        self.sms_from = sms_from
+        self.sms_to = sms_to
+        super(TwilioApiClient, self).__init__()
+
+    def basic_auth(self, user, password):
+        return "Basic " + (user + ":" + password).encode("base64").replace("\n", "")
+
+    def request(self, data):
+        endpoint = self.twilio_sms_endpoint.format(self.account_sid)
+        headers = {"Authorization": self.basic_auth(self.account_sid, self.auth_token)}
+        return self._request(path=endpoint, method="post", data=data, headers=headers)

--- a/src/sentry_plugins/twilio/client.py
+++ b/src/sentry_plugins/twilio/client.py
@@ -8,7 +8,7 @@ class TwilioApiClient(ApiClient):
     allow_redirects = False
     twilio_messages_endpoint = "https://api.twilio.com/2010-04-01/Accounts/{0}/Messages.json"
 
-    def __init__(self, account_sid=None, auth_token=None, sms_from=None, sms_to=None):
+    def __init__(self, account_sid, auth_token, sms_from, sms_to):
         self.account_sid = account_sid
         self.auth_token = auth_token
         self.sms_from = sms_from

--- a/src/sentry_plugins/twilio/client.py
+++ b/src/sentry_plugins/twilio/client.py
@@ -21,4 +21,6 @@ class TwilioApiClient(ApiClient):
     def request(self, data):
         endpoint = self.twilio_messages_endpoint.format(self.account_sid)
         headers = {"Authorization": self.basic_auth(self.account_sid, self.auth_token)}
+        # Twilio doesn't accept the json headers, so set this to False
+        # https://www.twilio.com/docs/usage/your-request-to-twilio#post
         return self._request(path=endpoint, method="post", data=data, headers=headers, json=False)

--- a/src/sentry_plugins/twilio/client.py
+++ b/src/sentry_plugins/twilio/client.py
@@ -6,7 +6,7 @@ from sentry_plugins.client import ApiClient
 class TwilioApiClient(ApiClient):
     plugin_name = "twilio"
     allow_redirects = False
-    twilio_sms_endpoint = "https://api.twilio.com/2010-04-01/Accounts/{0}/SMS/Messages.json"
+    twilio_messages_endpoint = "https://api.twilio.com/2010-04-01/Accounts/{0}/Messages.json"
 
     def __init__(self, account_sid=None, auth_token=None, sms_from=None, sms_to=None):
         self.account_sid = account_sid
@@ -19,6 +19,6 @@ class TwilioApiClient(ApiClient):
         return "Basic " + (user + ":" + password).encode("base64").replace("\n", "")
 
     def request(self, data):
-        endpoint = self.twilio_sms_endpoint.format(self.account_sid)
+        endpoint = self.twilio_messages_endpoint.format(self.account_sid)
         headers = {"Authorization": self.basic_auth(self.account_sid, self.auth_token)}
-        return self._request(path=endpoint, method="post", data=data, headers=headers)
+        return self._request(path=endpoint, method="post", data=data, headers=headers, json=False)

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -158,8 +158,7 @@ class TwilioPlugin(CorePluginMixin, NotificationPlugin):
                 errors.append(e)
 
         if errors:
-            if len(errors) == 1:
-                self.raise_error(errors[0])
+            self.raise_error(errors[0])
 
             # TODO: multi-exception
             raise Exception(errors)

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -54,8 +54,6 @@ class TwilioConfigurationFormTest(TestCase):
 
 
 class TwilioPluginTest(PluginTestCase):
-    # TODO: actually test the plugin
-
     @fixture
     def plugin(self):
         return TwilioPlugin()

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -1,8 +1,13 @@
 from __future__ import absolute_import
 
+import responses
+
 from exam import fixture
+from sentry.models import Rule
+from sentry.plugins.base import Notification
 from sentry.testutils import TestCase, PluginTestCase
 from sentry_plugins.twilio.plugin import TwilioConfigurationForm, TwilioPlugin
+from six.moves.urllib.parse import parse_qs
 
 
 class TwilioConfigurationFormTest(TestCase):
@@ -66,3 +71,36 @@ class TwilioPluginTest(PluginTestCase):
         for o in ("account_sid", "auth_token", "sms_from", "sms_to"):
             self.plugin.set_option(o, "foo", self.project)
         assert self.plugin.is_configured(self.project) is True
+
+    @responses.activate
+    def test_simple_notification(self):
+        responses.add("POST", "https://api.twilio.com/2010-04-01/Accounts/abcdef/Messages.json")
+        self.plugin.set_option("account_sid", "abcdef", self.project)
+        self.plugin.set_option("auth_token", "abcd", self.project)
+        self.plugin.set_option("sms_from", "4158675309", self.project)
+        self.plugin.set_option("sms_to", "4154444444", self.project)
+
+        event = self.store_event(
+            data={
+                "message": "Hello world",
+                "level": "warning",
+                "platform": "python",
+                "culprit": "foo.bar",
+            },
+            project_id=self.project.id,
+        )
+
+        rule = Rule.objects.create(project=self.project, label="my rule")
+
+        notification = Notification(event=event, rule=rule)
+
+        with self.options({"system.url-prefix": "http://example.com"}):
+            self.plugin.notify(notification)
+
+        request = responses.calls[0].request
+        payload = parse_qs(request.body)
+        assert payload == {
+            "To": ["+14154444444"],
+            "From": ["+14158675309"],
+            "Body": ["Sentry [%s] WARNING: Hello world" % self.project.slug.title()],
+        }

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -67,8 +67,8 @@ class TwilioPluginTest(PluginTestCase):
         self.assertPluginInstalled("twilio", self.plugin)
 
     def test_is_configured(self):
-        assert self.plugin.is_configured(self.project) is False
         for o in ("account_sid", "auth_token", "sms_from", "sms_to"):
+            assert self.plugin.is_configured(self.project) is False
             self.plugin.set_option(o, "foo", self.project)
         assert self.plugin.is_configured(self.project) is True
 


### PR DESCRIPTION
Add the `ApiClient` class to the Twilio plugin so as to standardize it with most of the other plugins and automatically give status codes for the purpose of capturing metrics in Datadog. I added a test to make sure the notification functionality is working as well. 

I also updated the plugin to use the [messages API endpoint](https://www.twilio.com/docs/sms/api/message-resource#create-a-message-resource), as the SMS one we had been using is deprecated according to [this](https://www.twilio.com/docs/api/errors/21605) and takes all the same parameters we'd already been sending.

