### PR TITLE
feat(integration-directory): hide deprecated plugins

### DIFF
--- a/src/sentry/plugins/__init__.py
+++ b/src/sentry/plugins/__init__.py
@@ -13,4 +13,5 @@ HIDDEN_PLUGINS = (
     "campfire",
     "youtrack",
     "clubhouse",
+    "pagerduty",
 )

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
@@ -7,14 +7,3 @@ export const colors = {
   [NOT_INSTALLED]: 'gray2',
   [PENDING]: 'yellowOrange',
 };
-
-export const legacyIds = [
-  'jira',
-  'bitbucket',
-  'github',
-  'gitlab',
-  'slack',
-  'pagerduty',
-  'clubhouse',
-  'vsts',
-];

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -25,7 +25,6 @@ import withOrganization from 'app/utils/withOrganization';
 import SearchInput from 'app/components/forms/searchInput';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import IntegrationRow from './integrationRow';
-import {legacyIds} from './constants';
 
 type AppOrProviderOrPlugin = SentryApp | IntegrationProvider | PluginWithProjectList;
 
@@ -252,7 +251,7 @@ export class OrganizationIntegrations extends AsyncComponent<
   renderPlugin = (plugin: PluginWithProjectList) => {
     const {organization} = this.props;
 
-    const isLegacy = legacyIds.includes(plugin.id);
+    const isLegacy = plugin.isHidden;
     const displayName = `${plugin.name} ${!!isLegacy ? '(Legacy)' : ''}`;
     //hide legacy integrations if we don't have any projects with them
     if (isLegacy && !plugin.projectList.length) {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -10,7 +10,6 @@ import * as modal from 'app/actionCreators/modal';
 import ContextPickerModal from 'app/components/contextPickerModal';
 import {t} from 'app/locale';
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
-import {legacyIds} from './constants';
 
 type State = {
   plugins: PluginWithProjectList[];
@@ -50,7 +49,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get integrationName() {
-    const isLegacy = legacyIds.includes(this.plugin.id);
+    const isLegacy = this.plugin.isHidden;
     const displayName = `${this.plugin.name} ${isLegacy ? '(Legacy)' : ''}`;
     return displayName;
   }

--- a/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -241,7 +241,7 @@ describe('IntegrationListDirectory', function() {
               status: 'unknown',
               description: 'Send alerts to PagerDuty.',
               isTestable: true,
-              isHidden: false,
+              isHidden: true,
               hasConfiguration: true,
               features: [],
               shortName: 'PagerDuty',

--- a/tests/js/spec/views/organizationIntegrations/pluginDetailedView.spec.js
+++ b/tests/js/spec/views/organizationIntegrations/pluginDetailedView.spec.js
@@ -30,7 +30,7 @@ describe('PluginDetailedView', function() {
             status: 'unknown',
             description: 'Send alerts to PagerDuty.',
             isTestable: true,
-            isHidden: false,
+            isHidden: true,
             hasConfiguration: true,
             features: [],
             shortName: 'PagerDuty',


### PR DESCRIPTION
This PR hides `Flodock`, `IRC`, `Campfire`, and `YouTrack` from the integration directory as they are due to be removed. This done by using the list of `HIDDEN_PLUGINS` and the field `isHidden` to determine which plugins we show in the integration directory instead of `legacyIds`. This has the added advantage of removing the redundant constant of `legacyIds` which is supposed to correspond to `HIDDEN_PLUGINS`.

Note that if you have a "hidden" plugin installed, it shows up but with the title "Legacy". Also, note that I have added `PagerDuty` to the list of hidden plugins since we now have a PagerDuty integration and we don't want `PagerDuty` to show up twice.