### PR TITLE
fix(integration details): Deduplicate feature tags

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -198,11 +198,19 @@ class AbstractIntegrationDetailedView<
     return {organization, features};
   }
 
+  cleanTags(featureData) {
+    const tags = featureData.map(feature =>
+      feature.featureGate.replace(/integrations/g, '').replace(/-/g, ' ')
+    );
+    return [...new Set(tags)];
+  }
+
   //Returns the content shown in the top section of the integration detail
   renderTopSection() {
     const {organization} = this.props;
 
     const {IntegrationFeatures} = getIntegrationFeatureGate();
+    const tags = this.cleanTags(this.featureData);
     return (
       <Flex>
         <PluginIcon pluginId={this.integrationSlug} size={50} />
@@ -214,11 +222,9 @@ class AbstractIntegrationDetailedView<
             </StatusWrapper>
           </Flex>
           <Flex>
-            {this.featureData.map(({featureGate}) => {
-              //modify the strings so it looks better
-              const feature = featureGate.replace(/integrations/g, '').replace(/-/g, ' ');
-              return <StyledTag key={feature}>{feature}</StyledTag>;
-            })}
+            {tags.map(feature => (
+              <StyledTag key={feature}>{feature}</StyledTag>
+            ))}
           </Flex>
         </NameContainer>
         <IntegrationFeatures {...this.featureProps}>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -1,3 +1,4 @@
+import uniq from 'lodash/uniq';
 import React from 'react';
 import styled from '@emotion/styled';
 import {RouteComponentProps} from 'react-router/lib/Router';
@@ -198,11 +199,12 @@ class AbstractIntegrationDetailedView<
     return {organization, features};
   }
 
-  cleanTags(featureData) {
-    const tags = featureData.map(feature =>
-      feature.featureGate.replace(/integrations/g, '').replace(/-/g, ' ')
+  cleanTags() {
+    return uniq(
+      this.featureData.map(feature =>
+        feature.featureGate.replace(/integrations/g, '').replace(/-/g, ' ')
+      )
     );
-    return [...new Set(tags)];
   }
 
   //Returns the content shown in the top section of the integration detail
@@ -210,7 +212,7 @@ class AbstractIntegrationDetailedView<
     const {organization} = this.props;
 
     const {IntegrationFeatures} = getIntegrationFeatureGate();
-    const tags = this.cleanTags(this.featureData);
+    const tags = this.cleanTags();
     return (
       <Flex>
         <PluginIcon pluginId={this.integrationSlug} size={50} />


### PR DESCRIPTION
For integrations that have multiple integration feature descriptions of the same name (e.g. Bitbucket with issue basic and commits), the tags are getting duplicated in the UI

**Duplicated**:
<img width="426" alt="Screen Shot 2020-02-21 at 2 58 01 PM" src="https://user-images.githubusercontent.com/29959063/75078529-b1b06880-54ba-11ea-999d-1ccbac75ca08.png">
**Deduplicated**:
<img width="397" alt="Screen Shot 2020-02-21 at 2 58 05 PM" src="https://user-images.githubusercontent.com/29959063/75078530-b37a2c00-54ba-11ea-95de-04c30ca77b0a.png">
