### PR TITLE
feat(analytics): Log snuba queries from event conditions

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -94,7 +94,7 @@ class BaseEventFrequencyCondition(EventCondition):
     def is_guessed_to_be_created_on_project_creation(self):
         """
         Best effort approximation on whether a rule with this condition was created on project creation based on how
-        closely the rule and project are created; and if the label matches the default name used onn project creation.
+        closely the rule and project are created; and if the label matches the default name used on project creation.
         :return:
             bool: True if rule is approximated to be created on project creation, False otherwise.
         """

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -98,7 +98,7 @@ class BaseEventFrequencyCondition(EventCondition):
         :return:
             bool: True if rule is approximated to be created on project creation, False otherwise.
         """
-        delta = abs(self.project.date_added - self.rule.date_added)
+        delta = abs(self.rule.date_added - self.project.date_added)
         return delta.total_seconds() < 30 and self.rule.label == DEFAULT_RULE_LABEL
 
 


### PR DESCRIPTION
The [Default Alerts](https://www.notion.so/sentry/Default-Alert-Options-450bbbc6f83b4ba29350fb9a59cf5746) project encourages the use of issue alert rules that will query Snuba. This metric monitors the increase in snuba query.