### PR TITLE
fix(ui): StackedBarChart Marker 24h display

### DIFF
--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -183,7 +183,8 @@ class StackedBarChart extends React.Component {
 
   timeLabelAsFull(point) {
     const timeMoment = moment(point.x * 1000);
-    return timeMoment.format('lll');
+    const format = this.use24Hours() ? 'MMM D, YYYY HH:mm' : 'lll';
+    return timeMoment.format(format);
   }
 
   getTimeLabel(point) {
@@ -209,7 +210,7 @@ class StackedBarChart extends React.Component {
   }
 
   renderMarker(marker, index, pointWidth) {
-    const timeLabel = moment(marker.x * 1000).format('lll');
+    const timeLabel = this.timeLabelAsFull(marker);
     const title = (
       <div style={{width: '130px'}}>
         {marker.label}

--- a/tests/js/spec/components/stackedBarChart.spec.jsx
+++ b/tests/js/spec/components/stackedBarChart.spec.jsx
@@ -61,4 +61,22 @@ describe('StackedBarChart', function() {
       expect(columns.at(2).text()).toEqual('last seen');
     });
   });
+  describe('functions', function() {
+    it('creates an AM/PM time label if use24Hours is disabled', function() {
+      const marker = {x: 1439776800, className: 'first-seen', label: 'first seen'};
+
+      const wrapper = shallow(<StackedBarChart />);
+      wrapper.instance().use24Hours = () => false;
+
+      expect(wrapper.instance().timeLabelAsFull(marker)).toMatch(/[A|P]M/);
+    });
+    it('creates a 24h time label if use24Hours is enabled', function() {
+      const marker = {x: 1439776800, className: 'first-seen', label: 'first seen'};
+
+      const wrapper = shallow(<StackedBarChart />);
+      wrapper.instance().use24Hours = () => true;
+
+      expect(wrapper.instance().timeLabelAsFull(marker)).not.toMatch(/[A|P]M/);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #16897
Addition on #4530

Fixes incorrect display of timestamp for markers in the StackedBarChart as described in #16897 when 24h time format was enabled.

- 24h option disabled stays the same:
<img width="337" alt="Screenshot 2020-03-03 at 12 36 14" src="https://user-images.githubusercontent.com/7622933/75777970-45095980-5d57-11ea-919b-f9825fb65427.png">


- 24h option enabled looks as follows:
<img width="337" alt="Screenshot 2020-03-03 at 12 35 20" src="https://user-images.githubusercontent.com/7622933/75777964-43d82c80-5d57-11ea-8ee3-45aa03bc42a5.png">

@getsentry/app-frontend