### PR TITLE
fix(workflow): Adding label and time to alert rule builder graph tooltip

### DIFF
--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -57,6 +57,7 @@ type EventsRequestPartialProps = {
   loading?: boolean;
   showLoading?: boolean;
   yAxis?: string | string[];
+  currentSeriesName?: string;
   children: (renderProps: RenderProps) => React.ReactNode;
 };
 
@@ -167,6 +168,10 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
      */
     showLoading: PropTypes.bool,
 
+    /**
+     * Name used for display current series data set tooltip
+     */
+    currentSeriesName: PropTypes.string,
     /**
      * The yAxis being plotted
      */
@@ -316,9 +321,10 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
    * Transforms query response into timeseries data to be used in a chart
    */
   transformTimeseriesData(data: EventsStatsData): Series[] {
+    const seriesName = this.props.currentSeriesName ?? 'Current';
     return [
       {
-        seriesName: 'Current',
+        seriesName,
         data: data.map(([timestamp, countsForTimestamp]) => ({
           name: timestamp * 1000,
           value: countsForTimestamp.reduce((acc, {count}) => acc + count, 0),

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -9,6 +9,7 @@ import {Panel} from 'app/components/panels';
 import {SeriesDataUnit} from 'app/types/echarts';
 import {getFormattedDate} from 'app/utils/dates';
 import EventsRequest from 'app/views/events/utils/eventsRequest';
+import {getDisplayForAlertRuleAggregation} from 'app/views/alerts/utils';
 import LoadingMask from 'app/components/loadingMask';
 import Placeholder from 'app/components/placeholder';
 import space from 'app/styles/space';
@@ -55,6 +56,7 @@ class TriggersChart extends React.PureComponent<Props> {
         period={getPeriodForTimeWindow(timeWindow)}
         yAxis={aggregation === AlertRuleAggregations.TOTAL ? 'event_count' : 'user_count'}
         includePrevious={false}
+        currentSeriesName={getDisplayForAlertRuleAggregation(aggregation)}
       >
         {({loading, reloading, timeseriesData}) => {
           let maxValue: SeriesDataUnit | undefined;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -224,10 +224,10 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
 
   render() {
     const {data, triggers, xAxis} = this.props;
-
     return (
       <LineChart
         isGroupedByDate
+        showTimeInTooltip
         forwardedRef={this.handleRef}
         grid={CHART_GRID}
         xAxis={xAxis}


### PR DESCRIPTION
Right now, if you hover over datapoints in the alert rule builder's graph, it just says "Current" beside the value, and does not show time.

This PR changes it so "Current" will be a label based on the metric ("Users" or "Events") instead, and the tooltip display the current time.

This fixes: https://app.asana.com/0/1143846759074121/1158430939488625