### PR TITLE
expt(workflow/ProjectCreation): Start AlertsDefaultExperiment

### DIFF
--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -23,7 +23,7 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
         experiment_variant = experiments.get(
             org=organization, experiment_name="AlertDefaultsExperiment"
         )
-        if experiment_variant == "test3Options":
+        if experiment_variant == "3OptionsV1":
             return Response(
                 [
                     info_extractor(rule_cls)
@@ -31,7 +31,7 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
                     if rule_type.startswith("condition/")
                 ]
             )
-        elif experiment_variant == "test2Options":
+        elif experiment_variant == "2OptionsV1":
             return Response(status=status.HTTP_200_OK)
 
         return Response(status=status.HTTP_404_NOT_FOUND)

--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -21,7 +21,7 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
             return context
 
         experiment_variant = experiments.get(
-            org=organization, experiment_name="AlertDefaultsExperimentTmp"
+            org=organization, experiment_name="AlertDefaultsExperiment"
         )
         if experiment_variant == "test3Options":
             return Response(

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -829,7 +829,7 @@ export type SentryAppComponent = {
 export type ActiveExperiments = {
   TrialUpgradeV2Experiment: 'upgrade' | 'trial' | -1;
   IntegrationDirectoryExperiment: '1' | '0';
-  AlertDefaultsExperimentTmp: 'testControl' | 'test2Options' | 'test3Options';
+  AlertDefaultsExperiment: 'controlV1' | '2OptionsV1' | '3OptionsV1';
 };
 
 type SavedQueryVersions = 1 | 2;

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -66,11 +66,15 @@ class CreateProject extends React.Component {
 
   componentDidMount() {
     const {organization} = this.props;
-    if (
-      ['2OptionsV1', '3OptionsV1', 'controlV1'].includes(
-        organization.experiments?.AlertDefaultsExperiment
-      )
-    ) {
+    const alertDefaultsExperimentVariant =
+      organization.experiments?.AlertDefaultsExperiment;
+    const isInAlertDefaultsExperiment = [
+      '2OptionsV1',
+      '3OptionsV1',
+      'controlV1',
+    ].includes(alertDefaultsExperimentVariant);
+
+    if (isInAlertDefaultsExperiment) {
       logExperiment({
         organization,
         key: 'AlertDefaultsExperiment',
@@ -79,11 +83,16 @@ class CreateProject extends React.Component {
         param: 'variant',
       });
     }
-    trackAnalyticsEvent({
+
+    let analyticsEventOptions = {
       eventKey: 'new_project.visited',
       eventName: 'New Project Page Visited',
       org_id: parseInt(this.props.organization.id, 10),
-    });
+    };
+    if (isInAlertDefaultsExperiment) {
+      analyticsEventOptions = {...analyticsEventOptions, alertDefaultsExperimentVariant};
+    }
+    trackAnalyticsEvent(analyticsEventOptions);
   }
 
   renderProjectForm = (

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -65,13 +65,20 @@ class CreateProject extends React.Component {
   }
 
   componentDidMount() {
-    logExperiment({
-      organization: this.props.organization,
-      key: 'AlertDefaultsExperiment',
-      unitName: 'org_id',
-      unitId: parseInt(this.props.organization.id, 10),
-      param: 'variant',
-    });
+    const {organization} = this.props;
+    if (
+      ['2OptionsV1', '3OptionsV1', 'controlV1'].includes(
+        organization.experiments?.AlertDefaultsExperiment
+      )
+    ) {
+      logExperiment({
+        organization,
+        key: 'AlertDefaultsExperiment',
+        unitName: 'org_id',
+        unitId: parseInt(organization.id, 10),
+        param: 'variant',
+      });
+    }
     trackAnalyticsEvent({
       eventKey: 'new_project.visited',
       eventName: 'New Project Page Visited',

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -84,13 +84,13 @@ class CreateProject extends React.Component {
       });
     }
 
-    let analyticsEventOptions = {
+    const analyticsEventOptions = {
       eventKey: 'new_project.visited',
       eventName: 'New Project Page Visited',
       org_id: parseInt(this.props.organization.id, 10),
     };
     if (isInAlertDefaultsExperiment) {
-      analyticsEventOptions = {...analyticsEventOptions, alertDefaultsExperimentVariant};
+      analyticsEventOptions.alert_defaults_experiment_variant = alertDefaultsExperimentVariant;
     }
     trackAnalyticsEvent(analyticsEventOptions);
   }

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -67,7 +67,7 @@ class CreateProject extends React.Component {
   componentDidMount() {
     logExperiment({
       organization: this.props.organization,
-      key: 'AlertDefaultsExperimentTmp',
+      key: 'AlertDefaultsExperiment',
       unitName: 'org_id',
       unitId: parseInt(this.props.organization.id, 10),
       param: 'variant',

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -14,7 +14,7 @@ const NewProject = ({organization}) => (
         <DocumentTitle title="Sentry" />
         <CreateProject
           hasIssueAlertOptionsEnabled={['test2Options', 'test3Options'].includes(
-            organization.experiments?.AlertDefaultsExperimentTmp
+            organization.experiments?.AlertDefaultsExperiment
           )}
         />
       </Content>

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -13,9 +13,9 @@ const NewProject = ({organization}) => (
       <Content>
         <DocumentTitle title="Sentry" />
         <CreateProject
-          hasIssueAlertOptionsEnabled={['test2Options', 'test3Options'].includes(
-            organization.experiments?.AlertDefaultsExperiment
-          )}
+          hasIssueAlertOptionsEnabled={['2Options', '3Options']
+            .map(variant => variant.concat('V1'))
+            .includes(organization.experiments?.AlertDefaultsExperiment)}
         />
       </Content>
     </div>

--- a/tests/sentry/api/endpoints/test_project_agnostic_rule_conditions.py
+++ b/tests/sentry/api/endpoints/test_project_agnostic_rule_conditions.py
@@ -7,7 +7,7 @@ from sentry.testutils import APITestCase
 
 
 class ProjectAgnosticRuleConditionsTest(APITestCase):
-    @patch("sentry.experiments.get", return_value="test3OptionsV1")
+    @patch("sentry.experiments.get", return_value="3OptionsV1")
     def test_simple(self, mocked_experiment):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")

--- a/tests/sentry/api/endpoints/test_project_agnostic_rule_conditions.py
+++ b/tests/sentry/api/endpoints/test_project_agnostic_rule_conditions.py
@@ -7,7 +7,7 @@ from sentry.testutils import APITestCase
 
 
 class ProjectAgnosticRuleConditionsTest(APITestCase):
-    @patch("sentry.experiments.get", return_value="test3Options")
+    @patch("sentry.experiments.get", return_value="test3OptionsV1")
     def test_simple(self, mocked_experiment):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")


### PR DESCRIPTION
Experiment name is changed to the actual experiment's name where actual data would be collected.
Variant names are also changed.
Sister PR: https://github.com/getsentry/getsentry/pull/3591