### PR TITLE
fix(discover) Fix incorrect tooltip times

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -227,22 +227,13 @@ class ChartZoom extends React.Component {
       ...xAxis,
     };
 
-    const tooltip = {
-      formatAxisLabel: (value, isTimestamp, isUtc) => {
-        if (!isTimestamp) {
-          return value;
-        }
-        return getFormattedDate(value, 'lll', {local: !isUtc});
-      },
-    };
-
     const renderProps = {
       // Zooming only works when grouped by date
       isGroupedByDate: true,
       onChartReady: this.handleChartReady,
       utc,
       dataZoom: DataZoom(),
-      tooltip,
+      showTimeInTooltip: true,
       toolBox: ToolBox(
         {},
         {

--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -8,7 +8,6 @@ function defaultFormatAxisLabel(value, isTimestamp, utc, showTimeInTooltip) {
   if (!isTimestamp) {
     return value;
   }
-
   const format = `MMM D, YYYY${showTimeInTooltip ? ' LT' : ''}`;
 
   return getFormattedDate(value, format, {local: !utc});

--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -1,11 +1,10 @@
 import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment-timezone';
 import isEqual from 'lodash/isEqual';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
-import {getUserTimezone} from 'app/utils/dates';
+import {getFormattedDate} from 'app/utils/dates';
 import {t} from 'app/locale';
 import MarkLine from 'app/components/charts/components/markLine';
 import SentryTypes from 'app/sentryTypes';
@@ -84,7 +83,7 @@ class ReleaseSeries extends React.Component {
   }
 
   getReleaseSeries = releases => {
-    const {utc, organization, router, tooltip} = this.props;
+    const {organization, router, tooltip} = this.props;
 
     return {
       seriesName: 'Releases',
@@ -99,9 +98,12 @@ class ReleaseSeries extends React.Component {
         },
         tooltip: tooltip || {
           formatter: ({data}) => {
-            const time = moment
-              .tz(data.value, utc ? 'UTC' : getUserTimezone())
-              .format('MMM D, YYYY LT');
+            // XXX using this.props here as this function does not get re-run
+            // unless projects are changed. Using a closure variable would result
+            // in stale values.
+            const time = getFormattedDate(data.value, 'MMM D, YYYY LT', {
+              local: !this.props.utc,
+            });
             const version = escape(formatVersion(data.name, true));
             return [
               '<div class="tooltip-series">',

--- a/tests/js/spec/components/charts/chartZoom.spec.jsx
+++ b/tests/js/spec/components/charts/chartZoom.spec.jsx
@@ -13,7 +13,6 @@ describe('ChartZoom', function() {
   const renderFunc = jest.fn(() => null);
   const routerContext = TestStubs.routerContext();
   let axisLabelFormatter;
-  let tooltipFormatter;
   const timestamp = 1531094400000;
 
   beforeAll(function() {});
@@ -33,7 +32,6 @@ describe('ChartZoom', function() {
         );
 
         axisLabelFormatter = renderFunc.mock.calls[0][0].xAxis.axisLabel.formatter;
-        tooltipFormatter = renderFunc.mock.calls[0][0].tooltip.formatAxisLabel;
       });
 
       it('formats axis label for first data point', function() {
@@ -42,10 +40,6 @@ describe('ChartZoom', function() {
 
       it('formats axis label for second data point', function() {
         expect(axisLabelFormatter(timestamp, 1)).toEqual('Jul 8, 2018 5:00 PM');
-      });
-
-      it('formats tooltip', function() {
-        expect(tooltipFormatter(timestamp, true, false)).toEqual('Jul 8, 2018 5:00 PM');
       });
     });
 
@@ -59,7 +53,10 @@ describe('ChartZoom', function() {
         );
 
         axisLabelFormatter = renderFunc.mock.calls[0][0].xAxis.axisLabel.formatter;
-        tooltipFormatter = renderFunc.mock.calls[0][0].tooltip.formatAxisLabel;
+      });
+
+      it('sets showTimeInTooltip prop for children', function() {
+        expect(renderFunc.mock.calls[0][0].showTimeInTooltip).toBe(true);
       });
 
       it('formats axis label for first data point', function() {
@@ -68,10 +65,6 @@ describe('ChartZoom', function() {
 
       it('formats axis label for second data point', function() {
         expect(axisLabelFormatter(timestamp, 1)).toEqual('Jul 9, 2018 12:00 AM');
-      });
-
-      it('formats tooltip', function() {
-        expect(tooltipFormatter(timestamp, true, true)).toEqual('Jul 9, 2018 12:00 AM');
       });
     });
   });
@@ -87,7 +80,6 @@ describe('ChartZoom', function() {
         );
 
         axisLabelFormatter = renderFunc.mock.calls[0][0].xAxis.axisLabel.formatter;
-        tooltipFormatter = renderFunc.mock.calls[0][0].tooltip.formatAxisLabel;
       });
       it('formats axis label for first data point', function() {
         expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 8, 2018 5:00 PM');
@@ -95,10 +87,6 @@ describe('ChartZoom', function() {
 
       it('formats axis label for second data point', function() {
         expect(axisLabelFormatter(timestamp, 1)).toEqual('5:00 PM');
-      });
-
-      it('formats tooltip', function() {
-        expect(tooltipFormatter(timestamp, true, false)).toEqual('Jul 8, 2018 5:00 PM');
       });
     });
 
@@ -112,7 +100,6 @@ describe('ChartZoom', function() {
         );
 
         axisLabelFormatter = renderFunc.mock.calls[0][0].xAxis.axisLabel.formatter;
-        tooltipFormatter = renderFunc.mock.calls[0][0].tooltip.formatAxisLabel;
       });
 
       it('formats axis label for first data point', function() {
@@ -121,10 +108,6 @@ describe('ChartZoom', function() {
 
       it('formats axis label for second data point', function() {
         expect(axisLabelFormatter(timestamp, 1)).toEqual('12:00 AM');
-      });
-
-      it('formats tooltip', function() {
-        expect(tooltipFormatter(timestamp, true, true)).toEqual('Jul 9, 2018 12:00 AM');
       });
     });
   });


### PR DESCRIPTION
Release times would be in the wrong timezone if you were not in UTC. Furthermore if you toggled UTC on/off in the global selection header the UTC prefernce would become stale do to closure references. Finally we can remove the tooltip in ChartZoom by telling the wrapped chart to show time in the tooltip, as we pretty much always want to do that.