### PR TITLE
test(ui): Avoid setting IS_PERCY in storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -91,7 +91,7 @@ module.exports = ({config}) => {
       }),
       new webpack.DefinePlugin({
         'process.env': {
-          IS_PERCY: true,
+          FIXED_DYNAMIC_CONTENT: true,
         },
       }),
     ],

--- a/src/sentry/static/sentry/app/utils/getDynamicText.tsx
+++ b/src/sentry/static/sentry/app/utils/getDynamicText.tsx
@@ -9,5 +9,5 @@ export default function getDynamicText<Value, Fixed = Value>({
   value: Value;
   fixed: Fixed;
 }): Value | Fixed {
-  return process.env.IS_PERCY ? fixed : value;
+  return process.env.IS_PERCY || process.env.FIXED_DYNAMIC_CONTENT ? fixed : value;
 }


### PR DESCRIPTION
We have some other test helpers (namely testablePose) which disables animations in percy. We don't want these disabled in storybook