### PR TITLE
feat(integrations): provide an integration name for Jira server and Github enterprise

### DIFF
--- a/src/sentry/integrations/github_enterprise/client.py
+++ b/src/sentry/integrations/github_enterprise/client.py
@@ -7,6 +7,7 @@ from sentry.integrations.github.client import GitHubClientMixin
 
 class GitHubEnterpriseAppsClient(GitHubClientMixin):
     base_url = None
+    integration_name = "github_enterprise"
 
     def __init__(self, base_url, integration, app_id, private_key, verify_ssl):
         self.base_url = u"https://{}/api/v3".format(base_url)

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -7,8 +7,13 @@ from oauthlib.oauth1 import SIGNATURE_RSA
 from requests_oauthlib import OAuth1
 from six.moves.urllib.parse import parse_qsl
 
+from sentry.integrations.jira.client import JiraApiClient
 from sentry.integrations.client import ApiClient, ApiError
 from sentry.utils.http import absolute_uri
+
+
+class JiraServerClient(JiraApiClient):
+    integration_name = "jira_server"
 
 
 class JiraServerSetupClient(ApiClient):

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -24,8 +24,7 @@ from sentry.integrations.jira import JiraIntegration
 from sentry.pipeline import PipelineView
 from sentry.utils.hashlib import sha1_text
 from sentry.web.helpers import render_to_response
-from sentry.integrations.jira.client import JiraApiClient
-from .client import JiraServer, JiraServerSetupClient
+from .client import JiraServer, JiraServerSetupClient, JiraServerClient
 
 
 logger = logging.getLogger("sentry.integrations.jira_server")
@@ -228,7 +227,7 @@ class JiraServerIntegration(JiraIntegration):
         if self.default_identity is None:
             self.default_identity = self.get_default_identity()
 
-        return JiraApiClient(
+        return JiraServerClient(
             self.model.metadata["base_url"],
             JiraServer(self.default_identity.data),
             self.model.metadata["verify_ssl"],


### PR DESCRIPTION
In Datadog, Jira Server currently shows up as Jira and Github Enterprise shows up as Github. By adding the `integration_name` to the subclass of the `ApiClient`, we can distinguish the integrations by their name.