### PR TITLE
feat(ui): change header text for context picker

### DIFF
--- a/src/sentry/static/sentry/app/components/contextPickerModal.tsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.tsx
@@ -202,6 +202,20 @@ class ContextPickerModal extends React.Component<Props> {
 
     this.navigateIfFinish([{slug: organization}], [{slug: value}]);
   };
+  get headerText() {
+    const {needOrg, needProject} = this.props;
+    if (needOrg && needProject) {
+      return t('Select an organization and a project to continue');
+    }
+    if (needOrg) {
+      return t('Select an organization to continue');
+    }
+    if (needProject) {
+      return t('Select a project to continue');
+    }
+    //if neither project nor org needs to be selected, nothing will render anyways
+    return '';
+  }
 
   render() {
     const {
@@ -230,10 +244,9 @@ class ContextPickerModal extends React.Component<Props> {
 
     return (
       <React.Fragment>
-        <Header closeButton>{t('Select...')}</Header>
+        <Header closeButton>{this.headerText}</Header>
         <Body>
           {loading && <StyledLoadingIndicator overlay />}
-          <div>{t('Select an organization/project to continue')}</div>
           {needOrg && (
             <StyledSelectControl
               deprecatedSelectControl


### PR DESCRIPTION
This PR changes the text you see in the project/org select modal. The text is dynamically generated based on whether you need to select a project and/or organization. The proposed styling changes were omitted so that we could tackle them globally in Sentry as opposed to just doing it in one place.

Before:
![old](https://user-images.githubusercontent.com/8533851/75811633-a1fa1500-5d41-11ea-9f01-93edd7b439bd.png)


After:
![Screen Shot 2020-03-03 at 11 22 22 AM](https://user-images.githubusercontent.com/8533851/75811643-a6bec900-5d41-11ea-82ac-46ec32febe03.png)
