### PR TITLE
fix(direnv) Remove symlink call for pre-commit

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -125,9 +125,6 @@ fi
 
 info "Checking pre-commit..."
 
-# this is cheap, so we'll just do it every time
-ln -sf config/hooks/* .git/hooks
-
 if ! require pre-commit; then
     info "Looks like you don't have pre-commit installed. Let's install it."
     make setup-git

--- a/.envrc
+++ b/.envrc
@@ -130,9 +130,6 @@ if ! require pre-commit; then
     make setup-git
 fi
 
-# this hotfix is cheap too, so just run it every time
-rm -f .git/hooks/pre-commit.legacy
-
 
 ### Node ###
 


### PR DESCRIPTION
This symlink call was messing up the pre-commit hooks. Remove it for now.