### PR TITLE
ref(webpack): updated tsloader use logic

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -237,7 +237,7 @@ let appConfig = {
         exclude: /(vendor|node_modules|dist)/,
         // Make sure we typecheck in CI, but not for local dev since that is run with
         // the fork-ts plugin
-        use: SHOULD_FORK_TS ? [babelLoaderConfig, tsLoaderConfig] : babelLoaderConfig,
+        use: SHOULD_FORK_TS ? babelLoaderConfig : [babelLoaderConfig, tsLoaderConfig],
       },
       {
         test: /\.po$/,


### PR DESCRIPTION
The old logic was correct, where if it is not CI (e.g. dev env) we want to only run babel

but if it is CI, then we want to run babel + ts-loader