### PR TITLE
fix(api): Scope auth cache to requested projects

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -148,6 +148,18 @@ class OrganizationSearchPermission(OrganizationPermission):
 class OrganizationEndpoint(Endpoint):
     permission_classes = (OrganizationPermission,)
 
+    def get_requested_project_ids(self, request):
+        """
+        Returns the project ids that were requested by the request.
+
+        To determine the projects to filter this endpoint by with full
+        permission checking, use ``get_projects``, instead.
+        """
+        try:
+            return set(map(int, request.GET.getlist("project")))
+        except ValueError:
+            raise ParseError(detail="Invalid project parameter. Values must be numbers.")
+
     def get_projects(
         self, request, organization, force_global_perms=False, include_all_accessible=False
     ):
@@ -171,10 +183,7 @@ class OrganizationEndpoint(Endpoint):
         standardize how this is used and remove this parameter.
         :return: A list of Project objects, or raises PermissionDenied.
         """
-        try:
-            project_ids = set(map(int, request.GET.getlist("project")))
-        except ValueError:
-            raise ParseError(detail="Invalid project parameter. Values must be numbers.")
+        project_ids = self._get_project_ids(request)
         return self._get_projects_by_id(
             project_ids, request, organization, force_global_perms, include_all_accessible
         )
@@ -326,7 +335,10 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         if getattr(request, "auth", None) and request.auth.id:
             actor_id = "apikey:%s" % request.auth.id
         if actor_id is not None:
-            key = "release_perms:1:%s" % hash_values([actor_id, organization.id, release.id])
+            project_ids = self.get_requested_project_ids(request)
+            key = "release_perms:1:%s" % hash_values(
+                [actor_id, organization.id, release.id, project_ids]
+            )
             has_perms = cache.get(key)
         if has_perms is None:
             has_perms = ReleaseProject.objects.filter(


### PR DESCRIPTION
Fixes a cache-bleed between projects when authenticating on the Release endpoint. For organizations without global access, this results in wrong permissions being applied when the user queries several projects in succession.
