### PR TITLE
ref(ui): Refactor/fix `<RuleNode>` to not trigger side effects during update

### DIFF
--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -1,3 +1,21 @@
+export type IssueAlertRuleFormField =
+  | {
+      type: 'choice';
+      choices?: [string, string][];
+      initial?: string;
+      placeholder?: string;
+    }
+  | {
+      type: 'string';
+      initial?: string;
+      placeholder?: string;
+    }
+  | {
+      type: 'number';
+      placeholder?: number | string;
+      initial?: string;
+    };
+
 /**
  * These templates that tell the UI how to render the action or condition
  * and what fields it needs
@@ -7,20 +25,7 @@ export type IssueAlertRuleActionTemplate = {
   label: string;
   enabled: boolean;
   formFields?: {
-    [key: string]:
-      | {
-          type: 'choice';
-          choices: [string, string][];
-          placeholder?: string;
-        }
-      | {
-          type: 'string';
-          placeholder?: string;
-        }
-      | {
-          type: 'number';
-          placeholder?: number | string;
-        };
+    [key: string]: IssueAlertRuleFormField;
   };
 };
 export type IssueAlertRuleConditionTemplate = IssueAlertRuleActionTemplate;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -28,7 +28,7 @@ type Props = {
   onPropertyChange: (rowIndex: number, name: string, value: string) => void;
 };
 
-class RuleNode extends React.PureComponent<Props> {
+class RuleNode extends React.Component<Props> {
   handleDelete = () => {
     const {index, onDelete} = this.props;
     onDelete(index);

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -21,17 +21,23 @@ type FormField = {
 };
 
 type Props = {
+  index: number;
   node?: IssueAlertRuleActionTemplate | IssueAlertRuleConditionTemplate | null;
   data?: IssueAlertRuleAction | IssueAlertRuleCondition;
-  onDelete: () => void;
-  onPropertyChange: (name: string, value: string) => void;
+  onDelete: (rowIndex: number) => void;
+  onPropertyChange: (rowIndex: number, name: string, value: string) => void;
 };
 
-class RuleNode extends React.Component<Props> {
+class RuleNode extends React.PureComponent<Props> {
+  handleDelete = () => {
+    const {index, onDelete} = this.props;
+    onDelete(index);
+  };
+
   getChoiceField = (name: string, fieldConfig: FormField) => {
     // Select the first item on this list
     // If it's not yet defined, call onPropertyChange to make sure the value is set on state
-    const {data, onPropertyChange} = this.props;
+    const {data, index, onPropertyChange} = this.props;
     let initialVal;
 
     if (data) {
@@ -41,7 +47,6 @@ class RuleNode extends React.Component<Props> {
         } else {
           initialVal = fieldConfig.choices[0][0];
         }
-        onPropertyChange(name, initialVal);
       } else {
         initialVal = data[name];
       }
@@ -68,13 +73,13 @@ class RuleNode extends React.Component<Props> {
           }),
         }}
         choices={choices}
-        onChange={({value}) => this.props.onPropertyChange(name, value)}
+        onChange={({value}) => onPropertyChange(index, name, value)}
       />
     );
   };
 
   getTextField = (name: string, fieldConfig: FormField) => {
-    const {data, onPropertyChange} = this.props;
+    const {data, index, onPropertyChange} = this.props;
 
     return (
       <InlineInput
@@ -83,14 +88,14 @@ class RuleNode extends React.Component<Props> {
         value={(data && data[name]) ?? ''}
         placeholder={`${fieldConfig.placeholder}`}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-          onPropertyChange(name, e.target.value)
+          onPropertyChange(index, name, e.target.value)
         }
       />
     );
   };
 
   getNumberField = (name: string, fieldConfig: FormField) => {
-    const {data, onPropertyChange} = this.props;
+    const {data, index, onPropertyChange} = this.props;
 
     return (
       <InlineInput
@@ -99,7 +104,7 @@ class RuleNode extends React.Component<Props> {
         value={(data && data[name]) ?? ''}
         placeholder={`${fieldConfig.placeholder}`}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-          onPropertyChange(name, e.target.value)
+          onPropertyChange(index, name, e.target.value)
         }
       />
     );
@@ -123,9 +128,9 @@ class RuleNode extends React.Component<Props> {
 
     const {label, formFields} = node;
 
-    const parts = label.split(/({\w+})/).map(part => {
+    const parts = label.split(/({\w+})/).map((part, i) => {
       if (!/^{\w+}$/.test(part)) {
-        return <Separator>{part}</Separator>;
+        return <Separator key={i}>{part}</Separator>;
       }
 
       const key = part.slice(1, -1);
@@ -157,7 +162,7 @@ class RuleNode extends React.Component<Props> {
   }
 
   render() {
-    const {data, onDelete} = this.props;
+    const {data} = this.props;
 
     return (
       <RuleRow>
@@ -165,7 +170,7 @@ class RuleNode extends React.Component<Props> {
         {this.renderRow()}
         <DeleteButton
           label={t('Delete Node')}
-          onClick={onDelete}
+          onClick={this.handleDelete}
           type="button"
           size="small"
           icon="icon-trash"

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -22,15 +22,14 @@ type Props = {
   // Placeholder for select control
   placeholder: string;
 
-  onPropertyChange: (ruleIndex: number) => (prop: string, val: string) => void;
+  onPropertyChange: (ruleIndex: number, prop: string, val: string) => void;
 
-  // TODO(ts): Type value
-  onAddRow: (value: unknown) => void;
+  onAddRow: (value: string) => void;
 
   onDeleteRow: (ruleIndex: number) => void;
 };
 
-class RuleNodeList extends React.Component<Props> {
+class RuleNodeList extends React.PureComponent<Props> {
   getNode = (
     id: string
   ):
@@ -69,10 +68,11 @@ class RuleNodeList extends React.Component<Props> {
               return (
                 <RuleNode
                   key={idx}
+                  index={idx}
                   node={this.getNode(item.id)}
-                  onDelete={() => onDeleteRow(idx)}
+                  onDelete={onDeleteRow}
                   data={item}
-                  onPropertyChange={onPropertyChange(idx)}
+                  onPropertyChange={onPropertyChange}
                 />
               );
             })}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -29,7 +29,7 @@ type Props = {
   onDeleteRow: (ruleIndex: number) => void;
 };
 
-class RuleNodeList extends React.PureComponent<Props> {
+class RuleNodeList extends React.Component<Props> {
   getNode = (
     id: string
   ):


### PR DESCRIPTION
I was initially trying to just fix some `console.error` during test and then found a React warning about triggering side effects during updates (e.g. setState inside of a `render()`). I did not know what was causing this as we definitely do not `setState()` in render. I ended up ~making a few components `PureComponents` and the necessary~ refactoring of props that were passed inline functions.

The actual problem was that in `RuleNode`, where we create components based on the backend field configuration, if we add a field that has an initial value (or is a select field with choices), it will call the `onPropertyChange` callback and trigger a sideeffect (`setState()`) that throws this warning. Moved that logic into the `onAddRow` handler instead.