### PR TITLE
ref(github-enterpise): stops using token as query param

### DIFF
--- a/src/sentry/identity/github_enterprise/provider.py
+++ b/src/sentry/identity/github_enterprise/provider.py
@@ -8,8 +8,10 @@ def get_user_info(url, access_token):
     session = http.build_session()
     resp = session.get(
         u"https://{}/api/v3/user".format(url),
-        params={"access_token": access_token},
-        headers={"Accept": "application/vnd.github.machine-man-preview+json"},
+        headers={
+            "Accept": "application/vnd.github.machine-man-preview+json",
+            "Authorization": "token %s" % access_token,
+        },
         verify=False,
     )
     resp.raise_for_status()


### PR DESCRIPTION
Github is deprecating using auth query parameters. This PR fixes one case where it's used for Github enterprise. For more details see: https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

This change was copied from @mattrobenolt's PR: #17022
