### PR TITLE
fix(subscriptions): More things to fix apm on the `QuerySubscriptionConsumer`

### DIFF
--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -93,7 +93,14 @@ class QuerySubscriptionConsumer(object):
 
                 i = i + 1
 
-                self.handle_message(message)
+                with sentry_sdk.start_span(
+                    Span(
+                        op="handle_message",
+                        transaction="query_subscription_consumer_process_message",
+                        sampled=True,
+                    )
+                ):
+                    self.handle_message(message)
 
                 # Track latest completed message here, for use in `shutdown` handler.
                 self.offsets[message.partition()] = message.offset() + 1
@@ -186,13 +193,7 @@ class QuerySubscriptionConsumer(object):
             )
 
             callback = subscriber_registry[subscription.type]
-            with sentry_sdk.start_span(
-                Span(
-                    op="process_message",
-                    transaction="query_subscription_consumer_process_message",
-                    sampled=True,
-                )
-            ) as span, metrics.timer(
+            with sentry_sdk.start_span(op="process_message") as span, metrics.timer(
                 "snuba_query_subscriber.callback.duration", instance=subscription.type
             ):
                 span.set_data("payload", contents)


### PR DESCRIPTION
We can't set data on a transaction. A span with transaction info becomes a transation, so moving
things around.
