### PR TITLE
misc: Stop using localhost

### DIFF
--- a/api-docs/sentry.conf.py
+++ b/api-docs/sentry.conf.py
@@ -31,7 +31,7 @@ SENTRY_USE_BIG_INTS = True
 SENTRY_CACHE = "sentry.cache.redis.RedisCache"
 
 CELERY_ALWAYS_EAGER = True
-BROKER_URL = "redis://localhost:%s" % SENTRY_APIDOCS_REDIS_PORT
+BROKER_URL = "redis://127.0.0.1:%s" % SENTRY_APIDOCS_REDIS_PORT
 
 SENTRY_RATELIMITER = "sentry.ratelimits.redis.RedisRateLimiter"
 SENTRY_BUFFER = "sentry.buffer.redis.RedisBuffer"
@@ -57,7 +57,7 @@ SENTRY_OPTIONS.update(
         "system.admin-email": "admin@sentry.io",
         "system.url-prefix": SENTRY_URL_PREFIX,
         "mail.backend": "django.core.mail.backends.smtp.EmailBackend",
-        "mail.host": "localhost",
+        "mail.host": "127.0.0.1",
         "mail.password": "",
         "mail.username": "",
         "mail.port": 25,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -482,7 +482,7 @@ SOCIAL_AUTH_FORCE_POST_DISCONNECT = True
 # Queue configuration
 from kombu import Exchange, Queue
 
-BROKER_URL = "redis://localhost:6379"
+BROKER_URL = "redis://127.0.0.1:6379"
 BROKER_TRANSPORT_OPTIONS = {}
 
 # Ensure workers run async by default
@@ -934,12 +934,12 @@ SENTRY_CELERYBEAT_MONITORS = {
 }
 
 # Web Service
-SENTRY_WEB_HOST = "localhost"
+SENTRY_WEB_HOST = "127.0.0.1"
 SENTRY_WEB_PORT = 9000
 SENTRY_WEB_OPTIONS = {}
 
 # SMTP Service
-SENTRY_SMTP_HOST = "localhost"
+SENTRY_SMTP_HOST = "127.0.0.1"
 SENTRY_SMTP_PORT = 1025
 
 SENTRY_INTERFACES = {
@@ -1049,7 +1049,7 @@ SENTRY_RATELIMITER_OPTIONS = {}
 SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE = "90%"
 
 # Snuba configuration
-SENTRY_SNUBA = os.environ.get("SNUBA", "http://localhost:1218")
+SENTRY_SNUBA = os.environ.get("SNUBA", "http://127.0.0.1:1218")
 
 # Node storage backend
 SENTRY_NODESTORE = "sentry.nodestore.django.DjangoNodeStorage"
@@ -1065,7 +1065,7 @@ SENTRY_SEARCH = os.environ.get(
 )
 SENTRY_SEARCH_OPTIONS = {}
 # SENTRY_SEARCH_OPTIONS = {
-#     'urls': ['http://localhost:9200/'],
+#     'urls': ['http://127.0.0.1:9200/'],
 #     'timeout': 5,
 # }
 
@@ -1671,7 +1671,7 @@ SENTRY_USER_PERMISSIONS = ("broadcasts.admin",)
 
 KAFKA_CLUSTERS = {
     "default": {
-        "bootstrap.servers": "localhost:9092",
+        "bootstrap.servers": "127.0.0.1:9092",
         "compression.type": "lz4",
         "message.max.bytes": 50000000,  # 50MB, default is 1MB
     }

--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -8,7 +8,7 @@ from .base import MetricsBackend
 
 
 class StatsdMetricsBackend(MetricsBackend):
-    def __init__(self, host="localhost", port=8125, **kwargs):
+    def __init__(self, host="127.0.0.1", port=8125, **kwargs):
         self.client = statsd.StatsClient(host=host, port=port)
         super(StatsdMetricsBackend, self).__init__(**kwargs)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -56,7 +56,7 @@ register("releasefile.cache-limit", type=Int, default=10 * 1024 * 1024, flags=FL
 
 # Mail
 register("mail.backend", default="smtp", flags=FLAG_NOSTORE)
-register("mail.host", default="localhost", flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
+register("mail.host", default="127.0.0.1", flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
 register("mail.port", default=25, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
 register("mail.username", flags=FLAG_REQUIRED | FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register("mail.password", flags=FLAG_REQUIRED | FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -46,7 +46,7 @@ DEPENDENCY_TEST_DATA = {
                 "NAME": "test",
                 "USER": "root",
                 "PASSWORD": "",
-                "HOST": "localhost",
+                "HOST": "127.0.0.1",
                 "PORT": "",
             }
         },


### PR DESCRIPTION
This is too unreliable on modern computers. /etc/hosts has entries for
both ::1 and 127.0.0.1, and it's afaik non deterministic or up to the
software to choose which address to use. This causes problems when
software decides to map localhost to ::1 instead since nothing we use
binds to ::1.