### PR TITLE
Revert "feat(switch): Add new feature switch for alerts"

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -841,8 +841,6 @@ SENTRY_FEATURES = {
     "organizations:internal-catchall": False,
     # Enable inviting members to organizations.
     "organizations:invite-members": True,
-    # Enable different issue alerts on new project creation.
-    "organizations:new-project-issue-alert-options": False,
     # Enable org-wide saved searches and user pinned search
     "organizations:org-saved-searches": False,
     # Enable access to more advanced (alpha) datascrubbing settings.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -78,7 +78,6 @@ default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA
 default_manager.add("organizations:large-debug-files", OrganizationFeature)  # NOQA
 default_manager.add("organizations:monitors", OrganizationFeature)  # NOQA
-default_manager.add("organizations:new-project-issue-alert-options", OrganizationFeature)  # NOQA
 default_manager.add("organizations:onboarding", OrganizationFeature)  # NOQA
 default_manager.add("organizations:org-saved-searches", OrganizationFeature)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA


### PR DESCRIPTION
Reverts getsentry/sentry#16623

Using experiments instead of feature switch / flag.
See: https://github.com/getsentry/sentry/pull/17134
Depends on: https://github.com/getsentry/sentry/pull/17134,