### PR TITLE
fix(grid): Adding ellipsis on overflow

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -165,7 +165,7 @@ export const GridHeadCellButton = styled('div')<GridEditableProps>`
   text-transform: uppercase;
   user-select: none;
 
-  background-color: ${p => {
+  background: ${p => {
     if (p.isDragging) {
       return p.theme.purple;
     }
@@ -189,7 +189,8 @@ export const GridHeadCellButton = styled('div')<GridEditableProps>`
     return p.theme.gray3;
   }};
 
-  a {
+  a,
+  div {
     color: inherit;
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
* Ellipsis used to truncate (when there are data and header can be clicked to sort) ![image](https://user-images.githubusercontent.com/1748388/75727359-a539c600-5c99-11ea-8d26-c5b364d0da1e.png)

* No ellipsis (when there's no data and header is unclickable) ![image](https://user-images.githubusercontent.com/1748388/75727368-a8cd4d00-5c99-11ea-8365-df5e9c3da188.png)

This PR fixes the above. Additionally, I caught an invalid CSS rule (`background-color: none`).
