### PR TITLE
fix(plugins): reset test results when initiating test

### DIFF
--- a/src/sentry/static/sentry/app/components/pluginConfig.jsx
+++ b/src/sentry/static/sentry/app/components/pluginConfig.jsx
@@ -71,6 +71,7 @@ class PluginConfig extends React.Component {
   };
 
   handleTestPlugin = async () => {
+    this.setState({testResults: ''});
     addLoadingMessage(t('Sending test...'));
 
     try {


### PR DESCRIPTION
This PR wipes out the result of the last test when initiating a new one.