### PR TITLE
auth: When logging out, always refresh the user's nonce

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -146,13 +146,8 @@ class AuthIndexEndpoint(Endpoint):
         Logout the Authenticated User
         `````````````````````````````
 
-        Deauthenticate the currently active session. Can also deactivate
-        all sessions for a user if the ``all`` parameter is sent.
+        Deauthenticate all active sessions for this user.
         """
-        if request.data.get("all"):
-            # Rotate the session nonce to invalidate all other sessions.
-            request.user.refresh_session_nonce()
-            request.user.save()
         logout(request._request)
         request.user = AnonymousUser()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -170,8 +170,6 @@ class SAML2SLSView(BaseView):
         should_logout = request.user.is_authenticated()
 
         def force_logout():
-            request.user.refresh_session_nonce()
-            request.user.save()
             logout(request)
 
         redirect_to = auth.process_slo(

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -79,16 +79,11 @@ class AuthLogoutEndpointTest(APITestCase):
         assert response.status_code == 204
         assert list(self.client.session.keys()) == []
 
-    def test_logged_in__invalidate_all_sessions(self):
+    def test_logged_out(self):
         user = self.create_user("foo@example.com")
         self.login_as(user)
-        response = self.client.delete(self.path, data={"all": 1})
+        response = self.client.delete(self.path)
         assert response.status_code == 204
         assert list(self.client.session.keys()) == []
         updated = type(user).objects.get(pk=user.id)
         assert updated.session_nonce != user.session_nonce
-
-    def test_logged_out(self):
-        response = self.client.delete(self.path)
-        assert response.status_code == 204
-        assert list(self.client.session.keys()) == []

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -194,3 +194,6 @@ class AuthSAML2Test(AuthProviderTestCase):
 
         assert redirect.path == "/slo_url"
         assert "SAMLResponse" in query
+
+        updated = type(self.user).objects.get(pk=self.user.id)
+        assert updated.session_nonce != self.user.session_nonce


### PR DESCRIPTION
This forces all sessions to be logged out and an existing cookie token
can't be reused.