### PR TITLE
ref(py3): bump sentry-flake8 to 0.3.1 to disallow itertools.izip

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,5 +11,5 @@ pytest-html==1.22.0
 pytest-sentry==0.1.1
 pytest-rerunfailures==8.0
 responses>=0.8.1,<0.9.0
-sentry-flake8==0.3.0
+sentry-flake8==0.3.1
 werkzeug==0.15.5

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from itertools import izip
-
 import six
 from django.db import IntegrityError, transaction
 from rest_framework.response import Response
@@ -28,6 +26,7 @@ from sentry.snuba.sessions import (
 )
 from sentry.utils.apidocs import scenario, attach_scenarios
 from sentry.utils.cache import cache
+from sentry.utils.compat import zip as izip
 
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"


### PR DESCRIPTION
This bumps sentry-flake8 to 0.3.1 which disallows itertools.izip, and fixes the lint errors.