### PR TITLE
fix(workflow): Incorporate alert rule's time window into graph start time

### DIFF
--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -48,6 +48,7 @@ from sentry.incidents.logic import (
     update_alert_rule_trigger_action,
     update_alert_rule_trigger,
     update_incident_status,
+    calculate_incident_prewindow,
 )
 from sentry.incidents.models import (
     AlertRule,
@@ -262,7 +263,9 @@ class GetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
         assert result.rollup == 15
         expected_start = start if start else incident.date_started
         expected_end = end if end else incident.current_end_date
-        expected_start = expected_start - (expected_end - expected_start) / 5
+        expected_start = expected_start - calculate_incident_prewindow(
+            expected_start, expected_end, incident
+        )
         assert result.start == expected_start
         assert result.end == expected_end
         assert [r["count"] for r in result.data["data"]] == expected_results
@@ -285,7 +288,9 @@ class BulkGetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
             assert result.rollup == 15
             expected_start = start if start else incident.date_started
             expected_end = end if end else incident.current_end_date
-            expected_start = expected_start - (expected_end - expected_start) / 5
+            expected_start = expected_start - calculate_incident_prewindow(
+                expected_start, expected_end, incident
+            )
             assert result.start == expected_start
             assert result.end == expected_end
             assert [r["count"] for r in result.data["data"]] == expected_results
@@ -557,7 +562,9 @@ class BulkGetIncidentStatusTest(TestCase, BaseIncidentsTest):
             expected_start = incident_stats["event_stats"].start
             expected_end = incident_stats["event_stats"].end
             if not changed:
-                expected_start = expected_start - (expected_end - expected_start) / 5
+                expected_start = expected_start - calculate_incident_prewindow(
+                    expected_start, expected_end, incident
+                )
                 changed = True
             assert event_stats.start == expected_start
             assert event_stats.end == expected_end


### PR DESCRIPTION
When showing incident graphs, we calculate a period before the start date to be about ~20% of the total duration to show some relevant data from before the incident was fired.

However, if an incident is really short, this period is too short to be meaningful. The calculation has been modified to be the maximum of this 20% range value or the alert's rule time window. This should create a more meaningful graph for incident's of any duration.