### PR TITLE
fix(discover) Fix tag navigation with reserved tags

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/tagsTable.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tagsTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import {LocationDescriptor} from 'history';
 
 import Link from 'app/components/links/link';
 import Tooltip from 'app/components/tooltip';
@@ -28,7 +29,7 @@ const TagsTable = (props: Props) => {
       <StyledTable>
         <tbody>
           {tags.map(tag => {
-            let target;
+            let target: LocationDescriptor | undefined;
             const tagInQuery = eventView.query.includes(`${tag.key}:`);
             const renderTagValue = () => {
               switch (tag.key) {

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -369,15 +369,13 @@ export function getExpandedResults(
 ): EventView {
   let nextView = eventView.clone();
   const fieldsToUpdate: number[] = [];
-
-  // Workaround around readonly typing
-  const aggregateAliases: string[] = [...AGGREGATE_ALIASES];
+  const specialKeys = Object.values(URL_PARAM);
 
   nextView.fields.forEach((field: FieldType, index: number) => {
     const column = explodeField(field);
 
     // Mark aggregated fields to be transformed into its un-aggregated form
-    if (column.aggregation || aggregateAliases.includes(column.field)) {
+    if (column.aggregation || AGGREGATE_ALIASES.includes(column.field)) {
       fieldsToUpdate.push(index);
       return;
     }
@@ -404,7 +402,10 @@ export function getExpandedResults(
       if (dataRow && dataRow.tags && dataRow.tags instanceof Array) {
         const tagIndex = dataRow.tags.findIndex(item => item.key === dataKey);
         if (tagIndex > -1) {
-          additionalConditions[column.field] = dataRow.tags[tagIndex].value;
+          const key = specialKeys.includes(column.field)
+            ? `tags[${column.field}]`
+            : column.field;
+          additionalConditions[key] = dataRow.tags[tagIndex].value;
         }
       }
     }
@@ -413,13 +414,12 @@ export function getExpandedResults(
   const transformedFields = new Set();
   const fieldsToDelete: number[] = [];
 
-  // make a best effort to transform aggregated columns with its non-aggregated form
+  // make a best effort to replace aggregated columns with their non-aggregated form
   fieldsToUpdate.forEach((indexToUpdate: number) => {
     const currentField: FieldType = nextView.fields[indexToUpdate];
     const exploded = explodeField(currentField);
 
     // check if we can use an aggregated transform function
-
     const fieldNameAlias = TRANSFORM_AGGREGATES[exploded.aggregation]
       ? exploded.aggregation
       : TRANSFORM_AGGREGATES[exploded.field]
@@ -450,21 +450,13 @@ export function getExpandedResults(
       return;
     }
 
-    // otherwise just use exploded.field as a column
-
-    if (!exploded.field) {
-      // edge case: transform count() into id
-
-      if (exploded.aggregation !== 'count') {
-        fieldsToDelete.push(indexToUpdate);
-        return;
-      }
-
+    // edge case: transform count() into id
+    if (exploded.aggregation === 'count') {
       exploded.field = 'id';
     }
 
-    if (transformedFields.has(exploded.field)) {
-      // this field is duplicated in another column. we remove this column
+    if (!exploded.field || transformedFields.has(exploded.field)) {
+      // If we don't have a field, or already have it, remove the current column
       fieldsToDelete.push(indexToUpdate);
       return;
     }
@@ -495,7 +487,6 @@ export function getExpandedResults(
       }
 
       const column = explodeFieldString(field);
-
       if (column.aggregation) {
         return acc;
       }
@@ -506,7 +497,6 @@ export function getExpandedResults(
     },
     {query: []}
   );
-
   nextView.query = stringifyQueryObject(queryWithNoAggregates);
 
   // Tokenize conditions and append additional conditions provided + generated.

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -57,6 +57,11 @@ describe('utils/tokenizeSearch', function() {
         object: {query: ['python', 'exception']},
         string: 'python exception',
       },
+      {
+        name: 'should quote tags with spaces',
+        object: {query: ['oh me', 'oh my'], browser: ['Chrome 36', 'Firefox 60']},
+        string: 'oh me oh my browser:"Chrome 36" browser:"Firefox 60"',
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -310,7 +310,7 @@ describe('getExpandedResults()', function() {
     environment: ['staging'],
   };
 
-  it('preserve aggregated fields', () => {
+  it('preserves aggregated fields', () => {
     let view = new EventView(state);
     let result = getExpandedResults(view, {}, {});
 
@@ -323,7 +323,6 @@ describe('getExpandedResults()', function() {
     expect(result.query).toEqual('event.type:error');
 
     // de-duplicate transformed columns
-
     view = new EventView({
       ...state,
       fields: [
@@ -345,7 +344,6 @@ describe('getExpandedResults()', function() {
     ]);
 
     // transform aliased fields, & de-duplicate any transforms
-
     view = new EventView({
       ...state,
       fields: [
@@ -436,6 +434,27 @@ describe('getExpandedResults()', function() {
     const result = getExpandedResults(view, {environment: 'dev'});
     expect(result.query).toEqual('event.type:error');
     expect(result.environment).toEqual(['staging', 'dev']);
+  });
+
+  it('applies tags that overlap globalselection state', () => {
+    const view = new EventView({
+      ...state,
+      fields: [{field: 'project'}, {field: 'environment'}, {field: 'title'}],
+    });
+    const event = {
+      title: 'something bad',
+      timestamp: '2020-02-13T17:05:46+00:00',
+      tags: [
+        {key: 'project', value: '12345'},
+        {key: 'environment', value: 'earth'},
+      ],
+    };
+    const result = getExpandedResults(view, {}, event);
+    expect(result.query).toEqual(
+      'event.type:error tags[project]:12345 tags[environment]:earth title:"something bad"'
+    );
+    expect(result.project).toEqual([42]);
+    expect(result.environment).toEqual(['staging']);
   });
 
   it('normalizes the timestamp field', () => {


### PR DESCRIPTION
When creating drilldown links on events that contain global selection header keywords. We need to prefix those to tags to prevent customer tags from falling into the global selection header.