### PR TITLE
fix(subscriptions): Retry when we get arbitrary errors from snuba while creating/deleting subscriptions

### DIFF
--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -214,7 +214,6 @@ def _create_in_snuba(
                 "resolution": int(resolution.total_seconds()),
             }
         ),
-        retries=False,
     )
     if response.status != 202:
         raise SnubaError("HTTP %s response from Snuba!" % response.status)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -218,11 +218,11 @@ _snuba_pool = connection_from_url(
     settings.SENTRY_SNUBA,
     retries=RetrySkipTimeout(
         total=5,
-        # Expand our retries to POST since all of
-        # our requests are POST and they don't mutate, so they
-        # are safe to retry. Without this, we aren't
-        # actually retrying at all.
-        method_whitelist={"GET", "POST"},
+        # Our calls to snuba frequently fail due to network issues. We want to
+        # automatically retry most requests. Some of our POSTs and all of our DELETEs
+        # do cause mutations, but we have other things in place to handle duplicate
+        # mutations.
+        method_whitelist={"GET", "POST", "DELETE"},
     ),
     timeout=30,
     maxsize=10,


### PR DESCRIPTION
I deliberately disabled this previously so that we wouldn't create duplicate mutations. It seems
like we have to do this though since these happen reasonably frequently.

Will follow this up with a PR to automatically delete subscriptions that we don't have a record of
in sentry, so that we don't have useless subscriptions running for no reason.

Is probably worth also adding stats to determine how often we're retrying here too. Will look into
that separately.