### PR TITLE
ref(pagerduty): Update to version 2

### DIFF
--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -155,7 +155,7 @@ class PagerDutyInstallationRedirect(PipelineView):
         setup_url = absolute_uri("/extensions/pagerduty/setup/")
 
         return (
-            u"https://%s.pagerduty.com/install/integration?app_id=%s&redirect_url=%s&version=1"
+            u"https://%s.pagerduty.com/install/integration?app_id=%s&redirect_url=%s&version=2"
             % (account_name, app_id, setup_url)
         )
 


### PR DESCRIPTION
PagerDuty is doing an operational improvement that requires us to update our app ID and version. Both app IDs will continue to work (for the time being) but I believe the ID still needs to match the appropriate version so this PR should be merged close to when we change the ID to minimize any disruption. 

cc @getsentry/ops 