### PR TITLE
chore(async-csv): Handle async errors in CSV export

### DIFF
--- a/src/sentry/api/endpoints/data_export.py
+++ b/src/sentry/api/endpoints/data_export.py
@@ -44,6 +44,7 @@ class DataExportEndpoint(OrganizationEndpoint):
         try:
             existing_data_exports = ExportedData.objects.filter(
                 organization=organization,
+                user=request.user,
                 query_type=data["query_type"],
                 query_info=data["query_info"],
                 date_finished=None,

--- a/src/sentry/api/endpoints/data_export.py
+++ b/src/sentry/api/endpoints/data_export.py
@@ -49,10 +49,6 @@ class DataExportEndpoint(OrganizationEndpoint):
                 date_finished=None,
             ).order_by("-date_added")
             if len(existing_data_exports) > 0:
-                # TODO(Leander): If this organization has requested the same export whilst it's in progress, serve it
-                # This will cause problems since any other user in the org won't get emailed, only the person who FIRST started it.
-                # The user field should be changed to a list or another field
-                # TODO(Leander): Tell the user on the FE that they're job had been started already
                 data_export = existing_data_exports[0]
                 status = 200
             else:

--- a/src/sentry/api/endpoints/data_export.py
+++ b/src/sentry/api/endpoints/data_export.py
@@ -49,6 +49,8 @@ class DataExportEndpoint(OrganizationEndpoint):
                 query_info=data["query_info"],
                 date_finished=None,
             ).order_by("-date_added")
+            # If this user has sent a sent a request with the same payload and organization,
+            # we return them the latest one that is NOT complete (i.e. don't start another)
             if len(existing_data_exports) > 0:
                 data_export = existing_data_exports[0]
                 status = 200

--- a/src/sentry/api/endpoints/data_export_details.py
+++ b/src/sentry/api/endpoints/data_export_details.py
@@ -23,6 +23,7 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
 
         try:
             data_export = ExportedData.objects.get(id=kwargs["data_export_id"])
+            # Ignore the download parameter unless we have a file to stream
             if request.GET.get("download") is not None and data_export.file is not None:
                 return self.download(data_export)
             return Response(serialize(data_export, request.user))

--- a/src/sentry/api/endpoints/data_export_details.py
+++ b/src/sentry/api/endpoints/data_export_details.py
@@ -23,7 +23,7 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
 
         try:
             data_export = ExportedData.objects.get(id=kwargs["data_export_id"])
-            if request.GET.get("download") is not None:
+            if request.GET.get("download") is not None and data_export.file is not None:
                 return self.download(data_export)
             return Response(serialize(data_export, request.user))
         except ExportedData.DoesNotExist:

--- a/src/sentry/models/exporteddata.py
+++ b/src/sentry/models/exporteddata.py
@@ -97,6 +97,17 @@ class ExportedData(Model):
         )
         msg.send_async([self.user.email])
 
+    def email_failure(self):
+        from sentry.utils.email import MessageBuilder
+
+        msg = MessageBuilder(
+            subject="[Export] An error has occured",
+            template="sentry/emails/data-export-failure.txt",
+            html_template="sentry/emails/data-export-failure.html",
+        )
+        msg.send_async([self.user.email])
+        self.delete()
+
     class Meta:
         app_label = "sentry"
         db_table = "sentry_exporteddata"

--- a/src/sentry/models/exporteddata.py
+++ b/src/sentry/models/exporteddata.py
@@ -97,11 +97,13 @@ class ExportedData(Model):
         )
         msg.send_async([self.user.email])
 
-    def email_failure(self):
+    def email_failure(self, message):
         from sentry.utils.email import MessageBuilder
 
         msg = MessageBuilder(
-            subject="[Export] An error has occured",
+            subject="We've encountered an Export Failure",
+            context={"error_message": message},
+            type="user.export-data",
             template="sentry/emails/data-export-failure.txt",
             html_template="sentry/emails/data-export-failure.html",
         )

--- a/src/sentry/models/exporteddata.py
+++ b/src/sentry/models/exporteddata.py
@@ -101,7 +101,7 @@ class ExportedData(Model):
         from sentry.utils.email import MessageBuilder
 
         msg = MessageBuilder(
-            subject="An error occured while processing your download",
+            subject="Unable to Export Data",
             context={"error_message": message},
             type="organization.export-data",
             template="sentry/emails/data-export-failure.txt",

--- a/src/sentry/models/exporteddata.py
+++ b/src/sentry/models/exporteddata.py
@@ -101,9 +101,9 @@ class ExportedData(Model):
         from sentry.utils.email import MessageBuilder
 
         msg = MessageBuilder(
-            subject="We've encountered an Export Failure",
+            subject="An error occured while processing your download",
             context={"error_message": message},
-            type="user.export-data",
+            type="organization.export-data",
             template="sentry/emails/data-export-failure.txt",
             html_template="sentry/emails/data-export-failure.html",
         )

--- a/src/sentry/models/exporteddata.py
+++ b/src/sentry/models/exporteddata.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import json
 import six
 from enum import Enum
 from datetime import timedelta
@@ -100,9 +101,14 @@ class ExportedData(Model):
     def email_failure(self, message):
         from sentry.utils.email import MessageBuilder
 
+        payload = self.query_info
+        payload["export_type"] = ExportQueryType.as_str(self.query_type)
         msg = MessageBuilder(
             subject="Unable to Export Data",
-            context={"error_message": message},
+            context={
+                "error_message": message,
+                "payload": json.dumps(payload, indent=2, sort_keys=True),
+            },
             type="organization.export-data",
             template="sentry/emails/data-export-failure.txt",
             html_template="sentry/emails/data-export-failure.html",

--- a/src/sentry/models/exporteddata.py
+++ b/src/sentry/models/exporteddata.py
@@ -101,7 +101,7 @@ class ExportedData(Model):
     def email_failure(self, message):
         from sentry.utils.email import MessageBuilder
 
-        payload = self.query_info
+        payload = self.query_info.copy()
         payload["export_type"] = ExportQueryType.as_str(self.query_type)
         msg = MessageBuilder(
             subject="Unable to Export Data",

--- a/src/sentry/models/exporteddata.py
+++ b/src/sentry/models/exporteddata.py
@@ -63,6 +63,12 @@ class ExportedData(Model):
             return None
         return self.date_expired.strftime("%-I:%M %p on %B %d, %Y (%Z)")
 
+    @property
+    def payload(self):
+        payload = self.query_info.copy()
+        payload["export_type"] = ExportQueryType.as_str(self.query_type)
+        return payload
+
     def delete_file(self):
         if self.file:
             self.file.delete()
@@ -101,13 +107,11 @@ class ExportedData(Model):
     def email_failure(self, message):
         from sentry.utils.email import MessageBuilder
 
-        payload = self.query_info.copy()
-        payload["export_type"] = ExportQueryType.as_str(self.query_type)
         msg = MessageBuilder(
             subject="Unable to Export Data",
             context={
                 "error_message": message,
-                "payload": json.dumps(payload, indent=2, sort_keys=True),
+                "payload": json.dumps(self.payload, indent=2, sort_keys=True),
             },
             type="organization.export-data",
             template="sentry/emails/data-export-failure.txt",

--- a/src/sentry/tasks/data_export.py
+++ b/src/sentry/tasks/data_export.py
@@ -35,7 +35,6 @@ def assemble_download(data_export):
             tf.seek(0)
             try:
                 with transaction.atomic():
-                    raise IntegrityError
                     file = File.objects.create(
                         name=file_name, type="export.csv", headers={"Content-Type": "text/csv"}
                     )

--- a/src/sentry/tasks/data_export.py
+++ b/src/sentry/tasks/data_export.py
@@ -45,6 +45,9 @@ def assemble_download(data_export):
     except DataExportError as err:
         # TODO(Leander): Implement logging
         return data_export.email_failure(message=err)
+    except BaseException as err:
+        # TODO(Leander): Implement logging
+        return data_export.email_failure(message="Internal processing failure")
 
 
 def process_discover_v2(data_export, file):

--- a/src/sentry/tasks/data_export.py
+++ b/src/sentry/tasks/data_export.py
@@ -45,7 +45,7 @@ def assemble_download(data_export):
     except DataExportError as err:
         # TODO(Leander): Implement logging
         return data_export.email_failure(message=err)
-    except BaseException as err:
+    except BaseException:
         # TODO(Leander): Implement logging
         return data_export.email_failure(message="Internal processing failure")
 

--- a/src/sentry/templates/sentry/emails/data-export-failure.html
+++ b/src/sentry/templates/sentry/emails/data-export-failure.html
@@ -5,6 +5,7 @@
 
 {% block main %}
     <h3>An error has occured with your data export</h3>
-    <p>We were unable to complete the bulk export of your data.</p>
+    <p>While trying to generate your data export, we encountered the following error:</p>
+    <p>{{error_message}}</p>
     <p>Please try again later</p>
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/data-export-failure.html
+++ b/src/sentry/templates/sentry/emails/data-export-failure.html
@@ -7,7 +7,6 @@
     <h3>Unable to Export Data</h3>
     <p>We were unable to generate your data export due to an internal processing error:</p>
     <p><code>{{error_message}}</code></p>
-    <p>Please try again later.</p>
     <br/>
     <p><strong>Troubleshooting &amp; References</strong></p>
     <ul>

--- a/src/sentry/templates/sentry/emails/data-export-failure.html
+++ b/src/sentry/templates/sentry/emails/data-export-failure.html
@@ -4,8 +4,14 @@
 {% load i18n %}
 
 {% block main %}
-    <h3>An error has occured with your data export</h3>
-    <p>While trying to generate your data export, we encountered the following error:</p>
-    <p>{{error_message}}</p>
-    <p>Please try again later</p>
+    <h3>Unable to Export Data</h3>
+    <p>We were unable to generate your data export due to an internal processing error:</p>
+    <p><code>{{error_message}}</code></p>
+    <p>Please try again later.</p>
+    <br/>
+    <p><strong>Troubleshooting &amp; References</strong></p>
+    <ul>
+        <li><a href="https://docs.sentry.io/">Documentation</a></li>
+        <li><a href="https://help.sentry.io/">FAQs</a></li>
+    </ul>
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/data-export-failure.html
+++ b/src/sentry/templates/sentry/emails/data-export-failure.html
@@ -1,0 +1,10 @@
+
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+
+{% block main %}
+    <h3>An error has occured with your data export</h3>
+    <p>We were unable to complete the bulk export of your data.</p>
+    <p>Please try again later</p>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/data-export-failure.html
+++ b/src/sentry/templates/sentry/emails/data-export-failure.html
@@ -5,9 +5,12 @@
 
 {% block main %}
     <h3>Unable to Export Data</h3>
-    <p>We were unable to generate your data export due to an internal processing error:</p>
-    <p><code>{{error_message}}</code></p>
-    <br/>
+    <p>We were unable to generate your data export due to an error:</p>
+    <code><pre>{{error_message}}</pre></code>
+    <p>We received the following payload:</p>
+    <code>
+        <pre>{{payload}}</pre>
+    </code>
     <p><strong>Troubleshooting &amp; References</strong></p>
     <ul>
         <li><a href="https://docs.sentry.io/">Documentation</a></li>

--- a/src/sentry/templates/sentry/emails/data-export-failure.txt
+++ b/src/sentry/templates/sentry/emails/data-export-failure.txt
@@ -1,4 +1,7 @@
-An error has occured with your data export
+An error has occured with your data export.
 
-We were unable to complete the bulk export of your data.
+While trying to generate your data export, we encountered the following error:
+
+{{error_message}}
+
 Please try again later

--- a/src/sentry/templates/sentry/emails/data-export-failure.txt
+++ b/src/sentry/templates/sentry/emails/data-export-failure.txt
@@ -5,8 +5,6 @@ We were unable to generate your data export due to an internal processing error:
 
     {{error_message}}
 
-Please try again later.
-
 Troubleshooting & References:
  - https://docs.sentry.io/ (Documentation)
  - https://help.sentry.io/ (FAQs)

--- a/src/sentry/templates/sentry/emails/data-export-failure.txt
+++ b/src/sentry/templates/sentry/emails/data-export-failure.txt
@@ -1,0 +1,4 @@
+An error has occured with your data export
+
+We were unable to complete the bulk export of your data.
+Please try again later

--- a/src/sentry/templates/sentry/emails/data-export-failure.txt
+++ b/src/sentry/templates/sentry/emails/data-export-failure.txt
@@ -1,7 +1,12 @@
-An error has occured with your data export.
+Unable to Export Data
+---------------------
 
-While trying to generate your data export, we encountered the following error:
+We were unable to generate your data export due to an internal processing error:
 
-{{error_message}}
+    {{error_message}}
 
-Please try again later
+Please try again later.
+
+Troubleshooting & References:
+ - https://docs.sentry.io/ (Documentation)
+ - https://help.sentry.io/ (FAQs)

--- a/src/sentry/templates/sentry/emails/data-export-failure.txt
+++ b/src/sentry/templates/sentry/emails/data-export-failure.txt
@@ -1,9 +1,13 @@
 Unable to Export Data
 ---------------------
 
-We were unable to generate your data export due to an internal processing error:
+We were unable to generate your data export due to an error:
 
     {{error_message}}
+
+We received the following payload:
+
+    {{payload}}
 
 Troubleshooting & References:
  - https://docs.sentry.io/ (Documentation)

--- a/tests/sentry/api/endpoints/test_data_export_details.py
+++ b/tests/sentry/api/endpoints/test_data_export_details.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import six
-
-from django.core.urlresolvers import reverse
+from datetime import timedelta
 from django.utils import timezone
 
 from sentry.models import ExportedData
@@ -13,38 +12,58 @@ from sentry.testutils import APITestCase
 class DataExportDetailsTest(APITestCase):
     endpoint = "sentry-api-0-organization-data-export-details"
 
-    TEST_DATE_ADDED = timezone.now()
+    def setUp(self):
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.login_as(user=self.user)
+        self.data_export = ExportedData.objects.create(
+            user=self.user, organization=self.organization, query_type=0, query_info={"env": "test"}
+        )
 
-    def test_simple(self):
+    def test_content(self):
         with self.feature("organizations:data-export"):
-            self.user = self.create_user("foo@example.com")
-            self.org = self.create_organization(owner=self.user, name="Toucan Sam")
-            self.login_as(user=self.user)
+            response = self.get_valid_response(self.organization.slug, self.data_export.id)
+        assert response.data["id"] == self.data_export.id
+        assert response.data["user"] == {
+            "id": six.binary_type(self.user.id),
+            "email": self.user.email,
+            "username": self.user.username,
+        }
+        assert response.data["dateCreated"] == self.data_export.date_added
+        assert response.data["query"] == {
+            "type": self.data_export.query_type,
+            "info": self.data_export.query_info,
+        }
 
-            data_export = ExportedData.objects.create(
-                organization=self.org,
-                user=self.user,
-                date_added=self.TEST_DATE_ADDED,
-                query_type=1,
-                query_info={"environment": "test"},
-            )
-            url = reverse(
-                self.endpoint,
-                kwargs={"data_export_id": data_export.id, "organization_slug": self.org.slug},
-            )
+    def test_early(self):
+        with self.feature("organizations:data-export"):
+            response = self.get_valid_response(self.organization.slug, self.data_export.id)
+        assert response.data["dateFinished"] is None
+        assert response.data["dateExpired"] is None
+        assert response.data["status"] == ExportStatus.Early
 
-            response = self.client.get(url, format="json")
-            assert response.status_code == 200
-            assert response.data == {
-                "id": data_export.id,
-                "user": {
-                    "id": six.binary_type(self.user.id),
-                    "email": self.user.email,
-                    "username": self.user.username,
-                },
-                "dateCreated": self.TEST_DATE_ADDED,
-                "dateFinished": None,
-                "dateExpired": None,
-                "query": {"type": data_export.query_type, "info": data_export.query_info},
-                "status": ExportStatus.Early,
-            }
+    def test_valid(self):
+        self.data_export.update(
+            date_finished=timezone.now() - timedelta(weeks=2),
+            date_expired=timezone.now() + timedelta(weeks=1),
+        )
+        with self.feature("organizations:data-export"):
+            response = self.get_valid_response(self.organization.slug, self.data_export.id)
+        assert response.data["dateFinished"] is not None
+        assert response.data["dateFinished"] == self.data_export.date_finished
+        assert response.data["dateExpired"] is not None
+        assert response.data["dateExpired"] == self.data_export.date_expired
+        assert response.data["status"] == ExportStatus.Valid
+
+    def test_expired(self):
+        self.data_export.update(
+            date_finished=timezone.now() - timedelta(weeks=2),
+            date_expired=timezone.now() - timedelta(weeks=1),
+        )
+        with self.feature("organizations:data-export"):
+            response = self.get_valid_response(self.organization.slug, self.data_export.id)
+        assert response.data["dateFinished"] is not None
+        assert response.data["dateFinished"] == self.data_export.date_finished
+        assert response.data["dateExpired"] is not None
+        assert response.data["dateExpired"] == self.data_export.date_expired
+        assert response.data["status"] == ExportStatus.Expired

--- a/tests/sentry/tasks/test_data_export.py
+++ b/tests/sentry/tasks/test_data_export.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
 
+import six
+
 from sentry.models import ExportedData, File
-from sentry.tasks.data_export import assemble_download, get_file_name
+from sentry.tasks.data_export import assemble_download, get_file_name, DataExportError
 from sentry.testutils import TestCase, SnubaTestCase
+from sentry.utils.compat.mock import patch
 
 
 class AssembleDownloadTest(TestCase, SnubaTestCase):
@@ -30,7 +33,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
         file_name = get_file_name("TESTING", "proj1_user1_test")
         assert file_name == "TESTING-proj1_user1_test.csv"
 
-    def test_assemble_download_issue_by_tag(self):
+    def test_issue_by_tag(self):
         de1 = ExportedData.objects.create(
             user=self.user,
             organization=self.org,
@@ -69,3 +72,36 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
         raw1, raw2 = sorted([raw1, raw2])
         assert raw1.startswith("bar,1,")
         assert raw2.startswith("bar2,2,")
+
+    @patch("sentry.models.ExportedData.email_failure")
+    def test_issue_by_tag_errors(self, emailer):
+        de1 = ExportedData.objects.create(
+            user=self.user,
+            organization=self.org,
+            query_type=2,
+            query_info={
+                "project_id": self.project.id + 1,
+                "group_id": self.event.group_id,
+                "key": "user",
+            },
+        )
+        with self.tasks():
+            assemble_download(de1)
+        error = emailer.call_args[1]["message"]
+        assert isinstance(error, DataExportError)
+        assert six.binary_type(error) == "Requested project does not exist"
+        de2 = ExportedData.objects.create(
+            user=self.user,
+            organization=self.org,
+            query_type=2,
+            query_info={
+                "project_id": self.project.id,
+                "group_id": self.event.group_id + 1,
+                "key": "user",
+            },
+        )
+        with self.tasks():
+            assemble_download(de2)
+        error = emailer.call_args[1]["message"]
+        assert isinstance(error, DataExportError)
+        assert six.binary_type(error) == "Requested issue does not exist"

--- a/tests/sentry/tasks/test_data_export.py
+++ b/tests/sentry/tasks/test_data_export.py
@@ -79,11 +79,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             user=self.user,
             organization=self.org,
             query_type=2,
-            query_info={
-                "project_id": self.project.id + 1,
-                "group_id": self.event.group_id,
-                "key": "user",
-            },
+            query_info={"project_id": -1, "group_id": self.event.group_id, "key": "user"},
         )
         with self.tasks():
             assemble_download(de1)
@@ -94,11 +90,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             user=self.user,
             organization=self.org,
             query_type=2,
-            query_info={
-                "project_id": self.project.id,
-                "group_id": self.event.group_id + 1,
-                "key": "user",
-            },
+            query_info={"project_id": self.project.id, "group_id": -1, "key": "user"},
         )
         with self.tasks():
             assemble_download(de2)


### PR DESCRIPTION
This PR will add a bunch of `try/except` blocks to catch errors wherever they may occur in the async job, and email the failure to the user, so they don't continue to wait for the failed export to complete.

Along with that, the behavior I've set is that upon a sent email, the failed ExportedData instance will delete itself. This to keep the DB clean, and prevent any errors with trying to allocate the reserved route.

---

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/35509934/75200436-86c44f80-571a-11ea-8c12-d3b64706531c.png">

The three possibilities for error text are:
 - Requested project does not exist
 - Requested issue does not exist
 - Failed to save the assembled file