### PR TITLE
chore(ui): Fix cryptic react warning in congrats video

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/congratsRobots.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/congratsRobots.jsx
@@ -17,7 +17,7 @@ const Message = () => (
 const CongratsRobots = () => (
   <CongratsRobotsWrapper>
     <AnimatedScene>
-      <StyledVideo autoPlay loop muted>
+      <StyledVideo autoPlay loop>
         <source src={video} type="video/mp4" />
         {/* Show message if browser doesn't support video */}
         <Message />


### PR DESCRIPTION
By removing the `muted` prop on the video tag we get rid of a cryptic
react error:

> unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering

See: https://github.com/airbnb/enzyme/issues/2326

This is likely only in tests, but we don't really need the muted prop,
as the video has no audio track anyway.