### PR TITLE
fix(thread): return null when thread is undefined

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threads.jsx
@@ -1,6 +1,7 @@
 import isNil from 'lodash/isNil';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import {t} from 'app/locale';
 import EventDataSection from 'app/components/events/eventDataSection';
 import SentryTypes from 'app/sentryTypes';
@@ -9,6 +10,7 @@ import CrashHeader from 'app/components/events/interfaces/crashHeader';
 import CrashContent from 'app/components/events/interfaces/crashContent';
 import Pills from 'app/components/pills';
 import Pill from 'app/components/pill';
+import {defined} from 'app/utils';
 
 import ThreadsSelector from './threadsSelector';
 import getThreadStacktrace from './getThreadStacktrace';
@@ -122,11 +124,13 @@ class ThreadsInterface extends React.Component {
 
   constructor(props) {
     super(props);
-    const thread = findBestThread(props.data.values);
+    const thread = defined(props.data.values)
+      ? findBestThread(props.data.values)
+      : undefined;
 
     this.state = {
       activeThread: thread,
-      stackView: getIntendedStackView(thread, props.event),
+      stackView: thread ? getIntendedStackView(thread, props.event) : undefined,
       stackType: 'original',
       newestFirst: isStacktraceNewestFirst(),
     };
@@ -163,13 +167,17 @@ class ThreadsInterface extends React.Component {
   };
 
   render() {
+    const threads = this.props.data.values || [];
+
+    if (threads.length === 0) {
+      return null;
+    }
+
     const evt = this.props.event;
     const {projectId, hideGuide} = this.props;
     const {stackView, stackType, newestFirst, activeThread} = this.state;
     const exception = this.getException();
     const stacktrace = this.getStacktrace();
-
-    const threads = this.props.data.values || [];
 
     const titleProps = {
       platform: evt.platform,

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelectorOption.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadsSelectorOption.tsx
@@ -60,7 +60,10 @@ const DetailsWrapper = styled('div')`
   overflow: hidden;
   display: grid;
   @media (min-width: ${props => props.theme.breakpoints[0]}) {
-    grid-template-columns: auto 1fr;
+    grid-template-columns: 50px 1fr;
+  }
+  @media (min-width: ${props => props.theme.breakpoints[2]}) {
+    grid-template-columns: 100px 1fr;
   }
 `;
 


### PR DESCRIPTION
**Type:** Fix

**Description:** 

When `this.props.data.values `is undefined, many functions are broken because they expect a defined thread. This PR fixes the problem by returning null in case of undefined thread

Ps: I also made a small change in threadSelector style