### PR TITLE
fix(ui): Support MenuItem as non-anchors

### DIFF
--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {Link} from 'react-router';
 import classNames from 'classnames';
 
-type Props = {
+type MenuItemProps = {
   header?: boolean;
   divider?: boolean;
   title?: string;
@@ -17,6 +17,8 @@ type Props = {
   className?: string;
   onClick?: (evt: React.MouseEvent) => void;
 };
+
+type Props = MenuItemProps & Omit<React.HTMLProps<HTMLLIElement>, keyof MenuItemProps>;
 
 class MenuItem extends React.Component<Props> {
   static propTypes = {
@@ -56,41 +58,73 @@ class MenuItem extends React.Component<Props> {
         </Link>
       );
     }
+    if (this.props.href) {
+      return (
+        <a
+          title={this.props.title}
+          onClick={this.handleClick}
+          href={this.props.href}
+          tabIndex={-1}
+        >
+          {this.props.children}
+        </a>
+      );
+    }
+
     return (
-      <a
+      <span
+        className="menu-target"
+        role="button"
         title={this.props.title}
         onClick={this.handleClick}
-        href={this.props.href}
         tabIndex={-1}
       >
         {this.props.children}
-      </a>
+      </span>
     );
   };
 
   render() {
+    const {
+      header,
+      divider,
+      title,
+      onSelect,
+      eventKey,
+      isActive,
+      noAnchor,
+      href,
+      to,
+      query,
+      className,
+      onClick,
+      children,
+      ...props
+    } = this.props;
+
     const classes = {
-      'dropdown-header': this.props.header,
-      divider: this.props.divider,
-      active: this.props.isActive,
+      'dropdown-header': header,
+      active: isActive,
+      divider,
     };
 
-    let children: React.ReactNode | null = null;
-    if (this.props.noAnchor) {
-      children = this.props.children;
-    } else if (this.props.header) {
-      children = this.props.children;
-    } else if (!this.props.divider) {
-      children = this.renderAnchor();
+    let renderChildren: React.ReactNode | null = null;
+    if (noAnchor) {
+      renderChildren = children;
+    } else if (header) {
+      renderChildren = children;
+    } else if (!divider) {
+      renderChildren = this.renderAnchor();
     }
 
     return (
       <li
         role="presentation"
-        className={classNames(this.props.className, classes)}
-        onClick={this.props.onClick}
+        className={classNames(className, classes)}
+        onClick={onClick}
+        {...props}
       >
-        {children}
+        {renderChildren}
       </li>
     );
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -191,13 +191,13 @@ class QueryList extends React.Component<Props> {
             return (
               <ContextMenu>
                 <MenuItem
-                  href="#delete-query"
+                  data-test-id="delete-query"
                   onClick={this.handleDeleteQuery(eventView)}
                 >
                   {t('Delete Query')}
                 </MenuItem>
                 <MenuItem
-                  href="#duplicate-query"
+                  data-test-id="duplicate-query"
                   onClick={this.handleDuplicateQuery(eventView)}
                 >
                   {t('Duplicate Query')}

--- a/src/sentry/static/sentry/less/dropdowns.less
+++ b/src/sentry/static/sentry/less/dropdowns.less
@@ -2,7 +2,8 @@
   z-index: 1001;
   .dropdown-header,
   .dropdown-toggle,
-  > li a {
+  > li a,
+  > li span.menu-target {
     display: block;
     padding: 3px 10px;
   }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1318,9 +1318,11 @@ header + .alert {
     }
   }
 
-  li a {
+  li a,
+  li span.menu-target {
     .transition(none);
     color: @gray-dark;
+    cursor: pointer;
 
     &:hover,
     &.hover {

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -455,7 +455,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             # Open the context menu
             card.find_element_by_css_selector('[data-test-id="context-menu"]').click()
             # Delete the query
-            card.find_element_by_css_selector('[href="#delete-query"]').click()
+            card.find_element_by_css_selector('[data-test-id="delete-query"]').click()
 
             # Wait for card to clear
             self.browser.wait_until_not(card_selector)
@@ -481,7 +481,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
             # Open the context menu, and duplicate
             card.find_element_by_css_selector('[data-test-id="context-menu"]').click()
-            card.find_element_by_css_selector('[href="#duplicate-query"]').click()
+            card.find_element_by_css_selector('[data-test-id="duplicate-query"]').click()
 
             duplicate_name = "{} copy".format(query.name)
             # Wait for new element to show up.

--- a/tests/js/spec/views/discover/result/index.spec.jsx
+++ b/tests/js/spec/views/discover/result/index.spec.jsx
@@ -186,7 +186,7 @@ describe('Result', function() {
 
         wrapper
           .find('ul.dropdown-menu')
-          .find('a')
+          .find('span')
           .at(1)
           .simulate('click');
 

--- a/tests/js/spec/views/eventsV2/queryList.spec.jsx
+++ b/tests/js/spec/views/eventsV2/queryList.spec.jsx
@@ -9,7 +9,7 @@ function openContextMenu(card) {
 }
 
 function clickMenuItem(card, selector) {
-  card.find(`DropdownMenu MenuItem[href="#${selector}"]`).simulate('click');
+  card.find(`DropdownMenu MenuItem[data-test-id="${selector}"]`).simulate('click');
 }
 
 describe('EventsV2 > QueryList', function() {

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -236,7 +236,7 @@ describe('EventsV2 > Results', function() {
 
     // Click one of the options.
     selector
-      .find('DropdownMenu MenuItem a')
+      .find('DropdownMenu MenuItem span')
       .first()
       .simulate('click');
     wrapper.update();

--- a/tests/js/spec/views/incidents/details/index.spec.jsx
+++ b/tests/js/spec/views/incidents/details/index.spec.jsx
@@ -115,7 +115,7 @@ describe('IncidentDetails', function() {
     expect(wrapper.find('Status').text()).not.toBe('Resolved');
     wrapper.find('[data-test-id="status-dropdown"] DropdownButton').simulate('click');
     wrapper
-      .find('[data-test-id="status-dropdown"] MenuItem a')
+      .find('[data-test-id="status-dropdown"] MenuItem span')
       .at(0)
       .simulate('click');
 

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -480,7 +480,7 @@ describe('IssueList,', function() {
 
       wrapper.find('IssueListSortOptions DropdownButton').simulate('click');
       wrapper
-        .find('IssueListSortOptions MenuItem a')
+        .find('IssueListSortOptions MenuItem span')
         .at(3)
         .simulate('click');
 


### PR DESCRIPTION
Probably better this way, but did this primarily to get rid of a warning