### PR TITLE
feature(discover) - Allow project to be sortable

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -233,20 +233,9 @@ class OrganizationEventsV2Endpoint(OrganizationEventsEndpointBase):
         if not ("project.id" in first_row or "projectid" in first_row):
             return results
 
-        projects = {
-            p["id"]: p["slug"]
-            for p in Project.objects.filter(organization=organization, id__in=project_ids).values(
-                "id", "slug"
-            )
-        }
         for result in results:
             for key in ("projectid", "project.id"):
                 if key in result:
-                    # Handle bizarre empty case
-                    if result[key] == 0:
-                        result["project.name"] = ""
-                    else:
-                        result["project.name"] = projects[result[key]]
                     if key not in fields:
                         del result[key]
 

--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -247,16 +247,12 @@ export const SPECIAL_FIELDS: SpecialFields = {
     },
   },
   project: {
-    sortField: null,
+    sortField: 'project',
     renderFunc: (data, {organization}) => {
-      const project = organization.projects.find(p => p.slug === data['project.name']);
+      const project = organization.projects.find(p => p.slug === data.project);
       return (
         <Container>
-          {project ? (
-            <ProjectBadge project={project} avatarSize={16} />
-          ) : (
-            data['project.name']
-          )}
+          {project ? <ProjectBadge project={project} avatarSize={16} /> : data.project}
         </Container>
       );
     },

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/utils.tsx
@@ -12,6 +12,7 @@ export function generateEventDetailsRoute({
 
 export function generateEventSlug(eventData: EventData): string {
   const id = eventData.id || eventData.latest_event;
+  const projectSlug = eventData.project || eventData['project.name'];
 
-  return `${eventData['project.name']}:${id}`;
+  return `${projectSlug}:${id}`;
 }

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -61,7 +61,7 @@ describe('getFieldRenderer', function() {
       createdAt: new Date(2019, 9, 3, 12, 13, 14),
       url: '/example',
       latest_event: 'deadbeef',
-      'project.name': project.slug,
+      project: project.slug,
     };
   });
 
@@ -112,7 +112,7 @@ describe('getFieldRenderer', function() {
   });
 
   it('can render project as an avatar', function() {
-    const renderer = getFieldRenderer('project', {'project.name': 'string'});
+    const renderer = getFieldRenderer('project', {project: 'string'});
     expect(renderer).toBeInstanceOf(Function);
     const wrapper = mountWithTheme(
       renderer(data, {location, organization}),

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1146,8 +1146,10 @@ class ResolveFieldListTest(unittest.TestCase):
         fields = ["event.type", "message"]
         result = resolve_field_list(fields, {})
         assert result["selected_columns"] == ["event.type", "message", "id", "project.id"]
-        assert result["aggregations"] == []
-        assert result["groupby"] == []
+        assert result["aggregations"] == [
+            ["transform(project_id, [], [], '')", None, "project.name"]
+        ]
+        assert result["groupby"] == ["event.type", "message", "id", "project.id"]
 
     def test_automatic_fields_with_aggregate_aliases(self):
         fields = ["title", "last_seen"]
@@ -1158,6 +1160,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["max", "timestamp", "last_seen"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == ["title"]
 
@@ -1178,6 +1181,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["quantile(0.99)(duration)", None, "p99"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == []
 
@@ -1209,6 +1213,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["quantile(0.95)(duration)", None, "p95"],
             ["quantile(0.99)(duration)", None, "p99"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == []
 
@@ -1217,27 +1222,28 @@ class ResolveFieldListTest(unittest.TestCase):
         result = resolve_field_list(fields, {})
         assert result["selected_columns"] == [
             "title",
-            "project.id",
             "issue.id",
             "user.id",
             "user.username",
             "user.email",
             "user.ip",
             "message",
+            "project.id",
         ]
         assert result["aggregations"] == [
             ["max", "timestamp", "last_seen"],
             ["argMax", ["id", "timestamp"], "latest_event"],
+            ["transform(project_id, [], [], '')", None, "project"],
         ]
         assert result["groupby"] == [
             "title",
-            "project.id",
             "issue.id",
             "user.id",
             "user.username",
             "user.email",
             "user.ip",
             "message",
+            "project.id",
         ]
 
     def test_aggregate_function_expansion(self):
@@ -1251,6 +1257,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["min", "timestamp", "min_timestamp"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == []
 
@@ -1265,6 +1272,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["count", None, "count_transaction_duration"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == []
 
@@ -1275,6 +1283,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["uniq", "user.id", "count_unique_user_id"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
 
     def test_aggregate_function_invalid_name(self):
@@ -1304,6 +1313,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["quantile(0.75)(duration)", None, "percentile_transaction_duration_0_75"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == []
 
@@ -1349,6 +1359,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["divide(count(), divide(3600, 60))", None, "rpm_3600"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == []
 
@@ -1381,6 +1392,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["divide(count(), divide(3600, 60))", None, "rpm"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == []
 
@@ -1393,6 +1405,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["divide(count(), 3600)", None, "rps_3600"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == []
 
@@ -1440,8 +1453,10 @@ class ResolveFieldListTest(unittest.TestCase):
         snuba_args = {"orderby": "-message"}
         result = resolve_field_list(fields, snuba_args)
         assert result["selected_columns"] == ["message", "id", "project.id"]
-        assert result["aggregations"] == []
-        assert result["groupby"] == []
+        assert result["aggregations"] == [
+            ["transform(project_id, [], [], '')", None, "project.name"]
+        ]
+        assert result["groupby"] == ["message", "id", "project.id"]
 
     def test_orderby_field_alias(self):
         fields = ["last_seen"]
@@ -1452,6 +1467,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["max", "timestamp", "last_seen"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == []
 
@@ -1465,5 +1481,14 @@ class ResolveFieldListTest(unittest.TestCase):
             ["uniq", "user", "count_unique_user"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
+            ["transform(projectid, [], [], '')", None, "project.name"],
         ]
         assert result["groupby"] == []
+
+    def test_orderby_project(self):
+        fields = ["project"]
+        snuba_args = {"orderby": "-project"}
+        result = resolve_field_list(fields, snuba_args)
+        assert result["orderby"] == ["-project"]
+        assert result["aggregations"] == [["transform(project_id, [], [], '')", None, "project"]]
+        assert result["groupby"] == ["project.id", "id"]

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -33,6 +33,107 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
             project_id=self.project.id,
         )
 
+    def test_project_mapping(self):
+        other_project = self.create_project(organization=self.organization)
+        self.store_event(
+            data={"message": "hello", "timestamp": iso_format(before_now(minutes=1))},
+            project_id=other_project.id,
+        )
+
+        result = discover.query(
+            selected_columns=["project", "message"],
+            query="",
+            params={"project_id": [other_project.id]},
+            orderby="project",
+        )
+
+        data = result["data"]
+        assert len(data) == 1
+        assert data[0]["project"] == other_project.slug
+
+    def test_sorting_project_name(self):
+        project_ids = []
+        for project_name in ["a" * 32, "z" * 32, "m" * 32]:
+            other_project = self.create_project(organization=self.organization, slug=project_name)
+            project_ids.append(other_project.id)
+            self.store_event(
+                data={"message": "ohh no", "timestamp": iso_format(before_now(minutes=1))},
+                project_id=other_project.id,
+            )
+
+        result = discover.query(
+            selected_columns=["project", "message"],
+            query="",
+            params={"project_id": project_ids},
+            orderby="project",
+        )
+        data = result["data"]
+        assert len(data) == 3
+        assert [item["project"] for item in data] == ["a" * 32, "m" * 32, "z" * 32]
+
+    def test_reverse_sorting_project_name(self):
+        project_ids = []
+        for project_name in ["a" * 32, "z" * 32, "m" * 32]:
+            other_project = self.create_project(organization=self.organization, slug=project_name)
+            project_ids.append(other_project.id)
+            self.store_event(
+                data={"message": "ohh no", "timestamp": iso_format(before_now(minutes=1))},
+                project_id=other_project.id,
+            )
+
+        result = discover.query(
+            selected_columns=["project", "message"],
+            query="",
+            params={"project_id": project_ids},
+            orderby="-project",
+        )
+        data = result["data"]
+        assert len(data) == 3
+        assert [item["project"] for item in data] == ["z" * 32, "m" * 32, "a" * 32]
+
+    def test_using_project_and_project_name(self):
+        project_ids = []
+        for project_name in ["a" * 32, "z" * 32, "m" * 32]:
+            other_project = self.create_project(organization=self.organization, slug=project_name)
+            project_ids.append(other_project.id)
+            self.store_event(
+                data={"message": "ohh no", "timestamp": iso_format(before_now(minutes=1))},
+                project_id=other_project.id,
+            )
+
+        result = discover.query(
+            selected_columns=["project.name", "message", "project"],
+            query="",
+            params={"project_id": project_ids},
+            orderby="project.name",
+        )
+        data = result["data"]
+        assert len(data) == 3
+        assert [item["project.name"] for item in data] == ["a" * 32, "m" * 32, "z" * 32]
+
+    def test_missing_project(self):
+        project_ids = []
+        for project_name in ["a" * 32, "z" * 32, "m" * 32]:
+            other_project = self.create_project(organization=self.organization, slug=project_name)
+            project_ids.append(other_project.id)
+            self.store_event(
+                data={"message": "ohh no", "timestamp": iso_format(before_now(minutes=1))},
+                project_id=other_project.id,
+            )
+
+        # delete the last project so its missing
+        other_project.delete()
+
+        result = discover.query(
+            selected_columns=["project.name", "message", "project"],
+            query="",
+            params={"project_id": project_ids},
+            orderby="project.name",
+        )
+        data = result["data"]
+        assert len(data) == 3
+        assert [item["project.name"] for item in data] == ["", "a" * 32, "z" * 32]
+
     def test_field_aliasing_in_selected_columns(self):
         result = discover.query(
             selected_columns=["project.id", "user.email", "release"],
@@ -88,11 +189,12 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         assert data[0]["user.email"] == "bruce@example.com"
         assert data[0]["release"] == "first-release"
 
-        assert len(result["meta"]) == 4
+        assert len(result["meta"]) == 9
         assert result["meta"][0] == {"name": "user.email", "type": "Nullable(String)"}
         assert result["meta"][1] == {"name": "release", "type": "Nullable(String)"}
         assert result["meta"][2] == {"name": "id", "type": "FixedString(32)"}
         assert result["meta"][3] == {"name": "project.id", "type": "UInt64"}
+        assert result["meta"][4] == {"name": "project.name", "type": "String"}
 
     def test_auto_fields_aggregates(self):
         result = discover.query(
@@ -238,13 +340,21 @@ class QueryTransformTest(TestCase):
         )
         mock_query.assert_called_with(
             selected_columns=["user_id", "username", "email", "ip_address", "project_id"],
-            aggregations=[],
+            aggregations=[
+                [
+                    "transform(project_id, [{}], ['{}'], '')".format(
+                        six.text_type(self.project.id), self.project.slug
+                    ),
+                    None,
+                    "project",
+                ]
+            ],
             filter_keys={"project_id": [self.project.id]},
             dataset=Dataset.Discover,
             end=None,
             start=None,
             conditions=[],
-            groupby=[],
+            groupby=["user_id", "username", "email", "ip_address", "project_id"],
             having=[],
             orderby=None,
             limit=50,
@@ -302,6 +412,13 @@ class QueryTransformTest(TestCase):
                 ["uniq", "duration", "count_unique_transaction_duration"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
+                [
+                    "transform(projectid, [{}], ['{}'], '')".format(
+                        six.text_type(self.project.id), self.project.slug
+                    ),
+                    None,
+                    "project.name",
+                ],
             ],
             filter_keys={"project_id": [self.project.id]},
             dataset=Dataset.Discover,
@@ -335,6 +452,13 @@ class QueryTransformTest(TestCase):
                 ["uniq", "transaction", "count_unique_transaction"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
+                [
+                    "transform(projectid, [{}], ['{}'], '')".format(
+                        six.text_type(self.project.id), self.project.slug
+                    ),
+                    None,
+                    "project.name",
+                ],
             ],
             filter_keys={"project_id": [self.project.id]},
             dataset=Dataset.Discover,
@@ -368,6 +492,13 @@ class QueryTransformTest(TestCase):
                 ["uniq", "transaction", "count_unique_transaction"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
+                [
+                    "transform(projectid, [{}], ['{}'], '')".format(
+                        six.text_type(self.project.id), self.project.slug
+                    ),
+                    None,
+                    "project.name",
+                ],
             ],
             filter_keys={"project_id": [self.project.id]},
             dataset=Dataset.Discover,
@@ -400,6 +531,13 @@ class QueryTransformTest(TestCase):
                 ["divide(countIf(notEquals(transaction_status, 0)), count())", None, "error_rate"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
+                [
+                    "transform(projectid, [{}], ['{}'], '')".format(
+                        six.text_type(self.project.id), self.project.slug
+                    ),
+                    None,
+                    "project.name",
+                ],
             ],
             filter_keys={"project_id": [self.project.id]},
             dataset=Dataset.Discover,
@@ -434,6 +572,13 @@ class QueryTransformTest(TestCase):
                 ["quantile(0.75)(duration)", None, "percentile_transaction_duration_0_75"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
+                [
+                    "transform(projectid, [{}], ['{}'], '')".format(
+                        six.text_type(self.project.id), six.text_type(self.project.slug)
+                    ),
+                    None,
+                    "project.name",
+                ],
             ],
             filter_keys={"project_id": [self.project.id]},
             dataset=Dataset.Discover,
@@ -861,6 +1006,7 @@ class QueryTransformTest(TestCase):
                 ["quantile(0.75)(duration)", None, "percentile_transaction_duration_0_75"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
+                ["transform(projectid, [39], ['bar'], '')", None, "project.name"],
             ],
             filter_keys={"project_id": [self.project.id]},
             dataset=Dataset.Discover,

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1006,7 +1006,13 @@ class QueryTransformTest(TestCase):
                 ["quantile(0.75)(duration)", None, "percentile_transaction_duration_0_75"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
-                ["transform(projectid, [39], ['bar'], '')", None, "project.name"],
+                [
+                    "transform(projectid, [{}], ['{}'], '')".format(
+                        six.text_type(self.project.id), six.text_type(self.project.slug)
+                    ),
+                    None,
+                    "project.name",
+                ],
             ],
             filter_keys={"project_id": [self.project.id]},
             dataset=Dataset.Discover,


### PR DESCRIPTION
- This introduces a unique sort field name to allow sorting by project name, it uses a clickhouse
  [transform](https://clickhouse.tech/docs/en/query_language/functions/other_functions/#transform-x-array-from-array-to) to change project ids to an index. The index is the location
  of that project if we sort by project slug.