### PR TITLE
fix(ui): updated event context comps display logic

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contexts.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts.jsx
@@ -123,14 +123,16 @@ class ContextChunk extends React.Component {
     }
 
     const evt = this.props.event;
-    const {type, alias, value} = this.props;
+    const {type, alias, value = {}} = this.props;
     const Component =
       type === 'default'
         ? getContextComponent(alias) || getContextComponent(type)
         : getContextComponent(type);
 
+    const isObjectValueEmpty = Object.values(value).filter(v => defined(v)).length === 0;
+
     // this can happen if the component does not exist
-    if (!Component) {
+    if (!Component || isObjectValueEmpty) {
       return null;
     }
 

--- a/src/sentry/static/sentry/app/components/events/contexts/app/app.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/app/app.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 
 import ContextBlock from 'app/components/events/contexts/contextBlockV2';
-import {defined} from 'app/utils';
 
 import getAppKnownData from './getAppKnownData';
 import {AppData, AppKnownDataType} from './types';
 
 type Props = {
-  data?: AppData;
+  data: AppData;
 };
 
 const appKnownDataValues = [
@@ -20,13 +19,9 @@ const appKnownDataValues = [
   AppKnownDataType.BUILD,
 ];
 
-const App = ({data}: Props) => {
-  if (!defined(data)) {
-    return null;
-  }
-
-  return <ContextBlock knownData={getAppKnownData(data, appKnownDataValues)} />;
-};
+const App = ({data}: Props) => (
+  <ContextBlock knownData={getAppKnownData(data, appKnownDataValues)} />
+);
 
 App.getTitle = () => 'App';
 

--- a/src/sentry/static/sentry/app/components/events/contexts/device/device.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device/device.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 
 import ContextBlock from 'app/components/events/contexts/contextBlockV2';
-import {defined} from 'app/utils';
 
 import {DeviceData, DeviceKnownDataType} from './types';
 import getDeviceKnownData from './getDeviceKnownData';
 
 type Props = {
-  data?: DeviceData;
+  data: DeviceData;
 };
 
 const deviceKnownDataValues = [
@@ -41,13 +40,9 @@ const deviceKnownDataValues = [
   DeviceKnownDataType.SCREEN_WIDTH_PIXELS,
 ];
 
-const Device = ({data}: Props) => {
-  if (!defined(data)) {
-    return null;
-  }
-
-  return <ContextBlock knownData={getDeviceKnownData(data, deviceKnownDataValues)} />;
-};
+const Device = ({data}: Props) => (
+  <ContextBlock knownData={getDeviceKnownData(data, deviceKnownDataValues)} />
+);
 
 Device.getTitle = () => 'Device';
 

--- a/src/sentry/static/sentry/app/components/events/contexts/gpu/gpu.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/gpu/gpu.tsx
@@ -6,7 +6,7 @@ import getOperatingSystemKnownData from './getGPUKnownData';
 import {GPUData, GPUKnownDataType} from './types';
 
 type Props = {
-  data?: GPUData;
+  data: GPUData;
 };
 
 const gpuKnownDataValues = [
@@ -20,10 +20,6 @@ const gpuKnownDataValues = [
 ];
 
 const GPU = ({data}: Props) => {
-  if (data === undefined || data === null) {
-    return null;
-  }
-
   if (data.vendor_id > 0) {
     gpuKnownDataValues.unshift[GPUKnownDataType.VENDOR_ID];
   }

--- a/src/sentry/static/sentry/app/components/events/contexts/operatingSystem/operatingSystem.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/operatingSystem/operatingSystem.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 
-import {defined} from 'app/utils';
 import ContextBlock from 'app/components/events/contexts/contextBlockV2';
 
 import getOperatingSystemKnownData from './getOperatingSystemKnownData';
 import {OperatingSystemKnownData, OperatingSystemKnownDataType} from './types';
 
 type Props = {
-  data?: OperatingSystemKnownData;
+  data: OperatingSystemKnownData;
 };
 
 const operatingSystemKnownDataValues = [
@@ -17,17 +16,11 @@ const operatingSystemKnownDataValues = [
   OperatingSystemKnownDataType.ROOTED,
 ];
 
-const OperatingSystem = ({data}: Props) => {
-  if (!defined(data)) {
-    return null;
-  }
-
-  return (
-    <ContextBlock
-      knownData={getOperatingSystemKnownData(data, operatingSystemKnownDataValues)}
-    />
-  );
-};
+const OperatingSystem = ({data}: Props) => (
+  <ContextBlock
+    knownData={getOperatingSystemKnownData(data, operatingSystemKnownDataValues)}
+  />
+);
 
 OperatingSystem.getTitle = () => 'Operating System';
 

--- a/src/sentry/static/sentry/app/components/events/contexts/runtime/runtime.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/runtime/runtime.tsx
@@ -1,24 +1,19 @@
 import React from 'react';
 
 import ContextBlock from 'app/components/events/contexts/contextBlockV2';
-import {defined} from 'app/utils';
 
 import getRuntimeKnownData from './getRuntimeKnownData';
 import {RuntimeData, RuntimeKnownDataType} from './types';
 
 type Props = {
-  data?: RuntimeData;
+  data: RuntimeData;
 };
 
 const runTimerKnownDataValues = [RuntimeKnownDataType.NAME, RuntimeKnownDataType.VERSION];
 
-const Runtime = ({data}: Props) => {
-  if (!defined(data)) {
-    return null;
-  }
-
-  return <ContextBlock knownData={getRuntimeKnownData(data, runTimerKnownDataValues)} />;
-};
+const Runtime = ({data}: Props) => (
+  <ContextBlock knownData={getRuntimeKnownData(data, runTimerKnownDataValues)} />
+);
 
 Runtime.getTitle = () => 'Runtime';
 

--- a/src/sentry/static/sentry/app/components/events/contexts/user/user.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/user/user.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 type Data = {
-  data?: null | {[key: string]: string};
+  data: {[key: string]: string};
 } & UserType;
 
 const userKnownDataValues = [
@@ -28,10 +28,6 @@ const userKnownDataValues = [
 ];
 
 const User = ({data}: Props) => {
-  if (!defined(data)) {
-    return null;
-  }
-
   const getKeyValueData = (val: object) => Object.keys(val).map(key => [key, val[key]]);
 
   return (


### PR DESCRIPTION
**Description:**

we were rendering  a` <EventDataSection> `component, even if  the value (the content data) had only null values. Consequence: Only the section title was being displayed.

This PR fixes the issue 😉

closes https://app.asana.com/0/1158284503473033/1164152859647417