### PR TITLE
ref(ui): updated Symbol source configurator types

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -25,7 +25,7 @@ REQUEST_CACHE_TIMEOUT = 3600
 logger = logging.getLogger(__name__)
 
 
-VALID_LAYOUTS = ("native", "symstore", "symstore_index2", "ssqp")
+VALID_LAYOUTS = ("native", "symstore", "symstore_index2", "ssqp", "unified", "debuginfod")
 
 VALID_FILE_TYPES = ("pe", "pdb", "mach_debug", "mach_code", "elf_debug", "elf_code", "breakpad")
 

--- a/src/sentry/static/sentry/app/data/debugFileSources.jsx
+++ b/src/sentry/static/sentry/app/data/debugFileSources.jsx
@@ -3,6 +3,8 @@ export const DEBUG_SOURCE_LAYOUTS = {
   symstore: 'Microsoft SymStore',
   symstore_index2: 'Microsoft SymStore (with index2.txt)',
   ssqp: 'Microsoft SSQP',
+  unified: 'Unified Symbol Server Layout',
+  debuginfod: 'debuginfod',
 };
 
 export const DEBUG_SOURCE_CASINGS = {


### PR DESCRIPTION
We are missing "unified" and "debuginfod" in the layout selector. Unified is actually useful and we use it internally, debuginfod did not come up as an actual request yet.

You can read more about it here: https://app.asana.com/0/1158284503473033/1165441649629993

after changes:

![image](https://user-images.githubusercontent.com/29228205/76213914-f7379a00-620b-11ea-969b-5a1fb627e153.png)
