### PR TITLE
feat(Slack plugin): Instrument Slack to emit Datadog metrics

### DIFF
--- a/src/sentry_plugins/slack/client.py
+++ b/src/sentry_plugins/slack/client.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+
+from sentry_plugins.client import ApiClient
+
+
+class SlackApiClient(ApiClient):
+    plugin_name = "slack"
+    allow_redirects = False
+
+    def __init__(self, webhook, username, icon_url, channel):
+        self.webhook = webhook
+        self.username = username
+        self.icon_url = icon_url
+        self.channel = channel
+        super(SlackApiClient, self).__init__()
+
+    def request(self, data):
+        return self._request(
+            path=self.webhook, method="post", data=data, json=False, allow_text=True
+        )

--- a/src/sentry_plugins/slack/plugin.py
+++ b/src/sentry_plugins/slack/plugin.py
@@ -249,9 +249,8 @@ class SlackPlugin(CorePluginMixin, notify.NotificationPlugin):
         client.request(values)
 
     def get_client(self, project):
-        webhook = self.get_option("webhook", project)
+        webhook = self.get_option("webhook", project).strip()
         # Apparently we've stored some bad data from before we used `URLField`.
-        webhook = webhook.strip(" ")
         username = (self.get_option("username", project) or "Sentry").strip()
         icon_url = self.get_option("icon_url", project)
         channel = (self.get_option("channel", project) or "").strip()

--- a/src/sentry_plugins/slack/plugin.py
+++ b/src/sentry_plugins/slack/plugin.py
@@ -19,7 +19,7 @@ LEVEL_TO_COLOR = {
 
 def track_response_code(status_code):
     metrics.incr(
-        "sentry-plugins.slack.http_response",
+        "sentry-plugins.http_response",
         sample_rate=1.0,
         tags={"status": status_code, "plugin": "slack"},
     )


### PR DESCRIPTION
This PR refactors the Slack plugin to use `ApiClient` so that it will emit Datadog metrics we can use to see when things are going well and when they're going poorly. 

The good news is that the webhook emits "normal" response codes unlike their web API, so we don't need to do any "ok: False" for 200s like in the integration. https://api.slack.com/messaging/webhooks