### PR TITLE
feat(integrations): Add logging to ApiClient and Jira

### DIFF
--- a/src/sentry/integrations/client.py
+++ b/src/sentry/integrations/client.py
@@ -120,24 +120,18 @@ def track_response_code(integration, code):
     )
 
 
-def log_request_failure(integration, error, code, context=None):
+def log_request_failure(integration, code, error=None, **context):
     logger = logging.getLogger("sentry.integrations")
 
-    if context is None:
-        logger.info(
-            "integrations.http_response",
-            extra={"integration": integration, "status": code, "error": six.text_type(error[:128])},
-        )
-    else:
-        logger.info(
-            "integrations.http_response",
-            extra={
-                "integration": integration,
-                "status": code,
-                "error": six.text_type(error[:128]),
-                "context": context,
-            },
-        )
+    logger.info(
+        "integrations.http_response",
+        extra={
+            "integration": integration,
+            "status": code,
+            "error": six.text_type(error[:128]) if error else None,
+            "context": context,
+        },
+    )
 
 
 class ApiClient(object):
@@ -216,7 +210,9 @@ class ApiClient(object):
                 sample_rate=1.0,
                 tags={"integration": self.integration_name, "status": "connection_error"},
             )
-            log_request_failure(self.integration_name, e, "connection_error", self.logging_context)
+            log_request_failure(
+                self.integration_name, "connection_error", e, context=self.logging_context
+            )
             raise ApiHostError.from_exception(e)
         except Timeout as e:
             metrics.incr(
@@ -224,23 +220,27 @@ class ApiClient(object):
                 sample_rate=1.0,
                 tags={"integration": self.integration_name, "status": "timeout"},
             )
-            log_request_failure(self.integration_name, e, "timeout", self.logging_context)
+            log_request_failure(self.integration_name, "timeout", e, context=self.logging_context)
             raise ApiTimeoutError.from_exception(e)
         except HTTPError as e:
             resp = e.response
             if resp is None:
                 track_response_code(self.integration_name, "unknown")
-                log_request_failure(self.integration_name, e, "unknown", self.logging_context)
+                log_request_failure(
+                    self.integration_name, "unknown", e, context=self.logging_context
+                )
                 self.logger.exception(
                     "request.error", extra={"integration": self.integration_name, "url": full_url}
                 )
                 raise ApiError("Internal Error")
             track_response_code(self.integration_name, resp.status_code)
-            log_request_failure(self.integration_name, e, resp.status_code, self.logging_context)
+            log_request_failure(
+                self.integration_name, resp.status_code, e, context=self.logging_context
+            )
             raise ApiError.from_response(resp)
 
         track_response_code(self.integration_name, resp.status_code)
-        log_request_failure(self.integration_name, e, resp.status_code, self.logging_context)
+        log_request_failure(self.integration_name, resp.status_code, context=self.logging_context)
         if resp.status_code == 204:
             return {}
 

--- a/src/sentry/integrations/client.py
+++ b/src/sentry/integrations/client.py
@@ -112,7 +112,7 @@ class SequenceApiResponse(list, BaseApiResponse):
         return self
 
 
-def track_response_data(integration, code, error=None, **context):
+def track_response_data(integration, code, error=None, context=None):
     logger = logging.getLogger("sentry.integrations.client")
 
     metrics.incr(

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -91,13 +91,13 @@ class JiraApiClient(ApiClient):
 
     integration_name = "jira"
 
-    def __init__(self, base_url, jira_style, verify_ssl):
+    def __init__(self, base_url, jira_style, verify_ssl, logging_context=None):
         self.base_url = base_url
         # `jira_style` encapsulates differences between jira server & jira cloud.
         # We only support one API version for Jira, but server/cloud require different
         # authentication mechanisms and caching.
         self.jira_style = jira_style
-        super(JiraApiClient, self).__init__(verify_ssl)
+        super(JiraApiClient, self).__init__(verify_ssl, logging_context)
 
     def request(self, method, path, data=None, params=None, **kwargs):
         """

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -278,7 +278,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             output.extend(["", "{code}", body, "{code}"])
         return "\n".join(output)
 
-    def get_client(self, context=None):
+    def get_client(self):
         return JiraApiClient(
             self.model.metadata["base_url"],
             JiraCloud(self.model.metadata["shared_secret"]),

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -158,7 +158,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             },
         ]
 
-        client = self.get_client(context=None)
+        client = self.get_client()
 
         try:
             statuses = [(c["id"], c["name"]) for c in client.get_valid_statuses()]
@@ -231,7 +231,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         return config
 
     def sync_metadata(self):
-        client = self.get_client(context=None)
+        client = self.get_client()
 
         try:
             server_info = client.get_server_info()
@@ -278,17 +278,19 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             output.extend(["", "{code}", body, "{code}"])
         return "\n".join(output)
 
-    def get_client(self, context):
+    def get_client(self, context=None):
         return JiraApiClient(
             self.model.metadata["base_url"],
             JiraCloud(self.model.metadata["shared_secret"]),
             verify_ssl=True,
-            logging_context=context,
+            logging_context={
+                "org_id": self.organization_id,
+                "integration_id": self._org_integration.integration.id,
+            },
         )
 
     def get_issue(self, issue_id, **kwargs):
-        context = {"issue_id": issue_id}
-        client = self.get_client(context)
+        client = self.get_client()
         issue = client.get_issue(issue_id)
         return {
             "key": issue_id,
@@ -300,8 +302,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         # https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=texteffects
         comment = group_note.data["text"]
         quoted_comment = self.create_comment_attribution(user_id, comment)
-        context = {"issue_id": issue_id, "user_id": user_id, "comment": comment}
-        return self.get_client(context).create_comment(issue_id, quoted_comment)
+        return self.get_client().create_comment(issue_id, quoted_comment)
 
     def create_comment_attribution(self, user_id, comment_text):
         user = User.objects.get(id=user_id)
@@ -310,15 +311,13 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
     def update_comment(self, issue_id, user_id, group_note):
         quoted_comment = self.create_comment_attribution(user_id, group_note.data["text"])
-        context = {"issue_id": issue_id, "user_id": user_id, "quoted_comment": quoted_comment}
-        return self.get_client(context).update_comment(
+        return self.get_client().update_comment(
             issue_id, group_note.data["external_id"], quoted_comment
         )
 
     def search_issues(self, query):
-        context = {"query": query}
         try:
-            return self.get_client(context).search_issues(query)
+            return self.get_client().search_issues(query)
         except ApiError as e:
             self.raise_error(e)
 
@@ -503,8 +502,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
         defaults = self.get_project_defaults(group.project_id)
         project_id = params.get("project", defaults.get("project"))
-        context = {"project_id": project_id}
-        client = self.get_client(context)
+        client = self.get_client()
         try:
             jira_projects = client.get_projects_list()
         except ApiError as e:
@@ -606,7 +604,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         return fields
 
     def create_issue(self, data, **kwargs):
-        client = self.get_client(context=None)
+        client = self.get_client()
         cleaned_data = {}
         # protect against mis-configured integration submitting a form without an
         # issuetype assigned.
@@ -710,7 +708,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         """
         Propagate a sentry issue's assignee to a jira issue's assignee
         """
-        client = self.get_client(context=None)
+        client = self.get_client()
 
         jira_user = None
         if assign:
@@ -761,7 +759,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         """
         Propagate a sentry issue's status to a linked issue's status.
         """
-        client = self.get_client(context=None)
+        client = self.get_client()
         jira_issue = client.get_issue(external_issue.key)
         jira_project = jira_issue["fields"]["project"]
 
@@ -803,7 +801,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         client.transition_issue(external_issue.key, transition["id"])
 
     def _get_done_statuses(self):
-        client = self.get_client(context=None)
+        client = self.get_client()
         statuses = client.get_valid_statuses()
         return {s["id"] for s in statuses if s["statusCategory"]["key"] == "done"}
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 import six
+from operator import attrgetter
 
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
@@ -285,7 +286,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             verify_ssl=True,
             logging_context={
                 "org_id": self.organization_id,
-                "integration_id": self._org_integration.integration.id,
+                "integration_id": attrgetter("_org_integration.integration.id")(self),
+                "org_integration_id": attrgetter("_org_integration.id")(self),
             },
         )
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -286,8 +286,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             verify_ssl=True,
             logging_context={
                 "org_id": self.organization_id,
-                "integration_id": attrgetter("_org_integration.integration.id")(self),
-                "org_integration_id": attrgetter("_org_integration.id")(self),
+                "integration_id": attrgetter("org_integration.integration.id")(self),
+                "org_integration_id": attrgetter("org_integration.id")(self),
             },
         )
 


### PR DESCRIPTION
This PR adds logging to the `ApiClient` class and refactors the Jira integration to use it and pass context (org ID and integration ID) to Kibana logs. 