### PR TITLE
ref(ui): Widen breadcrumbs category by 12px to support event.transaction

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
@@ -25,15 +25,24 @@ class Breadcrumb extends React.Component {
       classes.add('crumb-' + crumb.type.replace(/[\s_]+/g, '-').toLowerCase());
     }
 
-    // special case for 'ui.' category breadcrumbs
+    // special case for 'ui.' and `sentry.` category breadcrumbs
     // TODO: find a better way to customize UI around non-schema data
-    if (crumb.category && crumb.category.slice(0, 3) === 'ui.') {
-      classes.add('crumb-user');
+    const isDotSeparatedCategory = /.+\..+/.test(crumb.category);
+    if (isDotSeparatedCategory) {
+      const [category, subcategory] = crumb.category.split('.');
+      if (category === 'ui') {
+        classes.add('crumb-user');
+      } else if (category === 'sentry' && subcategory === 'transaction') {
+        // Warning has a precedence over other icons, so we want to force it.
+        classes.delete('crumb-warning');
+        classes.add('crumb-navigation');
+      }
     }
 
     if (crumb.last) {
       classes.add('crumb-last');
     }
+
     return [...classes].join(' ');
   };
 

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1835,8 +1835,8 @@ ul.crumbs {
       }
 
       .key {
-        width: 110px;
-        max-width: 110px;
+        width: 122px;
+        max-width: 122px;
         color: @gray-dark;
         line-height: 1.6 !important;
       }


### PR DESCRIPTION
Related SDK change: https://github.com/getsentry/sentry-javascript/pull/2450

Before:
![image](https://user-images.githubusercontent.com/1523305/75163252-33083500-571f-11ea-9c8c-be37c755de00.png)

After:
![image](https://user-images.githubusercontent.com/1523305/75163166-123fdf80-571f-11ea-87ea-93e0fdcf44dc.png)
