### PR TITLE
build(spa): Add index.html for experimental SPA

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -386,7 +386,7 @@ let appConfig = {
   devtool: IS_PRODUCTION ? 'source-map' : 'cheap-module-eval-source-map',
 };
 
-if (DEPLOY_PREVIEW_CONFIG) {
+if (SENTRY_EXPERIMENTAL_SPA) {
   /**
    * Generate a index.html file used for running the app in pure client mode.
    * This is currently used for PR deploy previews, where only the frontend


### PR DESCRIPTION
The logic here is slightly incorrect, we want to add the index.html when
SENTRY_EXPERIMENTAL_SPA is enabled, which will be true whe
DEPLOY_PREVIEW_CONFIG is configured.