### PR TITLE
feat(outcomes): Add data category and quantity

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -8,6 +8,7 @@ import logging
 import os.path
 import six
 from datetime import timedelta
+from enum import IntEnum, unique
 
 from collections import OrderedDict, namedtuple
 from django.conf import settings
@@ -484,3 +485,27 @@ DEFAULT_STORE_NORMALIZER_ARGS = dict(
 INTERNAL_INTEGRATION_TOKEN_COUNT_MAX = 20
 
 ALL_ACCESS_PROJECTS = {-1}
+
+
+@unique
+class DataCategory(IntEnum):
+    DEFAULT = 0
+    ERROR = 1
+    TRANSACTION = 2
+    SECURITY = 3
+    ATTACHMENT = 4
+    SESSION = 5
+    CRASH = 6
+
+    @classmethod
+    def from_event_type(cls, event_type):
+        if event_type == "error":
+            return DataCategory.ERROR
+        elif event_type == "transaction":
+            return DataCategory.TRANSACTION
+        elif event_type in ("csp", "hpkp", "expectct", "expectstaple"):
+            return DataCategory.SECURITY
+        return DataCategory.DEFAULT
+
+    def api_name(self):
+        return self.name.lower()

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -21,20 +21,6 @@ class QuotaScope(IntEnum):
         return self.name.lower()
 
 
-@unique
-class DataCategory(IntEnum):
-    DEFAULT = 0
-    ERROR = 1
-    TRANSACTION = 2
-    SECURITY = 3
-    ATTACHMENT = 4
-    SESSION = 5
-    CRASH = 6
-
-    def api_name(self):
-        return self.name.lower()
-
-
 class QuotaConfig(object):
     """
     Abstract configuration for a quota.

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -5,14 +5,8 @@ import six
 
 from time import time
 
-from sentry.quotas.base import (
-    DataCategory,
-    NotRateLimited,
-    Quota,
-    QuotaConfig,
-    QuotaScope,
-    RateLimited,
-)
+from sentry.constants import DataCategory
+from sentry.quotas.base import NotRateLimited, Quota, QuotaConfig, QuotaScope, RateLimited
 from sentry.utils.redis import (
     get_dynamic_cluster_from_options,
     validate_dynamic_cluster,

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from sentry_relay.processing import StoreNormalizer
 
 from sentry import features, reprocessing
+from sentry.constants import DataCategory
 from sentry.relay.config import get_project_config
 from sentry.datascrubbing import scrub_data
 from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
@@ -488,6 +489,8 @@ def _do_save_event(
             if data is not None:
                 metric_tags["event_type"] = event_type = data.get("type") or "none"
 
+    data_category = DataCategory.from_event_type(event_type)
+
     with metrics.global_tags(event_type=event_type):
         if data is not None:
             data = CanonicalKeyDict(data)
@@ -548,6 +551,7 @@ def _do_save_event(
                     None,
                     timestamp,
                     event_id,
+                    data_category,
                 )
 
         except HashDiscarded:
@@ -575,6 +579,7 @@ def _do_save_event(
                 reason,
                 timestamp,
                 event_id,
+                data_category,
             )
 
         finally:

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -2,8 +2,9 @@
 
 from __future__ import absolute_import
 
+from sentry.constants import DataCategory
 from sentry.models import OrganizationOption, ProjectKey
-from sentry.quotas.base import Quota, QuotaConfig, QuotaScope, DataCategory
+from sentry.quotas.base import Quota, QuotaConfig, QuotaScope
 from sentry.testutils import TestCase
 
 import pytest


### PR DESCRIPTION
Adds data categories (introduced in #17248) and quantities to outcomes. 

As a follow-up, we will start to track outcomes for attachments, session updates and other data. Note that both attributes are optional, although `quantity=1` is assumed as default. The default category shall be coerced in the consumers.