### PR TITLE
fix: snuba integration tests

### DIFF
--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -170,7 +170,7 @@ class RavenIntegrationTest(TransactionTestCase):
         assert group.data["title"] == "foo"
 
 
-class SentryRemoteTest(SnubaTestCase):
+class SentryRemoteTest(TestCase):
     @fixture
     def path(self):
         return reverse("sentry-api-store")


### PR DESCRIPTION
Small fix, reverted test base class.
Make test case executable, base class was changed by mistake.