### PR TITLE
fix(ui): Added raw fallback for parsing release versions

### DIFF
--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -22,10 +22,15 @@ export function userDisplayName(user: User | CommitAuthor): string {
 export const formatVersion = (rawVersion: string, withPackage = false) => {
   try {
     const parsedVersion = new Release(rawVersion);
+    const versionToDisplay = parsedVersion.describe();
 
-    return `${parsedVersion.describe()}${
-      withPackage && parsedVersion.package ? `, ${parsedVersion.package}` : ''
-    }`;
+    if (versionToDisplay.length) {
+      return `${versionToDisplay}${
+        withPackage && parsedVersion.package ? `, ${parsedVersion.package}` : ''
+      }`;
+    }
+
+    return rawVersion;
   } catch {
     return rawVersion;
   }


### PR DESCRIPTION
There has already been a fallback for when we can't parse the version with our package `@sentry/release-parser`.

This PR adds a fallback for when the parser package doesn't throw an error but returns an empty string instead.

This happens during some edge cases such as this one: https://github.com/getsentry/sentry/issues/17474