### PR TITLE
fix(ingest): Actually inline transaction events

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -176,7 +176,7 @@ register("store.lie-about-filter-status", default=False)
 
 # Toggles between processing transactions directly in the ingest consumer
 # (``False``) and spawning a save_event task (``True``).
-register("store.transactions-celery", default=False)
+register("store.transactions-celery", default=True)
 
 # Symbolicator refactors
 # - Disabling minidump stackwalking in endpoints

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -56,7 +56,7 @@ def get_test_message(request, default_project):
         em.normalize()
         normalized_event = dict(em.get_data())
         message = {
-            "type": request.param,
+            "type": "event",
             "start_time": time.time(),
             "event_id": event_id,
             "project_id": int(project_id),

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -43,7 +43,7 @@ def test_deduplication_works(default_project, task_runner, preprocess_event):
     for _ in range(2):
         process_event(
             {
-                "payload": json.dumps(payload),
+                "payload": payload,
                 "start_time": start_time,
                 "event_id": event_id,
                 "project_id": project_id,
@@ -94,7 +94,7 @@ def test_with_attachments(default_project, task_runner, preprocess_event):
 
     process_event(
         {
-            "payload": json.dumps(payload),
+            "payload": payload,
             "start_time": start_time,
             "event_id": event_id,
             "project_id": project_id,


### PR DESCRIPTION
We discovered that the ingest consumers were never actually trying to
batch transaction saving, because they were expecting a message type of
transaction instead of event.

Unfortunately this means we will have to eagerly decode the JSON payload
(which makes code uglier but has to happen anyway) to decide whether to
batch.

Also change the default of the store.transactions-celery option as it is
no longer clear whether batching works.