### PR TITLE
fix(workflow): Omitting cursor from queries

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -1,5 +1,6 @@
 import {RouteComponentProps} from 'react-router/lib/Router';
 import DocumentTitle from 'react-document-title';
+import omit from 'lodash/omit';
 import React from 'react';
 import moment from 'moment';
 import styled from '@emotion/styled';
@@ -150,9 +151,9 @@ class IncidentsListContainer extends React.Component<Props> {
     const {pathname, query} = location;
     const {orgId} = params;
 
-    const openIncidentsQuery = {...query, status: 'open'};
-    const closedIncidentsQuery = {...query, status: 'closed'};
-    const allIncidentsQuery = {...query, status: 'all'};
+    const openIncidentsQuery = omit({...query, status: 'open'}, 'cursor');
+    const closedIncidentsQuery = omit({...query, status: 'closed'}, 'cursor');
+    const allIncidentsQuery = omit({...query, status: 'all'}, 'cursor');
 
     const status = getQueryStatus(query.status);
     return (


### PR DESCRIPTION
When paging on an incident page and changing the filter type (say from "all" to "active"), the cursor remains as-is and this is a bad experience for a user.

We now reset the cursor when you switch filters.