### PR TITLE
fix(workflow): Improved error handling of target identifier

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/header.tsx
@@ -68,6 +68,18 @@ export default class DetailsHeader extends React.Component<Props> {
   render() {
     const {hasIncidentDetailsError, incident, params, onSubscriptionChange} = this.props;
     const isIncidentReady = !!incident && !hasIncidentDetailsError;
+    const eventLink = incident
+      ? {
+          pathname: `/organizations/${params.orgId}/events/`,
+
+          // Note we don't have project selector on here so there should be
+          // no query params to forward
+          query: {
+            group: incident.groups,
+          },
+        }
+      : '';
+
     const dateStarted = incident && moment(incident.dateStarted).format('LL');
     const duration =
       incident &&
@@ -126,6 +138,9 @@ export default class DetailsHeader extends React.Component<Props> {
             {incident && (
               <ItemValue>
                 <Count value={incident.totalEvents} />
+                <OpenLink to={eventLink}>
+                  <InlineSvg src="icon-open" size="14" />
+                </OpenLink>
               </ItemValue>
             )}
             {incident && (

--- a/src/sentry/static/sentry/app/views/alerts/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/header.tsx
@@ -68,18 +68,6 @@ export default class DetailsHeader extends React.Component<Props> {
   render() {
     const {hasIncidentDetailsError, incident, params, onSubscriptionChange} = this.props;
     const isIncidentReady = !!incident && !hasIncidentDetailsError;
-    const eventLink = incident
-      ? {
-          pathname: `/organizations/${params.orgId}/events/`,
-
-          // Note we don't have project selector on here so there should be
-          // no query params to forward
-          query: {
-            group: incident.groups,
-          },
-        }
-      : '';
-
     const dateStarted = incident && moment(incident.dateStarted).format('LL');
     const duration =
       incident &&
@@ -138,9 +126,6 @@ export default class DetailsHeader extends React.Component<Props> {
             {incident && (
               <ItemValue>
                 <Count value={incident.totalEvents} />
-                <OpenLink to={eventLink}>
-                  <InlineSvg src="icon-open" size="14" />
-                </OpenLink>
               </ItemValue>
             )}
             {incident && (

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -13,7 +13,7 @@ from sentry.incidents.endpoints.serializers import (
     string_to_action_type,
     string_to_action_target_type,
 )
-from sentry.incidents.logic import create_alert_rule_trigger, InvalidTriggerActionError
+from sentry.incidents.logic import create_alert_rule_trigger
 from sentry.incidents.models import (
     AlertRule,
     AlertRuleThresholdType,
@@ -449,5 +449,5 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
         )
         serializer = AlertRuleTriggerActionSerializer(context=self.context, data=base_params)
         assert serializer.is_valid()
-        with self.assertRaises(InvalidTriggerActionError):
+        with self.assertRaises(serializers.ValidationError):
             serializer.save()

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -219,7 +219,7 @@ class TestAlertRuleSerializer(TestCase):
 
     def test_invalid_slack_channel(self):
         # We had an error where an invalid slack channel was spitting out unclear
-        # error for the user, and CREATING THE RUEL. So the next save (after fixing slack action)
+        # error for the user, and CREATING THE RULE. So the next save (after fixing slack action)
         # says "Name already in use". This test makes sure that is not happening anymore.
         # We save a rule with an invalid slack, make sure we get back a useful error
         # and that the rule is not created.

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import six
 from exam import fixture
+from rest_framework import serializers
 
 from sentry.auth.access import from_user
 from sentry.incidents.endpoints.serializers import (
@@ -14,6 +15,7 @@ from sentry.incidents.endpoints.serializers import (
 )
 from sentry.incidents.logic import create_alert_rule_trigger, InvalidTriggerActionError
 from sentry.incidents.models import (
+    AlertRule,
     AlertRuleThresholdType,
     AlertRuleTriggerAction,
     AlertRuleEnvironment,
@@ -214,6 +216,46 @@ class TestAlertRuleSerializer(TestCase):
         serializer = AlertRuleSerializer(context=self.context, data=payload, partial=True)
 
         assert serializer.is_valid(), serializer.errors
+
+    def test_invalid_slack_channel(self):
+        # We had an error where an invalid slack channel was spitting out unclear
+        # error for the user, and CREATING THE RUEL. So the next save (after fixing slack action)
+        # says "Name already in use". This test makes sure that is not happening anymore.
+        # We save a rule with an invalid slack, make sure we get back a useful error
+        # and that the rule is not created.
+        base_params = self.valid_params.copy()
+        base_params["name"] = "Aun1qu3n4m3"
+        integration = Integration.objects.create(
+            external_id="1",
+            provider="slack",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
+        integration.add_organization(self.organization, self.user)
+        base_params["triggers"][0]["actions"].append(
+            {
+                "type": AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.SLACK
+                ).slug,
+                "targetType": action_target_type_to_string[
+                    AlertRuleTriggerAction.TargetType.SPECIFIC
+                ],
+                "targetIdentifier": "123",
+                "integration": six.text_type(integration.id),
+            }
+        )
+        serializer = AlertRuleSerializer(context=self.context, data=base_params)
+        assert serializer.is_valid()
+        with self.assertRaises(serializers.ValidationError):
+            serializer.save()
+
+        # Make sure the rule was not created.
+        assert len(list(AlertRule.objects.filter(name="Aun1qu3n4m3"))) == 0
+
+        # Make sure the action was not created.
+        alert_rule_trigger_actions = list(
+            AlertRuleTriggerAction.objects.filter(integration=integration)
+        )
+        assert len(alert_rule_trigger_actions) == 0
 
 
 class TestAlertRuleTriggerSerializer(TestCase):


### PR DESCRIPTION
Right now if you try to create an alert rule with an invalid slack channel, the api spits out a 500. 

This is bad for two reasons:
1. The alert rule is created, but the actions/triggers are not. So after fixing the slack channel, your next save will give an error like "This name is already in use". 

2. The frontend UI just says "Unable to save alert", when it could be displaying some useful information to the user.

This PR fixes this by:
1. We now wrap the create and update functions in transaction.atomic, so any trigger or action errors will prevent the alert rule from being created.
2. We now catch the slack error and spit out a serializer validation error. We can show this on the frontend.

Fixes https://app.asana.com/0/1143846759074121/1164197745024337 as well.