### PR TITLE
feat(charts): Allow `<EventsChart>` to accept `interval` query param

### DIFF
--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -145,7 +145,7 @@ class EventsChart extends React.Component {
             environment={environments}
             start={start}
             end={end}
-            interval={getInterval(this.props, true)}
+            interval={router?.location?.query?.interval || getInterval(this.props, true)}
             showLoading={false}
             query={query}
             includePrevious={includePrevious}


### PR DESCRIPTION
This allows `<EventsChart>` to use an `interval` defined in the url query string.