### PR TITLE
expt(workflow/projectCreation): Use experiments instead of feature flags

### DIFF
--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from rest_framework import status
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import experiments
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.rules import rules
 
@@ -20,9 +20,7 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
                 context["formFields"] = rule_cls.form_fields
             return context
 
-        if not features.has(
-            "organizations:new-project-issue-alert-options", organization, actor=request.user
-        ):
+        if experiments.get(org=organization, experiment_name="AlertDefaultsExperiment") != 1:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         return Response(

--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -20,7 +20,7 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
                 context["formFields"] = rule_cls.form_fields
             return context
 
-        if experiments.get(org=organization, experiment_name="AlertDefaultsExperiment") != 1:
+        if experiments.get(org=organization, experiment_name="AlertDefaultsExperimentTmp") != 1:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         return Response(

--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -20,6 +20,7 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
                 context["formFields"] = rule_cls.form_fields
             return context
 
+        # TODO(Jeff): Rename to `AlertDefaultsExperiment` on real experiment run
         if experiments.get(org=organization, experiment_name="AlertDefaultsExperimentTmp") != 1:
             return Response(status=status.HTTP_404_NOT_FOUND)
 

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -13,9 +13,9 @@ const NewProject = ({organization}) => (
       <Content>
         <DocumentTitle title="Sentry" />
         <CreateProject
-          hasIssueAlertOptionsEnabled={organization.features.includes(
-            'new-project-issue-alert-options'
-          )}
+          hasIssueAlertOptionsEnabled={
+            organization.experiments?.AlertDefaultsExperiment === 1
+          }
         />
       </Content>
     </div>

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -14,6 +14,7 @@ const NewProject = ({organization}) => (
         <DocumentTitle title="Sentry" />
         <CreateProject
           hasIssueAlertOptionsEnabled={
+            // TODO(Jeff): Rename to `AlertDefaultsExperiment` on real experiment run
             organization.experiments?.AlertDefaultsExperimentTmp === 1
           }
         />

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -14,7 +14,7 @@ const NewProject = ({organization}) => (
         <DocumentTitle title="Sentry" />
         <CreateProject
           hasIssueAlertOptionsEnabled={
-            organization.experiments?.AlertDefaultsExperiment === 1
+            organization.experiments?.AlertDefaultsExperimentTmp === 1
           }
         />
       </Content>

--- a/tests/sentry/api/endpoints/test_project_agnostic_rule_configurations.py
+++ b/tests/sentry/api/endpoints/test_project_agnostic_rule_configurations.py
@@ -1,21 +1,21 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
+from mock import patch
 
 from sentry.testutils import APITestCase
 
 
 class ProjectAgnosticRuleConfigurationsTest(APITestCase):
-    def test_simple(self):
+    @patch("sentry.experiments.get", return_value=1)
+    def test_simple(self, mocked_experiment):
+        self.login_as(user=self.user)
+        org = self.create_organization(owner=self.user, name="baz")
+        url = reverse("sentry-api-0-project-agnostic-rule-conditions", args=[org.slug])
+        response = self.client.get(url, format="json")
 
-        with self.feature("organizations:new-project-issue-alert-options"):
-            self.login_as(user=self.user)
-            org = self.create_organization(owner=self.user, name="baz")
-            url = reverse("sentry-api-0-project-agnostic-rule-conditions", args=[org.slug])
-            response = self.client.get(url, format="json")
-
-            assert response.status_code == 200, response.content
-            assert len(response.data) == 9
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 9
 
     def test_no_access(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Part of: https://www.notion.so/sentry/Default-Alert-Options-450bbbc6f83b4ba29350fb9a59cf5746


Experiment is off for everyone except those using the sentry org-slug
wantLGTM: @getsentry/app-frontend, @getsentry/app-backend 
Depends on : https://github.com/getsentry/getsentry/pull/3562