### PR TITLE
fix(ui): Require project access for event cause empty

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -109,6 +109,7 @@ export type Project = {
   isBookmarked: boolean;
   hasUserReports?: boolean;
   hasAccess: boolean;
+  firstEvent: 'string' | null;
 
   // XXX: These are part of the DetailedProject serializer
   plugins: Plugin[];

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -168,6 +168,7 @@ class GroupEventDetails extends React.Component<Props, State> {
     const {releasesCompletion} = this.state;
     return (
       project?.isMember &&
+      project?.firstEvent &&
       releasesCompletion?.some(({step, complete}) => step === 'commit' && !complete)
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -164,10 +164,11 @@ class GroupEventDetails extends React.Component<Props, State> {
   };
 
   get showExampleCommit() {
+    const {project} = this.props;
     const {releasesCompletion} = this.state;
     return (
-      releasesCompletion &&
-      releasesCompletion.some(({step, complete}) => step === 'commit' && !complete)
+      project?.isMember &&
+      releasesCompletion?.some(({step, complete}) => step === 'commit' && !complete)
     );
   }
 

--- a/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
+++ b/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
@@ -11,7 +11,10 @@ describe('EventCauseEmpty', function() {
   let putMock;
   const routerContext = TestStubs.routerContext();
   const organization = TestStubs.Organization();
-  const project = TestStubs.Project({platform: 'javascript'});
+  const project = TestStubs.Project({
+    platform: 'javascript',
+    firstEvent: '2020-01-01T23:54:33.831199Z',
+  });
 
   beforeEach(function() {
     MockApiClient.clearMockResponses();

--- a/tests/js/spec/views/organizationGroupDetails/groupEventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventDetails.spec.jsx
@@ -217,6 +217,8 @@ describe('groupEventDetails', () => {
   });
 
   describe('EventCauseEmpty', () => {
+    const proj = TestStubs.Project({firstEvent: '2020-01-01T01:00:00Z'});
+
     it('renders empty state', async function() {
       MockApiClient.addMockResponse({
         url: `/projects/${org.slug}/${project.slug}/releases/completion/`,
@@ -232,7 +234,7 @@ describe('groupEventDetails', () => {
         <GroupEventDetails
           api={new MockApiClient()}
           group={group}
-          project={project}
+          project={proj}
           organization={org}
           environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
           params={{orgId: org.slug, groupId: group.id, eventId: '1'}}
@@ -262,7 +264,7 @@ describe('groupEventDetails', () => {
         <GroupEventDetails
           api={new MockApiClient()}
           group={group}
-          project={project}
+          project={proj}
           organization={org}
           environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
           params={{orgId: org.slug, groupId: group.id, eventId: '1'}}
@@ -287,7 +289,7 @@ describe('groupEventDetails', () => {
         <GroupEventDetails
           api={new MockApiClient()}
           group={group}
-          project={project}
+          project={proj}
           organization={org}
           environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
           params={{orgId: org.slug, groupId: group.id, eventId: '1'}}
@@ -313,7 +315,7 @@ describe('groupEventDetails', () => {
         <GroupEventDetails
           api={new MockApiClient()}
           group={group}
-          project={project}
+          project={proj}
           organization={org}
           environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
           params={{orgId: org.slug, groupId: group.id, eventId: '1'}}


### PR DESCRIPTION
Only show the empty state to project members, and avoid displaying on sample events.