### PR TITLE
fix(bitbucketserver):Fix getting commits for Bitbucket server and add patch_set for commits

### DIFF
--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -17,6 +17,7 @@ class BitbucketServerAPIPath(object):
     repository_hook = u"/rest/api/1.0/projects/{project}/repos/{repo}/webhooks/{id}"
     repository_hooks = u"/rest/api/1.0/projects/{project}/repos/{repo}/webhooks"
     repository_commits = u"/rest/api/1.0/projects/{project}/repos/{repo}/commits"
+    commit_changes = u"/rest/api/1.0/projects/{project}/repos/{repo}/commits/{commit}/changes"
 
 
 class BitbucketServerSetupClient(ApiClient):
@@ -142,6 +143,20 @@ class BitbucketServer(ApiClient):
             BitbucketServerAPIPath.repository_commits.format(project=project, repo=repo),
             auth=self.get_auth(),
             params={"since": fromHash, "until": toHash, "merges": "exclude"},
+        )
+
+    def get_last_commits(self, project, repo, limit=10):
+        return self.get(
+            BitbucketServerAPIPath.repository_commits.format(project=project, repo=repo),
+            auth=self.get_auth(),
+            params={"merges": "exclude", "limit": limit},
+        )
+
+
+    def get_changelist(self, project, repo, commit):
+        return self.get(
+            BitbucketServerAPIPath.commit_changes.format(project=project, repo=repo, commit=commit),
+            auth=self.get_auth(),
         )
 
     def get_auth(self):

--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -152,7 +152,6 @@ class BitbucketServer(ApiClient):
             params={"merges": "exclude", "limit": limit},
         )
 
-
     def get_changelist(self, project, repo, commit):
         return self.get(
             BitbucketServerAPIPath.commit_changes.format(project=project, repo=repo, commit=commit),

--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -152,7 +152,7 @@ class BitbucketServer(ApiClient):
             params={"merges": "exclude", "limit": limit},
         )
 
-    def get_changelist(self, project, repo, commit):
+    def get_commit_filechanges(self, project, repo, commit):
         return self.get(
             BitbucketServerAPIPath.commit_changes.format(project=project, repo=repo, commit=commit),
             auth=self.get_auth(),

--- a/src/sentry/integrations/bitbucket_server/repository.py
+++ b/src/sentry/integrations/bitbucket_server/repository.py
@@ -4,12 +4,13 @@ import six
 
 from datetime import datetime
 from django.utils import timezone
+from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from sentry.models.integration import Integration
 from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
 from sentry.utils.http import absolute_uri
 from sentry.integrations.exceptions import ApiError, IntegrationError
-
+from sentry.utils.hashlib import md5_text
 
 class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
     name = "Bitbucket Server"
@@ -93,16 +94,16 @@ class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
                 return
             raise
 
-    def _format_commits(self, repo, commit_list):
+    def _format_commits(self, client, repo, commit_list):
         return [
             {
                 "id": c["id"],
                 "repository": repo.name,
                 "author_email": c["author"]["emailAddress"],
-                "author_name": c["author"]["displayName"],
+                "author_name": c["author"]["name"],
                 "message": c["message"],
                 "timestamp": datetime.fromtimestamp(c["authorTimestamp"] / 1000, timezone.utc),
-                "patch_set": None,
+                "patch_set": self._get_patchset(client, repo.config["project"], repo.config["repo"], c["id"]),
             }
             for c in commit_list["values"]
         ]
@@ -112,18 +113,54 @@ class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
         client = installation.get_client()
         # use config name because that is kept in sync via webhooks
 
-        # Bitbucket servers send an empty commit as a string of zeros
-        if "0" * 40 == start_sha:
-            start_sha = None
-
-        try:
-            res = client.get_commits(
-                repo.config["project"], repo.config["repo"], start_sha, end_sha
-            )
-        except Exception as e:
-            installation.raise_error(e)
+        if "0" * 40 == start_sha or start_sha is None:
+            try:
+                res = client.get_last_commits(repo.config["project"], repo.config["repo"], 10)
+            except Exception as e:
+                installation.raise_error(e)
+            else:
+                return self._format_commits(client, repo, res)
         else:
-            return self._format_commits(repo, res)
+            try:
+                res = client.get_commits(
+                    repo.config["project"], repo.config["repo"], start_sha, end_sha
+                )
+            except Exception as e:
+                installation.raise_error(e)
+            else:
+                return self._format_commits(client, repo, res)
 
     def repository_external_slug(self, repo):
         return repo.name
+
+    def _get_patchset(self, client, project, repo, sha):
+        """
+            Get the modified files for a commit
+        """
+
+        key = u"get_changelist:{}:{}".format(md5_text(project + repo).hexdigest(), sha)
+        commit_files = cache.get(key)
+        if commit_files is None:
+            commit_files = client.get_changelist(project, repo, sha)
+            cache.set(key, commit_files, 900)
+
+        return self._transform_patchset(commit_files)
+
+    def _transform_patchset(self, diff):
+        """Convert the patch data from Bitbucket into our internal format
+
+        See sentry.models.Release.set_commits
+        """
+        changes = []
+        for change in diff["values"]:
+            if change["type"] == "MODIFY":
+                changes.append({"path": change["path"]["toString"], "type": "M"})
+            if change["type"] == "ADD":
+                changes.append({"path": change["path"]["toString"], "type": "A"})
+            if change["type"] == "DELETE":
+                changes.append({"path": change["path"]["toString"], "type": "D"})
+            if change["type"] == "MOVE":
+                changes.append({"path": change["srcPath"]["toString"], "type": "D"})
+                changes.append({"path": change["path"]["toString"], "type": "A"})
+        return changes
+

--- a/src/sentry/integrations/bitbucket_server/repository.py
+++ b/src/sentry/integrations/bitbucket_server/repository.py
@@ -12,6 +12,7 @@ from sentry.utils.http import absolute_uri
 from sentry.integrations.exceptions import ApiError, IntegrationError
 from sentry.utils.hashlib import md5_text
 
+
 class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
     name = "Bitbucket Server"
 
@@ -163,4 +164,3 @@ class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
                 changes.append({"path": change["srcPath"]["toString"], "type": "D"})
                 changes.append({"path": change["path"]["toString"], "type": "A"})
         return changes
-

--- a/tests/sentry/integrations/bitbucket_server/test_repository.py
+++ b/tests/sentry/integrations/bitbucket_server/test_repository.py
@@ -77,7 +77,7 @@ class BitbucketServerRepositoryProviderTest(APITestCase):
         assert res == [
             {
                 "author_email": "sentryuser@getsentry.com",
-                "author_name": "SentryU",
+                "author_name": "Sentry User",
                 "message": "README.md edited online with Bitbucket",
                 "id": "e18e4e72de0d824edfbe0d73efe34cbd0d01d301",
                 "repository": "sentryuser/newsdiffs",

--- a/tests/sentry/integrations/bitbucket_server/test_repository.py
+++ b/tests/sentry/integrations/bitbucket_server/test_repository.py
@@ -11,7 +11,7 @@ from sentry.models import Integration, Repository, IdentityProvider, Identity, I
 from sentry.testutils import APITestCase
 from sentry.integrations.bitbucket_server.repository import BitbucketServerRepositoryProvider
 from sentry.integrations.exceptions import IntegrationError
-from .testutils import EXAMPLE_PRIVATE_KEY, COMPARE_COMMITS_EXAMPLE, REPO
+from .testutils import EXAMPLE_PRIVATE_KEY, COMPARE_COMMITS_EXAMPLE, REPO, COMMIT_CHANGELIST_EXAMPLE
 
 
 class BitbucketServerRepositoryProviderTest(APITestCase):
@@ -66,16 +66,27 @@ class BitbucketServerRepositoryProviderTest(APITestCase):
             json=COMPARE_COMMITS_EXAMPLE,
         )
 
+        responses.add(
+            responses.GET,
+            "https://bitbucket.example.com/rest/api/1.0/projects/sentryuser/repos/newsdiffs/commits/e18e4e72de0d824edfbe0d73efe34cbd0d01d301/changes",
+            json=COMMIT_CHANGELIST_EXAMPLE,
+        )
+
         res = self.provider.compare_commits(repo, None, "e18e4e72de0d824edfbe0d73efe34cbd0d01d301")
 
         assert res == [
             {
                 "author_email": "sentryuser@getsentry.com",
-                "author_name": "Sentry User",
+                "author_name": "SentryU",
                 "message": "README.md edited online with Bitbucket",
                 "id": "e18e4e72de0d824edfbe0d73efe34cbd0d01d301",
                 "repository": "sentryuser/newsdiffs",
-                "patch_set": None,
+                "patch_set": [
+                    {
+                        "path": "a.txt",
+                        "type": "M"
+                    }
+                ],
                 "timestamp": datetime.datetime(2019, 12, 19, 13, 56, 56, tzinfo=timezone.utc),
             }
         ]

--- a/tests/sentry/integrations/bitbucket_server/test_repository.py
+++ b/tests/sentry/integrations/bitbucket_server/test_repository.py
@@ -85,6 +85,22 @@ class BitbucketServerRepositoryProviderTest(APITestCase):
                     {
                         "path": "a.txt",
                         "type": "M"
+                    },
+                    {
+                        "path": "b.txt",
+                        "type": "A"
+                    },
+                    {
+                        "path": "c.txt",
+                        "type": "D"
+                    },
+                    {
+                        "path": "e.txt",
+                        "type": "D"
+                    },
+                    {
+                        "path": "d.txt",
+                        "type": "A"
                     }
                 ],
                 "timestamp": datetime.datetime(2019, 12, 19, 13, 56, 56, tzinfo=timezone.utc),

--- a/tests/sentry/integrations/bitbucket_server/testutils.py
+++ b/tests/sentry/integrations/bitbucket_server/testutils.py
@@ -91,16 +91,16 @@ COMMIT_CHANGELIST_EXAMPLE = {
             "path": {
                 "components": ["e.txt"],
                 "parent": "",
-                "name": "e.txt",
+                "name": "d.txt",
                 "extension": "txt",
-                "toString": "e.txt"
+                "toString": "d.txt"
             },
             "srcPath": {
                 "components": ["d.txt"],
                 "parent": "",
-                "name": "d.txt",
+                "name": "e.txt",
                 "extension": "txt",
-                "toString": "d.txt"
+                "toString": "e.txt"
             },
             "executable": False,
             "percentUnchanged": -1,

--- a/tests/sentry/integrations/bitbucket_server/testutils.py
+++ b/tests/sentry/integrations/bitbucket_server/testutils.py
@@ -52,6 +52,64 @@ COMMIT_CHANGELIST_EXAMPLE = {
             "properties": {
                 "gitChangeType": "MODIFY"
             }
+        },
+        {
+            "path": {
+                "components": ["b.txt"],
+                "parent": "",
+                "name": "b.txt",
+                "extension": "txt",
+                "toString": "b.txt"
+            },
+            "executable": False,
+            "percentUnchanged": -1,
+            "type": "ADD",
+            "nodeType": "FILE",
+            "srcExecutable": False,
+            "properties": {
+                "gitChangeType": "ADD"
+            }
+        },
+        {
+            "path": {
+                "components": ["c.txt"],
+                "parent": "",
+                "name": "c.txt",
+                "extension": "txt",
+                "toString": "c.txt"
+            },
+            "executable": False,
+            "percentUnchanged": -1,
+            "type": "DELETE",
+            "nodeType": "FILE",
+            "srcExecutable": False,
+            "properties": {
+                "gitChangeType": "DELETE"
+            }
+        },
+        {
+            "path": {
+                "components": ["e.txt"],
+                "parent": "",
+                "name": "e.txt",
+                "extension": "txt",
+                "toString": "e.txt"
+            },
+            "srcPath": {
+                "components": ["d.txt"],
+                "parent": "",
+                "name": "d.txt",
+                "extension": "txt",
+                "toString": "d.txt"
+            },
+            "executable": False,
+            "percentUnchanged": -1,
+            "type": "MOVE",
+            "nodeType": "FILE",
+            "srcExecutable": False,
+            "properties": {
+                "gitChangeType": "MOVE"
+            }
         }
     ]
 }

--- a/tests/sentry/integrations/bitbucket_server/testutils.py
+++ b/tests/sentry/integrations/bitbucket_server/testutils.py
@@ -34,6 +34,28 @@ COMPARE_COMMITS_EXAMPLE = {
     ]
 }
 
+COMMIT_CHANGELIST_EXAMPLE = {
+    "values": [
+        {
+            "path": {
+                "components": ["a.txt"],
+                "parent": "",
+                "name": "a.txt",
+                "extension": "txt",
+                "toString": "a.txt"
+            },
+            "executable": False,
+            "percentUnchanged": -1,
+            "type": "MODIFY",
+            "nodeType": "FILE",
+            "srcExecutable": False,
+            "properties": {
+                "gitChangeType": "MODIFY"
+            }
+        }
+    ]
+}
+
 REPO = {
     u"slug": u"helloworld",
     u"id": 72,


### PR DESCRIPTION
After doing some more testing on the Bitbucket Server integration, I realised that the author display name is not always set, which causes the `compare_commits` call to fail (This might also be the cause for #17398).

So this PR updates the integration to use `name` instead of `displayName`, which will always be available.

It also add the following improvements:

* If `start_sha` is empty, fetch the latest commits from the repository, which is also consistent with the Bitbucket and Github integrations
* Get the changed files for the commit in order to populate the `patch_set`

/cc @scefali 