### PR TITLE
fix(ui): Preserve correct project id when navigating from release list to detail

### DIFF
--- a/src/sentry/static/sentry/app/components/version.tsx
+++ b/src/sentry/static/sentry/app/components/version.tsx
@@ -67,7 +67,7 @@ const Version = ({
         <LinkComponent
           to={{
             pathname: `/organizations/${orgId}/releases/${encodeURIComponent(version)}/`,
-            query: {project: projectId},
+            query: projectId ? {project: projectId} : undefined,
           }}
           className={className}
         >

--- a/tests/js/spec/components/__snapshots__/versionV2.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/versionV2.spec.jsx.snap
@@ -37,9 +37,7 @@ exports[`Version renders 1`] = `
       to={
         Object {
           "pathname": "/organizations/sentry/releases/foo.bar.Baz%401.0.0%2B20200101/",
-          "query": Object {
-            "project": undefined,
-          },
+          "query": undefined,
         }
       }
     >
@@ -47,9 +45,7 @@ exports[`Version renders 1`] = `
         href={
           Object {
             "pathname": "/organizations/sentry/releases/foo.bar.Baz%401.0.0%2B20200101/",
-            "query": Object {
-              "project": undefined,
-            },
+            "query": undefined,
           }
         }
       >


### PR DESCRIPTION
Preserve correct project id when navigating from release list to detail.

The query with projectId not specified was overriding the query in GlobalSelectionLink component.