### PR TITLE
feat(outcomes): Dispatch event_discarded from outcomes consumer

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -536,7 +536,12 @@ class EventManager(object):
                 event=job["event"], hashes=hashes, release=job["release"], **kwargs
             )
         except HashDiscarded:
-            event_discarded.send_robust(project=project, sender=EventManager)
+            if options.get("sentry:skip-discarded-signal-in-save-event") != "1":
+                event_discarded.send_robust(project=project, sender=EventManager)
+
+                # The outcomes_consumer generically handles all FILTERED outcomes,
+                # but needs to skip this since it cannot dispatch event_discarded.
+                mark_signal_sent(project_id, job["event"].event_id)
 
             project_key = None
             if job["key_id"] is not None:
@@ -546,10 +551,6 @@ class EventManager(object):
                     pass
 
             quotas.refund(project, key=project_key, timestamp=start_time)
-
-            # The outcomes_consumer generically handles all FILTERED outcomes,
-            # but needs to skip this since it cannot dispatch event_discarded.
-            mark_signal_sent(project_id, job["event"].event_id)
 
             track_outcome(
                 project.organization_id,
@@ -568,6 +569,7 @@ class EventManager(object):
                 tags={"organization_id": project.organization_id, "platform": job["platform"]},
             )
             raise
+
         job["event"].group = job["group"]
 
         if options.get("sentry:skip-accepted-signal-in-save-event") != "1":


### PR DESCRIPTION
Moves dispatching of the `event_discarded` signal to outcomes consumers. As opposed to other signals, this is a special case of `Outcome.FILTERED`, where the reason is `"discarded_hash"`.