### PR TITLE
ref(event_saved): Send event_saved signal in outcomes_consumer

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -40,6 +40,7 @@ from sentry.coreapi import (
     decode_data,
     safely_load_json_string,
 )
+from sentry.ingest.outcomes_consumer import mark_signal_sent
 from sentry.interfaces.base import get_interface
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL, convert_crashreport_count
 from sentry.models import (
@@ -785,6 +786,7 @@ def _materialize_metadata_many(jobs):
 @metrics.wraps("save_event.send_event_saved_signal_many")
 def _send_event_saved_signal_many(jobs, projects):
     for job in jobs:
+        mark_signal_sent(project_id=job["project_id"], event_id=job["event"].event_id)
         event_saved.send_robust(
             project=projects[job["project_id"]], event_size=job["event"].size, sender=EventManager
         )

--- a/src/sentry/ingest/outcomes_consumer.py
+++ b/src/sentry/ingest/outcomes_consumer.py
@@ -100,7 +100,7 @@ def _process_signal(msg):
     remote_addr = msg.get("remote_addr")
 
     if outcome == Outcome.ACCEPTED:
-        event_saved.send_robust(project=project, sender=OutcomesConsumerWorker)
+        event_saved.send_robust(ip=remote_addr, project=project, sender=OutcomesConsumerWorker)
     elif outcome == Outcome.FILTERED:
         event_filtered.send_robust(ip=remote_addr, project=project, sender=OutcomesConsumerWorker)
     elif outcome == Outcome.RATE_LIMITED:

--- a/src/sentry/ingest/outcomes_consumer.py
+++ b/src/sentry/ingest/outcomes_consumer.py
@@ -100,7 +100,7 @@ def _process_signal(msg):
     remote_addr = msg.get("remote_addr")
 
     if outcome == Outcome.ACCEPTED:
-        event_saved.send_robust(ip=remote_addr, project=project, sender=OutcomesConsumerWorker)
+        event_saved.send_robust(project=project, sender=OutcomesConsumerWorker)
     elif outcome == Outcome.FILTERED:
         event_filtered.send_robust(ip=remote_addr, project=project, sender=OutcomesConsumerWorker)
     elif outcome == Outcome.RATE_LIMITED:

--- a/tests/sentry/ingest/outcome_consumer/test_outcomes_kafka.py
+++ b/tests/sentry/ingest/outcome_consumer/test_outcomes_kafka.py
@@ -303,7 +303,7 @@ def test_outcome_consumer_handles_accepted_outcomes(
 
     # verify that the appropriate filters were called
     assert len(event_saved_sink) == 2
-    assert set(event_saved_sink) == {"saved_event"}
+    assert set(event_saved_sink) == {"saved event"}
     assert len(event_dropped_sink) == 0
     assert len(event_filtered_sink) == 0
 


### PR DESCRIPTION
Moves the `event_saved` signal to the outcomes consumer. This will enable passing of event category as well as quantity to the signal handlers for billing in getsentry.