### PR TITLE
ref(discover) Simplify column abstractions in discover

### DIFF
--- a/src/sentry/static/sentry/app/utils/queryString.tsx
+++ b/src/sentry/static/sentry/app/utils/queryString.tsx
@@ -33,12 +33,12 @@ type QueryValue = string | string[] | undefined | null;
 export function appendTagCondition(
   query: QueryValue,
   key: string,
-  value: string
+  value: null | string
 ): string {
   let currentQuery = Array.isArray(query) ? query.pop() : isString(query) ? query : '';
 
   // The user key values have additional key data inside them.
-  if (key === 'user' && value.includes(':')) {
+  if (key === 'user' && isString(value) && value.includes(':')) {
     const parts = value.split(':', 2);
     key = [key, parts[0]].join('.');
     value = parts[1];

--- a/src/sentry/static/sentry/app/views/eventsV2/sortLink.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/sortLink.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {LocationDescriptorObject} from 'history';
 import omit from 'lodash/omit';
 
-import InlineSvg from 'app/components/inlineSvg';
+import {IconChevron} from 'app/icons';
 import Link from 'app/components/links/link';
 
 import EventView, {Field, Sort, isFieldSortable} from './eventView';
@@ -37,10 +37,9 @@ class SortLink extends React.Component<Props> {
     }
 
     if (currentSort.kind === 'desc') {
-      return <InlineSvg src="icon-chevron-down" />;
+      return <IconChevron size="xs" direction="down" />;
     }
-
-    return <InlineSvg src="icon-chevron-up" />;
+    return <IconChevron size="xs" direction="up" />;
   }
 
   render() {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -148,6 +148,13 @@ class ColumnEditCollection extends React.Component<Props, State> {
     this.setState({fieldOptions});
   }
 
+  keyForColumn(column: Column, isGhost: boolean): string {
+    if (column.kind === 'function') {
+      return [...column.function, isGhost].join(':');
+    }
+    return [...column.field, isGhost].join(':');
+  }
+
   cleanUpListeners() {
     if (this.state.isDragging) {
       window.removeEventListener('mousemove', this.onDragMove);
@@ -157,11 +164,8 @@ class ColumnEditCollection extends React.Component<Props, State> {
 
   // Signal to the parent that a new column has been added.
   handleAddColumn = () => {
-    const newColumns = [
-      ...this.props.columns,
-      {aggregation: '', field: '', refinement: undefined},
-    ];
-    this.props.onChange(newColumns);
+    const newColumn: Column = {kind: 'field', field: ''};
+    this.props.onChange([...this.props.columns, newColumn]);
   };
 
   handleUpdateColumn = (index: number, column: Column) => {
@@ -305,7 +309,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
     if (isDragging && isGhost === false && draggingTargetIndex === i) {
       placeholder = (
         <DragPlaceholder
-          key={`placeholder:${col.aggregation}:${col.field}:${col.refinement}`}
+          key={`placeholder:${this.keyForColumn(col, isGhost)}`}
           className={DRAG_CLASS}
         />
       );
@@ -323,9 +327,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
         : PlaceholderPosition.BOTTOM;
 
     return (
-      <React.Fragment
-        key={`${i}:${col.aggregation}:${col.field}:${col.refinement}:${isGhost}`}
-      >
+      <React.Fragment key={`${i}:${this.keyForColumn(col, isGhost)}`}>
         {position === PlaceholderPosition.TOP && placeholder}
         <RowContainer className={isGhost ? '' : DRAG_CLASS}>
           {canDelete ? (
@@ -369,7 +371,9 @@ class ColumnEditCollection extends React.Component<Props, State> {
     // Get the longest number of columns so we can layout the rows.
     // We always want at least 2 columns.
     const gridColumns = Math.max(
-      ...columns.map(col => (col.field && col.refinement !== undefined ? 3 : 2))
+      ...columns.map(col =>
+        col.kind === 'function' && col.function[2] !== undefined ? 3 : 2
+      )
     );
 
     return (

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -444,7 +444,7 @@ class BufferedInput extends React.Component<InputProps, InputState> {
 // Set a min-width to allow shrinkage in grid.
 const StyledInput = styled('input')`
   min-width: 50px;
-  /* Matcht the height of the select boxes */
+  /* Match the height of the select boxes */
   height: 37px;
 
   &:not([disabled='true']):invalid {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import {components} from 'react-select';
+import cloneDeep from 'lodash/cloneDeep';
 
 import Badge from 'app/components/badge';
 import SelectControl from 'app/components/forms/selectControl';
@@ -9,7 +10,12 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 
 import {FieldValueKind, FieldValue} from './types';
-import {FIELD_ALIASES, ColumnType, AggregateParameter} from '../eventQueryParams';
+import {
+  FIELD_ALIASES,
+  ColumnType,
+  Aggregation,
+  AggregateParameter,
+} from '../eventQueryParams';
 import {Column} from '../eventView';
 
 type FieldOptions = StringMap<SelectValue<FieldValue>>;
@@ -42,23 +48,31 @@ type Props = {
 
 class ColumnEditRow extends React.Component<Props> {
   handleFieldChange = ({value}) => {
-    const {column} = this.props;
-    let currentParams: [string, string, string | undefined] = [
-      column.aggregation,
-      column.field,
-      column.refinement,
-    ];
+    const current = this.props.column;
+    let column: Column = cloneDeep(this.props.column);
 
     switch (value.kind) {
       case FieldValueKind.TAG:
       case FieldValueKind.FIELD:
-        currentParams = ['', value.meta.name, undefined];
+        column = {kind: 'field', field: value.meta.name};
         break;
       case FieldValueKind.FUNCTION:
-        currentParams[0] = value.meta.name;
+        if (current.kind === 'field') {
+          column = {kind: 'function', function: [value.meta.name, '', undefined]};
+        } else if (current.kind === 'function') {
+          column = {
+            kind: 'function',
+            function: [value.meta.name, current.function[1], current.function[2]],
+          };
+        }
         // Backwards compatibility for field alias versions of functions.
-        if (currentParams[1] && FIELD_ALIASES.includes(currentParams[1])) {
-          currentParams = [currentParams[0], '', undefined];
+        if (
+          current.kind === 'function' &&
+          column.kind === 'function' &&
+          current.function[1] &&
+          FIELD_ALIASES.includes(current.function[1])
+        ) {
+          column.function = [column.function[1] as Aggregation, '', undefined];
         }
         break;
       default:
@@ -67,52 +81,57 @@ class ColumnEditRow extends React.Component<Props> {
 
     if (value.kind === FieldValueKind.FUNCTION) {
       value.meta.parameters.forEach((param: AggregateParameter, i: number) => {
+        if (column.kind !== 'function') {
+          return;
+        }
         if (param.kind === 'column') {
-          const field = this.getFieldOrTagValue(currentParams[i + 1]);
+          const field = this.getFieldOrTagValue(column.function[i + 1]);
           if (field === null) {
-            currentParams[i + 1] = param.defaultValue || '';
+            column.function[i + 1] = param.defaultValue || '';
           } else if (
             (field.kind === FieldValueKind.FIELD || field.kind === FieldValueKind.TAG) &&
             param.columnTypes.includes(field.meta.dataType)
           ) {
             // New function accepts current field.
-            currentParams[i + 1] = field.meta.name;
+            column.function[i + 1] = field.meta.name;
           } else {
             // field does not fit within new function requirements, use the default.
-            currentParams[i + 1] = param.defaultValue || '';
-            currentParams[i + 2] = '';
+            column.function[i + 1] = param.defaultValue || '';
+            column.function[i + 2] = undefined;
           }
         }
         if (param.kind === 'value') {
-          currentParams[i + 1] = param.defaultValue;
+          column.function[i + 1] = param.defaultValue;
         }
       });
 
-      if (value.meta.parameters.length === 0) {
-        currentParams = [currentParams[0], '', undefined];
+      if (column.kind === 'function' && value.meta.parameters.length === 0) {
+        column.function = [column.function[0], '', undefined];
       }
     }
 
-    this.triggerChange(...currentParams);
+    this.triggerChange(column);
   };
 
   handleFieldParameterChange = ({value}) => {
-    const {column} = this.props;
-    this.triggerChange(column.aggregation, value.meta.name, column.refinement);
+    const newColumn = cloneDeep(this.props.column);
+    if (newColumn.kind === 'function') {
+      newColumn.function[1] = value.meta.name;
+    }
+    this.triggerChange(newColumn);
   };
 
   handleRefinementChange = (value: string) => {
-    const {column} = this.props;
-    this.triggerChange(column.aggregation, column.field, value);
+    const newColumn = cloneDeep(this.props.column);
+    if (newColumn.kind === 'function') {
+      newColumn.function[2] = value;
+    }
+    this.triggerChange(newColumn);
   };
 
-  triggerChange(aggregation: string, field: string, refinement?: string) {
+  triggerChange(column: Column) {
     const {parentIndex} = this.props;
-    this.props.onChange(parentIndex, {
-      aggregation,
-      field,
-      refinement,
-    });
+    this.props.onChange(parentIndex, column);
   }
 
   getFieldOrTagValue(name: string | undefined): FieldValue | null {
@@ -151,20 +170,24 @@ class ColumnEditRow extends React.Component<Props> {
 
     const {column} = this.props;
     let {fieldOptions} = this.props;
-    const funcName = `function:${column.aggregation}`;
 
-    if (fieldOptions[funcName] !== undefined) {
-      field = fieldOptions[funcName].value;
-      // TODO move this closer to where it is used.
-      fieldParameter = this.getFieldOrTagValue(column.field);
-    } else if (!column.aggregation && FIELD_ALIASES.includes(column.field)) {
-      // Handle backwards compatible field aliases.
-      const aliasName = `function:${column.field}`;
-      if (fieldOptions[aliasName] !== undefined) {
-        field = fieldOptions[aliasName].value;
+    if (column.kind === 'function') {
+      const funcName = `function:${column.function[0]}`;
+      if (fieldOptions[funcName] !== undefined) {
+        field = fieldOptions[funcName].value;
+        // TODO move this closer to where it is used.
+        fieldParameter = this.getFieldOrTagValue(column.function[1]);
       }
-    } else {
-      field = this.getFieldOrTagValue(column.field);
+    } else if (column.kind === 'field') {
+      if (FIELD_ALIASES.includes(column.field)) {
+        // Handle backwards compatible field aliases.
+        const aliasName = `function:${column.field}`;
+        if (fieldOptions[aliasName] !== undefined) {
+          field = fieldOptions[aliasName].value;
+        }
+      } else {
+        field = this.getFieldOrTagValue(column.field);
+      }
     }
 
     // If our current field, or columnParameter is a virtual tag, add it to the option list.
@@ -195,7 +218,10 @@ class ColumnEditRow extends React.Component<Props> {
           }
           return {
             kind: 'value',
-            value: column.refinement || param.defaultValue || '',
+            value:
+              (column.kind === 'function' && column.function[2]) ||
+              param.defaultValue ||
+              '',
             dataType: param.dataType,
             required: param.required,
           };
@@ -368,16 +394,16 @@ type InputState = {value: string};
  * constraints better.
  */
 class BufferedInput extends React.Component<InputProps, InputState> {
+  constructor(props: InputProps) {
+    super(props);
+    this.input = React.createRef();
+  }
+
   state = {
     value: this.props.value,
   };
 
   private input: React.RefObject<HTMLInputElement>;
-
-  constructor(props: InputProps) {
-    super(props);
-    this.input = React.createRef();
-  }
 
   get isValid() {
     if (!this.input.current) {
@@ -418,6 +444,8 @@ class BufferedInput extends React.Component<InputProps, InputState> {
 // Set a min-width to allow shrinkage in grid.
 const StyledInput = styled('input')`
   min-width: 50px;
+  /* Matcht the height of the select boxes */
+  height: 37px;
 
   &:not([disabled='true']):invalid {
     border-color: ${p => p.theme.red};

--- a/src/sentry/static/sentry/app/views/eventsV2/table/headerCell.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/headerCell.tsx
@@ -18,8 +18,6 @@ type Props = {
 function HeaderCell(props: Props) {
   const {children, column, tableData} = props;
 
-  const field = column.eventViewField;
-
   // establish alignment based on the type
   const alignedTypes: ColumnValueType[] = ['number', 'duration', 'integer'];
   let align: Alignments = alignedTypes.includes(column.type) ? 'right' : 'left';
@@ -28,7 +26,7 @@ function HeaderCell(props: Props) {
     // fallback to align the column based on the table metadata
     const maybeType =
       tableData && tableData.meta
-        ? tableData.meta[getAggregateAlias(field.field)]
+        ? tableData.meta[getAggregateAlias(column.name)]
         : undefined;
 
     if (maybeType === 'integer' || maybeType === 'number') {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -44,52 +44,33 @@ export type TableViewProps = {
 /**
  * The `TableView` is marked with leading _ in its method names. It consumes
  * the EventView object given in its props to generate new EventView objects
- * for actions such as creating new columns, updating columns, sorting columns,
- * and re-ordering columns.
+ * for actions like resizing column.
+
+ * The entire state of the table view (or event view) is co-located within
+ * the EventView object. This object is fed from the props.
+ *
+ * Attempting to modify the state, and therefore, modifying the given EventView
+ * object given from its props, will generate new instances of EventView objects.
+ *
+ * In most cases, the new EventView object differs from the previous EventView
+ * object. The new EventView object is pushed to the location object.
  */
 class TableView extends React.Component<TableViewProps> {
   /**
-   * The entire state of the table view (or event view) is co-located within
-   * the EventView object. This object is fed from the props.
-   *
-   * Attempting to modify the state, and therefore, modifying the given EventView
-   * object given from its props, will generate new instances of EventView objects.
-   *
-   * In most cases, the new EventView object differs from the previous EventView
-   * object. The new EventView object is pushed to the location object.
+   * Updates a column on resizing
    */
-  _updateColumn = (columnIndex: number, nextColumn: TableColumn<keyof TableDataRow>) => {
-    const {location, eventView, tableData, organization} = this.props;
+  _resizeColumn = (columnIndex: number, nextColumn: TableColumn<keyof TableDataRow>) => {
+    const {location, eventView, organization} = this.props;
 
-    const payload = {
-      aggregation: String(nextColumn.aggregation),
-      field: String(nextColumn.field),
-      width: nextColumn.width ? Number(nextColumn.width) : COL_WIDTH_UNDEFINED,
-      refinement: nextColumn.refinement,
-    };
-
-    const tableMeta = (tableData && tableData.meta) || undefined;
-    const nextEventView = eventView.withUpdatedColumn(columnIndex, payload, tableMeta);
+    const newWidth = nextColumn.width ? Number(nextColumn.width) : COL_WIDTH_UNDEFINED;
+    const nextEventView = eventView.withResizedField(columnIndex, newWidth);
 
     if (nextEventView !== eventView) {
       const changed: string[] = [];
 
-      const prevField = explodeField(eventView.fields[columnIndex]);
-      const nextField = explodeField(nextEventView.fields[columnIndex]);
-
-      const aggregationChanged = prevField.aggregation !== nextField.aggregation;
-      const fieldChanged = prevField.field !== nextField.field;
-      const widthChanged = prevField.width !== nextField.width;
-
-      if (aggregationChanged) {
-        changed.push('aggregate');
-      }
-
-      if (fieldChanged) {
-        changed.push('field');
-      }
-
-      if (widthChanged) {
+      const prevField = eventView.fields[columnIndex];
+      const nextField = nextEventView.fields[columnIndex];
+      if (prevField.width !== nextField.width) {
         changed.push('width');
       }
 
@@ -99,7 +80,6 @@ class TableView extends React.Component<TableViewProps> {
         updated_at_index: columnIndex,
         changed,
         organization_id: parseInt(organization.id, 10),
-        ...payload,
       });
     }
 
@@ -148,10 +128,9 @@ class TableView extends React.Component<TableViewProps> {
     return (
       <HeaderCell column={column} tableData={tableData}>
         {({align}) => {
-          const field = column.eventViewField;
-
           const tableDataMeta = tableData && tableData.meta ? tableData.meta : undefined;
 
+          const field = {field: column.name, width: column.width};
           function generateSortLink(): LocationDescriptorObject | undefined {
             if (!tableDataMeta) {
               return undefined;
@@ -225,7 +204,7 @@ class TableView extends React.Component<TableViewProps> {
         {...modalProps}
         organization={organization}
         tagKeys={tagKeys}
-        columns={eventView.getColumns()}
+        columns={eventView.getColumns().map(col => col.column)}
         onApply={this.handleUpdateColumns}
       />
     ));
@@ -275,7 +254,7 @@ class TableView extends React.Component<TableViewProps> {
         grid={{
           renderHeadCell: this._renderGridHeaderCell as any,
           renderBodyCell: this._renderGridBodyCell as any,
-          onResizeColumn: this._updateColumn as any,
+          onResizeColumn: this._resizeColumn as any,
           renderPrependColumns: this._renderPrependColumns as any,
           prependColumnWidths: ['40px'],
         }}
@@ -297,10 +276,8 @@ const ExpandAggregateRow = (props: {
   tableMeta: MetaType;
 }) => {
   const {children, column, dataRow, eventView, location} = props;
-  const {eventViewField} = column;
-
-  const exploded = explodeField(eventViewField);
-  const {aggregation} = exploded;
+  const aggregation =
+    column.column.kind === 'function' ? column.column.function[0] : undefined;
 
   // count(column) drilldown
   if (aggregation === 'count') {
@@ -318,8 +295,8 @@ const ExpandAggregateRow = (props: {
   if (aggregation === 'count_unique') {
     // Drilldown into each distinct value and get a count() for each value.
     const nextView = getExpandedResults(eventView, {}, dataRow).withNewColumn({
-      field: '',
-      aggregation: 'count',
+      kind: 'function',
+      function: ['count', '', undefined],
     });
 
     const target = {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -63,7 +63,7 @@ class TableView extends React.Component<TableViewProps> {
     const {location, eventView, organization} = this.props;
 
     const newWidth = nextColumn.width ? Number(nextColumn.width) : COL_WIDTH_UNDEFINED;
-    const nextEventView = eventView.withResizedField(columnIndex, newWidth);
+    const nextEventView = eventView.withResizedColumn(columnIndex, newWidth);
 
     if (nextEventView !== eventView) {
       const changed: string[] = [];

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -18,7 +18,6 @@ import {
   getFieldRenderer,
   getExpandedResults,
   pushEventViewToLocation,
-  explodeField,
   MetaType,
 } from '../utils';
 import EventView, {Column, pickRelevantLocationQueryStrings} from '../eventView';

--- a/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
@@ -1,14 +1,7 @@
 import {GridColumnOrder, GridColumnSortBy} from 'app/components/gridEditable';
 
-import {
-  ColumnType,
-  ColumnValueType,
-  AggregateParameter,
-  Aggregation,
-  Field,
-  AggregationRefinement,
-} from '../eventQueryParams';
-import {Field as FieldType} from '../eventView';
+import {ColumnType, ColumnValueType, AggregateParameter} from '../eventQueryParams';
+import {Column} from '../eventView';
 import {MetaType} from '../utils';
 
 /**
@@ -17,10 +10,8 @@ import {MetaType} from '../utils';
 export type TableColumn<K> = GridColumnOrder<K> & {
   // key: K                     From GridColumn
   // name: string               From GridColumnHeader
-  aggregation: Aggregation;
-  field: Field;
-  refinement: AggregationRefinement;
-  eventViewField: Readonly<FieldType>;
+  column: Readonly<Column>;
+  width?: number;
 
   type: ColumnValueType;
   isSortable: boolean;

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -208,12 +208,10 @@ class Table extends React.Component<Props, State> {
 
     const tableDataMeta = tableData && tableData.meta ? tableData.meta : undefined;
 
-    const columnOrder = eventView.getColumns();
-
-    return columnOrder.map((column, index) => (
+    return eventView.getColumns().map((column, index) => (
       <HeaderCell column={column} tableData={tableData} key={index}>
         {({align}) => {
-          const field = column.eventViewField;
+          const field = eventView.fields[index];
 
           function generateSortLink(): LocationDescriptorObject | undefined {
             if (!tableDataMeta) {

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.jsx
@@ -30,30 +30,32 @@ describe('EventsV2 -> ColumnEditModal', function() {
   const tagKeys = ['browser.name', 'custom-field'];
   const columns = [
     {
+      kind: 'field',
       field: 'event.type',
     },
     {
+      kind: 'field',
       field: 'browser.name',
     },
     {
-      field: 'id',
-      aggregation: 'count',
+      kind: 'function',
+      function: ['count', 'id'],
     },
     {
-      field: 'title',
-      aggregation: 'count_unique',
+      kind: 'function',
+      function: ['count_unique', 'title'],
     },
     {
-      field: '',
-      aggregation: 'p95',
+      kind: 'function',
+      function: ['p95', ''],
     },
     {
+      kind: 'field',
       field: 'issue.id',
-      aggregation: '',
     },
     {
-      field: 'issue.id',
-      aggregation: 'count_unique',
+      kind: 'function',
+      function: ['count_unique', 'issue.id'],
     },
   ];
 
@@ -89,8 +91,8 @@ describe('EventsV2 -> ColumnEditModal', function() {
     const wrapper = mountModal(
       {
         columns: [
-          {aggregation: 'count_unique', field: 'user-defined'},
-          {aggregation: '', field: 'user-def'},
+          {kind: 'function', function: ['count_unique', 'user-defined']},
+          {kind: 'field', field: 'user-def'},
         ],
         onApply: () => void 0,
         tagKeys,
@@ -119,9 +121,9 @@ describe('EventsV2 -> ColumnEditModal', function() {
     const wrapper = mountModal(
       {
         columns: [
-          {aggregation: 'count', field: 'id'},
-          {aggregation: 'count_unique', field: 'title'},
-          {aggregation: 'apdex', field: 'transaction.duration', refinement: 200},
+          {kind: 'function', function: ['count', 'id']},
+          {kind: 'function', function: ['count_unique', 'title']},
+          {kind: 'function', function: ['apdex', 'transaction.duration', 200]},
         ],
         onApply: () => void 0,
         tagKeys,
@@ -147,7 +149,7 @@ describe('EventsV2 -> ColumnEditModal', function() {
     const onApply = jest.fn();
     const wrapper = mountModal(
       {
-        columns: [{aggregation: '', field: 'p95'}],
+        columns: [{kind: 'field', field: 'p95'}],
         onApply,
         tagKeys,
       },
@@ -165,7 +167,7 @@ describe('EventsV2 -> ColumnEditModal', function() {
       selectByLabel(wrapper, 'p99()', {name: 'field', at: 0, control: true});
       wrapper.find('button[aria-label="Apply"]').simulate('click');
       expect(onApply).toHaveBeenCalledWith([
-        {aggregation: 'p99', field: '', refinement: undefined},
+        {kind: 'function', function: ['p99', '', undefined]},
       ]);
     });
   });
@@ -264,10 +266,7 @@ describe('EventsV2 -> ColumnEditModal', function() {
 
       wrapper.find('button[aria-label="Apply"]').simulate('click');
 
-      expect(onApply).toHaveBeenCalledWith([
-        columns[1],
-        {field: 'title', aggregation: '', refinement: undefined},
-      ]);
+      expect(onApply).toHaveBeenCalledWith([columns[1], {kind: 'field', field: 'title'}]);
     });
   });
 });

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -150,14 +150,11 @@ describe('decodeColumnOrder', function() {
     expect(results[0]).toEqual({
       key: 'title',
       name: 'title',
-      aggregation: '',
-      refinement: undefined,
-      field: 'title',
-      width: 123,
-      eventViewField: {
+      column: {
+        kind: 'field',
         field: 'title',
-        width: 123,
       },
+      width: 123,
       isSortable: false,
       type: 'string',
     });
@@ -170,14 +167,11 @@ describe('decodeColumnOrder', function() {
     expect(results[0]).toEqual({
       key: 'count()',
       name: 'count()',
-      aggregation: 'count',
-      field: '',
-      refinement: undefined,
-      width: 123,
-      eventViewField: {
-        field: 'count()',
-        width: 123,
+      column: {
+        kind: 'function',
+        function: ['count', '', undefined],
       },
+      width: 123,
       isSortable: true,
       type: 'number',
     });
@@ -197,11 +191,11 @@ describe('decodeColumnOrder', function() {
     expect(results[0]).toEqual({
       key: 'avg(transaction.duration)',
       name: 'avg(transaction.duration)',
-      aggregation: 'avg',
-      field: 'transaction.duration',
-      refinement: undefined,
+      column: {
+        kind: 'function',
+        function: ['avg', 'transaction.duration', undefined],
+      },
       width: COL_WIDTH_UNDEFINED,
-      eventViewField: {field: 'avg(transaction.duration)'},
       isSortable: true,
       type: 'duration',
     });
@@ -217,11 +211,11 @@ describe('decodeColumnOrder', function() {
     expect(results[0]).toEqual({
       key: 'percentile(transaction.duration, 0.65)',
       name: 'percentile(transaction.duration, 0.65)',
-      aggregation: 'percentile',
-      field: 'transaction.duration',
-      refinement: '0.65',
+      column: {
+        kind: 'function',
+        function: ['percentile', 'transaction.duration', '0.65'],
+      },
       width: COL_WIDTH_UNDEFINED,
-      eventViewField: {field: 'percentile(transaction.duration, 0.65)'},
       isSortable: true,
       type: 'duration',
     });
@@ -341,8 +335,8 @@ describe('getExpandedResults()', function() {
 
   it('preserves aggregated fields', () => {
     let view = new EventView(state);
-    let result = getExpandedResults(view, {}, {});
 
+    let result = getExpandedResults(view, {}, {});
     expect(result.fields).toEqual([
       {field: 'id', width: -1}, // expect count() to be converted to id
       {field: 'timestamp', width: -1},
@@ -364,7 +358,6 @@ describe('getExpandedResults()', function() {
     });
 
     result = getExpandedResults(view, {}, {});
-
     expect(result.fields).toEqual([
       {field: 'id', width: -1}, // expect count() to be converted to id
       {field: 'timestamp', width: -1},
@@ -397,7 +390,6 @@ describe('getExpandedResults()', function() {
     });
 
     result = getExpandedResults(view, {}, {});
-
     expect(result.fields).toEqual([
       {field: 'timestamp', width: -1},
       {field: 'id', width: -1},
@@ -525,37 +517,32 @@ describe('getDiscoverLandingUrl', function() {
 describe('explodeField', function() {
   it('explodes fields', function() {
     expect(explodeField({field: 'foobar'})).toEqual({
-      aggregation: '',
+      kind: 'field',
       field: 'foobar',
-      width: -1,
     });
 
     // has width
     expect(explodeField({field: 'foobar', width: 123})).toEqual({
-      aggregation: '',
+      kind: 'field',
       field: 'foobar',
-      width: 123,
     });
 
     // has aggregation
     expect(explodeField({field: 'count(foobar)', width: 123})).toEqual({
-      aggregation: 'count',
-      field: 'foobar',
-      width: 123,
+      kind: 'function',
+      function: ['count', 'foobar', undefined],
     });
 
     // custom tag
     expect(explodeField({field: 'foo.bar.is-Enterprise_42', width: 123})).toEqual({
-      aggregation: '',
+      kind: 'field',
       field: 'foo.bar.is-Enterprise_42',
-      width: 123,
     });
 
     // custom tag with aggregation
     expect(explodeField({field: 'count(foo.bar.is-Enterprise_42)', width: 123})).toEqual({
-      aggregation: 'count',
-      field: 'foo.bar.is-Enterprise_42',
-      width: 123,
+      kind: 'function',
+      function: ['count', 'foo.bar.is-Enterprise_42', undefined],
     });
   });
 });


### PR DESCRIPTION
Reduce the amount of duplication we maintain for column structures and
use types that make the kind of column being worked on easier to
understand and better leverage typescript features.

The `Field` type now contains the URL name and width. While the `Column`
type contains more metadata about the field. Lastly the `TableColumn`
type contains the width and the `Column` but does not duplicate the
column attributes like it did before.

I've also refactored the resize action handler to use a simpler
eventView function that only handles resizing.

Make inputs the same sizes.