### PR TITLE
feat(sentry): Create 2nd Sentry client for frontend http requests

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -919,6 +919,8 @@ SENTRY_FRONTEND_PROJECT = None
 # DSN for the frontend to use explicitly, which takes priority
 # over SENTRY_FRONTEND_PROJECT or SENTRY_PROJECT
 SENTRY_FRONTEND_DSN = None
+# DSN for tracking all client HTTP requests (which can be noisy) [experimental]
+SENTRY_FRONTEND_REQUESTS_DSN = None
 
 # Configuration for JavaScript's whitelistUrls - defaults to ALLOWED_HOSTS
 SENTRY_FRONTEND_WHITELIST_URLS = None

--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -318,7 +318,7 @@ export class Client {
                   path
                 );
 
-                errorObjectToUse.removeFrames(2);
+                errorObjectToUse.removeFrames(3);
 
                 // Setting this to warning because we are going to capture all failed requests
                 scope.setLevel(Sentry.Severity.Warning);

--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -2,13 +2,13 @@ import isUndefined from 'lodash/isUndefined';
 import isNil from 'lodash/isNil';
 import get from 'lodash/get';
 import $ from 'jquery';
-import * as Sentry from '@sentry/browser';
 
 import {
   PROJECT_MOVED,
   SUDO_REQUIRED,
   SUPERUSER_REQUIRED,
 } from 'app/constants/apiErrorCodes';
+import {run} from 'app/utils/apiSentryClient';
 import {metric} from 'app/utils/analytics';
 import {openSudo, redirectToProject} from 'app/actionCreators/modal';
 import {uniqueId} from 'app/utils/guid';
@@ -242,11 +242,13 @@ export class Client {
     try {
       query = $.param(options.query || [], true);
     } catch (err) {
-      Sentry.withScope(scope => {
-        scope.setExtra('path', path);
-        scope.setExtra('query', options.query);
-        Sentry.captureException(err);
-      });
+      run(Sentry =>
+        Sentry.withScope(scope => {
+          scope.setExtra('path', path);
+          scope.setExtra('query', options.query);
+          Sentry.captureException(err);
+        })
+      );
       throw err;
     }
 
@@ -304,24 +306,26 @@ export class Client {
           });
 
           if (resp && resp.status !== 0 && resp.status !== 404) {
-            Sentry.withScope(scope => {
-              // `requestPromise` can pass its error object
-              const preservedError = options.preservedError || errorObject;
+            run(Sentry =>
+              Sentry.withScope(scope => {
+                // `requestPromise` can pass its error object
+                const preservedError = options.preservedError || errorObject;
 
-              const errorObjectToUse = createRequestError(
-                resp,
-                preservedError.stack,
-                method,
-                path
-              );
+                const errorObjectToUse = createRequestError(
+                  resp,
+                  preservedError.stack,
+                  method,
+                  path
+                );
 
-              errorObjectToUse.removeFrames(2);
+                errorObjectToUse.removeFrames(2);
 
-              // Setting this to warning because we are going to capture all failed requests
-              scope.setLevel(Sentry.Severity.Warning);
-              scope.setTag('http.statusCode', String(resp.status));
-              Sentry.captureException(errorObjectToUse);
-            });
+                // Setting this to warning because we are going to capture all failed requests
+                scope.setLevel(Sentry.Severity.Warning);
+                scope.setTag('http.statusCode', String(resp.status));
+                Sentry.captureException(errorObjectToUse);
+              })
+            );
           }
 
           this.handleRequestError(

--- a/src/sentry/static/sentry/app/bootstrap.jsx
+++ b/src/sentry/static/sentry/app/bootstrap.jsx
@@ -20,6 +20,7 @@ import jQuery from 'jquery';
 import moment from 'moment';
 
 import {metric} from 'app/utils/analytics';
+import {init as initApiSentryClient} from 'app/utils/apiSentryClient';
 import ConfigStore from 'app/stores/configStore';
 import Main from 'app/main';
 import ajaxCsrfSetup from 'app/utils/ajaxCsrfSetup';
@@ -49,6 +50,10 @@ function getSentryIntegrations(config) {
 // App setup
 if (window.__initialData) {
   ConfigStore.loadInitialData(window.__initialData);
+
+  if (window.__initialData.dsn_requests) {
+    initApiSentryClient(window.__initialData.dsn_requests);
+  }
 }
 
 // SDK INIT  --------------------------------------------------------

--- a/src/sentry/static/sentry/app/utils/apiSentryClient.tsx
+++ b/src/sentry/static/sentry/app/utils/apiSentryClient.tsx
@@ -1,0 +1,23 @@
+import * as Sentry from '@sentry/browser';
+
+let hub;
+
+function init(dsn) {
+  // This client is used to track all API requests that use `app/api`
+  // This is a bit noisy so we don't want it in the main project (yet)
+  const client = new Sentry.BrowserClient({
+    dsn,
+  });
+
+  hub = new Sentry.Hub(client);
+}
+
+const run = cb => {
+  if (!hub) {
+    return;
+  }
+
+  hub.run(cb);
+};
+
+export {init, run};

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -96,6 +96,13 @@ def _get_public_dsn():
     return result
 
 
+def _get_dsn_requests():
+    if settings.SENTRY_FRONTEND_REQUESTS_DSN:
+        return settings.SENTRY_FRONTEND_REQUESTS_DSN
+
+    return ""
+
+
 def get_client_config(request=None):
     """
     Provides initial bootstrap data needed to boot the frontend application.
@@ -145,6 +152,7 @@ def get_client_config(request=None):
         "distPrefix": get_asset_url("sentry", "dist/"),
         "needsUpgrade": needs_upgrade,
         "dsn": public_dsn,
+        "dsn_requests": _get_dsn_requests(),
         "statuspage": _get_statuspage(),
         "messages": [{"message": msg.message, "level": msg.tags} for msg in messages],
         "apmSampling": float(settings.SENTRY_APM_SAMPLING or 0),

--- a/tests/js/spec/api.spec.jsx
+++ b/tests/js/spec/api.spec.jsx
@@ -279,24 +279,5 @@ describe('api', function() {
         return {};
       });
     });
-
-    it('reports correct error and stacktrace to Sentry', async function() {
-      api.request('/some/url/');
-      await tick();
-
-      const errorObjectSentryCalled = Sentry.captureException.mock.calls[0][0];
-      expect(errorObjectSentryCalled.name).toBe('InternalServerError');
-      expect(errorObjectSentryCalled.message).toBe('GET /some/url/ 500');
-
-      // First line of stack should be this test case
-      expect(errorObjectSentryCalled.stack.split('\n')[1]).toContain('api.spec.jsx');
-    });
-
-    it('reports correct error and stacktrace to Sentry when using promises', async function() {
-      await expect(
-        api.requestPromise('/some/url/')
-      ).rejects.toThrowErrorMatchingInlineSnapshot('"GET /some/url/ 500"');
-      expect(Sentry.captureException).toHaveBeenCalled();
-    });
   });
 });


### PR DESCRIPTION
This was creating a lot of noise, and while I believe has some value, I
think the noise outweighs its value. Lets move this to a separate project
and maybe in the future we can evaluate if we can have APM transactions
solve any needs.