### PR TITLE
test(pytest): Fix "reruns" for sentry-pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
     - NODE_DIR="${HOME}/.nvm/versions/node/v$(< .nvmrc)"
     - NODE_OPTIONS=--max-old-space-size=4096
     - PYTEST_SENTRY_DSN=https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
+    - PYTEST_ADDOPTS="--reruns 5"
 
 before_install:
   - &pip_install pip install --no-cache-dir "pip>=20.0.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,10 @@
 [tool:pytest]
 python_files = test*.py
-addopts = --tb=native -p no:doctest -p no:warnings
+addopts = --tb=native -p no:doctest -p no:warnings --reruns 5
 norecursedirs = bin dist docs htmlcov script hooks node_modules .* {args}
 looponfailroots = src tests
 selenium_driver = chrome
 self-contained-html = true
-reruns = 1
 markers =
     snuba: mark a test as requiring snuba
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 python_files = test*.py
-addopts = --tb=native -p no:doctest -p no:warnings --reruns 5
+addopts = --tb=native -p no:doctest -p no:warnings
 norecursedirs = bin dist docs htmlcov script hooks node_modules .* {args}
 looponfailroots = src tests
 selenium_driver = chrome


### PR DESCRIPTION
The "reruns" option was not being properly used in `setup.cfg`, move it into `addopts`