### PR TITLE
fix(incidents): Respect global mail preference settings in metric alerts.

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -64,15 +64,10 @@ class EmailActionHandler(ActionHandler):
             if self.action.target_type == AlertRuleTriggerAction.TargetType.USER.value:
                 targets = [(target.id, target.email)]
             elif self.action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
-                alert_settings = self.project.get_member_alert_settings("mail:alert")
-                disabled_users = set(
-                    user_id for user_id, setting in alert_settings.items() if setting == 0
+                users = self.project.filter_to_subscribed_users(
+                    set(member.user for member in target.member_set)
                 )
-                targets = [
-                    (user_id, email)
-                    for user_id, email in target.member_set.values_list("user_id", "user__email")
-                    if user_id not in disabled_users
-                ]
+                targets = [(user.id, user.email) for user in users]
         # TODO: We need some sort of verification system to make sure we're not being
         # used as an email relay.
         # elif self.action.target_type == AlertRuleTriggerAction.TargetType.SPECIFIC.value:

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -65,6 +65,8 @@ class EmailActionHandlerGetTargetsTest(TestCase):
         UserOption.objects.set_value(
             user=self.user, key="mail:alert", value=0, project=self.project
         )
+        disabled_user = self.create_user()
+        UserOption.objects.set_value(user=disabled_user, key="subscribe_by_default", value="0")
 
         new_user = self.create_user()
         self.create_team_membership(team=self.team, user=new_user)

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -16,6 +16,7 @@ from sentry.models import (
     ReleaseProject,
     ReleaseProjectEnvironment,
     Rule,
+    UserOption,
 )
 from sentry.testutils import TestCase
 from sentry.utils.compat import zip
@@ -294,3 +295,54 @@ class CopyProjectSettingsTest(TestCase):
         assert project.copy_settings_from(self.other_project.id)
         self.assert_settings_copied(project)
         self.assert_other_project_settings_not_changed()
+
+
+class FilterToSubscribedUsersTest(TestCase):
+    def run_test(self, users, expected_users):
+        assert self.project.filter_to_subscribed_users(users) == expected_users
+
+    def test(self):
+        assert self.project.filter_to_subscribed_users([self.user]) == [self.user]
+
+    def test_global_enabled(self):
+        user = self.create_user()
+        UserOption.objects.set_value(user, "subscribe_by_default", "1")
+        self.run_test([user], [user])
+
+    def test_global_disabled(self):
+        user = self.create_user()
+        UserOption.objects.set_value(user, "subscribe_by_default", "0")
+        self.run_test([user], [])
+
+    def test_project_enabled(self):
+        user = self.create_user()
+        UserOption.objects.set_value(user, "subscribe_by_default", "0")
+        UserOption.objects.set_value(user, "mail:alert", 1, project=self.project)
+        self.run_test([user], [user])
+
+    def test_project_disabled(self):
+        user = self.create_user()
+        UserOption.objects.set_value(user, "subscribe_by_default", "1")
+        UserOption.objects.set_value(user, "mail:alert", 0, project=self.project)
+        self.run_test([user], [])
+
+    def test_mixed(self):
+        user_global_enabled = self.create_user()
+        UserOption.objects.set_value(user_global_enabled, "subscribe_by_default", "1")
+        user_global_disabled = self.create_user()
+        UserOption.objects.set_value(user_global_disabled, "subscribe_by_default", "0")
+        user_project_enabled = self.create_user()
+        UserOption.objects.set_value(user_project_enabled, "subscribe_by_default", "0")
+        UserOption.objects.set_value(user_project_enabled, "mail:alert", 1, project=self.project)
+        user_project_disabled = self.create_user()
+        UserOption.objects.set_value(user_project_disabled, "subscribe_by_default", "1")
+        UserOption.objects.set_value(user_project_disabled, "mail:alert", 0, project=self.project)
+        self.run_test(
+            [
+                user_global_enabled,
+                user_global_disabled,
+                user_project_enabled,
+                user_project_disabled,
+            ],
+            [user_global_enabled, user_project_enabled],
+        )


### PR DESCRIPTION
Noticed this in https://github.com/getsentry/sentry/pull/17583. We were only checking the users
specific project settings, but ignoring the global defaults. This fixes things so that we the global
default as well.