### PR TITLE
fix(storybook): Fix bad `versionV2` import

### DIFF
--- a/docs-ui/components/formatters.stories.js
+++ b/docs-ui/components/formatters.stories.js
@@ -8,7 +8,7 @@ import FileSize from 'app/components/fileSize';
 import Duration from 'app/components/duration';
 import DateTime from 'app/components/dateTime';
 import Count from 'app/components/count';
-import Version from 'app/components/versionV2';
+import Version from 'app/components/version';
 
 storiesOf('Utility|Formatters', module)
   .add(

--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -6,10 +6,7 @@ import styled from '@emotion/styled';
 import {APIRequestMethod} from 'app/api';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
-import FormModel, {
-  FormOptions,
-  FieldValue,
-} from 'app/views/settings/components/forms/model';
+import FormModel, {FormOptions} from 'app/views/settings/components/forms/model';
 import Panel from 'app/components/panels/panel';
 import space from 'app/styles/space';
 import {isRenderFunc} from 'app/utils/isRenderFunc';
@@ -296,5 +293,3 @@ const DefaultButtons = styled('div')`
   justify-content: flex-end;
   flex: 1;
 `;
-
-export {FieldValue};


### PR DESCRIPTION
Also fixes a warning with `forms/form` about exporting FieldValue, nothing imports `FieldValue` from form, so remove the export