### PR TITLE
chore(ui): Fix first-child warning in baseChart

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -346,7 +346,7 @@ const ChartContainer = styled('div')`
     margin-left: -8px;
   }
 
-  .echarts-for-react div:first-child {
+  .echarts-for-react div:first-of-type {
     width: 100% !important;
   }
 `;


### PR DESCRIPTION
Gets rid of the following warning:

> The pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type".

This is functionally equivelent. See: https://stackoverflow.com/questions/24657555/what-is-the-difference-between-first-child-and-first-of-type