### PR TITLE
fix: pin virtualenv for pre-commit, and misc touchups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ ensure-venv:
 ensure-pinned-pip: ensure-venv
 	$(PIP) install --no-cache-dir --upgrade "pip>=20.0.2"
 
-# TODO(joshuarli): pre-commit should be moved to requirements-dev.txt and setup-git should come after install-sentry-dev.
 setup-git: ensure-venv
 	@echo "--> Installing git hooks"
 	git config branch.autosetuprebase always

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ensure-venv:
 	@./scripts/ensure-venv.sh
 
 ensure-pinned-pip: ensure-venv
-	$(PIP) install --no-cache-dir "pip>=20.0.2"
+	$(PIP) install --no-cache-dir --upgrade "pip>=20.0.2"
 
 setup-git: ensure-venv
 	@echo "--> Installing git hooks"

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,19 @@ ensure-venv:
 ensure-pinned-pip: ensure-venv
 	$(PIP) install --no-cache-dir --upgrade "pip>=20.0.2"
 
+# TODO(joshuarli): pre-commit should be moved to requirements-dev.txt and setup-git should come after install-sentry-dev.
 setup-git: ensure-venv
 	@echo "--> Installing git hooks"
 	git config branch.autosetuprebase always
 	git config core.ignorecase false
 	cd .git/hooks && ln -sf ../../config/hooks/* ./
-	$(PIP) install "pre-commit==1.18.2"
+	@# XXX(joshuarli): virtualenv >= 20 doesn't work with the version of six we have pinned for sentry.
+	@# Since pre-commit is installed in the venv, it will install virtualenv in the venv as well.
+	@# We need to tell pre-commit to install an older virtualenv,
+	@# And we need to tell virtualenv to install an older six, so that sentry installation
+	@# won't complain about a newer six being present.
+	@# So, this six pin here needs to be synced with requirements-base.txt.
+	$(PIP) install "pre-commit==1.18.2" "virtualenv>=16.7,<20" "six>=1.10.0,<1.11.0"
 	pre-commit install --install-hooks
 	@echo ""
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ setup-git: ensure-venv
 	@echo ""
 
 node-version-check:
-	@test "$$(node -v)" = v"$$(cat .nvmrc)" || (echo 'node version does not match .nvmrc. Recommended to use https://github.com/creationix/nvm'; exit 1)
+	@test "$$(node -v)" = v"$$(cat .nvmrc)" || (echo 'node version does not match .nvmrc. Recommended to use https://github.com/volta-cli/volta'; exit 1)
 
 install-yarn-pkgs: node-version-check
 	@echo "--> Installing Yarn packages (for development)"

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # optionally opt out of virtualenv creation
+# WARNING: this will be removed (most likely renamed) soon!
 if [ "x$SENTRY_NO_VIRTUALENV_CREATION" == "x1" ]; then
     exit 0
 fi


### PR DESCRIPTION
virtualenv >= 20 doesn't work with the version of six (1.10.0) we have pinned for sentry.

Since pre-commit is installed in the venv, it will install virtualenv in the venv as well. We need to tell pre-commit to install an older virtualenv, and we also need to tell virtualenv to install an older six, so that sentry installation won't complain about a newer six being present.
