### PR TITLE
logging(pickle): Log when we load a pickle from django 1.9

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -6,7 +6,7 @@ import six
 
 from django.conf import settings
 
-from sentry.utils import warnings
+from sentry.utils import metrics, warnings
 from sentry.utils.sdk import configure_sdk
 from sentry.utils.warnings import DeprecatedSettingWarning
 
@@ -401,6 +401,9 @@ model_unpickle = django.db.models.base.model_unpickle
 
 def __model_unpickle_compat(model_id, attrs=None, factory=None):
     from django import VERSION
+
+    if attrs is not None or factory is not None:
+        metrics.incr("django.pickle.loaded_19_pickle.__model_unpickle_compat")
 
     if VERSION[:2] in [(1, 10), (1, 11)]:
         return model_unpickle(model_id)


### PR DESCRIPTION
I want to see whether we're actually loading Django 1.9 pickles anymore. This will also give us a
good idea whether we pickle django objects in the database at all.