### PR TITLE
ref(UI): Comment out Tags from Integration Directory

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -366,13 +366,13 @@ class OrganizationIntegrations extends AsyncComponent<
     const {reloading, displayedList} = this.state;
 
     const title = t('Integrations');
-    const tags = [
-      'Source Control',
-      'Ticketing',
-      'Data Forwarding',
-      'Release Management',
-      'Notifications',
-    ];
+    // const tags = [
+    //   'Source Control',
+    //   'Ticketing',
+    //   'Data Forwarding',
+    //   'Release Management',
+    //   'Notifications',
+    // ];
     return (
       <React.Fragment>
         <SentryDocumentTitle title={title} objSlug={orgId} />
@@ -384,17 +384,19 @@ class OrganizationIntegrations extends AsyncComponent<
           providers={this.providers}
           onInstall={this.onInstall}
         />
-        <SearchInput
-          value={this.state.searchInput || ''}
-          onChange={this.onSearchChange}
-          placeholder="Find a new integration, or one you already use."
-          width="100%"
-        />
-        <TagsContainer>
+        <SearchContainer>
+          <SearchInput
+            value={this.state.searchInput || ''}
+            onChange={this.onSearchChange}
+            placeholder="Find a new integration, or one you already use."
+            width="100%"
+          />
+        </SearchContainer>
+        {/* <TagsContainer>
           {tags.map(tag => (
             <Tag key={tag}>{tag}</Tag>
           ))}
-        </TagsContainer>
+        </TagsContainer> */}
         <Panel>
           <PanelHeader disablePadding>
             <Heading>{t('Integrations')}</Heading>
@@ -420,34 +422,40 @@ const Heading = styled('div')`
   padding-right: ${space(2)};
 `;
 
-const TagsContainer = styled('div')`
+const SearchContainer = styled('div')`
   display: flex;
-  flex-wrap: wrap;
-  padding-top: ${space(3)};
-  padding-bottom: ${space(1)};
+  width: 100%;
+  margin-bottom: ${space(2)};
 `;
 
-const Tag = styled('span')`
-  transition: border-color 0.15s ease;
-  font-size: 14px;
-  line-height: 1;
-  padding: ${space(1)};
-  margin: 0 ${space(1)} ${space(1)} 0;
-  border: 1px solid ${p => p.theme.borderDark};
-  border-radius: 30px;
-  height: 28px;
-  box-shadow: inset ${p => p.theme.dropShadowLight};
-  cursor: pointer;
+// const TagsContainer = styled('div')`
+//   display: flex;
+//   flex-wrap: wrap;
+//   padding-top: ${space(3)};
+//   padding-bottom: ${space(1)};
+// `;
 
-  &:focus {
-    outline: none;
-    border: 1px solid ${p => p.theme.gray1};
-  }
+// const Tag = styled('span')`
+//   transition: border-color 0.15s ease;
+//   font-size: 14px;
+//   line-height: 1;
+//   padding: ${space(1)};
+//   margin: 0 ${space(1)} ${space(1)} 0;
+//   border: 1px solid ${p => p.theme.borderDark};
+//   border-radius: 30px;
+//   height: 28px;
+//   box-shadow: inset ${p => p.theme.dropShadowLight};
+//   cursor: pointer;
 
-  &::placeholder {
-    color: ${p => p.theme.gray2};
-  }
-`;
+//   &:focus {
+//     outline: none;
+//     border: 1px solid ${p => p.theme.gray1};
+//   }
+
+//   &::placeholder {
+//     color: ${p => p.theme.gray2};
+//   }
+// `;
 
 export default withOrganization(OrganizationIntegrations);
 export {OrganizationIntegrations};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -366,13 +366,6 @@ class OrganizationIntegrations extends AsyncComponent<
     const {reloading, displayedList} = this.state;
 
     const title = t('Integrations');
-    // const tags = [
-    //   'Source Control',
-    //   'Ticketing',
-    //   'Data Forwarding',
-    //   'Release Management',
-    //   'Notifications',
-    // ];
     return (
       <React.Fragment>
         <SentryDocumentTitle title={title} objSlug={orgId} />
@@ -392,11 +385,6 @@ class OrganizationIntegrations extends AsyncComponent<
             width="100%"
           />
         </SearchContainer>
-        {/* <TagsContainer>
-          {tags.map(tag => (
-            <Tag key={tag}>{tag}</Tag>
-          ))}
-        </TagsContainer> */}
         <Panel>
           <PanelHeader disablePadding>
             <Heading>{t('Integrations')}</Heading>
@@ -427,35 +415,6 @@ const SearchContainer = styled('div')`
   width: 100%;
   margin-bottom: ${space(2)};
 `;
-
-// const TagsContainer = styled('div')`
-//   display: flex;
-//   flex-wrap: wrap;
-//   padding-top: ${space(3)};
-//   padding-bottom: ${space(1)};
-// `;
-
-// const Tag = styled('span')`
-//   transition: border-color 0.15s ease;
-//   font-size: 14px;
-//   line-height: 1;
-//   padding: ${space(1)};
-//   margin: 0 ${space(1)} ${space(1)} 0;
-//   border: 1px solid ${p => p.theme.borderDark};
-//   border-radius: 30px;
-//   height: 28px;
-//   box-shadow: inset ${p => p.theme.dropShadowLight};
-//   cursor: pointer;
-
-//   &:focus {
-//     outline: none;
-//     border: 1px solid ${p => p.theme.gray1};
-//   }
-
-//   &::placeholder {
-//     color: ${p => p.theme.gray2};
-//   }
-// `;
 
 export default withOrganization(OrganizationIntegrations);
 export {OrganizationIntegrations};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/shared/styledComponents.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/shared/styledComponents.tsx
@@ -3,14 +3,14 @@ import styled from '@emotion/styled';
 import {withTheme} from 'emotion-theming';
 import space from 'app/styles/space';
 
-const TagsContainer = styled('div')`
+export const TagsContainer = styled('div')`
   display: flex;
   flex-wrap: wrap;
   padding-top: ${space(3)};
   padding-bottom: ${space(1)};
 `;
 
-const Tag = styled(
+export const Tag = styled(
   withTheme((props: {theme?: any}) => {
     return <span />;
   })

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/shared/styledComponents.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/shared/styledComponents.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {withTheme} from 'emotion-theming';
 import space from 'app/styles/space';
 
 export const TagsContainer = styled('div')`
@@ -10,11 +9,7 @@ export const TagsContainer = styled('div')`
   padding-bottom: ${space(1)};
 `;
 
-export const Tag = styled(
-  withTheme((props: {theme?: any}) => {
-    return <span />;
-  })
-)`
+export const Tag = styled(p => <span {...p} />)`
   transition: border-color 0.15s ease;
   font-size: 14px;
   line-height: 1;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/shared/styledComponents.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/shared/styledComponents.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {withTheme} from 'emotion-theming';
+import space from 'app/styles/space';
+
+const TagsContainer = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  padding-top: ${space(3)};
+  padding-bottom: ${space(1)};
+`;
+
+const Tag = styled(
+  withTheme((props: {theme?: any}) => {
+    return <span />;
+  })
+)`
+  transition: border-color 0.15s ease;
+  font-size: 14px;
+  line-height: 1;
+  padding: ${space(1)};
+  margin: 0 ${space(1)} ${space(1)} 0;
+  border: 1px solid ${p => p.theme.borderDark};
+  border-radius: 30px;
+  height: 28px;
+  box-shadow: inset ${p => p.theme.dropShadowLight};
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+    border: 1px solid ${p => p.theme.gray1};
+  }
+
+  &::placeholder {
+    color: ${p => p.theme.gray2};
+  }
+`;


### PR DESCRIPTION
## Objective
Temporarily remove the categories that are listed below the integration directory search bar. 

## Solution
Those components has been moved to a new `shared` directory. Any instantiations of those components has been deleted from the Integration Directory List view.

## UI
<img width="999" alt="Screen Shot 2020-02-13 at 10 58 12 AM" src="https://user-images.githubusercontent.com/10491193/74468483-bf794480-4e4f-11ea-83d8-2c6609e4fe73.png">

## Test Plan
- Manually checked the new UI.