### PR TITLE
fix(tags facet) Apply turbo when providing sampling

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -572,6 +572,8 @@ def get_facets(query, params, limit=10, referrer=None):
             dataset=Dataset.Discover,
             referrer=referrer,
             sample=sample_rate,
+            # Ensures Snuba will not apply FINAL
+            turbo=sample_rate is not None,
         )
         results.extend(
             [
@@ -608,7 +610,8 @@ def get_facets(query, params, limit=10, referrer=None):
             limit=TOP_VALUES_DEFAULT_LIMIT,
             dataset=Dataset.Discover,
             referrer=referrer,
-            sample=sample_rate,
+            # Ensures Snuba will not apply FINAL
+            turbo=sample_rate is not None,
         )
         results.extend(
             [
@@ -631,6 +634,8 @@ def get_facets(query, params, limit=10, referrer=None):
             dataset=Dataset.Discover,
             referrer=referrer,
             sample=sample_rate,
+            # Ensures Snuba will not apply FINAL
+            turbo=sample_rate is not None,
             limitby=[TOP_VALUES_DEFAULT_LIMIT, "tags_key"],
         )
         results.extend(

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -610,6 +610,7 @@ def get_facets(query, params, limit=10, referrer=None):
             limit=TOP_VALUES_DEFAULT_LIMIT,
             dataset=Dataset.Discover,
             referrer=referrer,
+            sample=sample_rate,
             # Ensures Snuba will not apply FINAL
             turbo=sample_rate is not None,
         )


### PR DESCRIPTION
When applying SAMPLING, snuba can still decide it will add FINAL after replacements happened and before clickhouse has merged the rows. These two together don't work, so we need to tell snuba that we do not care of the consistency of the results and not to apply FINAL in any case.
This achieves that by passing Turbo together with sample.