### PR TITLE
fix(ui) Fix error in sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -240,7 +240,7 @@ class Sidebar extends React.Component {
     };
 
     // Bail as we can't do any more checks.
-    if (!organization) {
+    if (!organization || !organization.features) {
       return sidebarState;
     }
     const optState = localStorage.getItem('discover:version');


### PR DESCRIPTION
Sometimes `organization.features` is undefined. It shouldn't be but it is, and we have to account for that.

Fixes JAVASCRIPT-21G1
