### PR TITLE
fix(workflow): Fix Alerts activity items when created

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/activity/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/index.tsx
@@ -17,6 +17,7 @@ import withApi from 'app/utils/withApi';
 import {
   ActivityType,
   ActivityTypeDraft,
+  Incident,
   IncidentActivityType,
   IncidentStatus,
   NoteType,
@@ -31,6 +32,7 @@ type Activities = Array<ActivityType | ActivityType>;
 
 type Props = {
   api: Client;
+  incident?: Incident;
   incidentStatus: IncidentStatus | null;
   params: Params;
 };
@@ -203,7 +205,7 @@ class ActivityContainer extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const {api, params, ...props} = this.props;
+    const {api, params, incident, ...props} = this.props;
     const {alertId} = params;
     const me = ConfigStore.get('user');
 
@@ -214,6 +216,8 @@ class ActivityContainer extends React.PureComponent<Props, State> {
         me={me}
         api={api}
         {...this.state}
+        loading={this.state.loading || !incident}
+        incident={incident}
         onCreateNote={this.handleCreateNote}
         onUpdateNote={this.handleUpdateNote}
         onDeleteNote={this.handleDeleteNote}

--- a/src/sentry/static/sentry/app/views/alerts/details/activity/statusItem.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/statusItem.tsx
@@ -42,9 +42,6 @@ class StatusItem extends React.Component<Props> {
 
     return (
       <ActivityItem
-        bubbleProps={{
-          borderColor: 'transparent',
-        }}
         showTime={showTime}
         author={{
           type: activity.user ? 'user' : 'system',
@@ -61,7 +58,7 @@ class StatusItem extends React.Component<Props> {
                 ? tct('[user] was triggered', {
                     user: <AuthorName>{incident.alertRule.name}</AuthorName>,
                   })
-                : tct('[user] detected an alert', {
+                : tct('[user] created an alert', {
                     user: <AuthorName>{authorName}</AuthorName>,
                   }))}
           </div>

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -188,6 +188,7 @@ export default class DetailsBody extends React.Component<Props> {
               </SeenByTab>
             </StyledNavTabs>
             <Activity
+              incident={incident}
               params={params}
               incidentStatus={!!incident ? incident.status : null}
             />

--- a/tests/js/spec/views/incidents/details/activity.spec.jsx
+++ b/tests/js/spec/views/incidents/details/activity.spec.jsx
@@ -26,6 +26,7 @@ describe('IncidentDetails -> Activity', function() {
     mountWithTheme(
       <IncidentActivity
         params={{alertId: incident.identifier, orgId: organization.slug}}
+        incident={incident}
         {...props}
       />,
       routerContext


### PR DESCRIPTION
This fixes the activity status item to have the correct text (and bubble borders). Previously we were not passing the `incident` object, which `<StatusItem>` depends on.