### PR TITLE
ref(discover) Update chart tooltips round 2

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -105,7 +105,9 @@ class ReleaseSeries extends React.Component {
             const version = escape(formatVersion(data.name, true));
             return [
               '<div class="tooltip-series">',
-              `<div><span class="tooltip-label"><strong>Release</strong></span> ${version}</div>`,
+              `<div><span class="tooltip-label"><strong>${t(
+                'Release'
+              )}</strong></span> ${version}</div>`,
               '</div>',
               '<div class="tooltip-date">',
               time,

--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -12,6 +12,7 @@ import SentryTypes from 'app/sentryTypes';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
+import {escape} from 'app/utils';
 import {formatVersion} from 'app/utils/formatters';
 
 // This is not an exported action/function because releases list uses AsyncComponent
@@ -98,11 +99,19 @@ class ReleaseSeries extends React.Component {
         },
         tooltip: tooltip || {
           formatter: ({data}) => {
-            return `<div>${moment
+            const time = moment
               .tz(data.value, utc ? 'UTC' : getUserTimezone())
-              .format('MMM D, YYYY LT')} <br />
-            Release: ${formatVersion(data.name, true)}<br />
-            </div>`;
+              .format('MMM D, YYYY LT');
+            const version = escape(formatVersion(data.name, true));
+            return [
+              '<div class="tooltip-series">',
+              `<div><span class="tooltip-label"><strong>Release</strong></span> ${version}</div>`,
+              '</div>',
+              '<div class="tooltip-date">',
+              time,
+              '</div>',
+              '</div>',
+            ].join('');
           },
         },
         label: {

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -800,7 +800,7 @@ export const EChartsTooltip = PropTypes.shape({
 
   // The position of the tooltip's floating layer, which would follow the position of mouse by default.
   // See https://ecomfe.github.io/echarts-doc/public/en/option.html#tooltip.position
-  position: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  position: PropTypes.oneOfType([PropTypes.string, PropTypes.array, PropTypes.func]),
 
   // The content formatter of tooltip's floating layer which supports string template and callback function.
   // See https://ecomfe.github.io/echarts-doc/public/en/option.html#tooltip.formatter

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -260,10 +260,6 @@ const TransparentLoadingMask = styled(LoadingMask)`
 // Contains styling for chart elements as we can't easily style those
 // elements directly
 const ChartContainer = styled('div')`
-  .echarts-for-react div:first-child {
-    width: 100% !important;
-  }
-
   /* Tooltip styling */
   .tooltip-series,
   .tooltip-date {
@@ -304,6 +300,10 @@ const ChartContainer = styled('div')`
     border-top-color: ${p => p.theme.gray5};
     border-width: 8px;
     margin-left: -8px;
+  }
+
+  .echarts-for-react div:first-child {
+    width: 100% !important;
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
@@ -3,99 +3,31 @@ import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
 import {SelectValue} from 'app/types';
-import Duration from 'app/components/duration';
 import YAxisSelector from 'app/views/events/yAxisSelector';
-import {getFormattedDate} from 'app/utils/dates';
 import space from 'app/styles/space';
-import Version from 'app/components/version';
 
-import {decodeColumnOrder} from './utils';
 import {ChartControls, InlineContainer, SectionHeading} from './styles';
-
-type TooltipSeries = {
-  name: string;
-  value: number;
-};
-
-export type TooltipData = {
-  values: TooltipSeries[];
-  timestamp: number;
-};
 
 type Props = {
   total: number | null;
   yAxisValue: string;
   yAxisOptions: SelectValue<string>[];
   onChange: (value: string) => void;
-  hoverState: TooltipData;
 };
 
-function formatValue(val: string | number, columnName: string, itemName: string) {
-  // Extract metadata from the columnName so we can format the
-  // value appropriately.
-  const columnData = decodeColumnOrder([{field: columnName}])[0];
-
-  if (itemName === t('Release')) {
-    return (
-      <Value>
-        <Version version={String(val)} anchor={false} withPackage />
-      </Value>
-    );
-  }
-
-  if (val === null || val === undefined) {
-    return <Value>-</Value>;
-  }
-
-  if (columnData.type === 'duration' && typeof val === 'number') {
-    return (
-      <Value>
-        <Duration seconds={val / 1000} fixedDigits={2} abbreviation />
-      </Value>
-    );
-  }
-
-  const formatted = typeof val === 'number' ? val.toLocaleString() : val;
-  return <Value>{formatted}</Value>;
-}
-
-export default function ChartFooter({
-  total,
-  yAxisValue,
-  yAxisOptions,
-  hoverState,
-  onChange,
-}: Props) {
+export default function ChartFooter({total, yAxisValue, yAxisOptions, onChange}: Props) {
   const elements: React.ReactNode[] = [];
-  if (hoverState.values.length === 0) {
-    elements.push(<SectionHeading key="total-label">{t('Total')}</SectionHeading>);
-    elements.push(
-      total === null ? (
-        <Value data-test-id="loading-placeholder" key="total-value">
-          -
-        </Value>
-      ) : (
-        <Value key="total-value">{total.toLocaleString()}</Value>
-      )
-    );
-  } else {
-    elements.push(<SectionHeading key="time-label">{t('Time')}</SectionHeading>);
-    elements.push(
-      <Value key="time-value">
-        {getFormattedDate(hoverState.timestamp, 'MMM D, LTS', {local: true})}
+
+  elements.push(<SectionHeading key="total-label">{t('Total')}</SectionHeading>);
+  elements.push(
+    total === null ? (
+      <Value data-test-id="loading-placeholder" key="total-value">
+        -
       </Value>
-    );
-    hoverState.values.forEach(item => {
-      elements.push(
-        <SectionHeading key={`${item.name}-label`}>{item.name}</SectionHeading>
-      );
-      elements.push(
-        <React.Fragment key={`${item.name}-value`}>
-          {formatValue(item.value, yAxisValue, item.name)}
-        </React.Fragment>
-      );
-    });
-  }
+    ) : (
+      <Value key="total-value">{total.toLocaleString()}</Value>
+    )
+  );
 
   return (
     <ChartControls>

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -9,13 +9,8 @@ import {Panel} from 'app/components/panels';
 import getDynamicText from 'app/utils/getDynamicText';
 import EventsChart from 'app/views/events/eventsChart';
 
-import ChartFooter, {TooltipData} from './chartFooter';
+import ChartFooter from './chartFooter';
 import EventView from './eventView';
-
-const defaultTooltip: TooltipData = {
-  values: [],
-  timestamp: 0,
-};
 
 type Props = {
   router: ReactRouter.InjectedRouter;
@@ -27,26 +22,14 @@ type Props = {
   onAxisChange: (value: string) => void;
 };
 
-type State = {
-  tooltipData: TooltipData;
-};
-
-export default class ResultsChart extends React.Component<Props, State> {
-  state = {
-    tooltipData: defaultTooltip,
-  };
-
-  handleTooltipUpdate = (state: TooltipData) => {
-    this.setState({tooltipData: state});
-  };
-
+export default class ResultsChart extends React.Component<Props> {
   render() {
     const {eventView, location, organization, router, total, onAxisChange} = this.props;
 
     const yAxisValue = eventView.getYAxis();
 
     return (
-      <StyledPanel onMouseLeave={() => this.handleTooltipUpdate(defaultTooltip)}>
+      <StyledPanel>
         {getDynamicText({
           value: (
             <EventsChart
@@ -57,13 +40,11 @@ export default class ResultsChart extends React.Component<Props, State> {
               yAxis={yAxisValue}
               project={eventView.project as number[]}
               environment={eventView.environment as string[]}
-              onTooltipUpdate={this.handleTooltipUpdate}
             />
           ),
           fixed: 'events chart',
         })}
         <ChartFooter
-          hoverState={this.state.tooltipData}
           total={total}
           yAxisValue={yAxisValue}
           yAxisOptions={eventView.getYAxisOptions()}
@@ -75,10 +56,6 @@ export default class ResultsChart extends React.Component<Props, State> {
 }
 
 export const StyledPanel = styled(Panel)`
-  .echarts-for-react div:first-child {
-    width: 100% !important;
-  }
-
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     margin: 0;
   }


### PR DESCRIPTION
The last round of tooltip updates were not well loved. These changes put the tooltip content *back* into a tooltip. They also make the tooltip better looking and snappier.

I looked at events v1, metric alerts and dashboards and none of them seemed negatively impacted. Events v1 does reflect the updated tooltips.

![Screen Shot 2020-02-14 at 4 11 49 PM](https://user-images.githubusercontent.com/24086/74568824-e5354500-4f46-11ea-9ee5-c2da8001369d.png)
![Screen Shot 2020-02-14 at 4 12 03 PM](https://user-images.githubusercontent.com/24086/74568825-e5354500-4f46-11ea-84b1-f5e84b5ba340.png)
