### PR TITLE
fix(workflow): Fix Alert Rules query filter always updating `defaultQuery`

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -111,15 +111,14 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
           <FormField
             name="query"
             label={t('Filter')}
-            defaultValue=""
             placeholder="error.type:TypeError"
             help={t(
               'You can apply standard Sentry filter syntax to filter by status, user, etc.'
             )}
           >
-            {({onChange, onBlur, onKeyDown, value}) => (
+            {({onChange, onBlur, onKeyDown, initialData}) => (
               <SearchBar
-                defaultQuery={value}
+                defaultQuery={initialData?.query ?? ''}
                 disabled={disabled}
                 useFormWrapper={false}
                 organization={organization}


### PR DESCRIPTION
This fixes a bug where `<SearchBar>` was being re-rendered with updated defaultQuery == current query value, when it
is supposed to be loaded once with the saved query value. This was causing the tags search list to not be filtered down and updated properly.