### PR TITLE
fix(ui): Add width/height to mini loading indicator

### DIFF
--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -608,6 +608,8 @@ table.table.key-value {
 .loading.mini {
   margin: 4px 0;
   font-size: 13px;
+  width: 24px;
+  height: 24px;
 
   .loading-indicator {
     margin: 0;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -608,7 +608,6 @@ table.table.key-value {
 .loading.mini {
   margin: 4px 0;
   font-size: 13px;
-  width: 24px;
   height: 24px;
 
   .loading-indicator {


### PR DESCRIPTION
Otherwise, the loader can have wrong dimensions