### PR TITLE
feat(exclude_filters): Add signal_only option for buffers

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -60,20 +60,22 @@ class Buffer(Service):
         from sentry.event_manager import ScoreClause
 
         created = False
-        update_kwargs = dict((c, F(c) + v) for c, v in six.iteritems(columns))
-        if extra:
-            update_kwargs.update(extra)
-
-        # HACK(dcramer): this is gross, but we dont have a good hook to compute this property today
-        # XXX(dcramer): remove once we can replace 'priority' with something reasonable via Snuba
-        if model is Group and "last_seen" in update_kwargs and "times_seen" in update_kwargs:
-            update_kwargs["score"] = ScoreClause(
-                group=None,
-                times_seen=update_kwargs["times_seen"],
-                last_seen=update_kwargs["last_seen"],
-            )
 
         if not signal_only:
+            update_kwargs = dict((c, F(c) + v) for c, v in six.iteritems(columns))
+
+            if extra:
+                update_kwargs.update(extra)
+
+            # HACK(dcramer): this is gross, but we dont have a good hook to compute this property today
+            # XXX(dcramer): remove once we can replace 'priority' with something reasonable via Snuba
+            if model is Group and "last_seen" in update_kwargs and "times_seen" in update_kwargs:
+                update_kwargs["score"] = ScoreClause(
+                    group=None,
+                    times_seen=update_kwargs["times_seen"],
+                    last_seen=update_kwargs["last_seen"],
+                )
+
             _, created = model.objects.create_or_update(values=update_kwargs, **filters)
 
         buffer_incr_complete.send_robust(

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -37,6 +37,10 @@ class Buffer(Service):
     def incr(self, model, columns, filters, extra=None, exclude_filters=None):
         """
         >>> incr(Group, columns={'times_seen': 1}, filters={'pk': group.pk})
+        exclude_filters - added to be able to exclude filters by name when determining whether or not to
+        create or update a row for a model in the database. the primary reason for adding this(for now)
+        is to be able to add filters in the call to `buffer_incr_complete` which the receiver can use
+        in addition to the model attributes.
         """
         process_incr.apply_async(
             kwargs={"model": model, "columns": columns, "filters": filters, "extra": extra,

--- a/src/sentry/buffer/inprocess.py
+++ b/src/sentry/buffer/inprocess.py
@@ -11,5 +11,5 @@ class InProcessBuffer(Buffer):
               in development and testing environments.
     """
 
-    def incr(self, model, columns, filters, extra=None):
+    def incr(self, model, columns, filters, extra=None, exclude_filters=None):
         self.process(model, columns, filters, extra)

--- a/src/sentry/buffer/inprocess.py
+++ b/src/sentry/buffer/inprocess.py
@@ -11,5 +11,5 @@ class InProcessBuffer(Buffer):
               in development and testing environments.
     """
 
-    def incr(self, model, columns, filters, extra=None, exclude_filters=None):
-        self.process(model, columns, filters, extra)
+    def incr(self, model, columns, filters, extra=None, signal_only=None):
+        self.process(model, columns, filters, extra, signal_only)

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -179,7 +179,7 @@ class RedisBuffer(Buffer):
         - Insert/update a hashmap based on (model, columns)
             - Perform an incrby on counters
             - Perform a set (last write wins) on extra
-            - Set flag for whether or not to create/update the model in the database
+            - Perform a set on signal_only (only if True)
         - Add hashmap key to pending flushes
         """
 

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -189,8 +189,8 @@ class RedisBuffer(Buffer):
                     frozen_filters = tuple(sorted(filters.items()))
                     key = (frozen_filters, model)
 
-                    stored_columns, stored_extra, stored_exclude_filters = _local_buffers.get(
-                        key, ({}, None)
+                    stored_columns, stored_extra, stored_signal_only = _local_buffers.get(
+                        key, ({}, None, None)
                     )
 
                     for k, v in columns.items():

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -230,8 +230,8 @@ class RedisBuffer(Buffer):
                 pipe.hset(key, "e+" + column, pickle.dumps(value))
                 # pipe.hset(key, 'e+' + column, json.dumps(self._dump_value(value)))
 
-        if exclude_filters:
-            pipe.hsetnx(key, "ef", pickle.dumps(exclude_filters))
+        if isinstance(exclude_filters, set):
+            pipe.hsetnx(key, "ef", json.dumps(list(exclude_filters)))
 
         pipe.expire(key, self.key_expire)
         pipe.zadd(pending_key, time(), key)
@@ -328,7 +328,7 @@ class RedisBuffer(Buffer):
                 # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
                 filters = pickle.loads(values.pop("f"))
 
-            exclude_filters_values = pickle.loads(values.pop("ef")) if "ef" in values else None
+            exclude_filters_values = set(json.loads(values.pop("ef"))) if "ef" in values else None
 
             incr_values = {}
             extra_values = {}

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -328,13 +328,7 @@ class RedisBuffer(Buffer):
                 # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
                 filters = pickle.loads(values.pop("f"))
 
-            exclude_filters_values = None
-            if "ef" in values:
-                if values["ef"].startswith("{"):
-                    exclude_filters_values = self._load_values(json.loads(values.pop("ef")))
-                else:
-                    # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
-                    exclude_filters_values = pickle.loads(values.pop("ef"))
+            exclude_filters_values = pickle.loads(values.pop("ef")) if "ef" in values else None
 
             incr_values = {}
             extra_values = {}

--- a/tests/sentry/buffer/base/tests.py
+++ b/tests/sentry/buffer/base/tests.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 from sentry.utils.compat import mock
 
+from calendar import timegm
 from datetime import timedelta
 from django.utils import timezone
 from sentry.buffer.base import Buffer
@@ -65,3 +66,13 @@ class BufferTest(TestCase):
         self.buf.process(ReleaseProject, columns, filters)
         release_project_ = ReleaseProject.objects.get(id=release_project.id)
         assert release_project_.new_groups == 1
+
+    @mock.patch("sentry.buffer.base.process_incr")
+    def test_process_called_with_exclude_filters(self, process_incr):
+        model = mock.Mock()
+        columns = {"times_seen": 1}
+        filters = {"id": 1, "category": 0, "ts": timegm(timezone.now().timetuple())}
+        exclude_filters = {"category", "ts"}
+        self.buf.incr(model, columns, filters, exclude_filters)
+        kwargs = dict(model=model, columns=columns, filters=filters, extra=None, exclude_filters=exclude_filters)
+        process_incr.apply_async.assert_called_once_with(kwargs=kwargs)


### PR DESCRIPTION
Use `signal_only` to skip writing to the database. This is useful if we want to create/update a model in a receiver function instead of in `process`.