### PR TITLE
fix(workflow): Updating slack alert time window to be more accurate (i.e. correct?)

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -366,13 +366,13 @@ def get_alert_rule_environment_names(alert_rule):
     return [x.environment.name for x in AlertRuleEnvironment.objects.filter(alert_rule=alert_rule)]
 
 
-def get_incident_aggregates(incident):
+def get_incident_aggregates(incident, start=None, end=None, prewindow=False):
     """
-    Calculates aggregate stats across the life of an incident.
+    Calculates aggregate stats across the life of an incident, or the provided range.
     - count: Total count of events
     - unique_users: Total number of unique users
     """
-    query_params = build_incident_query_params(incident)
+    query_params = build_incident_query_params(incident, start, end, prewindow)
     return bulk_get_incident_aggregates([query_params])[0]
 
 

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -95,7 +95,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     },
                 )
             ),
-            "text": "0 events in the last 10 minutes\\Filter: level:error",
+            "text": "0 events in the last 10 minutes\nFilter: level:error",
             "fields": [],
             "mrkdwn_in": ["text"],
             "footer_icon": logo_url,


### PR DESCRIPTION
So the numbers coming in for slack alerts were not correct. I'm pretty sure this should fix that up, combined with the previous change to not include prewindow's in the slack calculations.

This PR uses the date_modified value of the most recently modified IncidentTrigger (we're assuming this is the one that the slack alert is firing for) and subtracting the associated alert rule's time window from that date as the start date. The end date is the date is was modified.

That means, if this slack alert function fires right away, or if it fires some 40 minutes later, the start and end time should still be reflective of the time window that triggered the alert.