### PR TITLE
fix for github sso issue.  the github client id app mismatch

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -128,8 +128,8 @@ options_mapper = {
     "mail.use-tls": "EMAIL_USE_TLS",
     "mail.from": "SERVER_EMAIL",
     "mail.subject-prefix": "EMAIL_SUBJECT_PREFIX",
-    "github-app.client-id": "GITHUB_APP_ID",
-    "github-app.client-secret": "GITHUB_API_SECRET",
+    "github.client-id": "GITHUB_APP_ID",
+    "github.client-secret": "GITHUB_API_SECRET",
 }
 
 


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/ISSUE-689

It was in front of us the entire time.  :| 

In https://github.com/getsentry/sentry/pull/16550/ , `GITHUB_APP_ID` got mapped to `github-app.client-id` when it should have been mapped to `github.client-id` 

For more context, see https://github.com/getsentry/getsentry/pull/3506