### PR TITLE
fix(discover) Fix query parsing and expanded view URL generation

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -278,6 +278,8 @@ def tokenize_query(query):
         'query': ['foo', 'bar'],
         'tag': ['value'],
     }
+
+    Has a companion implementation in static/app/utils/tokenizeSearch.tsx
     """
     result = defaultdict(list)
     query_params = defaultdict(list)

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -288,7 +288,7 @@ def tokenize_query(query):
         state = "query"
         for idx, char in enumerate(token):
             next_char = token[idx + 1] if idx < len(token) - 1 else None
-            if idx == 0 and char in ('"', "'"):
+            if idx == 0 and char in ('"', "'", ":"):
                 break
             if char == ":":
                 if next_char in (":", " "):

--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -19,7 +19,7 @@ export type QueryResults = {
  *     tag: ['value'],
  *   }
  *
- * Should stay in sync with src/sentry/search/utils:tokenize_query
+ * Should stay in sync with src.sentry.search.utils:tokenize_query
  */
 export function tokenizeSearch(query: string) {
   const tokens = splitSearchIntoTokens(query);
@@ -74,7 +74,7 @@ export function stringifyQueryObject(results: QueryResults) {
   const {query, ...tags} = results;
 
   const stringTags = flatMap(Object.entries(tags), ([k, values]) =>
-    values.map(tag => `${k}:${/\s/g.test(tag) ? `"${tag}"` : tag}`)
+    values.map(tag => `${k}:${/[\s\(\)]/g.test(tag) ? `"${tag}"` : tag}`)
   );
 
   return `${query.join(' ')} ${stringTags.join(' ')}`.trim();

--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -9,7 +9,7 @@ export type QueryResults = {
 };
 
 /**
- * Tokenize a search into a an object
+ * Tokenize a search into an object
  *
  * Example:
  *   tokenizeSearch('is:resolved foo bar tag:value');
@@ -18,6 +18,8 @@ export type QueryResults = {
  *     query: ['foo', 'bar'],
  *     tag: ['value'],
  *   }
+ *
+ * Should stay in sync with src/sentry/search/utils:tokenize_query
  */
 export function tokenizeSearch(query: string) {
   const tokens = splitSearchIntoTokens(query);
@@ -35,21 +37,19 @@ export function tokenizeSearch(query: string) {
     for (let i = 0, len = token.length; i < len; i++) {
       const char = token[i];
 
+      if (i === 0 && char === '"') {
+        break;
+      }
+
       // We may have entered a tag condition
       if (char === ':') {
-        tokenState = 'tags';
         const nextChar = token[i + 1] || '';
-
-        if (nextChar === '"') {
-          break;
-        }
-
-        // If we have a space or colon, we are in a query string,
-        // not a tag and can stop scanning.
-        if ([' ', ':'].includes(nextChar)) {
+        if ([':', ' '].includes(nextChar)) {
           tokenState = 'query';
-          break;
+        } else {
+          tokenState = 'tags';
         }
+        break;
       }
     }
     searchParams[tokenState].push(token);

--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -37,7 +37,7 @@ export function tokenizeSearch(query: string) {
     for (let i = 0, len = token.length; i < len; i++) {
       const char = token[i];
 
-      if (i === 0 && char === '"') {
+      if (i === 0 && (char === '"' || char === ':')) {
         break;
       }
 

--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -28,24 +28,30 @@ export function tokenizeSearch(query: string) {
   };
 
   for (const token of tokens) {
-    const tokenChars = Array.from(token);
     let tokenState: 'query' | 'tags' = 'query';
 
-    tokenChars.forEach((char, idx) => {
-      const nextChar = tokenChars.length > idx ? tokenChars[idx + 1] : null;
+    // Traverse the token and determine if it is a tag
+    // condition or bare words.
+    for (let i = 0, len = token.length; i < len; i++) {
+      const char = token[i];
 
-      if (idx === 0 && [':', ' '].includes(char)) {
-        return;
-      }
-
+      // We may have entered a tag condition
       if (char === ':') {
-        tokenState = [':', ' '].includes(nextChar !== null ? nextChar : '')
-          ? 'query'
-          : 'tags';
-        return;
-      }
-    });
+        tokenState = 'tags';
+        const nextChar = token[i + 1] || '';
 
+        if (nextChar === '"') {
+          break;
+        }
+
+        // If we have a space or colon, we are in a query string,
+        // not a tag and can stop scanning.
+        if ([' ', ':'].includes(nextChar)) {
+          tokenState = 'query';
+          break;
+        }
+      }
+    }
     searchParams[tokenState].push(token);
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -478,48 +478,35 @@ export function getExpandedResults(
     nextView = nextView.withDeletedColumn(index, undefined);
   });
 
-  // filter out any aggregates from the search conditions.
+  const parsedQuery = tokenizeSearch(nextView.query);
+
+  // Remove any aggregates from the search conditions.
   // otherwise, it'll lead to an invalid query result.
-  const queryWithNoAggregates = Object.entries(tokenizeSearch(nextView.query)).reduce(
-    (acc: QueryResults, [field, value]) => {
-      if (field === 'query') {
-        acc.query = value;
-        return acc;
-      }
+  for (const key in parsedQuery) {
+    const column = explodeFieldString(key);
+    if (column.aggregation) {
+      delete parsedQuery[key];
+    }
+  }
 
-      const column = explodeFieldString(field);
-      if (column.aggregation) {
-        return acc;
-      }
-
-      acc[field] = value;
-
-      return acc;
-    },
-    {query: []}
-  );
-  nextView.query = stringifyQueryObject(queryWithNoAggregates);
-
-  // Tokenize conditions and append additional conditions provided + generated.
-  Object.keys(additionalConditions).forEach(key => {
+  // Add additional conditions provided and generated.
+  for (const key in additionalConditions) {
     if (key === 'project' || key === 'project.id') {
       nextView.project = [...nextView.project, parseInt(additionalConditions[key], 10)];
-      return;
+      continue;
     }
     if (key === 'environment') {
       nextView.environment = [...nextView.environment, additionalConditions[key]];
-      return;
+      continue;
     }
-
-    // filter out any aggregates from provided additional conditions.
-    // otherwise, it'll lead to an invalid query result.
     const column = explodeFieldString(key);
+    // Skip aggregates as they will be invalid.
     if (column.aggregation) {
-      return;
+      continue;
     }
-
-    nextView.query = appendTagCondition(nextView.query, key, additionalConditions[key]);
-  });
+    parsedQuery[key] = [additionalConditions[key]];
+  }
+  nextView.query = stringifyQueryObject(parsedQuery);
 
   return nextView;
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -5,11 +5,7 @@ import isString from 'lodash/isString';
 import {Location, Query} from 'history';
 import {browserHistory} from 'react-router';
 
-import {
-  tokenizeSearch,
-  stringifyQueryObject,
-  QueryResults,
-} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
 import {t} from 'app/locale';
 import {Event, Organization, OrganizationSummary} from 'app/types';
 import {Client} from 'app/api';
@@ -18,7 +14,6 @@ import {getUtcDateString} from 'app/utils/dates';
 import {TagSegment} from 'app/components/tagDistributionMeter';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {disableMacros} from 'app/views/discover/result/utils';
-import {appendTagCondition} from 'app/utils/queryString';
 import {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
 
 import {

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -39,8 +39,8 @@ describe('utils/tokenizeSearch', function() {
       },
       {
         name: 'should tokenize words with :: in them',
-        string: 'Foo::bar()',
-        object: {query: ['Foo::bar()']},
+        string: 'key:Resque::DirtyExit',
+        object: {query: [], key: ['Resque::DirtyExit']},
       },
     ];
 

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -42,6 +42,11 @@ describe('utils/tokenizeSearch', function() {
         string: 'key:Resque::DirtyExit',
         object: {query: [], key: ['Resque::DirtyExit']},
       },
+      {
+        name: 'tokens that begin with a colon are still queries',
+        string: 'country:canada :unresolved',
+        object: {query: [':unresolved'], country: ['canada']},
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -76,6 +76,11 @@ describe('utils/tokenizeSearch', function() {
         object: {query: ['oh me', 'oh my'], browser: ['Chrome 36', 'Firefox 60']},
         string: 'oh me oh my browser:"Chrome 36" browser:"Firefox 60"',
       },
+      {
+        name: 'should quote tags with parens',
+        object: {query: ['bad things'], repository_id: ["UUID('long-value')"]},
+        string: 'bad things repository_id:"UUID(\'long-value\')"',
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -28,6 +28,20 @@ describe('utils/tokenizeSearch', function() {
         string: 'python  is:unresolved exception',
         object: {is: ['unresolved'], query: ['python', 'exception']},
       },
+      {
+        name: 'should tokenize the quoted tags',
+        string: 'event.type:error title:"QueryExecutionError: Code: 141."',
+        object: {
+          query: [],
+          title: ['QueryExecutionError: Code: 141.'],
+          'event.type': ['error'],
+        },
+      },
+      {
+        name: 'should tokenize words with :: in them',
+        string: 'Foo::bar()',
+        object: {query: ['Foo::bar()']},
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -390,7 +390,7 @@ describe('getExpandedResults()', function() {
 
     // appends to existing conditions
     result = getExpandedResults(view, {'event.type': 'csp'}, {});
-    expect(result.query).toEqual('event.type:error event.type:csp');
+    expect(result.query).toEqual('event.type:csp');
   });
 
   it('removes any aggregates in either search conditions or extra conditions', () => {
@@ -469,6 +469,18 @@ describe('getExpandedResults()', function() {
     };
     const result = getExpandedResults(view, {}, event);
     expect(result.query).toEqual('event.type:error timestamp:2020-02-13T17:05:46');
+  });
+
+  it('does not duplicate conditions', () => {
+    const view = new EventView({
+      ...state,
+      query: 'event.type:error title:bogus',
+    });
+    const event = {
+      title: 'bogus',
+    };
+    const result = getExpandedResults(view, {trace: 'abc123'}, event);
+    expect(result.query).toEqual('event.type:error title:bogus trace:abc123');
   });
 });
 

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -468,6 +468,12 @@ class ParseQueryTest(TestCase):
         result = self.parse_query('"release:foo"')
         assert result == {"tags": {}, "query": "release:foo"}
 
+    def test_quoted_tag_value(self):
+        result = self.parse_query('event.type:error title:"QueryExecutionError: Code: 141."')
+        assert result["query"] == ""
+        assert result["tags"]["title"] == "QueryExecutionError: Code: 141."
+        assert result["tags"]["event.type"] == "error"
+
 
 class GetLatestReleaseTest(TestCase):
     def test(self):

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -474,6 +474,11 @@ class ParseQueryTest(TestCase):
         assert result["tags"]["title"] == "QueryExecutionError: Code: 141."
         assert result["tags"]["event.type"] == "error"
 
+    def test_leading_colon(self):
+        result = self.parse_query('country:canada :unresolved')
+        assert result["query"] == ":unresolved"
+        assert result["tags"]["country"] == "canada"
+
 
 class GetLatestReleaseTest(TestCase):
     def test(self):


### PR DESCRIPTION
Our query string parser was incorrectly handling quoted strings in tag values. This resulted in broken conditions being generated when searches included a quoted string in the first token.

I've also fixed the query generation for tag links in the details view. These conditions would duplicate conditions of a field was in both the selected results and condition string. Now the inferred value overwrites the previous condition.