### PR TITLE
fix(discover2): Pass environments and projects properly

### DIFF
--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -167,6 +167,12 @@ class TransitionChart extends React.Component {
   }
 
   render() {
+    const {loading, reloading} = this.props;
+
+    if (loading && !reloading) {
+      return <LoadingPanel data-test-id="events-request-loading" />;
+    }
+
     // We make use of the key prop to explicitly remount the children
     // https://reactjs.org/docs/lists-and-keys.html#keys
     return (
@@ -242,9 +248,6 @@ class EventsChart extends React.Component {
                           <IconWarning color={theme.gray2} size="lg" />
                         </ErrorPanel>
                       );
-                    }
-                    if (loading && !reloading) {
-                      return <LoadingPanel data-test-id="events-request-loading" />;
                     }
 
                     return (

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -62,8 +62,8 @@ class ResultsChart extends React.Component<ResultsChartProps> {
               organization={organization}
               showLegend
               yAxis={yAxisValue}
-              project={globalSelection.project}
-              environment={globalSelection.environment}
+              projects={globalSelection.project}
+              environments={globalSelection.environment}
               start={start}
               end={end}
               period={globalSelection.statsPeriod}


### PR DESCRIPTION
Looks like the props `projects` and `environments` were never used for `<EventsChart/>` for months? 🤔 

I cannot track down in git blame to see where the previous props came from.