### PR TITLE
feat: upgrade structlog to 17.1.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,7 @@ simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0
 sqlparse>=0.2.0,<0.3.0
 statsd>=3.1.0,<3.2.0
-structlog==16.1.0
+structlog==17.1.0
 symbolic>=7.1.0,<8.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.10.0,<0.11.0

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -10,9 +10,10 @@ from django.db import models, transaction
 from django.utils import timezone
 from django.utils.encoding import force_bytes
 from django.utils.translation import ugettext_lazy as _
+
+import logging
 from enum import Enum
 from hashlib import md5
-from structlog import get_logger
 from uuid import uuid4
 from six.moves.urllib.parse import urlencode
 
@@ -230,7 +231,7 @@ class OrganizationMember(Model):
         try:
             msg.send_async([self.get_email()])
         except Exception as e:
-            logger = get_logger(name="sentry.mail")
+            logger = logging.getLogger("sentry.mail")
             logger.exception(e)
 
     def send_sso_link_email(self, actor, provider):

--- a/src/sentry/tasks/members.py
+++ b/src/sentry/tasks/members.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, print_function
 
+import logging
+
 from django.core.urlresolvers import reverse
-from structlog import get_logger
 
 from sentry import roles
 from sentry.models import InviteStatus, OrganizationMember
@@ -63,5 +64,5 @@ def send_invite_request_notification_email(member_id):
         try:
             msg.send_async([recipient.get_email()])
         except Exception as e:
-            logger = get_logger(name="sentry.mail")
+            logger = logging.getLogger("sentry.mail")
             logger.exception(e)


### PR DESCRIPTION
structlog tests and passes against Python 3.6 in 17.1.0: https://github.com/hynek/structlog/commit/2b534604600a587abeb9690291fb1158dfb6d4bd

The only backwards compat change listed in http://www.structlog.org/en/stable/changelog.html#id60 doesn't apply to us.