### PR TITLE
feat(discover) Revise column picker modal

### DIFF
--- a/docs-ui/components/columnEditor.stories.js
+++ b/docs-ui/components/columnEditor.stories.js
@@ -30,6 +30,14 @@ storiesOf('Discover|ColumnEditor', module).add(
         field: 'id',
         aggregation: 'count',
       },
+      {
+        field: 'title',
+        aggregation: 'count_unique',
+      },
+      {
+        field: '',
+        aggregation: 'p95',
+      },
     ];
 
     const showModal = () => {

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -85,6 +85,7 @@ export const AGGREGATIONS = {
     type: ['duration'],
     isSortable: true,
   },
+  /* TODO(mark) swap these in with the new column builder
   last_seen: {
     parameters: [],
     outputType: 'timestamp',
@@ -109,6 +110,7 @@ export const AGGREGATIONS = {
     type: [],
     isSortable: true,
   },
+  */
 } as const;
 
 assert(
@@ -200,6 +202,12 @@ export const FIELDS = {
   // Field alises defined in src/sentry/api/event_search.py
   project: 'string',
   issue: 'string',
+
+  // TODO(mark) Remove these with the new column builder.
+  last_seen: 'timestamp',
+  p75: 'duration',
+  p95: 'duration',
+  p99: 'duration',
 } as const;
 assert(FIELDS as Readonly<{[key in keyof typeof FIELDS]: ColumnValueType}>);
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -1,49 +1,112 @@
 import {assert} from 'app/types/utils';
 
-export type ColumnValueType =
-  | '*' // Matches to everything
+export type ColumnType =
+  | '*' // Matches to everything TODO(mark) remove this in favour of explicit type lists.
   | 'string'
   | 'integer'
   | 'number'
   | 'duration'
   | 'timestamp'
-  | 'boolean'
-  | 'never'; // Matches to nothing
+  | 'boolean';
+
+export type ColumnValueType = ColumnType | 'never'; // Matches to nothing
+
+export type AggregateParameter = {
+  kind: 'column' | 'value';
+  columnTypes: Readonly<ColumnType[]>;
+  required: boolean;
+};
 
 // Refer to src/sentry/api/event_search.py
 export const AGGREGATIONS = {
   count: {
-    type: '*',
+    parameters: [],
+    outputType: 'number',
+    type: ['*'],
     isSortable: true,
   },
   count_unique: {
-    type: '*',
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: ['string', 'integer', 'number', 'duration', 'timestamp', 'boolean'],
+        required: true,
+      },
+    ],
+    outputType: 'number',
+    type: ['*'],
     isSortable: true,
   },
-  /*
-  rpm: {
-    type: 'numeric',
-    isSortable: true,
-  },
-  pXX: {
-    type: 'numeric',
-    isSortable: true,
-  },
-  */
   min: {
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: ['integer', 'number', 'duration', 'timestamp'],
+        required: true,
+      },
+    ],
+    outputType: null,
     type: ['timestamp', 'duration'],
     isSortable: true,
   },
   max: {
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: ['integer', 'number', 'duration', 'timestamp'],
+        required: true,
+      },
+    ],
+    outputType: null,
     type: ['timestamp', 'duration'],
     isSortable: true,
   },
   avg: {
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: ['integer', 'number', 'duration'],
+        required: true,
+      },
+    ],
+    outputType: null,
     type: ['duration'],
     isSortable: true,
   },
   sum: {
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: ['integer', 'number', 'duration'],
+        required: true,
+      },
+    ],
+    outputType: null,
     type: ['duration'],
+    isSortable: true,
+  },
+  last_seen: {
+    parameters: [],
+    outputType: 'timestamp',
+    type: [],
+    isSortable: true,
+  },
+  p75: {
+    parameters: [],
+    outputType: 'duration',
+    type: [],
+    isSortable: true,
+  },
+  p95: {
+    parameters: [],
+    outputType: 'duration',
+    type: [],
+    isSortable: true,
+  },
+  p99: {
+    parameters: [],
+    outputType: 'duration',
+    type: [],
     isSortable: true,
   },
 } as const;
@@ -52,7 +115,10 @@ assert(
   AGGREGATIONS as Readonly<
     {
       [key in keyof typeof AGGREGATIONS]: {
-        type: '*' | Readonly<ColumnValueType[]>;
+        parameters: Readonly<AggregateParameter[]>;
+        // null means to inherit from the column.
+        outputType: null | ColumnType;
+        type: Readonly<ColumnType[]>;
         isSortable: boolean;
       };
     }
@@ -134,19 +200,6 @@ export const FIELDS = {
   // Field alises defined in src/sentry/api/event_search.py
   project: 'string',
   issue: 'string',
-
-  // duration aliases and fake functions.
-  // Once we've expanded the functions support these
-  // need to be revisited
-  p75: 'duration',
-  p95: 'duration',
-  p99: 'duration',
-
-  // TODO when these become real functions, we need to revisit how
-  // their types are inferred in decodeColumnOrder()
-  apdex: 'number',
-  impact: 'number',
-  error_rate: 'number',
 } as const;
 assert(FIELDS as Readonly<{[key in keyof typeof FIELDS]: ColumnValueType}>);
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -269,14 +269,14 @@ class ColumnEditCollection extends React.Component<Props, State> {
     };
     const ghost = (
       <Ghost ref={this.dragGhostRef} style={style}>
-        {this.renderItem(col, index, true)}
+        {this.renderItem(col, index, true, true)}
       </Ghost>
     );
 
     return ReactDOM.createPortal(ghost, this.portal);
   }
 
-  renderItem(col: Column, i: number, isGhost = false) {
+  renderItem(col: Column, i: number, canDelete: boolean, isGhost: boolean = false) {
     const {isDragging, draggingTargetIndex, fieldOptions} = this.state;
 
     // Replace the dragged row with a placeholder.
@@ -286,12 +286,16 @@ class ColumnEditCollection extends React.Component<Props, State> {
 
     return (
       <RowContainer key={`container-${i}`}>
-        <IconButton
-          aria-label={t('Drag to reorder columns')}
-          onMouseDown={event => this.startDrag(event, i)}
-        >
-          <IconGrabbable size="sm" />
-        </IconButton>
+        {canDelete ? (
+          <IconButton
+            aria-label={t('Drag to reorder columns')}
+            onMouseDown={event => this.startDrag(event, i)}
+          >
+            <IconGrabbable size="sm" />
+          </IconButton>
+        ) : (
+          <span />
+        )}
         <ColumnEditRow
           className={DRAG_CLASS}
           fieldOptions={fieldOptions}
@@ -299,15 +303,23 @@ class ColumnEditCollection extends React.Component<Props, State> {
           parentIndex={i}
           onChange={this.handleUpdateColumn}
         />
-        <IconButton aria-label={t('Remove column')} onClick={() => this.removeColumn(i)}>
-          <IconClose size="sm" />
-        </IconButton>
+        {canDelete ? (
+          <IconButton
+            aria-label={t('Remove column')}
+            onClick={() => this.removeColumn(i)}
+          >
+            <IconClose size="sm" />
+          </IconButton>
+        ) : (
+          <span />
+        )}
       </RowContainer>
     );
   }
 
   render() {
     const {columns} = this.props;
+    const canDelete = columns.length > 1;
     return (
       <div>
         {this.renderGhost()}
@@ -317,7 +329,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
             <strong>{t('Field Parameter')}</strong>
           </Heading>
         </RowContainer>
-        {columns.map((col: Column, i: number) => this.renderItem(col, i))}
+        {columns.map((col: Column, i: number) => this.renderItem(col, i, canDelete))}
         <RowContainer>
           <Actions>
             <Button size="xsmall" onClick={this.handleAddColumn}>
@@ -347,7 +359,7 @@ const Ghost = styled('div')`
   padding: 4px;
   border: 4px solid ${p => p.theme.borderLight};
   border-radius: 4px;
-  width: 400px;
+  width: 450px;
   opacity: 0.8;
   cursor: grabbing;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -9,12 +9,13 @@ import {
 } from 'app/components/events/interfaces/spans/utils';
 import {IconAdd, IconGrabbable, IconClose} from 'app/icons';
 import {t} from 'app/locale';
-import {OrganizationSummary} from 'app/types';
+import {SelectValue, OrganizationSummary} from 'app/types';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 
+import {AGGREGATIONS, FIELDS, TRACING_FIELDS} from '../eventQueryParams';
 import {Column} from '../eventView';
-import ColumnEditRow from './columnEditRow';
+import {ColumnEditRow, FieldValue, FieldValueKind} from './columnEditRow';
 
 type Props = {
   // Input columns
@@ -31,6 +32,8 @@ type State = {
   draggingTargetIndex: undefined | number;
   left: undefined | number;
   top: undefined | number;
+  // Stored as a object so we can find elements later.
+  fieldOptions: {[key: string]: SelectValue<FieldValue>};
 };
 
 const DRAG_CLASS = 'draggable-item';
@@ -43,6 +46,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
     draggingTargetIndex: void 0,
     left: void 0,
     top: void 0,
+    fieldOptions: {},
   };
 
   componentDidMount() {
@@ -58,6 +62,13 @@ class ColumnEditCollection extends React.Component<Props, State> {
 
       document.body.appendChild(this.portal);
     }
+    this.syncFields();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.tagKeys !== prevProps.tagKeys) {
+      this.syncFields();
+    }
   }
 
   componentWillUnmount() {
@@ -70,6 +81,62 @@ class ColumnEditCollection extends React.Component<Props, State> {
   previousUserSelect: UserSelectValues | null = null;
   portal: HTMLElement | null = null;
   dragGhostRef = React.createRef<HTMLDivElement>();
+
+  syncFields() {
+    const {organization, tagKeys} = this.props;
+
+    let fields = Object.keys(FIELDS);
+    let functions = Object.keys(AGGREGATIONS);
+
+    // Strip tracing features if the org doesn't have access.
+    if (!organization.features.includes('transaction-events')) {
+      fields = fields.filter(item => !TRACING_FIELDS.includes(item));
+      functions = functions.filter(item => !TRACING_FIELDS.includes(item));
+    }
+    const fieldOptions: {[key: string]: SelectValue<FieldValue>} = {};
+
+    // Index items by prefixed keys as custom tags
+    // can overlap both fields and function names.
+    // Having a mapping makes finding the value objects easier
+    // later as well.
+    functions.forEach(func => {
+      fieldOptions[`function:${func}`] = {
+        label: `${func}(...)`,
+        value: {
+          kind: FieldValueKind.FUNCTION,
+          meta: {
+            name: func,
+            parameters: AGGREGATIONS[func].parameters,
+          },
+        },
+      };
+    });
+
+    fields.forEach(field => {
+      fieldOptions[`field:${field}`] = {
+        label: field,
+        value: {
+          kind: FieldValueKind.FIELD,
+          meta: {
+            name: field,
+            dataType: FIELDS[field],
+          },
+        },
+      };
+    });
+
+    tagKeys.forEach(tag => {
+      fieldOptions[`tag:${tag}`] = {
+        label: tag,
+        value: {
+          kind: FieldValueKind.TAG,
+          meta: {name: tag, dataType: 'string'},
+        },
+      };
+    });
+
+    this.setState({fieldOptions});
+  }
 
   cleanUpListeners() {
     if (this.state.isDragging) {
@@ -210,8 +277,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
   }
 
   renderItem(col: Column, i: number, isGhost = false) {
-    const {organization, tagKeys} = this.props;
-    const {isDragging, draggingTargetIndex} = this.state;
+    const {isDragging, draggingTargetIndex, fieldOptions} = this.state;
 
     // Replace the dragged row with a placeholder.
     if (isDragging && isGhost === false && draggingTargetIndex === i) {
@@ -228,10 +294,9 @@ class ColumnEditCollection extends React.Component<Props, State> {
         </IconButton>
         <ColumnEditRow
           className={DRAG_CLASS}
-          organization={organization}
+          fieldOptions={fieldOptions}
           column={col}
           parentIndex={i}
-          tagKeys={tagKeys}
           onChange={this.handleUpdateColumn}
         />
         <IconButton aria-label={t('Remove column')} onClick={() => this.removeColumn(i)}>
@@ -248,8 +313,8 @@ class ColumnEditCollection extends React.Component<Props, State> {
         {this.renderGhost()}
         <RowContainer>
           <Heading>
-            <strong>{t('Column')}</strong>
-            <strong>{t('Function')}</strong>
+            <strong>{t('Tag / Field / Function')}</strong>
+            <strong>{t('Field Parameter')}</strong>
           </Heading>
         </RowContainer>
         {columns.map((col: Column, i: number) => this.renderItem(col, i))}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableModalEditColumn.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableModalEditColumn.tsx
@@ -17,6 +17,7 @@ import {
   TRACING_FIELDS,
   Aggregation,
   Field,
+  ColumnType,
 } from '../eventQueryParams';
 import {TableColumn} from './types';
 
@@ -260,15 +261,14 @@ function filterFieldByAggregation(
   fieldList = fieldList.reduce((accumulator, f) => {
     // tag keys are all strings, and values not in FIELDS is a tag.
     const fieldType = FIELDS[f] || 'string';
-    if (fieldType === 'never') {
+    if (fieldType === 'never' || typeof AGGREGATIONS[a] === 'undefined') {
       return accumulator;
     }
 
-    if (
-      AGGREGATIONS[a].type.includes(fieldType) ||
-      AGGREGATIONS[a].type === '*' ||
-      fieldType === '*'
-    ) {
+    const aggregate = AGGREGATIONS[a];
+    // Acts as a cast to get around the `as const` type narrowing.
+    const aggregateType: ColumnType[] = [...aggregate.type];
+    if (aggregateType.includes('*') || aggregateType.includes(fieldType as ColumnType)) {
       accumulator.push(f as Field);
     }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -221,13 +221,11 @@ export function decodeColumnOrder(
     }
     column.key = col.aggregationField;
 
-    // Aggregations on any field make numbers.
+    // Aggregations can have a strict outputType or they can inherit from their field.
     // Otherwise use the FIELDS data to infer types.
-    if (
-      AGGREGATIONS[column.aggregation] &&
-      AGGREGATIONS[column.aggregation].type === '*'
-    ) {
-      column.type = 'number';
+    const aggregate = AGGREGATIONS[column.aggregation];
+    if (aggregate && aggregate.outputType) {
+      column.type = aggregate.outputType;
     } else if (FIELDS[column.aggregation]) {
       column.type = FIELDS[column.aggregation];
     } else {


### PR DESCRIPTION
After playing with the previous picker inputs we found some awkward UX flows. This update simplifies building columns as fields, functions and tags are all in the first input. Once a function has been selected additional inputs are enabled to choose the function's column. In a future update additional parameter will be added for functions that require it.

This also greatly expands the front-end's understanding of our functions and should get close to the server side definitions that Evan is working on.

![columns v2](https://user-images.githubusercontent.com/24086/75591955-13d71380-5a4f-11ea-87da-d688ff220d53.gif)
