### PR TITLE
ref(outcomes): Send event_saved signal in outcomes_consumer

### DIFF
--- a/tests/sentry/ingest/outcome_consumer/test_outcomes_kafka.py
+++ b/tests/sentry/ingest/outcome_consumer/test_outcomes_kafka.py
@@ -2,335 +2,238 @@ from __future__ import absolute_import
 
 import logging
 import pytest
-import six.moves
+import six
 
 from sentry.ingest.outcomes_consumer import get_outcomes_consumer, mark_signal_sent, is_signal_sent
-from sentry.signals import event_filtered, event_dropped
+from sentry.signals import event_filtered, event_dropped, event_saved
 from sentry.testutils.factories import Factories
 from sentry.utils.outcomes import Outcome
 from django.conf import settings
 from sentry.utils import json
+from sentry.utils.json import prune_empty_keys
+
 
 logger = logging.getLogger(__name__)
 
 # Poll this amount of times (for 0.1 sec each) at most to wait for messages
-MAX_POLL_ITERATIONS = 100
+MAX_POLL_ITERATIONS = 50
+
+group_counter = 0
+
+
+def _get_next_group_id():
+    """
+    Returns a unique kafka consumer group identifier, which is required to get
+    tests passing.
+    """
+    global group_counter
+    group_counter += 1
+    return "test-outcome-consumer-%s" % group_counter
 
 
 def _get_event_id(base_event_id):
     return "{:032}".format(int(base_event_id))
 
 
-def _get_outcome(
-    event_id=None,
-    project_id=None,
-    org_id=None,
-    key_id=None,
-    outcome=None,
-    reason=None,
-    remote_addr=None,
-    timestamp=None,
-):
-    message = {}
-    if event_id is not None:
-        event_id = _get_event_id(event_id)
-        message["event_id"] = event_id
-    if project_id is not None:
-        message["project_id"] = project_id
-    if org_id is not None:
-        message["org_id"] = org_id
-    if key_id is not None:
-        message["key_id"] = key_id
-    if org_id is not None:
-        message["org_id"] = org_id
-    if outcome is not None:
-        message["outcome"] = outcome
-    if reason is not None:
-        message["reason"] = reason
-    if remote_addr is not None:
-        message["remote_addr"] = remote_addr
-    if timestamp is not None:
-        message["timestamp"] = timestamp
+class OutcomeTester(object):
+    def __init__(self, kafka_producer, kafka_admin, task_runner):
+        self.events_filtered = []
+        self.events_dropped = []
+        self.events_saved = []
 
-    msg = json.dumps(message)
-    return msg
+        event_filtered.connect(self._event_filtered_receiver)
+        event_dropped.connect(self._event_dropped_receiver)
+        event_saved.connect(self._event_saved_receiver)
+
+        self.task_runner = task_runner
+        self.topic_name = settings.KAFKA_OUTCOMES
+        self.organization = Factories.create_organization()
+        self.project = Factories.create_project(organization=self.organization)
+
+        self.producer = self._create_producer(kafka_producer, kafka_admin)
+
+    def track_outcome(
+        self,
+        event_id=None,
+        key_id=None,
+        outcome=None,
+        reason=None,
+        remote_addr=None,
+        timestamp=None,
+    ):
+        message = {
+            "project_id": self.project.id,
+            "org_id": self.organization.id,
+            "event_id": event_id,
+            "key_id": key_id,
+            "outcome": outcome,
+            "reason": reason,
+            "remote_addr": remote_addr,
+            "timestamp": timestamp,
+        }
+
+        message = json.dumps(prune_empty_keys(message))
+        self.producer.produce(self.topic_name, message)
+
+    def run(self, predicate=None):
+        if predicate is None:
+            predicate = lambda: True
+
+        consumer = get_outcomes_consumer(
+            max_batch_size=1,
+            max_batch_time=100,
+            group_id=_get_next_group_id(),
+            auto_offset_reset="earliest",
+        )
+
+        with self.task_runner():
+            i = 0
+            while predicate() and i < MAX_POLL_ITERATIONS:
+                consumer._run_once()
+                i += 1
+
+        # Verify that we consumed everything and didn't time out
+        # assert not predicate()
+        assert i < MAX_POLL_ITERATIONS
+
+    def _event_filtered_receiver(self, **kwargs):
+        self.events_filtered.append(kwargs)
+
+    def _event_dropped_receiver(self, **kwargs):
+        self.events_dropped.append(kwargs)
+
+    def _event_saved_receiver(self, **kwargs):
+        self.events_saved.append(kwargs)
+
+    def _create_producer(self, kafka_producer, kafka_admin):
+        # Clear the topic to ensure we run in a pristine environment
+        admin = kafka_admin(settings)
+        admin.delete_topic(self.topic_name)
+
+        producer = kafka_producer(settings)
+        return producer
 
 
-def _get_outcome_topic_name():
-    return settings.KAFKA_OUTCOMES
-
-
-def _setup_outcome_test(kafka_producer, kafka_admin):
-    topic_name = _get_outcome_topic_name()
-    organization = Factories.create_organization()
-    project = Factories.create_project(organization=organization)
-    project_id = project.id
-    producer = kafka_producer(settings)
-    admin = kafka_admin(settings)
-    admin.delete_topic(topic_name)
-    return producer, project_id, topic_name
+@pytest.fixture
+def outcome_tester(requires_kafka, kafka_producer, kafka_admin, task_runner):
+    return OutcomeTester(kafka_producer, kafka_admin, task_runner)
 
 
 @pytest.mark.django_db
-def test_outcome_consumer_ignores_outcomes_already_handled(
-    kafka_producer, task_runner, kafka_admin, requires_kafka
-):
-    producer, project_id, topic_name = _setup_outcome_test(kafka_producer, kafka_admin)
-
-    group_id = "test-outcome-consumer-1"
-    last_event_id = None
-
+def test_outcome_consumer_ignores_outcomes_already_handled(outcome_tester):
     # put a few outcome messages on the kafka topic and also mark them in the cache
     for i in range(4):
-        msg = _get_outcome(
-            event_id=i,
-            project_id=project_id,
+        event_id = _get_event_id(i)
+
+        if i < 2:
+            # pretend that we have already processed this outcome before
+            project_id = outcome_tester.project.id
+            mark_signal_sent(project_id=project_id, event_id=event_id)
+
+        outcome_tester.track_outcome(
+            event_id=event_id,
             outcome=Outcome.FILTERED,
             reason="some_reason",
             remote_addr="127.33.44.{}".format(i),
         )
-        if i in (0, 1):
-            # pretend that we have already processed this outcome before
-            mark_signal_sent(project_id=project_id, event_id=_get_event_id(i))
-        else:
-            # Last event is used to check when the outcome producer is done
-            last_event_id = _get_event_id(i)
-        # put the outcome on the kafka topic
-        producer.produce(topic_name, msg)
 
-    # setup django signals for event_filtered and event_dropped
-    event_filtered_sink = []
-    event_dropped_sink = []
-
-    def event_filtered_receiver(**kwargs):
-        event_filtered_sink.append(kwargs.get("ip"))
-
-    def event_dropped_receiver(**kwargs):
-        event_dropped_sink.append("something")
-
-    event_filtered.connect(event_filtered_receiver)
-    event_dropped.connect(event_dropped_receiver)
-
-    consumer = get_outcomes_consumer(
-        max_batch_size=1, max_batch_time=100, group_id=group_id, auto_offset_reset="earliest"
-    )
-
-    # run the outcome consumer
-    with task_runner():
-        i = 0
-        while (
-            not is_signal_sent(project_id=project_id, event_id=last_event_id)
-            and i < MAX_POLL_ITERATIONS
-        ):
-            consumer._run_once()
-            i += 1
-
-    assert is_signal_sent(project_id=project_id, event_id=last_event_id)
+    project_id = outcome_tester.project.id
+    outcome_tester.run(lambda: not is_signal_sent(project_id, event_id))
 
     # verify that no signal was called (since the events have been previously processed)
-    assert event_filtered_sink == ["127.33.44.2", "127.33.44.3"]
-    assert len(event_dropped_sink) == 0
+    ips = [outcome["ip"] for outcome in outcome_tester.events_filtered]
+    assert ips == ["127.33.44.2", "127.33.44.3"]
+    assert not outcome_tester.events_dropped
+    assert not outcome_tester.events_saved
 
 
 @pytest.mark.django_db
-def test_outcome_consumer_ignores_invalid_outcomes(
-    kafka_producer, task_runner, kafka_admin, requires_kafka
-):
-    producer, project_id, topic_name = _setup_outcome_test(kafka_producer, kafka_admin)
-
-    group_id = "test-outcome-consumer-2"
-
-    # put a few outcome messages on the kafka topic. Add two FILTERED items so
-    # we know when the producer has reached the end
+def test_outcome_consumer_ignores_invalid_outcomes(outcome_tester):
+    # Add two FILTERED items so we know when the producer has reached the end
     for i in range(4):
-        msg = _get_outcome(
-            event_id=i,
-            project_id=project_id,
+        outcome_tester.track_outcome(
+            event_id=_get_event_id(i),
             outcome=Outcome.INVALID if i < 2 else Outcome.FILTERED,
             reason="some_reason",
             remote_addr="127.33.44.{}".format(i),
         )
 
-        producer.produce(topic_name, msg)
-
-    # setup django signals for event_filtered and event_dropped
-    event_filtered_sink = []
-    event_dropped_sink = []
-
-    def event_filtered_receiver(**kwargs):
-        event_filtered_sink.append(kwargs.get("ip"))
-
-    def event_dropped_receiver(**kwargs):
-        event_dropped_sink.append("something")
-
-    event_filtered.connect(event_filtered_receiver)
-    event_dropped.connect(event_dropped_receiver)
-
-    consumer = get_outcomes_consumer(
-        max_batch_size=1, max_batch_time=100, group_id=group_id, auto_offset_reset="earliest"
-    )
-
-    # run the outcome consumer
-    with task_runner():
-        i = 0
-        while len(event_filtered_sink) < 2 and i < MAX_POLL_ITERATIONS:
-            consumer._run_once()
-            i += 1
+    outcome_tester.run(lambda: len(outcome_tester.events_filtered) < 2)
 
     # verify that the appropriate filters were called
-    assert event_filtered_sink == ["127.33.44.2", "127.33.44.3"]
-    assert len(event_dropped_sink) == 0
+    ips = [outcome["ip"] for outcome in outcome_tester.events_filtered]
+    assert ips == ["127.33.44.2", "127.33.44.3"]
+    assert not outcome_tester.events_dropped
+    assert not outcome_tester.events_saved
 
 
 @pytest.mark.django_db
-def test_outcome_consumer_remembers_handled_outcomes(
-    kafka_producer, task_runner, kafka_admin, requires_kafka
-):
-    producer, project_id, topic_name = _setup_outcome_test(kafka_producer, kafka_admin)
-
-    group_id = "test-outcome-consumer-3"
-
-    # put a few outcome messages on the kafka topic
+def test_outcome_consumer_remembers_handled_outcomes(outcome_tester):
     for i in six.moves.range(1, 3):
-        # emit the same outcome twice ( simulate the case when the  producer goes down without
-        # committing the kafka offsets and is restarted)
-        msg = _get_outcome(
-            event_id=1,
-            project_id=project_id,
+        # emit the same outcome twice (simulate the case when the producer goes
+        # down without committing the kafka offsets and is restarted)
+        outcome_tester.track_outcome(
+            event_id=_get_event_id(i),
             outcome=Outcome.FILTERED,
             reason="some_reason",
             remote_addr="127.33.44.{}".format(1),
         )
 
-        producer.produce(topic_name, msg)
+    outcome_tester.run(lambda: len(outcome_tester.events_filtered) < 1)
 
-    # setup django signals for event_filtered and event_dropped
-    event_filtered_sink = []
-    event_dropped_sink = []
-
-    def event_filtered_receiver(**kwargs):
-        event_filtered_sink.append(kwargs.get("ip"))
-
-    def event_dropped_receiver(**kwargs):
-        event_dropped_sink.append("something")
-
-    event_filtered.connect(event_filtered_receiver)
-    event_dropped.connect(event_dropped_receiver)
-
-    consumer = get_outcomes_consumer(
-        max_batch_size=1, max_batch_time=100, group_id=group_id, auto_offset_reset="earliest"
-    )
-
-    # run the outcome consumer
-    with task_runner():
-        i = 0
-        while not event_filtered_sink and i < MAX_POLL_ITERATIONS:
-            consumer._run_once()
-            i += 1
-
-    # verify that the appropriate filters were called
-    assert len(event_filtered_sink) == 1
-    assert event_filtered_sink == ["127.33.44.1"]
-    assert len(event_dropped_sink) == 0
+    ips = [outcome["ip"] for outcome in outcome_tester.events_filtered]
+    assert ips == ["127.33.44.1"]  # only once!
+    assert not outcome_tester.events_dropped
+    assert not outcome_tester.events_saved
 
 
 @pytest.mark.django_db
-def test_outcome_consumer_handles_filtered_outcomes(
-    kafka_producer, task_runner, kafka_admin, requires_kafka
-):
-    producer, project_id, topic_name = _setup_outcome_test(kafka_producer, kafka_admin)
-
-    group_id = "test-outcome-consumer-4"
-
-    # put a few outcome messages on the kafka topic
+def test_outcome_consumer_handles_filtered_outcomes(outcome_tester):
     for i in six.moves.range(1, 3):
-        msg = _get_outcome(
-            event_id=i,
-            project_id=project_id,
+        outcome_tester.track_outcome(
+            event_id=_get_event_id(i),
             outcome=Outcome.FILTERED,
             reason="some_reason",
             remote_addr="127.33.44.{}".format(i),
         )
 
-        producer.produce(topic_name, msg)
-
-    # setup django signals for event_filtered and event_dropped
-    event_filtered_sink = []
-    event_dropped_sink = []
-
-    def event_filtered_receiver(**kwargs):
-        event_filtered_sink.append(kwargs.get("ip"))
-
-    def event_dropped_receiver(**kwargs):
-        event_dropped_sink.append("something")
-
-    event_filtered.connect(event_filtered_receiver)
-    event_dropped.connect(event_dropped_receiver)
-
-    consumer = get_outcomes_consumer(
-        max_batch_size=1, max_batch_time=100, group_id=group_id, auto_offset_reset="earliest"
-    )
-
-    # run the outcome consumer
-    with task_runner():
-        i = 0
-        while len(event_filtered_sink) < 2 and i < MAX_POLL_ITERATIONS:
-            consumer._run_once()
-            i += 1
+    outcome_tester.run(lambda: len(outcome_tester.events_filtered) < 2)
 
     # verify that the appropriate filters were called
-    assert len(event_filtered_sink) == 2
-    assert set(event_filtered_sink) == set(["127.33.44.1", "127.33.44.2"])
-    assert len(event_dropped_sink) == 0
+    ips = [outcome["ip"] for outcome in outcome_tester.events_filtered]
+    assert len(ips) == 2
+    assert set(ips) == set(["127.33.44.1", "127.33.44.2"])
+    assert not outcome_tester.events_dropped
+    assert not outcome_tester.events_saved
 
 
 @pytest.mark.django_db
-def test_outcome_consumer_handles_rate_limited_outcomes(
-    kafka_producer, task_runner, kafka_admin, requires_kafka
-):
-    producer, project_id, topic_name = _setup_outcome_test(kafka_producer, kafka_admin)
-
-    group_id = "test-outcome-consumer-5"
-
-    # put a few outcome messages on the kafka topic
+def test_outcome_consumer_handles_rate_limited_outcomes(outcome_tester):
     for i in six.moves.range(1, 3):
-        msg = _get_outcome(
-            event_id=i,
-            project_id=project_id,
+        outcome_tester.track_outcome(
+            event_id=_get_event_id(i),
             outcome=Outcome.RATE_LIMITED,
             reason="reason_{}".format(i),
             remote_addr="127.33.44.{}".format(i),
         )
 
-        producer.produce(topic_name, msg)
+    outcome_tester.run(lambda: len(outcome_tester.events_dropped) < 2)
 
-    # setup django signals for event_filtered and event_dropped
-    event_filtered_sink = []
-    event_dropped_sink = []
+    assert not outcome_tester.events_filtered
+    tuples = [(o["ip"], o["reason_code"]) for o in outcome_tester.events_dropped]
+    assert set(tuples) == set([("127.33.44.1", "reason_1"), ("127.33.44.2", "reason_2")])
 
-    def event_filtered_receiver(**kwargs):
-        event_filtered_sink.append("something")
 
-    def event_dropped_receiver(**kwargs):
-        event_dropped_sink.append((kwargs.get("ip"), kwargs.get("reason_code")))
+@pytest.mark.django_db
+def test_outcome_consumer_handles_accepted_outcomes(outcome_tester):
+    for i in six.moves.range(1, 3):
+        outcome_tester.track_outcome(
+            event_id=_get_event_id(i),
+            outcome=Outcome.ACCEPTED,
+            remote_addr="127.33.44.{}".format(i),
+        )
 
-    event_filtered.connect(event_filtered_receiver)
-    event_dropped.connect(event_dropped_receiver)
+    outcome_tester.run(lambda: len(outcome_tester.events_saved) < 2)
 
-    consumer = get_outcomes_consumer(
-        max_batch_size=1, max_batch_time=100, group_id=group_id, auto_offset_reset="earliest"
-    )
-
-    # run the outcome consumer
-    with task_runner():
-        i = 0
-        while len(event_dropped_sink) < 2 and i < MAX_POLL_ITERATIONS:
-            consumer._run_once()
-            i += 1
-
-    # verify that the appropriate filters were called
-    assert len(event_filtered_sink) == 0
-    assert len(event_dropped_sink) == 2
-    assert set(event_dropped_sink) == set(
-        [("127.33.44.1", "reason_1"), ("127.33.44.2", "reason_2")]
-    )
+    assert not outcome_tester.events_filtered
+    assert len(outcome_tester.events_saved) == 2


### PR DESCRIPTION
Enables the outcomes consumer to dispatch `event_saved` signals for `Outcome.ACCEPTED`.

Follow-up to #17347
Ref #17291 (original PR)

#sync-getsentry