### PR TITLE
dev(direnv): give advice rather than automatically initialize state

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -56,8 +56,13 @@ It's recommended to use pyenv - please refer to https://docs.sentry.io/developme
     return 1
 }
 
-advice_install_sentry() {
+advice_install_sentry () {
     info "To install sentry, please type: make install-sentry-dev"
+    return 1
+}
+
+advice_install_pre_commit () {
+    info "To install pre-commit, please type: make setup-git"
     return 1
 }
 
@@ -133,8 +138,8 @@ fi
 info "Checking pre-commit..."
 
 if ! require pre-commit; then
-    info "Looks like you don't have pre-commit installed. Let's install it."
-    make setup-git
+    info "Looks like you don't have pre-commit installed."
+    advice_install_pre_commit
 fi
 
 

--- a/.envrc
+++ b/.envrc
@@ -66,6 +66,11 @@ advice_install_pre_commit () {
     return 1
 }
 
+advice_install_yarn_pkgs () {
+    info "To install yarn packages, please type: make install-yarn-pkgs"
+    return 1
+}
+
 ### Environment ###
 
 # don't write *.pyc files; using stale python code occasionally causes subtle problems
@@ -163,8 +168,8 @@ It's recommended to use volta - please refer to https://docs.sentry.io/developme
 fi
 
 if [ ! -x "node_modules/.bin/webpack" ]; then
-    info "You don't seem to have yarn packages installed. Let's install them."
-    make install-yarn-pkgs
+    info "You don't seem to have yarn packages installed."
+    advice_install_yarn_pkgs
 fi
 
 PATH_add node_modules/.bin

--- a/.envrc
+++ b/.envrc
@@ -47,13 +47,13 @@ EOF
     return 1
 }
 
-init_venv () {
+advice_init_venv () {
     deactivate 2>/dev/null || true
-    info "Creating a virtualenv for you."
+    info "To create a virtualenv, please type: python2.7 -m virtualenv .venv"
     require python2.7 || \
         die "You'll need to install python2.7, or make it available on your PATH.
 It's recommended to use pyenv - please refer to https://docs.sentry.io/development/contribute/environment"
-    python2.7 -m virtualenv .venv
+    return 1
 }
 
 ### Environment ###
@@ -98,12 +98,12 @@ if [ -n "$VIRTUAL_ENV" ]; then
     # we're enforcing that virtualenv be in .venv, since future tooling e.g. venv-update will rely on this.
     if [ "$VIRTUAL_ENV" != "${PWD}/.venv" ]; then
         info "You're in a virtualenv, but it's not in the expected location (${PWD}/.venv)"
-        init_venv
+        advice_init_venv
     fi
 else
     if [ ! -f ".venv/bin/activate" ]; then
         info "You don't seem to have a virtualenv."
-        init_venv
+        advice_init_venv
     fi
 fi
 

--- a/.envrc
+++ b/.envrc
@@ -134,6 +134,8 @@ python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
 
 if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
     info "Your .venv is activated, but sentry doesn't seem to be installed."
+    # XXX: if direnv fails, the venv won't be activated outside of direnv execution...
+    # So, it is critical that make install-sentry-dev is guarded by scripts/ensure-venv.
     advice_install_sentry
 fi
 

--- a/.envrc
+++ b/.envrc
@@ -56,6 +56,11 @@ It's recommended to use pyenv - please refer to https://docs.sentry.io/developme
     return 1
 }
 
+advice_install_sentry() {
+    info "To install sentry, please type: make install-sentry-dev"
+    return 1
+}
+
 ### Environment ###
 
 # don't write *.pyc files; using stale python code occasionally causes subtle problems
@@ -118,9 +123,8 @@ python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
     die "For some reason, the virtualenv isn't Python 2.7."
 
 if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
-    info "Your .venv is activated, but sentry doesn't seem to be installed. Let's install it."
-    make ensure-pinned-pip
-    SENTRY_LIGHT_BUILD=1 make install-sentry-dev
+    info "Your .venv is activated, but sentry doesn't seem to be installed."
+    advice_install_sentry
 fi
 
 

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ install-yarn-pkgs: node-version-check
 	# Add an additional check against `node_modules`
 	$(YARN) check --verify-tree || $(YARN) install --check-files
 
-install-sentry-dev: ensure-venv
+install-sentry-dev: ensure-pinned-pip
 	@echo "--> Installing Sentry (for development)"
 	# SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
 	# Webpacked assets are only necessary for devserver (which does it lazily anyways)


### PR DESCRIPTION
Some people have edge case setups (such as symlinked venvs) which sometimes results in direnv clobbering over stuff while doing first time initialization.

It was my hope that performing state initialization would be a helpful piece of automation, but this seems to have caused more harm than benefit. (I've personally had to disable direnv when switching between py2/3 environments.) Besides, the dev env docs already walk through how to initialize everything. So this would make direnv purely a state checker and on fail, it would give advice rather than mutate anything on the filesystem.

