### PR TITLE
expt(projectCreation/Workflow): Start variant expt manual testing

### DIFF
--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -21,7 +21,7 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
             return context
 
         experiment_variant = experiments.get(
-            org=organization, experiment_name="AlertDefaultsExperiment"
+            org=organization, experiment_name="AlertDefaultsExperimentTmp"
         )
         if experiment_variant == "test3Options":
             return Response(

--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -20,14 +20,18 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
                 context["formFields"] = rule_cls.form_fields
             return context
 
-        # TODO(Jeff): Rename to `AlertDefaultsExperiment` on real experiment run
-        if experiments.get(org=organization, experiment_name="AlertDefaultsExperimentTmp") != 1:
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
-        return Response(
-            [
-                info_extractor(rule_cls)
-                for rule_type, rule_cls in rules
-                if rule_type.startswith("condition/")
-            ]
+        experiment_variant = experiments.get(
+            org=organization, experiment_name="AlertDefaultsExperiment"
         )
+        if experiment_variant == "test3Options":
+            return Response(
+                [
+                    info_extractor(rule_cls)
+                    for rule_type, rule_cls in rules
+                    if rule_type.startswith("condition/")
+                ]
+            )
+        elif experiment_variant == "test2Options":
+            return Response(status=status.HTTP_200_OK)
+
+        return Response(status=status.HTTP_404_NOT_FOUND)

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -827,6 +827,7 @@ export type SentryAppComponent = {
 
 export type ActiveExperiments = {
   TrialUpgradeV2Experiment: 'upgrade' | 'trial' | -1;
+  AlertDefaultsExperiment: 'testControl' | 'test2Options' | 'test3Options';
 };
 
 type SavedQueryVersions = 1 | 2;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -827,7 +827,7 @@ export type SentryAppComponent = {
 
 export type ActiveExperiments = {
   TrialUpgradeV2Experiment: 'upgrade' | 'trial' | -1;
-  AlertDefaultsExperiment: 'testControl' | 'test2Options' | 'test3Options';
+  AlertDefaultsExperimentTmp: 'testControl' | 'test2Options' | 'test3Options';
 };
 
 type SavedQueryVersions = 1 | 2;

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -67,7 +67,7 @@ class CreateProject extends React.Component {
   componentDidMount() {
     logExperiment({
       organization: this.props.organization,
-      key: 'AlertDefaultsExperiment',
+      key: 'AlertDefaultsExperimentTmp',
       unitName: 'org_id',
       unitId: parseInt(this.props.organization.id, 10),
       param: 'variant',

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -65,13 +65,12 @@ class CreateProject extends React.Component {
   }
 
   componentDidMount() {
-    // TODO(jeff): Change key to AlertDefaultExperiment on the real experiment run
     logExperiment({
       organization: this.props.organization,
-      key: 'AlertDefaultExperimentTmp',
+      key: 'AlertDefaultsExperiment',
       unitName: 'org_id',
       unitId: parseInt(this.props.organization.id, 10),
-      param: 'exposed',
+      param: 'variant',
     });
     trackAdhocEvent({
       eventKey: 'new_project.visited',

--- a/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
@@ -105,7 +105,7 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
       ...super.getDefaultState(),
       conditions: [],
       intervalChoices: [],
-      alertSetting: '',
+      alertSetting: `${Actions.CREATE_ALERT_LATER}`,
       metric: MetricValues.ERRORS,
       interval: '',
       threshold: DEFAULT_THRESHOLD_VALUE,
@@ -243,7 +243,6 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
 
     if (!conditions || conditions.length === 0) {
       this.setStateAndUpdateParents({
-        alertSetting: `${Actions.CREATE_ALERT_LATER}`,
         conditions: undefined,
       });
       return;
@@ -259,7 +258,6 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
         );
       });
       this.setStateAndUpdateParents({
-        alertSetting: `${Actions.CREATE_ALERT_LATER}`,
         conditions: undefined,
       });
       return;

--- a/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
@@ -20,8 +20,8 @@ enum MetricValues {
 }
 enum Actions {
   ALERT_ON_EVERY_ISSUE,
-  CREATE_ALERT_LATER,
   CUSTOMIZED_ALERTS,
+  CREATE_ALERT_LATER,
 }
 
 const UNIQUE_USER_FREQUENCY_CONDITION: string =
@@ -105,7 +105,7 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
       ...super.getDefaultState(),
       conditions: [],
       intervalChoices: [],
-      alertSetting: `${Actions.CUSTOMIZED_ALERTS}`,
+      alertSetting: '',
       metric: MetricValues.ERRORS,
       interval: '',
       threshold: DEFAULT_THRESHOLD_VALUE,
@@ -128,8 +128,8 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
     hasProperlyLoadedConditions: boolean
   ): [string, string | ReactElement][] {
     const options: [string, React.ReactNode][] = [
-      [`${Actions.ALERT_ON_EVERY_ISSUE}`, t('Alert me on every new issue')],
       [`${Actions.CREATE_ALERT_LATER}`, t("I'll create my own alerts later")],
+      [`${Actions.ALERT_ON_EVERY_ISSUE}`, t('Alert me on every new issue')],
     ];
     if (hasProperlyLoadedConditions) {
       options.unshift([
@@ -242,7 +242,10 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
     );
 
     if (!conditions || conditions.length === 0) {
-      this.setStateAndUpdateParents({conditions: undefined});
+      this.setStateAndUpdateParents({
+        alertSetting: `${Actions.CREATE_ALERT_LATER}`,
+        conditions: undefined,
+      });
       return;
     }
 
@@ -255,11 +258,15 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
           new Error('Interval choices or sent from API endpoint is inconsistent or empty')
         );
       });
-      this.setStateAndUpdateParents({conditions: undefined});
+      this.setStateAndUpdateParents({
+        alertSetting: `${Actions.CREATE_ALERT_LATER}`,
+        conditions: undefined,
+      });
       return;
     }
 
     this.setStateAndUpdateParents({
+      alertSetting: `${Actions.CUSTOMIZED_ALERTS}`,
       conditions,
       intervalChoices,
       interval,

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -14,7 +14,7 @@ const NewProject = ({organization}) => (
         <DocumentTitle title="Sentry" />
         <CreateProject
           hasIssueAlertOptionsEnabled={['test2Options', 'test3Options'].includes(
-            organization.experiments?.AlertDefaultsExperiment
+            organization.experiments?.AlertDefaultsExperimentTmp
           )}
         />
       </Content>

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -13,10 +13,9 @@ const NewProject = ({organization}) => (
       <Content>
         <DocumentTitle title="Sentry" />
         <CreateProject
-          hasIssueAlertOptionsEnabled={
-            // TODO(Jeff): Rename to `AlertDefaultsExperiment` on real experiment run
-            organization.experiments?.AlertDefaultsExperimentTmp === 1
-          }
+          hasIssueAlertOptionsEnabled={['test2Options', 'test3Options'].includes(
+            organization.experiments?.AlertDefaultsExperiment
+          )}
         />
       </Content>
     </div>

--- a/tests/sentry/api/endpoints/test_project_agnostic_rule_configurations.py
+++ b/tests/sentry/api/endpoints/test_project_agnostic_rule_configurations.py
@@ -7,7 +7,7 @@ from sentry.testutils import APITestCase
 
 
 class ProjectAgnosticRuleConfigurationsTest(APITestCase):
-    @patch("sentry.experiments.get", return_value=1)
+    @patch("sentry.experiments.get", return_value="test3Options")
     def test_simple(self, mocked_experiment):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")


### PR DESCRIPTION
There are 3 variants tested for this experiment:
- Control: Issue Alert options will not be enabled
- 2 Options: Issue Alert options are enabled with: 'I'll create my alerts later" and "Alert me on every issue"
- 3 Options: 2 Options + a custom rule creator

This PR will allow for all three variants to be tested.
We are still using the experiment with the tmp suffix so that the experiments can be tested with our test-orgs.

Sister PR: https://github.com/getsentry/getsentry/pull/3611