### PR TITLE
feat(integrations): Support tagging Slack users in alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   </p>
 </p>
 
-# What's Sentry?
+# What's Sentry? 
 
 Sentry fundamentally is a service that helps you monitor and fix crashes
 in realtime. The server is in Python, but it contains a full API for

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   </p>
 </p>
 
-# What's Sentry? 
+# What's Sentry?
 
 Sentry fundamentally is a service that helps you monitor and fix crashes
 in realtime. The server is in Python, but it contains a full API for

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -110,6 +110,7 @@ class SlackNotifyServiceAction(EventAction):
             payload = {
                 "token": integration.metadata["access_token"],
                 "channel": channel,
+                "link_names": 1,
                 "attachments": json.dumps([attachment]),
             }
 


### PR DESCRIPTION
Add support to Slack integration that will identify @'s so users are notified.

Currently, I add tags to Slack alerts that contain the handles of the app owners \responsible for the alert. These are sent as plain text that do not trigger notifications. Using Slack keywords doesn't always work. 

Tested this change on an onpremise solution and was successfully able to leverage Slack's notifications by tagging @'s correctly.

See `link_names` in the [Slack Documentation](https://api.slack.com/methods/chat.postMessage)

**Before Change:**
![before-slack-change](https://user-images.githubusercontent.com/9503623/74953862-3a9ea580-53d0-11ea-8363-9f6fa0d9d767.jpg)

**After Change**
![after-slack-change](https://user-images.githubusercontent.com/9503623/74953889-42f6e080-53d0-11ea-875b-37c19dba53f2.jpg)

@getsentry/app-backend