### PR TITLE
auth: Stop using access_token as a querystring

### DIFF
--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -9,8 +9,10 @@ def get_user_info(access_token):
     session = http.build_session()
     resp = session.get(
         "https://api.github.com/user",
-        params={"access_token": access_token},
-        headers={"Accept": "application/vnd.github.machine-man-preview+json"},
+        headers={
+            "Accept": "application/vnd.github.machine-man-preview+json",
+            "Authorization": "token %s" % access_token,
+        },
     )
     resp.raise_for_status()
     resp = resp.json()

--- a/src/sentry/identity/github_enterprise/provider.py
+++ b/src/sentry/identity/github_enterprise/provider.py
@@ -8,8 +8,10 @@ def get_user_info(url, access_token):
     session = http.build_session()
     resp = session.get(
         u"https://{}/api/v3/user".format(url),
-        params={"access_token": access_token},
-        headers={"Accept": "application/vnd.github.machine-man-preview+json"},
+        headers={
+            "Accept": "application/vnd.github.machine-man-preview+json",
+            "Authorization": "token %s" % access_token,
+        },
         verify=False,
     )
     resp.raise_for_status()

--- a/src/sentry_plugins/github/client.py
+++ b/src/sentry_plugins/github/client.py
@@ -79,11 +79,12 @@ class GitHubClient(GitHubClientMixin, AuthApiClient):
 
     def get_installations(self):
         # TODO(jess): remove this whenever it's out of preview
-        headers = {"Accept": "application/vnd.github.machine-man-preview+json"}
+        headers = {
+            "Accept": "application/vnd.github.machine-man-preview+json",
+            "Authorization": "token %s" % self.auth.tokens["access_token"],
+        }
 
-        params = {"access_token": self.auth.tokens["access_token"]}
-
-        return self._request("GET", "/user/installations", headers=headers, params=params)
+        return self._request("GET", "/user/installations", headers=headers)
 
 
 class GitHubAppsClient(GitHubClientMixin, ApiClient):


### PR DESCRIPTION
Ref: https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters