### PR TITLE
fix(workflow): Change "View in Discover" link to include `interval`

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -59,7 +59,7 @@ export default class DetailsBody extends React.Component<Props> {
         .map(({id}) => Number(id)),
       version: 2 as const,
       start: incident.dateStarted,
-      end: getUtcDateString(new Date()),
+      end: incident.dateClosed ?? getUtcDateString(new Date()),
     };
 
     const discoverView = EventView.fromSavedQuery(discoverQuery);

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -11,6 +11,7 @@ import {NewQuery, Project} from 'app/types';
 import {PageContent} from 'app/styles/organization';
 import {defined} from 'app/utils';
 import {getDisplayForAlertRuleAggregation} from 'app/views/alerts/utils';
+import {getUtcDateString} from 'app/utils/dates';
 import {t} from 'app/locale';
 import Duration from 'app/components/duration';
 import EventView from 'app/views/eventsV2/eventView';
@@ -57,11 +58,17 @@ export default class DetailsBody extends React.Component<Props> {
         .filter(({slug}) => incident.projects.includes(slug))
         .map(({id}) => Number(id)),
       version: 2 as const,
-      range: `${incident.alertRule.timeWindow}m`,
+      start: incident.dateStarted,
+      end: getUtcDateString(new Date()),
     };
 
     const discoverView = EventView.fromSavedQuery(discoverQuery);
-    return discoverView.getResultsViewUrlTarget(orgId);
+    const {query, ...toObject} = discoverView.getResultsViewUrlTarget(orgId);
+
+    return {
+      query: {...query, interval: `${incident.alertRule.timeWindow}m`},
+      ...toObject,
+    };
   }
 
   /**

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -47,13 +47,16 @@ export default class DetailsBody extends React.Component<Props> {
 
     const timeWindowString = `${incident.alertRule.timeWindow}m`;
     const timeWindowInMs = intervalToMilliseconds(timeWindowString);
-    const started = moment(incident.dateStarted);
+    const startBeforeTimeWindow = moment(incident.dateStarted).subtract(
+      timeWindowInMs,
+      'ms'
+    );
     const end = incident.dateClosed ?? getUtcDateString(new Date());
 
     // We want the discover chart to start at "dateStarted" - "timeWindow" - "20%"
-    const start = started
-      .subtract(timeWindowInMs, 'ms')
-      .subtract(moment(end).diff(started, 'ms') * 0.2, 'ms');
+    const additionalWindowBeforeStart =
+      moment(end).diff(startBeforeTimeWindow, 'ms') * 0.2;
+    const start = startBeforeTimeWindow.subtract(additionalWindowBeforeStart, 'ms');
 
     const discoverQuery: NewQuery = {
       id: undefined,
@@ -69,7 +72,7 @@ export default class DetailsBody extends React.Component<Props> {
         .filter(({slug}) => incident.projects.includes(slug))
         .map(({id}) => Number(id)),
       version: 2 as const,
-      start,
+      start: getUtcDateString(start),
       end,
     };
 


### PR DESCRIPTION
Previously it was using the `timeWindow` alert rule setting as the query
period, which is wrong. Update to set `interval` for the events-stats
request to use `timeWindow`, and set the start/end dates to incident start
-> end (or now)

Requires https://github.com/getsentry/sentry/pull/17119