### PR TITLE
fix(workflow): Only update chart when query is finished

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -312,13 +312,14 @@ class SmartSearchBar extends React.Component {
     });
   };
 
-  onQueryBlur = () => {
+  onQueryBlur = e => {
     // wait 200ms before closing dropdown in case blur was a result of
     // clicking a menu option
+    const value = e.target.value;
     this.blurTimeout = setTimeout(() => {
       this.blurTimeout = null;
       this.setState({dropdownVisible: false});
-      callIfFunction(this.props.onBlur);
+      callIfFunction(this.props.onBlur, value);
     }, DROPDOWN_BLUR_DURATION);
   };
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -33,6 +33,7 @@ type Props = {
   organization: Organization;
   projectSlug: string;
   disabled: boolean;
+  onSearchBarBlur?:() => void;
 };
 
 type State = {
@@ -43,7 +44,9 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   state: State = {
     environments: null,
   };
-
+  blurFuncTest(...args){
+    console.log("blur test called",...args)
+  }
   componentDidMount() {
     this.fetchData();
   }
@@ -108,6 +111,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             isClearable
           />
           <FormField
+            onBlur={this.props.onSearchBarBlur}
             name="query"
             label={t('Filter')}
             defaultValue=""
@@ -116,12 +120,14 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
               'You can apply standard Sentry filter syntax to filter by status, user, etc.'
             )}
           >
-            {({onChange, onBlur, value}) => (
+            {({onChange, onBlur, onKeyDown, value}) => (
               <SearchBar
                 defaultQuery={value}
                 disabled={disabled}
                 useFormWrapper={false}
                 organization={organization}
+                onChange={onChange}
+                onKeyDown={onKeyDown}
                 onBlur={onBlur}
                 onSearch={query => onChange(query, {})}
               />

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -33,7 +33,7 @@ type Props = {
   organization: Organization;
   projectSlug: string;
   disabled: boolean;
-  onSearchBarBlur?:(query: string) => void;
+  onFilterUpdate: (query: string) => void;
 };
 
 type State = {
@@ -44,9 +44,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   state: State = {
     environments: null,
   };
-  blurFuncTest(...args){
-    console.log("blur test called",...args)
-  }
+
   componentDidMount() {
     this.fetchData();
   }
@@ -111,7 +109,6 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             isClearable
           />
           <FormField
-            onBlur={this.props.onSearchBarBlur}
             name="query"
             label={t('Filter')}
             defaultValue=""
@@ -128,8 +125,14 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                 organization={organization}
                 onChange={onChange}
                 onKeyDown={onKeyDown}
-                onBlur={query => onBlur(query)}
-                onSearch={query => onChange(query, {})}
+                onBlur={query => {
+                  onBlur(query);
+                  this.props.onFilterUpdate(query);
+                }}
+                onSearch={query => {
+                  this.props.onFilterUpdate(query);
+                  onChange(query, {});
+                }}
               />
             )}
           </FormField>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -68,7 +68,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {organization, disabled} = this.props;
+    const {organization, disabled, onFilterUpdate} = this.props;
 
     return (
       <Panel>
@@ -126,11 +126,11 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                 onChange={onChange}
                 onKeyDown={onKeyDown}
                 onBlur={query => {
+                  onFilterUpdate(query);
                   onBlur(query);
-                  this.props.onFilterUpdate(query);
                 }}
                 onSearch={query => {
-                  this.props.onFilterUpdate(query);
+                  onFilterUpdate(query);
                   onChange(query, {});
                 }}
               />

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -116,15 +116,13 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
               'You can apply standard Sentry filter syntax to filter by status, user, etc.'
             )}
           >
-            {({onChange, onBlur, onKeyDown, value}) => (
+            {({onChange, onBlur, value}) => (
               <SearchBar
                 defaultQuery={value}
                 disabled={disabled}
                 useFormWrapper={false}
                 organization={organization}
-                onChange={onChange}
                 onBlur={onBlur}
-                onKeyDown={onKeyDown}
                 onSearch={query => onChange(query, {})}
               />
             )}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -33,7 +33,7 @@ type Props = {
   organization: Organization;
   projectSlug: string;
   disabled: boolean;
-  onSearchBarBlur?:() => void;
+  onSearchBarBlur?:(query: string) => void;
 };
 
 type State = {
@@ -128,7 +128,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                 organization={organization}
                 onChange={onChange}
                 onKeyDown={onKeyDown}
-                onBlur={onBlur}
+                onBlur={query => onBlur(query)}
                 onSearch={query => onChange(query, {})}
               />
             )}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -1,7 +1,6 @@
 import {PlainRoute} from 'react-router/lib/Route';
 import {RouteComponentProps} from 'react-router/lib/Router';
 import React from 'react';
-import debounce from 'lodash/debounce';
 
 import { MetricAction } from 'app/types/alerts';
 import {Organization, Project, Config} from 'app/types';
@@ -261,12 +260,16 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     }
 
     return triggerErrors;
-  }
+  };
 
   handleFieldChange = (name: string, value: unknown) => {
-    if (['query', 'timeWindow', 'aggregation'].includes(name)) {
+    if (['timeWindow', 'aggregation'].includes(name)) {
       this.setState({[name]: value});
     }
+  };
+
+  handleSearchBarBlur = () => {
+    this.setState({ 'query': this.state.query });
   };
 
   handleSubmit = async (
@@ -410,7 +413,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
             onSubmit={this.handleSubmit}
             onSubmitSuccess={onSubmitSuccess}
             onCancel={this.handleCancel}
-            onFieldChange={debounce(this.handleFieldChange,200)}
+            onFieldChange={this.handleFieldChange}
             extraButton={
               !!rule.id ? (
                 <Confirm
@@ -445,6 +448,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
               projectSlug={params.projectId}
               organization={organization}
               disabled={!hasAccess}
+              onSearchBarBlur={this.handleSearchBarBlur}
             />
 
             <Triggers

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -2,7 +2,7 @@ import {PlainRoute} from 'react-router/lib/Route';
 import {RouteComponentProps} from 'react-router/lib/Router';
 import React from 'react';
 
-import { MetricAction } from 'app/types/alerts';
+import {MetricAction} from 'app/types/alerts';
 import {Organization, Project, Config} from 'app/types';
 import {
   addErrorMessage,
@@ -260,7 +260,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     }
 
     return triggerErrors;
-  };
+  }
 
   handleFieldChange = (name: string, value: unknown) => {
     if (['timeWindow', 'aggregation'].includes(name)) {
@@ -268,8 +268,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     }
   };
 
-  handleSearchBarBlur = (query) => {
-    this.setState({ 'query': query });
+  handleFilterUpdate = query => {
+    this.setState({query});
   };
 
   handleSubmit = async (
@@ -448,7 +448,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
               projectSlug={params.projectId}
               organization={organization}
               disabled={!hasAccess}
-              onSearchBarBlur={this.handleSearchBarBlur}
+              onFilterUpdate={this.handleFilterUpdate}
             />
 
             <Triggers

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -268,8 +268,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     }
   };
 
-  handleSearchBarBlur = () => {
-    this.setState({ 'query': this.state.query });
+  handleSearchBarBlur = (query) => {
+    this.setState({ 'query': query });
   };
 
   handleSubmit = async (

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -1,8 +1,9 @@
 import {PlainRoute} from 'react-router/lib/Route';
 import {RouteComponentProps} from 'react-router/lib/Router';
 import React from 'react';
+import debounce from 'lodash/debounce';
 
-import {MetricAction} from 'app/types/alerts';
+import { MetricAction } from 'app/types/alerts';
 import {Organization, Project, Config} from 'app/types';
 import {
   addErrorMessage,
@@ -409,7 +410,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
             onSubmit={this.handleSubmit}
             onSubmitSuccess={onSubmitSuccess}
             onCancel={this.handleCancel}
-            onFieldChange={this.handleFieldChange}
+            onFieldChange={debounce(this.handleFieldChange,200)}
             extraButton={
               !!rule.id ? (
                 <Confirm

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -243,7 +243,7 @@ describe('SmartSearchBar', function() {
       searchBar.state.dropdownVisible = true;
 
       jest.useFakeTimers();
-      searchBar.onQueryBlur();
+      searchBar.onQueryBlur({target: {value: 'test'}});
       jest.advanceTimersByTime(201); // doesn't close until 200ms
 
       expect(searchBar.state.dropdownVisible).toBe(false);


### PR DESCRIPTION
This PR aims to fix a few known issues:
Fixed chart re-rendering too much as you type: (https://app.asana.com/0/1143070838064087/1163136329300643)
Fixed error message appearing as you type (https://app.asana.com/0/1143070838064087/1163355932236027) - the message will only appear when you 'apply' the filter via enter, etc.
Addresses https://app.asana.com/0/1143070838064087/1160225808505467 as far as I've seen so far, they work equivalently now

It accomplishes all this by not making the event-stats api call on text field change and keydown. That call is what triggered the error, re-rendering, and seemed to block tag filtering (i.e. on `stack.filename`)