### PR TITLE
test(async-csv): Add frontend error handling and view tests

### DIFF
--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {Client} from 'app/api';
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import Feature from 'app/components/acl/feature';
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
@@ -40,17 +41,22 @@ class DataExport extends React.Component<Props, State> {
       organization: {slug},
       payload: {queryType, queryInfo},
     } = this.props;
-    const {id: dataExportId} = await api.requestPromise(
-      `/organizations/${slug}/data-export/`,
-      {
-        method: 'POST',
-        data: {
-          query_type: queryType,
-          query_info: queryInfo,
-        },
-      }
-    );
-    this.setState({inProgress: true, dataExportId});
+    try {
+      const {id: dataExportId} = await api.requestPromise(
+        `/organizations/${slug}/data-export/`,
+        {
+          method: 'POST',
+          data: {
+            query_type: queryType,
+            query_info: queryInfo,
+          },
+        }
+      );
+      addSuccessMessage(t("We'll email you when it's ready for download"));
+      this.setState({inProgress: true, dataExportId});
+    } catch (_err) {
+      addErrorMessage(t('Unable to begin bulk data export. Please try again.'));
+    }
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -9,7 +9,7 @@ import {t} from 'app/locale';
 
 import Button from 'app/components/button';
 
-enum DownloadStatus {
+export enum DownloadStatus {
   Early = 'EARLY',
   Valid = 'VALID',
   Expired = 'EXPIRED',
@@ -100,6 +100,7 @@ class DataDownload extends AsyncView<Props, State> {
           size="large"
           borderless
           href={`/api/0/organizations/${orgId}/data-export/${dataExportId}/?download=true`}
+          data-test="datadownload-button"
         >
           {t('Download CSV')}
         </Button>
@@ -127,7 +128,9 @@ class DataDownload extends AsyncView<Props, State> {
     return (
       <PageContent>
         <div className="pattern-bg" />
-        <ContentContainer>{this.renderContent()}</ContentContainer>
+        <ContentContainer data-test="datadownload-wrapper">
+          {this.renderContent()}
+        </ContentContainer>
       </PageContent>
     );
   }

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -100,7 +100,6 @@ class DataDownload extends AsyncView<Props, State> {
           size="large"
           borderless
           href={`/api/0/organizations/${orgId}/data-export/${dataExportId}/?download=true`}
-          data-test="datadownload-button"
         >
           {t('Download CSV')}
         </Button>
@@ -128,9 +127,7 @@ class DataDownload extends AsyncView<Props, State> {
     return (
       <PageContent>
         <div className="pattern-bg" />
-        <ContentContainer data-test="datadownload-wrapper">
-          {this.renderContent()}
-        </ContentContainer>
+        <ContentContainer>{this.renderContent()}</ContentContainer>
       </PageContent>
     );
   }

--- a/tests/js/spec/views/dataExport/dataDownload.spec.jsx
+++ b/tests/js/spec/views/dataExport/dataDownload.spec.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import DataDownload, {DownloadStatus} from 'app/views/dataExport/dataDownload';
+
+describe('DataDownload', function() {
+  beforeEach(MockApiClient.clearMockResponses);
+  const dateExpired = new Date();
+  const mockRouteParams = {
+    orgId: 'acme',
+    dataExportId: 721,
+  };
+  const getDataExportDetails = body =>
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockRouteParams.orgId}/data-export/${mockRouteParams.dataExportId}/`,
+      body,
+    });
+
+  it('should send a request to the data export endpoint', function() {
+    const getValid = getDataExportDetails(DownloadStatus.Valid);
+    mountWithTheme(<DataDownload params={mockRouteParams} />);
+    expect(getValid).toHaveBeenCalled();
+  });
+
+  it("should render the 'Early' view when appropriate", function() {
+    const status = DownloadStatus.Early;
+    getDataExportDetails({status});
+    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
+    expect(wrapper.state('download')).toEqual({status});
+    expect(wrapper.state('download').dateExpired).toBeUndefined();
+    const contentWrapper = wrapper.find('div[data-test="datadownload-wrapper"]');
+    expect(contentWrapper.children()).toHaveLength(3);
+    expect(contentWrapper.find('h3').text()).toBe("You're Early!");
+  });
+
+  it("should render the 'Expired' view when appropriate", function() {
+    const status = DownloadStatus.Expired;
+    getDataExportDetails({status});
+    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
+    expect(wrapper.state('download')).toEqual({status});
+    expect(wrapper.state('download').dateExpired).toBeUndefined();
+    const contentWrapper = wrapper.find('div[data-test="datadownload-wrapper"]');
+    expect(contentWrapper.children()).toHaveLength(3);
+    expect(contentWrapper.find('h3').text()).toBe('Sorry!');
+  });
+
+  it("should render the 'Valid' view when appropriate", function() {
+    const status = DownloadStatus.Valid;
+    getDataExportDetails({status, dateExpired});
+    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
+    expect(wrapper.state('download')).toEqual({dateExpired, status});
+    const contentWrapper = wrapper.find('div[data-test="datadownload-wrapper"]');
+    expect(contentWrapper.children()).toHaveLength(5);
+    expect(contentWrapper.find('h3').text()).toBe('Finally!');
+    const buttonWrapper = contentWrapper.find('a[data-test="datadownload-button"]');
+    expect(buttonWrapper.text()).toBe('Download CSV');
+    expect(buttonWrapper.props().href).toBe(
+      `/api/0/organizations/${mockRouteParams.orgId}/data-export/${mockRouteParams.dataExportId}/?download=true`
+    );
+    const dateString = d => `${d.toLocaleDateString()}, ${d.toLocaleTimeString()}`;
+    expect(contentWrapper.find('b').text()).toBe(dateString(dateExpired));
+  });
+});

--- a/tests/js/spec/views/dataExport/dataDownload.spec.jsx
+++ b/tests/js/spec/views/dataExport/dataDownload.spec.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountWithTheme, shallow} from 'sentry-test/enzyme';
 
 import DataDownload, {DownloadStatus} from 'app/views/dataExport/dataDownload';
 
 describe('DataDownload', function() {
   beforeEach(MockApiClient.clearMockResponses);
   const dateExpired = new Date();
+  const organization = TestStubs.Organization();
   const mockRouteParams = {
-    orgId: 'acme',
+    orgId: organization.slug,
     dataExportId: 721,
   };
   const getDataExportDetails = body =>
@@ -25,10 +26,10 @@ describe('DataDownload', function() {
   it("should render the 'Early' view when appropriate", function() {
     const status = DownloadStatus.Early;
     getDataExportDetails({status});
-    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
+    const wrapper = shallow(<DataDownload params={mockRouteParams} />);
     expect(wrapper.state('download')).toEqual({status});
     expect(wrapper.state('download').dateExpired).toBeUndefined();
-    const contentWrapper = wrapper.find('div[data-test="datadownload-wrapper"]');
+    const contentWrapper = wrapper.find('ContentContainer');
     expect(contentWrapper.children()).toHaveLength(3);
     expect(contentWrapper.find('h3').text()).toBe("You're Early!");
   });
@@ -36,10 +37,10 @@ describe('DataDownload', function() {
   it("should render the 'Expired' view when appropriate", function() {
     const status = DownloadStatus.Expired;
     getDataExportDetails({status});
-    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
+    const wrapper = shallow(<DataDownload params={mockRouteParams} />);
     expect(wrapper.state('download')).toEqual({status});
     expect(wrapper.state('download').dateExpired).toBeUndefined();
-    const contentWrapper = wrapper.find('div[data-test="datadownload-wrapper"]');
+    const contentWrapper = wrapper.find('ContentContainer');
     expect(contentWrapper.children()).toHaveLength(3);
     expect(contentWrapper.find('h3').text()).toBe('Sorry!');
   });
@@ -49,10 +50,10 @@ describe('DataDownload', function() {
     getDataExportDetails({status, dateExpired});
     const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
     expect(wrapper.state('download')).toEqual({dateExpired, status});
-    const contentWrapper = wrapper.find('div[data-test="datadownload-wrapper"]');
+    const contentWrapper = wrapper.find('ContentContainer').childAt(0);
     expect(contentWrapper.children()).toHaveLength(5);
     expect(contentWrapper.find('h3').text()).toBe('Finally!');
-    const buttonWrapper = contentWrapper.find('a[data-test="datadownload-button"]');
+    const buttonWrapper = contentWrapper.find('a[aria-label="Download CSV"]');
     expect(buttonWrapper.text()).toBe('Download CSV');
     expect(buttonWrapper.props().href).toBe(
       `/api/0/organizations/${mockRouteParams.orgId}/data-export/${mockRouteParams.dataExportId}/?download=true`


### PR DESCRIPTION
This PR will be adding some more unit tests, as well as a few tweaks to the error handling on the frontend using some toast notifications