### PR TITLE
ref(saml2): Disable RequestedAuthnContext from IdP

### DIFF
--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -339,10 +339,7 @@ def build_saml_config(provider_config, org):
         "signatureAlgorithm": avd.get("signature_algorithm", OneLogin_Saml2_Constants.RSA_SHA256),
         "digestAlgorithm": avd.get("digest_algorithm", OneLogin_Saml2_Constants.SHA256),
         "wantNameId": False,
-        "requestedAuthnContext": [
-            "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
-            "urn:federation:authentication:windows",
-        ],
+        "requestedAuthnContext": False,
     }
 
     # TODO(epurkhiser): This is also available in the helper and should probably come from there.


### PR DESCRIPTION
This is a PR regarding configuration for SSO with SAML2. 

* The new setting is `requestedAuthnContext` to `false`.
* The prev setting was `requestedAuthnContext` to `PasswordProtectedTransport` and `exact`

The previous setting was too restrictive and causing logins using certain authentication contexts (X509 with FIDO U2F<sup>[1]</sup>) with AzureAD<sup>[2]</sup> to fail (Refs ISSUE-706). 

Given that we do not use the context on our end for anything useful, I recommend turning it off. 

<sub>[1] We can make a simplification that FIDO U2F refers to passwordless authentication using a YubiKey.</sub>
<sub>[2] Azure Active Directory is an enterprise identity management solution. Some of our customers login to us through their portal.</sub>

<br>

### What  is `requestedAuthnContext`? 

`authnContext` is basically the methodology used by the Identity Provider (IdP) to authenticate the identity of the user. This information may be useful for a Service Provider (SP) if they need to assess the strictness of the authentication method by the IdP.

* An IdP would be a service which verifies the identity of the user (AzureAD, Okta, OneLogin)
* A SP would be an application which the user is trying to access (Sentry)

`requestedAuthnContext` is the framework within SAML2 for the IdP and SP to communicate their security requirements to each other and come to a consensus. 

In layman terms, if the SP sends:
* `Password` with `exact` means that SP accepts if the IdP uses password auth only
* `Password` with `minimum` means that SP accepts if the IdP uses password auth or another more secure method
* `false` means that SP will accept any methods used by the IdP (much like having omakase at a sushi place)

There are 25 authentication context within the SAML2 specs and this is just an initial list written in 2005. A few more have popped up since (e.g. `Password, MultiFactor` which is password+2FA), which makes it a little tricky to enforce `exact`. Additionally, it's unclear how "a more secure method" is determined. See [OASIS specs](https://docs.oasis-open.org/security/saml/v2.0/saml-authn-context-2.0-os.pdf).

<br>

### What is the problem?
* AzureAD enforces `exact`. All other values fail immediately.
* Using `PasswordProtectedTransport` and `X509` passes when using password+2FA, but fails when using U2F.
* Using `PasswordProtectedTransport` passes when using password+2FA, but fails when using U2F
* Using `X509` fails when using password+FA, but passes when using U2F
* Doing the logic on above means that we need to disable auth context for AzureAD to support the various auth methods.

<br>

### What are the solutions?

1. Set it to `false` for just AzureAD
2. Set it to `false` for everything

When turning `requestedAuthnContext` off, we should not delete the key but rather, set the value to `false`. We need to explicitly declare that we will accept any authentication context as this matters to some IdP.

I'm in favour of setting it to `false` for everything. 

<br>

### Why _everything_?

#### 1. Community consensus on default setting
* We are using the Python package by OneLogin and a OneLogin dev [thinks it was a mistake](https://github.com/onelogin/php-saml/issues/62#issuecomment-202795544) to set the default as `PasswordProtectedTransport` and `exact` and changed the PHP package to default to `false`

#### 2. Supports more use-cases out of the box
* We are not doing anything with the information around `authnContext`
* Picking a minimum level of security and then declaring `exact`/`minimum` isn't a foolproof guarantee, since there is a lot of implicit trust in the IdP to report the context correctly. 

We should default to a generic setting until we need something different

<br>

### What should we consider?
* Is there any requirements in our compliance agreements for us to guarantee some kind of minimum security level for authentication?