### PR TITLE
API-787: Add missing feature descriptions

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -95,6 +95,7 @@ class IntegrationFeatures(Enum):
     # features currently only existing on plugins:
     DATA_FORWARDING = "data-forwarding"
     SESSION_REPLAY = "session-replay"
+    DEPLOYMENT = "deployment"
 
 
 class IntegrationProvider(PipelineProvider):

--- a/src/sentry/plugins/utils.py
+++ b/src/sentry/plugins/utils.py
@@ -1,9 +1,18 @@
 from __future__ import absolute_import
 
 from sentry.plugins.bases import IssueTrackingPlugin2
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 
 class TestIssuePlugin2(IssueTrackingPlugin2):
     """This is only used in tests."""
 
     slug = "issuetrackingplugin2"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Create issues
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        )
+    ]

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -7,6 +7,7 @@ from sentry.plugins.bases.issue2 import IssuePlugin2, IssueGroupActionEndpoint
 from sentry.utils.http import absolute_uri
 
 from sentry_plugins.exceptions import ApiError
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 from .mixins import BitbucketMixin
 from .repository_provider import BitbucketRepositoryProvider
@@ -41,6 +42,27 @@ class BitbucketPlugin(BitbucketMixin, IssuePlugin2):
     conf_key = "bitbucket"
     auth_provider = "bitbucket"
     required_field = "repo"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Track commits and releases (learn more
+            [here](https://docs.sentry.io/learn/releases/))
+            """,
+            IntegrationFeatures.COMMITS,
+        ),
+        FeatureDescription(
+            """
+            Create Bitbucket issues from Sentry
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+        FeatureDescription(
+            """
+            Link Sentry issues to existing Bitbucket issues
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+    ]
 
     def get_group_urls(self):
         return super(BitbucketPlugin, self).get_group_urls() + [

--- a/src/sentry_plugins/clubhouse/plugin.py
+++ b/src/sentry_plugins/clubhouse/plugin.py
@@ -11,6 +11,7 @@ from sentry.utils.http import absolute_uri
 
 from sentry_plugins.base import CorePluginMixin
 from sentry_plugins.utils import get_secret_field_config
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 from .client import ClubhouseClient
 
@@ -22,6 +23,21 @@ class ClubhousePlugin(CorePluginMixin, IssuePlugin2):
     conf_title = title
     conf_key = "clubhouse"
     required_field = "token"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Create and link Sentry issue groups directly to a Clubhouse story in any of your
+            projects, providing a quick way to jump from a Sentry bug to tracked ticket!
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+        FeatureDescription(
+            """
+            Link Sentry issues to existing Clubhouse stories.
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+    ]
 
     issue_fields = frozenset(["id", "title", "url"])
 

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -20,6 +20,7 @@ from sentry.utils.http import absolute_uri
 from sentry_plugins.base import CorePluginMixin
 from sentry_plugins.constants import ERR_UNAUTHORIZED, ERR_INTERNAL
 from sentry_plugins.exceptions import ApiError
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 from .client import GitHubClient, GitHubAppsClient
 
@@ -69,6 +70,24 @@ class GitHubPlugin(GitHubMixin, IssuePlugin2):
     auth_provider = "github"
     required_field = "repo"
     logger = logging.getLogger("sentry.plugins.github")
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Create and link Sentry issue groups directly to a GitHub issue or pull
+            request in any of your repositories, providing a quick way to jump from
+            Sentry bug to tracked issue or PR!
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+        FeatureDescription(
+            """
+            Authorize repositories to be added to your Sentry organization to augment
+            sentry issues with commit data with [deployment
+            tracking](https://docs.sentry.io/learn/releases/).
+            """,
+            IntegrationFeatures.COMMITS,
+        ),
+    ]
 
     def get_group_urls(self):
         return super(GitHubPlugin, self).get_group_urls() + [

--- a/src/sentry_plugins/gitlab/plugin.py
+++ b/src/sentry_plugins/gitlab/plugin.py
@@ -6,6 +6,7 @@ from sentry.utils.http import absolute_uri
 from sentry_plugins.base import CorePluginMixin
 from sentry_plugins.exceptions import ApiError
 from sentry_plugins.utils import get_secret_field_config
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 from .client import GitLabClient
 
@@ -17,6 +18,34 @@ class GitLabPlugin(CorePluginMixin, IssuePlugin2):
     conf_title = title
     conf_key = "gitlab"
     required_field = "gitlab_url"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Track commits and releases (learn more
+            [here](https://docs.sentry.io/learn/releases/))
+            """,
+            IntegrationFeatures.COMMITS,
+        ),
+        FeatureDescription(
+            """
+            Resolve Sentry issues via GitLab commits and merge requests by
+            including `Fixes PROJ-ID` in the message
+            """,
+            IntegrationFeatures.COMMITS,
+        ),
+        FeatureDescription(
+            """
+            Create GitLab issues from Sentry
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+        FeatureDescription(
+            """
+            Link Sentry issues to existing GitLab issues
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        ),
+    ]
 
     def is_configured(self, request, project, **kwargs):
         return bool(

--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -10,6 +10,8 @@ from sentry_plugins.base import CorePluginMixin
 from sentry.plugins.base.configuration import react_plugin_config
 from sentry.plugins.bases import ReleaseTrackingPlugin
 
+from sentry.integrations import FeatureDescription, IntegrationFeatures
+
 logger = logging.getLogger("sentry.plugins.heroku")
 
 
@@ -80,6 +82,14 @@ class HerokuPlugin(CorePluginMixin, ReleaseTrackingPlugin):
     slug = "heroku"
     description = "Integrate Heroku release tracking."
     required_field = "repository"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Integrate Heroku release tracking.
+            """,
+            IntegrationFeatures.DEPLOYMENT,
+        )
+    ]
 
     def configure(self, project, request):
         return react_plugin_config(self, project, request)

--- a/src/sentry_plugins/jira/plugin.py
+++ b/src/sentry_plugins/jira/plugin.py
@@ -23,6 +23,7 @@ from sentry_plugins.base import CorePluginMixin
 from sentry_plugins.exceptions import ApiError, ApiUnauthorized
 from sentry_plugins.jira.client import JiraClient
 from sentry_plugins.utils import get_secret_field_config
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 # A list of common builtin custom field types for JIRA for easy reference.
 JIRA_CUSTOM_FIELD_TYPES = {
@@ -40,6 +41,15 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
     conf_title = title
     conf_key = slug
     required_field = "username"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Create and link Sentry issue groups directly to a Jira ticket in any of your
+            projects, providing a quick way to jump from a Sentry bug to tracked ticket!
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        )
+    ]
 
     def get_group_urls(self):
         _patterns = super(JiraPlugin, self).get_group_urls()

--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -7,6 +7,7 @@ from sentry.utils.http import absolute_uri
 
 from sentry_plugins.base import CorePluginMixin
 from sentry_plugins.utils import get_secret_field_config
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 from .client import PagerDutyClient
 
@@ -18,6 +19,15 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
     conf_key = slug
     conf_title = title
     required_field = "service_key"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Configure rule based PagerDuty alerts to automatically be triggered in a specific
+            service - or in multiple services!
+            """,
+            IntegrationFeatures.ALERT_RULE,
+        )
+    ]
 
     def error_message_from_json(self, data):
         message = data.get("message", "unknown error")

--- a/src/sentry_plugins/slack/plugin.py
+++ b/src/sentry_plugins/slack/plugin.py
@@ -4,6 +4,7 @@ from sentry import http, tagstore
 from sentry.plugins.bases import notify
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 from sentry_plugins.base import CorePluginMixin
 
@@ -22,6 +23,16 @@ class SlackPlugin(CorePluginMixin, notify.NotificationPlugin):
     description = "Post notifications to a Slack channel."
     conf_key = "slack"
     required_field = "webhook"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Configure rule based Slack notifications to automatically be posted into a
+            specific channel. Want any error that's happening more than 100 times a
+            minute to be posted in `#critical-errors`? Setup a rule for it!
+            """,
+            IntegrationFeatures.ALERT_RULE,
+        )
+    ]
 
     def is_configured(self, project):
         return bool(self.get_option("webhook", project))

--- a/src/sentry_plugins/vsts/plugin.py
+++ b/src/sentry_plugins/vsts/plugin.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 from mistune import markdown
 from sentry.plugins.bases.issue2 import IssueTrackingPlugin2
 from sentry.utils.http import absolute_uri
+from sentry.integrations import FeatureDescription, IntegrationFeatures
 
 from .mixins import VisualStudioMixin
 from .repository_provider import VisualStudioRepositoryProvider
@@ -17,6 +18,16 @@ class VstsPlugin(VisualStudioMixin, IssueTrackingPlugin2):
     conf_key = slug
     auth_provider = "visualstudio"
     required_field = "instance"
+    feature_descriptions = [
+        FeatureDescription(
+            """
+            Create and link Sentry issue groups directly to a Azure DevOps work item in any of
+            your projects, providing a quick way to jump from Sentry bug to tracked
+            work item!
+            """,
+            IntegrationFeatures.ISSUE_BASIC,
+        )
+    ]
 
     issue_fields = frozenset(["id", "title", "url"])
 

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -30,10 +30,6 @@ class OrganizationPluginsTest(APITestCase):
         response = self.client.get(self.url)
         assert filter(lambda x: not x["hasConfiguration"], response.data) == []
 
-    def test_all_have_feature_descriptions(self):
-        response = self.client.get(self.url)
-        assert filter(lambda x: not x["featureDescriptions"], response.data) == []
-
     def test_enabled_not_configured(self):
         plugins.get("webhooks").enable(self.projectA)
         response = self.client.get(self.url)

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -30,6 +30,10 @@ class OrganizationPluginsTest(APITestCase):
         response = self.client.get(self.url)
         assert filter(lambda x: not x["hasConfiguration"], response.data) == []
 
+    def test_all_have_feature_descriptions(self):
+        response = self.client.get(self.url)
+        assert filter(lambda x: not x["featureDescriptions"], response.data) == []
+
     def test_enabled_not_configured(self):
         plugins.get("webhooks").enable(self.projectA)
         response = self.client.get(self.url)


### PR DESCRIPTION
API-787: Add missing feature descriptions for project-based integrations:

- bitbucket
- clubhouse
- github
- gitlab
- heroku
- jira
- pagerduty
- slack
