### PR TITLE
ref(constants): Remove DataCategory.CRASH

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -495,7 +495,6 @@ class DataCategory(IntEnum):
     SECURITY = 3
     ATTACHMENT = 4
     SESSION = 5
-    CRASH = 6
 
     @classmethod
     def from_event_type(cls, event_type):


### PR DESCRIPTION
Removes the `"crash"` category as it is not going to be implemented for now.