### PR TITLE
feat(integrations): add slug to integration provider and improve provider type

### DIFF
--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -21,6 +21,7 @@ class IntegrationSerializer(Serializer):
             "status": obj.get_status_display(),
             "provider": {
                 "key": provider.key,
+                "slug": provider.key,
                 "name": provider.name,
                 "canAdd": provider.can_add,
                 "canDisable": provider.can_disable,

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -85,6 +85,7 @@ class IntegrationProviderSerializer(Serializer):
 
         return {
             "key": obj.key,
+            "slug": obj.key,
             "name": obj.name,
             "metadata": metadata,
             "canAdd": obj.can_add,

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -491,19 +491,22 @@ export enum RepositoryStatus {
   DELETION_IN_PROGRESS = 'deletion_in_progress',
 }
 
-export type IntegrationProvider = {
+type BaseIntegrationProvider = {
   key: string;
   slug: string;
   name: string;
   canAdd: boolean;
   canDisable: boolean;
   features: string[];
-  aspects: any; //TODO(ts)
+};
+
+export type IntegrationProvider = BaseIntegrationProvider & {
   setupDialog: {url: string; width: number; height: number};
   metadata: {
     description: string;
     features: IntegrationFeature[];
     author: string;
+    noun: string;
     issue_url: string;
     source_url: string;
     aspects: any; //TODO(ts)
@@ -576,7 +579,7 @@ export type Integration = {
   domainName: string;
   accountType: string;
   status: ObjectStatus;
-  provider: IntegrationProvider;
+  provider: BaseIntegrationProvider & {aspects: any};
   configOrganization: Field[];
   //TODO(ts): This includes the initial data that is passed into the integration's configuration form
   configData: object;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -493,13 +493,21 @@ export enum RepositoryStatus {
 
 export type IntegrationProvider = {
   key: string;
+  slug: string;
   name: string;
   canAdd: boolean;
   canDisable: boolean;
   features: string[];
   aspects: any; //TODO(ts)
   setupDialog: {url: string; width: number; height: number};
-  metadata: any; //TODO(ts)
+  metadata: {
+    description: string;
+    features: IntegrationFeature[];
+    author: string;
+    issue_url: string;
+    source_url: string;
+    aspects: any; //TODO(ts)
+  };
 };
 
 export type IntegrationFeature = {

--- a/tests/js/sentry-test/fixtures/githubIntegrationProvider.js
+++ b/tests/js/sentry-test/fixtures/githubIntegrationProvider.js
@@ -1,6 +1,7 @@
 export function GitHubIntegrationProvider(params = {}) {
   return {
     key: 'github',
+    slug: 'github',
     name: 'GitHub',
     canAdd: true,
     config: [],

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -65,6 +65,7 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
         "url": "/github-integration-setup-uri/",
         "width": 100,
       },
+      "slug": "github",
     }
   }
 >
@@ -218,6 +219,7 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
           "url": "/github-integration-setup-uri/",
           "width": 100,
         },
+        "slug": "github",
       }
     }
   >
@@ -650,6 +652,7 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                         "url": "/github-integration-setup-uri/",
                         "width": 100,
                       },
+                      "slug": "github",
                     }
                   }
                   size="small"
@@ -728,6 +731,7 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                             "url": "/github-integration-setup-uri/",
                             "width": 100,
                           },
+                          "slug": "github",
                         }
                       }
                     >

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -51,6 +51,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                 "status": integration.get_status_display(),
                 "provider": {
                     "key": provider.key,
+                    "slug": provider.key,
                     "name": provider.name,
                     "canAdd": provider.can_add,
                     "canDisable": provider.can_disable,
@@ -90,6 +91,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                 "status": integration.get_status_display(),
                 "provider": {
                     "key": provider.key,
+                    "slug": provider.key,
                     "name": provider.name,
                     "canAdd": provider.can_add,
                     "canDisable": provider.can_disable,

--- a/tests/sentry/api/endpoints/test_group_integrations.py
+++ b/tests/sentry/api/endpoints/test_group_integrations.py
@@ -43,6 +43,7 @@ class GroupIntegrationsTest(APITestCase):
                 "status": integration.get_status_display(),
                 "provider": {
                     "key": provider.key,
+                    "slug": provider.key,
                     "name": provider.name,
                     "canAdd": provider.can_add,
                     "canDisable": provider.can_disable,


### PR DESCRIPTION
We use `slug` for plugins and sentry apps. This PR makes first-party integrations align with those by adding the `slug` and using the same value we use for `key`.

I also made some changes to the type of `IntegrationProvider` that more accurately represents what the serializer actually does.