### PR TITLE
ref(plugins): remove client and and secret from github request params

### DIFF
--- a/src/sentry_plugins/github/client.py
+++ b/src/sentry_plugins/github/client.py
@@ -5,7 +5,6 @@ import datetime
 import jwt
 import time
 
-from django.conf import settings
 from sentry import options
 
 from sentry_plugins.client import ApiClient, AuthApiClient
@@ -43,10 +42,6 @@ class GitHubClient(GitHubClientMixin, AuthApiClient):
     def request_no_auth(self, method, path, data=None, params=None):
         if params is None:
             params = {}
-
-        params.update(
-            {"client_id": settings.GITHUB_APP_ID, "client_secret": settings.GITHUB_API_SECRET}
-        )
 
         return self._request(method, path, auth=None, data=data, params=params)
 


### PR DESCRIPTION
Using a clientId and clientSecret in query params is being deprecated: https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

It turns out we didn't need any auth at all in this function as explained in the Github docs:
https://developer.github.com/v3/users/

The only limitation of not having auth is that you the user email comes at `null`. That is OK because the only use case of this function is to get the ID of the user (see https://github.com/getsentry/sentry/blob/769814194fe4c13a385495c22873f9925b937f2c/src/sentry_plugins/github/endpoints/webhook.py#L169). We don't try to pull off the ID.

Here's what the response looks like in Postman when I have no auth:

```
{
    "login": "scefali",
    "id": 8533851,
    "node_id": "MDQ6VXNlcjg1MzM4NTE=",
    "avatar_url": "https://avatars0.githubusercontent.com/u/8533851?v=4",
    "gravatar_id": "",
    "url": "https://api.github.com/users/scefali",
    "html_url": "https://github.com/scefali",
    "followers_url": "https://api.github.com/users/scefali/followers",
    "following_url": "https://api.github.com/users/scefali/following{/other_user}",
    "gists_url": "https://api.github.com/users/scefali/gists{/gist_id}",
    "starred_url": "https://api.github.com/users/scefali/starred{/owner}{/repo}",
    "subscriptions_url": "https://api.github.com/users/scefali/subscriptions",
    "organizations_url": "https://api.github.com/users/scefali/orgs",
    "repos_url": "https://api.github.com/users/scefali/repos",
    "events_url": "https://api.github.com/users/scefali/events{/privacy}",
    "received_events_url": "https://api.github.com/users/scefali/received_events",
    "type": "User",
    "site_admin": false,
    "name": "Stephen Cefali",
    "company": "@getsentry",
    "blog": "https://www.linkedin.com/in/scefali",
    "location": "San Francisco",
    "email": null,
    "hireable": true,
    "bio": "Sr. Software Engineer at Sentry on the Ecosystem team",
    "public_repos": 47,
    "public_gists": 0,
    "followers": 8,
    "following": 5,
    "created_at": "2014-08-23T22:51:16Z",
    "updated_at": "2020-02-20T22:01:09Z"
}
```