### PR TITLE
perf(incidents): Cache fetching active incident in subscription processor.

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -668,7 +668,7 @@ def main(num_events=1, extra_events=False):
                 create_alert_rule_trigger(alert_rule, "critical", AlertRuleThresholdType.ABOVE, 10)
                 create_incident(
                     org,
-                    type=IncidentType.DETECTED,
+                    type_=IncidentType.DETECTED,
                     title="My Incident",
                     query="",
                     date_started=datetime.utcnow().replace(tzinfo=utc),

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -56,8 +56,54 @@ class IncidentSeen(Model):
 
 
 class IncidentManager(BaseManager):
+    CACHE_KEY = "incidents:active:%s:%s"
+
     def fetch_for_organization(self, organization, projects):
         return self.filter(organization=organization, projects__in=projects).distinct()
+
+    @classmethod
+    def _build_active_incident_cache_key(self, alert_rule_id, project_id):
+        return self.CACHE_KEY % (alert_rule_id, project_id)
+
+    def get_active_incident(self, alert_rule, project):
+        cache_key = self._build_active_incident_cache_key(alert_rule.id, project.id)
+        incident = cache.get(cache_key)
+        if incident is None:
+            try:
+                incident = (
+                    Incident.objects.filter(
+                        type=IncidentType.ALERT_TRIGGERED.value,
+                        alert_rule=alert_rule,
+                        projects=project,
+                    )
+                    .exclude(status=IncidentStatus.CLOSED.value)
+                    .order_by("-date_added")[0]
+                )
+            except IndexError:
+                # Set this to False so that we can have a negative cache as well.
+                incident = False
+            cache.set(cache_key, incident)
+            if incident is False:
+                incident = None
+        elif not incident:
+            # If we had a falsey not None value in the cache, then we stored that there
+            # are no current active incidents. Just set to None
+            incident = None
+
+        return incident
+
+    @classmethod
+    def clear_active_incident_cache(cls, instance, **kwargs):
+        for project in instance.projects.all():
+            cache.delete(cls._build_active_incident_cache_key(instance.alert_rule_id, project.id))
+
+    @classmethod
+    def clear_active_incident_project_cache(cls, instance, **kwargs):
+        cache.delete(
+            cls._build_active_incident_cache_key(
+                instance.incident.alert_rule_id, instance.project_id
+            )
+        )
 
     @TimedRetryPolicy.wrap(timeout=5, exceptions=(IntegrityError,))
     def create(self, organization, **kwargs):
@@ -558,3 +604,7 @@ post_delete.connect(AlertRuleTriggerManager.clear_alert_rule_trigger_cache, send
 post_save.connect(AlertRuleTriggerManager.clear_alert_rule_trigger_cache, sender=AlertRule)
 post_save.connect(AlertRuleTriggerManager.clear_trigger_cache, sender=AlertRuleTrigger)
 post_delete.connect(AlertRuleTriggerManager.clear_trigger_cache, sender=AlertRuleTrigger)
+
+post_save.connect(IncidentManager.clear_active_incident_cache, sender=Incident)
+post_save.connect(IncidentManager.clear_active_incident_project_cache, sender=IncidentProject)
+post_delete.connect(IncidentManager.clear_active_incident_project_cache, sender=IncidentProject)

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -71,19 +71,9 @@ class SubscriptionProcessor(object):
     @property
     def active_incident(self):
         if not hasattr(self, "_active_incident"):
-            try:
-                # Fetch the active incident if one exists for this alert rule.
-                self._active_incident = (
-                    Incident.objects.filter(
-                        type=IncidentType.ALERT_TRIGGERED.value,
-                        alert_rule=self.alert_rule,
-                        projects=self.subscription.project,
-                    )
-                    .exclude(status=IncidentStatus.CLOSED.value)
-                    .order_by("-date_added")[0]
-                )
-            except IndexError:
-                self._active_incident = None
+            self._active_incident = Incident.objects.get_active_incident(
+                self.alert_rule, self.subscription.project
+            )
         return self._active_incident
 
     @active_incident.setter

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -39,7 +39,7 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
 
         incident = create_incident(
             self.organization,
-            type=IncidentType.DETECTED,
+            type_=IncidentType.DETECTED,
             title="Incident #1",
             query="hello",
             aggregation=QueryAggregations.TOTAL,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -98,7 +98,7 @@ class CreateIncidentTest(TestCase):
         self.record_event.reset_mock()
         incident = create_incident(
             self.organization,
-            type=incident_type,
+            type_=incident_type,
             title=title,
             query=query,
             aggregation=aggregation,


### PR DESCRIPTION
This gets called whenever we have a value that hits a trigger. We could potentially have incidents
that fire and stay above a trigger for a long time, so it's a good idea to cache here.