### PR TITLE
test(py3): disable pytest-sentry and pytest-rerunfailures for py36 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -212,7 +212,7 @@ matrix:
     # Allowed to fail!
     - python: 3.6
       name: 'Python 3.6 backend (no migrations) [Postgres]'
-      env: TEST_SUITE=postgres DB=postgres SENTRY_PYTHON3=1
+      env: TEST_SUITE=postgres DB=postgres SENTRY_PYTHON3=1 PYTEST_ADDOPTS="" PYTEST_SENTRY_ALWAYS_REPORT=no
       services:
         - memcached
         - redis-server


### PR DESCRIPTION
Once they start working, py36 is probably gonna spam a lot, so disable both of these for now.
