### PR TITLE
fix(workflow): Don't include prewindow in slack aggregate calculation

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -270,8 +270,10 @@ def create_event_stat_snapshot(incident, start, end):
     )
 
 
-def build_incident_query_params(incident, start=None, end=None):
-    return bulk_build_incident_query_params([incident], start=start, end=end)[0]
+def build_incident_query_params(incident, start=None, end=None, prewindow=False):
+    return bulk_build_incident_query_params([incident], start=start, end=end, prewindow=prewindow)[
+        0
+    ]
 
 
 def bulk_build_incident_query_params(incidents, start=None, end=None, prewindow=False):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -265,17 +265,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data["name"] == "AUniqueName"
         assert resp.data["triggers"][1]["resolveThreshold"] == 75
 
-        # We had/have logic to remove unchanged fields from the serializer before passing them to update
-        # It is possible with an error here that sending an update without changing the field
-        # could nullify it. So we make sure it's not getting nullified here.
-        # we can an update with all the same fields, and it comes back as 125 instead of None.
-        with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
-        assert resp.data["name"] == "AUniqueName"
-        assert resp.data["triggers"][1]["resolveThreshold"] == 75
-
     def test_delete_trigger(self):
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -265,6 +265,17 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data["name"] == "AUniqueName"
         assert resp.data["triggers"][1]["resolveThreshold"] == 75
 
+        # We had/have logic to remove unchanged fields from the serializer before passing them to update
+        # It is possible with an error here that sending an update without changing the field
+        # could nullify it. So we make sure it's not getting nullified here.
+        # we can an update with all the same fields, and it comes back as 125 instead of None.
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(
+                self.organization.slug, alert_rule.id, **serialized_alert_rule
+            )
+        assert resp.data["name"] == "AUniqueName"
+        assert resp.data["triggers"][1]["resolveThreshold"] == 75
+
     def test_delete_trigger(self):
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -282,7 +282,9 @@ class GetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
 
 class BulkGetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
     def run_test(self, incidents, expected_results_list, start=None, end=None):
-        query_params_list = bulk_build_incident_query_params(incidents, start=start, end=end)
+        query_params_list = bulk_build_incident_query_params(
+            incidents, start=start, end=end, prewindow=True
+        )
         results = bulk_get_incident_event_stats(incidents, query_params_list, data_points=20)
         for incident, result, expected_results in zip(incidents, results, expected_results_list):
             # Duration of 300s / 20 data points


### PR DESCRIPTION
There is a bug with slack alerts not displaying the correct event counts.

I'm hoping this fixes it - but regardless, it's probably a bug to be including prewindow in the slack alert since the counts will end up being larger.

(The problem is a slack alert fired as CRITICAL and displayed 0 events (should have been >5), and RESOLVED and displayed 7 events (should have been <1)....this prewindow fix would only potentially address resolved's issue, but I don't think it's the full solution to why that happened because how could the count be smaller (0) for the critical slack alert if we're increasing the time range?)
