### PR TITLE
feat(async-csv): Implement streaming downloads on Issue By Tag view

### DIFF
--- a/src/sentry/api/endpoints/data_export_details.py
+++ b/src/sentry/api/endpoints/data_export_details.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from rest_framework.response import Response
+from django.http import StreamingHttpResponse
 
 from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationEventPermission
@@ -10,10 +11,6 @@ from sentry.models import ExportedData
 
 class DataExportDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationEventPermission,)
-
-    def download(self, data_export):
-        # TODO(Leander): Implement safe downloads
-        return
 
     def get(self, request, organization, **kwargs):
         """
@@ -31,3 +28,10 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
             return Response(serialize(data_export, request.user))
         except ExportedData.DoesNotExist:
             return Response(status=404)
+
+    def download(self, data_export):
+        file = data_export.file
+        fp = file.getfile()
+        response = StreamingHttpResponse(iter(lambda: fp.read(4096), b""), content_type="text/csv")
+        response["Content-Disposition"] = u'attachment; filename="{}"'.format(file.name)
+        return response

--- a/src/sentry/api/endpoints/data_export_details.py
+++ b/src/sentry/api/endpoints/data_export_details.py
@@ -31,7 +31,9 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
 
     def download(self, data_export):
         file = data_export.file
-        fp = file.getfile()
-        response = StreamingHttpResponse(iter(lambda: fp.read(4096), b""), content_type="text/csv")
+        raw_file = file.getfile()
+        response = StreamingHttpResponse(
+            iter(lambda: raw_file.read(4096), b""), content_type="text/csv"
+        )
         response["Content-Disposition"] = u'attachment; filename="{}"'.format(file.name)
         return response

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -36,10 +36,11 @@ class DataExport extends React.Component<Props, State> {
 
   async startDataExport() {
     const {
+      api,
       organization: {slug},
       payload,
     } = this.props;
-    const {id: dataExportId} = await this.props.api.requestPromise(
+    const {id: dataExportId} = await api.requestPromise(
       `/organizations/${slug}/data-export/`,
       {
         method: 'POST',
@@ -74,4 +75,5 @@ class DataExport extends React.Component<Props, State> {
   }
 }
 
+export {DataExport};
 export default withApi(withOrganization(DataExport));

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import {Client} from 'app/api';
+import Feature from 'app/components/acl/feature';
+import Tooltip from 'app/components/tooltip';
+import {t} from 'app/locale';
+import {Organization} from 'app/types';
+import withApi from 'app/utils/withApi';
+import withOrganization from 'app/utils/withOrganization';
+
+type DataExportPayload = {
+  query_type: number;
+  query_info: any; // TODO(ts): Formalize different possible payloads
+};
+
+type Props = {
+  api: Client;
+  organization: Organization;
+  payload: DataExportPayload;
+};
+
+type State = {
+  inProgress: boolean;
+  dataExportId?: number;
+};
+
+const TooltipMessages = {
+  start: "We'll get all your data in one place and email you when it's ready",
+  progress: "We'll email you when it's ready",
+} as const;
+
+class DataExport extends React.Component<Props, State> {
+  state: State = {
+    inProgress: false,
+  };
+
+  async startDataExport() {
+    const {
+      organization: {slug},
+      payload,
+    } = this.props;
+    const {id: dataExportId} = await this.props.api.requestPromise(
+      `/organizations/${slug}/data-export/`,
+      {
+        method: 'POST',
+        data: payload,
+      }
+    );
+    this.setState({inProgress: true, dataExportId});
+  }
+
+  render() {
+    const {inProgress, dataExportId} = this.state;
+    return (
+      <Feature features={['data-export']}>
+        {inProgress && dataExportId ? (
+          <Tooltip title={TooltipMessages.progress}>
+            <button className="btn btn-default btn-sm" disabled>
+              {t('Queued up!')}
+            </button>
+          </Tooltip>
+        ) : (
+          <Tooltip title={TooltipMessages.start}>
+            <button
+              className="btn btn-default btn-sm"
+              onClick={() => this.startDataExport()}
+            >
+              {t('Export All to CSV')}
+            </button>
+          </Tooltip>
+        )}
+      </Feature>
+    );
+  }
+}
+
+export default withApi(withOrganization(DataExport));

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -9,8 +9,8 @@ import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 
 type DataExportPayload = {
-  query_type: number;
-  query_info: any; // TODO(ts): Formalize different possible payloads
+  queryType: number;
+  queryInfo: any; // TODO(ts): Formalize different possible payloads
 };
 
 type Props = {
@@ -38,13 +38,16 @@ class DataExport extends React.Component<Props, State> {
     const {
       api,
       organization: {slug},
-      payload,
+      payload: {queryType, queryInfo},
     } = this.props;
     const {id: dataExportId} = await api.requestPromise(
       `/organizations/${slug}/data-export/`,
       {
         method: 'POST',
-        data: payload,
+        data: {
+          query_type: queryType,
+          query_info: queryInfo,
+        },
       }
     );
     this.setState({inProgress: true, dataExportId});

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -34,7 +34,7 @@ class DataExport extends React.Component<Props, State> {
     inProgress: false,
   };
 
-  async startDataExport() {
+  startDataExport = async () => {
     const {
       api,
       organization: {slug},
@@ -51,7 +51,7 @@ class DataExport extends React.Component<Props, State> {
       }
     );
     this.setState({inProgress: true, dataExportId});
-  }
+  };
 
   render() {
     const {inProgress, dataExportId} = this.state;
@@ -65,10 +65,7 @@ class DataExport extends React.Component<Props, State> {
           </Tooltip>
         ) : (
           <Tooltip title={TooltipMessages.start}>
-            <button
-              className="btn btn-default btn-sm"
-              onClick={() => this.startDataExport()}
-            >
+            <button className="btn btn-default btn-sm" onClick={this.startDataExport}>
               {t('Export All to CSV')}
             </button>
           </Tooltip>

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -53,10 +53,6 @@ class DataDownload extends AsyncView<Props, State> {
     return [['download', `/organizations/${orgId}/data-export/${dataExportId}/`]];
   }
 
-  handleDownload(): void {
-    // TODO(Leander): Send request to download endpoint
-  }
-
   renderExpired(): React.ReactNode {
     return (
       <React.Fragment>
@@ -85,8 +81,11 @@ class DataDownload extends AsyncView<Props, State> {
 
   renderValid(): React.ReactNode {
     const {download} = this.state;
-    // TODO(Leander): Fix this default fallback behavior
-    const d = new Date(download.dateExpired || '');
+    const {orgId, dataExportId} = this.props.params;
+    if (!download.dateExpired) {
+      return null;
+    }
+    const d = new Date(download.dateExpired);
     return (
       <React.Fragment>
         <h3>{t('Finally!')}</h3>
@@ -100,7 +99,7 @@ class DataDownload extends AsyncView<Props, State> {
           icon="icon-download"
           size="large"
           borderless
-          onClick={() => this.handleDownload()}
+          href={`/api/0/organizations/${orgId}/data-export/${dataExportId}/?download=true`}
         >
           {t('Download CSV')}
         </Button>
@@ -137,7 +136,6 @@ class DataDownload extends AsyncView<Props, State> {
 const ContentContainer = styled('div')`
   text-align: center;
   margin: ${space(4)} auto;
-  /* TODO(Leander): Responsive sizing */
   width: 350px;
   padding: ${space(4)};
   background: ${p => p.theme.whiteDark};

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -112,7 +112,7 @@ class GroupTagValues extends AsyncComponent<
           {tag.key === 'user' ? t('Affected Users') : tag.name}
           <a
             href={`/${orgId}/${group.project.slug}/issues/${group.id}/tags/${tagKey}/export/`}
-            className="btn btn-default btn-sm m-left"
+            className="btn btn-default btn-sm m-left m-right"
           >
             {t('Export Page to CSV')}
           </a>
@@ -151,6 +151,9 @@ class GroupTagValues extends AsyncComponent<
 const TableWrapper = styled('div')`
   .m-left {
     margin-left: ${space(1.5)};
+  }
+  .m-right {
+    margin-right: ${space(1.5)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -13,6 +13,7 @@ import ExternalLink from 'app/components/links/externalLink';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import Pagination from 'app/components/pagination';
 import TimeSince from 'app/components/timeSince';
+import DataExport from 'app/components/dataExport';
 import space from 'app/styles/space';
 import {Group, Tag, TagValue} from 'app/types';
 
@@ -113,8 +114,18 @@ class GroupTagValues extends AsyncComponent<
             href={`/${orgId}/${group.project.slug}/issues/${group.id}/tags/${tagKey}/export/`}
             className="btn btn-default btn-sm m-left"
           >
-            {t('Export to CSV')}
+            {t('Export Page to CSV')}
           </a>
+          <DataExport
+            payload={{
+              query_type: 2,
+              query_info: {
+                project_id: group.project.id,
+                group_id: group.id,
+                key: tagKey,
+              },
+            }}
+          />
         </h3>
         <table className="table table-striped">
           <thead>

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -118,8 +118,8 @@ class GroupTagValues extends AsyncComponent<
           </a>
           <DataExport
             payload={{
-              query_type: 2,
-              query_info: {
+              queryType: 2,
+              queryInfo: {
                 project_id: group.project.id,
                 group_id: group.id,
                 key: tagKey,

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -1,24 +1,71 @@
 import React from 'react';
-import {shallow} from 'sentry-test/enzyme';
+import {mount} from 'sentry-test/enzyme';
 
-import DataExport from 'app/components/dataExport';
+import WrappedDataExport, {DataExport} from 'app/components/dataExport';
 
 describe('DataExport', function() {
   const mockUnauthorizedOrg = TestStubs.Organization({
-    features: [''],
+    features: [],
   });
-  // const mockAuthorizedOrg = TestStubs.Organization({
-  //   features: ['data-export'],
-  // });
+  const mockAuthorizedOrg = TestStubs.Organization({
+    features: ['data-export'],
+  });
   const mockPayload = {
     query_type: 2,
     query_info: {project_id: '1', group_id: '1027', key: 'user'},
   };
+  const mockRouterContext = mockOrganization =>
+    TestStubs.routerContext([
+      {
+        organization: mockOrganization,
+      },
+    ]);
 
   it('should not render anything for an unauthorized organization', function() {
-    const wrapper = shallow(
-      <DataExport organization={mockUnauthorizedOrg} payload={mockPayload} />
+    const wrapper = mount(
+      <WrappedDataExport payload={mockPayload} />,
+      mockRouterContext(mockUnauthorizedOrg)
+    );
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+
+  it('should render the button for an authorized organization', function() {
+    const wrapper = mount(
+      <WrappedDataExport payload={mockPayload} />,
+      mockRouterContext(mockAuthorizedOrg)
     );
     expect(wrapper.isEmptyRender()).toBe(false);
+    expect(wrapper.text()).toBe('Export All to CSV');
+  });
+
+  it('should send a request and disable itself when clicked', async function() {
+    const url = `/organizations/${mockAuthorizedOrg.slug}/data-export/`;
+    const postDataExport = MockApiClient.addMockResponse({
+      url,
+      method: 'POST',
+      body: {id: 721},
+    });
+    const wrapper = mount(
+      <WrappedDataExport payload={mockPayload} />,
+      mockRouterContext(mockAuthorizedOrg)
+    );
+    wrapper.find('button').simulate('click');
+    expect(wrapper.find(DataExport).state()).toEqual({
+      inProgress: false,
+    });
+    expect(postDataExport).toHaveBeenCalledWith(url, {
+      data: mockPayload,
+      method: 'POST',
+      error: expect.anything(),
+      success: expect.anything(),
+    });
+    await tick();
+    wrapper.update();
+    expect(wrapper.text()).toBe('Queued up!');
+    expect(wrapper.find('button').is('[disabled]')).toBe(true);
+    expect(wrapper.find(DataExport).state()).toEqual({
+      inProgress: true,
+      dataExportId: 721,
+    });
   });
 });

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {shallow} from 'sentry-test/enzyme';
+
+import DataExport from 'app/components/dataExport';
+
+describe('DataExport', function() {
+  const mockUnauthorizedOrg = TestStubs.Organization({
+    features: [''],
+  });
+  // const mockAuthorizedOrg = TestStubs.Organization({
+  //   features: ['data-export'],
+  // });
+  const mockPayload = {
+    query_type: 2,
+    query_info: {project_id: '1', group_id: '1027', key: 'user'},
+  };
+
+  it('should not render anything for an unauthorized organization', function() {
+    const wrapper = shallow(
+      <DataExport organization={mockUnauthorizedOrg} payload={mockPayload} />
+    );
+    expect(wrapper.isEmptyRender()).toBe(false);
+  });
+});

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -11,8 +11,8 @@ describe('DataExport', function() {
     features: ['data-export'],
   });
   const mockPayload = {
-    query_type: 2,
-    query_info: {project_id: '1', group_id: '1027', key: 'user'},
+    queryType: 2,
+    queryInfo: {project_id: '1', group_id: '1027', key: 'user'},
   };
   const mockRouterContext = mockOrganization =>
     TestStubs.routerContext([
@@ -54,7 +54,10 @@ describe('DataExport', function() {
       inProgress: false,
     });
     expect(postDataExport).toHaveBeenCalledWith(url, {
-      data: mockPayload,
+      data: {
+        query_type: mockPayload.queryType,
+        query_info: mockPayload.queryInfo,
+      },
       method: 'POST',
       error: expect.anything(),
       success: expect.anything(),


### PR DESCRIPTION
**Note**: This UI isn't rendered unless the organization has the `org:data-export` feature, which isn't flagged for anyone yet, not even internal sentry staff

---

This PR will add the UI button to start up a bulk export, if the organization has the permissions. If not the button won't appear.

When clicked the button disables, and changes to `Queued up!`. There are also separate tool tip messages to explain more in depth how the feature works, depending on if the button has been clicked or not.

A separate PR (https://github.com/getsentry/sentry/pull/17102) will handle sending the email to notify the user. 

I tried playing around with how the interface would work, and decided against attaching a link to the button to take the user to the download page. They would arrive to see a _You're Early!_ message, and have to refresh until their download is complete, which I don't really like. If you have any recommendations for a better interface or things I should add, let me know.

---
Images:

<img width="593" alt="Screen Shot 2020-02-19 at 12 02 22 PM" src="https://user-images.githubusercontent.com/35509934/74871087-bab10680-530f-11ea-8e44-7c165180da5b.png">

<img width="606" alt="Screen Shot 2020-02-19 at 12 01 05 PM" src="https://user-images.githubusercontent.com/35509934/74885395-48015480-532a-11ea-974e-030bc9eb4d9f.png">

 ---

**[API-696](https://getsentry.atlassian.net/secure/RapidBoard.jspa?rapidView=19&modal=detail&selectedIssue=API-696)**