### PR TITLE
fix(integration-directory): fix bug where heroku and sessionstack did not show up

### DIFF
--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -24,7 +24,7 @@ class PluginManager(InstanceManager):
             yield plugin
 
     def plugin_that_can_be_configured(self):
-        for plugin in self.all():
+        for plugin in self.all(version=None):
             if plugin.has_project_conf():
                 yield plugin
 

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -24,8 +24,35 @@ class OrganizationPluginsTest(APITestCase):
     def test_no_configs(self):
         response = self.client.get(self.url)
         assert response.status_code == 200, (response.status_code, response.content)
-        # the number of plugins might change so let's just make sure we have most of them
-        assert len(response.data) > 18
+        # test needs to be updated if plugins are removed
+        expected_plugins = [
+            "amazon-sqs",
+            "asana",
+            "bitbucket",
+            "clubhouse",
+            "github",
+            "gitlab",
+            "heroku",
+            "jira",
+            "opsgenie",
+            "pagerduty",
+            "phabricator",
+            "pivotal",
+            "pushover",
+            "redmine",
+            "segment",
+            "sessionstack",
+            "slack",
+            "splunk",
+            "teamwork",
+            "trello",
+            "twilio",
+            "victorops",
+            "vsts",
+            "webhooks",
+        ]
+        for plugin in expected_plugins:
+            assert filter(lambda x: x["slug"] == plugin, response.data)
 
     def test_only_configuable_plugins(self):
         response = self.client.get(self.url)


### PR DESCRIPTION
For some reason, Heroku and SessionStack are version 2 plugins but the rest of the ones in the integration directory were version 1. Unless you specify `version=None` to `plugins.all`, those plugins won't show up. It's a bad API but it might be risky changing the behavior of  `plugins.all` when no version is provided.