### PR TITLE
fix(test) Fixate time better in discover tests

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
@@ -8,6 +8,7 @@ import ErrorRenderer from 'app/components/events/interfaces/breadcrumbs/errorRen
 import DefaultRenderer from 'app/components/events/interfaces/breadcrumbs/defaultRenderer';
 import ErrorBoundary from 'app/components/errorBoundary';
 import Tooltip from 'app/components/tooltip';
+import getDynamicText from 'app/utils/getDynamicText';
 
 class Breadcrumb extends React.Component {
   static propTypes = {
@@ -66,7 +67,12 @@ class Breadcrumb extends React.Component {
           </span>
           {defined(crumb.timestamp) ? (
             <Tooltip title={this.getTooltipTitle()}>
-              <span className="dt">{moment(crumb.timestamp).format('HH:mm:ss')}</span>
+              <span className="dt">
+                {getDynamicText({
+                  value: moment(crumb.timestamp).format('HH:mm:ss'),
+                  fixed: '00:00:00',
+                })}
+              </span>
             </Tooltip>
           ) : (
             <span className="dt" />

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -319,12 +319,13 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_errors_view(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        event_source = (("a", 1), ("b", 39), ("c", 69))
+        event_source = (("a", 14, 1), ("b", 13, 29), ("c", 12, 49))
         event_ids = []
         event_data = load_data("javascript")
         event_data["fingerprint"] = ["group-1"]
-        for id_prefix, offset in event_source:
-            event_time = iso_format(before_now(minutes=offset))
+        for id_prefix, hour, minute in event_source:
+            event_time = before_now().replace(hour=hour, minute=minute, second=0, microsecond=0)
+            event_time = iso_format(event_time)
             event_data.update(
                 {
                     "timestamp": event_time,

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -319,13 +319,12 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_errors_view(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        event_source = (("a", 14, 1), ("b", 13, 29), ("c", 12, 49))
+        event_source = (("a", 1), ("b", 39), ("c", 69))
         event_ids = []
         event_data = load_data("javascript")
         event_data["fingerprint"] = ["group-1"]
-        for id_prefix, hour, minute in event_source:
-            event_time = before_now().replace(hour=hour, minute=minute, second=0, microsecond=0)
-            event_time = iso_format(event_time)
+        for id_prefix, offset in event_source:
+            event_time = iso_format(before_now(minutes=offset))
             event_data.update(
                 {
                     "timestamp": event_time,


### PR DESCRIPTION
Don't use relative time for test events. Fixate the time parts so breadcrumbs have stable output.