### PR TITLE
ref(manage): Move manage/admin views into lightweight org context

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1003,129 +1003,6 @@ function routes() {
 
       <Redirect from="/account/" to="/settings/account/details/" />
 
-      <Route
-        path="/manage/"
-        componentPromise={() =>
-          import(/* webpackChunkName: "AdminLayout" */ 'app/views/admin/adminLayout')
-        }
-        component={errorHandler(LazyLoad)}
-      >
-        <IndexRoute
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "AdminOverview" */ 'app/views/admin/adminOverview'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="buffer/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "AdminBuffer" */ 'app/views/admin/adminBuffer')
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="relays/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "AdminRelays" */ 'app/views/admin/adminRelays')
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="organizations/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "AdminOrganizations" */ 'app/views/admin/adminOrganizations'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="projects/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "AdminProjects" */ 'app/views/admin/adminProjects'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="queue/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "AdminQueue" */ 'app/views/admin/adminQueue')
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="quotas/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "AdminQuotas" */ 'app/views/admin/adminQuotas')
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="settings/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "AdminSettings" */ 'app/views/admin/adminSettings'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route path="users/">
-          <IndexRoute
-            componentPromise={() =>
-              import(/* webpackChunkName: "AdminUsers" */ 'app/views/admin/adminUsers')
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path=":id"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "AdminUserEdit" */ 'app/views/admin/adminUserEdit'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-        </Route>
-        <Route
-          path="status/mail/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "AdminMail" */ 'app/views/admin/adminMail')
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="status/environment/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "AdminEnvironment" */ 'app/views/admin/adminEnvironment'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="status/packages/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "AdminPackages" */ 'app/views/admin/adminPackages'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="status/warnings/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "AdminWarnings" */ 'app/views/admin/adminWarnings'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        {hook('routes:admin')}
-      </Route>
       <Redirect from="/share/group/:shareId/" to="/share/issue/:shareId/" />
       <Route
         path="/share/issue/:shareId/"
@@ -1368,6 +1245,130 @@ function routes() {
             }
             component={errorHandler(LazyLoad)}
           />
+        </Route>
+
+        <Route
+          path="/manage/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "AdminLayout" */ 'app/views/admin/adminLayout')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "AdminOverview" */ 'app/views/admin/adminOverview'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="buffer/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "AdminBuffer" */ 'app/views/admin/adminBuffer')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="relays/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "AdminRelays" */ 'app/views/admin/adminRelays')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="organizations/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "AdminOrganizations" */ 'app/views/admin/adminOrganizations'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="projects/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "AdminProjects" */ 'app/views/admin/adminProjects'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="queue/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "AdminQueue" */ 'app/views/admin/adminQueue')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="quotas/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "AdminQuotas" */ 'app/views/admin/adminQuotas')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="settings/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "AdminSettings" */ 'app/views/admin/adminSettings'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route path="users/">
+            <IndexRoute
+              componentPromise={() =>
+                import(/* webpackChunkName: "AdminUsers" */ 'app/views/admin/adminUsers')
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path=":id"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminUserEdit" */ 'app/views/admin/adminUserEdit'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
+          <Route
+            path="status/mail/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "AdminMail" */ 'app/views/admin/adminMail')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="status/environment/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "AdminEnvironment" */ 'app/views/admin/adminEnvironment'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="status/packages/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "AdminPackages" */ 'app/views/admin/adminPackages'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="status/warnings/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "AdminWarnings" */ 'app/views/admin/adminWarnings'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          {hook('routes:admin')}
         </Route>
       </Route>
       {/* The heavyweight organization detail views */}

--- a/src/sentry/static/sentry/app/views/admin/adminLayout.jsx
+++ b/src/sentry/static/sentry/app/views/admin/adminLayout.jsx
@@ -1,28 +1,11 @@
 import DocumentTitle from 'react-document-title';
 import React from 'react';
 
-import Footer from 'app/components/footer';
-import HookStore from 'app/stores/hookStore';
+import Hook from 'app/components/hook';
 import ListLink from 'app/components/links/listLink';
 import Sidebar from 'app/components/sidebar';
-import withLatestContext from 'app/utils/withLatestContext';
-
-const SidebarWithLatest = withLatestContext(Sidebar);
 
 export default class AdminLayout extends React.Component {
-  constructor(props) {
-    super(props);
-    // Allow injection via getsentry et all
-    const hooksManage = [];
-    HookStore.get('admin:sidebar:manage').forEach(cb => {
-      hooksManage.push(cb());
-    });
-
-    this.state = {
-      hooksManage,
-    };
-  }
-
   getTitle = () => {
     return 'Sentry Admin';
   };
@@ -31,7 +14,7 @@ export default class AdminLayout extends React.Component {
     return (
       <DocumentTitle title={this.getTitle()}>
         <div className="app" css={{paddingTop: 20}}>
-          <SidebarWithLatest />
+          <Sidebar />
           <div className="container">
             <div className="content">
               <div className="row">
@@ -72,14 +55,13 @@ export default class AdminLayout extends React.Component {
                     <ListLink to="/manage/organizations/">Organizations</ListLink>
                     <ListLink to="/manage/projects/">Projects</ListLink>
                     <ListLink to="/manage/users/">Users</ListLink>
-                    {this.state.hooksManage}
+                    <Hook name="admin:sidebar:manage" />
                   </ul>
                 </div>
                 <div className="col-md-10">{this.props.children}</div>
               </div>
             </div>
           </div>
-          <Footer />
         </div>
       </DocumentTitle>
     );


### PR DESCRIPTION
Move admin views into `<OrganizationDetails>` so that it has access to an organization. Remove use of `withLatestContext`.

Also refactor to use `<Hook>`.