### PR TITLE
feat(ui): added component ExceptionStacktraceContent

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
@@ -28,11 +28,7 @@ class ExceptionContent extends React.Component {
         </h5>
 
         <Annotated object={exc} objectKey="value" required>
-          {value => (
-            <StyledPre className="exc-message" style={{marginTop: 0}}>
-              {value}
-            </StyledPre>
-          )}
+          {value => <StyledPre className="exc-message">{value}</StyledPre>}
         </Annotated>
 
         {exc.mechanism && (
@@ -69,4 +65,5 @@ export default ExceptionContent;
 
 const StyledPre = styled('pre')`
   margin-bottom: ${space(1)};
+  margin-top: 0;
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionContent.jsx
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from '@emotion/styled';
 
-import {defined} from 'app/utils';
+import space from 'app/styles/space';
 import Annotated from 'app/components/events/meta/annotated';
 import ExceptionMechanism from 'app/components/events/interfaces/exceptionMechanism';
-import StacktraceContent from 'app/components/events/interfaces/stacktraceContent';
 import SentryTypes from 'app/sentryTypes';
+
+import ExceptionStacktraceContent from './exceptionStacktraceContent';
 
 class ExceptionContent extends React.Component {
   static propTypes = {
@@ -27,33 +29,33 @@ class ExceptionContent extends React.Component {
 
         <Annotated object={exc} objectKey="value" required>
           {value => (
-            <pre className="exc-message" style={{marginTop: 0}}>
+            <StyledPre className="exc-message" style={{marginTop: 0}}>
               {value}
-            </pre>
+            </StyledPre>
           )}
         </Annotated>
 
         {exc.mechanism && (
           <ExceptionMechanism data={exc.mechanism} platform={this.props.platform} />
         )}
-        {defined(exc.stacktrace) && (
-          <StacktraceContent
-            data={
-              this.props.type === 'original'
-                ? exc.stacktrace
-                : exc.rawStacktrace || exc.stacktrace
-            }
-            expandFirstFrame={
-              platform === 'csharp' ? excIdx === values.length - 1 : excIdx === 0
-            }
-            includeSystemFrames={stackView === 'full'}
-            platform={this.props.platform}
-            newestFirst={newestFirst}
-            event={event}
-          />
-        )}
+        <ExceptionStacktraceContent
+          data={
+            this.props.type === 'original'
+              ? exc.stacktrace
+              : exc.rawStacktrace || exc.stacktrace
+          }
+          stackView={stackView}
+          stacktrace={exc.stacktrace}
+          expandFirstFrame={
+            platform === 'csharp' ? excIdx === values.length - 1 : excIdx === 0
+          }
+          platform={this.props.platform}
+          newestFirst={newestFirst}
+          event={event}
+        />
       </div>
     ));
+
     if (newestFirst) {
       children.reverse();
     }
@@ -64,3 +66,7 @@ class ExceptionContent extends React.Component {
 }
 
 export default ExceptionContent;
+
+const StyledPre = styled('pre')`
+  margin-bottom: ${space(1)};
+`;

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionStacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionStacktraceContent.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import {Frame, PlatformType} from 'app/components/events/interfaces/frame/types';
+import {defined} from 'app/utils';
+import StacktraceContent from 'app/components/events/interfaces/stacktraceContent';
+import {Panel} from 'app/components/panels';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import SentryTypes from 'app/sentryTypes';
+
+type StackViewType = 'app' | 'full' | 'raw';
+
+type Stacktrace = {
+  frames: Array<Frame>;
+  hasSystemFrames: boolean;
+  registers: {[key: string]: string} | null;
+  framesOmitted: any;
+};
+
+type Props = {
+  stackView: StackViewType;
+  data: Stacktrace | null;
+  event: SentryTypes.Event;
+  platform: PlatformType;
+  expandFirstFrame?: boolean;
+  newestFirst?: boolean;
+  stacktrace: Stacktrace;
+};
+
+const ExceptionStacktraceContent = ({
+  stackView,
+  stacktrace,
+  platform,
+  newestFirst,
+  data,
+  expandFirstFrame,
+  event,
+}: Props) => {
+  if (!defined(stacktrace)) {
+    return null;
+  }
+
+  if (
+    stackView === 'app' &&
+    stacktrace.frames.filter(frame => frame.inApp).length === 0
+  ) {
+    return (
+      <Panel dashedBorder>
+        <EmptyMessage
+          icon="icon-warning-sm"
+          title="No app only stacktrace has been found!"
+        />
+      </Panel>
+    );
+  }
+
+  return (
+    <StacktraceContent
+      data={data}
+      expandFirstFrame={expandFirstFrame}
+      includeSystemFrames={stackView === 'full'}
+      platform={platform}
+      newestFirst={newestFirst}
+      event={event}
+    />
+  );
+};
+
+export default ExceptionStacktraceContent;

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/types.tsx
@@ -3,6 +3,12 @@ export type PlatformType = 'java' | 'csharp' | 'other';
 export type Frame = {
   filename: string;
   module: string;
+  map: string;
+  preventCollapse: () => void;
+  errors: Array<any>;
+  context: Array<[number, string]>;
+  vars: {[key: string]: any};
+  inApp: boolean;
   function?: string;
   absPath?: string;
   rawFunction?: string;
@@ -12,9 +18,4 @@ export type Frame = {
   package?: string;
   origAbsPath?: string;
   mapUrl?: string;
-  map: string;
-  preventCollapse: () => void;
-  errors: Array<any>;
-  context: Array<[number, string]>;
-  vars: {[key: string]: any};
 };

--- a/tests/js/spec/components/events/__snapshots__/crashContent.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/crashContent.spec.jsx.snap
@@ -111,7 +111,7 @@ exports[`CrashContent renders with meta data 1`] = `
               <ErrorBoundary
                 mini={true}
               >
-                <pre
+                <StyledPre
                   className="exc-message"
                   style={
                     Object {
@@ -119,69 +119,78 @@ exports[`CrashContent renders with meta data 1`] = `
                     }
                   }
                 >
-                  <AnnotatedText
-                    chunks={Array []}
-                    errors={Array []}
-                    remarks={
-                      Array [
-                        Array [
-                          "device_id",
-                          "p",
-                          11,
-                          51,
-                        ],
-                      ]
+                  <pre
+                    className="exc-message css-16m13pv-StyledPre e1rxtykr0"
+                    style={
+                      Object {
+                        "marginTop": 0,
+                      }
                     }
-                    value="python err A949AE01EBB07300D62AE0178F0944DD21F8C98C err"
                   >
-                    <span>
-                      <Tooltip
-                        containerDisplayMode="inline-block"
-                        position="top"
-                        title="Pseudonymized because of PII rule \\"device_id\\""
-                      >
-                        <Manager>
-                          <Reference>
-                            <InnerReference
-                              setReferenceNode={[Function]}
-                            >
-                              <Container
-                                aria-describedby="tooltip-123456"
-                                containerDisplayMode="inline-block"
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                onMouseEnter={[Function]}
-                                onMouseLeave={[Function]}
+                    <AnnotatedText
+                      chunks={Array []}
+                      errors={Array []}
+                      remarks={
+                        Array [
+                          Array [
+                            "device_id",
+                            "p",
+                            11,
+                            51,
+                          ],
+                        ]
+                      }
+                      value="python err A949AE01EBB07300D62AE0178F0944DD21F8C98C err"
+                    >
+                      <span>
+                        <Tooltip
+                          containerDisplayMode="inline-block"
+                          position="top"
+                          title="Pseudonymized because of PII rule \\"device_id\\""
+                        >
+                          <Manager>
+                            <Reference>
+                              <InnerReference
+                                setReferenceNode={[Function]}
                               >
-                                <span
+                                <Container
                                   aria-describedby="tooltip-123456"
-                                  className="css-sce1yi-Container eowlwvy0"
+                                  containerDisplayMode="inline-block"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
-                                  <Redaction>
-                                    <span
-                                      className="css-1vnqw28-Redaction e1p1th7g1"
-                                    >
-                                      python err A949AE01EBB07300D62AE0178F0944DD21F8C98C err
-                                    </span>
-                                  </Redaction>
-                                </span>
-                              </Container>
-                            </InnerReference>
-                          </Reference>
-                        </Manager>
-                      </Tooltip>
-                       
-                    </span>
-                  </AnnotatedText>
-                </pre>
+                                  <span
+                                    aria-describedby="tooltip-123456"
+                                    className="css-sce1yi-Container eowlwvy0"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    <Redaction>
+                                      <span
+                                        className="css-1vnqw28-Redaction e1p1th7g1"
+                                      >
+                                        python err A949AE01EBB07300D62AE0178F0944DD21F8C98C err
+                                      </span>
+                                    </Redaction>
+                                  </span>
+                                </Container>
+                              </InnerReference>
+                            </Reference>
+                          </Manager>
+                        </Tooltip>
+                         
+                      </span>
+                    </AnnotatedText>
+                  </pre>
+                </StyledPre>
               </ErrorBoundary>
             </MetaData>
           </Annotated>
-          <StacktraceContent
+          <ExceptionStacktraceContent
             data={
               Object {
                 "frames": Array [],
@@ -199,15 +208,42 @@ exports[`CrashContent renders with meta data 1`] = `
               }
             }
             expandFirstFrame={true}
-            includeSystemFrames={true}
             newestFirst={true}
+            stackView="full"
+            stacktrace={
+              Object {
+                "frames": Array [],
+              }
+            }
           >
-            <div
-              className=" traceback full-traceback"
+            <StacktraceContent
+              data={
+                Object {
+                  "frames": Array [],
+                }
+              }
+              event={
+                Object {
+                  "dateCreated": "2019-05-21T18:01:48.762Z",
+                  "eventID": "12345678901234567890123456789012",
+                  "groupID": "1",
+                  "id": "1",
+                  "message": "ApiException",
+                  "tags": Array [],
+                  "title": "ApiException",
+                }
+              }
+              expandFirstFrame={true}
+              includeSystemFrames={true}
+              newestFirst={true}
             >
-              <ul />
-            </div>
-          </StacktraceContent>
+              <div
+                className=" traceback full-traceback"
+              >
+                <ul />
+              </div>
+            </StacktraceContent>
+          </ExceptionStacktraceContent>
         </div>
       </div>
     </ExceptionContent>

--- a/tests/js/spec/components/events/__snapshots__/crashContent.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/crashContent.spec.jsx.snap
@@ -113,19 +113,9 @@ exports[`CrashContent renders with meta data 1`] = `
               >
                 <StyledPre
                   className="exc-message"
-                  style={
-                    Object {
-                      "marginTop": 0,
-                    }
-                  }
                 >
                   <pre
-                    className="exc-message css-16m13pv-StyledPre e1rxtykr0"
-                    style={
-                      Object {
-                        "marginTop": 0,
-                      }
-                    }
+                    className="exc-message css-1q8nviw-StyledPre e1rxtykr0"
                   >
                     <AnnotatedText
                       chunks={Array []}


### PR DESCRIPTION
Description:

When all the flags `frame.inApp` are false, we don't display a proper content, but something like:

![image](https://user-images.githubusercontent.com/29228205/75713898-8d554880-5c7f-11ea-91e3-dd09c382c39f.png)

Now, we will display a warning, informing the user that no stacktrace was found in the application. Please see below:

![image](https://user-images.githubusercontent.com/29228205/75713827-6e56b680-5c7f-11ea-8ad1-dcfe10744e23.png)

#closes https://app.asana.com/0/1158284503473033/1163633389300945