### PR TITLE
ref(ingest): Remove inlined transactions store from consumer

### DIFF
--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -70,17 +70,8 @@ def get_test_message(request, default_project):
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.parametrize(
-    "inline_transactions", [True, False], ids=["inline_transactions", "worker_transactions"]
-)
 def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
-    task_runner,
-    kafka_producer,
-    kafka_admin,
-    requires_kafka,
-    default_project,
-    get_test_message,
-    inline_transactions,
+    task_runner, kafka_producer, kafka_admin, requires_kafka, default_project, get_test_message
 ):
     group_id = "test-consumer"
     topic_event_name = ConsumerType.get_topic_name(ConsumerType.Events)
@@ -103,7 +94,6 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
         auto_offset_reset="earliest",
     )
 
-    options.set("store.transactions-celery", not inline_transactions)
     with task_runner():
         i = 0
         while i < MAX_POLL_ITERATIONS:


### PR DESCRIPTION
We are not sure whether we want to batch directly inside of the
consumer, so let's back that out for now. Also there is no message
type=transaction so this happened to be dead code already.