### PR TITLE
ref(plugins): remove unneeded query param

### DIFF
--- a/src/sentry_plugins/github/client.py
+++ b/src/sentry_plugins/github/client.py
@@ -81,9 +81,7 @@ class GitHubClient(GitHubClientMixin, AuthApiClient):
         # TODO(jess): remove this whenever it's out of preview
         headers = {"Accept": "application/vnd.github.machine-man-preview+json"}
 
-        params = {"access_token": self.auth.tokens["access_token"]}
-
-        return self._request("GET", "/user/installations", headers=headers, params=params)
+        return self._request("GET", "/user/installations", headers=headers)
 
 
 class GitHubAppsClient(GitHubClientMixin, ApiClient):


### PR DESCRIPTION
Github is deprecating using auth in a query param: https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

We are using it here but we don't need to. Auth is provided downstream:

https://github.com/getsentry/sentry/blob/87805f305b78ed006fcea76be520d6ac2e527242/src/sentry_plugins/client.py#L235

That's why none of the other methods for `GitHubClient` specify auth