### PR TITLE
ref: Update relay to 0.5.5

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ redis-py-cluster==1.3.4
 redis>=2.10.3,<2.10.6
 requests-oauthlib==1.2.0
 requests[security]>=2.20.0,<2.21.0
-sentry-relay>=0.5.4,<0.6.0
+sentry-relay>=0.5.5,<0.6.0
 sentry-sdk>=0.13.5
 simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0


### PR DESCRIPTION
this is totally unnecessary to bump here, but I just want to make sure everybody gets the new selector syntax