### PR TITLE
feat(workflow): Fix forms on new Issue Alerts

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -176,7 +176,7 @@ const SelectControl = props => {
   const mappedValue =
     props.multiple && Array.isArray(value)
       ? value.map(val => choicesOrOptions.find(option => option.value === val))
-      : choicesOrOptions.find(opt => opt.value === value);
+      : choicesOrOptions.find(opt => opt.value === value) || value;
 
   // Allow the provided `styles` prop to override default styles using the same
   // function interface provided by react-styled. This ensures the `provided`

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -359,7 +359,7 @@ function routes() {
             name="Edit Alert Rule"
             componentPromise={() =>
               import(
-                /* webpackChunkName: "ProjectAlertRuleDetails" */ 'app/views/settings/projectAlerts/ruleDetailsNew'
+                /* webpackChunkName: "ProjectAlertRuleDetails" */ 'app/views/settings/projectAlerts/issueEditor'
               )
             }
             component={errorHandler(LazyLoad)}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import {Organization, Project} from 'app/types';
 import {createDefaultRule} from 'app/views/settings/incidentRules/constants';
 import recreateRoute from 'app/utils/recreateRoute';
+import withOrganization from 'app/utils/withOrganization';
+import withProject from 'app/utils/withProject';
 
 import RuleForm from './ruleForm';
 
@@ -41,4 +43,4 @@ class IncidentRulesCreate extends React.Component<Props> {
   }
 }
 
-export default IncidentRulesCreate;
+export default withProject(withOrganization(IncidentRulesCreate));

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -262,7 +262,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
           initialData={{...rule, environment, actionMatch, frequency: `${frequency}`}}
           submitLabel={t('Save Rule')}
         >
-          {ruleId && this.state.loading && <SemiTransparentLoadingMask />}
+          {this.state.loading && <SemiTransparentLoadingMask />}
           <Panel>
             <PanelHeader>{t('Configure Rule Conditions')}</PanelHeader>
             <PanelBody>
@@ -316,7 +316,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
               {this.hasError('conditions') && (
                 <PanelAlert type="error">
-                  {this.state.detailedError!.conditions[0]}
+                  {this.state.detailedError?.conditions[0]}
                 </PanelAlert>
               )}
 
@@ -335,7 +335,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
               {this.hasError('actions') && (
                 <PanelAlert type="error">
-                  {this.state.detailedError!.actions[0]}
+                  {this.state.detailedError?.actions[0]}
                 </PanelAlert>
               )}
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -186,9 +186,11 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   handlePropertyChange = (type: ConditionOrAction) => {
     return (idx: number) => {
       return (prop: string, val: string) => {
-        const rule = {...this.state.rule} as IssueAlertRule;
-        rule[type][idx][prop] = val;
-        this.setState({rule});
+        this.setState(state => {
+          const rule = {...state.rule} as IssueAlertRule;
+          rule[type][idx][prop] = val;
+          return {rule};
+        });
       };
     };
   };

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -49,16 +49,14 @@ class RuleNode extends React.Component<Props> {
 
     return (
       <SelectControl
-        deprecatedSelectControl
-        clearable={false}
+        isClearable={false}
         placeholder={t('Select integration')}
         noResultsText={t('No integrations available')}
-        height="35"
         name={name}
         value={initialVal}
         choices={fieldConfig.choices}
         key={name}
-        onChange={val => this.props.onPropertyChange(name, val)}
+        onChange={({value}) => this.props.onPropertyChange(name, value)}
       />
     );
   };

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -68,7 +68,7 @@ class RuleNode extends React.Component<Props> {
       <InlineInput
         type="text"
         name={name}
-        value={data && data[name]}
+        value={(data && data[name]) ?? ''}
         placeholder={`${fieldConfig.placeholder}`}
         key={name}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -85,7 +85,7 @@ class RuleNode extends React.Component<Props> {
       <InlineInput
         type="number"
         name={name}
-        value={data && data[name]}
+        value={(data && data[name]) ?? ''}
         placeholder={`${fieldConfig.placeholder}`}
         key={name}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -81,6 +81,7 @@ class RuleNodeList extends React.Component<Props> {
         <StyledSelectControl
           deprecatedSelectControl
           placeholder={placeholder}
+          value=""
           onChange={obj => onAddRow(obj ? obj.value : obj)}
           options={options}
         />

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -79,9 +79,8 @@ class RuleNodeList extends React.Component<Props> {
           </RuleNodes>
         )}
         <StyledSelectControl
-          deprecatedSelectControl
           placeholder={placeholder}
-          value=""
+          value={null}
           onChange={obj => onAddRow(obj ? obj.value : obj)}
           options={options}
         />

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleDetailsNew/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleDetailsNew/index.tsx
@@ -1,11 +1,6 @@
 import {RouteComponentProps} from 'react-router/lib/Router';
 import React from 'react';
 
-import {
-  IssueAlertRuleActionTemplate,
-  IssueAlertRuleConditionTemplate,
-} from 'app/types/alerts';
-import {Organization, Project} from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
@@ -13,8 +8,7 @@ import IssueEditor from 'app/views/settings/projectAlerts/issueEditor';
 import IncidentRulesCreate from 'app/views/settings/incidentRules/create';
 import PanelItem from 'app/components/panels/panelItem';
 import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
-import withOrganization from 'app/utils/withOrganization';
-import withProject from 'app/utils/withProject';
+import routeTitleGen from 'app/utils/routeTitle';
 
 type RouteParams = {
   orgId: string;
@@ -23,17 +17,10 @@ type RouteParams = {
   ruleId: string; //TODO(ts): Make ruleId optional
 };
 
-type Props = {
-  organization: Organization;
-  project: Project;
-} & RouteComponentProps<RouteParams, {}>;
+type Props = RouteComponentProps<RouteParams, {}>;
 
 type State = {
   alertType: string | null;
-  configs: {
-    actions: IssueAlertRuleActionTemplate[];
-    conditions: IssueAlertRuleConditionTemplate[];
-  } | null;
 } & AsyncView['state'];
 
 class RuleDetails extends AsyncView<Props, State> {
@@ -47,14 +34,15 @@ class RuleDetails extends AsyncView<Props, State> {
         : pathname.includes('metric-rules')
         ? 'metric'
         : null,
-      configs: null,
     };
   }
 
-  getEndpoints(): [string, string][] {
-    const {orgId, projectId} = this.props.params;
+  getTitle() {
+    return routeTitleGen(t('New Alert'), this.props.params.projectId, false);
+  }
 
-    return [['configs', `/projects/${orgId}/${projectId}/rules/configuration/`]];
+  getEndpoints(): [string, string][] {
+    return [];
   }
 
   handleChangeAlertType = (alertType: string) => {
@@ -69,7 +57,8 @@ class RuleDetails extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {alertType, configs} = this.state;
+    const {alertType} = this.state;
+
     return (
       <React.Fragment>
         <Panel>
@@ -102,11 +91,7 @@ class RuleDetails extends AsyncView<Props, State> {
         </Panel>
 
         {alertType === 'issue' ? (
-          <IssueEditor
-            {...this.props}
-            actions={configs && configs.actions}
-            conditions={configs && configs.conditions}
-          />
+          <IssueEditor {...this.props} />
         ) : alertType === 'metric' ? (
           <IncidentRulesCreate {...this.props} />
         ) : null}
@@ -115,4 +100,4 @@ class RuleDetails extends AsyncView<Props, State> {
   }
 }
 
-export default withProject(withOrganization(RuleDetails));
+export default RuleDetails;


### PR DESCRIPTION
This fixes issues with the new react-select on the new Issue Alerts view. This also moves around API calls so that we do not show the alert type chooser when editing an Issue Alert.