### PR TITLE
feat(tracing) Add rpm() and rps() function support to event stats

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -23,6 +23,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
 
         try:
             column = request.GET.get("yAxis", "count()")
+            rollup = self.get_rollup(request)
             # Backwards compatibility for incidents which uses the old
             # column aliases as it straddles both versions of events/discover.
             # We will need these aliases until discover2 flags are enabled for all
@@ -31,13 +32,17 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                 column = "count_unique(user)"
             elif column == "event_count":
                 column = "count()"
+            elif column == "rpm()":
+                column = "rpm(%d)" % rollup
+            elif column == "rps()":
+                column = "rps(%d)" % rollup
 
             params = self.get_filter_params(request, organization)
             result = discover.timeseries_query(
                 selected_columns=[column],
                 query=request.GET.get("query"),
                 params=params,
-                rollup=self.get_rollup(request),
+                rollup=rollup,
                 reference_event=self.reference_event(
                     request, organization, params.get("start"), params.get("end")
                 ),

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -913,7 +913,21 @@ FUNCTIONS = {
             },
         ],
         "transform": "quantile(%(percentile).2f)(%(column)s)",
-    }
+    },
+    "rps": {
+        "name": "rps",
+        "args": [
+            {"name": "interval", "type": NUMBER, "validator": lambda v: (v > 0, "must be positive integer")},
+        ],
+        "transform": "divide(count(), %(interval)d)",
+    },
+    "rpm": {
+        "name": "rpm",
+        "args": [
+            {"name": "interval", "type": NUMBER, "validator": lambda v: (v > 0, "must be positive integer")},
+        ],
+        "transform": "divide(count(), divide(%(interval)d, 60))",
+    },
 }
 
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -924,7 +924,7 @@ FUNCTIONS = {
     "rpm": {
         "name": "rpm",
         "args": [
-            {"name": "interval", "type": NUMBER, "validator": lambda v: (v >= 60, "can't be less than 60 seconds")},
+            {"name": "interval", "type": NUMBER, "validator": lambda v: (v >= 60, "must be greater than 60 seconds")},
         ],
         "transform": "divide(count(), divide(%(interval)d, 60))",
     },

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -924,7 +924,7 @@ FUNCTIONS = {
     "rpm": {
         "name": "rpm",
         "args": [
-            {"name": "interval", "type": NUMBER, "validator": lambda v: (v > 0, "must be positive integer")},
+            {"name": "interval", "type": NUMBER, "validator": lambda v: (v >= 60, "can't be less than 60 seconds")},
         ],
         "transform": "divide(count(), divide(%(interval)d, 60))",
     },

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1332,7 +1332,7 @@ class ResolveFieldListTest(unittest.TestCase):
         with pytest.raises(InvalidSearchQuery) as err:
             fields = ["rpm(30)"]
             result = resolve_field_list(fields, {})
-        assert "rpm(30): 30.0 argument invalid: can't be less than 60 seconds" in six.text_type(err)
+        assert "rpm(30): 30.0 argument invalid: must be greater than 60 seconds" in six.text_type(err)
 
     def test_rps_function(self):
         fields = ["rps(3600)"]

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1317,6 +1317,40 @@ class ResolveFieldListTest(unittest.TestCase):
             in six.text_type(err)
         )
 
+    def test_rpm_function(self):
+        fields = ["rpm(3600)"]
+        result = resolve_field_list(fields, {})
+
+        assert result["selected_columns"] == []
+        assert result["aggregations"] == [
+            ["divide(count(), divide(3600, 60))", None, "rpm_3600"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
+            ["argMax", ["project.id", "timestamp"], "projectid"],
+        ]
+        assert result["groupby"] == []
+
+        with pytest.raises(InvalidSearchQuery) as err:
+            fields = ["rpm(30)"]
+            result = resolve_field_list(fields, {})
+        assert "rpm(30): 30.0 argument invalid: can't be less than 60 seconds" in six.text_type(err)
+
+    def test_rps_function(self):
+        fields = ["rps(3600)"]
+        result = resolve_field_list(fields, {})
+
+        assert result["selected_columns"] == []
+        assert result["aggregations"] == [
+            ["divide(count(), 3600)", None, "rps_3600"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
+            ["argMax", ["project.id", "timestamp"], "projectid"],
+        ]
+        assert result["groupby"] == []
+
+        with pytest.raises(InvalidSearchQuery) as err:
+            fields = ["rps(0)"]
+            result = resolve_field_list(fields, {})
+        assert "rps(0): 0.0 argument invalid: must be positive integer" in six.text_type(err)
+
     def test_rollup_with_unaggregated_fields(self):
         with pytest.raises(InvalidSearchQuery) as err:
             fields = ["message"]


### PR DESCRIPTION
Add the ability to send rpm() and rps() functions to the event stats endpoint,
and use the rollup parameter to correctly average counts.