### PR TITLE
fix(ui) Add chunky resize handles

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -376,10 +376,10 @@ export const GridResizer = styled('div')<{dataRows: number}>`
   &:hover::before {
     position: absolute;
     top: 0;
-    right: 1px;
+    left: 3px;
     content: ' ';
     display: block;
-    width: 4px;
+    width: 5px;
     height: ${GRID_HEAD_ROW_HEIGHT}px;
     background-color: ${p => p.theme.purpleLight};
   }

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -369,4 +369,18 @@ export const GridResizer = styled('div')<{dataRows: number}>`
   &:focus::after {
     background-color: ${p => p.theme.purple};
   }
+
+  /**
+   * This element gives the resize handle a more visible knob to grab
+   */
+  &:hover::before {
+    position: absolute;
+    top: 0;
+    right: 1px;
+    content: ' ';
+    display: block;
+    width: 4px;
+    height: ${GRID_HEAD_ROW_HEIGHT}px;
+    background-color: ${p => p.theme.purpleLight};
+  }
 `;


### PR DESCRIPTION
Use a pseudo element to more clearly indicate where grab handles are.

![big-draggers](https://user-images.githubusercontent.com/24086/75813347-d5e33380-5d5d-11ea-9480-8a2e740eccec.gif)
