### PR TITLE
fix(discover) Reduce the maximum amount of data that can be requested

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -577,3 +577,18 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             )
 
         assert mock_query.call_count == 1
+
+    def test_invalid_interval(self):
+        with self.feature("organizations:discover-basic"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "end": iso_format(before_now()),
+                    "start": iso_format(before_now(hours=24)),
+                    "query": "",
+                    "interval": "1s",
+                    "yAxis": "count()",
+                },
+            )
+        assert response.status_code == 400


### PR DESCRIPTION
Cap requests to 4500 points which gives us enough space to answer 30minutes over 90 days. I'd like to dial down the resolution for the 30 and 90 day windows as we currently get more data than will fit on a screen.