### PR TITLE
feat(discover) Add modal component to column picker

### DIFF
--- a/docs-ui/components/columnEditor.stories.js
+++ b/docs-ui/components/columnEditor.stories.js
@@ -2,51 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
+import {action} from '@storybook/addon-actions';
 
-import ColumnEditCollection from 'app/views/eventsV2/table/columnEditCollection';
-
-/**
- * Fake modal container. Later on this will be a stateful
- * container that will update the EventView column edits
- * are submitted.
- */
-class FakeModal extends React.Component {
-  static propTypes = {
-    organization: PropTypes.object,
-    tagKeys: PropTypes.arrayOf(PropTypes.string),
-  };
-
-  state = {
-    columns: [
-      {
-        field: 'event.type',
-      },
-      {
-        field: 'browser.name',
-      },
-      {
-        field: 'id',
-        aggregation: 'count',
-      },
-    ],
-  };
-
-  handleChange = columns => {
-    this.setState({columns});
-  };
-
-  render() {
-    const {tagKeys, organization} = this.props;
-    return (
-      <ColumnEditCollection
-        organization={organization}
-        columns={this.state.columns}
-        tagKeys={tagKeys}
-        onChange={this.handleChange}
-      />
-    );
-  }
-}
+import {openModal} from 'app/actionCreators/modal';
+import Button from 'app/components/button';
+import GlobalModal from 'app/components/globalModal';
+import ColumnEditModal from 'app/views/eventsV2/table/columnEditModal';
 
 storiesOf('Discover|ColumnEditor', module).add(
   'all',
@@ -58,10 +19,35 @@ storiesOf('Discover|ColumnEditor', module).add(
       features: ['transaction-events'],
     };
     const tags = ['browser.name', 'custom-field'];
+    const columns = [
+      {
+        field: 'event.type',
+      },
+      {
+        field: 'browser.name',
+      },
+      {
+        field: 'id',
+        aggregation: 'count',
+      },
+    ];
+
+    const showModal = () => {
+      openModal(modalProps => (
+        <ColumnEditModal
+          {...modalProps}
+          organization={organization}
+          tagKeys={tags}
+          columns={columns}
+          onApply={action('onApply')}
+        />
+      ));
+    };
 
     return (
       <div>
-        <FakeModal organization={organization} tagKeys={tags} />
+        <Button onClick={showModal}>Edit columns</Button>
+        <GlobalModal />
       </div>
     );
   })

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -3,14 +3,15 @@ import ReactDOM from 'react-dom';
 import styled from '@emotion/styled';
 
 import Button from 'app/components/button';
-import {IconAdd, IconGrabbable, IconClose} from 'app/icons';
-import {t} from 'app/locale';
-import {OrganizationSummary} from 'app/types';
-import space from 'app/styles/space';
 import {
   UserSelectValues,
   setBodyUserSelect,
 } from 'app/components/events/interfaces/spans/utils';
+import {IconAdd, IconGrabbable, IconClose} from 'app/icons';
+import {t} from 'app/locale';
+import {OrganizationSummary} from 'app/types';
+import space from 'app/styles/space';
+import theme from 'app/utils/theme';
 
 import {Column} from '../eventView';
 import ColumnEditRow from './columnEditRow';
@@ -51,7 +52,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
       portal.style.position = 'absolute';
       portal.style.top = '0';
       portal.style.left = '0';
-      portal.style.zIndex = '10000';
+      portal.style.zIndex = String(theme.zIndex.modal);
 
       this.portal = portal;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import Button from 'app/components/button';
+import ButtonBar from 'app/components/buttonBar';
+import {DISCOVER2_DOCS_URL} from 'app/constants';
+import {ModalRenderProps} from 'app/actionCreators/modal';
+import {t} from 'app/locale';
+import {OrganizationSummary} from 'app/types';
+import {Column} from '../eventView';
+import ColumnEditCollection from './columnEditCollection';
+
+type Props = {
+  columns: Column[];
+  organization: OrganizationSummary;
+  tagKeys: string[];
+  // Fired when column selections have been applied.
+  onApply: (columns: Column[]) => void;
+} & ModalRenderProps;
+
+type State = {
+  columns: Column[];
+};
+
+class ColumnEditModal extends React.Component<Props, State> {
+  state = {
+    columns: this.props.columns,
+  };
+
+  handleChange = (columns: Column[]) => {
+    this.setState({columns});
+  };
+
+  handleApply = () => {
+    this.props.onApply(this.state.columns);
+    this.props.closeModal();
+  };
+
+  render() {
+    const {Header, Body, Footer, tagKeys, organization} = this.props;
+    return (
+      <React.Fragment>
+        <Header>
+          <h4>{t('Edit Columns')}</h4>
+        </Header>
+        <Body>
+          <ColumnEditCollection
+            organization={organization}
+            columns={this.state.columns}
+            tagKeys={tagKeys}
+            onChange={this.handleChange}
+          />
+        </Body>
+        <Footer>
+          <ButtonBar gap={1}>
+            <Button priority="default" to={DISCOVER2_DOCS_URL}>
+              {t('Read the Docs')}
+            </Button>
+            <Button priority="primary" onClick={this.handleApply}>
+              {t('Apply')}
+            </Button>
+          </ButtonBar>
+        </Footer>
+      </React.Fragment>
+    );
+  }
+}
+
+export default ColumnEditModal;


### PR DESCRIPTION
Add the modal window component for the new column editor. This component takes a list of columns and fires an onApply prop when the changes are ready to be applied.

Once this component is hooked up to the discover results table, we'll update the EventView and navigate to the new results.