### PR TITLE
fix(discover2): Normalize timestamp field for count() drilldowns

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -389,7 +389,16 @@ export function getExpandedResults(
     // match their name.
     if (dataRow) {
       if (dataRow[dataKey]) {
-        additionalConditions[column.field] = String(dataRow[dataKey]).trim();
+        const nextValue = String(dataRow[dataKey]).trim();
+
+        switch (column.field) {
+          case 'timestamp':
+            // normalize the "timestamp" field to ensure the payload works
+            additionalConditions[column.field] = getUtcDateString(nextValue);
+            break;
+          default:
+            additionalConditions[column.field] = nextValue;
+        }
       }
       // If we have an event, check tags as well.
       if (dataRow && dataRow.tags && dataRow.tags instanceof Array) {

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -437,6 +437,20 @@ describe('getExpandedResults()', function() {
     expect(result.query).toEqual('event.type:error');
     expect(result.environment).toEqual(['staging', 'dev']);
   });
+
+  it('normalizes the timestamp field', () => {
+    const view = new EventView({
+      ...state,
+      fields: [{field: 'timestamp'}],
+      sorts: [{field: 'timestamp', kind: 'desc'}],
+    });
+    const event = {
+      type: 'error',
+      timestamp: '2020-02-13T17:05:46+00:00',
+    };
+    const result = getExpandedResults(view, {}, event);
+    expect(result.query).toEqual('event.type:error timestamp:2020-02-13T17:05:46');
+  });
 });
 
 describe('getDiscoverLandingUrl', function() {


### PR DESCRIPTION
Today `count()` drilldowns with the `timestamp` present in the table will bork since we haven't normalized the `timestamp` value in the search conditions.