### PR TITLE
ref(signals): Only emit ingestion signals via outcomes

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -13,7 +13,7 @@ from django.db import connection, IntegrityError, router, transaction
 from django.db.models import Func
 from django.utils.encoding import force_text
 
-from sentry import buffer, eventstore, eventtypes, eventstream, features, tsdb, options
+from sentry import buffer, eventstore, eventtypes, eventstream, features, tsdb
 from sentry.attachments import attachment_cache
 from sentry.constants import (
     DataCategory,
@@ -41,7 +41,6 @@ from sentry.coreapi import (
     decode_data,
     safely_load_json_string,
 )
-from sentry.ingest.outcomes_consumer import mark_signal_sent
 from sentry.interfaces.base import get_interface
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL, convert_crashreport_count
 from sentry.models import (
@@ -72,7 +71,7 @@ from sentry.models import (
 )
 from sentry.plugins.base import plugins
 from sentry import quotas
-from sentry.signals import event_discarded, event_saved, first_event_received
+from sentry.signals import first_event_received
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.utils import json, metrics
 from sentry.utils.canonical import CanonicalKeyDict
@@ -536,13 +535,6 @@ class EventManager(object):
                 event=job["event"], hashes=hashes, release=job["release"], **kwargs
             )
         except HashDiscarded:
-            if options.get("sentry:skip-discarded-signal-in-save-event") != "1":
-                event_discarded.send_robust(project=project, sender=EventManager)
-
-                # The outcomes_consumer generically handles all FILTERED outcomes,
-                # but needs to skip this since it cannot dispatch event_discarded.
-                mark_signal_sent(project_id, job["event"].event_id)
-
             project_key = None
             if job["key_id"] is not None:
                 try:
@@ -553,14 +545,14 @@ class EventManager(object):
             quotas.refund(project, key=project_key, timestamp=start_time)
 
             track_outcome(
-                project.organization_id,
-                project_id,
-                job["key_id"],
-                Outcome.FILTERED,
-                FilterStatKeys.DISCARDED_HASH,
-                to_datetime(job["start_time"]),
-                job["event"].event_id,
-                job["category"],
+                org_id=project.organization_id,
+                project_id=project_id,
+                key_id=job["key_id"],
+                outcome=Outcome.FILTERED,
+                reason=FilterStatKeys.DISCARDED_HASH,
+                timestamp=to_datetime(job["start_time"]),
+                event_id=job["event"].event_id,
+                category=job["category"],
             )
 
             metrics.incr(
@@ -571,9 +563,6 @@ class EventManager(object):
             raise
 
         job["event"].group = job["group"]
-
-        if options.get("sentry:skip-accepted-signal-in-save-event") != "1":
-            _send_event_saved_signal_many(jobs, projects)
 
         # store a reference to the group id to guarantee validation of isolation
         # XXX(markus): No clue what this does
@@ -823,18 +812,6 @@ def _materialize_metadata_many(jobs):
         data["culprit"] = job["culprit"]
 
 
-@metrics.wraps("save_event.send_event_saved_signal_many")
-def _send_event_saved_signal_many(jobs, projects):
-    for job in jobs:
-        event_saved.send_robust(
-            project=projects[job["project_id"]],
-            event_size=job["event"].size,
-            category=job["category"],
-            quantity=1,
-            sender=EventManager,
-        )
-
-
 @metrics.wraps("save_event.get_or_create_environment_many")
 def _get_or_create_environment_many(jobs, projects):
     for job in jobs:
@@ -954,19 +931,15 @@ def _track_outcome_accepted_many(jobs):
     for job in jobs:
         event = job["event"]
 
-        # This is where we can finally say that we have accepted the event.
-        if options.get("sentry:skip-accepted-signal-in-save-event") != "1":
-            mark_signal_sent(event.project.id, event.event_id)
-
         track_outcome(
-            event.project.organization_id,
-            job["project_id"],
-            job["key_id"],
-            Outcome.ACCEPTED,
-            None,
-            to_datetime(job["start_time"]),
-            event.event_id,
-            job["category"],
+            org_id=event.project.organization_id,
+            project_id=job["project_id"],
+            key_id=job["key_id"],
+            outcome=Outcome.ACCEPTED,
+            reason=None,
+            timestamp=to_datetime(job["start_time"]),
+            event_id=event.event_id,
+            category=job["category"],
         )
 
 
@@ -1398,8 +1371,6 @@ def save_transaction_events(jobs, projects):
     _derive_plugin_tags_many(jobs, projects)
     _derive_interface_tags_many(jobs)
     _materialize_metadata_many(jobs)
-    if options.get("sentry:skip-accepted-signal-in-save-event") != "1":
-        _send_event_saved_signal_many(jobs, projects)
     _get_or_create_environment_many(jobs, projects)
     _get_or_create_release_associated_models(jobs, projects)
     _tsdb_record_all_metrics(jobs)

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -31,11 +31,6 @@ outcomes = settings.KAFKA_TOPICS[settings.KAFKA_OUTCOMES]
 outcomes_publisher = None
 
 
-def decide_signals_in_consumer():
-    rate = options.get("outcomes.signals-in-consumer-sample-rate")
-    return rate and rate > random.random()
-
-
 def decide_tsdb_in_consumer():
     rate = options.get("outcomes.tsdb-in-consumer-sample-rate")
     return rate and rate > random.random()

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -36,7 +36,7 @@ from sentry.models import (
     OrganizationIntegration,
     UserReport,
 )
-from sentry.signals import event_discarded, event_saved
+from sentry.utils.outcomes import Outcome
 from sentry.testutils import assert_mock_called_once_with_partial, TestCase
 from sentry.utils.data_filters import FilterStatKeys
 from sentry.relay.config import get_project_config
@@ -1015,18 +1015,16 @@ class EventManagerTest(TestCase):
 
         manager = EventManager(make_event(message="foo", event_id="b" * 32, fingerprint=["a" * 32]))
 
-        mock_event_discarded = mock.Mock()
-        event_discarded.connect(mock_event_discarded)
-        mock_event_saved = mock.Mock()
-        event_saved.connect(mock_event_saved)
+        from sentry.utils.outcomes import track_outcome
 
-        with self.tasks():
-            with self.assertRaises(HashDiscarded):
-                event = manager.save(1)
+        mock_track_outcome = mock.Mock(wraps=track_outcome)
+        with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
+            with self.tasks():
+                with self.assertRaises(HashDiscarded):
+                    event = manager.save(1)
 
-        assert not mock_event_saved.called
         assert_mock_called_once_with_partial(
-            mock_event_discarded, project=group.project, sender=EventManager, signal=event_discarded
+            mock_track_outcome, outcome=Outcome.FILTERED, reason=FilterStatKeys.DISCARDED_HASH
         )
 
         def query(model, key, **kwargs):
@@ -1042,17 +1040,15 @@ class EventManagerTest(TestCase):
         assert query(tsdb.models.organization_total_blacklisted, event.project.organization.id) == 1
         assert query(tsdb.models.project_total_blacklisted, event.project.id) == 1
 
-    def test_event_saved_signal(self):
-        mock_event_saved = mock.Mock()
-        event_saved.connect(mock_event_saved)
-
+    def test_event_accepted_outcome(self):
         manager = EventManager(make_event(message="foo"))
         manager.normalize()
-        event = manager.save(1)
 
-        assert_mock_called_once_with_partial(
-            mock_event_saved, project=event.group.project, sender=EventManager, signal=event_saved
-        )
+        mock_track_outcome = mock.Mock()
+        with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
+            manager.save(1)
+
+        assert_mock_called_once_with_partial(mock_track_outcome, outcome=Outcome.ACCEPTED)
 
     def test_checksum_rehashed(self):
         checksum = "invalid checksum hash"


### PR DESCRIPTION
This concludes moving all ingestion signals to outcomes consumers by removing them from the ingestion path:

- `event_saved` for `Outcome.ACCEPTED`
- `event_discarded` for `Outcome.FILTERED` with reason `"discarded-hash"`
- `event_filtered` for `Outcome.FILTERED`
- `event_dropped` for `Outcome.RATE_LIMITED`
