### PR TITLE
perf(subscriptions): Add script for load testing snuba subscriptions

### DIFF
--- a/src/sentry/subscription_test.py
+++ b/src/sentry/subscription_test.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+
+import random
+from datetime import timedelta
+from itertools import combinations
+
+from sentry.models.project import Project
+from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription
+from sentry.snuba.subscriptions import create_snuba_subscription, delete_snuba_subscription
+from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
+
+queries = ["level:error", "user.email:dfuller@sentry.io", "ConnectTimeout"]
+all_queries = [""]
+for i in range(1, len(queries) + 1):
+    all_queries.extend([" ".join(combo) for combo in combinations(queries, i)])
+aggregations = [QueryAggregations.TOTAL, QueryAggregations.UNIQUE_USERS]
+time_windows = [
+    timedelta(minutes=1),
+    timedelta(minutes=5),
+    timedelta(minutes=10),
+    timedelta(minutes=15),
+    timedelta(minutes=30),
+    timedelta(minutes=60),
+    timedelta(minutes=120),
+    timedelta(minutes=240),
+    timedelta(days=1),
+]
+# This isn't associated with any callbacks, so won't actually fire alert rules. Makes
+# it easy to identify these fake subs.
+FAKE_SUBSCRIPTION_TYPE = "load_test"
+
+
+def create_fake_subscriptions(
+    number_to_create, organization_slug="sentry", project_slug="sentry", seed=None
+):
+    random.seed(seed)
+    project = Project.objects.get(organization__slug=organization_slug, slug=project_slug)
+    for _ in range(number_to_create):
+        create_snuba_subscription(
+            project,
+            FAKE_SUBSCRIPTION_TYPE,
+            QueryDatasets.EVENTS,
+            random.choice(all_queries),
+            random.choice(aggregations),
+            time_window=random.choice(time_windows),
+            resolution=timedelta(minutes=1),
+            environment_names=None,
+        )
+
+
+def delete_fake_subscriptions():
+    for subscription in RangeQuerySetWrapperWithProgressBar(
+        QuerySubscription.objects.filter(type=FAKE_SUBSCRIPTION_TYPE)
+    ):
+        delete_snuba_subscription(subscription)


### PR DESCRIPTION
This script allows us to bulk create subscriptions in snuba. It creates them with random
permutations of various parameters.  We could potentially add some more items to `queries` to get
some queries with more terms going.

We create all the subscriptions with a fake type. This means that the `QuerySubscriptionConsumer`
will receive the updates, load the `QuerySubscription`, find no handler and just exit. So we're only
testing load on the Snuba/Clickhouse side for now.

Right now this is just on Sentry, but we can adapt it to add subscriptions to other random projects
too. These will have no effect on anything, so it's safe to do so.

When we're finished with the load test, or if we just need to stop it, we can run
`delete_fake_subscriptions` and it'll remove all the subscriptions that were created with this
script.

Probably no need to commit this to master.