### PR TITLE
fix(ui): Fix react-select3 design + value

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -87,12 +87,19 @@ const defaultStyles = {
     ...provided,
     lineHeight: '1.5',
     fontSize: theme.fontSizeMedium,
-    color: state.isSelected ? theme.white : theme.textColor,
-    backgroundColor: state.isSelected
-      ? theme.purpleLightest
-      : state.isFocused
-      ? theme.offWhite
-      : 'none',
+    color: state.isFocused
+      ? theme.textColor
+      : state.isSelected
+      ? theme.white
+      : theme.textColor,
+    backgroundColor: state.isFocused
+      ? theme.offWhiteLight
+      : state.isSelected
+      ? theme.purple
+      : 'transparent',
+    '&:active': {
+      backgroundColor: theme.offWhiteLight,
+    },
   }),
   valueContainer: provided => ({
     ...provided,

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -87,16 +87,16 @@ const defaultStyles = {
     ...provided,
     lineHeight: '1.5',
     fontSize: theme.fontSizeMedium,
-    color: state.isSelected || state.isFocused ? theme.white : theme.textColor,
+    color: state.isSelected ? theme.white : theme.textColor,
     backgroundColor: state.isSelected
       ? theme.purpleLightest
       : state.isFocused
-      ? theme.purpleLight
+      ? theme.offWhite
       : 'none',
   }),
   valueContainer: provided => ({
     ...provided,
-    alignItems: 'flex-start',
+    alignItems: 'center',
   }),
   multiValue: () => ({
     color: '#007eff',
@@ -104,7 +104,6 @@ const defaultStyles = {
     borderRadius: '2px',
     border: '1px solid #c2e0ff',
     display: 'flex',
-    marginTop: '4px',
     marginRight: '4px',
   }),
   multiValueLabel: provided => ({
@@ -167,7 +166,10 @@ const SelectControl = props => {
 
   // Value is expected to be object like the options list, we map it back from
   // the options list
-  const mappedValue = choicesOrOptions.find(opt => opt.value === value);
+  const mappedValue =
+    props.multiple && Array.isArray(value)
+      ? value.map(val => choicesOrOptions.find(option => option.value === val))
+      : choicesOrOptions.find(opt => opt.value === value);
 
   // Allow the provided `styles` prop to override default styles using the same
   // function interface provided by react-styled. This ensures the `provided`

--- a/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
@@ -60,23 +60,13 @@ export default class SelectField extends React.Component {
       <InputField
         {...otherProps}
         alignRight={this.props.small}
-        field={({onChange, onBlur, disabled, required: _required, ...props}) => {
-          // We remove the required property here since applying it to the
-          // DOM causes the native tooltip to render in strange places.
-          const choices = getChoices(props);
-
+        field={({onChange, onBlur, required: _required, ...props}) => {
           return (
             <SelectControl
               {...props}
               clearable={allowClear}
               multiple={multiple}
-              disabled={disabled}
               onChange={this.handleChange.bind(this, onBlur, onChange)}
-              value={props.value}
-              options={choices.map(([value, label]) => ({
-                value,
-                label,
-              }))}
             />
           );
         }}

--- a/tests/js/spec/components/group/__snapshots__/externalIssueForm.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueForm.spec.jsx.snap
@@ -760,18 +760,6 @@ exports[`ExternalIssueForm link renders 1`] = `
                                         onCloseResetsInput={false}
                                         onKeyDown={[Function]}
                                         onSelectResetsInput={false}
-                                        options={
-                                          Array [
-                                            Object {
-                                              "label": "test",
-                                              "value": "scefali/test",
-                                            },
-                                            Object {
-                                              "label": "ZeldaBazaar",
-                                              "value": "scefali/ZeldaBazaar",
-                                            },
-                                          ]
-                                        }
                                         placeholder="--"
                                         small={false}
                                         stacked={true}
@@ -825,18 +813,6 @@ exports[`ExternalIssueForm link renders 1`] = `
                                           onCloseResetsInput={false}
                                           onKeyDown={[Function]}
                                           onSelectResetsInput={false}
-                                          options={
-                                            Array [
-                                              Object {
-                                                "label": "test",
-                                                "value": "scefali/test",
-                                              },
-                                              Object {
-                                                "label": "ZeldaBazaar",
-                                                "value": "scefali/ZeldaBazaar",
-                                              },
-                                            ]
-                                          }
                                           placeholder="--"
                                           small={false}
                                           stacked={true}
@@ -889,18 +865,6 @@ exports[`ExternalIssueForm link renders 1`] = `
                                             onCloseResetsInput={false}
                                             onKeyDown={[Function]}
                                             onSelectResetsInput={false}
-                                            options={
-                                              Array [
-                                                Object {
-                                                  "label": "test",
-                                                  "value": "scefali/test",
-                                                },
-                                                Object {
-                                                  "label": "ZeldaBazaar",
-                                                  "value": "scefali/ZeldaBazaar",
-                                                },
-                                              ]
-                                            }
                                             placeholder="--"
                                             small={false}
                                             stacked={true}
@@ -954,18 +918,6 @@ exports[`ExternalIssueForm link renders 1`] = `
                                               onCloseResetsInput={false}
                                               onKeyDown={[Function]}
                                               onSelectResetsInput={false}
-                                              options={
-                                                Array [
-                                                  Object {
-                                                    "label": "test",
-                                                    "value": "scefali/test",
-                                                  },
-                                                  Object {
-                                                    "label": "ZeldaBazaar",
-                                                    "value": "scefali/ZeldaBazaar",
-                                                  },
-                                                ]
-                                              }
                                               placeholder="--"
                                               small={false}
                                               stacked={true}
@@ -1871,7 +1823,6 @@ exports[`ExternalIssueForm link renders 1`] = `
                                         onCloseResetsInput={false}
                                         onKeyDown={[Function]}
                                         onSelectResetsInput={false}
-                                        options={Array []}
                                         placeholder="--"
                                         small={false}
                                         stacked={true}
@@ -1913,7 +1864,6 @@ exports[`ExternalIssueForm link renders 1`] = `
                                           onCloseResetsInput={false}
                                           onKeyDown={[Function]}
                                           onSelectResetsInput={false}
-                                          options={Array []}
                                           placeholder="--"
                                           small={false}
                                           stacked={true}
@@ -1954,7 +1904,6 @@ exports[`ExternalIssueForm link renders 1`] = `
                                             onCloseResetsInput={false}
                                             onKeyDown={[Function]}
                                             onSelectResetsInput={false}
-                                            options={Array []}
                                             placeholder="--"
                                             small={false}
                                             stacked={true}
@@ -1996,7 +1945,6 @@ exports[`ExternalIssueForm link renders 1`] = `
                                               onCloseResetsInput={false}
                                               onKeyDown={[Function]}
                                               onSelectResetsInput={false}
-                                              options={Array []}
                                               placeholder="--"
                                               small={false}
                                               stacked={true}


### PR DESCRIPTION
This fixes new `react-select` components that use `multiple=true`, `value` was not correctly loading the selected values because it expects an array of `react-select`'s `option` objects and the values we get from our APIs are just a list of `option.value`.

We were also duplicating things in SelectField that were handled in SelectControl.

Also cleans up some CSS

## Old
![image](https://user-images.githubusercontent.com/79684/74394297-2ef42300-4dc1-11ea-9c46-a0caf14e400e.png)

## New
![image](https://user-images.githubusercontent.com/79684/74394109-c9079b80-4dc0-11ea-811e-88a4b244f0f0.png)
