### PR TITLE
ref(workflow): Simply removing an unneeded test

### DIFF
--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -265,17 +265,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data["name"] == "AUniqueName"
         assert resp.data["triggers"][1]["resolveThreshold"] == 75
 
-        # We had/have logic to remove unchanged fields from the serializer before passing them to update
-        # It is possible with an error here that sending an update without changing the field
-        # could nullify it. So we make sure it's not getting nullified here.
-        # we can an update with all the same fields, and it comes back as 75 instead of None.
-        with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
-        assert resp.data["name"] == "AUniqueName"
-        assert resp.data["triggers"][1]["resolveThreshold"] == 75
-
     def test_delete_trigger(self):
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]


### PR DESCRIPTION
We've removed the functionality to remove unchanged fields, and so this test and comment is not needed.