### PR TITLE
fix(sourcemaps): Do a better job of excluding node_modules

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -540,7 +540,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         # or those created by bundle/webpack internals
         if self.data.get("platform") == "node" and (
             "node_modules" in frame.get("abs_path")
-            or not frame.get("abs_path").startswith("/", "app:", "webpack:")
+            or not frame.get("abs_path").startswith(("/", "app:", "webpack:"))
         ):
             return
 

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -539,7 +539,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         # therefore we only process user-land frames (starting with /)
         # or those created by bundle/webpack internals
         if self.data.get("platform") == "node" and (
-            frame.get("abs_path").includes("node_modules")
+            "node_modules" in frame.get("abs_path")
             or not frame.get("abs_path").startswith("/", "app:", "webpack:")
         ):
             return

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -538,8 +538,9 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         # can't fetch if this is internal node module as well
         # therefore we only process user-land frames (starting with /)
         # or those created by bundle/webpack internals
-        if self.data.get("platform") == "node" and not frame.get("abs_path").startswith(
-            ("/", "app:", "webpack:")
+        if self.data.get("platform") == "node" and (
+            frame.get("abs_path").includes("node_modules")
+            or not frame.get("abs_path").startswith("/", "app:", "webpack:")
         ):
             return
 


### PR DESCRIPTION
For `node` events, when we do our source map processing, server-side, we make a point to [exclude code from local `node_modules` folders](https://github.com/getsentry/sentry/blob/29d584f6950fd3a3d8ab7ef8e487caa46fb9db61/src/sentry/lang/javascript/processor.py#L538-L544), since a) there's no possibility of us being able to retrieve it, and b) we shouldn't need to since it's unlikely to be minified/source mapped/etc and since the SDK [records pre- and post-context data](https://github.com/getsentry/sentry-javascript/blob/0ceba7998cabeb06a2f85ae1986509ab78dc2a7a/packages/node/src/parsers.ts#L188-L218) as part of [processing the stacktrace](https://github.com/getsentry/sentry-javascript/blob/0ceba7998cabeb06a2f85ae1986509ab78dc2a7a/packages/node/src/parsers.ts#L180), before the event is sent. Specifically, on the server, we only process frames whose paths start with `"/"`, `"app:"`, or `"webpack:"`.

That middle prefix, `"app:"`, comes directly from the SDK's `RewriteFrames` [integration](https://github.com/getsentry/sentry-javascript/blob/268c7e764f3b76a46d1e0d8447fa0da740498fbf/packages/integrations/src/rewriteframes.ts#L40), where we substitute it in for details of the path specific the machine hosting the app (if any). When using that integration, you can provide a `root` configuration option, to tell the integration about those machine-specific details. And when you do that, we look at the [relative path](https://github.com/getsentry/sentry-javascript/blob/268c7e764f3b76a46d1e0d8447fa0da740498fbf/packages/integrations/src/rewriteframes.ts#L39) from that root to the file in question. The intent here is to turn `/some/irrelevant/stuff/myapp/path/to/file.js` into `app:///path/to/file.js`, and for that it works great.

What is also does, though, is take paths to files _outside_ of your app (like `node_modules` files) and transform their paths into things like `app:///../node_modules/someModule/path/to/someScript.js`. As a result, the server-side check for whether or not we should skip the file fails, we continue to process the file, and (as predicted) run into problems:

![image](https://user-images.githubusercontent.com/14812505/76247065-2514e280-61fc-11ea-9b05-8a59d77f85f0.png)

This PR simply casts a wider net when looking for files to exclude.
