### PR TITLE
feat(metrics) - Add a metric for group changes

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -424,10 +424,10 @@ def track_update_groups(function):
     def wrapper(request, projects, *args, **kwargs):
         try:
             response = function(request, projects, *args, **kwargs)
-        except Exception as error:
+        except Exception:
             metrics.incr("group.update.http_response", sample_rate=1.0, tags={"status": 500})
             # Continue raising the error now that we've incr the metric
-            raise error
+            raise
 
         serializer = GroupValidator(
             data=request.data, partial=True, context={"project": projects[0]}

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -421,10 +421,12 @@ def self_subscribe_and_assign_issue(acting_user, group):
 
 
 def track_update_groups(function):
-    def wrapper(request, *args, **kwargs):
-        response = function(request, *args, **kwargs)
+    def wrapper(request, projects, *args, **kwargs):
+        response = function(request, projects, *args, **kwargs)
 
-        serializer = GroupValidator(data=request.data, partial=True)
+        serializer = GroupValidator(
+            data=request.data, partial=True, context={"project": projects[0]}
+        )
         results = dict(serializer.validated_data) if serializer.is_valid() else {}
         tags = {key: True for key in results.keys()}
         tags["status"] = response.status_code


### PR DESCRIPTION
- This is for an SLO to be added in DataDog to find out the % of actions
  that are successful when updating groups
- Using a decorator to have as small an impact to the `update_groups`
  function as possible, and catch anywhere this function is used.
- @JTCunning requesting review to make sure the `sample_rate=1.0` is okay