### PR TITLE
test(js): Throw on `console.error` during js tests

### DIFF
--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -1,31 +1,26 @@
 // eslint-disable-next-line no-console
 const originalConsoleError = console.error;
 
-// List of `console.error` messages to fail on
-const BAD_ERRORS = [
-  'Failed prop type',
-  'Failed child context type',
-  'Warning: Each child in an array or iterator should have a unique "key" prop',
-  'React does not recognize the `[^`]+` prop on a DOM element',
-  'Warning: Received `[^`]+` for a non-boolean attribute `[^`]+`',
-];
+// List of `console.error` messages to ignore
+// (i.e. don't fail tests when we get these messages)
+const IGNORED_ERRORS = ['Warning: Creatable Select'];
 
 // This is needed because when we throw the captured error message, it will
 // also `console.error` it
 const REPEATED_ERROR = 'Error: Uncaught [Error: Warning: ';
 
-const BAD_ERRORS_REGEX = new RegExp(BAD_ERRORS.join('|'));
+const IGNORED_ERRORS_REGEX = new RegExp(IGNORED_ERRORS.join('|'));
 
 // eslint-disable-next-line no-console
 console.error = (message, ...args) => {
   if (
     typeof message === 'string' &&
     message.indexOf(REPEATED_ERROR) !== 0 &&
-    BAD_ERRORS_REGEX.test(message)
+    !IGNORED_ERRORS_REGEX.test(message)
   ) {
     originalConsoleError(message, ...args);
     throw new Error(message);
-  } else if (!BAD_ERRORS_REGEX.test(message)) {
+  } else if (IGNORED_ERRORS_REGEX.test(message)) {
     originalConsoleError(message, ...args);
   }
 };

--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -1,26 +1,37 @@
+/* global fail */
+
 // eslint-disable-next-line no-console
 const originalConsoleError = console.error;
 
 // List of `console.error` messages to ignore
 // (i.e. don't fail tests when we get these messages)
-const IGNORED_ERRORS = ['Warning: Creatable Select'];
+const IGNORED_ERRORS = [
+  (message, ...args) => message?.includes('Warning: ') && args[0] === 'CreatableSelect',
+  message =>
+    message?.includes(
+      'The pseudo class ":first-child" is potentially unsafe when doing server-side rendering.'
+    ),
+];
 
 // This is needed because when we throw the captured error message, it will
 // also `console.error` it
-const REPEATED_ERROR = 'Error: Uncaught [Error: Warning: ';
+const REPEATED_ERROR = 'Error: Uncaught [Error: ';
 
-const IGNORED_ERRORS_REGEX = new RegExp(IGNORED_ERRORS.join('|'));
+jest.spyOn(console, 'error').mockImplementation((message, ...args) => {
+  const isIgnored = IGNORED_ERRORS.some(checkFn => checkFn(message, ...args));
 
-// eslint-disable-next-line no-console
-console.error = (message, ...args) => {
   if (
     typeof message === 'string' &&
     message.indexOf(REPEATED_ERROR) !== 0 &&
-    !IGNORED_ERRORS_REGEX.test(message)
+    !isIgnored
   ) {
     originalConsoleError(message, ...args);
-    throw new Error(message);
-  } else if (IGNORED_ERRORS_REGEX.test(message)) {
-    originalConsoleError(message, ...args);
+    const err = new Error('Warnings received from console.error()');
+    const lines = err.stack?.split('\n');
+    const startIndex = lines?.findIndex(line => line.includes('tests/js/spec'));
+    err.stack = ['\n', lines?.[0], ...lines?.slice(startIndex)].join('\n');
+
+    // `fail` is a global from jest/jasmine
+    fail(err);
   }
-};
+});


### PR DESCRIPTION
jest will now fail whenever `console.error` is called - there is a list of ignored messages.