### PR TITLE
fix(issues) Fix 500 error in group events on invalid queries

### DIFF
--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -307,6 +307,16 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         )
         assert response.status_code == 400
 
+    def test_invalid_query(self):
+        self.login_as(user=self.user)
+        first_seen = timezone.now() - timedelta(days=5)
+        group = self.create_group(first_seen=first_seen)
+        response = self.client.get(
+            u"/api/0/issues/{}/events/".format(group.id),
+            data={"statsPeriod": "7d", "query": "foo(bar"},
+        )
+        assert response.status_code == 400
+
     def test_multiple_group(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
Invalid user filtering queries should not trigger 500 errors.

Fixes SENTRY-FA1