### PR TITLE
fix(analytics): Change key name

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -88,7 +88,7 @@ class CreateProject extends React.Component {
     const analyticsEventOptions = {
       eventKey: 'new_project.visited',
       eventName: 'New Project Page Visited',
-      org_id: parseInt(this.props.organization.id, 10),
+      organization_id: parseInt(this.props.organization.id, 10),
     };
     if (isInAlertDefaultsExperiment) {
       analyticsEventOptions.alert_defaults_experiment_variant = alertDefaultsExperimentVariant;


### PR DESCRIPTION
From org_id to organization_id as the former is not captured by
amplitude.

Related PRs: https://github.com/getsentry/reload/pull/147