### PR TITLE
fix(api) Don't 500 on invalid per_page parameters

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -236,7 +236,10 @@ class Endpoint(APIView):
     ):
         assert (paginator and not paginator_kwargs) or (paginator_cls and paginator_kwargs)
 
-        per_page = int(request.GET.get("per_page", default_per_page))
+        try:
+            per_page = int(request.GET.get("per_page", default_per_page))
+        except ValueError:
+            raise ParseError(detail="Invalid per_page parameter.")
 
         input_cursor = None
         if request.GET.get("cursor"):
@@ -253,7 +256,7 @@ class Endpoint(APIView):
         try:
             cursor_result = paginator.get_result(limit=per_page, cursor=input_cursor)
         except BadPaginationError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
+            return ParseError(detail=six.text_type(e))
 
         # map results based on callback
         if on_results:

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -22,7 +22,7 @@ class DummyPaginationEndpoint(Endpoint):
     permission_classes = ()
 
     def get(self, request):
-        values = [x for x in xrange(0, 100)]
+        values = [x for x in range(0, 100)]
 
         def data_fn(offset, limit):
             page_offset = offset * limit

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -6,6 +6,7 @@ from django.http import HttpRequest
 from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
+from sentry.api.paginator import GenericOffsetPaginator
 from sentry.models import ApiKey
 from sentry.testutils import APITestCase
 
@@ -15,6 +16,23 @@ class DummyEndpoint(Endpoint):
 
     def get(self, request):
         return Response({"ok": True})
+
+
+class DummyPaginationEndpoint(Endpoint):
+    permission_classes = ()
+
+    def get(self, request):
+        values = [x for x in xrange(0, 100)]
+
+        def data_fn(offset, limit):
+            page_offset = offset * limit
+            return values[page_offset : page_offset + limit]
+
+        return self.paginate(
+            request=request,
+            paginator=GenericOffsetPaginator(data_fn),
+            on_results=lambda results: results,
+        )
 
 
 _dummy_endpoint = DummyEndpoint.as_view()
@@ -38,6 +56,28 @@ class EndpointTest(APITestCase):
         assert response.status_code == 200, response.content
 
         assert response["Access-Control-Allow-Origin"] == "http://example.com"
+
+
+class PaginateTest(APITestCase):
+    def setUp(self):
+        super(PaginateTest, self).setUp()
+        self.request = HttpRequest()
+        self.request.method = "GET"
+        self.view = DummyPaginationEndpoint().as_view()
+
+    def test_success(self):
+        response = self.view(self.request)
+        assert response.status_code == 200, response.content
+
+    def test_invalid_per_page(self):
+        self.request.GET = {"per_page": "nope"}
+        response = self.view(self.request)
+        assert response.status_code == 400
+
+    def test_invalid_cursor(self):
+        self.request.GET = {"cursor": "no:no:no"}
+        response = self.view(self.request)
+        assert response.status_code == 400
 
 
 class EndpointJSONBodyTest(APITestCase):


### PR DESCRIPTION
Fixes SENTRY-F2A