### PR TITLE
fix(issues) Correctly handle internal field names

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -191,6 +191,7 @@ class AbstractQueryExecutor:
             totals=True,  # Needs to have totals_mode=after_having_exclusive so we get groups matching HAVING only
             turbo=get_sample,  # Turn off FINAL when in sampling mode
             sample=1,  # Don't use clickhouse sampling, even when in turbo mode.
+            condition_resolver=snuba.get_snuba_column_name,
         )
         rows = snuba_results["data"]
         total = snuba_results["totals"]["total"]

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -745,6 +745,7 @@ def aliased_query(
     having=None,
     dataset=None,
     orderby=None,
+    condition_resolver=None,
     **kwargs
 ):
     """
@@ -775,7 +776,8 @@ def aliased_query(
             derived_columns.append(aggregation[2])
 
     if conditions:
-        column_resolver = functools.partial(resolve_column, dataset=dataset)
+        condition_resolver = condition_resolver or resolve_column
+        column_resolver = functools.partial(condition_resolver, dataset=dataset)
         for (i, condition) in enumerate(conditions):
             replacement = resolve_condition(condition, column_resolver)
             conditions[i] = replacement


### PR DESCRIPTION
Issue search should not be using internal field names. Instead all non-public event columns should be handled as tags. The default aliasing logic in `aliased_query` allows internal field names to be used as a shim for snuba queries that come from within the application. However, issue search should be using the more conservative get_snuba_column_name() which doesn't allow internal field usage.

cc @lobsterkatie @priscilawebdev @rhcarvalho 