### PR TITLE
ref(native): Do not wait when querying symbolicator

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1772,8 +1772,7 @@ SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT = 1800
 # Log warning when process_event is taking more than n seconds to process event
 SYMBOLICATOR_PROCESS_EVENT_WARN_TIMEOUT = 120
 
-# Block process_event for this many seconds to wait for response If too low, a
-# lot of stuff ends up being unnecessarily rescheduled in the sleep queue. If
-# too high, we might have a backlog in the process-event queue that affects
-# events from unrelated platforms
-SYMBOLICATOR_POLL_TIMEOUT = 2
+# Block process_event for this many seconds to wait for a response from
+# symbolicator. If too low, too many events up in the sleep queue. If too high,
+# process_event might backlog and affect events from other platforms.
+SYMBOLICATOR_POLL_TIMEOUT = 4

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -313,8 +313,6 @@ class SymbolicatorSession(object):
         self.timeout = timeout
         self.session = None
 
-        self._query_params = {"timeout": timeout, "scope": project_id}
-
     def __enter__(self):
         self.open()
         return self
@@ -389,35 +387,41 @@ class SymbolicatorSession(object):
                 time.sleep(wait)
                 wait *= 2.0
 
+    def _create_task(self, path, **kwargs):
+        params = {"timeout": self.timeout, "scope": self.project_id}
+        return self._request(method="post", path=path, params=params, **kwargs)
+
     def symbolicate_stacktraces(self, stacktraces, modules, signal=None):
         json = {"sources": self.sources, "stacktraces": stacktraces, "modules": modules}
 
         if signal:
             json["signal"] = signal
 
-        return self._request("post", "symbolicate", params=self._query_params, json=json)
+        return self._create_task("symbolicate", json=json)
 
     def upload_minidump(self, minidump):
         return self._request(
-            method="post",
             path="minidump",
-            params=self._query_params,
             data={"sources": json.dumps(self.sources)},
             files={"upload_file_minidump": minidump},
         )
 
     def upload_applecrashreport(self, report):
         return self._request(
-            method="post",
             path="applecrashreport",
-            params=self._query_params,
             data={"sources": json.dumps(self.sources)},
             files={"apple_crash_report": report},
         )
 
     def query_task(self, task_id):
         task_url = "requests/%s" % (task_id,)
-        return self._request("get", task_url, params=self._query_params)
+
+        params = {
+            "timeout": 0,  # Only wait when creating, but not when querying tasks
+            "scope": self.project_id,
+        }
+
+        return self._request("get", task_url, params=params)
 
     def healthcheck(self):
         return self._request("get", "healthcheck")

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -400,14 +400,14 @@ class SymbolicatorSession(object):
         return self._create_task("symbolicate", json=json)
 
     def upload_minidump(self, minidump):
-        return self._request(
+        return self._create_task(
             path="minidump",
             data={"sources": json.dumps(self.sources)},
             files={"upload_file_minidump": minidump},
         )
 
     def upload_applecrashreport(self, report):
-        return self._request(
+        return self._create_task(
             path="applecrashreport",
             data={"sources": json.dumps(self.sources)},
             files={"apple_crash_report": report},


### PR DESCRIPTION
This removes the timeout when querying symbolicator after waking up from the sleep queue to prevent an increasing buildup of blocking jobs. Since the sleep queue effectively already waits 30s each time, there is no point in blocking process_event for another few seconds.