### PR TITLE
feat(integrations): Support tagging Slack users in alerts

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -110,6 +110,7 @@ class SlackNotifyServiceAction(EventAction):
             payload = {
                 "token": integration.metadata["access_token"],
                 "channel": channel,
+                "link_names": 1,
                 "attachments": json.dumps([attachment]),
             }
 


### PR DESCRIPTION
Adds a flag in the Slack message POST that will identify @'s so users are notified in Slack

from @northcott-j in https://github.com/getsentry/sentry/pull/17161