### PR TITLE
ref(ingest): Completely inline save_event into consumer for transactions

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -463,15 +463,6 @@ class EventManager(object):
 
         _get_or_create_release_many(jobs, projects)
 
-        # XXX: remove
-        if job["dist"] and job["release"]:
-            job["dist"] = job["release"].add_dist(job["dist"], job["event"].datetime)
-            # dont allow a conflicting 'dist' tag
-            pop_tag(job["data"], "dist")
-            set_tag(job["data"], "sentry:dist", job["dist"].name)
-        else:
-            job["dist"] = None
-
         _get_event_user_many(jobs, projects)
 
         with metrics.timer("event_manager.load_grouping_config"):
@@ -510,16 +501,12 @@ class EventManager(object):
 
         _materialize_metadata_many(jobs)
 
-        job["received_timestamp"] = received_timestamp = job["event"].data.get("received") or float(
-            job["event"].datetime.strftime("%s")
-        )
-
         if not issueless_event:
             # The group gets the same metadata as the event when it's flushed but
             # additionally the `last_received` key is set.  This key is used by
             # _save_aggregate.
             group_metadata = dict(job["materialized_metadata"])
-            group_metadata["last_received"] = received_timestamp
+            group_metadata["last_received"] = job["received_timestamp"]
             kwargs = {
                 "platform": job["platform"],
                 "message": job["event"].search_message,
@@ -588,13 +575,7 @@ class EventManager(object):
                 group=job["group"], environment=job["environment"]
             )
 
-        # Enusre the _metrics key exists. This is usually created during
-        # and prefilled with ingestion sizes.
-        event_metrics = job["event"].data.get("_metrics") or {}
-        job["event"].data["_metrics"] = event_metrics
-
-        # Capture the actual size that goes into node store.
-        event_metrics["bytes.stored.event"] = len(json.dumps(dict(job["event"].data.items())))
+        _materialize_event_metrics(jobs)
 
         if not issueless_event:
             # Load attachments first, but persist them at the very last after
@@ -603,7 +584,9 @@ class EventManager(object):
             attachments = get_attachments(cache_key, job["event"])
             for attachment in attachments:
                 key = "bytes.stored.%s" % (attachment.type,)
-                event_metrics[key] = (event_metrics.get(key) or 0) + len(attachment.data)
+                job["event_metrics"][key] = (job["event_metrics"].get(key) or 0) + len(
+                    attachment.data
+                )
 
         _nodestore_save_many(jobs)
 
@@ -642,7 +625,9 @@ class EventManager(object):
         metric_tags = {"from_relay": "_relay_processed" in job["data"]}
 
         metrics.timing(
-            "events.latency", received_timestamp - job["recorded_timestamp"], tags=metric_tags
+            "events.latency",
+            job["received_timestamp"] - job["recorded_timestamp"],
+            tags=metric_tags,
         )
         metrics.timing("events.size.data.post_save", job["event"].size, tags=metric_tags)
         metrics.incr(
@@ -698,6 +683,10 @@ def _pull_out_data(jobs, projects):
         if transaction_name:
             set_tag(data, "transaction", transaction_name)
 
+        job["received_timestamp"] = job["event"].data.get("received") or float(
+            job["event"].datetime.strftime("%s")
+        )
+
 
 @metrics.wraps("save_event.get_or_create_release_many")
 def _get_or_create_release_many(jobs, projects):
@@ -729,6 +718,13 @@ def _get_or_create_release_many(jobs, projects):
             set_tag(data, "sentry:release", release.version)
 
             job["release"] = release
+
+            if job["dist"]:
+                job["dist"] = job["release"].add_dist(job["dist"], job["event"].datetime)
+
+                # dont allow a conflicting 'dist' tag
+                pop_tag(job["data"], "dist")
+                set_tag(job["data"], "sentry:dist", job["dist"].name)
 
 
 @metrics.wraps("save_event.get_event_user_many")
@@ -902,7 +898,7 @@ def _eventstream_insert_many(jobs):
             is_new=job["is_new"],
             is_regression=job["is_regression"],
             is_new_group_environment=job["is_new_group_environment"],
-            primary_hash=job["data"]["hashes"][0],
+            primary_hash=job["data"]["hashes"][0] if "hashes" in job["data"] else "",
             received_timestamp=job["received_timestamp"],
             # We are choosing to skip consuming the event back
             # in the eventstream if it's flagged as raw.
@@ -1294,3 +1290,62 @@ def _find_hashes(project, hash_list):
     return map(
         lambda hash: GroupHash.objects.get_or_create(project=project, hash=hash)[0], hash_list
     )
+
+
+@metrics.wraps("event_manager.save_transactions.materialize_event_metrics")
+def _materialize_event_metrics(jobs):
+    for job in jobs:
+        # Enusre the _metrics key exists. This is usually created during
+        # and prefilled with ingestion sizes.
+        event_metrics = job["event"].data.get("_metrics") or {}
+        job["event"].data["_metrics"] = event_metrics
+
+        # Capture the actual size that goes into node store.
+        event_metrics["bytes.stored.event"] = len(json.dumps(dict(job["event"].data.items())))
+        job["event_metrics"] = event_metrics
+
+
+@metrics.wraps("event_manager.save_transaction_events")
+def save_transaction_events(events, projects):
+    with metrics.timer("event_manager.save_transactions.collect_organization_ids"):
+        organization_ids = set(project.organization_id for project in six.itervalues(projects))
+
+    with metrics.timer("event_manager.save_transactions.fetch_organizations"):
+        organizations = {
+            o.id: o for o in Organization.objects.get_many_from_cache(organization_ids)
+        }
+
+    with metrics.timer("event_manager.save_transactions.set_organization_cache"):
+        for project in six.itervalues(projects):
+            try:
+                project._organization_cache = organizations[project.organization_id]
+            except KeyError:
+                continue
+
+    with metrics.timer("event_manager.save_transactions.prepare_jobs"):
+        jobs = list(
+            {
+                "data": event,
+                "project_id": event["project"],
+                "raw": False,
+                "group": None,
+                "is_new": False,
+                "is_regression": False,
+                "is_new_group_environment": False,
+            }
+            for event in events
+        )
+
+    _pull_out_data(jobs, projects)
+    _get_or_create_release_many(jobs, projects)
+    _get_event_user_many(jobs, projects)
+    _derive_plugin_tags_many(jobs, projects)
+    _derive_interface_tags_many(jobs)
+    _materialize_metadata_many(jobs)
+    _send_event_saved_signal_many(jobs, projects)
+    _get_or_create_environment_many(jobs, projects)
+    _get_or_create_release_associated_models(jobs, projects)
+    _tsdb_record_all_metrics(jobs)
+    _materialize_event_metrics(jobs)
+    _nodestore_save_many(jobs)
+    _eventstream_insert_many(jobs)

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -23,6 +23,7 @@ from sentry.utils.kafka import create_batching_kafka_consumer
 from sentry.utils.batching_kafka_consumer import AbstractBatchWorker
 from sentry.attachments import CachedAttachment, attachment_cache
 from sentry.ingest.userreport import Conflict, save_userreport
+from sentry.event_manager import save_transaction_events
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,7 @@ class IngestConsumerWorker(AbstractBatchWorker):
     def flush_batch(self, batch):
         attachment_chunks = []
         other_messages = []
+        transactions = []
 
         projects_to_fetch = set()
 
@@ -70,8 +72,10 @@ class IngestConsumerWorker(AbstractBatchWorker):
                 message_type = message["type"]
                 projects_to_fetch.add(message["project_id"])
 
-                if message_type in ("event", "transaction"):
+                if message_type == "event":
                     other_messages.append((process_event, message))
+                elif message_type == "transaction":
+                    transactions.append(message)
                 elif message_type == "attachment_chunk":
                     attachment_chunks.append(message)
                 elif message_type == "attachment":
@@ -84,23 +88,44 @@ class IngestConsumerWorker(AbstractBatchWorker):
         with metrics.timer("ingest_consumer.fetch_projects"):
             projects = {p.id: p for p in Project.objects.get_many_from_cache(projects_to_fetch)}
 
-        # attachment_chunk messages need to be processed before attachment/event messages.
-        with metrics.timer("ingest_consumer.process_attachment_chunk_batch"):
-            for _ in self.pool.imap_unordered(
-                lambda msg: process_attachment_chunk(msg, projects=projects),
-                attachment_chunks,
-                chunksize=100,
-            ):
-                pass
+        if attachment_chunks:
+            # attachment_chunk messages need to be processed before attachment/event messages.
+            with metrics.timer("ingest_consumer.process_attachment_chunk_batch"):
+                for _ in self.pool.imap_unordered(
+                    lambda msg: process_attachment_chunk(msg, projects=projects),
+                    attachment_chunks,
+                    chunksize=100,
+                ):
+                    pass
 
-        with metrics.timer("ingest_consumer.process_other_messages_batch"):
-            for _ in self.pool.imap_unordered(
-                lambda args: args[0](args[1], projects=projects), other_messages, chunksize=100
-            ):
-                pass
+        if other_messages:
+            with metrics.timer("ingest_consumer.process_other_messages_batch"):
+                for _ in self.pool.imap_unordered(
+                    lambda args: args[0](args[1], projects=projects), other_messages, chunksize=100
+                ):
+                    pass
+
+        if transactions:
+            process_transactions_batch(transactions, projects)
 
     def shutdown(self):
         pass
+
+
+@metrics.wraps("ingest_consumer.process_transactions_batch")
+def process_transactions_batch(messages, projects):
+    events = []
+    for message in messages:
+        payload = message["payload"]
+        project_id = int(message["project_id"])
+
+        if project_id not in projects:
+            continue
+
+        data = json.loads(payload)
+        events.append(data)
+
+    save_transaction_events(events, projects)
 
 
 @metrics.wraps("ingest_consumer.process_event")

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -122,8 +122,9 @@ def process_transactions_batch(messages, projects):
         if project_id not in projects:
             continue
 
-        data = json.loads(payload)
-        events.append(data)
+        with metrics.timer("ingest_consumer.decode_transaction_json"):
+            data = json.loads(payload)
+            events.append(data)
 
     save_transaction_events(events, projects)
 

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_kafka.py
@@ -19,40 +19,59 @@ logger = logging.getLogger(__name__)
 MAX_POLL_ITERATIONS = 100
 
 
-def _get_test_message(project):
+@pytest.fixture(params=["transaction", "event"])
+def get_test_message(request, default_project):
     """
     creates a test message to be inserted in a kafka queue
     """
-    now = datetime.datetime.now()
-    # the event id should be 32 digits
-    event_id = "{}".format(now.strftime("000000000000%Y%m%d%H%M%S%f"))
-    message_text = "some message {}".format(event_id)
-    project_id = project.id  # must match the project id set up by the test fixtures
-    event = {
-        "message": message_text,
-        "extra": {"the_id": event_id},
-        "project_id": project_id,
-        "event_id": event_id,
-    }
 
-    em = EventManager(event, project=project)
-    em.normalize()
-    normalized_event = dict(em.get_data())
-    message = {
-        "type": "event",
-        "start_time": time.time(),
-        "event_id": event_id,
-        "project_id": int(project_id),
-        "payload": json.dumps(normalized_event),
-    }
+    def inner(project=default_project):
+        now = datetime.datetime.now()
+        # the event id should be 32 digits
+        event_id = "{}".format(now.strftime("000000000000%Y%m%d%H%M%S%f"))
+        message_text = "some message {}".format(event_id)
+        project_id = project.id  # must match the project id set up by the test fixtures
+        if request.param == "transaction":
+            event = {
+                "type": "transaction",
+                "timestamp": now.isoformat(),
+                "start_timestamp": now.isoformat(),
+                "event_id": event_id,
+                "spans": [],
+                "contexts": {
+                    "trace": {
+                        "parent_span_id": "8988cec7cc0779c1",
+                        "type": "trace",
+                        "op": "foobar",
+                        "trace_id": "a7d67cf796774551a95be6543cacd459",
+                        "span_id": "babaae0d4b7512d9",
+                        "status": "ok",
+                    }
+                },
+            }
+        elif request.param == "event":
+            event = {"message": message_text, "extra": {"the_id": event_id}, "event_id": event_id}
 
-    val = msgpack.packb(message)
-    return val, event_id
+        em = EventManager(event, project=project)
+        em.normalize()
+        normalized_event = dict(em.get_data())
+        message = {
+            "type": request.param,
+            "start_time": time.time(),
+            "event_id": event_id,
+            "project_id": int(project_id),
+            "payload": json.dumps(normalized_event),
+        }
+
+        val = msgpack.packb(message)
+        return val, event_id
+
+    return inner
 
 
 @pytest.mark.django_db(transaction=True)
 def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
-    task_runner, kafka_producer, kafka_admin, requires_kafka, default_project
+    task_runner, kafka_producer, kafka_admin, requires_kafka, default_project, get_test_message
 ):
     group_id = "test-consumer"
     topic_event_name = ConsumerType.get_topic_name(ConsumerType.Events)
@@ -63,9 +82,9 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
 
     event_ids = set()
     for _ in range(3):
-        message, event_id = _get_test_message(default_project)
-        event_ids.add(event_id)
+        message, event_id = get_test_message()
         producer.produce(topic_event_name, message)
+        event_ids.add(event_id)
 
     consumer = get_ingest_consumer(
         max_batch_size=2,
@@ -88,5 +107,9 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
     for event_id in event_ids:
         message = eventstore.get_event_by_id(default_project.id, event_id)
         assert message is not None
-        # check that the data has not been scrambled
-        assert message.data["extra"]["the_id"] == event_id
+        assert message.data["event_id"] == event_id
+        if message.data["type"] == "transaction":
+            assert message.data["spans"] == []
+            assert message.data["contexts"]["trace"]
+        else:
+            assert message.data["extra"]["the_id"] == event_id


### PR DESCRIPTION
Follow up to #17191 

TODO:

- [x] replace eventmanager.save() calls with this