### PR TITLE
feat(discover2): Delete global header from landing page.

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -17,7 +17,6 @@ import Banner from 'app/components/banner';
 import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
 import Feature from 'app/components/acl/feature';
-import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import NoProjectMessage from 'app/components/noProjectMessage';
 import SearchBar from 'app/components/searchBar';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
@@ -298,12 +297,9 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
         renderDisabled={this.renderNoAccess}
       >
         <SentryDocumentTitle title={t('Discover')} objSlug={organization.slug}>
-          <React.Fragment>
-            <GlobalSelectionHeader organization={organization} />
-            <StyledPageContent>
-              <NoProjectMessage organization={organization}>{body}</NoProjectMessage>
-            </StyledPageContent>
-          </React.Fragment>
+          <StyledPageContent>
+            <NoProjectMessage organization={organization}>{body}</NoProjectMessage>
+          </StyledPageContent>
         </SentryDocumentTitle>
       </Feature>
     );


### PR DESCRIPTION
Delete global header from landing page since:

- they're not reflected at all on Saved Query cards, and
- only projects and environment are reflected onto Pre-built Query cards. Their `statsPeriod` is fixed to `24h`.