### PR TITLE
fix(discover) - Fixing csv exports containing #

### DIFF
--- a/src/sentry/static/sentry/app/views/discover/result/utils.tsx
+++ b/src/sentry/static/sentry/app/views/discover/result/utils.tsx
@@ -366,7 +366,11 @@ export function downloadAsCsv(result: SnubaResult) {
     }),
   });
 
-  const encodedDataUrl = encodeURI(`data:text/csv;charset=utf8,${csvContent}`);
+  // Need to also manually replace # since encodeURI skips them
+  const encodedDataUrl = encodeURI(`data:text/csv;charset=utf8,${csvContent}`).replace(
+    /#/g,
+    '%23'
+  );
 
   window.location.assign(encodedDataUrl);
 }

--- a/src/sentry/static/sentry/app/views/discover/result/utils.tsx
+++ b/src/sentry/static/sentry/app/views/discover/result/utils.tsx
@@ -367,10 +367,7 @@ export function downloadAsCsv(result: SnubaResult) {
   });
 
   // Need to also manually replace # since encodeURI skips them
-  const encodedDataUrl = encodeURI(`data:text/csv;charset=utf8,${csvContent}`).replace(
-    /#/g,
-    '%23'
-  );
+  const encodedDataUrl = `data:text/csv;charset=utf8,${encodeURIComponent(csvContent)}`;
 
   window.location.assign(encodedDataUrl);
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -336,10 +336,7 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
   });
 
   // Need to also manually replace # since encodeURI skips them
-  const encodedDataUrl = encodeURI(`data:text/csv;charset=utf8,${csvContent}`).replace(
-    /#/g,
-    '%23'
-  );
+  const encodedDataUrl = `data:text/csv;charset=utf8,${encodeURIComponent(csvContent)}`;
 
   // Create a download link then click it, this is so we can get a filename
   const link = document.createElement('a');

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -335,7 +335,11 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
     }),
   });
 
-  const encodedDataUrl = encodeURI(`data:text/csv;charset=utf8,${csvContent}`);
+  // Need to also manually replace # since encodeURI skips them
+  const encodedDataUrl = encodeURI(`data:text/csv;charset=utf8,${csvContent}`).replace(
+    /#/g,
+    '%23'
+  );
 
   // Create a download link then click it, this is so we can get a filename
   const link = document.createElement('a');

--- a/tests/js/spec/views/discover/result/utils.spec.jsx
+++ b/tests/js/spec/views/discover/result/utils.spec.jsx
@@ -432,7 +432,7 @@ describe('Utils', function() {
       downloadAsCsv(result);
       expect(locationSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          encodeURI('message,environment\r\ntest 1,prod\r\ntest 2,test')
+          encodeURIComponent('message,environment\r\ntest 1,prod\r\ntest 2,test')
         )
       );
     });
@@ -449,12 +449,12 @@ describe('Utils', function() {
     it('quotes unsafe strings', function() {
       const result = {
         meta: [{name: 'message'}],
-        data: [{message: '=HYPERLINK(http://some-bad-website)'}],
+        data: [{message: '=HYPERLINK(http://some-bad-website#)'}],
       };
       downloadAsCsv(result);
       expect(locationSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          encodeURI("message\r\n'=HYPERLINK(http://some-bad-website)")
+          encodeURIComponent("message\r\n'=HYPERLINK(http://some-bad-website#)")
         )
       );
     });


### PR DESCRIPTION
- Currently if a line includes # everything afterward gets truncated
  since it gets treated as an anchor tag in the url we send the user to.
  - I thought encodeURI would do this replacing for us TBH, but it looks
    like it only handles base urls well.