### PR TITLE
ref(ui): added new datascrubbers settings tab

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -378,7 +378,7 @@ export default class AsyncComponent<
    *   ['stateKeyName', '/endpoint/', {optional: 'query params'}, {options}]
    * ]
    */
-  getEndpoints(): [string, string, any?, any?][] {
+  getEndpoints(): Array<[string, string, any?, any?]> {
     const endpoint = this.getEndpoint();
     if (!endpoint) {
       return [];

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1,6 +1,7 @@
 import {Redirect, Route, IndexRoute, IndexRedirect} from 'react-router';
 import React from 'react';
 
+import {t} from 'app/locale';
 import {EXPERIMENTAL_SPA} from 'app/constants';
 import App from 'app/views/app';
 import AuthLayout from 'app/views/auth/layout';
@@ -391,6 +392,18 @@ function routes() {
         }
         component={errorHandler(LazyLoad)}
       />
+
+      <Route
+        name={t('Data Privacy')}
+        path="data-privacy/"
+        component={errorHandler(LazyLoad)}
+        componentPromise={() =>
+          import(
+            /* webpackChunkName: "ProjectDataPrivacy" */ 'app/views/settings/projectDataPrivacy/projectDataPrivacy'
+          )
+        }
+      />
+
       <Route
         path="debug-symbols/"
         name="Debug Information Files"

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formPanel.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
 import {sanitizeQuerySelector} from 'app/utils/sanitizeQuerySelector';
-import {Scope} from 'app/types';
+import {Scope, StringMap} from 'app/types';
 
 import {FieldObject, JsonFormObject} from './type';
 
@@ -20,7 +20,7 @@ type Props = {
 
   // TODO(ts): See if this is still in use
   access?: Scope[];
-  features?: string[];
+  features?: StringMap<any>;
 
   additionalFieldProps: {[key: string]: any};
 

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
@@ -47,6 +47,13 @@ export default function getConfiguration({project}: ConfigParams): NavigationSec
           description: t('Manage issue ownership rules for a project'),
         },
         {
+          path: `${pathPrefix}/data-privacy/`,
+          title: t('Data Privacy'),
+          description: t('Configure Datascrubbers for a project'),
+          show: ({features}) => features!.has('datascrubbers-v2'),
+          badge: () => 'new',
+        },
+        {
           path: `${pathPrefix}/data-forwarding/`,
           title: t('Data Forwarding'),
         },

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacy.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacy.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import Feature from 'app/components/acl/feature';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
+import {PanelAlert} from 'app/components/panels';
+import {t} from 'app/locale';
+
+import ProjectDataPrivacyContent from './projectDataPrivacyContent';
+
+const ProjectDataPrivacy = ({
+  params,
+  organization,
+}: ProjectDataPrivacyContent['props']) => (
+  <Feature
+    features={['datascrubbers-v2']}
+    organization={organization}
+    renderDisabled={() => (
+      <FeatureDisabled
+        alert={PanelAlert}
+        features={organization.features}
+        featureName={t('Data Privacy - new')}
+      />
+    )}
+  >
+    <ProjectDataPrivacyContent params={params} organization={organization} />
+  </Feature>
+);
+
+export default ProjectDataPrivacy;

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {t} from 'app/locale';
+import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+import JsonForm from 'app/views/settings/components/forms/jsonForm';
+import Form from 'app/views/settings/components/forms/form';
+import {fields} from 'app/data/forms/projectGeneralSettings';
+import AsyncView from 'app/views/asyncView';
+import ProjectActions from 'app/actions/projectActions';
+import {Organization} from 'app/types';
+
+type Props = {
+  organization: Organization;
+  params: {
+    orgId: string;
+    projectId: string;
+  };
+};
+
+class ProjectDataPrivacyContent extends AsyncView<Props> {
+  static contextTypes = {
+    // left the router contextType to satisfy the compiler
+    router: PropTypes.object,
+  };
+
+  getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
+    const {orgId, projectId} = this.props.params;
+    return [['data', `/projects/${orgId}/${projectId}/`]];
+  }
+
+  renderBody() {
+    const {organization} = this.context;
+    const project = this.state.data;
+    const {orgId, projectId} = this.props.params;
+    const endpoint = `/projects/${orgId}/${projectId}/`;
+    const access = new Set(organization.access);
+    const features = new Set(organization.features);
+
+    return (
+      <React.Fragment>
+        <SettingsPageHeader title={t('Data Privacy')} />
+        <Form
+          saveOnBlur
+          allowUndo
+          initialData={project}
+          apiMethod="PUT"
+          apiEndpoint={endpoint}
+          onSubmitSuccess={resp => {
+            // This will update our project context
+            ProjectActions.updateSuccess(resp);
+          }}
+        >
+          <JsonForm
+            title={t('Data Privacy')}
+            additionalFieldProps={{
+              organization,
+            }}
+            features={features}
+            disabled={!access.has('project:write')}
+            fields={[
+              fields.dataScrubber,
+              fields.dataScrubberDefaults,
+              fields.scrubIPAddresses,
+              fields.sensitiveFields,
+              fields.safeFields,
+              fields.storeCrashReports,
+              fields.relayPiiConfig,
+            ]}
+          />
+        </Form>
+      </React.Fragment>
+    );
+  }
+}
+
+export default ProjectDataPrivacyContent;

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -31,6 +31,9 @@ import handleXhrErrorResponse from 'app/utils/handleXhrErrorResponse';
 import marked from 'app/utils/marked';
 import recreateRoute from 'app/utils/recreateRoute';
 import routeTitleGen from 'app/utils/routeTitle';
+import Link from 'app/components/links/link';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import Feature from 'app/components/acl/feature';
 
 class ProjectGeneralSettings extends AsyncView {
   static propTypes = {
@@ -471,19 +474,37 @@ class ProjectGeneralSettings extends AsyncView {
             />
           )}
 
-          <JsonForm
-            {...jsonFormProps}
-            title={t('Data Privacy')}
-            fields={[
-              fields.dataScrubber,
-              fields.dataScrubberDefaults,
-              fields.scrubIPAddresses,
-              fields.sensitiveFields,
-              fields.safeFields,
-              fields.storeCrashReports,
-              fields.relayPiiConfig,
-            ]}
-          />
+          <Feature features={['datascrubbers-v2']}>
+            {({hasFeature}) =>
+              hasFeature ? (
+                <Panel>
+                  <PanelHeader>{t('Data Privacy')}</PanelHeader>
+                  <EmptyMessage
+                    title={t('Data Privacy section now has its own tab')}
+                    description={
+                      <Link to={`/settings/${orgId}/projects/${projectId}/data-privacy/`}>
+                        {t('Go to Data Privacy')}
+                      </Link>
+                    }
+                  />
+                </Panel>
+              ) : (
+                <JsonForm
+                  {...jsonFormProps}
+                  title={t('Data Privacy')}
+                  fields={[
+                    fields.dataScrubber,
+                    fields.dataScrubberDefaults,
+                    fields.scrubIPAddresses,
+                    fields.sensitiveFields,
+                    fields.safeFields,
+                    fields.storeCrashReports,
+                    fields.relayPiiConfig,
+                  ]}
+                />
+              )
+            }
+          </Feature>
 
           <JsonForm
             {...jsonFormProps}


### PR DESCRIPTION
**Type:** Refactor

**Description:** 

Moved data scrubbing settings  to it's own tab

You can read more about here:  https://app.asana.com/0/1155078590577881/1162552643825565

In the General settings, the Data Privacy section has been replaced by an empty component, stating that it has been moved to its own tab. Please see:

![image](https://user-images.githubusercontent.com/29228205/74943523-cde9d200-53f4-11ea-822c-2a6d68fda3f4.png)


An overview of the Datascrubbers Settings Tab:
![image](https://user-images.githubusercontent.com/29228205/74943482-bc082f00-53f4-11ea-8af1-b257575538aa.png)

