### PR TITLE
ref(oauth): stop using deprecated query param for github

### DIFF
--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -9,8 +9,10 @@ def get_user_info(access_token):
     session = http.build_session()
     resp = session.get(
         "https://api.github.com/user",
-        params={"access_token": access_token},
-        headers={"Accept": "application/vnd.github.machine-man-preview+json"},
+        headers={
+            "Accept": "application/vnd.github.machine-man-preview+json",
+            "Authorization": "token %s" % access_token,
+        },
     )
     resp.raise_for_status()
     resp = resp.json()


### PR DESCRIPTION
Github is deprecating using auth query parameters. This PR fixes one case where it's used for `GitHubIdentityProvider`. For more details see: https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

This change was copied from @mattrobenolt's PR: #17022