### PR TITLE
test: fix python-related issues in storybook deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -206,12 +206,12 @@ matrix:
 
     # Deploy 'storybook' (component & style guide) - allowed to fail
     - name: 'Storybook Deploy'
+      language: node_js
       env: STORYBOOK_BUILD=1
       before_install:
         # travis pyenv will attempt to use .python-version, but the appropriate python version won't be installed.
         # since we don't need python here, we have to remove this.
         - rm .python-version
-        - nvm install
         # Decrypt the credentials we added to the repo using the key we added with the Travis command line tool
         - openssl aes-256-cbc -K $encrypted_020be61ef175_key -iv $encrypted_020be61ef175_iv -in .travis/storybook-credentials.tar.gz.enc -out credentials.tar.gz -d
         # If the SDK is not already cached, download it and unpack it

--- a/.travis.yml
+++ b/.travis.yml
@@ -208,6 +208,9 @@ matrix:
     - name: 'Storybook Deploy'
       env: STORYBOOK_BUILD=1
       before_install:
+        # travis pyenv will attempt to use .python-version, but the appropriate python version won't be installed.
+        # since we don't need python here, we have to remove this.
+        - rm .python-version
         - nvm install
         # Decrypt the credentials we added to the repo using the key we added with the Travis command line tool
         - openssl aes-256-cbc -K $encrypted_020be61ef175_key -iv $encrypted_020be61ef175_iv -in .travis/storybook-credentials.tar.gz.enc -out credentials.tar.gz -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -206,9 +206,9 @@ matrix:
 
     # Deploy 'storybook' (component & style guide) - allowed to fail
     - name: 'Storybook Deploy'
-      language: node_js
       env: STORYBOOK_BUILD=1
       before_install:
+        - nvm install
         # Decrypt the credentials we added to the repo using the key we added with the Travis command line tool
         - openssl aes-256-cbc -K $encrypted_020be61ef175_key -iv $encrypted_020be61ef175_iv -in .travis/storybook-credentials.tar.gz.enc -out credentials.tar.gz -d
         # If the SDK is not already cached, download it and unpack it


### PR DESCRIPTION
Not entirely sure why it's still failing, but since the recent pyenv .python-version changes, it would error like

```
$ gcloud auth activate-service-account --key-file client-secret.json

pyenv: version `2.7.16' is not installed (set by /home/travis/build/getsentry/sentry/.python-version)

The command "gcloud auth activate-service-account --key-file client-secret.json" failed and exited with 1 during .
```

This PR unblocks `gcloud auth activate-service-account --key-file client-secret.json`.
