### PR TITLE
chore(discover) Update field list with python code.

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -826,6 +826,9 @@ def get_filter(query=None, params=None):
     return eventstore.Filter(**kwargs)
 
 
+# When adding aliases to this list please also update
+# static/app/views/eventsV2/eventQueryParams.tsx so that
+# the UI builder stays in sync.
 FIELD_ALIASES = {
     "last_seen": {"aggregations": [["max", "timestamp", "last_seen"]]},
     "latest_event": {"aggregations": [["argMax", ["id", "timestamp"], "latest_event"]]},
@@ -860,6 +863,9 @@ FIELD_ALIASES = {
     },
 }
 
+# When adding functions to this list please also update
+# static/app/views/eventsV2/eventQueryParams.tsx so that
+# the UI builder stays in sync.
 VALID_AGGREGATES = {
     "count_unique": {"snuba_name": "uniq", "fields": "*"},
     "count": {"snuba_name": "count", "fields": "*"},
@@ -901,6 +907,9 @@ FUNCTION_PATTERN = re.compile(r"^(?P<function>[^\(]+)\((?P<columns>[^\)]*)\)$")
 NUMERIC_COLUMN = "numeric_column"
 NUMBER = "number"
 
+# When adding functions to this list please also update
+# static/app/views/eventsV2/eventQueryParams.tsx so that
+# the UI builder stays in sync.
 FUNCTIONS = {
     "percentile": {
         "name": "percentile",

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -10,7 +10,7 @@ export type ColumnValueType =
   | 'boolean'
   | 'never'; // Matches to nothing
 
-// Refer to src/sentry/api/event_searc.py
+// Refer to src/sentry/api/event_search.py
 export const AGGREGATIONS = {
   count: {
     type: '*',

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -10,7 +10,7 @@ export type ColumnValueType =
   | 'boolean'
   | 'never'; // Matches to nothing
 
-// Refer to src/sentry/utils/snuba.py
+// Refer to src/sentry/api/event_searc.py
 export const AGGREGATIONS = {
   count: {
     type: '*',
@@ -46,12 +46,6 @@ export const AGGREGATIONS = {
     type: ['duration'],
     isSortable: true,
   },
-  /*
-  cidr: {
-    type: 'string',
-    isSortable: true,
-  },
-  */
 } as const;
 
 assert(
@@ -67,70 +61,56 @@ assert(
 
 export type Aggregation = keyof typeof AGGREGATIONS | '';
 
-// TODO(leedongwei)
-// Add line-breaks to these fields that'll show on TableModalEditColumn. It's
-// hella dense at the moment.
 /**
- * Refer to src/sentry/utils/snuba.py, search for SENTRY_SNUBA_MAP
+ * Refer to src/sentry/snuba/events.py, search for Columns
  */
 export const FIELDS = {
   id: 'string',
-
-  title: 'string',
-  project: 'string',
-  environment: 'string',
-  release: 'string',
-  issue: 'string',
-  dist: 'string',
-
-  message: 'string',
-  location: 'string',
-  culprit: 'string',
+  // issue.id and project.id are omitted on purpose.
+  // Customers should use `issue` and `project` instead.
   timestamp: 'timestamp',
   time: 'timestamp',
-  transaction: 'string',
 
-  'event.type': 'string',
+  culprit: 'string',
+  location: 'string',
+  message: 'string',
   'platform.name': 'string',
-  last_seen: 'never',
-  latest_event: 'never',
+  environment: 'string',
+  release: 'string',
+  dist: 'string',
+  title: 'string',
+  'event.type': 'string',
+  // tags.key and tags.value are omitted on purpose as well.
 
+  transaction: 'string',
   user: 'string',
   'user.id': 'string',
   'user.email': 'string',
   'user.username': 'string',
   'user.ip': 'string',
-  sdk: 'string',
   'sdk.name': 'string',
   'sdk.version': 'string',
-  http: 'string',
   'http.method': 'string',
   'http.url': 'string',
-  os: 'string',
   'os.build': 'string',
   'os.kernel_version': 'string',
-  device: 'string',
   'device.name': 'string',
   'device.brand': 'string',
   'device.locale': 'string',
   'device.uuid': 'string',
-  'device.model_id': 'string',
   'device.arch': 'string',
   'device.battery_level': 'number',
   'device.orientation': 'string',
   'device.simulator': 'boolean',
   'device.online': 'boolean',
   'device.charging': 'boolean',
-  geo: 'string',
   'geo.country_code': 'string',
   'geo.region': 'string',
   'geo.city': 'string',
-  error: 'string',
   'error.type': 'string',
   'error.value': 'string',
   'error.mechanism': 'string',
   'error.handled': 'boolean',
-  stack: 'string',
   'stack.abs_path': 'string',
   'stack.filename': 'string',
   'stack.package': 'string',
@@ -140,19 +120,33 @@ export const FIELDS = {
   'stack.colno': 'number',
   'stack.lineno': 'number',
   'stack.stack_level': 'number',
+  // contexts.key and contexts.value omitted on purpose.
 
+  // Transaction event fields.
   'transaction.duration': 'duration',
   'transaction.op': 'string',
   'transaction.status': 'string',
+
+  trace: 'string',
+  'trace.span': 'string',
+  'trace.parent_span': 'string',
+
+  // Field alises defined in src/sentry/api/event_search.py
+  project: 'string',
+  issue: 'string',
+
+  // duration aliases and fake functions.
+  // Once we've expanded the functions support these
+  // need to be revisited
+  p75: 'duration',
+  p95: 'duration',
+  p99: 'duration',
+
   // TODO when these become real functions, we need to revisit how
   // their types are inferred in decodeColumnOrder()
   apdex: 'number',
   impact: 'number',
   error_rate: 'number',
-  // duration aliases
-  p75: 'duration',
-  p95: 'duration',
-  p99: 'duration',
 } as const;
 assert(FIELDS as Readonly<{[key in keyof typeof FIELDS]: ColumnValueType}>);
 


### PR DESCRIPTION
Update the field lists used in the discover UI to match the public schema defined in python. A few fields have been omitted as they are deprecated or have better replacements via field aliases.