### PR TITLE
ref(py3): compat fixes for external utils

### DIFF
--- a/src/sentry/utils/distutils/commands/build_js_sdk_registry.py
+++ b/src/sentry/utils/distutils/commands/build_js_sdk_registry.py
@@ -17,17 +17,8 @@ LOADER_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__), "
 # We cannot leverage six here, so we need to vendor
 # bits that we need.
 if sys.version_info[0] == 3:
-
-    def iteritems(d, **kw):
-        return iter(d.items(**kw))
-
     from urllib.request import urlopen
-
 else:
-
-    def iteritems(d, **kw):
-        return d.iteritems(**kw)  # NOQA
-
     from urllib2 import urlopen
 
 

--- a/src/sentry/utils/distutils/commands/build_js_sdk_registry.py
+++ b/src/sentry/utils/distutils/commands/build_js_sdk_registry.py
@@ -2,6 +2,7 @@
 # process.  Thus we do not want to import non stdlib things here.
 from __future__ import absolute_import
 
+import io
 import os
 import sys
 import json
@@ -17,6 +18,7 @@ LOADER_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__), "
 # We cannot leverage six here, so we need to vendor
 # bits that we need.
 if sys.version_info[0] == 3:
+    unicode = str  # NOQA
     from urllib.request import urlopen
 else:
     from urllib2 import urlopen
@@ -29,9 +31,10 @@ def dump_registry(path, data):
         os.makedirs(directory)
     except OSError:
         pass
-    with open(fn, "wb") as f:
-        json.dump(data, f, indent=2)
-        f.write("\n")
+    with io.open(fn, "wt", encoding="utf-8") as f:
+        # XXX: ideally, we use six.text_type here, but we can't use six.
+        f.write(unicode(json.dumps(data, indent=2)))  # NOQA
+        f.write(u"\n")
 
 
 def sync_registry():

--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -21,7 +21,7 @@ DOC_FOLDER = os.environ.get("INTEGRATION_DOC_FOLDER") or os.path.abspath(
 # We cannot leverage six here, so we need to vendor
 # bits that we need.
 if sys.version_info[0] == 3:
-    unicode = str
+    unicode = str  # NOQA
 
     def iteritems(d, **kw):
         return iter(d.items(**kw))
@@ -63,7 +63,7 @@ def dump_doc(path, data):
     except OSError:
         pass
     with io.open(fn, "wt", encoding="utf-8") as f:
-        f.write(unicode(json.dumps(data, indent=2)))
+        f.write(unicode(json.dumps(data, indent=2)))  # NOQA
         f.write(u"\n")
 
 

--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -63,6 +63,7 @@ def dump_doc(path, data):
     except OSError:
         pass
     with io.open(fn, "wt", encoding="utf-8") as f:
+        # XXX: ideally, we use six.text_type here, but we can't use six.
         f.write(unicode(json.dumps(data, indent=2)))  # NOQA
         f.write(u"\n")
 

--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -21,6 +21,7 @@ DOC_FOLDER = os.environ.get("INTEGRATION_DOC_FOLDER") or os.path.abspath(
 # We cannot leverage six here, so we need to vendor
 # bits that we need.
 if sys.version_info[0] == 3:
+    unicode = str
 
     def iteritems(d, **kw):
         return iter(d.items(**kw))
@@ -62,8 +63,8 @@ def dump_doc(path, data):
     except OSError:
         pass
     with io.open(fn, "wt", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
-        f.write("\n")
+        f.write(unicode(json.dumps(data, indent=2)))
+        f.write(u"\n")
 
 
 def load_doc(path):

--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -2,6 +2,7 @@
 # process.  Thus we do not want to import non stdlib things here.
 from __future__ import absolute_import
 
+import io
 import os
 import sys
 import json
@@ -60,7 +61,7 @@ def dump_doc(path, data):
         os.makedirs(directory)
     except OSError:
         pass
-    with open(fn, "wb") as f:
+    with io.open(fn, "wt", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
         f.write("\n")
 
@@ -70,7 +71,7 @@ def load_doc(path):
         return None
     fn = os.path.join(DOC_FOLDER, path + ".json")
     try:
-        with open(fn, "rb") as f:
+        with io.open(fn, "rt", encoding="utf-8") as f:
             return json.load(f)
     except IOError:
         return None


### PR DESCRIPTION
Apparently, `six` can't be used in these two files. But here's py3 compatibility fixes without six. Decoupled from (to make that pr less big) and tested working in https://github.com/getsentry/sentry/pull/17124.