### PR TITLE
fix(sentry-apps): prevent members from uninstalling sentry apps

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -250,6 +250,7 @@ class SentryAppDetailedView extends AsyncComponent<
                           app={this.state.sentryApp}
                           onClickUninstall={this.handleUninstall}
                           onUninstallModalOpen={() => {}} //TODO: Implement tracking analytics
+                          disabled={!hasAccess}
                         />
                       );
                     }}

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/installButtons.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/installButtons.tsx
@@ -12,12 +12,14 @@ type UninstallButtonProps = {
   app: SentryApp;
   onClickUninstall?: (install: SentryAppInstallation) => void;
   onUninstallModalOpen?: () => void; //used for analytics
+  disabled?: boolean;
 };
 export const UninstallButton = ({
   install,
   app,
   onClickUninstall,
   onUninstallModalOpen,
+  disabled,
 }: UninstallButtonProps) => {
   const message = t(`Are you sure you want to remove the ${app.slug} installation?`);
 
@@ -27,6 +29,7 @@ export const UninstallButton = ({
       priority="danger"
       onConfirm={() => onClickUninstall && install && onClickUninstall(install)} //called when the user confirms the action
       onConfirming={onUninstallModalOpen} //called when the confirm modal opens
+      disabled={disabled}
     >
       <StyledButton borderless icon="icon-trash" data-test-id="sentry-app-uninstall">
         {t('Uninstall')}

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/sentryApplicationRowButtons.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/sentryApplicationRowButtons.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import Access from 'app/components/acl/access';
 
 import {t} from 'app/locale';
-import {LightWeightOrganization, SentryApp, SentryAppInstallation} from 'app/types';
+import {Organization, SentryApp, SentryAppInstallation} from 'app/types';
 import ActionButtons from './actionButtons';
 import {InstallButton, UninstallButton} from './installButtons';
 
 type Props = {
-  organization: LightWeightOrganization;
+  organization: Organization;
   app: SentryApp;
   install?: SentryAppInstallation;
 
@@ -44,12 +44,18 @@ const SentryApplicationRowButtons = ({
     }
     //if installed, render the uninstall button and if installed, render install button
     return !!install ? (
-      <UninstallButton
-        install={install}
-        app={app}
-        onClickUninstall={onClickUninstall}
-        onUninstallModalOpen={onUninstallModalOpen}
-      />
+      //only restrict uninstall for sentry apps by role since install popup will
+      <Access organization={organization} access={['org:integrations']}>
+        {({hasAccess}) => (
+          <UninstallButton
+            install={install}
+            app={app}
+            onClickUninstall={onClickUninstall}
+            onUninstallModalOpen={onUninstallModalOpen}
+            disabled={!hasAccess}
+          />
+        )}
+      </Access>
     ) : (
       <InstallButton onClickInstall={onClickInstall} />
     );


### PR DESCRIPTION
There is a bug that allows members to click uninstall on a Sentry App in both the integration directory and the existing integrations page. When a member clicks uninstall, they get an error from the server because they don't have the proper permissions.
