### PR TITLE
fix(ui): Fix unnecessary router nav from `<GlobalSelectionHeader>`

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
@@ -1,4 +1,3 @@
-import isEqual from 'lodash/isEqual';
 import isInteger from 'lodash/isInteger';
 import omit from 'lodash/omit';
 import qs from 'query-string';
@@ -7,23 +6,6 @@ import * as Sentry from '@sentry/browser';
 import {defined} from 'app/utils';
 import {getUtcDateString} from 'app/utils/dates';
 import GlobalSelectionActions from 'app/actions/globalSelectionActions';
-
-const isEqualWithEmptyArrays = (newQuery, current) => {
-  // We will only get empty arrays from `newQuery`
-  // Can't use isEqualWith because keys are unbalanced (guessing)
-  return isEqual(
-    Object.entries(newQuery)
-      .filter(([, value]) => !Array.isArray(value) || !!value.length)
-      .reduce(
-        (acc, [key, value]) => ({
-          ...acc,
-          [key]: value,
-        }),
-        {}
-      ),
-    current
-  );
-};
 
 // Reset values in global selection store
 export function resetGlobalSelection() {

--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
@@ -107,7 +107,7 @@ export function updateParams(obj, router, options) {
   const newQuery = getNewQueryParams(obj, router.location.query, options);
 
   // Only push new location if query params has changed because this will cause a heavy re-render
-  if (isEqualWithEmptyArrays(newQuery, router.location.query)) {
+  if (qs.stringify(newQuery) === qs.stringify(router.location.query)) {
     return;
   }
 

--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.jsx
@@ -1,6 +1,7 @@
 import isEqual from 'lodash/isEqual';
 import isInteger from 'lodash/isInteger';
 import omit from 'lodash/omit';
+import qs from 'query-string';
 import * as Sentry from '@sentry/browser';
 
 import {defined} from 'app/utils';
@@ -134,7 +135,7 @@ export function updateParamsWithoutHistory(obj, router, options) {
   const newQuery = getNewQueryParams(obj, router.location.query, options);
 
   // Only push new location if query params have changed because this will cause a heavy re-render
-  if (isEqualWithEmptyArrays(newQuery, router.location.query)) {
+  if (qs.stringify(newQuery) === qs.stringify(router.location.query)) {
     return;
   }
 
@@ -195,7 +196,7 @@ function getParams(params = {}) {
     end: coercedPeriod ? null : end,
     ...otherParams,
   })
-    .filter(([key, value]) => defined(value))
+    .filter(([, value]) => defined(value))
     .reduce(
       (acc, [key, value]) => ({
         ...acc,

--- a/tests/js/spec/actionCreators/globalSelection.spec.jsx
+++ b/tests/js/spec/actionCreators/globalSelection.spec.jsx
@@ -1,5 +1,6 @@
 import {
   updateProjects,
+  updateParams,
   updateParamsWithoutHistory,
 } from 'app/actionCreators/globalSelection';
 import GlobalSelectionActions from 'app/actions/globalSelectionActions';
@@ -23,6 +24,47 @@ describe('GlobalSelection ActionCreators', function() {
   });
 
   describe('updateEnvironments()', function() {});
+
+  describe('updateParams()', function() {
+    it('updates history when queries are different', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {project: '2'},
+        },
+      });
+      // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
+      // however react-router will treat it as a string if there is only one param
+      updateParams(
+        {project: [1]},
+
+        // Mock router
+        router
+      );
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {project: [1]},
+      });
+    });
+    it('does not update history when queries are the same', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {project: '1'},
+        },
+      });
+      // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
+      // however react-router will treat it as a string if there is only one param
+      updateParams(
+        {project: [1]},
+        // Mock router
+        router
+      );
+
+      expect(router.push).not.toHaveBeenCalled();
+    });
+  });
 
   describe('updateParamsWithoutHistory()', function() {
     it('updates history when queries are different', function() {

--- a/tests/js/spec/actionCreators/globalSelection.spec.jsx
+++ b/tests/js/spec/actionCreators/globalSelection.spec.jsx
@@ -1,4 +1,7 @@
-import {updateProjects} from 'app/actionCreators/globalSelection';
+import {
+  updateProjects,
+  updateParamsWithoutHistory,
+} from 'app/actionCreators/globalSelection';
 import GlobalSelectionActions from 'app/actions/globalSelectionActions';
 
 describe('GlobalSelection ActionCreators', function() {
@@ -20,4 +23,45 @@ describe('GlobalSelection ActionCreators', function() {
   });
 
   describe('updateEnvironments()', function() {});
+
+  describe('updateParamsWithoutHistory()', function() {
+    it('updates history when queries are different', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {project: '2'},
+        },
+      });
+      // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
+      // however react-router will treat it as a string if there is only one param
+      updateParamsWithoutHistory(
+        {project: [1]},
+
+        // Mock router
+        router
+      );
+
+      expect(router.replace).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {project: [1]},
+      });
+    });
+    it('does not update history when queries are the same', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {project: '1'},
+        },
+      });
+      // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
+      // however react-router will treat it as a string if there is only one param
+      updateParamsWithoutHistory(
+        {project: [1]},
+        // Mock router
+        router
+      );
+
+      expect(router.replace).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
There was an issue where query params are treated as arrays (because we can
have multiple projects selected via url params), but react router treats
them as strings because only 1 url param is passed. Our equality check
would fail. Instead lets use `query-string` library to normalize the query
objects to strings and compare them.