### PR TITLE
set the sample rate for sso metric to be the same

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -150,7 +150,7 @@ def handle_existing_identity(
         return HttpResponseRedirect(auth.get_login_redirect(request))
 
     state.clear()
-    metrics.incr("sso.login-success", tags={"provider": provider.key}, skip_internal=False)
+    metrics.incr("sso.login-success", tags={"provider": provider.key}, skip_internal=False, sample_rate=1.0)
 
     return HttpResponseRedirect(auth.get_login_redirect(request))
 


### PR DESCRIPTION
setting the sso login successs sample rate to be 1, same as the sso error

related to https://github.com/getsentry/sentry/pull/16899