### PR TITLE
fix(eventprocessing): Lower poll timeout for symbolicator

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1771,3 +1771,9 @@ SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT = 1800
 
 # Log warning when process_event is taking more than n seconds to process event
 SYMBOLICATOR_PROCESS_EVENT_WARN_TIMEOUT = 120
+
+# Block process_event for this many seconds to wait for response If too low, a
+# lot of stuff ends up being unnecessarily rescheduled in the sleep queue. If
+# too high, we might have a backlog in the process-event queue that affects
+# events from unrelated platforms
+SYMBOLICATOR_POLL_TIMEOUT = 2

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -21,7 +21,6 @@ from sentry.tasks.store import RetrySymbolication
 
 MAX_ATTEMPTS = 3
 REQUEST_CACHE_TIMEOUT = 3600
-SYMBOLICATOR_TIMEOUT = 5
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +108,7 @@ class Symbolicator(object):
             url=base_url,
             project_id=six.text_type(project.id),
             event_id=six.text_type(event_id),
-            timeout=SYMBOLICATOR_TIMEOUT,
+            timeout=settings.SYMBOLICATOR_POLL_TIMEOUT,
             sources=get_sources_for_project(project),
         )
 


### PR DESCRIPTION
the avg response time is <1s.

cc @JTCunning 