### PR TITLE
fix(discover2): Ensure long form x-axis labels do not get clipped.

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -214,7 +214,7 @@ class ChartZoom extends React.Component {
       return children(props);
     }
 
-    const dateFormat = useShortDate ? 'MMM Do' : 'lll';
+    const dateFormat = useShortDate ? 'MMM Do' : 'll[\n]LT';
     const hasShortInterval = useShortInterval(this.props);
     const xAxisOptions = {
       axisLabel: {

--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -219,7 +219,7 @@ class ChartZoom extends React.Component {
     const xAxisOptions = {
       axisLabel: {
         showMaxLabel: false,
-        showMiLabel: false,
+        showMinLabel: false,
         formatter: (value, index) => {
           const firstItem = index === 0;
           const format = hasShortInterval && !firstItem ? 'LT' : dateFormat;

--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -218,6 +218,8 @@ class ChartZoom extends React.Component {
     const hasShortInterval = useShortInterval(this.props);
     const xAxisOptions = {
       axisLabel: {
+        showMaxLabel: false,
+        showMiLabel: false,
         formatter: (value, index) => {
           const firstItem = index === 0;
           const format = hasShortInterval && !firstItem ? 'LT' : dateFormat;

--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -214,7 +214,7 @@ class ChartZoom extends React.Component {
       return children(props);
     }
 
-    const dateFormat = useShortDate ? 'MMM Do' : 'll[\n]LT';
+    const dateFormat = useShortDate ? 'MMM Do' : 'MMM D LT';
     const hasShortInterval = useShortInterval(this.props);
     const xAxisOptions = {
       axisLabel: {

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -85,8 +85,8 @@ class EventsAreaChart extends React.Component {
         previousPeriod={previousTimeseriesData ? [previousTimeseriesData] : null}
         grid={{
           left: '24px',
-          right: '24px',
-          top: '24px',
+          right: '48px',
+          top: '32px',
           bottom: '12px',
         }}
       />

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -85,7 +85,7 @@ class EventsAreaChart extends React.Component {
         previousPeriod={previousTimeseriesData ? [previousTimeseriesData] : null}
         grid={{
           left: '24px',
-          right: '48px',
+          right: '24px',
           top: '32px',
           bottom: '12px',
         }}

--- a/tests/js/spec/components/charts/chartZoom.spec.jsx
+++ b/tests/js/spec/components/charts/chartZoom.spec.jsx
@@ -35,11 +35,11 @@ describe('ChartZoom', function() {
       });
 
       it('formats axis label for first data point', function() {
-        expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 8, 2018 5:00 PM');
+        expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 8 5:00 PM');
       });
 
       it('formats axis label for second data point', function() {
-        expect(axisLabelFormatter(timestamp, 1)).toEqual('Jul 8, 2018 5:00 PM');
+        expect(axisLabelFormatter(timestamp, 1)).toEqual('Jul 8 5:00 PM');
       });
     });
 
@@ -60,11 +60,11 @@ describe('ChartZoom', function() {
       });
 
       it('formats axis label for first data point', function() {
-        expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 9, 2018 12:00 AM');
+        expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 9 12:00 AM');
       });
 
       it('formats axis label for second data point', function() {
-        expect(axisLabelFormatter(timestamp, 1)).toEqual('Jul 9, 2018 12:00 AM');
+        expect(axisLabelFormatter(timestamp, 1)).toEqual('Jul 9 12:00 AM');
       });
     });
   });
@@ -82,7 +82,7 @@ describe('ChartZoom', function() {
         axisLabelFormatter = renderFunc.mock.calls[0][0].xAxis.axisLabel.formatter;
       });
       it('formats axis label for first data point', function() {
-        expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 8, 2018 5:00 PM');
+        expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 8 5:00 PM');
       });
 
       it('formats axis label for second data point', function() {
@@ -103,7 +103,7 @@ describe('ChartZoom', function() {
       });
 
       it('formats axis label for first data point', function() {
-        expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 9, 2018 12:00 AM');
+        expect(axisLabelFormatter(timestamp, 0)).toEqual('Jul 9 12:00 AM');
       });
 
       it('formats axis label for second data point', function() {


### PR DESCRIPTION
Using newlines to break up longish x-axis labels using method described here: https://github.com/moment/moment/issues/4569

Reference: https://momentjs.com/docs/#/displaying/format/

Also shrinking the grid area.

**Before:**

![Screen Shot 2020-02-27 at 3 40 49 PM](https://user-images.githubusercontent.com/139499/75486358-609cea80-597a-11ea-8211-00d551277632.png)

**After:**

<img width="1184" alt="Screen Shot 2020-03-03 at 10 06 02 PM" src="https://user-images.githubusercontent.com/139499/75841234-36dd2c80-5d9b-11ea-9d99-798db242bbe4.png">

## TODO

- [x] investigate tick markers alignment
