### PR TITLE
fix(discover) Improve table resizing behavior

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -341,7 +341,9 @@ class GridEditable<
 
     // The last column has no resizer and should always be a flexible column
     // to prevent underflows.
-    widths[widths.length - 1] = `minmax(${COL_WIDTH_MINIMUM}px, auto)`;
+    if (widths.length > 0) {
+      widths[widths.length - 1] = `minmax(${COL_WIDTH_MINIMUM}px, auto)`;
+    }
 
     grid.style.gridTemplateColumns = `${prepend} ${widths.join(' ')}`;
   }

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -320,14 +320,13 @@ export const GridBodyCellStatus = props => (
  * We have a fat GridResizer and we use the ::after pseudo-element to draw
  * a thin 1px border.
  *
- * The right-most GridResizer has a width of 2px and no right padding to make it
- * more obvious as it is usually sitting next to the border for <Panel>
+ * The right most cell does not have a resizer as resizing from that side does strange things.
  */
-export const GridResizer = styled('div')<{dataRows: number; isLast?: boolean}>`
+export const GridResizer = styled('div')<{dataRows: number}>`
   position: absolute;
   top: 0px;
-  right: ${p => (p.isLast ? '0px' : '-5px')};
-  width: ${p => (p.isLast ? '6px' : '9px')};
+  right: -6px;
+  width: 11px;
 
   height: ${p => {
     const numOfRows = p.dataRows;
@@ -341,8 +340,8 @@ export const GridResizer = styled('div')<{dataRows: number; isLast?: boolean}>`
     return height;
   }}px;
 
-  padding-left: 4px;
-  padding-right: ${p => (p.isLast ? '0px' : '4px')};
+  padding-left: 5px;
+  padding-right: 5px;
 
   cursor: col-resize;
   z-index: ${Z_INDEX_GRID_RESIZER};


### PR DESCRIPTION
Improve the resizing of the results table in a few ways:

* The last column is now always set to auto-fill. This prevents
  underflow situations where a query with narrow columns is loaded into
  a wider screen. It also prevents results from being resized so that
  they don't fill 100% of the available space.
* Fixed the active state of the resize bar in firefox. Preventing the
  default there stops the `:active` style from being applied.
* Made the resize bar hit area 1px wider on each side.
* Double clicking the resize handle will convert a column to auto-fill
  making it easier to get back to an auto layout table.