### PR TITLE
feat(ui): Redesigned release health index page

### DIFF
--- a/src/sentry/static/sentry/app/components/releaseStats.tsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.tsx
@@ -2,13 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {Release} from 'app/types';
+import {Release, ProjectRelease} from 'app/types';
 import AvatarList from 'app/components/avatar/avatarList';
 import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
 
 type Props = {
-  release: Release;
+  release: Release | ProjectRelease;
   withHeading: boolean;
 };
 

--- a/src/sentry/static/sentry/app/components/version.tsx
+++ b/src/sentry/static/sentry/app/components/version.tsx
@@ -145,6 +145,14 @@ Version.propTypes = {
   className: PropTypes.string,
 };
 
+// TODO(matej): try to wrap version with this when truncate prop is true (in seperate PR)
+// const VersionWrapper = styled('div')`
+//   ${overflowEllipsis};
+//   max-width: 100%;
+//   width: auto;
+//   display: inline-block;
+// `;
+
 const VersionText = styled('span')<{truncate?: boolean}>`
   ${p =>
     p.truncate &&

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -115,6 +115,30 @@ export type Project = {
   processingIssues: number;
 } & AvatarProject;
 
+export type ProjectRelease = {
+  version: string;
+  dateCreated: string;
+  dateReleased: string | null;
+  commitCount: number;
+  authors: User[];
+  newGroups: number;
+  healthData: Health | null;
+  projectSlug: string;
+};
+
+export type Health = {
+  crash_free_users: number | null;
+  total_users: number;
+  crash_free_sessions: number | null;
+  stats: HealthGraphData;
+  crashes: number;
+  errors: number;
+  adoption: number | null;
+};
+export type HealthGraphData = {
+  [key: string]: [number, number][];
+};
+
 export type Team = {
   id: string;
   slug: string;
@@ -748,7 +772,7 @@ export type Release = {
   authors: User[];
   owner?: any; // TODO(ts)
   newGroups: number;
-  projects: {slug: string; name: string}[];
+  projects: {slug: string; name: string; healthData?: Health | null}[];
 } & BaseRelease;
 
 export type BaseRelease = {

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -76,7 +76,7 @@ class ReleasesList extends AsyncView<Props, State> {
 
     router.push({
       ...location,
-      query: {...location.query, query},
+      query: {...location.query, cursor: undefined, query},
     });
   };
 
@@ -85,7 +85,7 @@ class ReleasesList extends AsyncView<Props, State> {
 
     router.push({
       ...location,
-      query: {...location.query, sort},
+      query: {...location.query, cursor: undefined, sort},
     });
   };
 
@@ -197,12 +197,10 @@ const StyledPageHeader = styled(PageHeader)`
   }
 `;
 const SortAndFilterWrapper = styled('div')`
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-column-gap: ${space(2)};
   margin-bottom: ${space(2)};
-
-  & > *:not(:last-child) {
-    margin-right: ${space(1)};
-  }
 `;
 
 export default withOrganization(ReleasesList);

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 import {Location} from 'history';
 import * as ReactRouter from 'react-router';
 import {Params} from 'react-router/lib/Router';
-import uniq from 'lodash/uniq';
-import flatten from 'lodash/flatten';
+import styled from '@emotion/styled';
+import pick from 'lodash/pick';
 
 import {t} from 'app/locale';
-import {Organization, Release} from 'app/types';
+import space from 'app/styles/space';
 import AsyncView from 'app/views/asyncView';
 import BetaTag from 'app/components/betaTag';
+import {Organization, Release, ProjectRelease} from 'app/types';
 import routeTitleGen from 'app/utils/routeTitle';
 import SearchBar from 'app/components/searchBar';
 import Pagination from 'app/components/pagination';
 import PageHeading from 'app/components/pageHeading';
-import {getQuery} from 'app/views/releases/list/utils';
 import withOrganization from 'app/utils/withOrganization';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import NoProjectMessage from 'app/components/noProjectMessage';
@@ -23,6 +23,9 @@ import EmptyStateWarning from 'app/components/emptyStateWarning';
 import ReleaseCard from 'app/views/releasesV2/list/releaseCard';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import Projects from 'app/utils/projects';
+import {URL_PARAM} from 'app/constants/globalSelectionHeader';
+
+import ReleaseListSortOptions from './releaseListSortOptions';
 
 type Props = {
   params: Params;
@@ -46,26 +49,77 @@ class ReleasesList extends AsyncView<Props, State> {
 
   getEndpoints(): [string, string, {}][] {
     const {organization, location} = this.props;
-    return [
-      [
-        'releases',
-        `/organizations/${organization.slug}/releases/`,
-        {query: getQuery(location.query)},
-      ],
-    ];
+
+    const query = {
+      ...pick(location.query, [...Object.values(URL_PARAM), 'cursor', 'query', 'sort']),
+      per_page: 50,
+      health: 1,
+    };
+
+    return [['releases', `/organizations/${organization.slug}/releases/`, {query}]];
   }
 
-  handleReleaseSearch = (query: string) => {
-    const {location, router, params} = this.props;
+  getQuery() {
+    const {query} = this.props.location.query;
+
+    return typeof query === 'string' ? query : undefined;
+  }
+
+  getSort() {
+    const {sort} = this.props.location.query;
+
+    return typeof sort === 'string' ? sort : undefined;
+  }
+
+  handleSearch = (query: string) => {
+    const {location, router} = this.props;
 
     router.push({
-      pathname: `/organizations/${params.orgId}/releases-v2/`,
+      ...location,
       query: {...location.query, query},
+    });
+  };
+
+  handleSort = (sort: string) => {
+    const {location, router} = this.props;
+
+    router.push({
+      ...location,
+      query: {...location.query, sort},
     });
   };
 
   renderLoading() {
     return this.renderBody();
+  }
+
+  transformToProjectRelease(releases: Release[]): ProjectRelease[] {
+    return releases.flatMap(release => {
+      return release.projects.map(project => {
+        const {
+          version,
+          dateCreated,
+          dateReleased,
+          commitCount,
+          authors,
+          lastEvent,
+          newGroups,
+        } = release;
+        const {slug, healthData} = project;
+        return {
+          version,
+          dateCreated,
+          dateReleased,
+          commitCount,
+          authors,
+          lastEvent,
+          newGroups,
+          healthData: healthData!,
+          projectSlug: slug,
+          // TODO(releasesv2): make api send also project platform
+        };
+      });
+    });
   }
 
   renderInnerBody() {
@@ -80,20 +134,16 @@ class ReleasesList extends AsyncView<Props, State> {
       return <EmptyStateWarning small>{t('There are no releases.')}</EmptyStateWarning>;
     }
 
-    const projectSlugs: string[] = uniq(
-      flatten(releases.map((r: Release) => r.projects.map(p => p.slug)))
-    );
+    const projectReleases = this.transformToProjectRelease(releases);
 
     return (
-      <Projects orgId={organization.slug} slugs={projectSlugs}>
+      <Projects orgId={organization.slug} slugs={projectReleases.map(r => r.projectSlug)}>
         {({projects}) =>
-          releases.map((release: Release) => (
+          projectReleases.map((release: ProjectRelease) => (
             <ReleaseCard
-              key={release.version}
+              key={`${release.version}-${release.dateCreated}`}
               release={release}
-              projects={projects.filter(project =>
-                release.projects.map(p => p.slug).includes(project.slug)
-              )}
+              project={projects.find(p => p.slug === release.projectSlug)}
             />
           ))
         }
@@ -102,7 +152,7 @@ class ReleasesList extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {organization, location} = this.props;
+    const {organization} = this.props;
 
     return (
       <React.Fragment>
@@ -110,18 +160,22 @@ class ReleasesList extends AsyncView<Props, State> {
 
         <NoProjectMessage organization={organization}>
           <PageContent>
-            <PageHeader>
+            <StyledPageHeader>
               <PageHeading>
                 {t('Releases v2')} <BetaTag />
               </PageHeading>
-              <SearchBar
-                placeholder={t('Search for a release')}
-                onSearch={this.handleReleaseSearch}
-                defaultQuery={
-                  typeof location.query.query === 'string' ? location.query.query : ''
-                }
-              />
-            </PageHeader>
+              <SortAndFilterWrapper>
+                <ReleaseListSortOptions
+                  selected={this.getSort()}
+                  onSelect={this.handleSort}
+                />
+                <SearchBar
+                  placeholder={t('Search')}
+                  onSearch={this.handleSearch}
+                  defaultQuery={this.getQuery()}
+                />
+              </SortAndFilterWrapper>
+            </StyledPageHeader>
 
             <IntroBanner />
 
@@ -134,6 +188,22 @@ class ReleasesList extends AsyncView<Props, State> {
     );
   }
 }
+
+const StyledPageHeader = styled(PageHeader)`
+  flex-wrap: wrap;
+  margin-bottom: 0;
+  ${PageHeading} {
+    margin-bottom: ${space(2)};
+  }
+`;
+const SortAndFilterWrapper = styled('div')`
+  display: flex;
+  margin-bottom: ${space(2)};
+
+  & > *:not(:last-child) {
+    margin-right: ${space(1)};
+  }
+`;
 
 export default withOrganization(ReleasesList);
 export {ReleasesList};

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releaseHealth.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releaseHealth.tsx
@@ -1,70 +1,98 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {Release} from 'app/types';
+import {ProjectRelease} from 'app/types';
 import {PanelHeader, PanelBody, PanelItem} from 'app/components/panels';
-import ProjectBadge from 'app/components/idBadge/projectBadge';
-import {t} from 'app/locale';
+import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
 import CircleProgress from 'app/components/circularProgressbar';
 import Count from 'app/components/count';
+import {defined} from 'app/utils';
 
 import UsersChart from './usersChart';
 import {mockData} from './mock';
 
 type Props = {
-  release: Release;
+  release: ProjectRelease;
 };
 
 const ReleaseHealth = ({release}: Props) => {
+  const {
+    adoption,
+    total_users,
+    crash_free_users,
+    crash_free_sessions,
+    crashes,
+    errors,
+  } = release.healthData!;
+
+  // TODO(releasesv2): make dynamic once api is finished
   return (
     <React.Fragment>
       <StyledPanelHeader>
         <HeaderLayout>
-          <ProjectColumn>{t('Project')}</ProjectColumn>
+          <DailyUsersColumn>{t('Daily active users')}</DailyUsersColumn>
+          <AdoptionColumn>{t('Release adoption')}</AdoptionColumn>
           <CrashFreeUsersColumn>{t('Crash free users')}</CrashFreeUsersColumn>
           <CrashFreeSessionsColumn>{t('Crash free sessions')}</CrashFreeSessionsColumn>
-          <DailyUsersColumn>{t('Daily active users')}</DailyUsersColumn>
           <CrashesColumn>{t('Crashes')}</CrashesColumn>
           <ErrorsColumn>{t('Errors')}</ErrorsColumn>
         </HeaderLayout>
       </StyledPanelHeader>
 
       <PanelBody>
-        {release.projects.map((project, index) => (
-          <PanelItem key={project.slug}>
-            <Layout>
-              <ProjectColumn>
-                <ProjectBadge project={project} avatarSize={14} />
-              </ProjectColumn>
-              {/* TODO(releasesv2): make dynamic once api is finished */}
-              <CrashFreeUsersColumn>
-                <CircleProgress value={mockData[index].crashFreeUsersPercent} />
-                <CircleProgressCaption>
-                  {mockData[index].crashFreeUsersPercent}%
-                </CircleProgressCaption>
-              </CrashFreeUsersColumn>
-              <CrashFreeSessionsColumn>
-                <CircleProgress value={mockData[index].crashFreeUsersSessionsPercent} />
-                <CircleProgressCaption>
-                  {mockData[index].crashFreeUsersSessionsPercent}%
-                </CircleProgressCaption>
-              </CrashFreeSessionsColumn>
-              <DailyUsersColumn>
-                <ChartWrapper>
-                  <UsersChart data={mockData[index].graphData} statsPeriod="24h" />
-                </ChartWrapper>
-                {mockData[index].dailyActiveUsers}%
-              </DailyUsersColumn>
-              <CrashesColumn>
-                <ColoredCount value={mockData[index].crashes} />
-              </CrashesColumn>
-              <ErrorsColumn>
-                <ColoredCount value={mockData[index].errors} />
-              </ErrorsColumn>
-            </Layout>
-          </PanelItem>
-        ))}
+        <StyledPanelItem>
+          <Layout>
+            <DailyUsersColumn>
+              <ChartWrapper>
+                <UsersChart data={mockData[0].graphData} height={20} statsPeriod="24h" />
+              </ChartWrapper>
+            </DailyUsersColumn>
+
+            <AdoptionColumn>
+              {defined(adoption) ? (
+                <React.Fragment>
+                  <CircleProgress value={adoption} />
+                  <CircleProgressCaption>
+                    {`${adoption}% ${tn('with %s user', 'with %s users', total_users)}`}
+                  </CircleProgressCaption>
+                </React.Fragment>
+              ) : (
+                '-'
+              )}
+            </AdoptionColumn>
+
+            <CrashFreeUsersColumn>
+              {defined(crash_free_users) ? (
+                <React.Fragment>
+                  <CircleProgress value={crash_free_users} />
+                  <CircleProgressCaption>{crash_free_users}%</CircleProgressCaption>
+                </React.Fragment>
+              ) : (
+                '-'
+              )}
+            </CrashFreeUsersColumn>
+
+            <CrashFreeSessionsColumn>
+              {defined(crash_free_sessions) ? (
+                <React.Fragment>
+                  <CircleProgress value={crash_free_sessions} />
+                  <CircleProgressCaption>{crash_free_sessions}%</CircleProgressCaption>
+                </React.Fragment>
+              ) : (
+                '-'
+              )}
+            </CrashFreeSessionsColumn>
+
+            <CrashesColumn>
+              <Count value={crashes ?? 0} />
+            </CrashesColumn>
+
+            <ErrorsColumn>
+              <Count value={errors ?? 0} />
+            </ErrorsColumn>
+          </Layout>
+        </StyledPanelItem>
       </PanelBody>
     </React.Fragment>
   );
@@ -72,6 +100,8 @@ const ReleaseHealth = ({release}: Props) => {
 
 const StyledPanelHeader = styled(PanelHeader)`
   border-top: 1px solid ${p => p.theme.borderDark};
+  border-bottom: none;
+  padding-bottom: ${space(1)};
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   color: ${p => p.theme.gray2};
@@ -80,18 +110,18 @@ const StyledPanelHeader = styled(PanelHeader)`
 
 const Layout = styled('div')`
   display: grid;
-  grid-template-areas: 'project crash-free-users crash-free-sessions daily-users crashes errors';
-  grid-template-columns: 1fr 1fr 1fr 200px 1fr 1fr;
+  grid-template-areas: 'daily-users adoption crash-free-users crash-free-sessions crashes errors';
+  grid-template-columns: 3fr minmax(230px, 2fr) 2fr 2fr 1fr 1fr;
   grid-column-gap: ${space(1.5)};
   width: 100%;
   align-items: center;
   @media (max-width: ${p => p.theme.breakpoints[2]}) {
-    grid-template-areas: 'project crash-free-users crash-free-sessions crashes errors';
+    grid-template-areas: 'adoption crash-free-users crash-free-sessions crashes errors';
     grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
   }
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    grid-template-areas: 'project crash-free-users crash-free-sessions';
-    grid-template-columns: 1fr 1fr 1fr;
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
+    grid-template-areas: 'crash-free-users crash-free-sessions errors';
+    grid-template-columns: 2fr 2fr 1fr;
   }
 `;
 
@@ -103,26 +133,14 @@ const Column = styled('div')`
   overflow: hidden;
 `;
 
-const RightColumn = styled('div')`
-  overflow: 'hidden';
+const RightColumn = styled(Column)`
   text-align: right;
 `;
 
-const ProjectColumn = styled(Column)`
-  grid-area: project;
+const CenterColumn = styled(Column)`
+  text-align: center;
 `;
-const CrashFreeUsersColumn = styled(Column)`
-  grid-area: crash-free-users;
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    text-align: right;
-  }
-`;
-const CrashFreeSessionsColumn = styled(Column)`
-  grid-area: crash-free-sessions;
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    text-align: right;
-  }
-`;
+
 const DailyUsersColumn = styled(Column)`
   grid-area: daily-users;
   display: flex;
@@ -130,17 +148,37 @@ const DailyUsersColumn = styled(Column)`
     display: none;
   }
 `;
+const AdoptionColumn = styled(Column)`
+  grid-area: adoption;
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
+    display: none;
+  }
+`;
+const CrashFreeUsersColumn = styled(CenterColumn)`
+  grid-area: crash-free-users;
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
+    text-align: left;
+  }
+`;
+const CrashFreeSessionsColumn = styled(CenterColumn)`
+  grid-area: crash-free-sessions;
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
+    text-align: left;
+  }
+`;
 const CrashesColumn = styled(RightColumn)`
   grid-area: crashes;
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
     display: none;
   }
 `;
 const ErrorsColumn = styled(RightColumn)`
   grid-area: errors;
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    display: none;
-  }
+`;
+
+const StyledPanelItem = styled(PanelItem)`
+  background: ${p => p.theme.offWhite};
+  padding-top: 0;
 `;
 
 const CircleProgressCaption = styled('span')`
@@ -148,15 +186,11 @@ const CircleProgressCaption = styled('span')`
 `;
 
 const ChartWrapper = styled('div')`
-  width: 150px;
   margin-right: ${space(2)};
-  position: relative;
-  bottom: 4px;
-`;
-
-const ColoredCount = styled(Count)`
-  /* TODO(releasesv2): decide on threshold, make dynamic */
-  ${p => p.value > 7000 && `color: ${p.theme.red};`}
+  g > .barchart-rect {
+    background: ${p => p.theme.gray2};
+    fill: ${p => p.theme.gray2};
+  }
 `;
 
 export default ReleaseHealth;

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releaseListSortOptions.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releaseListSortOptions.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {t} from 'app/locale';
+import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
+
+type Props = {
+  selected?: string;
+  onSelect: (key: string) => void;
+};
+
+const ReleaseListSortOptions = ({selected = 'date', onSelect}: Props) => {
+  const filterOptions = [
+    {
+      key: 'date',
+      label: t('Date Created'),
+    },
+    {
+      key: 'adoptionRate',
+      label: t('Adoption Rate'),
+    },
+    {
+      key: 'crashFreeUsers',
+      label: t('Crash Free Users'),
+    },
+    {
+      key: 'crashFreeSessions',
+      label: t('Crash Free Sessions'),
+    },
+  ];
+
+  const label = (
+    <React.Fragment>
+      <LabelText>{t('Sort by')}: &nbsp; </LabelText>
+      {filterOptions.find(filterItem => filterItem.key === selected)?.label}
+    </React.Fragment>
+  );
+
+  return (
+    <DropdownControl label={label}>
+      {filterOptions.map(filterItem => (
+        <DropdownItem
+          key={filterItem.key}
+          onSelect={onSelect}
+          eventKey={filterItem.key}
+          isActive={selected === filterItem.key}
+        >
+          {filterItem.label}
+        </DropdownItem>
+      ))}
+    </DropdownControl>
+  );
+};
+
+const LabelText = styled('em')`
+  font-style: normal;
+  color: ${p => p.theme.gray2};
+`;
+
+export default ReleaseListSortOptions;


### PR DESCRIPTION
New iteration of release health index page that supports per project releases and ordering.

<img width="1437" alt="Screenshot 2020-02-27 at 18 04 43" src="https://user-images.githubusercontent.com/9060071/75470685-55a18480-5991-11ea-8eea-b0b97ffa22b1.png">

Couple of minor things still different than in figma.
This is just a playground for us, behind `releases-v2` feature flag.