### PR TITLE
fix: Show permalink for org wide tokens

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -354,7 +354,11 @@ class GroupSerializerBase(Serializer):
         # because the user isn't an org member. Instead we can use the auth token and the installation
         # it's associated with to find out what organization the token has access to.
         is_valid_sentryapp = False
-        if getattr(request.user, "is_sentry_app", False) and isinstance(request.auth, ApiToken):
+        if (
+            request
+            and getattr(request.user, "is_sentry_app", False)
+            and isinstance(request.auth, ApiToken)
+        ):
             is_valid_sentryapp = SentryAppInstallationToken.has_organization_access(
                 request.auth, obj.organization
             )

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -354,7 +354,7 @@ class GroupSerializerBase(Serializer):
         # because the user isn't an org member. Instead we can use the auth token and the installation
         # it's associated with to find out what organization the token has access to.
         is_valid_sentryapp = False
-        if hasattr(request.user, "is_sentry_app") and isinstance(request.auth, ApiToken):
+        if getattr(request.user, "is_sentry_app", False) and isinstance(request.auth, ApiToken):
             is_valid_sentryapp = SentryAppInstallationToken.has_organization_access(
                 request.auth, obj.organization
             )

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -17,6 +17,7 @@ from sentry.api.fields.actor import Actor
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import LOG_LEVELS, StatsPeriod
 from sentry.models import (
+    ApiToken,
     Commit,
     Environment,
     Group,
@@ -33,6 +34,7 @@ from sentry.models import (
     GroupSubscription,
     GroupSubscriptionReason,
     Integration,
+    SentryAppInstallationToken,
     User,
     UserOption,
     UserOptionValue,
@@ -347,8 +349,20 @@ class GroupSerializerBase(Serializer):
         # do not return the permalink which contains private information i.e. org name.
         request = env.request
         is_superuser = request and is_active_superuser(request) and request.user == user
-        if is_superuser or (
-            user.is_authenticated() and user.get_orgs().filter(id=obj.organization.id).exists()
+
+        # If user is a sentry_app then it's a proxy user meaning we can't do a org lookup via `get_orgs()`
+        # because the user isn't an org member. Instead we can use the auth token and the installation
+        # it's associated with to find out what organization the token has access to.
+        is_valid_sentryapp = False
+        if hasattr(request.user, "is_sentry_app") and isinstance(request.auth, ApiToken):
+            is_valid_sentryapp = SentryAppInstallationToken.has_organization_access(
+                request.auth, obj.organization
+            )
+
+        if (
+            is_superuser
+            or (user.is_authenticated() and user.get_orgs().filter(id=obj.organization.id).exists())
+            or is_valid_sentryapp
         ):
             permalink = obj.get_absolute_url()
         else:

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -25,6 +25,15 @@ class SentryAppInstallationToken(Model):
         db_table = "sentry_sentryappinstallationtoken"
         unique_together = (("sentry_app_installation", "api_token"),)
 
+    @classmethod
+    def has_organization_access(cls, token, organization):
+        try:
+            install = cls.objects.get(api_token=token).sentry_app_installation
+        except cls.DoesNotExist:
+            return False
+
+        return install.organization == organization
+
 
 class SentryAppInstallation(ParanoidModel):
     __core__ = True

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -28,11 +28,13 @@ class SentryAppInstallationToken(Model):
     @classmethod
     def has_organization_access(cls, token, organization):
         try:
-            install = cls.objects.get(api_token=token).sentry_app_installation
+            install_token = cls.objects.select_related("sentry_app_installation").get(
+                api_token=token
+            )
         except cls.DoesNotExist:
             return False
 
-        return install.organization == organization
+        return install_token.sentry_app_installation.organization_id == organization.id
 
 
 class SentryAppInstallation(ParanoidModel):

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -150,6 +150,22 @@ class GroupDetailsTest(APITestCase):
         assert "http://" in result
         assert "{}/issues/{}".format(group.organization.slug, group.id) in result
 
+    def test_permalink_sentry_app_installation_token(self):
+        project = self.create_project(organization=self.organization, teams=[self.team])
+        internal_app = self.create_internal_integration(
+            name="Internal app",
+            organization=self.organization,
+            scopes=("project:read", "org:read", "event:write"),
+        )
+        token = internal_app.installations.first().api_token
+
+        group = self.create_group(project=project)
+        url = u"/api/0/issues/{}/".format(group.id)
+        response = self.client.get(url, HTTP_AUTHORIZATION="Bearer {}".format(token), format="json")
+        result = response.data["permalink"]
+        assert "http://" in result
+        assert "{}/issues/{}".format(group.organization.slug, group.id) in result
+
 
 class GroupUpdateTest(APITestCase):
     def test_resolve(self):


### PR DESCRIPTION
**Problem:**
The `GroupSerializer` is used for our shared issue view, and because of that we need to make sure that in that case we don't return the permalink url since that data contains private information (e.g. the org slug). We do this by checking the request user and making sure they have access to the organization. However, this falls apart for people using org wide tokens because those tokens are associated with the organization itself and not a user (who would have access to organizations).

**Solution:** 
Use the auth token to find the organization it has access to (through the `sentry_app_installation`). Then we can check that the organization matches the group/issue's organization we are serializing. 