### PR TITLE
ref(social-auth): stop using token query parameter

### DIFF
--- a/src/social_auth/backends/github.py
+++ b/src/social_auth/backends/github.py
@@ -1,16 +1,12 @@
 """
 GitHub OAuth support.
-
 This contribution adds support for GitHub OAuth service. The settings
 GITHUB_APP_ID and GITHUB_API_SECRET must be defined with the values
 given by GitHub application registration process.
-
 GITHUB_ORGANIZATION is an optional setting that will allow you to constrain
 authentication to a given GitHub organization.
-
 Extended permissions are supported by defining GITHUB_EXTENDED_PERMISSIONS
 setting, it must be a list of values to request.
-
 By default account id and token expiration time are stored in extra_data
 field, check OAuthBackend class for details on how to extend it.
 """
@@ -20,7 +16,7 @@ import simplejson
 
 from django.conf import settings
 from six.moves.urllib.error import HTTPError
-from six.moves.urllib.parse import urlencode
+from six.moves.urllib.request import Request
 from social_auth.utils import dsa_urlopen
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.exceptions import AuthFailed
@@ -46,10 +42,12 @@ class GithubBackend(OAuthBackend):
 
     def _fetch_emails(self, access_token):
         """Fetch private emails from Github account"""
-        url = GITHUB_USER_DATA_URL + "/emails?" + urlencode({"access_token": access_token})
+        req = Request(
+            GITHUB_USER_DATA_URL + "/emails", headers={"Authorization": "token %s" % access_token}
+        )
 
         try:
-            data = simplejson.load(dsa_urlopen(url))
+            data = simplejson.load(dsa_urlopen(req))
         except (ValueError, HTTPError):
             data = []
         return data
@@ -93,26 +91,25 @@ class GithubAuth(BaseOAuth2):
 
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data from service"""
-        url = GITHUB_USER_DATA_URL + "?" + urlencode({"access_token": access_token})
+        req = Request(GITHUB_USER_DATA_URL, headers={"Authorization": "token %s" % access_token})
 
         try:
-            data = simplejson.load(dsa_urlopen(url))
+            data = simplejson.load(dsa_urlopen(req))
         except ValueError:
             data = None
 
         # if we have a github organization defined, test that the current users
         # is a member of that organization.
         if data and self.GITHUB_ORGANIZATION:
-            member_url = (
+            req = Request(
                 GITHUB_ORGANIZATION_MEMBER_OF_URL.format(
                     org=self.GITHUB_ORGANIZATION, username=data.get("login")
-                )
-                + "?"
-                + urlencode({"access_token": access_token})
+                ),
+                headers={"Authorization": "token %s" % access_token},
             )
 
             try:
-                response = dsa_urlopen(member_url)
+                response = dsa_urlopen(req)
             except HTTPError:
                 data = None
             else:


### PR DESCRIPTION
Github is deprecating using auth query parameters. This PR fixes one case where it's used for Github social auth. For more details see: https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

This change was copied from @mattrobenolt's PR: https://github.com/getsentry/sentry/pull/17022