### PR TITLE
fix: Do not error on null frames in JS processor

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -493,7 +493,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             frames.extend(
                 [
                     f
-                    for f in info.stacktrace["frames"]
+                    for f in info.stacktrace["frames"] or ()
                     if f is not None and f.get("lineno") is not None
                 ]
             )


### PR DESCRIPTION
Fixes SENTRY-DRB