### PR TITLE
fix(integration-directory) update experiment name

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationViewController.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationViewController.tsx
@@ -18,7 +18,7 @@ class IntegrationViewController extends React.Component<Props> {
   componentDidMount() {
     logExperiment({
       organization: this.props.organization,
-      key: 'IntegrationsDirectoryExperiment',
+      key: 'IntegrationDirectoryExperiment',
       unitName: 'org_id',
       unitId: parseInt(this.props.organization.id, 10),
       param: 'variant',


### PR DESCRIPTION
For the `logExperiment` function to work properly, the name has to be an exact match for an existing experiment (see https://github.com/getsentry/getsentry/blob/master/static/getsentry/gsApp/utils/logExperiment.jsx#L32). We had an extra `s` in the string so it failed. Here is where the experiment is defined: https://github.com/getsentry/getsentry/blob/master/getsentry/web/apps.py#L30