### PR TITLE
fix(workflow): Fix zIndex for Metric Alerts chart in settings

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownBubble.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownBubble.tsx
@@ -1,6 +1,7 @@
-import styled from '@emotion/styled';
 import {css} from '@emotion/core';
+import styled from '@emotion/styled';
 
+import SettingsHeader from 'app/views/settings/components/settingsHeader';
 import themeObj from 'app/utils/theme';
 
 type Params = {
@@ -121,6 +122,10 @@ const DropdownBubble = styled('div')<Params>`
   /* This is needed to be able to cover e.g. pagination buttons, but also be
    * below dropdown actor button's zindex */
   z-index: ${p => p.theme.zIndex.dropdownAutocomplete.menu};
+
+  ${SettingsHeader} & {
+    z-index: ${p => p.theme.zIndex.dropdownAutocomplete.menu + 2};
+  }
 `;
 
 export default DropdownBubble;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsHeader.tsx
@@ -2,10 +2,16 @@ import styled from '@emotion/styled';
 
 import space from 'app/styles/space';
 
+// This is required to offer components that sit between this settings header
+// and i.e. dropdowns, some zIndex layer room
+//
+// e.g. app/views/settings/incidentRules/triggers/chart/
+const HEADER_Z_INDEX_OFFSET = 5;
+
 const SettingsHeader = styled('div')`
   position: sticky;
   top: 0;
-  z-index: ${p => p.theme.zIndex.header};
+  z-index: ${p => p.theme.zIndex.header + HEADER_Z_INDEX_OFFSET};
   padding: ${space(3)} ${space(4)};
   border-bottom: 1px solid ${p => p.theme.borderLight};
   background: #fff;

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -83,6 +83,31 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
                     ";z-index:",
                     [Function],
                     ";",
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "__emotion_base": "div",
+                      "__emotion_forwardProp": undefined,
+                      "__emotion_real": [Circular],
+                      "__emotion_styles": Array [
+                        "label:SettingsHeader;",
+                        "position:sticky;top:0;z-index:",
+                        [Function],
+                        ";padding:",
+                        "20px",
+                        " ",
+                        "30px",
+                        ";border-bottom:1px solid ",
+                        [Function],
+                        ";background:#fff;",
+                      ],
+                      "defaultProps": undefined,
+                      "displayName": "SettingsHeader",
+                      "render": [Function],
+                      "withComponent": [Function],
+                    },
+                    " &{z-index:",
+                    [Function],
+                    ";}",
                     "label:BubbleWithMinWidth;",
                     Object {
                       "name": "13s4dk6",
@@ -110,7 +135,7 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
                 onMouseLeave={[Function]}
               >
                 <div
-                  className="css-1q3f0gl-DropdownBubble-BubbleWithMinWidth ejumqxq11"
+                  className="css-1lfbn3y-DropdownBubble-BubbleWithMinWidth ejumqxq11"
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   onMouseEnter={[Function]}
@@ -297,6 +322,31 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
                     ";z-index:",
                     [Function],
                     ";",
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "__emotion_base": "div",
+                      "__emotion_forwardProp": undefined,
+                      "__emotion_real": [Circular],
+                      "__emotion_styles": Array [
+                        "label:SettingsHeader;",
+                        "position:sticky;top:0;z-index:",
+                        [Function],
+                        ";padding:",
+                        "20px",
+                        " ",
+                        "30px",
+                        ";border-bottom:1px solid ",
+                        [Function],
+                        ";background:#fff;",
+                      ],
+                      "defaultProps": undefined,
+                      "displayName": "SettingsHeader",
+                      "render": [Function],
+                      "withComponent": [Function],
+                    },
+                    " &{z-index:",
+                    [Function],
+                    ";}",
                     "label:BubbleWithMinWidth;",
                     Object {
                       "name": "13s4dk6",
@@ -324,7 +374,7 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
                 onMouseLeave={[Function]}
               >
                 <div
-                  className="css-1q3f0gl-DropdownBubble-BubbleWithMinWidth ejumqxq11"
+                  className="css-1lfbn3y-DropdownBubble-BubbleWithMinWidth ejumqxq11"
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   onMouseEnter={[Function]}


### PR DESCRIPTION
This fixes some zIndex issues in the Metric Alerts rule builder. The
project dropdown from the header breadcrumb is underneath the metric alerts
chart, but there are also dropdowns inside of the content area that share
the header dropdown zindex, but need to be underneath the chart.

![image](https://user-images.githubusercontent.com/79684/75939620-92f98c80-5e3f-11ea-8885-466fb17e2a4f.png)

