### PR TITLE
fix(sidebar): Remove `withLatestContext` from sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -1,21 +1,13 @@
-import isEqual from 'lodash/isEqual';
-import {withRouter, browserHistory} from 'react-router';
+import {css} from '@emotion/core';
+import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
-import styled from '@emotion/styled';
-import {css} from '@emotion/core';
+import isEqual from 'lodash/isEqual';
 import queryString from 'query-string';
+import styled from '@emotion/styled';
 
-import {extractSelectionParameters} from 'app/components/organizations/globalSelectionHeader/utils';
-import {hideSidebar, showSidebar} from 'app/actionCreators/preferences';
-import {load as loadIncidents} from 'app/actionCreators/serviceIncidents';
-import {t} from 'app/locale';
-import ConfigStore from 'app/stores/configStore';
-import Feature from 'app/components/acl/feature';
-import GuideAnchor from 'app/components/assistant/guideAnchor';
-import HookStore from 'app/stores/hookStore';
 import {
   IconActivity,
   IconChevron,
@@ -32,25 +24,32 @@ import {
   IconSupport,
   IconTelescope,
 } from 'app/icons';
+import {extractSelectionParameters} from 'app/components/organizations/globalSelectionHeader/utils';
+import {getDiscoverLandingUrl} from 'app/views/eventsV2/utils';
+import {hideSidebar, showSidebar} from 'app/actionCreators/preferences';
+import {load as loadIncidents} from 'app/actionCreators/serviceIncidents';
+import {t} from 'app/locale';
+import ConfigStore from 'app/stores/configStore';
+import Feature from 'app/components/acl/feature';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
+import HookStore from 'app/stores/hookStore';
 import PreferencesStore from 'app/stores/preferencesStore';
 import SentryTypes from 'app/sentryTypes';
+import localStorage from 'app/utils/localStorage';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
-import localStorage from 'app/utils/localStorage';
-import withLatestContext from 'app/utils/withLatestContext';
-import {getDiscoverLandingUrl} from 'app/views/eventsV2/utils';
+import withOrganization from 'app/utils/withOrganization';
 
 import {getSidebarPanelContainer} from './sidebarPanel';
 import Broadcasts from './broadcasts';
-import ServiceIncidents from './serviceIncidents';
 import OnboardingStatus from './onboardingStatus';
+import ServiceIncidents from './serviceIncidents';
 import SidebarDropdown from './sidebarDropdown';
 import SidebarHelp from './help';
 import SidebarItem from './sidebarItem';
 
 class Sidebar extends React.Component {
   static propTypes = {
-    router: PropTypes.object,
     organization: SentryTypes.Organization,
     collapsed: PropTypes.bool,
     location: PropTypes.object,
@@ -124,11 +123,6 @@ class Sidebar extends React.Component {
     if (this.mq) {
       this.mq.removeListener(this.handleMediaQueryChange);
       this.mq = null;
-    }
-
-    // Unlisten to router changes
-    if (this.routerListener) {
-      this.routerListener();
     }
   }
 
@@ -610,34 +604,37 @@ class Sidebar extends React.Component {
   }
 }
 
-const SidebarContainer = withRouter(
-  createReactClass({
-    displayName: 'SidebarContainer',
-    mixins: [Reflux.listenTo(PreferencesStore, 'onPreferenceChange')],
-    getInitialState() {
-      return {
-        collapsed: PreferencesStore.getInitialState().collapsed,
-      };
-    },
+const SidebarContainer = createReactClass({
+  displayName: 'SidebarContainer',
+  contextTypes: {
+    location: PropTypes.any,
+  },
+  mixins: [Reflux.listenTo(PreferencesStore, 'onPreferenceChange')],
+  getInitialState() {
+    return {
+      collapsed: PreferencesStore.getInitialState().collapsed,
+    };
+  },
 
-    onPreferenceChange(store) {
-      if (store.collapsed === this.state.collapsed) {
-        return;
-      }
+  onPreferenceChange(store) {
+    if (store.collapsed === this.state.collapsed) {
+      return;
+    }
 
-      this.setState({
-        collapsed: store.collapsed,
-      });
-    },
+    this.setState({
+      collapsed: store.collapsed,
+    });
+  },
 
-    render() {
-      return <Sidebar {...this.props} collapsed={this.state.collapsed} />;
-    },
-  })
-);
+  render() {
+    return (
+      <Sidebar {...this.props} collapsed={this.state.collapsed} location={location} />
+    );
+  },
+});
 
 export {Sidebar};
-export default withLatestContext(SidebarContainer);
+export default withOrganization(SidebarContainer);
 
 const responsiveFlex = css`
   display: flex;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.tsx
@@ -41,12 +41,11 @@ const SidebarDropdown = ({api, org, orientation, collapsed, config, user}: Props
   const hasOrganization = !!org;
   const hasUser = !!user;
 
-  // If there is no org in context, we use an org from `withLatestContext`
-  // (which uses an org from organizations index endpoint versus details endpoint)
-  // and does not have `access`
-  const hasOrgRead = org && org.access && org.access.indexOf('org:read') > -1;
-  const hasMemberRead = org && org.access && org.access.indexOf('member:read') > -1;
-  const hasTeamRead = org && org.access && org.access.indexOf('team:read') > -1;
+  // It's possible we do not have an org in context (e.g. RouteNotFound)
+  // Otherwise, we should have the full org
+  const hasOrgRead = org?.access?.includes('org:read');
+  const hasMemberRead = org?.access?.includes('member:read');
+  const hasTeamRead = org?.access?.includes('team:read');
   const canCreateOrg = ConfigStore.get('features').has('organizations:create');
 
   // Avatar to use: Organization --> user --> Sentry

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.tsx
@@ -35,7 +35,7 @@ type Props = {
 const SidebarDropdown = ({api, org, orientation, collapsed, config, user}: Props) => {
   const handleLogout = async () => {
     await logout(api);
-    window.location.assign('/auth/login');
+    window.location.assign('/auth/login/');
   };
 
   const hasOrganization = !!org;

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -189,12 +189,13 @@ describe('Sidebar', function() {
       jest.useRealTimers();
     });
 
-    it('has can logout', function() {
+    it('has can logout', async function() {
       const mock = MockApiClient.addMockResponse({
         url: '/auth/',
         method: 'DELETE',
         status: 204,
       });
+      jest.spyOn(window.location, 'assign').mockImplementation(() => {});
 
       let org = TestStubs.Organization();
       org = {
@@ -209,6 +210,10 @@ describe('Sidebar', function() {
       wrapper.find('SidebarDropdownActor').simulate('click');
       wrapper.find('SidebarMenuItem[data-test-id="sidebarSignout"]').simulate('click');
       expect(mock).toHaveBeenCalled();
+
+      await tick();
+      expect(window.location.assign).toHaveBeenCalledWith('/auth/login/');
+      window.location.assign.mockRestore();
     });
   });
 


### PR DESCRIPTION
We can use the simpler `withOrganization` instead. I believe this may be
causing https://sentry.io/organizations/sentry/issues/1511192153/events/b803485e9fdd4e75be89ec8e3f7b28c9/?project=11276