### PR TITLE
fix(discover2): Stabilize charts rendering when zooming.

### DIFF
--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -94,6 +94,87 @@ class EventsAreaChart extends React.Component {
   }
 }
 
+class TransitionChart extends React.Component {
+  static propTypes = {
+    reloading: PropTypes.bool,
+    loading: PropTypes.bool,
+  };
+
+  state = {
+    prevReloading: this.props.reloading,
+    prevLoading: this.props.loading,
+    key: 1,
+  };
+
+  static getDerivedStateFromProps(props, state) {
+    // Transitions are controlled using variables called:
+    // - loading and,
+    // - reloading (also called pending in other apps)
+    //
+    // This component remounts the chart to ensure the stable transition
+    // from one data set to the next.
+
+    const prevReloading = state.prevReloading;
+    const nextReloading = props.reloading;
+
+    const prevLoading = state.prevLoading;
+    const nextLoading = props.loading;
+
+    // whenever loading changes, we explicitly remount the children by updating
+    // the key prop; regardless of what state reloading is in
+    if (prevLoading !== nextLoading) {
+      return {
+        prevReloading: nextReloading,
+        prevLoading: nextLoading,
+        key: state.key + 1,
+      };
+    }
+
+    // invariant: prevLoading === nextLoading
+
+    // if loading is true, and hasn't changed from the previous re-render,
+    // do not remount the children.
+    if (nextLoading) {
+      return {
+        prevReloading: nextReloading,
+        prevLoading: nextLoading,
+        key: state.key,
+      };
+    }
+
+    // invariant: loading is false
+
+    // whenever the chart is transitioning from the reloading (pending) state to a non-loading state,
+    // remount the children
+    if (prevReloading && !nextReloading) {
+      return {
+        prevReloading: nextReloading,
+        prevLoading: nextLoading,
+        key: state.key + 1,
+      };
+    }
+
+    // do not remount the children in these remaining cases:
+    // !prevReloading && !nextReloading (re-render with no prop change)
+    // prevReloading && nextReloading (re-render with no prop change)
+    // !prevReloading && nextReloading (from loaded to pending state)
+
+    return {
+      prevReloading: nextReloading,
+      prevLoading: nextLoading,
+      key: state.key,
+    };
+  }
+
+  render() {
+    // We make use of the key prop to explicitly remount the children
+    // https://reactjs.org/docs/lists-and-keys.html#keys
+    return (
+      <React.Fragment key={String(this.state.key)}>{this.props.children}</React.Fragment>
+    );
+  }
+}
+
 class EventsChart extends React.Component {
   static propTypes = {
     api: PropTypes.object,
@@ -167,19 +248,21 @@ class EventsChart extends React.Component {
                     }
 
                     return (
-                      <React.Fragment>
-                        <TransparentLoadingMask visible={reloading} />
-                        <EventsAreaChart
-                          {...zoomRenderProps}
-                          loading={loading}
-                          reloading={reloading}
-                          utc={utc}
-                          showLegend={showLegend}
-                          releaseSeries={releaseSeries}
-                          timeseriesData={timeseriesData}
-                          previousTimeseriesData={previousTimeseriesData}
-                        />
-                      </React.Fragment>
+                      <TransitionChart loading={loading} reloading={reloading}>
+                        <React.Fragment>
+                          <TransparentLoadingMask visible={reloading} />
+                          <EventsAreaChart
+                            {...zoomRenderProps}
+                            loading={loading}
+                            reloading={reloading}
+                            utc={utc}
+                            showLegend={showLegend}
+                            releaseSeries={releaseSeries}
+                            timeseriesData={timeseriesData}
+                            previousTimeseriesData={previousTimeseriesData}
+                          />
+                        </React.Fragment>
+                      </TransitionChart>
                     );
                   }}
                 </ReleaseSeries>


### PR DESCRIPTION
Continuation of https://github.com/getsentry/sentry/pull/17186

Zooming in a chart multiple times can lead to the following state:

<img width="1175" alt="Screen Shot 2020-02-24 at 11 12 23 AM" src="https://user-images.githubusercontent.com/139499/75169530-b7928d80-56f6-11ea-9908-66e07a10da79.png">

There may be a race condition between the functions provided by [`chartZoom.jsx`](https://github.com/getsentry/sentry/blob/f989583a8b0ef525bc15f53e1b8455ec46e76ae1/src/sentry/static/sentry/app/components/charts/chartZoom.jsx) are consumed, and updating the graph data.

When zooming, we re-mount Events area chart whenever new data is loaded to ensure stable charts rendering. We remount by making use of monotonically increasing prop keys https://reactjs.org/docs/lists-and-keys.html#keys.

