### PR TITLE
ref(ingest): Remove mark_signal_sent from outcomes consumers

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -33,23 +33,22 @@ def batch_buffers_incr():
         assert _local_buffers is None
         _local_buffers = {}
 
-    try:
-        yield
-    finally:
+    yield
+
+    with _local_buffers_lock:
         from sentry.app import buffer
 
-        with _local_buffers_lock:
-            buffers_to_flush = _local_buffers
-            _local_buffers = None
+        buffers_to_flush = _local_buffers
+        _local_buffers = None
 
-            for (filters, model), (columns, extra, signal_only) in buffers_to_flush.items():
-                buffer.incr(
-                    model=model,
-                    columns=columns,
-                    filters=dict(filters),
-                    extra=extra,
-                    signal_only=signal_only,
-                )
+        for (filters, model), (columns, extra, signal_only) in buffers_to_flush.items():
+            buffer.incr(
+                model=model,
+                columns=columns,
+                filters=dict(filters),
+                extra=extra,
+                signal_only=signal_only,
+            )
 
 
 class PendingBuffer(object):


### PR DESCRIPTION
This PR should speed up outcomes consumers and fixes a consistency bug if consumers are killed during deploys.

### Removing `is_signal_sent`

The functions `mark_signal_sent` and `is_signal_sent` were introduced to coordinate moving signals from the store views into outcomes consumers. To avoid that signals emitted twice for an event, it was marked as _sent_ by the store view and then skipped in the outcomes consumer. This transition is now complete, as all signals are handled by the consumer and code to emit them has been removed from all other locations.

There is still a small fraction of outcomes that are skipped due to `is_signal_sent`. These occur when rate-limited or filtered event_ids are ingested multiple times. For accepted and saved events, a consistent check is performed and the event is dropped silently otherwise. 

**Argument 1**: We can drop `mark_signal_sent` for these cases, since it is more correct. If we filter or rate_limit an event twice, we should also count it in the respective usage tables multiple times. This is also what was done by the old Python store code.

### Consistency during consumer restarts

The other reason why outcomes consumers marked signals as sent is to avoid emitting signals multiple times if the consumer restarts in the middle of a batch. As it turns out **the premise was wrong and we under-count at every consumer restart**. There are the following cases to consider:

1. The consumer shuts down while inactive. In this case, all offsets are committed and the outcome will not be processed again.
2. The consumer receives `SIGTERM` while reading a batch. It will drop the current batch and skip flushing or committing offsets. Since the entire outcome consumer work is performed during flush, this behavior is correct. Also it is extremely rare, since most time is spent in flushing the batch.
3. The consumer receives `SIGTERM` while flushing a batch. This is the most common case at the moment due to long flush times. The consumer does not react to sigterm but continues to flush. If it manages to finish flushing within the shutdown timeout, everything is committed correctly.
4. Shutdown timeout while flushing. **This is the critical case**. The consumer is killed instantly and no offsets are committed. At this point, some of the signals have been marked as sent. However, flushing to `buffers` is deferred and not executed at that time. When the consumer is killed, buffers are not written to Redis but the signals were marked as sent. Thus, they are under-counted.
5. There is an exception while processing an outcome. `batch_buffers_incr` writes buffers to Redis, then the consumer restarts without flushing offsets. In this case, the signal is correctly skipped since it was marked as sent.

**Argument 2**: If we don't commit offsets, we shouldn't flush `buffers` either to keep the state consistent. In that case, we can also stop to mark signals as sent, because we need to resend them when the consumer restarts. This also helps to restore consistency if the consumer is killed during shutdown.
