### PR TITLE
feat(ui): Added issue stream link into project settings page

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.jsx
@@ -12,6 +12,7 @@ import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
+import Button from 'app/components/button';
 
 const CodeBlock = styled('pre')`
   word-break: break-all;
@@ -42,7 +43,20 @@ class ProjectOwnership extends AsyncView {
 
     return (
       <div>
-        <SettingsPageHeader title={t('Issue Owners')} />
+        <SettingsPageHeader
+          title={t('Issue Owners')}
+          action={
+            <Button
+              to={{
+                pathname: `/organizations/${organization.slug}/issues/`,
+                query: {project: project.id},
+              }}
+              size="small"
+            >
+              {t('View Issues')}
+            </Button>
+          }
+        />
         <PermissionAlert />
         <Panel>
           <PanelHeader>{t('Ownership Rules')}</PanelHeader>

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -31,6 +31,7 @@ import handleXhrErrorResponse from 'app/utils/handleXhrErrorResponse';
 import marked from 'app/utils/marked';
 import recreateRoute from 'app/utils/recreateRoute';
 import routeTitleGen from 'app/utils/routeTitle';
+import {IconIssues} from 'app/icons';
 import Link from 'app/components/links/link';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import Feature from 'app/components/acl/feature';
@@ -399,7 +400,21 @@ class ProjectGeneralSettings extends AsyncView {
 
     return (
       <div>
-        <SettingsPageHeader title={t('Project Settings')} />
+        <SettingsPageHeader
+          title={t('Project Settings')}
+          action={
+            <Button
+              to={{
+                pathname: `/organizations/${organization.slug}/issues/`,
+                query: {project: project.id},
+              }}
+              size="small"
+              icon={<IconIssues size="xs" />}
+            >
+              {t('Issues Stream')}
+            </Button>
+          }
+        />
         <PermissionAlert />
 
         <Form

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -35,6 +35,7 @@ import {IconIssues} from 'app/icons';
 import Link from 'app/components/links/link';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import Feature from 'app/components/acl/feature';
+import Access from 'app/components/acl/access';
 
 class ProjectGeneralSettings extends AsyncView {
   static propTypes = {
@@ -403,16 +404,18 @@ class ProjectGeneralSettings extends AsyncView {
         <SettingsPageHeader
           title={t('Project Settings')}
           action={
-            <Button
-              to={{
-                pathname: `/organizations/${organization.slug}/issues/`,
-                query: {project: project.id},
-              }}
-              size="small"
-              icon={<IconIssues size="xs" />}
-            >
-              {t('Issues Stream')}
-            </Button>
+            <Access isSuperuser>
+              <Button
+                to={{
+                  pathname: `/organizations/${organization.slug}/issues/`,
+                  query: {project: project.id},
+                }}
+                size="small"
+                icon={<IconIssues size="xs" />}
+              >
+                {t('Issues Stream')}
+              </Button>
+            </Access>
           }
         />
         <PermissionAlert />

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -31,11 +31,9 @@ import handleXhrErrorResponse from 'app/utils/handleXhrErrorResponse';
 import marked from 'app/utils/marked';
 import recreateRoute from 'app/utils/recreateRoute';
 import routeTitleGen from 'app/utils/routeTitle';
-import {IconIssues} from 'app/icons';
 import Link from 'app/components/links/link';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import Feature from 'app/components/acl/feature';
-import Access from 'app/components/acl/access';
 
 class ProjectGeneralSettings extends AsyncView {
   static propTypes = {
@@ -401,23 +399,7 @@ class ProjectGeneralSettings extends AsyncView {
 
     return (
       <div>
-        <SettingsPageHeader
-          title={t('Project Settings')}
-          action={
-            <Access isSuperuser>
-              <Button
-                to={{
-                  pathname: `/organizations/${organization.slug}/issues/`,
-                  query: {project: project.id},
-                }}
-                size="small"
-                icon={<IconIssues size="xs" />}
-              >
-                {t('Issues Stream')}
-              </Button>
-            </Access>
-          }
-        />
+        <SettingsPageHeader title={t('Project Settings')} />
         <PermissionAlert />
 
         <Form

--- a/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
@@ -6,6 +6,21 @@ exports[`ProjectTeamsSettings render() renders 1`] = `
 >
   <div>
     <StyledSettingsPageHeading
+      action={
+        <ForwardRef
+          size="small"
+          to={
+            Object {
+              "pathname": "/organizations/org-slug/issues/",
+              "query": Object {
+                "project": "2",
+              },
+            }
+          }
+        >
+          View Issues
+        </ForwardRef>
+      }
       noTitleStyles={false}
       title="Issue Owners"
     />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9060071/76196567-bed39400-61ea-11ea-8cc5-d4a086352cbd.png)

This PR adds an Issues Stream link of the given project into the project's general settings page.

This has been a major pain point for some of our staff - they lacked the ability to quickly jump to the respective issues stream from the project's settings page.