### PR TITLE
feat(workflow): Stop NotifyEventServiceAction from showing if it has no services

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -36,6 +36,15 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
             if hasattr(node, "form_fields"):
                 context["formFields"] = node.form_fields
 
+            # It is possible for a project to have no services. In that scenario we do
+            # not want the front end to render the action as the action does not have
+            # options.
+            if (
+                node.id == "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
+                and len(node.get_services()) == 0
+            ):
+                continue
+
             if rule_type.startswith("condition/"):
                 condition_list.append(context)
             elif rule_type.startswith("action/"):

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -44,9 +44,11 @@ class ProjectRuleConfigurationTest(APITestCase):
         rules.add(rule)
         return rules
 
-    def run_mock_rules_test(self, expected_actions, querystring_params):
+    def run_mock_rules_test(self, expected_actions, querystring_params, rules=None):
+        if not rules:
+            rules = self.rules
         self.login_as(user=self.user)
-        with patch("sentry.api.endpoints.project_rules_configuration.rules", self.rules):
+        with patch("sentry.api.endpoints.project_rules_configuration.rules", rules):
             url = reverse(
                 "sentry-api-0-project-rules-configuration",
                 kwargs={
@@ -71,3 +73,33 @@ class ProjectRuleConfigurationTest(APITestCase):
     def test_filter_show_notify_email_action_override(self):
         self.run_mock_rules_test(0, {"issue_alerts_targeting": "0"})
         self.run_mock_rules_test(1, {"issue_alerts_targeting": "1"})
+
+    def test_show_notify_event_service_action(self):
+        rules = RuleRegistry()
+        rule = Mock()
+        rule.id = "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
+        rule.rule_type = "action/lol"
+        node = rule.return_value
+        node.id = rule.id
+        node.label = "hello"
+        node.prompt = "hello"
+        node.is_enabled.return_value = True
+        node.form_fields = {}
+        node.get_services.return_value = [Mock()]
+        rules.add(rule)
+        self.run_mock_rules_test(1, {}, rules=rules)
+
+    def test_hide_empty_notify_event_service_action(self):
+        rules = RuleRegistry()
+        rule = Mock()
+        rule.id = "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
+        rule.rule_type = "action/lol"
+        node = rule.return_value
+        node.id = rule.id
+        node.label = "hello"
+        node.prompt = "hello"
+        node.is_enabled.return_value = True
+        node.form_fields = {}
+        node.get_services.return_value = []
+        rules.add(rule)
+        self.run_mock_rules_test(0, {}, rules=rules)


### PR DESCRIPTION
Stop `NotifyEventServiceAction` from showing if it has no services

### Changes
- `ProjectRulesConfigurationEndpoint::get` will not return `NotifyEventServiceAction` (JSONified) if there are no available services.

See https://github.com/getsentry/sentry/pull/17570 for additional context
Feature doc: https://www.notion.so/sentry/Issue-Alert-Targeting-30805fa4d233467ab2edb3eb98fce25e
Depending on: #17571 (for project.flags)