### PR TITLE
fix(issue search) trace tag was failing to search

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import logging
 import six
-import uuid
 from functools import partial
 from django.utils.http import urlquote
 from rest_framework.response import Response
@@ -218,18 +217,9 @@ class OrganizationEventsV2Endpoint(OrganizationEventsEndpointBase):
 
         # TODO(mark) move all of this result formatting into discover.query()
         # once those APIs are used across the application.
-        tests = {
-            "transaction.status": "transaction.status" in first_row,
-            "trace": "trace" in first_row,
-        }
-        if any(tests.values()):
+        if "transaction.status" in first_row:
             for row in results:
-                if tests["transaction.status"]:
-                    row["transaction.status"] = SPAN_STATUS_CODE_TO_NAME.get(
-                        row["transaction.status"]
-                    )
-                if tests["trace"]:
-                    row["trace"] = uuid.UUID(row["trace"]).hex
+                row["transaction.status"] = SPAN_STATUS_CODE_TO_NAME.get(row["transaction.status"])
 
         fields = request.GET.getlist("field")
         issues = {}

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import re
-import uuid
 from collections import namedtuple
 from copy import deepcopy
 from datetime import datetime
@@ -684,21 +683,6 @@ def convert_search_filter_to_snuba_query(search_filter):
                 )
             )
         return [name, search_filter.operator, internal_value]
-    elif name == "trace":
-        if not search_filter.value.raw_value:
-            operator = "IS NULL" if search_filter.operator == "=" else "IS NOT NULL"
-            return [name, operator, None]
-
-        try:
-            return [
-                name,
-                search_filter.operator,
-                six.text_type(uuid.UUID(search_filter.value.raw_value)),
-            ]
-        except Exception:
-            raise InvalidSearchQuery(
-                "Invalid value for the trace condition. Value must be a hexadecimal UUID string."
-            )
     else:
         value = (
             int(to_timestamp(value)) * 1000

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -164,7 +164,10 @@ class Columns(Enum):
     TRANSACTION_STATUS = Column(None, None, "transaction_status", "transaction.status")
     # Tracing context fields.
     TRACE_ID = Column(
-        "events.contexts[trace.trace_id]", "contexts[trace.trace_id]", "trace_id", "trace"
+        "events.contexts[trace.trace_id]",
+        "contexts[trace.trace_id]",
+        "contexts[trace.trace_id]",
+        "trace",
     )
     SPAN_ID = Column(
         "events.contexts[trace.span_id]",

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1105,6 +1105,7 @@ class GetSnubaQueryArgsTest(TestCase):
         assert "Invalid value" in six.text_type(err)
         assert "cancelled," in six.text_type(err)
 
+    @pytest.mark.xfail(reason="this breaks issue search so needs to be redone")
     def test_trace_id(self):
         result = get_filter("trace:{}".format("a0fa8803753e40fd8124b21eeb2986b5"))
         assert result.conditions == [["trace", "=", "a0fa8803-753e-40fd-8124-b21eeb2986b5"]]

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -143,18 +143,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400
         assert "Invalid format for numeric search" in response.data["detail"]
 
-    def test_invalid_search_query(self):
-        now = timezone.now()
-        self.create_group(checksum="a" * 32, last_seen=now - timedelta(seconds=1))
-        self.login_as(user=self.user)
-
-        response = self.get_response(sort_by="date", query="trace:123")
-        assert response.status_code == 400
-        assert (
-            "Invalid value for the trace condition. Value must be a hexadecimal UUID string."
-            in response.data["detail"]
-        )
-
     def test_simple_pagination(self):
         event1 = self.store_event(
             data={"timestamp": iso_format(before_now(seconds=2)), "fingerprint": ["group-1"]},

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -70,6 +70,32 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(group.id)
 
+    def test_trace_search(self):
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": iso_format(before_now(seconds=1)),
+                "contexts": {
+                    "trace": {
+                        "parent_span_id": "8988cec7cc0779c1",
+                        "type": "trace",
+                        "op": "foobar",
+                        "trace_id": "a7d67cf796774551a95be6543cacd459",
+                        "span_id": "babaae0d4b7512d9",
+                        "status": "ok",
+                    }
+                },
+            },
+            project_id=self.project.id,
+        )
+
+        self.login_as(user=self.user)
+        response = self.get_valid_response(
+            sort_by="date", query="is:unresolved trace:a7d67cf796774551a95be6543cacd459"
+        )
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == six.text_type(event.group.id)
+
     def test_feature_gate(self):
         # ensure there are two or more projects
         self.create_project(organization=self.project.organization)


### PR DESCRIPTION
When we moved the trace tag to a UUID for discover queries it broke issue search
so revert those optimizations for now, and we can revisit how to do this in a
way that doesn't break issues.