### PR TITLE
feat(plugins): Instrument Amazon SQS to emit Datadog metrics

### DIFF
--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -30,7 +30,8 @@ def get_regions():
 
 
 def track_response_metric(success):
-    # boto3's send_message doesn't return success/fail
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Queue.send_message
+    # boto3's send_message doesn't return success/fail or http codes
     # success is a boolean based on whether there was an exception or not
     metrics.incr("plugins.amazon-sqs.http_response", tags={"success": success})
 

--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -36,9 +36,13 @@ def track_response_metric(fn):
     def wrapper(*args, **kwargs):
         try:
             success = fn(*args, **kwargs)
-            metrics.incr("plugins.amazon-sqs.http_response", tags={"success": success})
+            metrics.incr(
+                "data-forwarding.http_response", tags={"plugin": "amazon-sqs", "success": success}
+            )
         except Exception:
-            metrics.incr("plugins.amazon-sqs.http_response", tags={"success": False})
+            metrics.incr(
+                "data-forwarding.http_response", tags={"plugin": "amazon-sqs", "success": False}
+            )
             raise
         return success
 


### PR DESCRIPTION
This PR adds Datadog metrics to the Amazon SQS plugin so we can monitor it's health. As mentioned in a comment, the `boto3` library's `send_message` doesn't return success/fail like `send_messages` does, nor does it return a response code. Instead, I'm logging a boolean "success" based on whether or not an exception happened after trying to send the message.