### PR TITLE
fix(discover) Gracefully handle non-existent issues

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -974,8 +974,11 @@ def shrink_time_window(issues, start):
     stale groups.
     """
     if issues and len(issues) == 1:
-        group = Group.objects.get(pk=list(issues)[0])
-        start = max(start, naiveify_datetime(group.first_seen) - timedelta(minutes=5))
+        try:
+            group = Group.objects.get(pk=list(issues)[0])
+            start = max(start, naiveify_datetime(group.first_seen) - timedelta(minutes=5))
+        except Group.DoesNotExist:
+            return start
 
     return start
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1317,4 +1317,3 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             data = response.data["data"]
             assert len(data) == 1
             assert data[0]["count"] == 0
-            assert False

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1290,3 +1290,31 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                     assert data[0]["issue"] == event1.group.qualified_short_id
                 else:
                     assert data[0].get("issue", None) is None
+
+    def test_search_for_nonexistent_issue(self):
+        self.login_as(user=self.user)
+
+        project1 = self.create_project()
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "transaction": "/example",
+                "message": "how to make fast",
+                "timestamp": self.two_min_ago,
+                "fingerprint": ["group_1"],
+            },
+            project_id=project1.id,
+        )
+
+        with self.feature(
+            {"organizations:discover-basic": True, "organizations:global-views": True}
+        ):
+            response = self.client.get(
+                self.url, format="json", data={"field": ["count()"], "query": "issue.id:112358"}
+            )
+
+            assert response.status_code == 200, response.content
+            data = response.data["data"]
+            assert len(data) == 1
+            assert data[0]["count"] == 0
+            assert False


### PR DESCRIPTION
We opportunistically try to shrink the time window on queries with single issues
but if the issue doesn't exist it was throwing an unhandled exception. Catch the
exception so the query executes gracefully.