### PR TITLE
fix(snuba): Snuba timeseries serializer was adding an extra entry to the payload response

### DIFF
--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -126,7 +126,7 @@ def value_from_row(row, tagkey):
 
 def zerofill(data, start, end, rollup):
     rv = []
-    start = ((int(to_timestamp(start)) // rollup) * rollup) - rollup
+    start = (int(to_timestamp(start)) // rollup) * rollup
     end = ((int(to_timestamp(end)) // rollup) * rollup) + rollup
     i = 0
     for key in six.moves.xrange(start, end, rollup):

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -35,8 +35,8 @@ class IncidentSerializerTest(TestCase):
         assert result["dateDetected"] == incident.date_detected
         assert result["dateCreated"] == incident.date_added
         assert result["dateClosed"] == incident.date_closed
-        assert len(result["eventStats"]["data"]) == 62
-        assert [data[1] for data in result["eventStats"]["data"]] == [[]] * 62
+        assert len(result["eventStats"]["data"]) == 61
+        assert [data[1] for data in result["eventStats"]["data"]] == [[]] * 61
         assert result["totalEvents"] == 0
         assert result["uniqueUsers"] == 0
 


### PR DESCRIPTION
An extra time series entry was being added to the Snuba time series payload response. This is making graphs look wonky:

<img width="1440" alt="Screen Shot 2020-03-03 at 7 13 47 PM" src="https://user-images.githubusercontent.com/139499/75832056-2ae57080-5d83-11ea-8ac0-2916ae9b6668.png">
<img width="1167" alt="Screen Shot 2020-03-03 at 7 13 08 PM" src="https://user-images.githubusercontent.com/139499/75832058-2caf3400-5d83-11ea-887a-b5594a483232.png">

## TODO

- [x] fix tests
