### PR TITLE
fix(discover) - Project is now a name instead of an id

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -319,12 +319,7 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
     fields: headings,
     data: data.map(row =>
       headings.map(col => {
-        // alias for project doesn't match the table data name
-        if (col === 'project') {
-          col = 'project.name';
-        } else {
-          col = getAggregateAlias(col);
-        }
+        col = getAggregateAlias(col);
         return disableMacros(row[col]);
       })
     ),
@@ -486,7 +481,7 @@ export function getExpandedResults(
 
   // Add additional conditions provided and generated.
   for (const key in additionalConditions) {
-    if (key === 'project' || key === 'project.id') {
+    if (key === 'project.id') {
       nextView.project = [...nextView.project, parseInt(additionalConditions[key], 10)];
       continue;
     }
@@ -497,6 +492,10 @@ export function getExpandedResults(
     const column = explodeFieldString(key);
     // Skip aggregates as they will be invalid.
     if (column.aggregation) {
+      continue;
+    }
+    // Skip project name
+    if (key === 'project' || key === 'project.name') {
       continue;
     }
     parsedQuery[key] = [additionalConditions[key]];

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -420,11 +420,8 @@ describe('getExpandedResults()', function() {
 
   it('applies project condition to project property', () => {
     const view = new EventView(state);
-    let result = getExpandedResults(view, {project: 1});
-    expect(result.query).toEqual('event.type:error');
-    expect(result.project).toEqual([42, 1]);
 
-    result = getExpandedResults(view, {'project.id': 1});
+    const result = getExpandedResults(view, {'project.id': 1});
     expect(result.query).toEqual('event.type:error');
     expect(result.project).toEqual([42, 1]);
   });


### PR DESCRIPTION
- This means that parseInt on the name will result in NaN
- This broke the csv export for projects, since it was using the wrong
  col name