### PR TITLE
fix(workflow): Fix clearing environments in Alert Rules

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
@@ -25,9 +25,16 @@ export async function addOrUpdateRule(
   }`;
   const method = isExisting ? 'PUT' : 'POST';
 
+  // Clearing environments from the UI will result in a null value
+  // which will error in API, make sure we normalize to empty array
+  const {environment, ...restOfRule} = rule;
+
   return api.requestPromise(endpoint, {
     method,
-    data: rule,
+    data: {
+      ...restOfRule,
+      environment: environment ?? [],
+    },
   });
 }
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
@@ -25,15 +25,14 @@ export async function addOrUpdateRule(
   }`;
   const method = isExisting ? 'PUT' : 'POST';
 
-  // Clearing environments from the UI will result in a null value
-  // which will error in API, make sure we normalize to empty array
-  const {environment, ...restOfRule} = rule;
-
   return api.requestPromise(endpoint, {
     method,
     data: {
-      ...restOfRule,
-      environment: environment ?? [],
+      ...rule,
+
+      // Clearing environments from the UI will result in a null value
+      // which will error in API, make sure we normalize to empty array
+      environment: rule.environment ?? [],
     },
   });
 }


### PR DESCRIPTION
This makes sure that `environment` is a valid value when we add or update alert rules. This fixes an issue where the select component would change the environment value to null when you cleared its value.