### PR TITLE
feat(globalheader): Add allowClearTimeRange prop.

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -120,6 +120,11 @@ class GlobalSelectionHeader extends React.Component {
      */
     showRelative: PropTypes.bool,
 
+    /**
+     * Allow user to clear the time range selection
+     */
+    allowClearTimeRange: PropTypes.bool,
+
     // Callbacks //
     onChangeProjects: PropTypes.func,
     onUpdateProjects: PropTypes.func,
@@ -559,6 +564,7 @@ class GlobalSelectionHeader extends React.Component {
       showRelative,
       showDateSelector,
       showEnvironmentSelector,
+      allowClearTimeRange,
     } = this.props;
     const {period, start, end, utc} = this.props.selection.datetime || {};
 
@@ -645,6 +651,7 @@ class GlobalSelectionHeader extends React.Component {
                 onChange={this.handleChangeTime}
                 onUpdate={this.handleUpdateTime}
                 organization={organization}
+                allowClearTimeRange={allowClearTimeRange}
               />
             </HeaderItemPosition>
           </React.Fragment>

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -111,6 +111,11 @@ class TimeRangeSelector extends React.PureComponent {
      * Just used for metrics
      */
     organization: SentryTypes.Organization,
+
+    /**
+     * Allow user to clear the time range selection
+     */
+    allowClearTimeRange: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -229,6 +234,8 @@ class TimeRangeSelector extends React.PureComponent {
 
   handleClear = () => {
     const {onChange} = this.props;
+
+    console.log('cleear this.state', this.state);
     const newDateTime = {
       relative: null,
       start: null,
@@ -294,7 +301,7 @@ class TimeRangeSelector extends React.PureComponent {
   };
 
   render() {
-    const {showAbsolute, showRelative, organization} = this.props;
+    const {showAbsolute, showRelative, organization, allowClearTimeRange} = this.props;
     const {start, end, relative} = this.state;
 
     const shouldShowAbsolute = showAbsolute;
@@ -328,7 +335,7 @@ class TimeRangeSelector extends React.PureComponent {
               }
               hasChanges={this.state.hasChanges}
               onClear={this.handleClear}
-              allowClear
+              allowClear={allowClearTimeRange}
               {...getActorProps()}
             >
               {getDynamicText({value: summary, fixed: 'start to end'})}

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -315,6 +315,9 @@ class TimeRangeSelector extends React.PureComponent {
 
     const relativeSelected = isAbsoluteSelected ? null : relative || DEFAULT_STATS_PERIOD;
 
+    const allowClear =
+      typeof allowClearTimeRange === 'boolean' ? allowClearTimeRange : true;
+
     return (
       <DropdownMenu
         isOpen={this.state.isOpen}
@@ -334,7 +337,7 @@ class TimeRangeSelector extends React.PureComponent {
               }
               hasChanges={this.state.hasChanges}
               onClear={this.handleClear}
-              allowClear={allowClearTimeRange}
+              allowClear={allowClear}
               {...getActorProps()}
             >
               {getDynamicText({value: summary, fixed: 'start to end'})}

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -235,7 +235,6 @@ class TimeRangeSelector extends React.PureComponent {
   handleClear = () => {
     const {onChange} = this.props;
 
-    console.log('cleear this.state', this.state);
     const newDateTime = {
       relative: null,
       start: null,


### PR DESCRIPTION
Enable or disable the ability for the user to clear the time range selection.

**`allowClearTimeRange=true`:**

<img width="1234" alt="Screen Shot 2020-02-26 at 11 21 14 AM" src="https://user-images.githubusercontent.com/139499/75364729-2d7b2e00-588a-11ea-9824-73a9a99dc450.png">

**`allowClearTimeRange=false`:**

<img width="1247" alt="Screen Shot 2020-02-26 at 11 21 02 AM" src="https://user-images.githubusercontent.com/139499/75364755-3966f000-588a-11ea-9252-68a828565a3f.png">

-------


The performance view will make use of default time ranges of 24 hours or less; as opposed to 14 days. We plan on setting the default by passing an object thru the `globalselection` prop.
