### PR TITLE
fix(UI): Unexpected event propagation on button click

### DIFF
--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -99,6 +99,8 @@ class Button extends React.Component<ButtonProps, {}> {
 
     // Don't allow clicks when disabled or busy
     if (disabled || busy) {
+      e.preventDefault();
+      e.stopPropagation();
       return;
     }
 


### PR DESCRIPTION
Inside forms, clicking on disabled buttons propagate events to the form, even when it bypasses the button's onClick handler--thus triggering the form's submission handler. 

This prevents the propagation of click events for disabled buttons; which should be the expected behaviour.