### PR TITLE
fix(subscriptions): Use correct topic in query_subscription_consumer.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1682,7 +1682,7 @@ KAFKA_CLUSTERS = {
 
 KAFKA_EVENTS = "events"
 KAFKA_OUTCOMES = "outcomes"
-KAFKA_SNUBA_QUERY_SUBSCRIPTIONS = "snuba-query-subscriptions"
+KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS = "events-subscription-results"
 KAFKA_INGEST_EVENTS = "ingest-events"
 KAFKA_INGEST_ATTACHMENTS = "ingest-attachments"
 KAFKA_INGEST_TRANSACTIONS = "ingest-transactions"
@@ -1690,9 +1690,9 @@ KAFKA_INGEST_TRANSACTIONS = "ingest-transactions"
 KAFKA_TOPICS = {
     KAFKA_EVENTS: {"cluster": "default", "topic": KAFKA_EVENTS},
     KAFKA_OUTCOMES: {"cluster": "default", "topic": KAFKA_OUTCOMES},
-    KAFKA_SNUBA_QUERY_SUBSCRIPTIONS: {
+    KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS: {
         "cluster": "default",
-        "topic": KAFKA_SNUBA_QUERY_SUBSCRIPTIONS,
+        "topic": KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS,
     },
     # Topic for receiving simple events (error events without attachments) from Relay
     KAFKA_INGEST_EVENTS: {"cluster": "default", "topic": KAFKA_INGEST_EVENTS},

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -46,14 +46,14 @@ class QuerySubscriptionConsumer(object):
     These values are passed along to a callback associated with the subscription.
     """
 
-    topic_to_dataset = {settings.KAFKA_SNUBA_QUERY_SUBSCRIPTIONS: QueryDatasets.EVENTS}
+    topic_to_dataset = {settings.KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS: QueryDatasets.EVENTS}
 
     def __init__(
         self, group_id, topic=None, commit_batch_size=100, initial_offset_reset="earliest"
     ):
         self.group_id = group_id
         if not topic:
-            topic = settings.KAFKA_SNUBA_QUERY_SUBSCRIPTIONS
+            topic = settings.KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS
         self.topic = topic
         cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]
         self.bootstrap_servers = settings.KAFKA_CLUSTERS[cluster_name]["bootstrap.servers"]

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -56,7 +56,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
             pool.urlopen.return_value.status = 202
             self.consumer.handle_message(
                 self.build_mock_message(
-                    self.valid_wrapper, topic=settings.KAFKA_SNUBA_QUERY_SUBSCRIPTIONS
+                    self.valid_wrapper, topic=settings.KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS
                 )
             )
             pool.urlopen.assert_called_once_with(


### PR DESCRIPTION
While developing the query subscription consumer I defined `KAFKA_SNUBA_QUERY_SUBSCRIPTIONS` to
specify the topic we'd use for the subscription consumer. When we went live in production we defined
`KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS`, which is what we actually use to define the topic in prod, but
didn't update code to use this as well.

Fixes SENTRY-FD7