### PR TITLE
fix(apm): Add error_rate as yAxis option.

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -30,6 +30,7 @@ export const AGGREGATE_ALIASES = [
   'p99',
   'last_seen',
   'latest_event',
+  'error_rate',
 ];
 
 // default list of yAxis options

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -164,4 +164,5 @@ export const TRACING_FIELDS = [
   'p99',
   'p95',
   'p75',
+  'error_rate',
 ];


### PR DESCRIPTION
Add `error_rate` as a yAxis option. I also marked `error_rate` as one of the tracing fields to be removed for customers that don't have access to transactions. 