### PR TITLE
fix(discover) Fix navigating with user facets

### DIFF
--- a/src/sentry/static/sentry/app/utils/queryString.tsx
+++ b/src/sentry/static/sentry/app/utils/queryString.tsx
@@ -37,7 +37,14 @@ export function appendTagCondition(
 ): string {
   let currentQuery = Array.isArray(query) ? query.pop() : isString(query) ? query : '';
 
-  if (isString(value) && value.indexOf(' ') > -1) {
+  // The user key values have additional key data inside them.
+  if (key === 'user' && value.includes(':')) {
+    const parts = value.split(':', 2);
+    key = [key, parts[0]].join('.');
+    value = parts[1];
+  }
+
+  if (isString(value) && value.includes(' ')) {
     value = `"${value}"`;
   }
   if (currentQuery) {

--- a/tests/js/spec/utils/queryString.spec.js
+++ b/tests/js/spec/utils/queryString.spec.js
@@ -55,4 +55,18 @@ describe('appendTagCondition', function() {
     const result = utils.appendTagCondition(null, 'color', 'purple red');
     expect(result).toEqual('color:"purple red"');
   });
+
+  it('special cases user tags', function() {
+    let result = utils.appendTagCondition('', 'user', 'something');
+    expect(result).toEqual('user:something');
+
+    result = utils.appendTagCondition('', 'user', 'id:1');
+    expect(result).toEqual('user.id:1');
+
+    result = utils.appendTagCondition('', 'user', 'email:foo@example.com');
+    expect(result).toEqual('user.email:foo@example.com');
+
+    result = utils.appendTagCondition('', 'user', 'name:jill jones');
+    expect(result).toEqual('user.name:"jill jones"');
+  });
 });


### PR DESCRIPTION
The user tags contain more stuff inside them that we need to repack to create valid queries. Doing that in querystring utils lets us improve both issues and discover.