### PR TITLE
fix(integration): Remove URL validator from jira server and bitbucket server

### DIFF
--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -6,7 +6,6 @@ import six
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.backends import default_backend
 from django import forms
-from django.core.validators import URLValidator
 from django.views.decorators.csrf import csrf_exempt
 from sentry.integrations import (
     IntegrationFeatures,
@@ -77,7 +76,6 @@ class InstallationForm(forms.Form):
             "The base URL for your Bitbucket Server instance, including the host and protocol."
         ),
         widget=forms.TextInput(attrs={"placeholder": "https://bitbucket.example.com"}),
-        validators=[URLValidator()],
     )
     verify_ssl = forms.BooleanField(
         label=_("Verify SSL"),

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -7,7 +7,6 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.backends import default_backend
 from django import forms
 from django.core.urlresolvers import reverse
-from django.core.validators import URLValidator
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
 from six.moves.urllib.parse import urlparse
@@ -86,7 +85,6 @@ class InstallationForm(forms.Form):
         label=_("Jira URL"),
         help_text=_("The base URL for your Jira Server instance, including the host and protocol."),
         widget=forms.TextInput(attrs={"placeholder": "https://jira.example.com"}),
-        validators=[URLValidator()],
     )
     verify_ssl = forms.BooleanField(
         label=_("Verify SSL"),

--- a/tests/sentry/integrations/bitbucket_server/test_integration.py
+++ b/tests/sentry/integrations/bitbucket_server/test_integration.py
@@ -22,22 +22,6 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, "Submit</button>")
 
     @responses.activate
-    def test_validate_url(self):
-        # Start pipeline and go to setup page.
-        self.client.get(self.setup_path)
-
-        # Submit credentials
-        data = {
-            "url": "bitbucket.example.com/",
-            "verify_ssl": False,
-            "consumer_key": "sentry-bot",
-            "private_key": EXAMPLE_PRIVATE_KEY,
-        }
-        resp = self.client.post(self.setup_path, data=data)
-        assert resp.status_code == 200
-        self.assertContains(resp, "Enter a valid URL")
-
-    @responses.activate
     def test_validate_private_key(self):
         responses.add(
             responses.POST,

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -24,22 +24,6 @@ class JiraServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, "Submit</button>")
 
     @responses.activate
-    def test_validate_url(self):
-        # Start pipeline and go to setup page.
-        self.client.get(self.setup_path)
-
-        # Submit credentials
-        data = {
-            "url": "jira.example.com/",
-            "verify_ssl": False,
-            "consumer_key": "sentry-bot",
-            "private_key": EXAMPLE_PRIVATE_KEY,
-        }
-        resp = self.client.post(self.setup_path, data=data)
-        assert resp.status_code == 200
-        self.assertContains(resp, "Enter a valid URL")
-
-    @responses.activate
     def test_validate_private_key(self):
         responses.add(
             responses.POST,


### PR DESCRIPTION
The Jira and Bitbucket Server integrations are the only ones using a URL validator, while none of the other on-premise integrations validates the url (gitlab, Github enterprise). This means Jira and Bitbucket server can't be used without using a FQDN. This PR proposes to remove these validators to be more consistent with the other implementations and allow using basic DNS names for the URL.

Fixes #17376