### PR TITLE
feat(relay): Expose event retention to Relay

### DIFF
--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -10,8 +10,7 @@ from sentry_sdk.tracing import Span
 from sentry.api.base import Endpoint
 from sentry.api.permissions import RelayPermission
 from sentry.api.authentication import RelayAuthentication
-from sentry.relay import config
-from sentry.relay import projectconfig_cache
+from sentry.relay import config, projectconfig_cache
 from sentry.models import Project, ProjectKey, Organization, OrganizationOption
 from sentry.utils import metrics, json
 

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -124,6 +124,9 @@ def get_project_config(project, org_options=None, full_config=True, project_keys
     with Hub.current.start_span(op="get_grouping_config_dict_for_project"):
         project_cfg["groupingConfig"] = get_grouping_config_dict_for_project(project)
 
+    with Hub.current.start_span(op="get_event_retention"):
+        project_cfg["eventRetention"] = quotas.get_event_retention(project.organization)
+
     return ProjectConfig(project, **cfg)
 
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 from django.core.urlresolvers import reverse
 
+from sentry import quotas
 from sentry.utils import safe
 from sentry.models.relay import Relay
 from sentry.models import Project
@@ -149,6 +150,12 @@ def test_internal_relays_should_receive_full_configs(
     assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubDefaults") is True
     assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubIpAddresses") is True
     assert safe.get_path(cfg, "config", "datascrubbingSettings", "sensitiveFields") == []
+
+    # Event retention depends on settings, so assert the actual value. Likely
+    # `None` in dev, but must not be missing.
+    assert cfg["config"]["eventRetention"] == quotas.get_event_retention(
+        default_project.organization
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This allows relay to set the retention directly for session events.