### PR TITLE
ref(ui): Minor improvements to context picker modal

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/navigation.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/navigation.tsx
@@ -24,7 +24,7 @@ export function navigateTo(to: string, router: InjectedRouter) {
           comingFromProjectId={comingFromProjectId}
           onFinish={path => {
             closeModal();
-            router.push(path);
+            setTimeout(() => router.push(path), 0);
           }}
         />
       ),

--- a/src/sentry/static/sentry/app/components/contextPickerModal.tsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.tsx
@@ -90,7 +90,7 @@ class ContextPickerModal extends React.Component<Props> {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     // Component may be mounted before projects is fetched, check if we can finish when
     // component is updated with projects
     if (prevProps.projects !== this.props.projects) {
@@ -296,7 +296,7 @@ const ContextPickerModalContainer = createReactClass<ContainerProps, ContainerSt
     };
   },
 
-  handleSelectOrganization(organizationSlug) {
+  handleSelectOrganization(organizationSlug: string) {
     this.setState({selectedOrganization: organizationSlug});
   },
 


### PR DESCRIPTION
- Ensure the modal closes before pushing to the router. We do this by
   pushing the router.push call to the end of the callback queue,
   ensuring closeModal happens first.

 - Some minor typescript types