### PR TITLE
fix(ui) Use different icons for one and many events

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -5,11 +5,12 @@ import {Location} from 'history';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
+import {IconEvent, IconStack} from 'app/icons';
 import {t} from 'app/locale';
 import {assert} from 'app/types/utils';
-import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/links/link';
 import Tooltip from 'app/components/tooltip';
+import space from 'app/styles/space';
 
 import {
   downloadAsCsv,
@@ -220,8 +221,14 @@ class TableView extends React.Component<TableViewProps> {
     dataRow?: any,
     rowIndex?: number
   ): React.ReactNode[] => {
+    const {eventView} = this.props;
+    const hasAggregates = eventView.getAggregateFields().length > 0;
     if (isHeader) {
-      return [<StyledIconStack key="header-icon" src="icon-stack" size="14px" />];
+      return [
+        <HeaderIcon key="header-icon">
+          {hasAggregates ? <IconStack size="sm" /> : <IconEvent size="sm" />}
+        </HeaderIcon>,
+      ];
     }
     const {organization, location} = this.props;
     const eventSlug = generateEventSlug(dataRow);
@@ -236,9 +243,9 @@ class TableView extends React.Component<TableViewProps> {
 
     return [
       <Tooltip key={`eventlink${rowIndex}`} title={t('View Details')}>
-        <Link to={target} data-test-id="view-events">
-          <InlineSvg src="icon-stack" size="14px" />
-        </Link>
+        <IconLink to={target} data-test-id="view-events">
+          {hasAggregates ? <IconStack size="sm" /> : <IconEvent size="sm" />}
+        </IconLink>
       </Tooltip>,
     ];
   };
@@ -486,9 +493,18 @@ const ExpandAggregateRow = (props: {
   return <React.Fragment>{children({willExpand: false})}</React.Fragment>;
 };
 
-const StyledIconStack = styled(InlineSvg)`
-  vertical-align: top;
-  color: ${p => p.theme.gray3};
+const HeaderIcon = styled('span')`
+  & > svg {
+    vertical-align: top;
+    color: ${p => p.theme.gray3};
+  }
+`;
+
+// Fudge the icon down so it is center aligned with the table contents.
+const IconLink = styled(Link)`
+  position: relative;
+  display: inline-block;
+  top: 3px;
 `;
 
 export default TableView;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -10,7 +10,6 @@ import {t} from 'app/locale';
 import {assert} from 'app/types/utils';
 import Link from 'app/components/links/link';
 import Tooltip from 'app/components/tooltip';
-import space from 'app/styles/space';
 
 import {
   downloadAsCsv,


### PR DESCRIPTION
Attempt to communicate that results are not aggregated by the icon we use. One pancake = one event, stack of pancakes = aggregate.