### PR TITLE
feat(workflow): Add Solo Mail Action with Targeting

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -227,6 +227,7 @@ SENTRY_RULES = (
     "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition",
     "sentry.rules.conditions.event_attribute.EventAttributeCondition",
     "sentry.rules.conditions.level.LevelCondition",
+    "sentry.rules.actions.notify_email.NotifyEmailAction",
 )
 
 # methods as defined by http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html + PATCH

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -17,12 +17,41 @@ logger = logging.getLogger("sentry.digests")
 
 Notification = namedtuple("Notification", "event rules")
 
+# TODO(jeff): Do I need to used special characters or randomize this string to reduce probability of collision.
+TARGETED_MAIL_ACTION_SYMBOL = "targeted_mail"
+
+
+def is_targeted_action_key(key):
+    return [
+        token
+        for idx, token in enumerate(key.split(":"))
+        if idx == 0 and token == TARGETED_MAIL_ACTION_SYMBOL
+    ].length == 1
+
+
+def split_key_for_targeted_action(key):
+    # TODO(jeff): Change import once logic has been bubbled to action
+    from sentry.rules.actions.notify_email import MailPlugin
+
+    _, _, project_id, target_type, target_identifier = key.split(":", 4)
+    return MailPlugin(), Project.objects.get(pk=project_id), target_type, target_identifier
+
 
 def split_key(key):
     from sentry.plugins.base import plugins
 
     plugin_slug, _, project_id = key.split(":", 2)
     return plugins.get(plugin_slug), Project.objects.get(pk=project_id)
+
+
+def unsplit_key_for_targeted_action(project, target_type, target_id=None):
+    sanitised_target_id = target_id if (target_id is not None) else -1
+    return u"{targeted_action_symbol}:p:{project.id}:{target_type}:{sanitised_target_id}".format(
+        targeted_action_symbol=TARGETED_MAIL_ACTION_SYMBOL,
+        project=project,
+        target_type=target_type,
+        sanitised_target_id=sanitised_target_id,
+    )
 
 
 def unsplit_key(plugin, project):

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -21,16 +21,21 @@ Notification = namedtuple("Notification", "event rules")
 TARGETED_MAIL_ACTION_SYMBOL = "targeted_mail"
 
 
+# TODO(jeff):tests needed for these new methods
 def is_targeted_action_key(key):
-    return [
-        token
-        for idx, token in enumerate(key.split(":"))
-        if idx == 0 and token == TARGETED_MAIL_ACTION_SYMBOL
-    ].length == 1
+    return (
+        len(
+            [
+                token
+                for idx, token in enumerate(key.split(":"))
+                if idx == 0 and token == TARGETED_MAIL_ACTION_SYMBOL
+            ]
+        )
+        == 1
+    )
 
 
 def split_key_for_targeted_action(key):
-    # TODO(jeff): Change import once logic has been bubbled to action
     from sentry.rules.actions.notify_email import MailAdapter
 
     _, _, project_id, target_type, target_identifier = key.split(":", 4)

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -17,11 +17,10 @@ logger = logging.getLogger("sentry.digests")
 
 Notification = namedtuple("Notification", "event rules")
 
-# TODO(jeff): Do I need to used special characters or randomize this string to reduce probability of collision.
 TARGETED_MAIL_ACTION_SYMBOL = "targeted_mail"
 
 
-# TODO(jeff):tests needed for these new methods
+# TODO(jeff): Tests needed
 def is_targeted_action_key(key):
     return (
         len(
@@ -35,6 +34,7 @@ def is_targeted_action_key(key):
     )
 
 
+# TODO(jeff): Tests needed
 def split_key_for_targeted_action(key):
     from sentry.rules.actions.notify_email import MailAdapter
 
@@ -49,6 +49,7 @@ def split_key(key):
     return plugins.get(plugin_slug), Project.objects.get(pk=project_id)
 
 
+# TODO(jeff): Tests needed
 def unsplit_key_for_targeted_action(project, target_type, target_id=None):
     sanitised_target_id = target_id if (target_id is not None) else -1
     return u"{targeted_action_symbol}:p:{project.id}:{target_type}:{sanitised_target_id}".format(

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -31,10 +31,10 @@ def is_targeted_action_key(key):
 
 def split_key_for_targeted_action(key):
     # TODO(jeff): Change import once logic has been bubbled to action
-    from sentry.rules.actions.notify_email import MailPlugin
+    from sentry.rules.actions.notify_email import MailAdapter
 
     _, _, project_id, target_type, target_identifier = key.split(":", 4)
-    return MailPlugin(), Project.objects.get(pk=project_id), target_type, target_identifier
+    return MailAdapter(), Project.objects.get(pk=project_id), target_type, target_identifier
 
 
 def split_key(key):

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -20,7 +20,6 @@ Notification = namedtuple("Notification", "event rules")
 TARGETED_MAIL_ACTION_SYMBOL = "targeted_mail"
 
 
-# TODO(jeff): Tests needed
 def is_targeted_action_key(key):
     return (
         len(
@@ -34,12 +33,16 @@ def is_targeted_action_key(key):
     )
 
 
-# TODO(jeff): Tests needed
 def split_key_for_targeted_action(key):
     from sentry.rules.actions.notify_email import MailAdapter
 
-    _, _, project_id, target_type, target_identifier = key.split(":", 4)
-    return MailAdapter(), Project.objects.get(pk=project_id), target_type, target_identifier
+    _, _, project_id, target_type, target_identifier_str = key.split(":", 4)
+    return (
+        MailAdapter(),
+        Project.objects.get(pk=project_id),
+        target_type,
+        int(target_identifier_str),
+    )
 
 
 def split_key(key):
@@ -49,7 +52,6 @@ def split_key(key):
     return plugins.get(plugin_slug), Project.objects.get(pk=project_id)
 
 
-# TODO(jeff): Tests needed
 def unsplit_key_for_targeted_action(project, target_type, target_id=None):
     sanitised_target_id = target_id if (target_id is not None) else -1
     return u"{targeted_action_symbol}:p:{project.id}:{target_type}:{sanitised_target_id}".format(

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -21,16 +21,7 @@ TARGETED_MAIL_ACTION_SYMBOL = "targeted_mail"
 
 
 def is_targeted_action_key(key):
-    return (
-        len(
-            [
-                token
-                for idx, token in enumerate(key.split(":"))
-                if idx == 0 and token == TARGETED_MAIL_ACTION_SYMBOL
-            ]
-        )
-        == 1
-    )
+    return key.startswith("{symbol}:".format(symbol=TARGETED_MAIL_ACTION_SYMBOL))
 
 
 def split_key_for_targeted_action(key):

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -44,7 +44,7 @@ def split_key(key):
 
 
 def unsplit_key_for_targeted_action(project, target_type, target_id=None):
-    sanitised_target_id = target_id if (target_id is not None) else -1
+    sanitised_target_id = target_id if target_id is not None else -1
     return u"{targeted_action_symbol}:p:{project.id}:{target_type}:{sanitised_target_id}".format(
         targeted_action_symbol=TARGETED_MAIL_ACTION_SYMBOL,
         project=project,

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -339,7 +339,6 @@ class MailPlugin(NotificationPlugin):
             kwargs={"project_id": project.id},
         )
 
-    # TODO(jeff): Yeet this method
     def notify(self, notification, target_type, target_identifier=None, **kwargs):
         from sentry.models import Commit, Release
 
@@ -453,8 +452,8 @@ class MailPlugin(NotificationPlugin):
     # TODO(Jeff): Not required, but there is a dependency on mail plugin due to the way we send digests (sent key will
     #  be used to instantiate the MailPlugin to handle the notifyDigest call)
     # TODO(Jeff): How do we supply the additional argument (target_id) to digest?
-    def notify_digest(self, project, digest):
-        user_ids = self.get_send_to(project)
+    def notify_digest(self, project, digest, target_type, target_identifier=None):
+        user_ids = self.get_send_to(project, target_type, target_identifier)
         for user_id, digest in get_personalized_digests(project.id, digest, user_ids):
             start, end, counts = get_digest_metadata(digest)
 
@@ -471,7 +470,7 @@ class MailPlugin(NotificationPlugin):
                     key=lambda record: record.timestamp,
                 )
                 notification = Notification(record.value.event, rules=record.value.rules)
-                return self.notify(notification)
+                return self.notify(notification, target_type, target_identifier)
 
             context = {
                 "start": start,

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -1,0 +1,503 @@
+"""
+Used for notifying a *specific* plugin
+"""
+from __future__ import absolute_import
+
+from django import forms
+
+from sentry.db.models.fields.bounded import BoundedBigIntegerField
+
+# from sentry.plugins.base import plugins
+from sentry.rules.actions.base import EventAction
+
+# from sentry.rules.actions.services import PluginService, SentryAppService
+# from sentry.models import SentryApp
+# from sentry.utils.safe import safe_execute
+
+
+CHOICES = [("Member", "Member"), ("Owner", "Owner"), ("Team", "Team")]
+
+
+class NotifyEmailForm(forms.Form):
+    targetType = forms.ChoiceField(choices=CHOICES)
+    targetIdentifier = BoundedBigIntegerField().formfield(required=False)
+
+
+class NotifyEmailAction(EventAction):
+    form_cls = NotifyEmailForm
+    label = "Send an email to {targetType}"
+
+    def __init__(self, *args, **kwargs):
+        super(NotifyEmailAction, self).__init__(*args, **kwargs)
+        self.form_fields = {"targetType": {"type": "mailAction", "choices": CHOICES}}
+
+    def after(self, event, state):
+        extra = {"event_id": event.event_id}
+        plugin = MailPlugin()
+        if not plugin.is_enabled(self.project):
+            extra["project_id"] = self.project.id
+            self.logger.info("rules.fail.is_enabled", extra=extra)
+            return
+
+        group = event.group
+
+        if not plugin.should_notify(group=group, event=event):
+            extra["group_id"] = group.id
+            self.logger.info("rule.fail.should_notify", extra=extra)
+            return
+
+        metrics.incr("notifications.sent", instance=plugin.slug, skip_internal=False)
+        yield self.future(plugin.rule_notify)
+
+    # def get_sentry_app_services(self):
+    #     apps = SentryApp.objects.filter(
+    #         installations__organization_id=self.project.organization_id, is_alertable=True
+    #     ).distinct()
+    #     results = [SentryAppService(app) for app in apps]
+    #     return results
+
+    # def get_plugins(self):
+    #     from sentry.plugins.bases.notify import NotificationPlugin
+    #
+    #     results = []
+    #     for plugin in plugins.for_project(self.project, version=1):
+    #         if not isinstance(plugin, NotificationPlugin):
+    #             continue
+    #         results.append(PluginService(plugin))
+    #
+    #     for plugin in plugins.for_project(self.project, version=2):
+    #         for notifier in safe_execute(plugin.get_notifiers, _with_transaction=False) or ():
+    #             results.append(PluginService(notifier))
+    #
+    #     return results
+
+    # def get_services(self):
+    #     services = self.get_plugins()
+    #     services += self.get_sentry_app_services()
+    #     return services
+
+    def get_form_instance(self):
+        return self.form_cls(self.data)
+
+
+import itertools
+import logging
+import six
+
+import sentry
+
+from django.core.urlresolvers import reverse
+from django.utils import dateformat
+from django.utils.encoding import force_text
+from django.utils.safestring import mark_safe
+
+from sentry import options
+from sentry.models import ProjectOwnership, User
+
+from sentry.digests.utilities import get_digest_metadata, get_personalized_digests
+from sentry.plugins.base.structs import Notification
+from sentry.plugins.bases.notify import NotificationPlugin
+from sentry.utils import metrics
+from sentry.utils.cache import cache
+from sentry.utils.committers import get_serialized_event_file_committers
+from sentry.utils.email import MessageBuilder, group_id_to_email
+from sentry.utils.http import absolute_uri
+from sentry.utils.linksign import generate_signed_link
+
+from sentry.plugins.sentry_mail.activity import emails
+
+NOTSET = object()
+
+logger = logging.getLogger(__name__)
+
+
+class MailPlugin(NotificationPlugin):
+    title = "Mail"
+    conf_key = "mail"
+    slug = "mail"
+    version = sentry.VERSION
+    author = "Sentry Team"
+    author_url = "https://github.com/getsentry/sentry"
+    project_default_enabled = True
+    project_conf_form = None
+    subject_prefix = None
+
+    def _subject_prefix(self):
+        if self.subject_prefix is not None:
+            return self.subject_prefix
+        return options.get("mail.subject-prefix")
+
+    def _build_message(
+        self,
+        project,
+        subject,
+        template=None,
+        html_template=None,
+        body=None,
+        reference=None,
+        reply_reference=None,
+        headers=None,
+        context=None,
+        send_to=None,
+        type=None,
+    ):
+        if send_to is None:
+            send_to = self.get_send_to(project)
+        if not send_to:
+            logger.debug("Skipping message rendering, no users to send to.")
+            return
+
+        subject_prefix = self.get_option("subject_prefix", project) or self._subject_prefix()
+        subject_prefix = force_text(subject_prefix)
+        subject = force_text(subject)
+
+        msg = MessageBuilder(
+            subject="%s%s" % (subject_prefix, subject),
+            template=template,
+            html_template=html_template,
+            body=body,
+            headers=headers,
+            type=type,
+            context=context,
+            reference=reference,
+            reply_reference=reply_reference,
+        )
+        msg.add_users(send_to, project=project)
+        return msg
+
+    def _send_mail(self, *args, **kwargs):
+        message = self._build_message(*args, **kwargs)
+        if message is not None:
+            return message.send_async()
+
+    def get_notification_settings_url(self):
+        return absolute_uri(reverse("sentry-account-settings-notifications"))
+
+    def get_project_url(self, project):
+        return absolute_uri(u"/{}/{}/".format(project.organization.slug, project.slug))
+
+    def is_configured(self, project, **kwargs):
+        # Nothing to configure here
+        return True
+
+    def should_notify(self, group, event):
+        send_to = self.get_sendable_users(group.project)
+        if not send_to:
+            return False
+
+        return super(MailPlugin, self).should_notify(group, event)
+
+    def get_send_to(self, project, event=None):
+        """
+        Returns a list of user IDs for the users that should receive
+        notifications for the provided project.
+
+        This result may come from cached data.
+        """
+        if not (project and project.teams.exists()):
+            logger.debug("Tried to send notification to invalid project: %r", project)
+            return []
+
+        if event:
+            owners, _ = ProjectOwnership.get_owners(project.id, event.data)
+            if owners != ProjectOwnership.Everyone:
+                if not owners:
+                    metrics.incr(
+                        "features.owners.send_to",
+                        tags={"organization": project.organization_id, "outcome": "empty"},
+                        skip_internal=True,
+                    )
+                    return []
+
+                metrics.incr(
+                    "features.owners.send_to",
+                    tags={"organization": project.organization_id, "outcome": "match"},
+                    skip_internal=True,
+                )
+                send_to_list = set()
+                teams_to_resolve = set()
+                for owner in owners:
+                    if owner.type == User:
+                        send_to_list.add(owner.id)
+                    else:
+                        teams_to_resolve.add(owner.id)
+
+                # get all users in teams
+                if teams_to_resolve:
+                    send_to_list |= set(
+                        User.objects.filter(
+                            is_active=True,
+                            sentry_orgmember_set__organizationmemberteam__team__id__in=teams_to_resolve,
+                        ).values_list("id", flat=True)
+                    )
+
+                alert_settings = project.get_member_alert_settings(self.alert_option_key)
+                disabled_users = set(
+                    user for user, setting in alert_settings.items() if setting == 0
+                )
+                return send_to_list - disabled_users
+            else:
+                metrics.incr(
+                    "features.owners.send_to",
+                    tags={"organization": project.organization_id, "outcome": "everyone"},
+                    skip_internal=True,
+                )
+
+        cache_key = "%s:send_to:%s" % (self.get_conf_key(), project.pk)
+        send_to_list = cache.get(cache_key)
+        if send_to_list is None:
+            send_to_list = [s for s in self.get_sendable_users(project) if s]
+            cache.set(cache_key, send_to_list, 60)  # 1 minute cache
+
+        return send_to_list
+
+    def add_unsubscribe_link(self, context, user_id, project, referrer):
+        context["unsubscribe_link"] = generate_signed_link(
+            user_id,
+            "sentry-account-email-unsubscribe-project",
+            referrer,
+            kwargs={"project_id": project.id},
+        )
+
+    def notify(self, notification, **kwargs):
+        from sentry.models import Commit, Release
+
+        event = notification.event
+
+        environment = event.get_tag("environment")
+
+        group = event.group
+        project = group.project
+        org = group.organization
+
+        subject = event.get_email_subject()
+
+        query_params = {"referrer": "alert_email"}
+        if environment:
+            query_params["environment"] = environment
+        link = group.get_absolute_url(params=query_params)
+
+        template = "sentry/emails/error.txt"
+        html_template = "sentry/emails/error.html"
+
+        rules = []
+        for rule in notification.rules:
+            rule_link = "/settings/%s/projects/%s/alerts/rules/%s/" % (
+                org.slug,
+                project.slug,
+                rule.id,
+            )
+
+            rules.append((rule.label, rule_link))
+
+        enhanced_privacy = org.flags.enhanced_privacy
+
+        # lets identify possibly suspect commits and owners
+        commits = {}
+        try:
+            committers = get_serialized_event_file_committers(project, event)
+        except (Commit.DoesNotExist, Release.DoesNotExist):
+            pass
+        except Exception as exc:
+            logging.exception(six.text_type(exc))
+        else:
+            for committer in committers:
+                for commit in committer["commits"]:
+                    if commit["id"] not in commits:
+                        commit_data = commit.copy()
+                        commit_data["shortId"] = commit_data["id"][:7]
+                        commit_data["author"] = committer["author"]
+                        commit_data["subject"] = commit_data["message"].split("\n", 1)[0]
+                        commits[commit["id"]] = commit_data
+
+        context = {
+            "project_label": project.get_full_name(),
+            "group": group,
+            "event": event,
+            "link": link,
+            "rules": rules,
+            "enhanced_privacy": enhanced_privacy,
+            "commits": sorted(commits.values(), key=lambda x: x["score"], reverse=True),
+            "environment": environment,
+        }
+
+        # if the organization has enabled enhanced privacy controls we dont send
+        # data which may show PII or source code
+        if not enhanced_privacy:
+            interface_list = []
+            for interface in six.itervalues(event.interfaces):
+                body = interface.to_email_html(event)
+                if not body:
+                    continue
+                text_body = interface.to_string(event)
+                interface_list.append((interface.get_title(), mark_safe(body), text_body))
+
+            context.update({"tags": event.tags, "interfaces": interface_list})
+
+        headers = {
+            "X-Sentry-Logger": group.logger,
+            "X-Sentry-Logger-Level": group.get_level_display(),
+            "X-Sentry-Project": project.slug,
+            "X-Sentry-Reply-To": group_id_to_email(group.id),
+        }
+
+        for user_id in self.get_send_to(project=project, event=event):
+            self.add_unsubscribe_link(context, user_id, project, "alert_email")
+
+            self._send_mail(
+                subject=subject,
+                template=template,
+                html_template=html_template,
+                project=project,
+                reference=group,
+                headers=headers,
+                type="notify.error",
+                context=context,
+                send_to=[user_id],
+            )
+
+    def get_digest_subject(self, group, counts, date):
+        return u"{short_id} - {count} new {noun} since {date}".format(
+            short_id=group.qualified_short_id,
+            count=len(counts),
+            noun="alert" if len(counts) == 1 else "alerts",
+            date=dateformat.format(date, "N j, Y, P e"),
+        )
+
+    def notify_digest(self, project, digest):
+        user_ids = self.get_send_to(project)
+        for user_id, digest in get_personalized_digests(project.id, digest, user_ids):
+            start, end, counts = get_digest_metadata(digest)
+
+            # If there is only one group in this digest (regardless of how many
+            # rules it appears in), we should just render this using the single
+            # notification template. If there is more than one record for a group,
+            # just choose the most recent one.
+            if len(counts) == 1:
+                group = six.next(iter(counts))
+                record = max(
+                    itertools.chain.from_iterable(
+                        groups.get(group, []) for groups in six.itervalues(digest)
+                    ),
+                    key=lambda record: record.timestamp,
+                )
+                notification = Notification(record.value.event, rules=record.value.rules)
+                return self.notify(notification)
+
+            context = {
+                "start": start,
+                "end": end,
+                "project": project,
+                "digest": digest,
+                "counts": counts,
+            }
+
+            headers = {"X-Sentry-Project": project.slug}
+
+            group = six.next(iter(counts))
+            subject = self.get_digest_subject(group, counts, start)
+
+            self.add_unsubscribe_link(context, user_id, project, "alert_digest")
+            self._send_mail(
+                subject=subject,
+                template="sentry/emails/digests/body.txt",
+                html_template="sentry/emails/digests/body.html",
+                project=project,
+                reference=project,
+                headers=headers,
+                type="notify.digest",
+                context=context,
+                send_to=[user_id],
+            )
+
+    def notify_about_activity(self, activity):
+        email_cls = emails.get(activity.type)
+        if not email_cls:
+            logger.debug(
+                u"No email associated with activity type `{}`".format(activity.get_type_display())
+            )
+            return
+
+        email = email_cls(activity)
+        email.send()
+
+    def handle_user_report(self, payload, project, **kwargs):
+        from sentry.models import Group, GroupSubscription, GroupSubscriptionReason
+
+        group = Group.objects.get(id=payload["report"]["issue"]["id"])
+
+        participants = GroupSubscription.objects.get_participants(group=group)
+
+        if not participants:
+            return
+
+        org = group.organization
+        enhanced_privacy = org.flags.enhanced_privacy
+
+        context = {
+            "project": project,
+            "project_link": absolute_uri(
+                u"/{}/{}/".format(project.organization.slug, project.slug)
+            ),
+            "issue_link": absolute_uri(
+                u"/{}/{}/issues/{}/".format(
+                    project.organization.slug, project.slug, payload["report"]["issue"]["id"]
+                )
+            ),
+            # TODO(dcramer): we dont have permalinks to feedback yet
+            "link": absolute_uri(
+                u"/{}/{}/issues/{}/feedback/".format(
+                    project.organization.slug, project.slug, payload["report"]["issue"]["id"]
+                )
+            ),
+            "group": group,
+            "report": payload["report"],
+            "enhanced_privacy": enhanced_privacy,
+        }
+
+        subject_prefix = self.get_option("subject_prefix", project) or self._subject_prefix()
+        subject_prefix = force_text(subject_prefix)
+        subject = force_text(
+            u"{}{} - New Feedback from {}".format(
+                subject_prefix, group.qualified_short_id, payload["report"]["name"]
+            )
+        )
+
+        headers = {"X-Sentry-Project": project.slug}
+
+        # TODO(dcramer): this is copypasta'd from activity notifications
+        # and while it'd be nice to re-use all of that, they are currently
+        # coupled to <Activity> instances which makes this tough
+        for user, reason in participants.items():
+            context.update(
+                {
+                    "reason": GroupSubscriptionReason.descriptions.get(
+                        reason, "are subscribed to this issue"
+                    ),
+                    "unsubscribe_link": generate_signed_link(
+                        user.id,
+                        "sentry-account-email-unsubscribe-issue",
+                        kwargs={"issue_id": group.id},
+                    ),
+                }
+            )
+
+            msg = MessageBuilder(
+                subject=subject,
+                template="sentry/emails/activity/new-user-feedback.txt",
+                html_template="sentry/emails/activity/new-user-feedback.html",
+                headers=headers,
+                type="notify.user-report",
+                context=context,
+                reference=group,
+            )
+            msg.add_users([user.id], project=project)
+            msg.send_async()
+
+    def handle_signal(self, name, payload, **kwargs):
+        if name == "user-reports.created":
+            self.handle_user_report(payload, **kwargs)
+
+
+# Legacy compatibility
+MailProcessor = MailPlugin

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -111,7 +111,7 @@ class MailPlugin(NotificationPlugin):
         from sentry.models import ProjectOption
         from sentry.tasks.digests import deliver_digest
         from sentry.digests import get_option_key as get_digest_option_key
-        from sentry.digests.notifications import event_to_record, unsplit_key
+        from sentry.digests.notifications import event_to_record, unsplit_key_for_targeted_action
         from sentry import digests
 
         # TODO(Jeff): Why did we remove rate limits
@@ -141,7 +141,9 @@ class MailPlugin(NotificationPlugin):
                     project, get_digest_option_key(self.get_conf_key(), key)
                 )
 
-            digest_key = unsplit_key(self, event.group.project)
+            digest_key = unsplit_key_for_targeted_action(
+                event.group.project, target_type, target_identifier
+            )
             extra["digest_key"] = digest_key
             immediate_delivery = digests.add(
                 digest_key,

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -217,9 +217,9 @@ class MailPlugin(NotificationPlugin):
     # def get_project_url(self, project):
     #     return absolute_uri(u"/{}/{}/".format(project.organization.slug, project.slug))
     #
-    # def is_configured(self, project, **kwargs):
-    #     # Nothing to configure here
-    #     return True
+    def is_configured(self, project, **kwargs):
+        # Nothing to configure here
+        return True
 
     def should_notify(self, group, event):
         send_to = self.get_sendable_users(group.project)

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -24,10 +24,20 @@ from sentry.utils.committers import get_serialized_event_file_committers
 from sentry.utils.email import MessageBuilder, group_id_to_email
 from sentry.utils.linksign import generate_signed_link
 
-ISSUE_OWNERS = "IssueOwners"
-TEAM = "Team"
-MEMBER = "Member"
-CHOICES = [(ISSUE_OWNERS, "Issue Owners"), (TEAM, "Team"), (MEMBER, "Member")]
+from enum import Enum
+
+
+class NotifyEmailActionTargetType(Enum):
+    ISSUE_OWNERS = "IssueOwners"
+    TEAM = "Team"
+    MEMBER = "Member"
+
+
+CHOICES = [
+    (NotifyEmailActionTargetType.ISSUE_OWNERS.value, "Issue Owners"),
+    (NotifyEmailActionTargetType.TEAM.value, "Team"),
+    (NotifyEmailActionTargetType.MEMBER.value, "Member"),
+]
 
 
 class MailAdapter(object):
@@ -188,11 +198,11 @@ class MailAdapter(object):
             return return_set(self.get_send_to_all_in_project(project))
 
         send_to = []
-        if target_type == ISSUE_OWNERS:
+        if target_type == NotifyEmailActionTargetType.ISSUE_OWNERS.value:
             send_to = self.get_send_to_owners(event, project)
-        elif target_type == MEMBER:
+        elif target_type == NotifyEmailActionTargetType.MEMBER.value:
             send_to = self.get_send_to_member(target_identifier)
-        elif target_type == TEAM:
+        elif target_type == NotifyEmailActionTargetType.TEAM.value:
             send_to = self.get_send_to_team(project, target_identifier)
         return return_set(send_to)
 
@@ -451,7 +461,7 @@ class NotifyEmailForm(forms.Form):
         targetType = cleaned_data.get("targetType")
         targetIdentifier = cleaned_data.get("targetIdentifier")
 
-        if targetType == ISSUE_OWNERS:
+        if targetType == NotifyEmailActionTargetType.ISSUE_OWNERS.value:
             self.cleaned_data["targetType"] = targetType
             return
 

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -112,7 +112,7 @@ class NotifyEmailAction(EventAction):
         metrics.incr("notifications.sent", instance=plugin.slug, skip_internal=False)
         yield self.future(
             lambda event, futures: plugin.rule_notify(
-                event, futures, self.data.targetType, self.data.get("targetIdentifier", None)
+                event, futures, self.data["targetType"], self.data.get("targetIdentifier", None)
             )
         )
 

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -465,7 +465,6 @@ class NotifyEmailForm(forms.Form):
 
         self.cleaned_data["targetType"] = targetType
         self.cleaned_data["targetIdentifier"] = targetIdentifier
-        return
 
 
 class NotifyEmailAction(EventAction):

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -284,7 +284,7 @@ class MailAdapter(object):
                     ).values_list("id", flat=True)
                 )
 
-            alert_settings = project.get_member_alert_settings(self.alert_option_key)
+            alert_settings = project.get_member_alert_settings(self.legacy_mail.alert_option_key)
             disabled_users = set(user for user, setting in alert_settings.items() if setting == 0)
             return send_to_list - disabled_users
         else:

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -64,8 +64,6 @@ class MailAdapter(object):
         from sentry.digests.notifications import event_to_record, unsplit_key_for_targeted_action
         from sentry import digests
 
-        # TODO(Jeff): Why did we remove rate limits
-
         rules = []
         extra = {
             "event_id": event.event_id,
@@ -159,9 +157,9 @@ class MailAdapter(object):
 
     def get_sendable_users(self, project):
         """
-             Return a collection of user IDs that are eligible to receive
-             notifications for the provided project.
-             """
+        Return a collection of user IDs that are eligible to receive
+        notifications for the provided project.
+        """
         return project.get_notification_recipients(self.legacy_mail.alert_option_key)
 
     def should_notify(self, group):
@@ -175,7 +173,6 @@ class MailAdapter(object):
         # No rate limit checks needed as mail should be throttled due to digests.
         return True
 
-    # TODO: Maybe this should shift into the action.
     def get_send_to(self, project, target_type, target_identifier=None, event=None):
         """
         Returns a list of user IDs for the users that should receive
@@ -192,7 +189,6 @@ class MailAdapter(object):
         if not (project and project.teams.exists()):
             self.logger.debug("Tried to send notification to invalid project: %r", project)
             return set()
-        # TODO(jeff): check if notification.event can be None
 
         if not event:
             return return_set(self.get_send_to_all_in_project(project))
@@ -249,7 +245,6 @@ class MailAdapter(object):
         return disabled_users
 
     def get_send_to_team(self, project, target_identifier):
-        # TODO(Jeff): need to implement filtering based on user mail options
         if target_identifier is None:
             return []
         try:
@@ -267,7 +262,6 @@ class MailAdapter(object):
         try:
             user = User.objects.get(id=int(target_identifier))
         except User.DoesNotExist:
-            # TODO(jeff): consider throwing an error?
             return []
         return [user.id]
 
@@ -457,7 +451,6 @@ class NotifyEmailForm(forms.Form):
 
     def clean(self):
         cleaned_data = super(NotifyEmailForm, self).clean()
-        # TODO(jeff): Change case
         targetType = cleaned_data.get("targetType")
         targetIdentifier = cleaned_data.get("targetIdentifier")
 

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -52,10 +52,10 @@ logger = logging.getLogger(__name__)
 
 # TargetType = Enum('TargetType', 'owners team member')
 # TODD(jeff): change this to issue owners
-OWNERS = "Owners"
+OWNERS = "IssueOwners"
 TEAM = "Team"
 MEMBER = "Member"
-CHOICES = [(OWNERS, "Owners"), (TEAM, "Team"), (MEMBER, "Member")]
+CHOICES = [(OWNERS, "Issue Owners"), (TEAM, "Team"), (MEMBER, "Member")]
 
 
 class NotifyEmailForm(forms.Form):
@@ -97,10 +97,6 @@ class NotifyEmailAction(EventAction):
     def after(self, event, state):
         extra = {"event_id": event.event_id}
         plugin = MailPlugin()
-        # if not plugin.is_enabled(self.project):
-        #     extra["project_id"] = self.project.id
-        #     self.logger.info("rules.fail.is_enabled", extra=extra)
-        #     return
 
         group = event.group
 

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -194,9 +194,15 @@ class MailAdapter(object):
         """
 
         def return_set(xs):
+            from collections import Iterable
+
             if isinstance(xs, set):
                 return xs
-            return set(xs) if xs or xs == 0 else set()
+
+            if isinstance(xs, Iterable):
+                return set(xs) if xs else set()
+
+            return {xs} if xs is not None else set()
 
         if not (project and project.teams.exists()):
             self.logger.debug("Tried to send notification to invalid project: %r", project)

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -514,6 +514,7 @@ class NotifyEmailForm(forms.Form):
 class NotifyEmailAction(EventAction):
     form_cls = NotifyEmailForm
     label = "Send an email to {targetType}"
+    prompt = "Send an email"
     metrics_slug = "EmailAction"
     mail_adapter = MailAdapter()
 

--- a/src/sentry/rules/actions/notify_email.py
+++ b/src/sentry/rules/actions/notify_email.py
@@ -275,6 +275,12 @@ class MailAdapter(object):
 
     @staticmethod
     def get_send_to_member(target_identifier):
+        """
+        No checking for disabled users is done. If a user explicitly specifies a member as a target to send to, it
+        should overwrite the user's personal mail settings.
+        :param target_identifier:
+        :return: Iterable[int] id of member that should be sent to.
+        """
         if target_identifier is None:
             return []
         try:

--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -39,6 +39,7 @@ def schedule_digests():
         deliver_digest.delay(entry.key, entry.timestamp)
 
 
+# TODO(jeff): Need to update tests
 @instrumented_task(name="sentry.tasks.digests.deliver_digest", queue="digests.delivery")
 def deliver_digest(key, schedule_timestamp=None):
     from sentry import digests

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -12,9 +12,32 @@ from sentry.digests.notifications import (
     group_records,
     sort_group_contents,
     sort_rule_groups,
+    split_key_for_targeted_action,
+    is_targeted_action_key,
+    unsplit_key_for_targeted_action,
 )
 from sentry.models import Rule
+from sentry.rules.actions.notify_email import NotifyEmailActionTargetType
 from sentry.testutils import TestCase
+
+
+class TargetedActionsKeyTest(TestCase):
+    def test_split_unsplit_idempotency(self):
+        project = self.project
+        target_type = NotifyEmailActionTargetType.MEMBER.value
+        target_id = 2
+        key = unsplit_key_for_targeted_action(project, target_type, target_id)
+        _, actual_project, actual_target_type, actual_id = split_key_for_targeted_action(key)
+        assert actual_project == project
+        assert actual_target_type == target_type
+        assert actual_id == target_id
+
+    def test_targeted_action_key_detection(self):
+        project = self.project
+        target_type = NotifyEmailActionTargetType.MEMBER.value
+        target_id = 2
+        key = unsplit_key_for_targeted_action(project, target_type, target_id)
+        assert is_targeted_action_key(key)
 
 
 class RewriteRecordTestCase(TestCase):

--- a/tests/sentry/rules/actions/test_notify_email.py
+++ b/tests/sentry/rules/actions/test_notify_email.py
@@ -1,0 +1,540 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from sentry.utils.compat.mock import MagicMock, patch
+
+from sentry.testutils.cases import RuleTestCase
+from sentry.rules.actions.notify_email import NotifyEmailAction, MailPlugin
+from sentry.tasks.sentry_apps import notify_sentry_app
+
+from datetime import datetime
+
+from sentry.utils.compat import mock
+import pytz
+import pytest
+
+# import six
+# from django.contrib.auth.models import AnonymousUser
+from django.core import mail
+
+# from django.db.models import F
+from django.utils import timezone
+from exam import fixture
+from sentry.utils.compat.mock import Mock
+
+# from sentry.api.serializers import serialize, UserReportWithGroupSerializer
+from sentry.digests.notifications import build_digest, event_to_record
+from sentry.models import (
+    OrganizationMember,
+    OrganizationMemberTeam,
+    ProjectOwnership,
+    ProjectOption,
+    Repository,
+    Rule,
+    UserOption,
+)
+from sentry.ownership.grammar import Owner, Matcher, dump_schema
+from sentry.plugins.base import Notification
+
+# from sentry.plugins.sentry_mail.activity.base import ActivityEmail
+from sentry.event_manager import get_event_type
+from sentry.testutils import TestCase
+
+from sentry.utils.email import MessageBuilder
+from sentry.event_manager import EventManager
+from sentry.testutils.helpers.datetime import before_now, iso_format
+
+OWNERS = "Owners"
+
+
+class NotifyEmailTest(RuleTestCase):
+    rule_cls = NotifyEmailAction
+
+    @pytest.mark.skip(reason="This is a todo")
+    def test_applies_correctly_for_plugins(self):
+        event = self.get_event()
+
+        plugin = MagicMock()
+        plugin.is_enabled.return_value = True
+        plugin.should_notify.return_value = True
+
+        rule = self.get_rule(data={"service": "mail"})
+
+        with patch("sentry.plugins.base.plugins.get") as get_plugin:
+            get_plugin.return_value = plugin
+
+            results = list(rule.after(event=event, state=self.get_state()))
+
+        assert len(results) == 1
+        assert plugin.should_notify.call_count == 1
+        assert results[0].callback is plugin.rule_notify
+
+    @pytest.mark.skip(reason="This is a todo")
+    def test_applies_correctly_for_sentry_apps(self):
+        event = self.get_event()
+
+        self.create_sentry_app(
+            organization=event.organization, name="Test Application", is_alertable=True
+        )
+
+        rule = self.get_rule(data={"service": "test-application"})
+
+        results = list(rule.after(event=event, state=self.get_state()))
+
+        assert len(results) == 1
+        assert results[0].callback is notify_sentry_app
+
+    @pytest.mark.skip(reason="This is a todo")
+    def test_notify_sentry_app_and_plugin_with_same_slug(self):
+        event = self.get_event()
+
+        self.create_sentry_app(organization=event.organization, name="Notify", is_alertable=True)
+
+        plugin = MagicMock()
+        plugin.is_enabled.return_value = True
+        plugin.should_notify.return_value = True
+
+        rule = self.get_rule(data={"service": "notify"})
+
+        with patch("sentry.plugins.base.plugins.get") as get_plugin:
+            get_plugin.return_value = plugin
+
+            results = list(rule.after(event=event, state=self.get_state()))
+
+        assert len(results) == 2
+        assert plugin.should_notify.call_count == 1
+        assert results[0].callback is notify_sentry_app
+        assert results[1].callback is plugin.rule_notify
+
+
+class MailPluginTest(TestCase):
+    @fixture
+    def plugin(self):
+        return MailPlugin()
+
+    @mock.patch(
+        "sentry.models.ProjectOption.objects.get_value", Mock(side_effect=lambda p, k, d, **kw: d)
+    )
+    @mock.patch(
+        "sentry.rules.actions.notify_email.MailPlugin.get_sendable_users", Mock(return_value=[])
+    )
+    def test_should_notify_no_sendable_users(self):
+        assert not self.plugin.should_notify(group=Mock(), event=Mock())
+
+    def test_simple_notification(self):
+        event = self.store_event(
+            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
+        )
+
+        rule = Rule.objects.create(project=self.project, label="my rule")
+
+        notification = Notification(event=event, rule=rule)
+
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
+            self.plugin.notify(notification, OWNERS)
+
+        msg = mail.outbox[0]
+        assert msg.subject == "[Sentry] BAR-1 - Hello world"
+        assert "my rule" in msg.alternatives[0][0]
+
+    @mock.patch("sentry.interfaces.stacktrace.Stacktrace.get_title")
+    @mock.patch("sentry.interfaces.stacktrace.Stacktrace.to_email_html")
+    @mock.patch("sentry.rules.actions.notify_email.MailPlugin._send_mail")
+    def test_notify_users_renders_interfaces_with_utf8(
+        self, _send_mail, _to_email_html, _get_title
+    ):
+        _to_email_html.return_value = u"רונית מגן"
+        _get_title.return_value = "Stacktrace"
+
+        event = self.store_event(
+            data={"message": "Soubor ji\xc5\xbe existuje", "stacktrace": {"frames": [{}]}},
+            project_id=self.project.id,
+        )
+
+        notification = Notification(event=event)
+
+        with self.options({"system.url-prefix": "http://example.com"}):
+            self.plugin.notify(notification, OWNERS)
+
+        _get_title.assert_called_once_with()
+        _to_email_html.assert_called_once_with(event)
+
+    @mock.patch("sentry.rules.actions.notify_email.MailPlugin._send_mail")
+    def test_notify_users_does_email(self, _send_mail):
+        event_manager = EventManager({"message": "hello world", "level": "error"})
+        event_manager.normalize()
+        event_data = event_manager.get_data()
+        event_type = get_event_type(event_data)
+        event_data["type"] = event_type.key
+        event_data["metadata"] = event_type.get_metadata(event_data)
+
+        event = event_manager.save(self.project.id)
+        group = event.group
+
+        notification = Notification(event=event)
+
+        with self.options({"system.url-prefix": "http://example.com"}):
+            self.plugin.notify(notification, OWNERS)
+
+        assert _send_mail.call_count == 1
+        args, kwargs = _send_mail.call_args
+        self.assertEquals(kwargs.get("project"), self.project)
+        self.assertEquals(kwargs.get("reference"), group)
+        assert kwargs.get("subject") == u"BAR-1 - hello world"
+
+    @mock.patch("sentry.rules.actions.notify_email.MailPlugin._send_mail")
+    def test_multiline_error(self, _send_mail):
+        event_manager = EventManager({"message": "hello world\nfoo bar", "level": "error"})
+        event_manager.normalize()
+        event_data = event_manager.get_data()
+        event_type = get_event_type(event_data)
+        event_data["type"] = event_type.key
+        event_data["metadata"] = event_type.get_metadata(event_data)
+
+        event = event_manager.save(self.project.id)
+
+        notification = Notification(event=event)
+
+        with self.options({"system.url-prefix": "http://example.com"}):
+            self.plugin.notify(notification, OWNERS)
+
+        assert _send_mail.call_count == 1
+        args, kwargs = _send_mail.call_args
+        assert kwargs.get("subject") == u"BAR-1 - hello world"
+
+    def test_get_sendable_users(self):
+        from sentry.models import UserOption, User
+
+        user = self.create_user(email="foo@example.com", is_active=True)
+        user2 = self.create_user(email="baz@example.com", is_active=True)
+        self.create_user(email="baz2@example.com", is_active=True)
+
+        # user with inactive account
+        self.create_user(email="bar@example.com", is_active=False)
+        # user not in any groups
+        self.create_user(email="bar2@example.com", is_active=True)
+
+        organization = self.create_organization(owner=user)
+        team = self.create_team(organization=organization)
+
+        project = self.create_project(name="Test", teams=[team])
+        OrganizationMemberTeam.objects.create(
+            organizationmember=OrganizationMember.objects.get(user=user, organization=organization),
+            team=team,
+        )
+        self.create_member(user=user2, organization=organization, teams=[team])
+
+        # all members
+        assert sorted(set([user.pk, user2.pk])) == sorted(self.plugin.get_sendable_users(project))
+
+        # disabled user2
+        UserOption.objects.create(key="mail:alert", value=0, project=project, user=user2)
+
+        assert user2.pk not in self.plugin.get_sendable_users(project)
+
+        user4 = User.objects.create(username="baz4", email="bar@example.com", is_active=True)
+        self.create_member(user=user4, organization=organization, teams=[team])
+        assert user4.pk in self.plugin.get_sendable_users(project)
+
+        # disabled by default user4
+        uo1 = UserOption.objects.create(
+            key="subscribe_by_default", value="0", project=project, user=user4
+        )
+
+        assert user4.pk not in self.plugin.get_sendable_users(project)
+
+        uo1.delete()
+
+        UserOption.objects.create(
+            key="subscribe_by_default", value=u"0", project=project, user=user4
+        )
+
+        assert user4.pk not in self.plugin.get_sendable_users(project)
+
+    def test_notify_users_with_utf8_subject(self):
+        event = self.store_event(
+            data={"message": "רונית מגן", "level": "error"}, project_id=self.project.id
+        )
+
+        notification = Notification(event=event)
+
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
+            self.plugin.notify(notification, OWNERS)
+
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert msg.subject == u"[Sentry] BAR-1 - רונית מגן"
+
+    def test_get_digest_subject(self):
+        assert (
+            self.plugin.get_digest_subject(
+                mock.Mock(qualified_short_id="BAR-1"),
+                {mock.sentinel.group: 3},
+                datetime(2016, 9, 19, 1, 2, 3, tzinfo=pytz.utc),
+            )
+            == "BAR-1 - 1 new alert since Sept. 19, 2016, 1:02 a.m. UTC"
+        )
+
+    @pytest.mark.skip(reason="This is a todo")
+    @mock.patch.object(MailPlugin, "notify", side_effect=MailPlugin.notify, autospec=True)
+    def test_notify_digest(self, notify):
+        project = self.project
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(minutes=1)), "fingerprint": ["group-1"]},
+            project_id=project.id,
+        )
+        event2 = self.store_event(
+            data={"timestamp": iso_format(before_now(minutes=1)), "fingerprint": ["group-2"]},
+            project_id=project.id,
+        )
+
+        rule = project.rule_set.all()[0]
+        digest = build_digest(
+            project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
+        )
+
+        with self.tasks():
+            self.plugin.notify_digest(project, digest)
+
+        assert notify.call_count == 0
+        assert len(mail.outbox) == 1
+
+        message = mail.outbox[0]
+        assert "List-ID" in message.message()
+
+    @pytest.mark.skip(reason="This is a todo")
+    @mock.patch.object(MailPlugin, "notify", side_effect=MailPlugin.notify, autospec=True)
+    @mock.patch.object(MessageBuilder, "send_async", autospec=True)
+    def test_notify_digest_single_record(self, send_async, notify):
+        event = self.store_event(data={}, project_id=self.project.id)
+        rule = self.project.rule_set.all()[0]
+        digest = build_digest(self.project, (event_to_record(event, (rule,)),))
+        self.plugin.notify_digest(self.project, digest)
+        assert send_async.call_count == 1
+        assert notify.call_count == 1
+
+    @pytest.mark.skip(reason="This is a todo")
+    def test_notify_digest_subject_prefix(self):
+        ProjectOption.objects.set_value(
+            project=self.project, key=u"mail:subject_prefix", value="[Example prefix] "
+        )
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(minutes=1)), "fingerprint": ["group-1"]},
+            project_id=self.project.id,
+        )
+        event2 = self.store_event(
+            data={"timestamp": iso_format(before_now(minutes=1)), "fingerprint": ["group-2"]},
+            project_id=self.project.id,
+        )
+
+        rule = self.project.rule_set.all()[0]
+
+        digest = build_digest(
+            self.project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
+        )
+
+        with self.tasks():
+            self.plugin.notify_digest(self.project, digest)
+
+        assert len(mail.outbox) == 1
+
+        msg = mail.outbox[0]
+
+        assert msg.subject.startswith("[Example prefix]")
+
+    def test_notify_with_suspect_commits(self):
+        repo = Repository.objects.create(
+            organization_id=self.organization.id, name=self.organization.id
+        )
+        release = self.create_release(project=self.project, version="v12")
+        release.set_commits(
+            [
+                {
+                    "id": "a" * 40,
+                    "repository": repo.name,
+                    "author_email": "bob@example.com",
+                    "author_name": "Bob",
+                    "message": "i fixed a bug",
+                    "patch_set": [{"path": "src/sentry/models/release.py", "type": "M"}],
+                }
+            ]
+        )
+
+        event = self.store_event(
+            data={
+                "message": "Kaboom!",
+                "platform": "python",
+                "timestamp": iso_format(before_now(seconds=1)),
+                "stacktrace": {
+                    "frames": [
+                        {
+                            "function": "handle_set_commits",
+                            "abs_path": "/usr/src/sentry/src/sentry/tasks.py",
+                            "module": "sentry.tasks",
+                            "in_app": True,
+                            "lineno": 30,
+                            "filename": "sentry/tasks.py",
+                        },
+                        {
+                            "function": "set_commits",
+                            "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
+                            "module": "sentry.models.release",
+                            "in_app": True,
+                            "lineno": 39,
+                            "filename": "sentry/models/release.py",
+                        },
+                    ]
+                },
+                "tags": {"sentry:release": release.version},
+            },
+            project_id=self.project.id,
+        )
+
+        with self.tasks():
+            notification = Notification(event=event)
+
+            self.plugin.notify(notification, OWNERS)
+
+        assert len(mail.outbox) >= 1
+
+        msg = mail.outbox[-1]
+
+        assert "Suspect Commits" in msg.body
+
+
+class MailPluginOwnersTest(TestCase):
+    @fixture
+    def plugin(self):
+        return MailPlugin()
+
+    def setUp(self):
+        from sentry.ownership.grammar import Rule
+
+        self.user = self.create_user(email="foo@example.com", is_active=True)
+        self.user2 = self.create_user(email="baz@example.com", is_active=True)
+
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
+
+        self.project = self.create_project(name="Test", teams=[self.team])
+        OrganizationMemberTeam.objects.create(
+            organizationmember=OrganizationMember.objects.get(
+                user=self.user, organization=self.organization
+            ),
+            team=self.team,
+        )
+        self.create_member(user=self.user2, organization=self.organization, teams=[self.team])
+        self.group = self.create_group(
+            first_seen=timezone.now(),
+            last_seen=timezone.now(),
+            project=self.project,
+            message="hello  world",
+            logger="root",
+        )
+        ProjectOwnership.objects.create(
+            project_id=self.project.id,
+            schema=dump_schema(
+                [
+                    Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)]),
+                    Rule(Matcher("path", "*.jx"), [Owner("user", self.user2.email)]),
+                    Rule(
+                        Matcher("path", "*.cbl"),
+                        [Owner("user", self.user.email), Owner("user", self.user2.email)],
+                    ),
+                ]
+            ),
+            fallthrough=True,
+        )
+
+    def make_event_data(self, filename, url="http://example.com"):
+        mgr = EventManager(
+            {
+                "tags": [("level", "error")],
+                "stacktrace": {"frames": [{"lineno": 1, "filename": filename}]},
+                "request": {"url": url},
+            }
+        )
+        mgr.normalize()
+        data = mgr.get_data()
+        event_type = get_event_type(data)
+        data["type"] = event_type.key
+        data["metadata"] = event_type.get_metadata(data)
+
+        return data
+
+    def assert_notify(self, event, emails_sent_to):
+        mail.outbox = []
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
+            self.plugin.notify(Notification(event=event), OWNERS)
+        assert len(mail.outbox) == len(emails_sent_to)
+        assert sorted(email.to[0] for email in mail.outbox) == sorted(emails_sent_to)
+
+    def test_get_send_to_with_team_owners(self):
+        event = self.store_event(data=self.make_event_data("foo.py"), project_id=self.project.id)
+        assert sorted(set([self.user.pk, self.user2.pk])) == sorted(
+            self.plugin.get_send_to(self.project, OWNERS, event=event.data)
+        )
+
+        # Make sure that disabling mail alerts works as expected
+        UserOption.objects.set_value(
+            user=self.user2, key="mail:alert", value=0, project=self.project
+        )
+        assert set([self.user.pk]) == self.plugin.get_send_to(
+            self.project, OWNERS, event=event.data
+        )
+
+    def test_get_send_to_with_user_owners(self):
+        event = self.store_event(data=self.make_event_data("foo.cbl"), project_id=self.project.id)
+        assert sorted(set([self.user.pk, self.user2.pk])) == sorted(
+            self.plugin.get_send_to(self.project, event.data)
+        )
+
+        # Make sure that disabling mail alerts works as expected
+        UserOption.objects.set_value(
+            user=self.user2, key="mail:alert", value=0, project=self.project
+        )
+        assert set([self.user.pk]) == self.plugin.get_send_to(
+            self.project, OWNERS, event=event.data
+        )
+
+    def test_get_send_to_with_user_owner(self):
+        event = self.store_event(data=self.make_event_data("foo.jx"), project_id=self.project.id)
+        assert set([self.user2.pk]) == self.plugin.get_send_to(
+            self.project, OWNERS, event=event.data
+        )
+
+    def test_get_send_to_with_fallthrough(self):
+        event = self.store_event(data=self.make_event_data("foo.jx"), project_id=self.project.id)
+        assert set([self.user2.pk]) == self.plugin.get_send_to(
+            self.project, OWNERS, event=event.data
+        )
+
+    def test_get_send_to_without_fallthrough(self):
+        ProjectOwnership.objects.get(project_id=self.project.id).update(fallthrough=False)
+        event = self.store_event(data=self.make_event_data("foo.cpp"), project_id=self.project.id)
+        assert set() == self.plugin.get_send_to(self.project, OWNERS, event=event.data)
+
+    def test_notify_users_with_owners(self):
+        event_all_users = self.store_event(
+            data=self.make_event_data("foo.cbl"), project_id=self.project.id
+        )
+        self.assert_notify(event_all_users, [self.user.email, self.user2.email])
+
+        event_team = self.store_event(
+            data=self.make_event_data("foo.py"), project_id=self.project.id
+        )
+        self.assert_notify(event_team, [self.user.email, self.user2.email])
+
+        event_single_user = self.store_event(
+            data=self.make_event_data("foo.jx"), project_id=self.project.id
+        )
+        self.assert_notify(event_single_user, [self.user2.email])
+
+        # Make sure that disabling mail alerts works as expected
+        UserOption.objects.set_value(
+            user=self.user2, key="mail:alert", value=0, project=self.project
+        )
+        event_all_users = self.store_event(
+            data=self.make_event_data("foo.cbl"), project_id=self.project.id
+        )
+        self.assert_notify(event_all_users, [self.user.email])

--- a/tests/sentry/rules/actions/test_notify_email.py
+++ b/tests/sentry/rules/actions/test_notify_email.py
@@ -275,7 +275,6 @@ class MailPluginTest(TestCase):
             == "BAR-1 - 1 new alert since Sept. 19, 2016, 1:02 a.m. UTC"
         )
 
-    @pytest.mark.skip(reason="This is a todo")
     @mock.patch.object(MailPlugin, "notify", side_effect=MailPlugin.notify, autospec=True)
     def test_notify_digest(self, notify):
         project = self.project
@@ -294,7 +293,7 @@ class MailPluginTest(TestCase):
         )
 
         with self.tasks():
-            self.plugin.notify_digest(project, digest)
+            self.plugin.notify_digest(project, digest, OWNERS)
 
         assert notify.call_count == 0
         assert len(mail.outbox) == 1
@@ -302,18 +301,16 @@ class MailPluginTest(TestCase):
         message = mail.outbox[0]
         assert "List-ID" in message.message()
 
-    @pytest.mark.skip(reason="This is a todo")
     @mock.patch.object(MailPlugin, "notify", side_effect=MailPlugin.notify, autospec=True)
     @mock.patch.object(MessageBuilder, "send_async", autospec=True)
     def test_notify_digest_single_record(self, send_async, notify):
         event = self.store_event(data={}, project_id=self.project.id)
         rule = self.project.rule_set.all()[0]
         digest = build_digest(self.project, (event_to_record(event, (rule,)),))
-        self.plugin.notify_digest(self.project, digest)
+        self.plugin.notify_digest(self.project, digest, OWNERS)
         assert send_async.call_count == 1
         assert notify.call_count == 1
 
-    @pytest.mark.skip(reason="This is a todo")
     def test_notify_digest_subject_prefix(self):
         ProjectOption.objects.set_value(
             project=self.project, key=u"mail:subject_prefix", value="[Example prefix] "
@@ -334,7 +331,7 @@ class MailPluginTest(TestCase):
         )
 
         with self.tasks():
-            self.plugin.notify_digest(self.project, digest)
+            self.plugin.notify_digest(self.project, digest, OWNERS)
 
         assert len(mail.outbox) == 1
 

--- a/tests/sentry/rules/actions/test_notify_email.py
+++ b/tests/sentry/rules/actions/test_notify_email.py
@@ -1,29 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from sentry.utils.compat.mock import MagicMock, patch
-
-from sentry.testutils.cases import RuleTestCase
-from sentry.rules.actions.notify_email import NotifyEmailAction, MailPlugin
-from sentry.tasks.sentry_apps import notify_sentry_app
-
-from datetime import datetime
-
-from sentry.utils.compat import mock
 import pytz
-import pytest
-
-# import six
-# from django.contrib.auth.models import AnonymousUser
-from django.core import mail
-
-# from django.db.models import F
-from django.utils import timezone
+from datetime import datetime
 from exam import fixture
-from sentry.utils.compat.mock import Mock
 
-# from sentry.api.serializers import serialize, UserReportWithGroupSerializer
+from django.core import mail
+from django.utils import timezone
+
 from sentry.digests.notifications import build_digest, event_to_record
+from sentry.event_manager import get_event_type, EventManager
 from sentry.models import (
     OrganizationMember,
     OrganizationMemberTeam,
@@ -35,91 +21,41 @@ from sentry.models import (
 )
 from sentry.ownership.grammar import Owner, Matcher, dump_schema
 from sentry.plugins.base import Notification
-
-# from sentry.plugins.sentry_mail.activity.base import ActivityEmail
-from sentry.event_manager import get_event_type
 from sentry.testutils import TestCase
-
-from sentry.utils.email import MessageBuilder
-from sentry.event_manager import EventManager
+from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.utils.compat import mock
+from sentry.utils.compat.mock import Mock
+from sentry.utils.email import MessageBuilder
+from sentry.rules.actions.notify_email import NotifyEmailAction, MailAdapter
 
-OWNERS = "Owners"
+OWNERS = "IssueOwners"
 
 
 class NotifyEmailTest(RuleTestCase):
     rule_cls = NotifyEmailAction
 
-    @pytest.mark.skip(reason="This is a todo")
-    def test_applies_correctly_for_plugins(self):
+    def test_simple(self):
         event = self.get_event()
-
-        plugin = MagicMock()
-        plugin.is_enabled.return_value = True
-        plugin.should_notify.return_value = True
-
-        rule = self.get_rule(data={"service": "mail"})
-
-        with patch("sentry.plugins.base.plugins.get") as get_plugin:
-            get_plugin.return_value = plugin
-
-            results = list(rule.after(event=event, state=self.get_state()))
-
-        assert len(results) == 1
-        assert plugin.should_notify.call_count == 1
-        assert results[0].callback is plugin.rule_notify
-
-    @pytest.mark.skip(reason="This is a todo")
-    def test_applies_correctly_for_sentry_apps(self):
-        event = self.get_event()
-
-        self.create_sentry_app(
-            organization=event.organization, name="Test Application", is_alertable=True
-        )
-
-        rule = self.get_rule(data={"service": "test-application"})
+        rule = self.get_rule()
 
         results = list(rule.after(event=event, state=self.get_state()))
-
         assert len(results) == 1
-        assert results[0].callback is notify_sentry_app
-
-    @pytest.mark.skip(reason="This is a todo")
-    def test_notify_sentry_app_and_plugin_with_same_slug(self):
-        event = self.get_event()
-
-        self.create_sentry_app(organization=event.organization, name="Notify", is_alertable=True)
-
-        plugin = MagicMock()
-        plugin.is_enabled.return_value = True
-        plugin.should_notify.return_value = True
-
-        rule = self.get_rule(data={"service": "notify"})
-
-        with patch("sentry.plugins.base.plugins.get") as get_plugin:
-            get_plugin.return_value = plugin
-
-            results = list(rule.after(event=event, state=self.get_state()))
-
-        assert len(results) == 2
-        assert plugin.should_notify.call_count == 1
-        assert results[0].callback is notify_sentry_app
-        assert results[1].callback is plugin.rule_notify
 
 
-class MailPluginTest(TestCase):
+class MailAdapterTest(TestCase):
     @fixture
-    def plugin(self):
-        return MailPlugin()
+    def adapter(self):
+        return MailAdapter()
 
     @mock.patch(
         "sentry.models.ProjectOption.objects.get_value", Mock(side_effect=lambda p, k, d, **kw: d)
     )
     @mock.patch(
-        "sentry.rules.actions.notify_email.MailPlugin.get_sendable_users", Mock(return_value=[])
+        "sentry.rules.actions.notify_email.MailAdapter.get_sendable_users", Mock(return_value=[])
     )
     def test_should_notify_no_sendable_users(self):
-        assert not self.plugin.should_notify(group=Mock(), event=Mock())
+        assert not self.adapter.should_notify(group=Mock())
 
     def test_simple_notification(self):
         event = self.store_event(
@@ -131,7 +67,7 @@ class MailPluginTest(TestCase):
         notification = Notification(event=event, rule=rule)
 
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
-            self.plugin.notify(notification, OWNERS)
+            self.adapter.notify(notification, OWNERS)
 
         msg = mail.outbox[0]
         assert msg.subject == "[Sentry] BAR-1 - Hello world"
@@ -139,7 +75,7 @@ class MailPluginTest(TestCase):
 
     @mock.patch("sentry.interfaces.stacktrace.Stacktrace.get_title")
     @mock.patch("sentry.interfaces.stacktrace.Stacktrace.to_email_html")
-    @mock.patch("sentry.rules.actions.notify_email.MailPlugin._send_mail")
+    @mock.patch("sentry.rules.actions.notify_email.MailAdapter._send_mail")
     def test_notify_users_renders_interfaces_with_utf8(
         self, _send_mail, _to_email_html, _get_title
     ):
@@ -154,12 +90,12 @@ class MailPluginTest(TestCase):
         notification = Notification(event=event)
 
         with self.options({"system.url-prefix": "http://example.com"}):
-            self.plugin.notify(notification, OWNERS)
+            self.adapter.notify(notification, OWNERS)
 
         _get_title.assert_called_once_with()
         _to_email_html.assert_called_once_with(event)
 
-    @mock.patch("sentry.rules.actions.notify_email.MailPlugin._send_mail")
+    @mock.patch("sentry.rules.actions.notify_email.MailAdapter._send_mail")
     def test_notify_users_does_email(self, _send_mail):
         event_manager = EventManager({"message": "hello world", "level": "error"})
         event_manager.normalize()
@@ -174,7 +110,7 @@ class MailPluginTest(TestCase):
         notification = Notification(event=event)
 
         with self.options({"system.url-prefix": "http://example.com"}):
-            self.plugin.notify(notification, OWNERS)
+            self.adapter.notify(notification, OWNERS)
 
         assert _send_mail.call_count == 1
         args, kwargs = _send_mail.call_args
@@ -182,7 +118,7 @@ class MailPluginTest(TestCase):
         self.assertEquals(kwargs.get("reference"), group)
         assert kwargs.get("subject") == u"BAR-1 - hello world"
 
-    @mock.patch("sentry.rules.actions.notify_email.MailPlugin._send_mail")
+    @mock.patch("sentry.rules.actions.notify_email.MailAdapter._send_mail")
     def test_multiline_error(self, _send_mail):
         event_manager = EventManager({"message": "hello world\nfoo bar", "level": "error"})
         event_manager.normalize()
@@ -196,7 +132,7 @@ class MailPluginTest(TestCase):
         notification = Notification(event=event)
 
         with self.options({"system.url-prefix": "http://example.com"}):
-            self.plugin.notify(notification, OWNERS)
+            self.adapter.notify(notification, OWNERS)
 
         assert _send_mail.call_count == 1
         args, kwargs = _send_mail.call_args
@@ -225,23 +161,23 @@ class MailPluginTest(TestCase):
         self.create_member(user=user2, organization=organization, teams=[team])
 
         # all members
-        assert sorted(set([user.pk, user2.pk])) == sorted(self.plugin.get_sendable_users(project))
+        assert sorted(set([user.pk, user2.pk])) == sorted(self.adapter.get_sendable_users(project))
 
         # disabled user2
         UserOption.objects.create(key="mail:alert", value=0, project=project, user=user2)
 
-        assert user2.pk not in self.plugin.get_sendable_users(project)
+        assert user2.pk not in self.adapter.get_sendable_users(project)
 
         user4 = User.objects.create(username="baz4", email="bar@example.com", is_active=True)
         self.create_member(user=user4, organization=organization, teams=[team])
-        assert user4.pk in self.plugin.get_sendable_users(project)
+        assert user4.pk in self.adapter.get_sendable_users(project)
 
         # disabled by default user4
         uo1 = UserOption.objects.create(
             key="subscribe_by_default", value="0", project=project, user=user4
         )
 
-        assert user4.pk not in self.plugin.get_sendable_users(project)
+        assert user4.pk not in self.adapter.get_sendable_users(project)
 
         uo1.delete()
 
@@ -249,7 +185,7 @@ class MailPluginTest(TestCase):
             key="subscribe_by_default", value=u"0", project=project, user=user4
         )
 
-        assert user4.pk not in self.plugin.get_sendable_users(project)
+        assert user4.pk not in self.adapter.get_sendable_users(project)
 
     def test_notify_users_with_utf8_subject(self):
         event = self.store_event(
@@ -259,7 +195,7 @@ class MailPluginTest(TestCase):
         notification = Notification(event=event)
 
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
-            self.plugin.notify(notification, OWNERS)
+            self.adapter.notify(notification, OWNERS)
 
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]
@@ -267,7 +203,7 @@ class MailPluginTest(TestCase):
 
     def test_get_digest_subject(self):
         assert (
-            self.plugin.get_digest_subject(
+            self.adapter.get_digest_subject(
                 mock.Mock(qualified_short_id="BAR-1"),
                 {mock.sentinel.group: 3},
                 datetime(2016, 9, 19, 1, 2, 3, tzinfo=pytz.utc),
@@ -275,7 +211,7 @@ class MailPluginTest(TestCase):
             == "BAR-1 - 1 new alert since Sept. 19, 2016, 1:02 a.m. UTC"
         )
 
-    @mock.patch.object(MailPlugin, "notify", side_effect=MailPlugin.notify, autospec=True)
+    @mock.patch.object(MailAdapter, "notify", side_effect=MailAdapter.notify, autospec=True)
     def test_notify_digest(self, notify):
         project = self.project
         event = self.store_event(
@@ -293,7 +229,7 @@ class MailPluginTest(TestCase):
         )
 
         with self.tasks():
-            self.plugin.notify_digest(project, digest, OWNERS)
+            self.adapter.notify_digest(project, digest, OWNERS)
 
         assert notify.call_count == 0
         assert len(mail.outbox) == 1
@@ -301,13 +237,13 @@ class MailPluginTest(TestCase):
         message = mail.outbox[0]
         assert "List-ID" in message.message()
 
-    @mock.patch.object(MailPlugin, "notify", side_effect=MailPlugin.notify, autospec=True)
+    @mock.patch.object(MailAdapter, "notify", side_effect=MailAdapter.notify, autospec=True)
     @mock.patch.object(MessageBuilder, "send_async", autospec=True)
     def test_notify_digest_single_record(self, send_async, notify):
         event = self.store_event(data={}, project_id=self.project.id)
         rule = self.project.rule_set.all()[0]
         digest = build_digest(self.project, (event_to_record(event, (rule,)),))
-        self.plugin.notify_digest(self.project, digest, OWNERS)
+        self.adapter.notify_digest(self.project, digest, OWNERS)
         assert send_async.call_count == 1
         assert notify.call_count == 1
 
@@ -331,7 +267,7 @@ class MailPluginTest(TestCase):
         )
 
         with self.tasks():
-            self.plugin.notify_digest(self.project, digest, OWNERS)
+            self.adapter.notify_digest(self.project, digest, OWNERS)
 
         assert len(mail.outbox) == 1
 
@@ -390,7 +326,7 @@ class MailPluginTest(TestCase):
         with self.tasks():
             notification = Notification(event=event)
 
-            self.plugin.notify(notification, OWNERS)
+            self.adapter.notify(notification, OWNERS)
 
         assert len(mail.outbox) >= 1
 
@@ -402,7 +338,7 @@ class MailPluginTest(TestCase):
 class MailPluginOwnersTest(TestCase):
     @fixture
     def plugin(self):
-        return MailPlugin()
+        return MailAdapter()
 
     def setUp(self):
         from sentry.ownership.grammar import Rule


### PR DESCRIPTION
Adds a new mail action that allows actor targets to be defined

### Problem
Issue alerts cannot be directed to specific users or teams. By default they go to project owners (which in most cases isn't set up), and fall through to all members of all teams associated with the project, which creates a noise problem.

### Solution
Provide granular targets for mail action to reduce the amount of inbox noise.
Please view screencast for implemented render: https://drive.google.com/file/d/1gcWFNUHPlUgrmEnoeyPUE8drTaku9PBW/view

### Changes
- Add `"sentry.rules.actions.notify_email.NotifyEmailAction"` to ` SENTRY_RULES`
- Extend `digests/notifications` to support new keys for targeted action
- Add `MailAdapter` to handle mail processing
- Add `NotifyEmailAction` to handle rule processing
- Add `NotifyEmailForm` for input validation
- Update `digests` to handle digests from the new action
- Add Alert Banners that explains Issue Owners and Member targets
- Add Tests
- When `__has_issue_alerts_targeting` query param is set to `1`, it allows issue alerts targeting to be manually tested  @billyvg for 👀 

### TODO
- Add tests for `digests`

#### TODO(New PR)
- Change default rule options in project creation to use the `NotifyEmailAction`
- Remove plugin UI

### Related PRs:
- feat(plugin): Make Mail Plugin non-configurable #17842


### Feature Flags
Guards the endpoint. If an organization does not have `Issue-alerts-targeting` enabled, it will not receive the new action in the JSON response. Suppose the organization already has applied the action, there will not be flags to guard the action from being triggered as it may break user expectations.

Screencast: https://drive.google.com/file/d/1gcWFNUHPlUgrmEnoeyPUE8drTaku9PBW/view
Related: https://github.com/getsentry/sentry/pull/17599
Feature doc: https://www.notion.so/sentry/Issue-Alert-Targeting-30805fa4d233467ab2edb3eb98fce25e
Dependent on: Add project bit flag (https://github.com/getsentry/sentry/pull/17884)