### PR TITLE
fix(Analytics): Use trackAdhocEvent over trackAnalyticsEvent

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -75,7 +75,6 @@ class CreateProject extends React.Component {
     });
     trackAdhocEvent({
       eventKey: 'new_project.visited',
-      eventName: 'New Project Page Visited',
       org_id: parseInt(this.props.organization.id, 10),
     });
   }

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -22,7 +22,7 @@ import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import withTeams from 'app/utils/withTeams';
 import IssueAlertOptions from 'app/views/projectInstall/issueAlertOptions';
-import {trackAnalyticsEvent, logExperiment} from 'app/utils/analytics';
+import {trackAdhocEvent, trackAnalyticsEvent, logExperiment} from 'app/utils/analytics';
 
 class CreateProject extends React.Component {
   static propTypes = {
@@ -73,7 +73,7 @@ class CreateProject extends React.Component {
       unitId: parseInt(this.props.organization.id, 10),
       param: 'exposed',
     });
-    trackAnalyticsEvent({
+    trackAdhocEvent({
       eventKey: 'new_project.visited',
       eventName: 'New Project Page Visited',
       org_id: parseInt(this.props.organization.id, 10),


### PR DESCRIPTION
Addresses https://github.com/getsentry/sentry/pull/17035#discussion_r382816283
> We generally use trackAdhocEvent for higher volume events due to certain rate limits. ...