### PR TITLE
ref(ux): External links should open in a new tab

### DIFF
--- a/src/sentry/auth/providers/saml2/auth0/templates/sentry_auth_auth0/select-idp.html
+++ b/src/sentry/auth/providers/saml2/auth0/templates/sentry_auth_auth0/select-idp.html
@@ -22,7 +22,7 @@
 
   <fieldset class="form-actions">
     <button type="submit" class="btn btn-primary" name="action_save">{% trans "Continue" %}</button>
-    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#auth0">
+    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#auth0" target="_blank">
       Need help finding your Metadata URL?
     </a>
   </fieldset>

--- a/src/sentry/auth/providers/saml2/auth0/templates/sentry_auth_auth0/select-idp.html
+++ b/src/sentry/auth/providers/saml2/auth0/templates/sentry_auth_auth0/select-idp.html
@@ -22,7 +22,7 @@
 
   <fieldset class="form-actions">
     <button type="submit" class="btn btn-primary" name="action_save">{% trans "Continue" %}</button>
-    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#auth0" target="_blank">
+    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#auth0" target="_blank" rel="noopener">
       Need help finding your Metadata URL?
     </a>
   </fieldset>

--- a/src/sentry/auth/providers/saml2/okta/templates/sentry_auth_okta/select-idp.html
+++ b/src/sentry/auth/providers/saml2/okta/templates/sentry_auth_okta/select-idp.html
@@ -22,7 +22,7 @@
 
     <fieldset class="form-actions">
       <button type="submit" class="btn btn-primary" name="action_save">{% trans "Continue" %}</button>
-      <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#okta">
+      <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#okta" target="_blank">
         Need help finding your Metadata URL?
       </a>
     </fieldset>

--- a/src/sentry/auth/providers/saml2/okta/templates/sentry_auth_okta/select-idp.html
+++ b/src/sentry/auth/providers/saml2/okta/templates/sentry_auth_okta/select-idp.html
@@ -22,7 +22,7 @@
 
     <fieldset class="form-actions">
       <button type="submit" class="btn btn-primary" name="action_save">{% trans "Continue" %}</button>
-      <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#okta" target="_blank">
+      <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#okta" target="_blank" rel="noopener">
         Need help finding your Metadata URL?
       </a>
     </fieldset>

--- a/src/sentry/auth/providers/saml2/onelogin/templates/sentry_auth_onelogin/select-idp.html
+++ b/src/sentry/auth/providers/saml2/onelogin/templates/sentry_auth_onelogin/select-idp.html
@@ -22,7 +22,7 @@
 
   <fieldset class="form-actions">
     <button type="submit" class="btn btn-primary" name="action_save">{% trans "Continue" %}</button>
-    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#onelogin" target="_blank">
+    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#onelogin" target="_blank" rel="noopener">
       Need help finding your Issuer URL?
     </a>
   </fieldset>

--- a/src/sentry/auth/providers/saml2/onelogin/templates/sentry_auth_onelogin/select-idp.html
+++ b/src/sentry/auth/providers/saml2/onelogin/templates/sentry_auth_onelogin/select-idp.html
@@ -22,7 +22,7 @@
 
   <fieldset class="form-actions">
     <button type="submit" class="btn btn-primary" name="action_save">{% trans "Continue" %}</button>
-    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#onelogin">
+    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#onelogin" target="_blank">
       Need help finding your Issuer URL?
     </a>
   </fieldset>

--- a/src/sentry/auth/providers/saml2/rippling/templates/sentry_auth_rippling/select-idp.html
+++ b/src/sentry/auth/providers/saml2/rippling/templates/sentry_auth_rippling/select-idp.html
@@ -22,7 +22,7 @@
 
   <fieldset class="form-actions">
     <button type="submit" class="btn btn-primary" name="action_save">{% trans "Continue" %}</button>
-    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#rippling">
+    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#rippling" target="_blank">
       Need help finding your Metadata URL?
     </a>
   </fieldset>

--- a/src/sentry/auth/providers/saml2/rippling/templates/sentry_auth_rippling/select-idp.html
+++ b/src/sentry/auth/providers/saml2/rippling/templates/sentry_auth_rippling/select-idp.html
@@ -22,7 +22,7 @@
 
   <fieldset class="form-actions">
     <button type="submit" class="btn btn-primary" name="action_save">{% trans "Continue" %}</button>
-    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#rippling" target="_blank">
+    <a class="pull-right" style="margin-top: 7px" href="https://docs.sentry.io/learn/sso/#rippling" target="_blank" rel="noopener">
       Need help finding your Metadata URL?
     </a>
   </fieldset>


### PR DESCRIPTION
Not sure if this is strictly enforced across the product but I'd like it to be the case (especially here because they will come back to continue their SSO config), unless it is obvious that it's an exit-point away from Sentry.