### PR TITLE
test: Fix eventstream test

### DIFF
--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -53,9 +53,9 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
 
     @patch("sentry.eventstream.insert")
     def test(self, mock_eventstream_insert):
-        now = datetime.utcnow()
-
         def _get_event_count():
+            now = datetime.utcnow()
+
             return snuba.query(
                 start=now - timedelta(days=1),
                 end=now + timedelta(days=1),
@@ -65,7 +65,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
 
         assert _get_event_count() == 0
 
-        event = self.__build_event(now)
+        event = self.__build_event(datetime.utcnow())
 
         # verify eventstream was called by EventManager
         insert_args, insert_kwargs = list(mock_eventstream_insert.call_args)


### PR DESCRIPTION
Since result cache has been turned on in Snuba (in https://github.com/getsentry/snuba/pull/807), the second request to snuba.query() will yield the same result as the first. Since the first call didn't really test anything, just remove it.