### PR TITLE
feat(experiments): make experiment fields optional

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -68,7 +68,7 @@ export type LightWeightOrganization = OrganizationSummary & {
     maxRate: number | null;
   };
   defaultRole: string;
-  experiments: ActiveExperiments;
+  experiments: Partial<ActiveExperiments>;
   allowJoinRequests: boolean;
   scrapeJavaScript: boolean;
   isDefault: boolean;


### PR DESCRIPTION
The organization field `experiments` will come out to be an empty object if you aren't using getsentry. Safer to just use `Partial` on experiment fields so we don't break on-prem or local development Sentry.