### PR TITLE
feat(Slack): Instrument Slack to emit Datadog metrics

### DIFF
--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -124,12 +124,12 @@ class SlackEventEndpoint(Endpoint):
 
         session = http.build_session()
         req = session.post("https://slack.com/api/chat.unfurl", data=payload)
-        req.raise_for_status()
         status_code = req.status_code
-        resp = req.json()
-        if not resp.get("ok"):
-            logger.error("slack.event.unfurl-error", extra={"response": resp})
-        track_response_code(status_code, resp.get("ok"))
+        response = req.json()
+        track_response_code(status_code, response.get("ok"))
+        req.raise_for_status()
+        if not response.get("ok"):
+            logger.error("slack.event.unfurl-error", extra={"response": response})
         return self.respond()
 
     # TODO(dcramer): implement app_uninstalled and tokens_revoked

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -12,9 +12,10 @@ from sentry import http
 from sentry.api.base import Endpoint
 from sentry.incidents.models import Incident
 from sentry.models import Group, Project
+from sentry.utils import metrics
 
 from .requests import SlackEventRequest, SlackRequestError
-from .utils import build_group_attachment, build_incident_attachment, logger
+from .utils import build_group_attachment, build_incident_attachment, logger, SLACK_DATADOG_METRIC
 
 # XXX(dcramer): this could be more tightly bound to our configured domain,
 # but slack limits what we can unfurl anyways so its probably safe
@@ -125,10 +126,14 @@ class SlackEventEndpoint(Endpoint):
         session = http.build_session()
         req = session.post("https://slack.com/api/chat.unfurl", data=payload)
         req.raise_for_status()
+        status_code = req.status_code
         resp = req.json()
         if not resp.get("ok"):
             logger.error("slack.event.unfurl-error", extra={"response": resp})
-
+        metrics.incr(
+            SLACK_DATADOG_METRIC,
+            tags={"ok": False if resp.get("ok") is False else True, "status": status_code},
+        )
         return self.respond()
 
     # TODO(dcramer): implement app_uninstalled and tokens_revoked

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -13,6 +13,7 @@ from sentry.integrations import (
 )
 from sentry.pipeline import NestedPipelineView
 from sentry.utils.http import absolute_uri
+from .utils import track_response_code
 
 DESCRIPTION = """
 Connect your Sentry organization to one or more Slack workspaces, and start
@@ -112,7 +113,9 @@ class SlackIntegrationProvider(IntegrationProvider):
         session = http.build_session()
         resp = session.get("https://slack.com/api/team.info", params=payload)
         resp.raise_for_status()
+        status_code = resp.status_code
         resp = resp.json()
+        track_response_code(status_code, resp.get("ok"))
 
         return resp["team"]
 
@@ -122,7 +125,9 @@ class SlackIntegrationProvider(IntegrationProvider):
         session = http.build_session()
         resp = session.get("https://slack.com/api/auth.test", params=payload)
         resp.raise_for_status()
+        status_code = resp.status_code
         resp = resp.json()
+        track_response_code(status_code, resp.get("ok"))
 
         return resp["user_id"]
 

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -115,16 +115,15 @@ class SlackNotifyServiceAction(EventAction):
 
             session = http.build_session()
             resp = session.post("https://slack.com/api/chat.postMessage", data=payload, timeout=5)
-            resp.raise_for_status()
             status_code = resp.status_code
-            resp = resp.json()
-            track_response_code(status_code, resp.get("ok"))
-
-            if not resp.get("ok"):
+            response = resp.json()
+            track_response_code(status_code, response.get("ok"))
+            resp.raise_for_status()
+            if not response.get("ok"):
                 self.logger.info(
                     "rule.fail.slack_post",
                     extra={
-                        "error": resp.get("error"),
+                        "error": response.get("error"),
                         "project_id": event.project_id,
                         "event_id": event.event_id,
                     },

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -8,7 +8,7 @@ from sentry.rules.actions.base import EventAction
 from sentry.utils import metrics, json
 from sentry.models import Integration
 
-from .utils import build_group_attachment, get_channel_id, strip_channel_name, SLACK_DATADOG_METRIC
+from .utils import build_group_attachment, get_channel_id, strip_channel_name, track_response_code
 
 
 class SlackNotifyServiceForm(forms.Form):
@@ -118,10 +118,7 @@ class SlackNotifyServiceAction(EventAction):
             resp.raise_for_status()
             status_code = resp.status_code
             resp = resp.json()
-            metrics.incr(
-                SLACK_DATADOG_METRIC,
-                tags={"ok": False if resp.get("ok") is False else True, "status": status_code},
-            )
+            track_response_code(status_code, resp.get("ok"))
 
             if not resp.get("ok"):
                 self.logger.info(


### PR DESCRIPTION
This PR adds Datadog metrics to the Slack integration so we can know when things are going wrong. Slack is unique in that it returns a 200 ok if the result is anything but a 500, so this adds the tags `ok` and `status` where `ok: False` means something went wrong, and `ok: True` or the absence of `ok` means things went well (so in this case, I set the tag to `ok: True` if `ok` wasn't received). 