### PR TITLE
feat: Legacy plugins should say legacy on detailed view.

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
@@ -7,3 +7,14 @@ export const colors = {
   [NOT_INSTALLED]: 'gray2',
   [PENDING]: 'yellowOrange',
 };
+
+export const legacyIds = [
+  'jira',
+  'bitbucket',
+  'github',
+  'gitlab',
+  'slack',
+  'pagerduty',
+  'clubhouse',
+  'vsts',
+];

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -34,6 +34,7 @@ import withOrganization from 'app/utils/withOrganization';
 import SearchInput from 'app/components/forms/searchInput';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import IntegrationRow from './integrationRow';
+import {legacyIds} from './constants';
 
 type AppOrProviderOrPlugin = SentryApp | IntegrationProvider | PluginWithProjectList;
 
@@ -321,16 +322,6 @@ class OrganizationIntegrations extends AsyncComponent<
   renderPlugin = (plugin: PluginWithProjectList) => {
     const {organization} = this.props;
 
-    const legacyIds = [
-      'jira',
-      'bitbucket',
-      'github',
-      'gitlab',
-      'slack',
-      'pagerduty',
-      'clubhouse',
-      'vsts',
-    ];
     const isLegacy = legacyIds.includes(plugin.id);
     const displayName = `${plugin.name} ${!!isLegacy ? '(Legacy)' : ''}`;
     //hide legacy integrations if we don't have any projects with them

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -51,7 +51,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
 
   get integrationName() {
     const isLegacy = legacyIds.includes(this.plugin.id);
-    const displayName = `${this.plugin.name} ${!!isLegacy ? '(Legacy)' : ''}`;
+    const displayName = `${this.plugin.name} ${isLegacy ? '(Legacy)' : ''}`;
     return displayName;
   }
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -10,6 +10,7 @@ import {openModal} from 'app/actionCreators/modal';
 import ContextPickerModal from 'app/components/contextPickerModal';
 import {t} from 'app/locale';
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
+import {legacyIds} from './constants';
 
 type State = {
   plugins: PluginWithProjectList[];
@@ -49,7 +50,9 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get integrationName() {
-    return this.plugin.name;
+    const isLegacy = legacyIds.includes(this.plugin.id);
+    const displayName = `${this.plugin.name} ${!!isLegacy ? '(Legacy)' : ''}`;
+    return displayName;
   }
 
   get featureData() {


### PR DESCRIPTION
## Objective
Plugins that have replacements like Jira, Github, PagerDuty, etc, should say Legacy in the title of the detailed view. 

## UI
<img width="1002" alt="Screen Shot 2020-02-14 at 3 19 21 PM" src="https://user-images.githubusercontent.com/10491193/74575944-d0a07f00-4f3d-11ea-9758-e7d702763e16.png">
