### PR TITLE
feat(events): Fetch from /api/0/organizations/:org/events-stats/ with multiple yAxis options

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -1,7 +1,7 @@
 import {Client} from 'app/api';
 import {canIncludePreviousPeriod} from 'app/views/events/utils/canIncludePreviousPeriod';
 import {getPeriod} from 'app/utils/getPeriod';
-import {EventsStats, Organization} from 'app/types';
+import {EventsStats, Organization, YAxisEventsStats} from 'app/types';
 
 const getBaseUrl = (org: Organization) => `/organizations/${org.slug}/events-stats/`;
 
@@ -16,7 +16,7 @@ type Options = {
   includePrevious?: boolean;
   limit?: number;
   query?: string;
-  yAxis?: string;
+  yAxis?: string | string[];
   field?: string[];
   referenceEvent?: string;
 };
@@ -51,7 +51,7 @@ export const doEventsRequest = (
     field,
     referenceEvent,
   }: Options
-): Promise<EventsStats> => {
+): Promise<EventsStats | YAxisEventsStats> => {
   const shouldDoublePeriod = canIncludePreviousPeriod(includePrevious, period);
   const urlQuery = Object.fromEntries(
     Object.entries({

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -234,6 +234,10 @@ export type EventsStats = {
   totals?: {count: number};
 };
 
+export type YAxisEventsStats = {
+  [yAxisName: string]: EventsStats;
+};
+
 // Avatars are a more primitive version of User.
 export type AvatarUser = {
   id: string;

--- a/src/sentry/static/sentry/app/types/utils.tsx
+++ b/src/sentry/static/sentry/app/types/utils.tsx
@@ -6,3 +6,8 @@
 // value is true:
 // eslint-disable-next-line prettier/prettier
 export function assert(_value: unknown): asserts _value {}
+
+// This declares a function which asserts that the expression called
+// value is of type Type:
+// eslint-disable-next-line prettier/prettier
+export function assertType<Type>(_value: unknown): asserts _value is Type {}

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -3,8 +3,9 @@ import omitBy from 'lodash/omitBy';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {Organization, EventsStats, EventsStatsData} from 'app/types';
+import {Organization, EventsStats, YAxisEventsStats, EventsStatsData} from 'app/types';
 import {Series, SeriesDataUnit} from 'app/types/echarts';
+import {assert, assertType} from 'app/types/utils';
 
 import {Client} from 'app/api';
 import {addErrorMessage} from 'app/actionCreators/indicator';
@@ -15,20 +16,26 @@ import SentryTypes from 'app/sentryTypes';
 
 import LoadingPanel from '../loadingPanel';
 
-type RenderProps = {
-  loading: boolean;
-  reloading: boolean;
-  errored: boolean;
-
+type TimeSeriesData = {
   // timeseries data
   timeseriesData?: Series[];
   allTimeseriesData?: EventsStatsData;
   originalTimeseriesData?: EventsStatsData;
-  timeseriesTotals?: object;
+  timeseriesTotals?: {count: number};
   originalPreviousTimeseriesData?: EventsStatsData | null;
   previousTimeseriesData?: Series | null;
   timeAggregatedData?: Series | {};
 };
+
+type LoadingProps = {
+  loading: boolean;
+  reloading: boolean;
+  errored: boolean;
+};
+
+type YAxisResults = {[yAxisName: string]: TimeSeriesData};
+
+type RenderProps = LoadingProps & TimeSeriesData & {results?: YAxisResults};
 
 type DefaultProps = {
   period: any;
@@ -50,7 +57,7 @@ type EventsRequestPartialProps = {
   referenceEvent?: string;
   loading?: boolean;
   showLoading?: boolean;
-  yAxis?: string;
+  yAxis?: string | string[];
   children: (renderProps: RenderProps) => React.ReactNode;
 };
 
@@ -63,7 +70,7 @@ type EventsRequestProps = DefaultProps & TimeAggregationProps & EventsRequestPar
 type EventsRequestState = {
   reloading: boolean;
   errored: boolean;
-  timeseriesData: null | EventsStats;
+  timeseriesData: null | EventsStats | YAxisEventsStats;
 };
 
 const propNamesToIgnore = ['api', 'children', 'organization', 'loading'];
@@ -164,7 +171,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     /**
      * The yAxis being plotted
      */
-    yAxis: PropTypes.string,
+    yAxis: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
 
     field: PropTypes.arrayOf(PropTypes.string),
     referenceEvent: PropTypes.string,
@@ -182,7 +189,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     includeTransformedData: true,
   };
 
-  state = {
+  state: EventsRequestState = {
     reloading: !!this.props.loading,
     errored: false,
     timeseriesData: null,
@@ -207,7 +214,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
 
   fetchData = async () => {
     const {api, ...props} = this.props;
-    let timeseriesData: EventsStats | null = null;
+    let timeseriesData: EventsStats | YAxisEventsStats | null = null;
 
     this.setState(state => ({
       reloading: state.timeseriesData !== null,
@@ -309,7 +316,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
   /**
    * Transforms query response into timeseries data to be used in a chart
    */
-  transformTimeseriesData(data: EventsStatsData): [Series] {
+  transformTimeseriesData(data: EventsStatsData): Series[] {
     return [
       {
         seriesName: 'Current',
@@ -362,6 +369,55 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     if (showLoading && loading) {
       return <LoadingPanel data-test-id="events-request-loading" />;
     }
+
+    assert(timeseriesData);
+
+    if (Array.isArray(props.yAxis) && timeseriesData) {
+      // if yAxis is an array, then the API endpoint will return multiple sets of data
+      // in the form of a map: {[yAxisName: string]: EventsStats}
+
+      assertType<YAxisEventsStats>(timeseriesData);
+
+      const results: YAxisResults = Object.fromEntries(
+        props.yAxis.map((yAxisName: string): [string, TimeSeriesData] => {
+          const {
+            data: transformedTimeseriesData,
+            allData: allTimeseriesData,
+            originalData: originalTimeseriesData,
+            totals: timeseriesTotals,
+            originalPreviousData: originalPreviousTimeseriesData,
+            previousData: previousTimeseriesData,
+            timeAggregatedData,
+          } = this.processData(timeseriesData[yAxisName]);
+
+          // timeseries data
+          return [
+            yAxisName,
+            {
+              timeseriesData: transformedTimeseriesData,
+              allTimeseriesData,
+              originalTimeseriesData,
+              timeseriesTotals,
+              originalPreviousTimeseriesData,
+              previousTimeseriesData,
+              timeAggregatedData,
+            },
+          ];
+        })
+      );
+
+      return children({
+        loading,
+        reloading,
+        errored,
+        // timeseries data
+        results,
+        // sometimes we want to reference props that were given to EventsRequest
+        ...props,
+      });
+    }
+
+    assertType<EventsStats>(timeseriesData);
 
     const {
       data: transformedTimeseriesData,

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -27,7 +27,7 @@ type TimeSeriesData = {
   timeAggregatedData?: Series | {};
 };
 
-type LoadingProps = {
+type LoadingStatus = {
   loading: boolean;
   reloading: boolean;
   errored: boolean;
@@ -35,7 +35,7 @@ type LoadingProps = {
 
 type YAxisResults = {[yAxisName: string]: TimeSeriesData};
 
-type RenderProps = LoadingProps & TimeSeriesData & {results?: YAxisResults};
+type RenderProps = LoadingStatus & TimeSeriesData & {results?: YAxisResults};
 
 type DefaultProps = {
   period: any;

--- a/tests/js/spec/views/events/utils/eventsRequest.spec.jsx
+++ b/tests/js/spec/views/events/utils/eventsRequest.spec.jsx
@@ -279,4 +279,178 @@ describe('EventsRequest', function() {
       );
     });
   });
+
+  describe('yAxis', function() {
+    beforeEach(function() {
+      doEventsRequest.mockClear();
+    });
+
+    it('supports yAxis', async function() {
+      doEventsRequest.mockImplementation(() =>
+        Promise.resolve({
+          data: [
+            [
+              new Date(),
+              [
+                {...COUNT_OBJ, count: 321},
+                {...COUNT_OBJ, count: 79},
+              ],
+            ],
+            [new Date(), [COUNT_OBJ]],
+          ],
+        })
+      );
+
+      wrapper = mount(
+        <EventsRequest {...DEFAULTS} includePrevious yAxis="apdex()">
+          {mock}
+        </EventsRequest>
+      );
+
+      await tick();
+      wrapper.update();
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          loading: false,
+          allTimeseriesData: [
+            [
+              expect.anything(),
+              [
+                expect.objectContaining({count: 321}),
+                expect.objectContaining({count: 79}),
+              ],
+            ],
+            [expect.anything(), [expect.objectContaining({count: 123})]],
+          ],
+          timeseriesData: [
+            {
+              seriesName: expect.anything(),
+              data: [
+                expect.objectContaining({
+                  name: expect.anything(),
+                  value: 123,
+                }),
+              ],
+            },
+          ],
+          previousTimeseriesData: {
+            seriesName: 'Previous',
+            data: [
+              expect.objectContaining({
+                name: expect.anything(),
+                value: 400,
+              }),
+            ],
+          },
+
+          originalTimeseriesData: [
+            [expect.anything(), [expect.objectContaining({count: 123})]],
+          ],
+
+          originalPreviousTimeseriesData: [
+            [
+              expect.anything(),
+              [
+                expect.objectContaining({count: 321}),
+                expect.objectContaining({count: 79}),
+              ],
+            ],
+          ],
+        })
+      );
+    });
+
+    it('supports multiple yAxis', async function() {
+      doEventsRequest.mockImplementation(() =>
+        Promise.resolve({
+          'rpm()': {
+            data: [
+              [
+                new Date(),
+                [
+                  {...COUNT_OBJ, count: 321},
+                  {...COUNT_OBJ, count: 79},
+                ],
+              ],
+              [new Date(), [COUNT_OBJ]],
+            ],
+          },
+          'apdex()': {
+            data: [
+              [
+                new Date(),
+                [
+                  {...COUNT_OBJ, count: 321},
+                  {...COUNT_OBJ, count: 79},
+                ],
+              ],
+              [new Date(), [COUNT_OBJ]],
+            ],
+          },
+        })
+      );
+
+      wrapper = mount(
+        <EventsRequest {...DEFAULTS} includePrevious yAxis={['apdex()', 'rpm()']}>
+          {mock}
+        </EventsRequest>
+      );
+
+      await tick();
+      wrapper.update();
+
+      const expectedDataResponse = {
+        allTimeseriesData: [
+          [
+            expect.anything(),
+            [expect.objectContaining({count: 321}), expect.objectContaining({count: 79})],
+          ],
+          [expect.anything(), [expect.objectContaining({count: 123})]],
+        ],
+        timeseriesData: [
+          {
+            seriesName: expect.anything(),
+            data: [
+              expect.objectContaining({
+                name: expect.anything(),
+                value: 123,
+              }),
+            ],
+          },
+        ],
+        previousTimeseriesData: {
+          seriesName: 'Previous',
+          data: [
+            expect.objectContaining({
+              name: expect.anything(),
+              value: 400,
+            }),
+          ],
+        },
+
+        originalTimeseriesData: [
+          [expect.anything(), [expect.objectContaining({count: 123})]],
+        ],
+
+        originalPreviousTimeseriesData: [
+          [
+            expect.anything(),
+            [expect.objectContaining({count: 321}), expect.objectContaining({count: 79})],
+          ],
+        ],
+      };
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          loading: false,
+
+          results: {
+            'apdex()': expect.objectContaining(expectedDataResponse),
+            'rpm()': expect.objectContaining(expectedDataResponse),
+          },
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
Update some frontend code that fetches from `/api/0/organizations/:org/events-stats/` to be able to pass multiple `yAxis` options, and parse the response that contains sets of chart data.

The backend changeset that adds this was in https://github.com/getsentry/sentry/pull/17177

The Performance page will make use of this.

------

For the TypeScript pros, this PR also adds `assertType<Type>` type utility function to assert types without resorting to generic types gymnastics. 