### PR TITLE
fix(issues) Don't log errors for 401 and 403 errors

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/savedSearches.jsx
@@ -113,7 +113,11 @@ export function fetchRecentSearches(api, orgId, type, query) {
     },
   });
 
-  promise.catch(handleXhrErrorResponse('Unable to fetch recent searches'));
+  promise.catch(resp => {
+    if (resp.status !== 401 && resp.status !== 403) {
+      handleXhrErrorResponse('Unable to fetch recent searches')(resp);
+    }
+  });
 
   return promise;
 }
@@ -138,7 +142,7 @@ export function pinSearch(api, orgId, type, query) {
 
   promise.catch(handleXhrErrorResponse('Unable to pin search'));
 
-  promise.catch(err => {
+  promise.catch(() => {
     SavedSearchesActions.unpinSearch(type);
   });
 


### PR DESCRIPTION
When saved searches fail due to an expired session we don't need to be
notified.

Fixes JAVASCRIPT-TG2