### PR TITLE
feature(search) - Allow aliases for durations

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -9,7 +9,7 @@ import six
 from django.utils.functional import cached_property
 from parsimonious.expressions import Optional
 from parsimonious.exceptions import IncompleteParseError, ParseError
-from parsimonious.nodes import Node
+from parsimonious.nodes import Node, RegexNode
 from parsimonious.grammar import Grammar, NodeVisitor
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 
@@ -17,6 +17,7 @@ from sentry import eventstore
 from sentry.models import Project
 from sentry.models.group import Group
 from sentry.search.utils import (
+    parse_duration,
     parse_datetime_range,
     parse_datetime_string,
     parse_datetime_value,
@@ -97,7 +98,7 @@ search               = (boolean_term / paren_term / search_term)*
 boolean_term         = (paren_term / search_term) space? (boolean_operator space? (paren_term / search_term) space?)+
 paren_term           = space? open_paren space? (paren_term / boolean_term)+ space? closed_paren space?
 search_term          = key_val_term / quoted_raw_search / raw_search
-key_val_term         = space? (tag_filter / time_filter / rel_time_filter / specific_time_filter
+key_val_term         = space? (tag_filter / time_filter / rel_time_filter / specific_time_filter / duration_filter
                        / numeric_filter / aggregate_filter / aggregate_date_filter / has_filter
                        / is_filter / quoted_basic_filter / basic_filter)
                        space?
@@ -111,12 +112,14 @@ quoted_basic_filter  = negation? search_key sep quoted_value
 time_filter          = search_key sep? operator date_format
 # filter for relative dates
 rel_time_filter      = search_key sep rel_date_format
+# filter for durations
+duration_filter      = search_key sep operator? duration_format
 # exact time filter for dates
 specific_time_filter = search_key sep date_format
 # Numeric comparison filter
 numeric_filter       = search_key sep operator? numeric_value
 # Aggregate numeric filter
-aggregate_filter        = aggregate_key sep operator? numeric_value
+aggregate_filter        = aggregate_key sep operator? (numeric_value / duration_format)
 aggregate_date_filter   = aggregate_key sep operator? (date_format / rel_date_format)
 
 # has filter for not null type checks
@@ -138,6 +141,7 @@ quoted_key           = ~r"\"([a-zA-Z0-9_\.:-]+)\""
 
 date_format          = ~r"\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{1,6})?)?Z?(?=\s|$)"
 rel_date_format      = ~r"[\+\-][0-9]+[wdhm](?=\s|$)"
+duration_format      = ~r"([0-9\.]+)(ms|s|min|hr|day|wk)(?=\s|$)"
 
 # NOTE: the order in which these operators are listed matters
 # because for example, if < comes before <= it will match that
@@ -234,6 +238,7 @@ class SearchVisitor(NodeVisitor):
     # A list of mappers that map source keys to a target name. Format is
     # <target_name>: [<list of source names>],
     key_mappings = {}
+    duration_keys = set(["transaction.duration", "p75", "p95", "p99"])
     numeric_keys = set(
         [
             "project_id",
@@ -389,12 +394,16 @@ class SearchVisitor(NodeVisitor):
     def visit_aggregate_filter(self, node, children):
         (search_key, _, operator, search_value) = children
         operator = operator[0] if not isinstance(operator, Node) else "="
+        search_value = search_value[0] if not isinstance(search_value, RegexNode) else search_value
 
         try:
-            search_value = SearchValue(float(search_value.text))
+            if search_value.expr_name == "duration_format":
+                search_value = parse_duration(*search_value.match.groups())
+            else:
+                search_value = float(search_value.text)
         except ValueError:
             raise InvalidSearchQuery(u"Invalid aggregate query condition: {}".format(search_key))
-        return AggregateFilter(search_key, operator, search_value)
+        return AggregateFilter(search_key, operator, SearchValue(search_value))
 
     def visit_aggregate_date_filter(self, node, children):
         (search_key, _, operator, search_value) = children
@@ -417,6 +426,20 @@ class SearchVisitor(NodeVisitor):
         if search_key.name in self.date_keys:
             try:
                 search_value = parse_datetime_string(search_value)
+            except InvalidQuery as exc:
+                raise InvalidSearchQuery(six.text_type(exc))
+            return SearchFilter(search_key, operator, SearchValue(search_value))
+        else:
+            search_value = operator + search_value if operator != "=" else search_value
+            return self._handle_basic_filter(search_key, "=", SearchValue(search_value))
+
+    def visit_duration_filter(self, node, children):
+        (search_key, _, operator, search_value) = children
+
+        operator = operator[0] if not isinstance(operator, Node) else "="
+        if search_key.name in self.duration_keys:
+            try:
+                search_value = parse_duration(*search_value.match.groups())
             except InvalidQuery as exc:
                 raise InvalidSearchQuery(six.text_type(exc))
             return SearchFilter(search_key, operator, SearchValue(search_value))

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -403,6 +403,8 @@ class SearchVisitor(NodeVisitor):
                 search_value = float(search_value.text)
         except ValueError:
             raise InvalidSearchQuery(u"Invalid aggregate query condition: {}".format(search_key))
+        except InvalidQuery as exc:
+            raise InvalidSearchQuery(six.text_type(exc))
         return AggregateFilter(search_key, operator, SearchValue(search_value))
 
     def visit_aggregate_date_filter(self, node, children):

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -141,7 +141,7 @@ quoted_key           = ~r"\"([a-zA-Z0-9_\.:-]+)\""
 
 date_format          = ~r"\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{1,6})?)?Z?(?=\s|$)"
 rel_date_format      = ~r"[\+\-][0-9]+[wdhm](?=\s|$)"
-duration_format      = ~r"([0-9\.]+)(ms|s|min|hr|day|wk)(?=\s|$)"
+duration_format      = ~r"([0-9\.]+)(ms|s|min|m|hr|h|day|d|wk|w)(?=\s|$)"
 
 # NOTE: the order in which these operators are listed matters
 # because for example, if < comes before <= it will match that
@@ -238,7 +238,7 @@ class SearchVisitor(NodeVisitor):
     # A list of mappers that map source keys to a target name. Format is
     # <target_name>: [<list of source names>],
     key_mappings = {}
-    duration_keys = set(["transaction.duration", "p75", "p95", "p99"])
+    duration_keys = set(["transaction.duration"])
     numeric_keys = set(
         [
             "project_id",
@@ -403,8 +403,7 @@ class SearchVisitor(NodeVisitor):
                 _, agg_additions = resolve_field(search_key.name, None)
                 if len(agg_additions) > 0:
                     # Extract column and function name out so we can check if we should parse as duration
-                    column, function = agg_additions[0][-2:]
-                    if column in self.duration_keys or function in self.duration_keys:
+                    if agg_additions[0][-2] in self.duration_keys:
                         aggregate_value = parse_duration(*search_value.match.groups())
 
             if aggregate_value is None:

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -40,6 +40,28 @@ def parse_status_value(value):
     raise ValueError("Invalid status value")
 
 
+def parse_duration(value, interval, granularity=0.01):
+    value = float(value)
+    if interval == "ms":
+        delta = timedelta(milliseconds=value)
+    elif interval == "s":
+        delta = timedelta(seconds=value)
+    elif interval == "min":
+        delta = timedelta(minutes=value)
+    elif interval == "hr":
+        delta = timedelta(hours=value)
+    elif interval == "day":
+        delta = timedelta(days=value)
+    elif interval == "wk":
+        delta = timedelta(days=value * 7)
+    else:
+        raise InvalidQuery(
+            u"{} is not a valid duration type, must be ms, s, min, hr, day or wk".format(interval)
+        )
+
+    return delta.total_seconds() * 1000.0
+
+
 def parse_datetime_range(value):
     try:
         flag, count, interval = value[0], int(value[1:-1]), value[-1]

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -40,8 +40,12 @@ def parse_status_value(value):
     raise ValueError("Invalid status value")
 
 
-def parse_duration(value, interval, granularity=0.01):
-    value = float(value)
+def parse_duration(value, interval):
+    try:
+        value = float(value)
+    except ValueError:
+        raise InvalidQuery(u"{} is not a valid duration value".format(value))
+
     if interval == "ms":
         delta = timedelta(milliseconds=value)
     elif interval == "s":

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -50,17 +50,19 @@ def parse_duration(value, interval):
         delta = timedelta(milliseconds=value)
     elif interval == "s":
         delta = timedelta(seconds=value)
-    elif interval == "min":
+    elif interval in ["min", "m"]:
         delta = timedelta(minutes=value)
-    elif interval == "hr":
+    elif interval in ["hr", "h"]:
         delta = timedelta(hours=value)
-    elif interval == "day":
+    elif interval in ["day", "d"]:
         delta = timedelta(days=value)
-    elif interval == "wk":
+    elif interval in ["wk", "w"]:
         delta = timedelta(days=value * 7)
     else:
         raise InvalidQuery(
-            u"{} is not a valid duration type, must be ms, s, min, hr, day or wk".format(interval)
+            u"{} is not a valid duration type, must be ms, s, min, m, hr, h, day, d, wk or w".format(
+                interval
+            )
         )
 
     return delta.total_seconds() * 1000.0

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from sentry.api.event_search import (
+    AggregateKey,
     event_search_grammar,
     get_filter,
     resolve_field_list,
@@ -548,6 +549,32 @@ class ParseSearchQueryTest(unittest.TestCase):
         for invalid_query in invalid_queries:
             with self.assertRaisesRegexp(InvalidSearchQuery, "Invalid format for numeric search"):
                 parse_search_query(invalid_query)
+
+    def test_duration_filter(self):
+        assert parse_search_query("transaction.duration:>500s") == [
+            SearchFilter(
+                key=SearchKey(name="transaction.duration"),
+                operator=">",
+                value=SearchValue(raw_value=500000.0),
+            )
+        ]
+
+    def test_aggregate_duration_filter(self):
+        assert parse_search_query("avg(transaction.duration):>500s") == [
+            SearchFilter(
+                key=AggregateKey(name="avg(transaction.duration)"),
+                operator=">",
+                value=SearchValue(raw_value=500000.0),
+            )
+        ]
+
+    def test_invalid_duration_filter(self):
+        with self.assertRaises(InvalidSearchQuery, expected_regex="not a valid duration value"):
+            parse_search_query("transaction.duration:>..500s")
+
+    def test_invalid_aggregate_duration_filter(self):
+        with self.assertRaises(InvalidSearchQuery, expected_regex="not a valid duration value"):
+            parse_search_query("avg(transaction.duration):>..500s")
 
     def test_quotes_filtered_on_raw(self):
         # Enclose the full raw query? Strip it.

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -576,6 +576,10 @@ class ParseSearchQueryTest(unittest.TestCase):
         with self.assertRaises(InvalidSearchQuery, expected_regex="not a valid duration value"):
             parse_search_query("avg(transaction.duration):>..500s")
 
+    def test_invalid_aggregate_column_with_duration_filter(self):
+        with self.assertRaises(InvalidSearchQuery, regex="not a duration column"):
+            parse_search_query("avg(stack.colno):>500s")
+
     def test_quotes_filtered_on_raw(self):
         # Enclose the full raw query? Strip it.
         assert parse_search_query('thinger:unknown "what is this?"') == [

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -904,6 +904,44 @@ class QueryTransformTest(TestCase):
         )
 
     @patch("sentry.snuba.discover.raw_query")
+    def test_duration_aliases(self, mock_query):
+        mock_query.return_value = {
+            "meta": [{"name": "transaction"}, {"name": "duration"}],
+            "data": [{"transaction": "api.do_things", "duration": 200}],
+        }
+        start_time = before_now(minutes=10)
+        end_time = before_now(seconds=1)
+        test_cases = [
+            ("1ms", 1),
+            ("1.5s", 1500),
+            ("1.00min", 1000 * 60),
+            ("3.45hr", 1000 * 60 * 60 * 3.45),
+        ]
+        for query_string, value in test_cases:
+            discover.query(
+                selected_columns=["transaction", "p95"],
+                query="http.method:GET p95:>{}".format(query_string),
+                params={"project_id": [self.project.id], "start": start_time, "end": end_time},
+                use_aggregate_conditions=True,
+            )
+
+            mock_query.assert_called_with(
+                selected_columns=["transaction"],
+                conditions=[["http_method", "=", "GET"]],
+                filter_keys={"project_id": [self.project.id]},
+                groupby=["transaction"],
+                dataset=Dataset.Discover,
+                aggregations=[["quantile(0.95)(duration)", None, "p95"]],
+                having=[["p95", ">", value]],
+                end=end_time,
+                start=start_time,
+                orderby=None,
+                limit=50,
+                offset=None,
+                referrer=None,
+            )
+
+    @patch("sentry.snuba.discover.raw_query")
     def test_alias_aggregate_conditions_with_brackets(self, mock_query):
         mock_query.return_value = {
             "meta": [{"name": "transaction"}, {"name": "duration"}],
@@ -967,6 +1005,47 @@ class QueryTransformTest(TestCase):
             offset=None,
             referrer=None,
         )
+
+    @patch("sentry.snuba.discover.raw_query")
+    def test_aggregate_duration_alias(self, mock_query):
+        mock_query.return_value = {
+            "meta": [{"name": "transaction"}, {"name": "duration"}],
+            "data": [{"transaction": "api.do_things", "duration": 200}],
+        }
+        start_time = before_now(minutes=10)
+        end_time = before_now(seconds=1)
+
+        test_cases = [
+            ("1ms", 1),
+            ("1.5s", 1500),
+            ("1.00min", 1000 * 60),
+            ("3.45hr", 1000 * 60 * 60 * 3.45),
+        ]
+        for query_string, value in test_cases:
+            discover.query(
+                selected_columns=["transaction", "avg(transaction.duration)", "max(time)"],
+                query="http.method:GET avg(transaction.duration):>{}".format(query_string),
+                params={"project_id": [self.project.id], "start": start_time, "end": end_time},
+                use_aggregate_conditions=True,
+            )
+            mock_query.assert_called_with(
+                selected_columns=["transaction"],
+                conditions=[["http_method", "=", "GET"]],
+                filter_keys={"project_id": [self.project.id]},
+                groupby=["transaction"],
+                dataset=Dataset.Discover,
+                aggregations=[
+                    ["avg", "duration", "avg_transaction_duration"],
+                    ["max", "time", "max_time"],
+                ],
+                having=[["avg_transaction_duration", ">", value]],
+                end=end_time,
+                start=start_time,
+                orderby=None,
+                limit=50,
+                offset=None,
+                referrer=None,
+            )
 
     @patch("sentry.snuba.discover.raw_query")
     def test_aggregate_condition_missing_selected_column(self, mock_query):

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -914,8 +914,12 @@ class QueryTransformTest(TestCase):
         test_cases = [
             ("1ms", 1),
             ("1.5s", 1500),
+            ("23.4m", 1000 * 60 * 23.4),
             ("1.00min", 1000 * 60),
             ("3.45hr", 1000 * 60 * 60 * 3.45),
+            ("1.23h", 1000 * 60 * 60 * 1.23),
+            ("3wk", 1000 * 60 * 60 * 24 * 7 * 3),
+            ("2.1w", 1000 * 60 * 60 * 24 * 7 * 2.1),
         ]
         for query_string, value in test_cases:
             discover.query(
@@ -931,8 +935,10 @@ class QueryTransformTest(TestCase):
                 filter_keys={"project_id": [self.project.id]},
                 groupby=["transaction"],
                 dataset=Dataset.Discover,
-                aggregations=[["quantile(0.95)(duration)", None, "p95"]],
-                having=[["p95", ">", value]],
+                aggregations=[
+                    ["quantile(0.95)", "duration", "percentile_transaction_duration_0_95"]
+                ],
+                having=[["percentile_transaction_duration_0_95", ">", value]],
                 end=end_time,
                 start=start_time,
                 orderby=None,


### PR DESCRIPTION
- This allows us to use `ms`, `s`, `min`, `hr`, `day` and `wk` in our searches
- These values were selected to match what we display on the frontend,
  which is why its different from our other durations eg. `hr` instead of
  `h`