### PR TITLE
dev(direnv): ignore already-activated venvs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -35,13 +35,13 @@ require () {
 
 info () {
     cat <<EOF
-${bold}direnv: ${1}${reset}
+${bold}direnv: ${@}${reset}
 EOF
 }
 
 die () {
     >&2 cat <<EOF
-${red}${bold}direnv FATAL: ${1}
+${red}${bold}direnv FATAL: ${@}
 ${reset}
 EOF
     return 1
@@ -117,20 +117,15 @@ fi
 deactivate 2>/dev/null || true
 
 source .venv/bin/activate
+
 # XXX: ideally, direnv is able to export PS1 as modified by sourcing venvs
 #      but we'd have to patch direnv, and ".venv" isn't descriptive anyways
 unset PS1
-[ "$(command -v python)" != "${PWD}/.venv/bin/python" ] && die "Failed to activate virtualenv."
 
-# direnv set -u's, so we need to do this.
-VIRTUAL_ENV="${VIRTUAL_ENV:-}"
-
-# We're explicitly disallowing symlinked venvs.
-if [ "$VIRTUAL_ENV" != "${PWD}/.venv" ]; then
-    # VIRTUAL_ENV is written into the venv's activate script at creation time.
-    # So symlinked venvs isn't the only possibility, but the most likely one.
-    info "Your virtualenv's probably symlinked. " \
-         "We want everyone to be on the same page here, so you'll have to recreate your virtualenv."
+# We're explicitly disallowing symlinked venvs (python would resolve to the canonical location)
+if [ "$(command -v python)" != "${PWD}/.venv/bin/python" ]; then
+    info "Failed to activate virtualenv. Your virtualenv's probably symlinked." \
+    "We want everyone to be on the same page here, so you'll have to recreate your virtualenv."
     advice_init_venv
 fi
 

--- a/.envrc
+++ b/.envrc
@@ -104,30 +104,35 @@ done
 
 ### Python ###
 
-info "Checking virtualenv..."
+info "Activating virtualenv..."
 
-# direnv set -u's, so we need to do this.
-VIRTUAL_ENV="${VIRTUAL_ENV:-}"
-
-if [ -n "$VIRTUAL_ENV" ]; then
-    # we're enforcing that virtualenv be in .venv, since future tooling e.g. venv-update will rely on this.
-    if [ "$VIRTUAL_ENV" != "${PWD}/.venv" ]; then
-        info "You're in a virtualenv, but it's not in the expected location (${PWD}/.venv)"
-        advice_init_venv
-    fi
-else
-    if [ ! -f ".venv/bin/activate" ]; then
-        info "You don't seem to have a virtualenv."
-        advice_init_venv
-    fi
+# we're enforcing that virtualenv be in .venv, since future tooling e.g. venv-update will rely on this.
+if [ ! -f ".venv/bin/activate" ]; then
+    info "You don't seem to have a virtualenv."
+    advice_init_venv
 fi
 
-info "Activating virtualenv..."
+# The user might be cd'ing into sentry with another non-direnv managed
+# (in that it would be automatically deactivated) virtualenv active.
+deactivate 2>/dev/null || true
+
 source .venv/bin/activate
 # XXX: ideally, direnv is able to export PS1 as modified by sourcing venvs
 #      but we'd have to patch direnv, and ".venv" isn't descriptive anyways
 unset PS1
 [ "$(command -v python)" != "${PWD}/.venv/bin/python" ] && die "Failed to activate virtualenv."
+
+# direnv set -u's, so we need to do this.
+VIRTUAL_ENV="${VIRTUAL_ENV:-}"
+
+# We're explicitly disallowing symlinked venvs.
+if [ "$VIRTUAL_ENV" != "${PWD}/.venv" ]; then
+    # VIRTUAL_ENV is written into the venv's activate script at creation time.
+    # So symlinked venvs isn't the only possibility, but the most likely one.
+    info "Your virtualenv's probably symlinked. " \
+         "We want everyone to be on the same page here, so you'll have to recreate your virtualenv."
+    advice_init_venv
+fi
 
 python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
     die "For some reason, the virtualenv isn't Python 2.7."


### PR DESCRIPTION
The user might be cd'ing into sentry with another non-direnv managed (in that it would be automatically deactivated) virtualenv active.

In that case, the VIRTUAL_ENV comparison will just fail. It used to start overwriting `.venv` in an attempt to do first-time bootstrapping/init - that's been remedied in https://github.com/getsentry/sentry/pull/17533, but it really is just better design to ignore already-activated virtualenvs.