### PR TITLE
fix(migration): 0051 shouldn't be atomic

### DIFF
--- a/src/sentry/migrations/0051_fix_auditlog_pickled_data.py
+++ b/src/sentry/migrations/0051_fix_auditlog_pickled_data.py
@@ -47,7 +47,7 @@ class Migration(migrations.Migration):
     # By default we prefer to run in a transaction, but for migrations where you want
     # to `CREATE INDEX CONCURRENTLY` this needs to be set to False. Typically you'll
     # want to create an index concurrently when adding one to an existing table.
-    atomic = True
+    atomic = False
 
     dependencies = [("sentry", "0050_auto_20200306_2346")]
 


### PR DESCRIPTION
Since we run these via a manual migration tool this shouldn't be atomic.