### PR TITLE
fix(ui): Move event cause empty to per organization

### DIFF
--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -14,7 +14,7 @@ from sentry.utils.compat import zip
 
 PROMPTS = {
     "releases": {"required_fields": ["organization_id", "project_id"]},
-    "suspect_commits": {"required_fields": ["organization_id", "project_id"]},
+    "suspect_commits": {"required_fields": ["organization_id"]},
 }
 
 VALID_STATUSES = frozenset(("snoozed", "dismissed"))

--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -65,11 +65,10 @@ class EventCauseEmpty extends React.Component {
   }
 
   async fetchData() {
-    const {api, project, organization} = this.props;
+    const {api, organization} = this.props;
 
     const data = await api.requestPromise('/promptsactivity/', {
       query: {
-        project_id: project.id,
         organization_id: organization.id,
         feature: 'suspect_commits',
       },
@@ -157,7 +156,6 @@ class EventCauseEmpty extends React.Component {
                   {t('Snooze')}
                 </SnoozeButton>
                 <DismissButton
-                  title={t('Dismiss for this project')}
                   size="small"
                   onClick={() =>
                     this.handleClick({

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupUserFeedback.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupUserFeedback.jsx
@@ -2,13 +2,14 @@ import React from 'react';
 import isEqual from 'lodash/isEqual';
 
 import SentryTypes from 'app/sentryTypes';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
 import EventUserFeedback from 'app/components/events/userFeedback';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {Panel} from 'app/components/panels';
 import Pagination from 'app/components/pagination';
+import {t} from 'app/locale';
 import withOrganization from 'app/utils/withOrganization';
-import UserFeedbackEmpty from 'app/views/userFeedback/userFeedbackEmpty';
 
 import {fetchGroupUserReports} from './utils';
 
@@ -91,7 +92,9 @@ class GroupUserFeedback extends React.Component {
 
     return (
       <Panel>
-        <UserFeedbackEmpty projectIds={[group.project.id]} />
+        <EmptyStateWarning>
+          <p>{t('No user reports have been collected.')}</p>
+        </EmptyStateWarning>
       </Panel>
     );
   }


### PR DESCRIPTION
- Dismiss event cause empty state per organization instead of per project
- Remove empty state from group user feedback, since it's on organization user feedback