### PR TITLE
fix(apm): Pass eventView for the spans interface

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -69,6 +69,7 @@ class EventEntries extends React.Component {
     isShare: PropTypes.bool,
     showExampleCommit: PropTypes.bool,
     showTagSummary: PropTypes.bool,
+    eventView: PropTypes.object,
   };
 
   static defaultProps = {
@@ -114,7 +115,7 @@ class EventEntries extends React.Component {
   }
 
   renderEntries() {
-    const {event, project, organization, isShare} = this.props;
+    const {event, project, organization, isShare, eventView} = this.props;
 
     const entries = event && event.entries;
 
@@ -132,6 +133,13 @@ class EventEntries extends React.Component {
             console.error('Unregistered interface: ' + entry.type);
           return null;
         }
+
+        // inject additional props for certain interfaces
+        const extraProps = {};
+        if (entry.type === 'spans' && eventView) {
+          extraProps.eventView = eventView;
+        }
+
         return (
           <Component
             key={'entry-' + entryIdx}
@@ -141,6 +149,7 @@ class EventEntries extends React.Component {
             type={entry.type}
             data={entry.data}
             isShare={isShare}
+            {...extraProps}
           />
         );
       } catch (ex) {

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -176,6 +176,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                   location={location}
                   showExampleCommit={false}
                   showTagSummary={false}
+                  eventView={eventView}
                 />
               )}
             </Projects>


### PR DESCRIPTION
This is necessary for the "View Child" button on the span view; and other things.

Fixes JAVASCRIPT-21JB