### PR TITLE
feat(migrations): Fail loudly when cannot migrate any event

### DIFF
--- a/src/sentry/migrations/0024_auto_20191230_2052.py
+++ b/src/sentry/migrations/0024_auto_20191230_2052.py
@@ -98,6 +98,11 @@ def backfill_eventstream(apps, schema_editor):
                 )
             )
 
+    if processed == 0:
+        raise Exception(
+            "Cannot migrate any event. If this is okay, re-run migrations with SENTRY_SKIP_EVENTS_BACKFILL_FOR_10 environment variable set to skip this step."
+        )
+
     print("Event migration done. Migrated {} of {} events.\n".format(processed, count))
 
 


### PR DESCRIPTION
This is to avoid potential data loss in cases like #17422. If we cannot migrate any event, fail loudly, stopping migrations on their tracks and ask the user to explicitly bypass this migration.

I've also considered failing on a certain threshold of `processed / count` but decided against that since it is hard to have a general threshold that would work for everyone, or even for a majority.