### PR TITLE
feat(integrations): standardizing API clients

### DIFF
--- a/src/sentry_plugins/exceptions.py
+++ b/src/sentry_plugins/exceptions.py
@@ -53,6 +53,21 @@ class ApiHostError(ApiError):
         return cls("Unable to reach host: {}".format(host))
 
 
+class ApiTimeoutError(ApiError):
+    code = 504
+
+    @classmethod
+    def from_exception(cls, exception):
+        if getattr(exception, "request"):
+            return cls.from_request(exception.request)
+        return cls("Timed out reaching host")
+
+    @classmethod
+    def from_request(cls, request):
+        host = urlparse(request.url).netloc
+        return cls(u"Timed out attempting to reach host: {}".format(host))
+
+
 class ApiUnauthorized(ApiError):
     code = 401
 


### PR DESCRIPTION
This PR does two things:
1. Simplifies the calls to `track_response_data` in the integration API client
2. Modifies the plugin API client to be more like the integration API client:
   a. Adds a field for timeout
   b. Adds another error handling case for timeout errors
   c. Adds logging for requests
   d. Add `logging_context` as optional param to init function

This PR will also enable us to potentially create a base class that we could use in both API clients since they will be more standardized.