### PR TITLE
logging(pickle): Add warning and stack trace around unpickling old models

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import click
+import logging
 import os
 import six
 
@@ -9,6 +10,8 @@ from django.conf import settings
 from sentry.utils import metrics, warnings
 from sentry.utils.sdk import configure_sdk
 from sentry.utils.warnings import DeprecatedSettingWarning
+
+logger = logging.getLogger("sentry.runner.initializer")
 
 
 def register_plugins(settings, raise_on_plugin_load_failure=False):
@@ -404,6 +407,10 @@ def __model_unpickle_compat(model_id, attrs=None, factory=None):
 
     if attrs is not None or factory is not None:
         metrics.incr("django.pickle.loaded_19_pickle.__model_unpickle_compat", sample_rate=1)
+        logger.warning(
+            "django.compat.model-unpickle-compat",
+            extra={"model_id": model_id, "attrs": attrs, "factory": factory, "stack": True},
+        )
 
     if VERSION[:2] in [(1, 10), (1, 11)]:
         return model_unpickle(model_id)


### PR DESCRIPTION
Looks like this is still happening. I want to understand where we're getting these pickles, since
it'll be important to understand where old pickles are stored in our systems. This is happening at a
pretty low rate, so just adding as a warning with stack trace.