### PR TITLE
fix(discover) Change quantile function to pass column

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -979,8 +979,8 @@ class IntervalDefault(NumberRange):
 FUNCTIONS = {
     "percentile": {
         "name": "percentile",
-        "args": [DurationColumn("column"), NumberRange("percentile", 0, 1)],
-        "transform": u"quantile({percentile:.2f})({column})",
+        "args": [DurationColumnNoLookup("column"), NumberRange("percentile", 0, 1)],
+        "aggregate": [u"quantile({percentile:.2f})", u"{column}", None],
     },
     "rps": {
         "name": "rps",
@@ -1127,6 +1127,7 @@ def resolve_function(field, match=None, params=None):
     elif "aggregate" in function:
         aggregate = deepcopy(function["aggregate"])
 
+        aggregate[0] = aggregate[0].format(**arguments)
         if isinstance(aggregate[1], six.string_types):
             aggregate[1] = aggregate[1].format(**arguments)
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1228,9 +1228,9 @@ class ResolveFieldListTest(unittest.TestCase):
                 None,
                 "impact_transaction_duration_300",
             ],
-            ["quantile(0.75)(duration)", None, "percentile_transaction_duration_0_75"],
-            ["quantile(0.95)(duration)", None, "percentile_transaction_duration_0_95"],
-            ["quantile(0.99)(duration)", None, "percentile_transaction_duration_0_99"],
+            ["quantile(0.75)", "transaction.duration", "percentile_transaction_duration_0_75"],
+            ["quantile(0.95)", "transaction.duration", "percentile_transaction_duration_0_95"],
+            ["quantile(0.99)", "transaction.duration", "percentile_transaction_duration_0_99"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
             ["transform(projectid, array(), array(), '')", None, "project.name"],
         ]
@@ -1332,7 +1332,7 @@ class ResolveFieldListTest(unittest.TestCase):
 
         assert result["selected_columns"] == []
         assert result["aggregations"] == [
-            ["quantile(0.75)(duration)", None, "percentile_transaction_duration_0_75"],
+            ["quantile(0.75)", "transaction.duration", "percentile_transaction_duration_0_75"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
             ["transform(projectid, array(), array(), '')", None, "project.name"],

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -448,7 +448,7 @@ class QueryTransformTest(TestCase):
         mock_query.assert_called_with(
             selected_columns=["transaction"],
             aggregations=[
-                ["quantile(0.95)(duration)", None, "percentile_transaction_duration_0_95"],
+                ["quantile(0.95)", "duration", "percentile_transaction_duration_0_95"],
                 ["uniq", "transaction", "count_unique_transaction"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
@@ -488,7 +488,7 @@ class QueryTransformTest(TestCase):
         mock_query.assert_called_with(
             selected_columns=["transaction"],
             aggregations=[
-                ["quantile(0.95)(duration)", None, "percentile_transaction_duration_0_95"],
+                ["quantile(0.95)", "duration", "percentile_transaction_duration_0_95"],
                 ["uniq", "transaction", "count_unique_transaction"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
@@ -569,7 +569,7 @@ class QueryTransformTest(TestCase):
         mock_query.assert_called_with(
             selected_columns=["transaction"],
             aggregations=[
-                ["quantile(0.75)(duration)", None, "percentile_transaction_duration_0_75"],
+                ["quantile(0.75)", "duration", "percentile_transaction_duration_0_75"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
                 [
@@ -893,9 +893,7 @@ class QueryTransformTest(TestCase):
             filter_keys={"project_id": [self.project.id]},
             groupby=["transaction"],
             dataset=Dataset.Discover,
-            aggregations=[
-                ["quantile(0.95)(duration)", None, "percentile_transaction_duration_0_95"]
-            ],
+            aggregations=[["quantile(0.95)", "duration", "percentile_transaction_duration_0_95"]],
             having=[["percentile_transaction_duration_0_95", ">", 5]],
             end=end_time,
             start=start_time,
@@ -926,9 +924,7 @@ class QueryTransformTest(TestCase):
             filter_keys={"project_id": [self.project.id]},
             groupby=["transaction"],
             dataset=Dataset.Discover,
-            aggregations=[
-                ["quantile(0.95)(duration)", None, "percentile_transaction_duration_0_95"]
-            ],
+            aggregations=[["quantile(0.95)", "duration", "percentile_transaction_duration_0_95"]],
             having=[["percentile_transaction_duration_0_95", ">", 5]],
             end=end_time,
             start=start_time,
@@ -1007,7 +1003,7 @@ class QueryTransformTest(TestCase):
         mock_query.assert_called_with(
             selected_columns=["transaction"],
             aggregations=[
-                ["quantile(0.75)(duration)", None, "percentile_transaction_duration_0_75"],
+                ["quantile(0.75)", "duration", "percentile_transaction_duration_0_75"],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
                 [


### PR DESCRIPTION
Pass the column that the quantile is operating on properly, instead of being
hardcoded into the snuba string. This fixes some of the discover bugs that were
failing because of mismatched datasets. Since the column is explicit in the
aggregate, snuba can properly NULL it out instead of throwing an exception when
running the query against the errors dataset.