### PR TITLE
fix(discover2): Pass yAxis explicitly to the query card's graph

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -54,6 +54,7 @@ class MiniGraph extends React.Component<Props> {
       period,
       project: eventView.project,
       environment: eventView.environment,
+      yAxis: eventView.getYAxis(),
     };
   }
 
@@ -67,6 +68,7 @@ class MiniGraph extends React.Component<Props> {
       organization,
       project,
       environment,
+      yAxis,
     } = this.getRefreshProps(this.props);
 
     return (
@@ -81,6 +83,7 @@ class MiniGraph extends React.Component<Props> {
         project={project as number[]}
         environment={environment as string[]}
         includePrevious={false}
+        yAxis={yAxis}
       >
         {({loading, timeseriesData, errored}) => {
           if (errored) {


### PR DESCRIPTION
Pass yAxis explicitly to the query card's graph. Previously it was implicitly using `count()`.