### PR TITLE
ref(guides): Refactor assistant guides backend

### DIFF
--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
+import six
+
 from copy import deepcopy
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError
 from django.http import HttpResponse
 from django.utils import timezone
 from rest_framework import serializers
@@ -18,18 +20,28 @@ VALID_STATUSES = frozenset(("viewed", "dismissed"))
 
 
 class AssistantSerializer(serializers.Serializer):
-    guide_id = serializers.IntegerField(required=True)
-    status = serializers.ChoiceField(choices=zip(VALID_STATUSES, VALID_STATUSES), required=True)
-    useful = serializers.BooleanField()
+    guide = serializers.CharField(required=False)
+    guide_id = serializers.IntegerField(required=False)
+    status = serializers.ChoiceField(choices=zip(VALID_STATUSES, VALID_STATUSES))
+    useful = serializers.BooleanField(required=False)
 
-    def validate_guide_id(self, value):
-        valid_ids = manager.get_valid_ids()
+    def validate(self, attrs):
+        attrs = super(AssistantSerializer, self).validate(attrs)
+        guide = attrs.get("guide")
+        guide_id = attrs.get("guide_id")
 
-        if not value:
-            raise serializers.ValidationError("Assistant guide id is required")
-        if value not in valid_ids:
-            raise serializers.ValidationError("Not a valid assistant guide id")
-        return value
+        if guide_id:
+            return attrs
+
+        if not guide:
+            raise serializers.ValidationError("Assistant guide or guide_id is required")
+
+        guide_id = manager.get_guide_id(guide)
+        if not guide_id:
+            raise serializers.ValidationError("Not a valid assistant guide")
+        attrs["guide_id"] = guide_id
+
+        return attrs
 
 
 class AssistantEndpoint(Endpoint):
@@ -41,26 +53,37 @@ class AssistantEndpoint(Endpoint):
         seen_ids = set(
             AssistantActivity.objects.filter(user=request.user).values_list("guide_id", flat=True)
         )
-        for k, v in guides.items():
-            v["seen"] = v["id"] in seen_ids
+
+        for key, value in six.iteritems(guides):
+            value["seen"] = value["id"] in seen_ids
+
+        if "v2" in request.GET:
+            guides = [
+                {"guide": key, "seen": value["seen"] in seen_ids}
+                for key, value in six.iteritems(guides)
+            ]
         return Response(guides)
 
     def put(self, request):
         """Mark a guide as viewed or dismissed.
 
         Request is of the form {
-            'guide_id': <guide_id>,
+            'guide_id': <guide_id> - OR -
+            'guide': guide key (e.g. 'issue'),
             'status': 'viewed' / 'dismissed',
             'useful' (optional): true / false,
         }
         """
-        serializer = AssistantSerializer(data=request.data, partial=True)
+        serializer = AssistantSerializer(data=request.data)
+
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        guide_id = request.data["guide_id"]
-        status = request.data["status"]
-        useful = request.data.get("useful")
+        data = serializer.validated_data
+
+        guide_id = data["guide_id"]
+        status = data["status"]
+        useful = data.get("useful")
 
         fields = {}
         if useful is not None:
@@ -71,8 +94,7 @@ class AssistantEndpoint(Endpoint):
             fields["dismissed_ts"] = timezone.now()
 
         try:
-            with transaction.atomic():
-                AssistantActivity.objects.create(user=request.user, guide_id=guide_id, **fields)
+            AssistantActivity.objects.create(user=request.user, guide_id=guide_id, **fields)
         except IntegrityError:
             pass
 

--- a/src/sentry/assistant/manager.py
+++ b/src/sentry/assistant/manager.py
@@ -13,5 +13,10 @@ class AssistantManager(object):
     def get_valid_ids(self):
         return list(v["id"] for k, v in six.iteritems(self._guides))
 
+    def get_guide_id(self, guide):
+        guide = self._guides.get(guide)
+        if guide:
+            return guide.get("id")
+
     def all(self):
         return self._guides

--- a/tests/sentry/api/endpoints/test_assistant.py
+++ b/tests/sentry/api/endpoints/test_assistant.py
@@ -1,16 +1,19 @@
 from __future__ import absolute_import
 
 from copy import deepcopy
+from exam import fixture
 
 from django.core.urlresolvers import reverse
+from django.utils import timezone
 
 from sentry.assistant import manager
+from sentry.models import AssistantActivity
 from sentry.testutils import APITestCase
 
 
-class AssistantActivity(APITestCase):
+class AssistantActivityTest(APITestCase):
     def setUp(self):
-        super(AssistantActivity, self).setUp()
+        super(AssistantActivityTest, self).setUp()
         self.login_as(user=self.user)
         self.path = reverse("sentry-api-0-assistant")
         self.guides = manager.all()
@@ -49,3 +52,87 @@ class AssistantActivity(APITestCase):
                 steps_i = set(s["target"] for s in guides[i]["steps"])
                 steps_j = set(s["target"] for s in guides[j]["steps"])
                 assert not (steps_i & steps_j)
+
+
+class AssistantActivityV2Test(APITestCase):
+    endpoint = "sentry-api-0-assistant"
+
+    @fixture
+    def guides(self):
+        return manager.all()
+
+    def setUp(self):
+        super(AssistantActivityV2Test, self).setUp()
+        self.create_organization(owner=self.user)
+        self.login_as(user=self.user)
+
+    def test_simple(self):
+        resp = self.get_response(qs_params={"v2": 1})
+        assert resp.status_code == 200
+
+        assert len(resp.data) == len(manager.all())
+        for guide in resp.data:
+            assert guide["seen"] is False
+
+    def test_dismissed(self):
+        guide = "issue"
+        AssistantActivity.objects.create(
+            user=self.user, guide_id=self.guides[guide]["id"], dismissed_ts=timezone.now()
+        )
+        resp = self.get_response(qs_params={"v2": 1})
+        assert resp.status_code == 200
+        assert {"guide": guide, "seen": True} in resp.data
+
+    def test_viewed(self):
+        guide = "issue"
+        AssistantActivity.objects.create(
+            user=self.user, guide_id=self.guides[guide]["id"], viewed_ts=timezone.now()
+        )
+        resp = self.get_response(qs_params={"v2": 1})
+        assert resp.status_code == 200
+        assert {"guide": guide, "seen": True} in resp.data
+
+
+class AssistantActivityV2UpdateTest(APITestCase):
+    endpoint = "sentry-api-0-assistant"
+    method = "put"
+
+    @fixture
+    def guides(self):
+        return manager.all()
+
+    def setUp(self):
+        super(AssistantActivityV2UpdateTest, self).setUp()
+        self.create_organization(owner=self.user)
+        self.login_as(user=self.user)
+
+    def test_invalid_inputs(self):
+        resp = self.get_response(guide="guide_does_not_exist")
+        assert resp.status_code == 400
+
+        resp = self.get_response(guide="guide_does_not_exist", status="dismissed")
+        assert resp.status_code == 400
+
+        resp = self.get_response(status="dismissed")
+        assert resp.status_code == 400
+
+        resp = self.get_response(guide="issue", status="whats_my_name_again")
+        assert resp.status_code == 400
+
+    def test_dismissed(self):
+        guide = "issue_stream"
+        resp = self.get_response(guide=guide, status="dismissed")
+        assert resp.status_code == 201
+
+        activity = AssistantActivity.objects.get(user=self.user, guide_id=self.guides[guide]["id"])
+        assert activity.dismissed_ts
+        assert not activity.viewed_ts
+
+    def test_viewed(self):
+        guide = "issue_stream"
+        resp = self.get_response(guide=guide, status="viewed")
+        assert resp.status_code == 201
+
+        activity = AssistantActivity.objects.get(user=self.user, guide_id=self.guides[guide]["id"])
+        assert activity.viewed_ts
+        assert not activity.dismissed_ts

--- a/tests/sentry/api/endpoints/test_assistant.py
+++ b/tests/sentry/api/endpoints/test_assistant.py
@@ -19,11 +19,15 @@ class AssistantActivityTest(APITestCase):
         self.guides = manager.all()
 
     def test_invalid_inputs(self):
-        # Invalid guide id.
-        resp = self.client.put(self.path, {"guide_id": 1938})
+        # Missing status
+        resp = self.client.put(self.path, {"guide_id": 1})
         assert resp.status_code == 400
 
-        # Invalid status.
+        # Invalid guide id
+        resp = self.client.put(self.path, {"guide_id": 1938, "status": "dismissed"})
+        assert resp.status_code == 400
+
+        # Invalid status
         resp = self.client.put(self.path, {"guide_id": 1, "status": "whats_my_name_again"})
         assert resp.status_code == 400
 

--- a/tests/sentry/api/endpoints/test_assistant.py
+++ b/tests/sentry/api/endpoints/test_assistant.py
@@ -79,7 +79,7 @@ class AssistantActivityV2Test(APITestCase):
             assert guide["seen"] is False
 
     def test_dismissed(self):
-        guide = "issue"
+        guide = "issue_stream"
         AssistantActivity.objects.create(
             user=self.user, guide_id=self.guides[guide]["id"], dismissed_ts=timezone.now()
         )
@@ -88,7 +88,7 @@ class AssistantActivityV2Test(APITestCase):
         assert {"guide": guide, "seen": True} in resp.data
 
     def test_viewed(self):
-        guide = "issue"
+        guide = "issue_stream"
         AssistantActivity.objects.create(
             user=self.user, guide_id=self.guides[guide]["id"], viewed_ts=timezone.now()
         )


### PR DESCRIPTION
Adding support for the next version of the assistant guides endpoint via a query param. The guides content (description, title, etc.) will move to the frontend, and this will map guide ids to guide keys for the frontend as well. I'll come back to clean up the endpoint once the frontend has fully moved over.