### PR TITLE
build(travis): Remove `storybook-deploy` from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -204,7 +204,7 @@ matrix:
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
-    # Deploy 'storybook' (component & style guide) - allowed to fail
+    # Deploy 'storybook' (component & style guide)
     - name: 'Storybook Deploy'
       language: node_js
       env: STORYBOOK_BUILD=1
@@ -225,9 +225,6 @@ matrix:
       script: bash .travis/deploy-storybook.sh
       after_success: skip
       after_failure: skip
-
-  allow_failures:
-    - name: 'Storybook Deploy'
 
 notifications:
   webhooks:


### PR DESCRIPTION
CI should fail when we have issues in our storybook stories.