### PR TITLE
fix(ui) Fix refinement showing up when it shouldn't

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -52,13 +52,13 @@ class ColumnEditRow extends React.Component<Props> {
     switch (value.kind) {
       case FieldValueKind.TAG:
       case FieldValueKind.FIELD:
-        currentParams = ['', value.meta.name, ''];
+        currentParams = ['', value.meta.name, undefined];
         break;
       case FieldValueKind.FUNCTION:
         currentParams[0] = value.meta.name;
         // Backwards compatibility for field alias versions of functions.
         if (currentParams[1] && FIELD_ALIASES.includes(currentParams[1])) {
-          currentParams = [currentParams[0], '', ''];
+          currentParams = [currentParams[0], '', undefined];
         }
         break;
       default:

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.jsx
@@ -266,7 +266,7 @@ describe('EventsV2 -> ColumnEditModal', function() {
 
       expect(onApply).toHaveBeenCalledWith([
         columns[1],
-        {field: 'title', aggregation: '', refinement: ''},
+        {field: 'title', aggregation: '', refinement: undefined},
       ]);
     });
   });


### PR DESCRIPTION
The refinement column should only show up when a function includes a 3rd parameter. Changing to a field should not fill the refinement with a non-undefined value.