### PR TITLE
feat(workflow/projectCreation): Add default value to event threshold

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
@@ -44,7 +44,6 @@ type Props = AsyncComponent['props'] & {
 type State = AsyncComponent['state'] & {
   conditions: any;
   intervalChoices: [string, string][] | undefined;
-  placeholder: string;
   threshold: string;
   interval: string;
   alertSetting: string;
@@ -95,10 +94,7 @@ function unpackConditions(conditions: any[]) {
   const intervalChoices = conditions
     .map(condition => condition.formFields?.interval?.choices)
     .reduce(equalityReducer);
-  const placeholder = conditions
-    .map(condition => condition.formFields?.value?.placeholder)
-    .reduce(equalityReducer);
-  return {intervalChoices, placeholder, interval: intervalChoices?.[0]?.[0]};
+  return {intervalChoices, interval: intervalChoices?.[0]?.[0]};
 }
 
 class IssueAlertOptions extends AsyncComponent<Props, State> {
@@ -110,8 +106,7 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
       alertSetting: `${Actions.CUSTOMIZED_ALERTS}`,
       metric: MetricValues.ERRORS,
       interval: '',
-      placeholder: '',
-      threshold: '',
+      threshold: '10',
     };
   }
 
@@ -144,7 +139,6 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
             min="0"
             name=""
             value={this.state.threshold}
-            placeholder={this.state.placeholder}
             key={name}
             onChange={threshold =>
               this.setStateAndUpdateParents({threshold: threshold.target.value})
@@ -249,15 +243,13 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
       return;
     }
 
-    const {intervalChoices, placeholder, interval} = unpackConditions(conditions);
-    if (!intervalChoices || !placeholder || !interval) {
+    const {intervalChoices, interval} = unpackConditions(conditions);
+    if (!intervalChoices || !interval) {
       Sentry.withScope(scope => {
         scope.setExtra('props', this.props);
         scope.setExtra('state', this.state);
         Sentry.captureException(
-          new Error(
-            'Interval choices or value placeholder sent from API endpoint is inconsistent or empty'
-          )
+          new Error('Interval choices or sent from API endpoint is inconsistent or empty')
         );
       });
       this.setStateAndUpdateParents({conditions: undefined});
@@ -267,7 +259,6 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
     this.setStateAndUpdateParents({
       conditions,
       intervalChoices,
-      placeholder,
       interval,
     });
   }

--- a/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
@@ -35,6 +35,8 @@ const METRIC_CONDITION_MAP = {
   [MetricValues.USERS]: UNIQUE_USER_FREQUENCY_CONDITION,
 } as const;
 
+const DEFAULT_THRESHOLD_VALUE: string = '10';
+
 type StateUpdater = (updatedData: RequestDataFragment) => void;
 type Props = AsyncComponent['props'] & {
   organization: Organization;
@@ -106,7 +108,7 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
       alertSetting: `${Actions.CUSTOMIZED_ALERTS}`,
       metric: MetricValues.ERRORS,
       interval: '',
-      threshold: '10',
+      threshold: DEFAULT_THRESHOLD_VALUE,
     };
   }
 
@@ -138,6 +140,7 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
             type="number"
             min="0"
             name=""
+            placeholder={DEFAULT_THRESHOLD_VALUE}
             value={this.state.threshold}
             key={name}
             onChange={threshold =>

--- a/tests/js/spec/views/projectInstall/createProject.spec.jsx
+++ b/tests/js/spec/views/projectInstall/createProject.spec.jsx
@@ -195,6 +195,12 @@ describe('CreateProject', function() {
         .find('PlatformCard')
         .first()
         .simulate('click');
+      expectSubmitButtonToBeDisabled(false);
+
+      wrapper
+        .find('input[data-test-id="range-input"]')
+        .first()
+        .simulate('change', {target: {value: ''}});
       expectSubmitButtonToBeDisabled(true);
 
       wrapper

--- a/tests/js/spec/views/projectInstall/issueAlertOptions.spec.jsx
+++ b/tests/js/spec/views/projectInstall/issueAlertOptions.spec.jsx
@@ -76,13 +76,13 @@ describe('IssueAlertOptions', function() {
     expect(wrapper.find('RadioLineItem')).toHaveLength(2);
   });
 
-  it('should render only the `Default Rule` and `Create Later` option on responses with different placeholder values', () => {
+  it('should render all(three) options on responses with different placeholder values', () => {
     MockApiClient.addMockResponse({
       url: URL,
       body: MOCK_RESP_INCONSISTENT_PLACEHOLDERS,
     });
     const wrapper = mountWithTheme(<IssueAlertOptions {...props} />, routerContext);
-    expect(wrapper.find('RadioLineItem')).toHaveLength(2);
+    expect(wrapper.find('RadioLineItem')).toHaveLength(3);
   });
 
   it('should ignore conditions that are not `sentry.rules.conditions.event_frequency.EventFrequencyCondition` and `sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition` ', () => {
@@ -114,16 +114,25 @@ describe('IssueAlertOptions', function() {
 
     const wrapper = mountWithTheme(<IssueAlertOptions {...props} />, routerContext);
 
-    expect(wrapper.find('input[data-test-id="range-input"]').props().placeholder).toBe(
-      100
-    );
-
     [
       ['metric-select-control', ['occurrences of', 'users affected by']],
       [
         'interval-select-control',
         ['one minute', 'one hour', 'one day', 'one week', '30 days'],
       ],
-    ].forEach(tuple => selectControlVerifier(wrapper, tuple[0], tuple[1]));
+    ].forEach(([dataTestId, options]) =>
+      selectControlVerifier(wrapper, dataTestId, options)
+    );
+  });
+
+  it('should pre-fill threshold value after a valid server response', () => {
+    MockApiClient.addMockResponse({
+      url: URL,
+      body: MOCK_RESP_VERBOSE,
+    });
+
+    const wrapper = mountWithTheme(<IssueAlertOptions {...props} />, routerContext);
+
+    expect(wrapper.find('input[data-test-id="range-input"]').props().value).toBe('10');
   });
 });


### PR DESCRIPTION
Having a placeholder value is confusing as the user expects the value to be a default pre-filled value. This PR changes the placeholder value to a default value that can be used to submit forms.

See: https://www.notion.so/sentry/Default-Alert-Options-450bbbc6f83b4ba29350fb9a59cf5746