### PR TITLE
refs: Mark model_unpickle_compat logs as errors so we see them in sentry

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -405,7 +405,7 @@ def __model_unpickle_compat(model_id, attrs=None, factory=None):
 
     if attrs is not None or factory is not None:
         metrics.incr("django.pickle.loaded_19_pickle.__model_unpickle_compat", sample_rate=1)
-        logger.warning(
+        logger.error(
             "django.compat.model-unpickle-compat",
             extra={"model_id": model_id, "attrs": attrs, "factory": factory, "stack": True},
         )


### PR DESCRIPTION
It looks like we don't send warnings to sentry for the sentry project. These are low volume and
it'll be helpful to see the stack for these.