### PR TITLE
fix(discover2): Make Discover2 chart not janky.

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -480,13 +480,19 @@ class EventView {
     return newQuery;
   }
 
-  getGlobalSelection() {
+  getGlobalSelection(): {
+    start: string | undefined;
+    end: string | undefined;
+    statsPeriod: string | undefined;
+    environment: string[];
+    project: number[];
+  } {
     return {
       start: this.start,
       end: this.end,
       statsPeriod: this.statsPeriod,
-      project: this.project,
-      environment: this.environment,
+      project: this.project as number[],
+      environment: this.environment as string[],
     };
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -202,7 +202,7 @@ class Results extends React.Component<Props, State> {
   };
 
   render() {
-    const {organization, location, router} = this.props;
+    const {organization, location, router, api} = this.props;
     const {eventView, error, totalValues} = this.state;
     const query = location.query.query || '';
     const title = this.getDocumentTitle();
@@ -228,6 +228,7 @@ class Results extends React.Component<Props, State> {
                     onSearch={this.handleSearch}
                   />
                   <ResultsChart
+                    api={api}
                     router={router}
                     organization={organization}
                     eventView={eventView}

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -2,48 +2,127 @@ import React from 'react';
 import styled from '@emotion/styled';
 import * as ReactRouter from 'react-router';
 import {Location} from 'history';
+import isEqual from 'lodash/isEqual';
 
 import {Organization} from 'app/types';
-
+import {getUtcToLocalDateObject} from 'app/utils/dates';
+import {Client} from 'app/api';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel} from 'app/components/panels';
 import getDynamicText from 'app/utils/getDynamicText';
-import EventsChart from 'app/views/events/eventsChart';
+import {EventsChart} from 'app/views/events/eventsChart';
 
 import ChartFooter from './chartFooter';
 import EventView from './eventView';
 
-type Props = {
+type ResultsChartProps = {
+  api: Client;
   router: ReactRouter.InjectedRouter;
   organization: Organization;
   eventView: EventView;
   location: Location;
-
-  total: number | null;
-  onAxisChange: (value: string) => void;
 };
 
-export default class ResultsChart extends React.Component<Props> {
+class ResultsChart extends React.Component<ResultsChartProps> {
+  shouldComponentUpdate(nextProps: ResultsChartProps) {
+    const {eventView, ...restProps} = this.props;
+    const {eventView: nextEventView, ...restNextProps} = nextProps;
+
+    if (!eventView.isEqualTo(nextEventView)) {
+      return true;
+    }
+
+    return !isEqual(restProps, restNextProps);
+  }
+
   render() {
-    const {eventView, location, organization, router, total, onAxisChange} = this.props;
+    const {api, eventView, location, organization, router} = this.props;
 
     const yAxisValue = eventView.getYAxis();
 
+    const globalSelection = eventView.getGlobalSelection();
+    const start = globalSelection.start
+      ? getUtcToLocalDateObject(globalSelection.start)
+      : undefined;
+
+    const end = globalSelection.end
+      ? getUtcToLocalDateObject(globalSelection.end)
+      : undefined;
+
+    const {utc} = getParams(location.query);
+
     return (
-      <StyledPanel>
+      <React.Fragment>
         {getDynamicText({
           value: (
             <EventsChart
+              api={api}
               router={router}
               query={eventView.getEventsAPIPayload(location).query}
               organization={organization}
               showLegend
               yAxis={yAxisValue}
-              project={eventView.project as number[]}
-              environment={eventView.environment as string[]}
+              project={globalSelection.project as number[]}
+              environment={globalSelection.environment as string[]}
+              start={start}
+              end={end}
+              period={globalSelection.statsPeriod}
+              utc={utc === 'true'}
             />
           ),
           fixed: 'events chart',
         })}
+      </React.Fragment>
+    );
+  }
+}
+
+type ResultsChartContainerProps = {
+  api: Client;
+  router: ReactRouter.InjectedRouter;
+  eventView: EventView;
+  location: Location;
+  organization: Organization;
+
+  // chart footer props
+  total: number | null;
+  onAxisChange: (value: string) => void;
+};
+
+class ResultsChartContainer extends React.Component<ResultsChartContainerProps> {
+  shouldComponentUpdate(nextProps: ResultsChartContainerProps) {
+    const {eventView, ...restProps} = this.props;
+    const {eventView: nextEventView, ...restNextProps} = nextProps;
+
+    if (!eventView.isEqualTo(nextEventView)) {
+      return true;
+    }
+
+    return !isEqual(restProps, restNextProps);
+  }
+
+  render() {
+    const {
+      api,
+      eventView,
+      location,
+      router,
+      total,
+      onAxisChange,
+      organization,
+    } = this.props;
+
+    const yAxisValue = eventView.getYAxis();
+
+    return (
+      <StyledPanel>
+        <ResultsChart
+          api={api}
+          eventView={eventView}
+          location={location}
+          organization={organization}
+          router={router}
+        />
         <ChartFooter
           total={total}
           yAxisValue={yAxisValue}
@@ -54,6 +133,8 @@ export default class ResultsChart extends React.Component<Props> {
     );
   }
 }
+
+export default ResultsChartContainer;
 
 export const StyledPanel = styled(Panel)`
   @media (min-width: ${p => p.theme.breakpoints[1]}) {

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -62,8 +62,8 @@ class ResultsChart extends React.Component<ResultsChartProps> {
               organization={organization}
               showLegend
               yAxis={yAxisValue}
-              project={globalSelection.project as number[]}
-              environment={globalSelection.environment as string[]}
+              project={globalSelection.project}
+              environment={globalSelection.environment}
               start={start}
               end={end}
               period={globalSelection.statsPeriod}


### PR DESCRIPTION
A few factors were making the Discover2 chart graph seem janky.

The following changes ensures the result graph is loaded at most once:

- We explicitly use EventsChart to avoid usage of withGlobalSelection()
- Explicit shouldComponentUpdate() to explicitly compare EventView objects using their isEqualTo method.