### PR TITLE
chore: remove unused strict-rfc3339

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,6 @@ simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0
 sqlparse>=0.2.0,<0.3.0
 statsd>=3.1.0,<3.2.0
-strict-rfc3339>=0.7
 structlog==16.1.0
 symbolic>=7.1.0,<8.0.0
 toronado>=0.0.11,<0.1.0


### PR DESCRIPTION
I missed this one while culling unused dependencies a while back.