### PR TITLE
ref(integration directory): Update the detailed integration view to match the design

### DIFF
--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -60,7 +60,7 @@ export type SingleIntegrationEvent = {
     | 'Integrations: Plugin Add to Project Clicked';
   integration: string; //the slug
   already_installed?: boolean;
-  integration_tab?: 'configurations' | 'information';
+  integration_tab?: 'configurations' | 'overview';
 } & (SentryAppEvent | NonSentryAppEvent);
 
 type SentryAppEvent = {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -24,7 +24,7 @@ import {
 import Alert, {Props as AlertProps} from 'app/components/alert';
 import ExternalLink from 'app/components/links/externalLink';
 import marked, {singleLineRenderer} from 'app/utils/marked';
-import {IconClose} from 'app/icons';
+import {IconClose, IconGithub} from 'app/icons';
 import IntegrationStatus from './integrationStatus';
 
 type Tab = 'information' | 'configurations';
@@ -347,11 +347,15 @@ class AbstractIntegrationDetailedView<
                 <AuthorName>{this.author}</AuthorName>
               </div>
             )}
-            {this.resourceLinks.map(({title, url}) => (
-              <ExternalLink key={url} href={url}>
-                {t(title)}
-              </ExternalLink>
-            ))}
+            {this.resourceLinks.map(({title, url}) => {
+              const icon = title === 'View Source' ? <IconCode /> : <StyledIconGithub />;
+              return (
+                <ExternalLinkContainer key={url}>
+                  {icon}
+                  <ExternalLink href={url}>{t(title)}</ExternalLink>
+                </ExternalLinkContainer>
+              );
+            })}
           </Metadata>
         </Flex>
       </React.Fragment>
@@ -444,10 +448,6 @@ const Metadata = styled(Flex)`
   font-size: 0.9em;
   margin-left: ${space(4)};
   margin-right: 100px;
-
-  a {
-    margin-bottom: ${space(2)};
-  }
 `;
 
 const AuthorName = styled('div')`
@@ -500,5 +500,16 @@ const EmptyConfigurationBody = styled('div')`
   line-height: 28px;
   color: ${p => p.theme.gray2};
   padding-bottom: ${space(2)};
+`;
+
+const IconCode = () => (
+  <span className="icon-code2" style={{fontWeight: 'bold', marginRight: space(1)}} />
+);
+const StyledIconGithub = styled(IconGithub)`
+  margin-right: ${space(1)};
+`;
+
+const ExternalLinkContainer = styled('div')`
+  margin-bottom: ${space(2)};
 `;
 export default AbstractIntegrationDetailedView;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -24,7 +24,7 @@ import {
 import Alert, {Props as AlertProps} from 'app/components/alert';
 import ExternalLink from 'app/components/links/externalLink';
 import marked, {singleLineRenderer} from 'app/utils/marked';
-import {IconClose, IconGithub} from 'app/icons';
+import {IconClose, IconGithub, IconGeneric, IconDocs} from 'app/icons';
 import IntegrationStatus from './integrationStatus';
 
 type Tab = 'overview' | 'configurations';
@@ -109,6 +109,23 @@ class AbstractIntegrationDetailedView<
   get featureData(): IntegrationFeature[] {
     // Allow children to implement this
     throw new Error('Not implemented');
+  }
+
+  getIcon(title: string) {
+    switch (title) {
+      case 'View Source':
+        return <StyledIconCode />;
+      case 'Report Issue':
+        return <StyledIconGithub />;
+      case 'Documentation':
+        return <StyledIconDocs />;
+      case 'Splunk Setup Instructions':
+        return <StyledIconDocs />;
+      case 'Trello Setup Instructions':
+        return <StyledIconDocs />;
+      default:
+        return <StyledIconGeneric />;
+    }
   }
 
   onTabChange = (value: Tab) => {
@@ -332,10 +349,9 @@ class AbstractIntegrationDetailedView<
               </div>
             )}
             {this.resourceLinks.map(({title, url}) => {
-              const icon = title === 'View Source' ? <IconCode /> : <StyledIconGithub />;
               return (
                 <ExternalLinkContainer key={url}>
-                  {icon}
+                  {this.getIcon(title)}
                   <ExternalLink href={url}>{t(title)}</ExternalLink>
                 </ExternalLinkContainer>
               );
@@ -486,14 +502,23 @@ const EmptyConfigurationBody = styled('div')`
   padding-bottom: ${space(2)};
 `;
 
-const IconCode = () => (
+const StyledIconCode = () => (
   <span className="icon-code2" style={{fontWeight: 'bold', marginRight: space(1)}} />
 );
+
 const StyledIconGithub = styled(IconGithub)`
+  margin-right: ${space(1)};
+`;
+
+const StyledIconGeneric = styled(IconGeneric)`
+  margin-right: ${space(1)};
+`;
+const StyledIconDocs = styled(IconDocs)`
   margin-right: ${space(1)};
 `;
 
 const ExternalLinkContainer = styled('div')`
   margin-bottom: ${space(2)};
+  display: flex;
 `;
 export default AbstractIntegrationDetailedView;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -152,18 +152,6 @@ class AbstractIntegrationDetailedView<
     throw new Error('Not implemented');
   }
 
-  renderButton(
-    _disabledFromFeatures: boolean, //from the feature gate
-    _userHasAccess: boolean, //from user permissions
-    configurations: boolean = true
-  ): React.ReactElement {
-    // Allow children to implement this
-    if (!configurations && _disabledFromFeatures) {
-      return <div />;
-    }
-    return this.renderTopButton(_disabledFromFeatures, _userHasAccess);
-  }
-
   //Returns the permission descriptions, only use by Sentry Apps
   renderPermissions(): React.ReactElement | null {
     //default is don't render permissions
@@ -178,7 +166,7 @@ class AbstractIntegrationDetailedView<
           But that doesn’t have to be the case for long! Add an installation to get
           started.
         </EmptyConfigurationBody>
-        <div>{this.renderAddInstallButton(false)}</div>
+        <div>{this.renderAddInstallButton(true)}</div>
       </EmptyConfigurationContainer>
     );
   }
@@ -249,7 +237,7 @@ class AbstractIntegrationDetailedView<
     );
   }
 
-  renderAddInstallButton(configurations = true) {
+  renderAddInstallButton(hideButton = false) {
     const {organization} = this.props;
     const {IntegrationDirectoryFeatures} = getIntegrationFeatureGate();
 
@@ -265,7 +253,11 @@ class AbstractIntegrationDetailedView<
                   )}
                   disabled={hasAccess}
                 >
-                  {this.renderButton(disabled, hasAccess, configurations)}
+                  {!hideButton && disabled ? (
+                    <div />
+                  ) : (
+                    this.renderTopButton(disabled, hasAccess)
+                  )}
                 </Tooltip>
               )}
             </Access>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -124,7 +124,7 @@ class AbstractIntegrationDetailedView<
   //Returns the string that is shown as the title of a tab
   getTabDiplay(tab: Tab): string {
     //default is return the tab
-    return tab;
+    return tab === 'information' ? 'overview' : 'configurations';
   }
 
   //Render the button at the top which is usually just an installation button
@@ -140,6 +140,46 @@ class AbstractIntegrationDetailedView<
   renderPermissions(): React.ReactElement | null {
     //default is don't render permissions
     return null;
+  }
+
+  renderEmptyConfigurations() {
+    const {organization} = this.props;
+    const {IntegrationDirectoryFeatures} = getIntegrationFeatureGate();
+
+    return (
+      <EmptyConfigurationContainer>
+        <EmptyConfigurationTitle>You haven't set anything up yet</EmptyConfigurationTitle>
+        <EmptyConfigurationBody>
+          But that doesn’t have to be the case for long! Add an installation to get
+          started.
+        </EmptyConfigurationBody>
+        <div>
+          <IntegrationDirectoryFeatures {...this.featureProps}>
+            {({disabled, disabledReason}) =>
+              disabled ? (
+                <div />
+              ) : (
+                <DisableWrapper>
+                  <Access organization={organization} access={['org:integrations']}>
+                    {({hasAccess}) => (
+                      <Tooltip
+                        title={t(
+                          'You must be an organization owner, manager or admin to install this.'
+                        )}
+                        disabled={hasAccess}
+                      >
+                        {this.renderTopButton(disabled, hasAccess)}
+                      </Tooltip>
+                    )}
+                  </Access>
+                  {disabled && <DisabledNotice reason={disabledReason} />}
+                </DisableWrapper>
+              )
+            }
+          </IntegrationDirectoryFeatures>
+        </div>
+      </EmptyConfigurationContainer>
+    );
   }
 
   //Returns the list of configurations for the integration
@@ -208,12 +248,37 @@ class AbstractIntegrationDetailedView<
     );
   }
 
+  renderAddInstallButton() {
+    const {organization} = this.props;
+    const {IntegrationDirectoryFeatures} = getIntegrationFeatureGate();
+
+    return (
+      <IntegrationDirectoryFeatures {...this.featureProps}>
+        {({disabled, disabledReason}) => (
+          <DisableWrapper>
+            <Access organization={organization} access={['org:integrations']}>
+              {({hasAccess}) => (
+                <Tooltip
+                  title={t(
+                    'You must be an organization owner, manager or admin to install this.'
+                  )}
+                  disabled={hasAccess}
+                >
+                  {this.renderTopButton(disabled, hasAccess)}
+                </Tooltip>
+              )}
+            </Access>
+            {disabled && <DisabledNotice reason={disabledReason} />}
+          </DisableWrapper>
+        )}
+      </IntegrationDirectoryFeatures>
+    );
+  }
+
   //Returns the content shown in the top section of the integration detail
   renderTopSection() {
-    const {organization} = this.props;
-
-    const {IntegrationDirectoryFeatures} = getIntegrationFeatureGate();
     const tags = this.cleanTags();
+
     return (
       <Flex>
         <PluginIcon pluginId={this.integrationSlug} size={50} />
@@ -230,25 +295,7 @@ class AbstractIntegrationDetailedView<
             ))}
           </Flex>
         </NameContainer>
-        <IntegrationDirectoryFeatures {...this.featureProps}>
-          {({disabled, disabledReason}) => (
-            <DisableWrapper>
-              <Access organization={organization} access={['org:integrations']}>
-                {({hasAccess}) => (
-                  <Tooltip
-                    title={t(
-                      'You must be an organization owner, manager or admin to install this.'
-                    )}
-                    disabled={hasAccess}
-                  >
-                    {this.renderTopButton(disabled, hasAccess)}
-                  </Tooltip>
-                )}
-              </Access>
-              {disabled && <DisabledNotice reason={disabledReason} />}
-            </DisableWrapper>
-          )}
-        </IntegrationDirectoryFeatures>
+        {this.renderAddInstallButton()}
       </Flex>
     );
   }
@@ -333,7 +380,7 @@ const FlexContainer = styled('div')`
 `;
 
 const CapitalizedLink = styled('a')`
-  text-transform: 'capitalize';
+  text-transform: capitalize;
 `;
 
 const StyledTag = styled(Tag)`
@@ -427,5 +474,31 @@ const CreatedContainer = styled('div')`
   color: ${p => p.theme.gray2};
   font-weight: 600;
   font-size: 12px;
+`;
+
+const EmptyConfigurationContainer = styled('div')`
+  height: 200px;
+  background: #ffffff;
+  border: 1px solid #c6becf;
+  box-sizing: border-box;
+  box-shadow: 0px 2px 1px rgba(0, 0, 0, 0.08);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const EmptyConfigurationTitle = styled('div')`
+  font-size: 22px;
+  line-height: 31px;
+  padding-bottom: ${space(2)};
+`;
+
+const EmptyConfigurationBody = styled('div')`
+  font-size: 16px;
+  line-height: 28px;
+  color: ${p => p.theme.gray2};
+  padding-bottom: ${space(2)};
 `;
 export default AbstractIntegrationDetailedView;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -237,7 +237,7 @@ class AbstractIntegrationDetailedView<
     );
   }
 
-  renderAddInstallButton(hideButton = false) {
+  renderAddInstallButton(hideButtonIfDisabled = false) {
     const {organization} = this.props;
     const {IntegrationDirectoryFeatures} = getIntegrationFeatureGate();
 
@@ -253,7 +253,7 @@ class AbstractIntegrationDetailedView<
                   )}
                   disabled={hasAccess}
                 >
-                  {!hideButton && disabled ? (
+                  {!hideButtonIfDisabled && disabled ? (
                     <div />
                   ) : (
                     this.renderTopButton(disabled, hasAccess)

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
@@ -9,8 +9,13 @@ import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import IntegrationItem from 'app/views/organizationIntegrations/integrationItem';
 import Tooltip from 'app/components/tooltip';
-import {IntegrationProvider, Integration, Organization} from 'app/types';
+import {IntegrationProvider, Integration, Organization, ObjectStatus} from 'app/types';
 import {SingleIntegrationEvent} from 'app/utils/integrationUtil';
+import CircleIndicator from 'app/components/circleIndicator';
+import theme from 'app/utils/theme';
+import space from 'app/styles/space';
+
+import {colors} from './constants';
 
 const CONFIGURABLE_FEATURES = ['commits', 'alert-rule'];
 
@@ -134,7 +139,7 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
         {({hasAccess}) => (
           <IntegrationFlex key={integration.id} className={className}>
             <IntegrationItemBox>
-              <IntegrationItem compact integration={integration} />
+              <IntegrationItem integration={integration} />
             </IntegrationItemBox>
             <div>
               {integration.status === 'disabled' && (
@@ -181,6 +186,8 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
                 </StyledButton>
               </Confirm>
             </div>
+
+            <IntegrationStatus status={integration.status} />
           </IntegrationFlex>
         )}
       </Access>
@@ -199,4 +206,42 @@ const IntegrationFlex = styled('div')`
 
 const IntegrationItemBox = styled('div')`
   flex: 1;
+`;
+
+const IntegrationStatus = styled((props: {status: ObjectStatus}) => {
+  const {status, ...p} = props;
+  const color = status === 'active' ? theme.success : theme.gray2;
+  const children = (
+    <div {...p}>
+      <CircleIndicator size={6} color={color} />
+      <IntegrationStatusText>{`${t(
+        status === 'active' ? 'enabled' : 'disabled'
+      )}`}</IntegrationStatusText>
+    </div>
+  );
+  return status === 'active' ? (
+    children
+  ) : (
+    <Tooltip
+      title={t('This Integration has been disconnected from the external provider')}
+    >
+      {children}
+    </Tooltip>
+  );
+})`
+  display: flex;
+  align-items: center;
+  color: ${p => p.theme.gray2};
+  font-weight: light;
+  text-transform: capitalize;
+  &:before {
+    content: '|';
+    color: ${p => p.theme.gray1};
+    margin-right: ${space(1)};
+    font-weight: normal;
+  }
+`;
+
+const IntegrationStatusText = styled('div')`
+  margin: 0 ${space(0.75)} 0 ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
 import Access from 'app/components/acl/access';
-import AddIntegrationButton from 'app/views/organizationIntegrations/addIntegrationButton';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
@@ -14,8 +13,6 @@ import {SingleIntegrationEvent} from 'app/utils/integrationUtil';
 import CircleIndicator from 'app/components/circleIndicator';
 import theme from 'app/utils/theme';
 import space from 'app/styles/space';
-
-import {colors} from './constants';
 
 const CONFIGURABLE_FEATURES = ['commits', 'alert-rule'];
 
@@ -142,7 +139,7 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
               <IntegrationItem integration={integration} />
             </IntegrationItemBox>
             <div>
-              {integration.status === 'disabled' && (
+              {/* {integration.status === 'disabled' && (
                 <AddIntegrationButton
                   size="xsmall"
                   priority="success"
@@ -150,7 +147,7 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
                   onAddIntegration={this.reinstallIntegration}
                   reinstall
                 />
-              )}
+              )} */}
               {integration.status === 'active' && (
                 <Tooltip
                   disabled={this.hasConfiguration()}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
@@ -200,24 +200,26 @@ const IntegrationItemBox = styled('div')`
   flex: 1;
 `;
 
-const IntegrationStatus = styled((props: {status: ObjectStatus}) => {
-  const {status, ...p} = props;
-  const color = status === 'active' ? theme.success : theme.gray2;
-
-  return (
-    <Tooltip
-      title={t('This Integration has been disconnected from the external provider')}
-      disabled={status === 'active'}
-    >
-      <div {...p}>
-        <CircleIndicator size={6} color={color} />
-        <IntegrationStatusText>{`${t(
-          status === 'active' ? 'enabled' : 'disabled'
-        )}`}</IntegrationStatusText>
-      </div>
-    </Tooltip>
-  );
-})`
+const IntegrationStatus = styled(
+  (props: React.HTMLAttributes<HTMLElement> & {status: ObjectStatus}) => {
+    const {status, ...p} = props;
+    const color = status === 'active' ? theme.success : theme.gray2;
+    const titleText =
+      status === 'active'
+        ? 'This Integration can be disabled by clicking the Uninstall button'
+        : 'This Integration has been disconnected from the external provider';
+    return (
+      <Tooltip title={t(titleText)}>
+        <div {...p}>
+          <CircleIndicator size={6} color={color} />
+          <IntegrationStatusText>{`${t(
+            status === 'active' ? 'enabled' : 'disabled'
+          )}`}</IntegrationStatusText>
+        </div>
+      </Tooltip>
+    );
+  }
+)`
   display: flex;
   align-items: center;
   color: ${p => p.theme.gray2};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
@@ -206,15 +206,15 @@ const IntegrationStatus = styled(
     const color = status === 'active' ? theme.success : theme.gray2;
     const titleText =
       status === 'active'
-        ? 'This Integration can be disabled by clicking the Uninstall button'
-        : 'This Integration has been disconnected from the external provider';
+        ? t('This Integration can be disabled by clicking the Uninstall button')
+        : t('This Integration has been disconnected from the external provider');
     return (
-      <Tooltip title={t(titleText)}>
+      <Tooltip title={titleText}>
         <div {...p}>
           <CircleIndicator size={6} color={color} />
-          <IntegrationStatusText>{`${t(
-            status === 'active' ? 'enabled' : 'disabled'
-          )}`}</IntegrationStatusText>
+          <IntegrationStatusText>{`${
+            status === 'active' ? t('enabled') : t('disabled')
+          }`}</IntegrationStatusText>
         </div>
       </Tooltip>
     );

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
@@ -139,16 +139,7 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
               <IntegrationItem integration={integration} />
             </IntegrationItemBox>
             <div>
-              {/* {integration.status === 'disabled' && (
-                <AddIntegrationButton
-                  size="xsmall"
-                  priority="success"
-                  provider={provider}
-                  onAddIntegration={this.reinstallIntegration}
-                  reinstall
-                />
-              )} */}
-              {integration.status === 'active' && (
+              {
                 <Tooltip
                   disabled={this.hasConfiguration()}
                   position="left"
@@ -157,14 +148,18 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
                   <StyledButton
                     borderless
                     icon="icon-settings"
-                    disabled={!this.hasConfiguration() || !hasAccess}
+                    disabled={
+                      !this.hasConfiguration() ||
+                      !hasAccess ||
+                      integration.status !== 'active'
+                    }
                     to={`/settings/${organization.slug}/integrations/${provider.key}/${integration.id}/`}
                     data-test-id="integration-configure-button"
                   >
                     Configure
                   </StyledButton>
                 </Tooltip>
-              )}
+              }
             </div>
             <div>
               <Confirm
@@ -208,21 +203,18 @@ const IntegrationItemBox = styled('div')`
 const IntegrationStatus = styled((props: {status: ObjectStatus}) => {
   const {status, ...p} = props;
   const color = status === 'active' ? theme.success : theme.gray2;
-  const children = (
-    <div {...p}>
-      <CircleIndicator size={6} color={color} />
-      <IntegrationStatusText>{`${t(
-        status === 'active' ? 'enabled' : 'disabled'
-      )}`}</IntegrationStatusText>
-    </div>
-  );
-  return status === 'active' ? (
-    children
-  ) : (
+
+  return (
     <Tooltip
       title={t('This Integration has been disconnected from the external provider')}
+      disabled={status === 'active'}
     >
-      {children}
+      <div {...p}>
+        <CircleIndicator size={6} color={color} />
+        <IntegrationStatusText>{`${t(
+          status === 'active' ? 'enabled' : 'disabled'
+        )}`}</IntegrationStatusText>
+      </div>
     </Tooltip>
   );
 })`

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
@@ -64,7 +64,7 @@ export class InstalledPlugin extends React.Component<Props> {
     if (enabled) {
       await this.pluginUpdate({enabled});
     } else {
-      await this.pluginUpdate({enabled}, 'DELETE');
+      await this.pluginUpdate({}, 'DELETE');
     }
   };
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
@@ -25,7 +25,7 @@ export type Props = {
   projectItem: PluginProjectItem;
   organization: Organization;
   onResetConfiguration: (projectId: string) => void;
-  onEnablePlugin: (projectId: string, status: boolean) => void;
+  onPluginEnableStatusChange: (projectId: string, status: boolean) => void;
   trackIntegrationEvent: (
     options: Pick<SingleIntegrationEvent, 'eventKey' | 'eventName'> & {project_id: string}
   ) => void; //analytics callback
@@ -105,14 +105,18 @@ export class InstalledPlugin extends React.Component<Props> {
       addSuccessMessage(
         tct('Configuration was [action].', {action: status ? 'enabled' : 'disabled'})
       );
-      this.props.onEnablePlugin(projectId, status);
+      this.props.onPluginEnableStatusChange(projectId, status);
       this.props.trackIntegrationEvent({
-        eventKey: 'integrations.enabled',
-        eventName: 'Integrations: Enabled',
+        eventKey: status ? 'integrations.enabled' : 'integrations.disabled',
+        eventName: status ? 'Integrations: Enabled' : 'Integrations: Disabled',
         project_id: projectId,
       });
     } catch (_err) {
-      addErrorMessage(t('Unable to enable configuration'));
+      addErrorMessage(
+        tct('Unable to [action] configuration.', {
+          action: status ? 'enabled' : 'disabled',
+        })
+      );
     }
   };
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
@@ -48,29 +48,23 @@ export class InstalledPlugin extends React.Component<Props> {
     );
   }
 
-  pluginUpdate = async (data: object) => {
+  pluginUpdate = async (data: object, method: 'POST' | 'DELETE' = 'POST') => {
     const {organization, projectItem, plugin} = this.props;
     // no try/catch so the caller will have to have it
     await this.props.api.requestPromise(
       `/projects/${organization.slug}/${projectItem.projectSlug}/plugins/${plugin.id}/`,
       {
-        method: 'POST',
+        method,
         data,
       }
     );
   };
 
   updatePluginEnableStatus = async (enabled: boolean) => {
-    const {organization, projectItem, plugin} = this.props;
     if (enabled) {
       await this.pluginUpdate({enabled});
     } else {
-      await this.props.api.requestPromise(
-        `/projects/${organization.slug}/${projectItem.projectSlug}/plugins/${plugin.id}/`,
-        {
-          method: 'DELETE',
-        }
-      );
+      await this.pluginUpdate({enabled}, 'DELETE');
     }
   };
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
@@ -97,7 +97,7 @@ export class InstalledPlugin extends React.Component<Props> {
       addLoadingMessage(t('Enabling...'));
       await this.updatePluginEnableStatus(status);
       addSuccessMessage(
-        tct('Configuration was [action].', {action: status ? 'enabled' : 'disabled'})
+        status ? t('Configuration was enabled.') : t('Configuration was disabled.')
       );
       this.props.onPluginEnableStatusChange(projectId, status);
       this.props.trackIntegrationEvent({
@@ -107,9 +107,9 @@ export class InstalledPlugin extends React.Component<Props> {
       });
     } catch (_err) {
       addErrorMessage(
-        tct('Unable to [action] configuration.', {
-          action: status ? 'enabled' : 'disabled',
-        })
+        status
+          ? t('Unable to enable configuration.')
+          : t('Unable to disable configuration.')
       );
     }
   };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {t, tct} from 'app/locale';
+import {t} from 'app/locale';
 import Access from 'app/components/acl/access';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -227,6 +227,12 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
 const InstallWrapper = styled('div')`
   padding: ${space(2)};
   border: 1px solid ${p => p.theme.borderLight};
+  border-bottom: none;
+  background-color: white;
+
+  &:last-child {
+    border-bottom: 1px solid ${p => p.theme.borderLight};
+  }
 `;
 
 export default withOrganization(IntegrationDetailedView);

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -200,24 +200,27 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     const {configurations} = this.state;
     const {organization} = this.props;
     const provider = this.provider;
-    return (
-      <div>
-        {configurations.map(integration => (
-          <InstallWrapper key={integration.id}>
-            <InstalledIntegration
-              organization={organization}
-              provider={provider}
-              integration={integration}
-              onRemove={this.onRemove}
-              onDisable={this.onDisable}
-              onReinstallIntegration={this.onInstall}
-              data-test-id={integration.id}
-              trackIntegrationEvent={this.trackIntegrationEvent}
-            />
-          </InstallWrapper>
-        ))}
-      </div>
-    );
+    if (configurations.length) {
+      return (
+        <div>
+          {configurations.map(integration => (
+            <InstallWrapper key={integration.id}>
+              <InstalledIntegration
+                organization={organization}
+                provider={provider}
+                integration={integration}
+                onRemove={this.onRemove}
+                onDisable={this.onDisable}
+                onReinstallIntegration={this.onInstall}
+                data-test-id={integration.id}
+                trackIntegrationEvent={this.trackIntegrationEvent}
+              />
+            </InstallWrapper>
+          ))}
+        </div>
+      );
+    }
+    return this.renderEmptyConfigurations();
   }
 }
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.tsx
@@ -1,11 +1,8 @@
-import {Box, Flex} from 'reflexbox';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {t} from 'app/locale';
 import IntegrationIcon from 'app/views/organizationIntegrations/integrationIcon';
-import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
 import {Integration} from 'app/types';
 
@@ -28,24 +25,14 @@ export default class IntegrationItem extends React.Component<Props> {
 
   render() {
     const {integration, compact} = this.props;
-
     return (
       <Flex>
-        <Box>
+        <div>
           <IntegrationIcon size={compact ? 22 : 32} integration={integration} />
-        </Box>
+        </div>
         <Labels compact={compact}>
           <IntegrationName data-test-id="integration-name">
             {integration.name}
-            {integration.status === 'disabled' && (
-              <Tooltip
-                title={t(
-                  'This Integration has been disconnected from the external provider'
-                )}
-              >
-                <small> — {t('Disabled')}</small>
-              </Tooltip>
-            )}
           </IntegrationName>
           <DomainName compact={compact}>{integration.domainName}</DomainName>
         </Labels>
@@ -54,6 +41,9 @@ export default class IntegrationItem extends React.Component<Props> {
   }
 }
 
+const Flex = styled('div')`
+  display: flex;
+`;
 type StyledProps = Pick<Props, 'compact'>;
 const Labels = styled('div')<StyledProps>`
   box-sizing: border-box;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -1,6 +1,7 @@
 import groupBy from 'lodash/groupBy';
 import debounce from 'lodash/debounce';
 import React from 'react';
+import styled from '@emotion/styled';
 import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {
@@ -16,7 +17,7 @@ import {
   trackIntegrationEvent,
   getSentryAppInstallStatus,
 } from 'app/utils/integrationUtil';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
 import PermissionAlert from 'app/views/settings/organization/permissionAlert';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
@@ -25,6 +26,8 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import withOrganization from 'app/utils/withOrganization';
 import SearchInput from 'app/components/forms/searchInput';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
+import space from 'app/styles/space';
+
 import IntegrationRow from './integrationRow';
 
 type AppOrProviderOrPlugin = SentryApp | IntegrationProvider | PluginWithProjectList;
@@ -349,11 +352,38 @@ export class OrganizationIntegrations extends AsyncComponent<
 
         <PermissionAlert access={['org:integrations']} />
         <Panel>
-          <PanelBody>{displayedList.map(this.renderIntegration)}</PanelBody>
+          <PanelBody>
+            {displayedList.length ? (
+              displayedList.map(this.renderIntegration)
+            ) : (
+              <EmptyResultsContainer>
+                <EmptyResultsBody>
+                  {tct('No Integrations found for "[searchTerm]".', {
+                    searchTerm: this.state.searchInput,
+                  })}
+                </EmptyResultsBody>
+              </EmptyResultsContainer>
+            )}
+          </PanelBody>
         </Panel>
       </React.Fragment>
     );
   }
 }
+
+const EmptyResultsContainer = styled('div')`
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const EmptyResultsBody = styled('div')`
+  font-size: 16px;
+  line-height: 28px;
+  color: ${p => p.theme.gray2};
+  padding-bottom: ${space(2)};
+`;
 
 export default withOrganization(OrganizationIntegrations);

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -161,7 +161,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
               plugin={plugin}
               projectItem={projectItem}
               onResetConfiguration={this.handleResetConfiguration}
-              onEnablePlugin={this.handlePluginEnableStatus}
+              onPluginEnableStatusChange={this.handlePluginEnableStatus}
               trackIntegrationEvent={this.trackIntegrationEvent}
             />
           ))}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -15,8 +15,6 @@ type State = {
   plugins: PluginWithProjectList[];
 };
 
-type Tab = AbstractIntegrationDetailedView['state']['tab'];
-
 class PluginDetailedView extends AbstractIntegrationDetailedView<
   AbstractIntegrationDetailedView['props'],
   State & AbstractIntegrationDetailedView['state']
@@ -126,14 +124,6 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
     );
   };
 
-  getTabDiplay(tab: Tab) {
-    //we want to show project configurations to make it more clear
-    if (tab === 'configurations') {
-      return 'project configurations';
-    }
-    return tab;
-  }
-
   renderTopButton(disabledFromFeatures: boolean, userHasAccess: boolean) {
     return (
       <AddButton
@@ -151,21 +141,24 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
   renderConfigurations() {
     const plugin = this.plugin;
     const {organization} = this.props;
-    return (
-      <div>
-        {plugin.projectList.map((projectItem: PluginProjectItem) => (
-          <InstalledPlugin
-            key={projectItem.projectId}
-            organization={organization}
-            plugin={plugin}
-            projectItem={projectItem}
-            onResetConfiguration={this.handleResetConfiguration}
-            onEnablePlugin={this.handleEnablePlugin}
-            trackIntegrationEvent={this.trackIntegrationEvent}
-          />
-        ))}
-      </div>
-    );
+    if (plugin.projectList.length) {
+      return (
+        <div>
+          {plugin.projectList.map((projectItem: PluginProjectItem) => (
+            <InstalledPlugin
+              key={projectItem.projectId}
+              organization={organization}
+              plugin={plugin}
+              projectItem={projectItem}
+              onResetConfiguration={this.handleResetConfiguration}
+              onEnablePlugin={this.handleEnablePlugin}
+              trackIntegrationEvent={this.trackIntegrationEvent}
+            />
+          ))}
+        </div>
+      );
+    }
+    return this.renderEmptyConfigurations();
   }
 }
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -79,7 +79,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
     });
   };
 
-  handleEnablePlugin = (projectId: string) => {
+  handlePluginEnableStatus = (projectId: string, enable: boolean = true) => {
     //make a copy of our project list
     const projectList = this.plugin.projectList.slice();
     //find the index of the project
@@ -92,7 +92,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
     //update item in array
     projectList[index] = {
       ...projectList[index],
-      enabled: true,
+      enabled: enable,
     };
 
     //update state
@@ -161,7 +161,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
               plugin={plugin}
               projectItem={projectItem}
               onResetConfiguration={this.handleResetConfiguration}
-              onEnablePlugin={this.handleEnablePlugin}
+              onEnablePlugin={this.handlePluginEnableStatus}
               trackIntegrationEvent={this.trackIntegrationEvent}
             />
           ))}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -15,6 +15,8 @@ type State = {
   plugins: PluginWithProjectList[];
 };
 
+type Tab = AbstractIntegrationDetailedView['state']['tab'];
+
 class PluginDetailedView extends AbstractIntegrationDetailedView<
   AbstractIntegrationDetailedView['props'],
   State & AbstractIntegrationDetailedView['state']
@@ -123,6 +125,14 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
       {}
     );
   };
+
+  getTabDiplay(tab: Tab) {
+    //we want to show project configurations to make it more clear
+    if (tab === 'configurations') {
+      return 'project configurations';
+    }
+    return 'overview';
+  }
 
   renderTopButton(disabledFromFeatures: boolean, userHasAccess: boolean) {
     return (

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -17,7 +17,7 @@ import withOrganization from 'app/utils/withOrganization';
 import SplitInstallationIdModal from 'app/views/organizationIntegrations/SplitInstallationIdModal';
 import {openModal} from 'app/actionCreators/modal';
 import {getSentryAppInstallStatus} from 'app/utils/integrationUtil';
-import {UninstallButton} from '../settings/organizationDeveloperSettings/sentryApplicationRow/installButtons';
+import {UninstallAppButton} from '../settings/organizationDeveloperSettings/sentryApplicationRow/installButtons';
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 
 type State = {
@@ -245,7 +245,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
         {t('Accept & Install')}
       </InstallButton>
     ) : (
-      <UninstallButton
+      <UninstallAppButton
         install={this.install}
         app={this.sentryApp}
         onClickUninstall={this.handleUninstall}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -32,7 +32,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   AbstractIntegrationDetailedView['props'],
   State & AbstractIntegrationDetailedView['state']
 > {
-  tabs: Tab[] = ['information'];
+  tabs: Tab[] = ['overview'];
   getEndpoints(): ([string, string, any] | [string, string])[] {
     const {
       organization,

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/installButtons.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/installButtons.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import {SentryApp, SentryAppInstallation} from 'app/types';
 import {IconSubtract} from 'app/icons';
 import space from 'app/styles/space';
@@ -23,7 +23,9 @@ export const UninstallButton = ({
   onUninstallModalOpen,
   disabled,
 }: UninstallButtonProps) => {
-  const message = t(`Are you sure you want to remove the ${app.slug} installation?`);
+  const message = tct('Are you sure you want to remove the [slug] installation?', {
+    slug: app.slug,
+  });
 
   return (
     <Confirm
@@ -67,7 +69,9 @@ export const UninstallAppButton = ({
   onUninstallModalOpen,
   disabled,
 }: UninstallButtonProps) => {
-  const message = t(`Are you sure you want to remove the ${app.slug} installation?`);
+  const message = tct('Are you sure you want to remove the [slug] installation?', {
+    slug: app.slug,
+  });
 
   return (
     <Confirm

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/installButtons.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/installButtons.tsx
@@ -6,6 +6,8 @@ import Confirm from 'app/components/confirm';
 
 import {t} from 'app/locale';
 import {SentryApp, SentryAppInstallation} from 'app/types';
+import {IconSubtract} from 'app/icons';
+import space from 'app/styles/space';
 
 type UninstallButtonProps = {
   install: SentryAppInstallation;
@@ -31,7 +33,8 @@ export const UninstallButton = ({
       onConfirming={onUninstallModalOpen} //called when the confirm modal opens
       disabled={disabled}
     >
-      <StyledButton borderless icon="icon-trash" data-test-id="sentry-app-uninstall">
+      <StyledButton size="small" data-test-id="sentry-app-uninstall">
+        <IconSubtract circle style={{marginRight: space(0.75)}} />
         {t('Uninstall')}
       </StyledButton>
     </Confirm>
@@ -56,4 +59,10 @@ export const InstallButton = ({onClickInstall}: InstallButtonProps) => {
 
 const StyledButton = styled(Button)`
   color: ${p => p.theme.gray2};
+  background: #ffffff;
+
+  border: ${p => `1px solid ${p.theme.gray2}`};
+  box-sizing: border-box;
+  box-shadow: 0px 2px 1px rgba(0, 0, 0, 0.08);
+  border-radius: 4px;
 `;

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/installButtons.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/installButtons.tsx
@@ -33,8 +33,7 @@ export const UninstallButton = ({
       onConfirming={onUninstallModalOpen} //called when the confirm modal opens
       disabled={disabled}
     >
-      <StyledButton size="small" data-test-id="sentry-app-uninstall">
-        <IconSubtract circle style={{marginRight: space(0.75)}} />
+      <StyledButton borderless icon="icon-trash" data-test-id="sentry-app-uninstall">
         {t('Uninstall')}
       </StyledButton>
     </Confirm>
@@ -58,6 +57,35 @@ export const InstallButton = ({onClickInstall}: InstallButtonProps) => {
 };
 
 const StyledButton = styled(Button)`
+  color: ${p => p.theme.gray2};
+`;
+
+export const UninstallAppButton = ({
+  install,
+  app,
+  onClickUninstall,
+  onUninstallModalOpen,
+  disabled,
+}: UninstallButtonProps) => {
+  const message = t(`Are you sure you want to remove the ${app.slug} installation?`);
+
+  return (
+    <Confirm
+      message={message}
+      priority="danger"
+      onConfirm={() => onClickUninstall && install && onClickUninstall(install)} //called when the user confirms the action
+      onConfirming={onUninstallModalOpen} //called when the confirm modal opens
+      disabled={disabled}
+    >
+      <StyledUninstallButton size="small" data-test-id="sentry-app-uninstall">
+        <IconSubtract circle style={{marginRight: space(0.75)}} />
+        {t('Uninstall')}
+      </StyledUninstallButton>
+    </Confirm>
+  );
+};
+
+const StyledUninstallButton = styled(Button)`
   color: ${p => p.theme.gray2};
   background: #ffffff;
 

--- a/tests/js/spec/views/organizationIntegrations/sentryAppDetailedView.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/sentryAppDetailedView.spec.jsx
@@ -127,13 +127,13 @@ describe('SentryAppDetailedView', function() {
         wrapper.update();
         wrapperState = wrapper;
         expect(wrapper.find('IntegrationStatus').props().status).toEqual('Installed');
-        expect(wrapper.find('UninstallButton').exists()).toEqual(true);
+        expect(wrapper.find('UninstallAppButton').exists()).toEqual(true);
       });
 
       it('uninstalls app', async function() {
-        expect(wrapperState.find('UninstallButton')).toHaveLength(1);
+        expect(wrapperState.find('UninstallAppButton')).toHaveLength(1);
         wrapperState
-          .find('UninstallButton')
+          .find('UninstallAppButton')
           .props()
           .onClickUninstall();
         await tick();
@@ -300,7 +300,7 @@ describe('SentryAppDetailedView', function() {
       expect(createRequest).toHaveBeenCalled();
       wrapper.update();
       expect(wrapper.find('IntegrationStatus').props().status).toEqual('Installed');
-      expect(wrapper.find('UninstallButton').exists()).toEqual(true);
+      expect(wrapper.find('UninstallAppButton').exists()).toEqual(true);
     });
   });
 

--- a/tests/js/spec/views/settings/organizationIntegrations/sentryAppInstallationDetail.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/sentryAppInstallationDetail.spec.jsx
@@ -54,7 +54,7 @@ describe('Sentry App Installations', function() {
         <SentryAppInstallationDetail {...props} install={install} />,
         routerContext
       );
-      expect(wrapper.find('[icon="icon-trash"]').exists()).toBe(true);
+      expect(wrapper.find('UninstallButton').exists()).toBe(true);
     });
 
     it('install button opens permissions modal', () => {


### PR DESCRIPTION
## Objective
Update the detailed integration view to match the design.
- Add symbols for resources in `Overview` tab.
- Update the uninstall button for Sentry apps to match the design.
- Update the configurations row to match design.
- First-party integration configurations should have the status indicator for enable/disable.
- Plugin configurations should use the enable/disable toggle.
- Update the empty configuration screen.
- Update the no search results screen in list view.

## UI
<img width="1440" alt="Screen Shot 2020-02-26 at 5 22 56 PM" src="https://user-images.githubusercontent.com/10491193/75403554-ec504180-58bc-11ea-9fcb-44992002c123.png">
<img width="1440" alt="Screen Shot 2020-02-26 at 5 24 41 PM" src="https://user-images.githubusercontent.com/10491193/75403558-ece8d800-58bc-11ea-931f-d92e2f26093c.png">
<img width="1440" alt="Screen Shot 2020-02-26 at 5 24 13 PM" src="https://user-images.githubusercontent.com/10491193/75403559-ed816e80-58bc-11ea-8541-e2a614a8337e.png">
<img width="1440" alt="Screen Shot 2020-02-26 at 5 24 01 PM" src="https://user-images.githubusercontent.com/10491193/75403560-ed816e80-58bc-11ea-95ad-2144ad3f2dc3.png">
<img width="1440" alt="Screen Shot 2020-02-26 at 5 23 43 PM" src="https://user-images.githubusercontent.com/10491193/75403561-ed816e80-58bc-11ea-8273-e5a802f48f98.png">
<img width="1440" alt="Screen Shot 2020-02-26 at 5 23 29 PM" src="https://user-images.githubusercontent.com/10491193/75403562-ee1a0500-58bc-11ea-9233-2b5c634cb975.png">
<img width="1440" alt="Screen Shot 2020-02-26 at 5 23 09 PM" src="https://user-images.githubusercontent.com/10491193/75403563-ee1a0500-58bc-11ea-8f6b-46e500a52509.png">
