### PR TITLE
fix(ui): Fixed CommandPalette autocompletion

### DIFF
--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -298,7 +298,7 @@ class AutoComplete extends React.Component {
       console.warn('getItemProps requires an object with an `item` key');
     }
 
-    const newIndex = index || this.items.size;
+    const newIndex = index ?? this.items.size;
     this.items.set(newIndex, item);
 
     return {

--- a/src/sentry/static/sentry/app/components/search/index.jsx
+++ b/src/sentry/static/sentry/app/components/search/index.jsx
@@ -146,6 +146,7 @@ class Search extends React.Component {
     const itemProps = {
       ...getItemProps({
         item,
+        index,
       }),
     };
 


### PR DESCRIPTION
This PR fixes an issue with commandPalette  - it is sometimes selecting the previous result upon hitting enter.

![chrome-capture (7)](https://user-images.githubusercontent.com/9060071/75350874-81484000-58a7-11ea-9809-69c07cc650fc.gif)

Like for example on the attached GIF where I type DSN - Daniel is the first result for a split second, but immediately replaced with Client Keys (DSN). After hitting enter it takes me to Daniel's detail.
