### PR TITLE
fix(integration-directory): fix bug where pressing back doesn't work for internal integrations

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -37,7 +37,10 @@ const IntegrationRow = (props: Props) => {
     configurations,
   } = props;
 
-  const baseUrl = `/settings/${organization.slug}/${urlMap[type]}/${slug}/`;
+  const baseUrl =
+    publishStatus === 'internal'
+      ? `/settings/${organization.slug}/developer-settings/${slug}/`
+      : `/settings/${organization.slug}/${urlMap[type]}/${slug}/`;
 
   const renderDetails = () => {
     if (type === 'sentryApp') {

--- a/tests/js/spec/views/organizationIntegrations/integrationRow.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRow.spec.jsx
@@ -34,7 +34,7 @@ describe('IntegrationRow', function() {
         'My Headband Washer'
       );
       expect(wrapper.find('IntegrationName').props().to).toEqual(
-        `/settings/${org.slug}/sentry-apps/my-headband-washer-289499/`
+        `/settings/${org.slug}/developer-settings/my-headband-washer-289499/`
       );
       expect(wrapper.find('IntegrationStatus').props().status).toEqual('Installed');
       expect(wrapper.find('PublishStatus').props().status).toEqual('internal');


### PR DESCRIPTION
We redirect internal integrations from the detail page to the developer settings page which stops the back button from working properly.