### PR TITLE
fix: Do not error on existing bad releases

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -252,6 +252,8 @@ class ReleaseSerializer(Serializer):
 
     def serialize(self, obj, attrs, user, **kwargs):
         def expose_version_info(info):
+            if info is None:
+                return None
             version = {"raw": info["version_raw"]}
             if info["version_parsed"]:
                 version.update(

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -21,7 +21,7 @@ from sentry.db.models import (
     sane_repr,
 )
 
-from sentry_relay import parse_release
+from sentry_relay import parse_release, RelayError
 from sentry.constants import BAD_RELEASE_CHARS, COMMIT_RANGE_DELIMITER
 from sentry.models import CommitFileChange
 from sentry.signals import issue_resolved
@@ -196,7 +196,11 @@ class Release(Model):
 
     @cached_property
     def version_info(self):
-        return parse_release(self.version)
+        try:
+            parse_release(self.version)
+        except RelayError:
+            # This can happen on invalid legacy releases
+            return None
 
     @classmethod
     def merge(cls, to_release, from_releases):


### PR DESCRIPTION
Since there are currently bad releases in the database (which will not work on release info but will let you view events) this changes the API to not error in such cases.