### PR TITLE
feat(ui): De-emphasized deprecated dsn

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -85,7 +85,7 @@ class ProjectKeyCredentials extends React.Component<Props, State> {
               <StyledField
                 label={null}
                 help={t(
-                  "Deprecated DSN includes the secret which is no longer required by Sentry' newer versions of SDKs. If you are unsure which to use, follow installation instructions for your language."
+                  'Deprecated DSN includes a secret which is no longer required by newer SDK versions. If you are unsure which to use, follow installation instructions for your language.'
                 )}
                 inline={false}
                 flexibleControlStateSize
@@ -106,7 +106,7 @@ class ProjectKeyCredentials extends React.Component<Props, State> {
           <Field
             label={t('DSN (Deprecated)')}
             help={t(
-              "This DSN includes the secret which is no longer required by Sentry' newer versions of SDKs. If you are unsure which to use, follow installation instructions for your language."
+              'Deprecated DSN includes a secret which is no longer required by newer SDK versions. If you are unsure which to use, follow installation instructions for your language.'
             )}
             inline={false}
             flexibleControlStateSize

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import styled from '@emotion/styled';
 
 import {ProjectKey} from 'app/views/settings/project/projectKeys/types';
 import {t, tct} from 'app/locale';
 import ExternalLink from 'app/components/links/externalLink';
+import Link from 'app/components/links/link';
 import Field from 'app/views/settings/components/forms/field';
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 import getDynamicText from 'app/utils/getDynamicText';
+import space from 'app/styles/space';
 
 const DEFAULT_PROPS = {
   showDsn: true,
@@ -23,10 +26,25 @@ type Props = {
   data: ProjectKey;
 } & typeof DEFAULT_PROPS;
 
-class ProjectKeyCredentials extends React.Component<Props> {
+type State = {
+  showDeprecatedDsn: boolean;
+};
+
+class ProjectKeyCredentials extends React.Component<Props, State> {
   static defaultProps = DEFAULT_PROPS;
 
+  state = {
+    showDeprecatedDsn: false,
+  };
+
+  toggleDeprecatedDsn = () => {
+    this.setState(state => ({
+      showDeprecatedDsn: !state.showDeprecatedDsn,
+    }));
+  };
+
   render() {
+    const {showDeprecatedDsn} = this.state;
     const {
       projectId,
       data,
@@ -43,17 +61,48 @@ class ProjectKeyCredentials extends React.Component<Props> {
     return (
       <React.Fragment>
         {showDsnPublic && (
-          <Field label={t('DSN')} inline={false} flexibleControlStateSize>
+          <Field
+            label={t('DSN')}
+            inline={false}
+            flexibleControlStateSize
+            help={tct('The DSN tells the SDK where to send the events to. [link]', {
+              link: showDsn ? (
+                <Link onClick={this.toggleDeprecatedDsn}>
+                  {showDeprecatedDsn
+                    ? t('Hide deprecated DSN')
+                    : t('Show deprecated DSN')}
+                </Link>
+              ) : null,
+            })}
+          >
             <TextCopyInput>
               {getDynamicText({
                 value: data.dsn.public,
                 fixed: '__DSN__',
               })}
             </TextCopyInput>
+            {showDeprecatedDsn && (
+              <StyledField
+                label={null}
+                help={t(
+                  "Deprecated DSN includes the secret which is no longer required by Sentry' newer versions of SDKs. If you are unsure which to use, follow installation instructions for your language."
+                )}
+                inline={false}
+                flexibleControlStateSize
+              >
+                <TextCopyInput>
+                  {getDynamicText({
+                    value: data.dsn.secret,
+                    fixed: '__DSN_DEPRECATED__',
+                  })}
+                </TextCopyInput>
+              </StyledField>
+            )}
           </Field>
         )}
 
-        {showDsn && (
+        {/* this edge case should imho not happen, but just to be sure */}
+        {!showDsnPublic && showDsn && (
           <Field
             label={t('DSN (Deprecated)')}
             help={t(
@@ -166,4 +215,9 @@ class ProjectKeyCredentials extends React.Component<Props> {
     );
   }
 }
+
+const StyledField = styled(Field)`
+  padding: ${space(0.5)} 0 0 0;
+`;
+
 export default ProjectKeyCredentials;


### PR DESCRIPTION
Since this is deprecated already for a long time, we decided to de-emphasize it even more.

Before:
![image](https://user-images.githubusercontent.com/9060071/75675927-7d8e3200-5c88-11ea-9b77-722aee4d5736.png)


After:
![chrome-capture (9)](https://user-images.githubusercontent.com/9060071/75675882-65b6ae00-5c88-11ea-914a-0a642cf5c384.gif)
