### PR TITLE
feat(integration-directory): change search integrations to filter integrations

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -342,7 +342,7 @@ export class OrganizationIntegrations extends AsyncComponent<
               <SearchInput
                 value={this.state.searchInput || ''}
                 onChange={this.onSearchChange}
-                placeholder="Search Integrations..."
+                placeholder="Filter Integrations..."
                 width="25em"
               />
             }


### PR DESCRIPTION
This PR changes “Search Integrations” to “Filter Integrations” so we can differentiate it more from the search bar in the upper right.

