### PR TITLE
build(js): Fix `react-refresh` babel plugin always loaded in dev

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -53,7 +53,10 @@ module.exports = {
           },
         ],
       ],
-      plugins: ['@babel/plugin-transform-react-jsx-source', 'react-refresh/babel'],
+      plugins: [
+        '@babel/plugin-transform-react-jsx-source',
+        !!process.env.SENTRY_UI_HOT_RELOAD ? 'react-refresh/babel' : null,
+      ].filter(Boolean),
     },
     test: {
       plugins: ['dynamic-import-node'],


### PR DESCRIPTION
This fixes the `react-refresh` babel plugin from always being loaded in prod. We only want it loading when `SENTRY_UI_HOT_RELOAD` exists. Otherwise this was causing runtime errors in development when using without env var.