### PR TITLE
ref(onboarding): Map onboarding tasks IDs to string keys

### DIFF
--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -4,35 +4,34 @@ from django.utils import timezone
 from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.models import OnboardingTask, OnboardingTaskStatus, OrganizationOnboardingTask
+from sentry.models import OnboardingTaskStatus, OrganizationOnboardingTask
 from sentry.receivers import try_mark_onboarding_complete
 
 
 class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
     def post(self, request, organization):
         try:
-            task_id = int(request.data["task"])
-        except (TypeError, ValueError):
-            return Response(status=500)
+            task_id = OrganizationOnboardingTask.TASK_LOOKUP_BY_KEY[request.data["task"]]
+        except KeyError:
+            return Response({"detail": "Invalid task key"}, status=422)
 
-        if request.data["status"] == "skipped" and task_id in (
-            OnboardingTask.INVITE_MEMBER,
-            OnboardingTask.SECOND_PLATFORM,
-            OnboardingTask.USER_CONTEXT,
-            OnboardingTask.RELEASE_TRACKING,
-            OnboardingTask.SOURCEMAPS,
-            OnboardingTask.USER_REPORTS,
-            OnboardingTask.ISSUE_TRACKER,
-            OnboardingTask.NOTIFICATION_SERVICE,
+        status = OrganizationOnboardingTask.STATUS_LOOKUP_BY_KEY.get(request.data["status"])
+        if status is None:
+            return Response({"detail": "Invalid status key"}, status=422)
+
+        # Cannot skip unskippable tasks
+        if (
+            status == OnboardingTaskStatus.SKIPPED
+            and task_id not in OrganizationOnboardingTask.SKIPPABLE_TASKS
         ):
-            rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
-                organization=organization,
-                user=request.user,
-                task=request.data["task"],
-                values={"status": OnboardingTaskStatus.SKIPPED, "date_completed": timezone.now()},
-            )
-            if rows_affected or created:
-                try_mark_onboarding_complete(organization.id)
-            return Response(status=204)
+            return Response(status=422)
 
-        return Response(status=404)
+        rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
+            organization=organization,
+            user=request.user,
+            task=task_id,
+            values={"status": OnboardingTaskStatus.SKIPPED, "date_completed": timezone.now()},
+        )
+        if rows_affected or created:
+            try_mark_onboarding_complete(organization.id)
+        return Response(status=204)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -111,8 +111,8 @@ class OrganizationSerializer(Serializer):
 class OnboardingTasksSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "task": obj.task,
-            "status": dict(OrganizationOnboardingTask.STATUS_CHOICES).get(obj.status).lower(),
+            "task": OrganizationOnboardingTask.TASK_KEY_MAP.get(obj.task),
+            "status": OrganizationOnboardingTask.STATUS_KEY_MAP.get(obj.status),
             "user": obj.user.name if obj.user else None,
             "dateCompleted": obj.date_completed,
             "data": obj.data,

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -20,32 +20,37 @@ class OnboardingTask(object):
     FIRST_PROJECT = 1
     FIRST_EVENT = 2
     INVITE_MEMBER = 3
-    SECOND_PLATFORM = 4  # dependent on FIRST_EVENT.
-    USER_CONTEXT = 5  # dependent on FIRST_EVENT
-    RELEASE_TRACKING = 6  # dependent on FIRST_EVENT
-    SOURCEMAPS = (
-        7
-    )  # dependent on RELEASE_TRACKING and one of the platforms being javascript or node
-    USER_REPORTS = 8  # Only for web frameworks
+    SECOND_PLATFORM = 4
+    USER_CONTEXT = 5
+    RELEASE_TRACKING = 6
+    SOURCEMAPS = 7
+    USER_REPORTS = 8
     ISSUE_TRACKER = 9
-    NOTIFICATION_SERVICE = 10
-
-    REQUIRED_ONBOARDING_TASKS = frozenset([1, 2, 3, 4, 5, 6, 7, 9, 10])
+    ALERT_RULE = 10
 
 
 class OnboardingTaskStatus(object):
-    """
-    Pending is applicable for:
-    first event: user confirms that sdk has been installed
-    second platform: user confirms that sdk has been installed
-    user context: user has added user context to sdk
-    invite member: until the member has successfully joined org
-    issue tracker: tracker added, issue not yet created
-    """
-
     COMPLETE = 1
     PENDING = 2
     SKIPPED = 3
+
+
+# NOTE: data fields for some event types are as follows:
+#
+#   FIRST_EVENT:      { 'platform':  'flask', }
+#   INVITE_MEMBER:    { 'invited_member': user.id, 'teams': [team.id] }
+#   ISSUE_TRACKER:    { 'plugin': 'plugin_name' }
+#   ISSUE_ASSIGNMENT: { 'assigned_member': user.id }
+#   SECOND_PLATFORM:  { 'platform': 'javascript' }
+#
+# NOTE: Currently the `PENDING` status is applicable for the following
+# onboarding tasks:
+#
+#   FIRST_EVENT:     User confirms that sdk has been installed
+#   INVITE_MEMBER:   Until the member has successfully joined org
+#   SECOND_PLATFORM: User confirms that sdk has been installed
+#   USER_CONTEXT:    User has added user context to sdk
+#   ISSUE_TRACKER:   Tracker added, issue not yet created
 
 
 class OrganizationOnboardingTaskManager(BaseManager):
@@ -68,36 +73,64 @@ class OrganizationOnboardingTaskManager(BaseManager):
 class OrganizationOnboardingTask(Model):
     """
     Onboarding tasks walk new Sentry orgs through basic features of Sentry.
-    data field options (not all tasks have data fields):
-        FIRST_EVENT: { 'platform':  'flask', }
-        INVITE_MEMBER: { 'invited_member': user.id, 'teams': [team.id] }
-        ISSUE_TRACKER | NOTIFICATION_SERVICE: { 'plugin': 'plugin_name' }
-        ISSUE_ASSIGNMENT: { 'assigned_member': user.id }
-        SECOND_PLATFORM: { 'platform': 'javascript' }
     """
 
     __core__ = False
 
     TASK_CHOICES = (
-        # Send an organization's first event to Sentry
-        (OnboardingTask.FIRST_EVENT, "First event"),
-        (OnboardingTask.INVITE_MEMBER, "Invite member"),  # Add a second member to your Sentry org.
-        (OnboardingTask.ISSUE_TRACKER, "Issue tracker"),  # Hook up an external issue tracker.
-        (
-            OnboardingTask.NOTIFICATION_SERVICE,
-            "Notification services",
-        ),  # Setup a notification services
-        (OnboardingTask.SECOND_PLATFORM, "Second platform"),  # Send an event from a second platform
-        (OnboardingTask.USER_CONTEXT, "User context"),  # Add user context to errors
-        (OnboardingTask.SOURCEMAPS, "Upload sourcemaps"),  # Upload sourcemaps for compiled js code
-        (OnboardingTask.RELEASE_TRACKING, "Release tracking"),  # Add release data to Sentry events
-        (OnboardingTask.USER_REPORTS, "User reports"),  # Send user reports
+        (OnboardingTask.FIRST_PROJECT, "create_project"),
+        (OnboardingTask.FIRST_EVENT, "send_first_event"),
+        (OnboardingTask.INVITE_MEMBER, "invite_member"),
+        (OnboardingTask.SECOND_PLATFORM, "setup_second_platform"),
+        (OnboardingTask.USER_CONTEXT, "setup_user_context"),
+        (OnboardingTask.RELEASE_TRACKING, "setup_release_tracking"),
+        (OnboardingTask.SOURCEMAPS, "setup_sourcemaps"),
+        (OnboardingTask.USER_REPORTS, "setup_user_reports"),
+        (OnboardingTask.ISSUE_TRACKER, "setup_issue_tracker"),
+        (OnboardingTask.ALERT_RULE, "setup_alert_rules"),
     )
 
     STATUS_CHOICES = (
-        (OnboardingTaskStatus.COMPLETE, "Complete"),
-        (OnboardingTaskStatus.PENDING, "Pending"),
-        (OnboardingTaskStatus.SKIPPED, "Skipped"),
+        (OnboardingTaskStatus.COMPLETE, "complete"),
+        (OnboardingTaskStatus.PENDING, "pending"),
+        (OnboardingTaskStatus.SKIPPED, "skipped"),
+    )
+
+    # Used in the API to map IDs to string keys. This keeps things
+    # a bit more maintainable on the frontend.
+    TASK_KEY_MAP = dict(TASK_CHOICES)
+    TASK_LOOKUP_BY_KEY = {v: k for k, v in TASK_CHOICES}
+
+    STATUS_KEY_MAP = dict(STATUS_CHOICES)
+    STATUS_LOOKUP_BY_KEY = {v: k for k, v in STATUS_CHOICES}
+
+    # Tasks which must be completed for the onboarding to be considered
+    # complete.
+    REQUIRED_ONBOARDING_TASKS = frozenset(
+        [
+            OnboardingTask.FIRST_PROJECT,
+            OnboardingTask.FIRST_EVENT,
+            OnboardingTask.INVITE_MEMBER,
+            OnboardingTask.SECOND_PLATFORM,
+            OnboardingTask.USER_CONTEXT,
+            OnboardingTask.RELEASE_TRACKING,
+            OnboardingTask.SOURCEMAPS,
+            OnboardingTask.ISSUE_TRACKER,
+            OnboardingTask.ALERT_RULE,
+        ]
+    )
+
+    SKIPPABLE_TASKS = frozenset(
+        [
+            OnboardingTask.INVITE_MEMBER,
+            OnboardingTask.SECOND_PLATFORM,
+            OnboardingTask.USER_CONTEXT,
+            OnboardingTask.RELEASE_TRACKING,
+            OnboardingTask.SOURCEMAPS,
+            OnboardingTask.USER_REPORTS,
+            OnboardingTask.ISSUE_TRACKER,
+            OnboardingTask.ALERT_RULE,
+        ]
     )
 
     organization = FlexibleForeignKey("sentry.Organization")

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -42,7 +42,7 @@ def try_mark_onboarding_complete(organization_id):
             & (Q(status=OnboardingTaskStatus.COMPLETE) | Q(status=OnboardingTaskStatus.SKIPPED))
         ).values_list("task", flat=True)
     )
-    if completed >= OnboardingTask.REQUIRED_ONBOARDING_TASKS:
+    if completed >= OrganizationOnboardingTask.REQUIRED_ONBOARDING_TASKS:
         try:
             with transaction.atomic():
                 OrganizationOption.objects.create(
@@ -283,7 +283,7 @@ def record_plugin_enabled(plugin, project, user, **kwargs):
         task = OnboardingTask.ISSUE_TRACKER
         status = OnboardingTaskStatus.PENDING
     elif isinstance(plugin, NotificationPlugin):
-        task = OnboardingTask.NOTIFICATION_SERVICE
+        task = OnboardingTask.ALERT_RULE
         status = OnboardingTaskStatus.COMPLETE
     else:
         return

--- a/src/sentry/static/sentry/app/components/onboardingWizard/getOnboardingTasks.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/getOnboardingTasks.tsx
@@ -1,7 +1,7 @@
 import {t} from 'app/locale';
 import {openInviteMembersModal} from 'app/actionCreators/modal';
 import {sourceMaps} from 'app/data/platformCategories';
-import {Organization, OnboardingTaskDescriptor} from 'app/types';
+import {Organization, OnboardingTaskDescriptor, OnboardingTaskKey} from 'app/types';
 
 function hasPlatformWithSourceMaps(organization: Organization): boolean {
   if (!organization || !organization.projects) {
@@ -15,7 +15,7 @@ export default function getOnboardingTasks(
 ): OnboardingTaskDescriptor[] {
   return [
     {
-      task: 1,
+      task: OnboardingTaskKey.FIRST_PROJECT,
       title: t('Create a project'),
       description: t('Create your first Sentry project'),
       detailedDescription: t(
@@ -28,7 +28,7 @@ export default function getOnboardingTasks(
       display: true,
     },
     {
-      task: 2,
+      task: OnboardingTaskKey.FIRST_EVENT,
       title: t('Send your first event'),
       description: t("Install Sentry's client"),
       detailedDescription: t('Choose your platform and send an event.'),
@@ -39,7 +39,7 @@ export default function getOnboardingTasks(
       display: true,
     },
     {
-      task: 3,
+      task: OnboardingTaskKey.INVITE_MEMBER,
       title: t('Invite team members'),
       description: t('Bring your team aboard'),
       detailedDescription: t(
@@ -53,7 +53,7 @@ export default function getOnboardingTasks(
       display: true,
     },
     {
-      task: 4,
+      task: OnboardingTaskKey.SECOND_PLATFORM,
       title: t('Add a second platform'),
       description: t('Add Sentry to a second platform'),
       detailedDescription: t('Capture errors from both your front and back ends.'),
@@ -64,7 +64,7 @@ export default function getOnboardingTasks(
       display: true,
     },
     {
-      task: 5,
+      task: OnboardingTaskKey.USER_CONTEXT,
       title: t('Add user context'),
       description: t('Know who is being affected by crashes'),
       detailedDescription: t(
@@ -78,7 +78,7 @@ export default function getOnboardingTasks(
       display: true,
     },
     {
-      task: 6,
+      task: OnboardingTaskKey.RELEASE_TRACKING,
       title: t('Set up release tracking'),
       description: t('See which releases cause errors'),
       detailedDescription: t(
@@ -92,7 +92,7 @@ export default function getOnboardingTasks(
       display: true,
     },
     {
-      task: 7,
+      task: OnboardingTaskKey.SOURCEMAPS,
       title: t('Upload source maps'),
       description: t('Deminify JavaScript stack traces'),
       detailedDescription: t(
@@ -106,7 +106,7 @@ export default function getOnboardingTasks(
       display: hasPlatformWithSourceMaps(organization),
     },
     {
-      task: 8,
+      task: OnboardingTaskKey.USER_REPORTS,
       title: 'User crash reports',
       description: t('Collect user feedback when your application crashes'),
       skippable: true,
@@ -116,7 +116,7 @@ export default function getOnboardingTasks(
       display: false,
     },
     {
-      task: 9,
+      task: OnboardingTaskKey.ISSUE_TRACKER,
       title: t('Set up issue tracking'),
       description: t('Link to Sentry issues within your issue tracker'),
       skippable: true,
@@ -126,8 +126,8 @@ export default function getOnboardingTasks(
       display: false,
     },
     {
-      task: 10,
-      title: t('Set up an alerts service'),
+      task: OnboardingTaskKey.ALERT_RULE,
+      title: t('Configure alerting rules'),
       description: t('Configure alerting rules to control error emails'),
       detailedDescription: t('Receive Sentry alerts in Slack, PagerDuty, and more.'),
       skippable: true,

--- a/src/sentry/static/sentry/app/components/onboardingWizard/toDoItem.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/toDoItem.tsx
@@ -12,12 +12,12 @@ import InlineSvg from 'app/components/inlineSvg';
 import Button from 'app/components/button';
 import space from 'app/styles/space';
 import ExternalLink from 'app/components/links/externalLink';
-import {OnboardingTask, Organization} from 'app/types';
+import {OnboardingTask, Organization, OnboardingTaskKey} from 'app/types';
 import {navigateTo} from 'app/actionCreators/navigation';
 
 type Props = ReactRouter.WithRouterProps & {
   task: OnboardingTask;
-  onSkip: (taskKey: number) => void;
+  onSkip: (taskKey: OnboardingTaskKey) => void;
   organization: Organization;
 };
 
@@ -51,7 +51,7 @@ class TodoItem extends React.Component<Props, State> {
     });
   }
 
-  handleSkip = (taskKey: number) => {
+  handleSkip = (taskKey: OnboardingTaskKey) => {
     this.recordAnalytics('skipped');
     this.props.onSkip(taskKey);
     this.setState({showConfirmation: false});

--- a/src/sentry/static/sentry/app/components/onboardingWizard/todoList.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/todoList.tsx
@@ -6,7 +6,7 @@ import TodoItem from 'app/components/onboardingWizard/toDoItem';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import {Client} from 'app/api';
-import {Organization, OnboardingTask} from 'app/types';
+import {Organization, OnboardingTask, OnboardingTaskKey} from 'app/types';
 
 type Props = {
   api: Client;
@@ -42,7 +42,7 @@ class TodoList extends React.Component<Props, State> {
     this.setState({tasks});
   }
 
-  skipTask = async (skippedTask: number) => {
+  skipTask = async (skippedTask: OnboardingTaskKey) => {
     const {organization, api} = this.props;
 
     await api.requestPromise(`/organizations/${organization.slug}/onboarding-tasks/`, {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -861,8 +861,21 @@ export type IntegrationIssueConfig = {
   icon: string[];
 };
 
+export enum OnboardingTaskKey {
+  FIRST_PROJECT = 'create_project',
+  FIRST_EVENT = 'send_first_event',
+  INVITE_MEMBER = 'invite_member',
+  SECOND_PLATFORM = 'setup_second_platform',
+  USER_CONTEXT = 'setup_user_context',
+  RELEASE_TRACKING = 'setup_release_tracking',
+  SOURCEMAPS = 'setup_sourcemaps',
+  USER_REPORTS = 'setup_user_reports',
+  ISSUE_TRACKER = 'setup_issue_tracker',
+  ALERT_RULE = 'setup_alert_rules',
+}
+
 export type OnboardingTaskDescriptor = {
-  task: number;
+  task: OnboardingTaskKey;
   title: string;
   description: string;
   detailedDescription?: string;
@@ -881,7 +894,7 @@ export type OnboardingTaskDescriptor = {
 );
 
 export type OnboardingTaskStatus = {
-  task: number;
+  task: OnboardingTaskKey;
   status: 'skipped' | 'pending' | 'complete';
   user: string | null;
   dateCompleted: string;

--- a/tests/js/spec/components/onboardingWizard/todoList.spec.jsx
+++ b/tests/js/spec/components/onboardingWizard/todoList.spec.jsx
@@ -17,7 +17,7 @@ describe('TodoList', function() {
       <TodoList organization={organization} />,
       routerContext
     );
-    expect(wrapper.find('Action[data-test-id=7]').exists()).toBe(false);
+    expect(wrapper.find('Action[data-test-id="setup_sourcemaps"]').exists()).toBe(false);
   });
 
   it('does not render `upload source maps` task with python project', function() {
@@ -28,7 +28,7 @@ describe('TodoList', function() {
       <TodoList organization={organization} />,
       routerContext
     );
-    expect(wrapper.find('Action[data-test-id=7]').exists()).toBe(false);
+    expect(wrapper.find('Action[data-test-id="setup_sourcemaps"]').exists()).toBe(false);
   });
 
   it('renders `upload source maps` task with js project', function() {
@@ -39,9 +39,9 @@ describe('TodoList', function() {
       <TodoList organization={organization} />,
       routerContext
     );
-    expect(wrapper.find('Action[data-test-id=7] ItemHeader').text()).toBe(
-      'Upload source maps'
-    );
+    expect(
+      wrapper.find('Action[data-test-id="setup_sourcemaps"] ItemHeader').text()
+    ).toBe('Upload source maps');
   });
 
   it('opens invite members modal on `invite team members` task click', function() {
@@ -50,7 +50,7 @@ describe('TodoList', function() {
       <TodoList organization={organization} />,
       routerContext
     );
-    wrapper.find('Action[data-test-id=3]').simulate('click');
+    wrapper.find('Action[data-test-id="invite_member"]').simulate('click');
     expect(openInviteMembersModal).toHaveBeenCalled();
   });
 });

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1319,7 +1319,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                     className="css-1vmqa5q-StyledTodoList epgvp2d0"
                   >
                     <WithOrganizationMockWrapper
-                      key="1"
+                      key="create_project"
                       onSkip={[Function]}
                       task={
                         Object {
@@ -1330,7 +1330,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                           "location": "/organizations/org-slug/projects/new/",
                           "prereq": Array [],
                           "skippable": false,
-                          "task": 1,
+                          "task": "create_project",
                           "title": "Create a project",
                         }
                       }
@@ -1374,7 +1374,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             "location": "/organizations/org-slug/projects/new/",
                             "prereq": Array [],
                             "skippable": false,
-                            "task": 1,
+                            "task": "create_project",
                             "title": "Create a project",
                           }
                         }
@@ -1752,7 +1752,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                               "location": "/organizations/org-slug/projects/new/",
                               "prereq": Array [],
                               "skippable": false,
-                              "task": 1,
+                              "task": "create_project",
                               "title": "Create a project",
                             }
                           }
@@ -1768,16 +1768,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                   className="css-9av8oo-Content ev4hf7u1"
                                 >
                                   <Action
-                                    data-test-id={1}
+                                    data-test-id="create_project"
                                     onClick={[Function]}
                                   >
                                     <ActionTarget
-                                      data-test-id={1}
+                                      data-test-id="create_project"
                                       onClick={[Function]}
                                     >
                                       <div
                                         className="css-kvrkkk-ActionTarget ev4hf7u6"
-                                        data-test-id={1}
+                                        data-test-id="create_project"
                                         onClick={[Function]}
                                       >
                                         <Checkbox>
@@ -1977,7 +1977,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                       </withRouter(TodoItem)>
                     </WithOrganizationMockWrapper>
                     <WithOrganizationMockWrapper
-                      key="2"
+                      key="send_first_event"
                       onSkip={[Function]}
                       task={
                         Object {
@@ -1990,7 +1990,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             1,
                           ],
                           "skippable": false,
-                          "task": 2,
+                          "task": "send_first_event",
                           "title": "Send your first event",
                         }
                       }
@@ -2036,7 +2036,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                               1,
                             ],
                             "skippable": false,
-                            "task": 2,
+                            "task": "send_first_event",
                             "title": "Send your first event",
                           }
                         }
@@ -2416,7 +2416,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                 1,
                               ],
                               "skippable": false,
-                              "task": 2,
+                              "task": "send_first_event",
                               "title": "Send your first event",
                             }
                           }
@@ -2432,16 +2432,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                   className="css-9av8oo-Content ev4hf7u1"
                                 >
                                   <Action
-                                    data-test-id={2}
+                                    data-test-id="send_first_event"
                                     onClick={[Function]}
                                   >
                                     <ActionTarget
-                                      data-test-id={2}
+                                      data-test-id="send_first_event"
                                       onClick={[Function]}
                                     >
                                       <div
                                         className="css-kvrkkk-ActionTarget ev4hf7u6"
-                                        data-test-id={2}
+                                        data-test-id="send_first_event"
                                         onClick={[Function]}
                                       >
                                         <Checkbox>
@@ -2641,7 +2641,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                       </withRouter(TodoItem)>
                     </WithOrganizationMockWrapper>
                     <WithOrganizationMockWrapper
-                      key="3"
+                      key="invite_member"
                       onSkip={[Function]}
                       task={
                         Object {
@@ -2653,7 +2653,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                           "display": true,
                           "prereq": Array [],
                           "skippable": true,
-                          "task": 3,
+                          "task": "invite_member",
                           "title": "Invite team members",
                         }
                       }
@@ -2698,7 +2698,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             "display": true,
                             "prereq": Array [],
                             "skippable": true,
-                            "task": 3,
+                            "task": "invite_member",
                             "title": "Invite team members",
                           }
                         }
@@ -3077,7 +3077,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                               "display": true,
                               "prereq": Array [],
                               "skippable": true,
-                              "task": 3,
+                              "task": "invite_member",
                               "title": "Invite team members",
                             }
                           }
@@ -3093,16 +3093,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                   className="css-9av8oo-Content ev4hf7u1"
                                 >
                                   <Action
-                                    data-test-id={3}
+                                    data-test-id="invite_member"
                                     onClick={[Function]}
                                   >
                                     <ActionTarget
-                                      data-test-id={3}
+                                      data-test-id="invite_member"
                                       onClick={[Function]}
                                     >
                                       <div
                                         className="css-kvrkkk-ActionTarget ev4hf7u6"
-                                        data-test-id={3}
+                                        data-test-id="invite_member"
                                         onClick={[Function]}
                                       >
                                         <Checkbox>
@@ -3369,7 +3369,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                       </withRouter(TodoItem)>
                     </WithOrganizationMockWrapper>
                     <WithOrganizationMockWrapper
-                      key="4"
+                      key="setup_second_platform"
                       onSkip={[Function]}
                       task={
                         Object {
@@ -3383,7 +3383,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             2,
                           ],
                           "skippable": true,
-                          "task": 4,
+                          "task": "setup_second_platform",
                           "title": "Add a second platform",
                         }
                       }
@@ -3430,7 +3430,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                               2,
                             ],
                             "skippable": true,
-                            "task": 4,
+                            "task": "setup_second_platform",
                             "title": "Add a second platform",
                           }
                         }
@@ -3811,7 +3811,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                 2,
                               ],
                               "skippable": true,
-                              "task": 4,
+                              "task": "setup_second_platform",
                               "title": "Add a second platform",
                             }
                           }
@@ -3827,16 +3827,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                   className="css-9av8oo-Content ev4hf7u1"
                                 >
                                   <Action
-                                    data-test-id={4}
+                                    data-test-id="setup_second_platform"
                                     onClick={[Function]}
                                   >
                                     <ActionTarget
-                                      data-test-id={4}
+                                      data-test-id="setup_second_platform"
                                       onClick={[Function]}
                                     >
                                       <div
                                         className="css-kvrkkk-ActionTarget ev4hf7u6"
-                                        data-test-id={4}
+                                        data-test-id="setup_second_platform"
                                         onClick={[Function]}
                                       >
                                         <Checkbox>
@@ -4102,7 +4102,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                       </withRouter(TodoItem)>
                     </WithOrganizationMockWrapper>
                     <WithOrganizationMockWrapper
-                      key="5"
+                      key="setup_user_context"
                       onSkip={[Function]}
                       task={
                         Object {
@@ -4117,7 +4117,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             2,
                           ],
                           "skippable": true,
-                          "task": 5,
+                          "task": "setup_user_context",
                           "title": "Add user context",
                         }
                       }
@@ -4165,7 +4165,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                               2,
                             ],
                             "skippable": true,
-                            "task": 5,
+                            "task": "setup_user_context",
                             "title": "Add user context",
                           }
                         }
@@ -4547,7 +4547,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                 2,
                               ],
                               "skippable": true,
-                              "task": 5,
+                              "task": "setup_user_context",
                               "title": "Add user context",
                             }
                           }
@@ -4563,23 +4563,23 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                   className="css-9av8oo-Content ev4hf7u1"
                                 >
                                   <Action
-                                    data-test-id={5}
+                                    data-test-id="setup_user_context"
                                     onClick={[Function]}
                                   >
                                     <ActionExternalLink
-                                      data-test-id={5}
+                                      data-test-id="setup_user_context"
                                       href="https://docs.sentry.io/enriching-error-data/context/#capturing-the-user"
                                       onClick={[Function]}
                                     >
                                       <ForwardRef
                                         className="css-1usfu4d-ActionExternalLink ev4hf7u5"
-                                        data-test-id={5}
+                                        data-test-id="setup_user_context"
                                         href="https://docs.sentry.io/enriching-error-data/context/#capturing-the-user"
                                         onClick={[Function]}
                                       >
                                         <a
                                           className="css-1usfu4d-ActionExternalLink ev4hf7u5"
-                                          data-test-id={5}
+                                          data-test-id="setup_user_context"
                                           href="https://docs.sentry.io/enriching-error-data/context/#capturing-the-user"
                                           onClick={[Function]}
                                           rel="noreferrer noopener"
@@ -4850,7 +4850,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                       </withRouter(TodoItem)>
                     </WithOrganizationMockWrapper>
                     <WithOrganizationMockWrapper
-                      key="6"
+                      key="setup_release_tracking"
                       onSkip={[Function]}
                       task={
                         Object {
@@ -4865,7 +4865,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             2,
                           ],
                           "skippable": true,
-                          "task": 6,
+                          "task": "setup_release_tracking",
                           "title": "Set up release tracking",
                         }
                       }
@@ -4913,7 +4913,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                               2,
                             ],
                             "skippable": true,
-                            "task": 6,
+                            "task": "setup_release_tracking",
                             "title": "Set up release tracking",
                           }
                         }
@@ -5295,7 +5295,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                 2,
                               ],
                               "skippable": true,
-                              "task": 6,
+                              "task": "setup_release_tracking",
                               "title": "Set up release tracking",
                             }
                           }
@@ -5311,16 +5311,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                   className="css-9av8oo-Content ev4hf7u1"
                                 >
                                   <Action
-                                    data-test-id={6}
+                                    data-test-id="setup_release_tracking"
                                     onClick={[Function]}
                                   >
                                     <ActionTarget
-                                      data-test-id={6}
+                                      data-test-id="setup_release_tracking"
                                       onClick={[Function]}
                                     >
                                       <div
                                         className="css-kvrkkk-ActionTarget ev4hf7u6"
-                                        data-test-id={6}
+                                        data-test-id="setup_release_tracking"
                                         onClick={[Function]}
                                       >
                                         <Checkbox>

--- a/tests/sentry/api/endpoints/test_onboarding.py
+++ b/tests/sentry/api/endpoints/test_onboarding.py
@@ -7,7 +7,7 @@ from sentry.testutils import APITestCase
 
 
 class SkipOnboardingTaskTest(APITestCase):
-    def test_skip_onboarding_task(self):
+    def test_upadte_onboarding_task(self):
         self.login_as(user=self.user)
 
         organization = self.create_organization(name="foo", owner=self.user)
@@ -16,7 +16,9 @@ class SkipOnboardingTaskTest(APITestCase):
             kwargs={"organization_slug": organization.slug},
         )
 
-        resp = self.client.post(url, data={"task": "9", "status": "skipped"}, format="json")
+        resp = self.client.post(
+            url, data={"task": "setup_issue_tracker", "status": "skipped"}, format="json"
+        )
         assert resp.status_code == 204
 
         oot = OrganizationOnboardingTask.objects.get(

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -131,7 +131,7 @@ class OrganizationDetailsTest(APITestCase):
         url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
         response = self.client.get(url, format="json")
         assert len(response.data["onboardingTasks"]) == 1
-        assert response.data["onboardingTasks"][0]["task"] == 1
+        assert response.data["onboardingTasks"][0]["task"] == "create_project"
 
 
 class OrganizationUpdateTest(APITestCase):

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -275,7 +275,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         task = OrganizationOnboardingTask.objects.get(
             organization=self.organization,
-            task=OnboardingTask.NOTIFICATION_SERVICE,
+            task=OnboardingTask.ALERT_RULE,
             status=OnboardingTaskStatus.COMPLETE,
         )
         assert task is not None


### PR DESCRIPTION
This makes it a bit easier on the frontend to deal with these things,

Though now in retrospect we probably could just take advantage of typescript and use an enum.