### PR TITLE
feat: Do not mark signal as sent in save_event

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -13,7 +13,7 @@ from django.db import connection, IntegrityError, router, transaction
 from django.db.models import Func
 from django.utils.encoding import force_text
 
-from sentry import buffer, eventstore, eventtypes, eventstream, features, tsdb
+from sentry import buffer, eventstore, eventtypes, eventstream, features, tsdb, options
 from sentry.attachments import attachment_cache
 from sentry.constants import (
     DataCategory,
@@ -541,7 +541,8 @@ class EventManager(object):
             raise
         job["event"].group = job["group"]
 
-        _send_event_saved_signal_many(jobs, projects)
+        if options.get("sentry:skip-accepted-signal-in-save-event") != "1":
+            _send_event_saved_signal_many(jobs, projects)
 
         # store a reference to the group id to guarantee validation of isolation
         # XXX(markus): No clue what this does

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -9,7 +9,7 @@ from django.conf import settings
 
 from sentry_relay.processing import StoreNormalizer
 
-from sentry import features, reprocessing
+from sentry import features, reprocessing, options
 from sentry.constants import DataCategory
 from sentry.relay.config import get_project_config
 from sentry.datascrubbing import scrub_data
@@ -532,7 +532,8 @@ def _do_save_event(
 
             with metrics.timer("tasks.store.do_save_event.track_outcome"):
                 # This is where we can finally say that we have accepted the event.
-                mark_signal_sent(event.project.id, event_id)
+                if options.get("sentry:skip-accepted-signal-in-save-event") != "1":
+                    mark_signal_sent(event.project.id, event_id)
                 track_outcome(
                     event.project.organization_id,
                     event.project.id,


### PR DESCRIPTION
When the option is set, we won't be sending event_saved signal (and marking it as sent) in `save_event` task.

Follow-up to #17347
Ref #17291 (original PR)