### PR TITLE
fix(workflow/projectCreation): UI

### DIFF
--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -23,7 +23,7 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
         experiment_variant = experiments.get(
             org=organization, experiment_name="AlertDefaultsExperiment"
         )
-        if experiment_variant == "3OptionsV1":
+        if experiment_variant == "3OptionsV2":
             return Response(
                 [
                     info_extractor(rule_cls)

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -829,7 +829,7 @@ export type SentryAppComponent = {
 export type ActiveExperiments = {
   TrialUpgradeV2Experiment: 'upgrade' | 'trial' | -1;
   IntegrationDirectoryExperiment: '1' | '0';
-  AlertDefaultsExperiment: 'controlV1' | '2OptionsV1' | '3OptionsV1';
+  AlertDefaultsExperiment: 'controlV1' | '2OptionsV1' | '3OptionsV2';
 };
 
 type SavedQueryVersions = 1 | 2;

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -71,7 +71,7 @@ class CreateProject extends React.Component {
       organization.experiments?.AlertDefaultsExperiment;
     const isInAlertDefaultsExperiment = [
       '2OptionsV1',
-      '3OptionsV1',
+      '3OptionsV2',
       'controlV1',
     ].includes(alertDefaultsExperimentVariant);
 

--- a/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
@@ -34,7 +34,7 @@ const METRIC_CONDITION_MAP = {
   [MetricValues.USERS]: UNIQUE_USER_FREQUENCY_CONDITION,
 } as const;
 
-const DEFAULT_THRESHOLD_VALUE: string = '10';
+const DEFAULT_PLACEHOLDER_VALUE: string = '10';
 
 type StateUpdater = (updatedData: RequestDataFragment) => void;
 type Props = AsyncComponent['props'] & {
@@ -107,7 +107,7 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
       alertSetting: `${Actions.CREATE_ALERT_LATER}`,
       metric: MetricValues.ERRORS,
       interval: '',
-      threshold: DEFAULT_THRESHOLD_VALUE,
+      threshold: '',
     };
   }
 
@@ -131,7 +131,7 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
       [`${Actions.ALERT_ON_EVERY_ISSUE}`, t('Alert me on every new issue')],
     ];
     if (hasProperlyLoadedConditions) {
-      options.unshift([
+      options.push([
         `${Actions.CUSTOMIZED_ALERTS}`,
         <CustomizeAlertsGrid key={Actions.CUSTOMIZED_ALERTS}>
           {t('When there are more than')}
@@ -139,7 +139,7 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
             type="number"
             min="0"
             name=""
-            placeholder={DEFAULT_THRESHOLD_VALUE}
+            placeholder={DEFAULT_PLACEHOLDER_VALUE}
             value={this.state.threshold}
             key={name}
             onChange={threshold =>
@@ -263,7 +263,6 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
     }
 
     this.setStateAndUpdateParents({
-      alertSetting: `${Actions.CUSTOMIZED_ALERTS}`,
       conditions,
       intervalChoices,
       interval,

--- a/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/newProject.jsx
@@ -13,9 +13,9 @@ const NewProject = ({organization}) => (
       <Content>
         <DocumentTitle title="Sentry" />
         <CreateProject
-          hasIssueAlertOptionsEnabled={['2Options', '3Options']
-            .map(variant => variant.concat('V1'))
-            .includes(organization.experiments?.AlertDefaultsExperiment)}
+          hasIssueAlertOptionsEnabled={['2OptionsV1', '3OptionsV2'].includes(
+            organization.experiments?.AlertDefaultsExperiment
+          )}
         />
       </Content>
     </div>

--- a/tests/js/spec/views/projectInstall/createProject.spec.jsx
+++ b/tests/js/spec/views/projectInstall/createProject.spec.jsx
@@ -188,7 +188,10 @@ describe('CreateProject', function() {
         .simulate('click');
       expectSubmitButtonToBeDisabled(true);
 
-      wrapper.find('input[data-test-id="range-input"]');
+      wrapper
+        .find('input[data-test-id="range-input"]')
+        .first()
+        .simulate('change', {target: {value: '2'}});
       expectSubmitButtonToBeDisabled(true);
 
       wrapper
@@ -217,7 +220,7 @@ describe('CreateProject', function() {
 
       wrapper
         .find('RadioLineItem')
-        .last()
+        .first()
         .simulate('click');
       expectSubmitButtonToBeDisabled(false);
     });

--- a/tests/js/spec/views/projectInstall/issueAlertOptions.spec.jsx
+++ b/tests/js/spec/views/projectInstall/issueAlertOptions.spec.jsx
@@ -125,7 +125,7 @@ describe('IssueAlertOptions', function() {
     );
   });
 
-  it('should pre-fill threshold value after a valid server response', () => {
+  it('should not pre-fill threshold value after a valid server response', () => {
     MockApiClient.addMockResponse({
       url: URL,
       body: MOCK_RESP_VERBOSE,
@@ -133,6 +133,6 @@ describe('IssueAlertOptions', function() {
 
     const wrapper = mountWithTheme(<IssueAlertOptions {...props} />, routerContext);
 
-    expect(wrapper.find('input[data-test-id="range-input"]').props().value).toBe('10');
+    expect(wrapper.find('input[data-test-id="range-input"]').props().value).toBe('');
   });
 });

--- a/tests/sentry/api/endpoints/test_project_agnostic_rule_conditions.py
+++ b/tests/sentry/api/endpoints/test_project_agnostic_rule_conditions.py
@@ -7,7 +7,7 @@ from sentry.testutils import APITestCase
 
 
 class ProjectAgnosticRuleConditionsTest(APITestCase):
-    @patch("sentry.experiments.get", return_value="3OptionsV1")
+    @patch("sentry.experiments.get", return_value="3OptionsV2")
     def test_simple(self, mocked_experiment):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")


### PR DESCRIPTION
Provides small UI fixes:
- Reorder custom rule option to the last row.
- Remove default value for custom rule option

Since the UX is now different, we'll be capturing metrics for this new UI in a different experiment
-  Update experiment variant

3OptionsV2:
![image](https://user-images.githubusercontent.com/23180853/76125617-0ae7c400-5fb2-11ea-9ad2-b90cd5eca7cc.png)
2OptionsV1:
![image](https://user-images.githubusercontent.com/23180853/76125638-1affa380-5fb2-11ea-89f9-5b405639e64f.png)
controlV1:
![image](https://user-images.githubusercontent.com/23180853/76125687-31a5fa80-5fb2-11ea-98c2-dfc608080d7f.png)

Blocked by: https://github.com/getsentry/getsentry/pull/3642