### PR TITLE
fix(workflow): Double slice is bad mmkay

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -88,7 +88,7 @@ class TriggersChart extends React.PureComponent<Props> {
                         },
                       }}
                       maxValue={maxValue ? maxValue.value : maxValue}
-                      data={timeseriesData?.slice(0, -1)}
+                      data={timeseriesData}
                       triggers={triggers}
                     />
                   </React.Fragment>


### PR DESCRIPTION
We were removing the last item from the array of data array's before passing it to the chart, which was doing the same - this resulted in us passing no data to the chart.