### PR TITLE
feat(IntegrationDirectory): Update integrationListDirectory to use experiment variant

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -837,6 +837,7 @@ export type SentryAppComponent = {
 export type ActiveExperiments = {
   TrialUpgradeV2Experiment: 'upgrade' | 'trial' | -1;
   AlertDefaultsExperiment: 'controlV1' | '2OptionsV1' | '3OptionsV2';
+  IntegrationDirectorySortWeightExperiment: '1' | '0';
 };
 
 type SavedQueryVersions = 1 | 2;

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -30,13 +30,14 @@ export const getAnalyticsSessionId = () =>
 
 export const getSortIntegrationsByWeightActive = (organization?: Organization) => {
   const variant = organization?.experiments?.IntegrationDirectorySortWeightExperiment;
-  if (localStorage.getItem(SORT_INTEGRATIONS_BY_WEIGHT) === '1') {
-    return true;
+  switch (localStorage.getItem(SORT_INTEGRATIONS_BY_WEIGHT)) {
+    case '1':
+      return true;
+    case '0':
+      return false;
+    default:
+      return variant && variant === '1';
   }
-  if (localStorage.getItem(SORT_INTEGRATIONS_BY_WEIGHT) === '0') {
-    return false;
-  }
-  return variant && variant === '1';
 };
 
 export type SingleIntegrationEvent = {

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -28,8 +28,16 @@ export const clearAnalyticsSession = () => {
 export const getAnalyticsSessionId = () =>
   window.sessionStorage.getItem(INTEGRATIONS_ANALYTICS_SESSION_KEY);
 
-export const getSortIntegrationsByWeightActive = () =>
-  localStorage.getItem(SORT_INTEGRATIONS_BY_WEIGHT) === '1';
+export const getSortIntegrationsByWeightActive = (organization?: Organization) => {
+  const variant = organization?.experiments?.IntegrationDirectorySortWeightExperiment;
+  if (localStorage.getItem(SORT_INTEGRATIONS_BY_WEIGHT) === '1') {
+    return true;
+  }
+  if (localStorage.getItem(SORT_INTEGRATIONS_BY_WEIGHT) === '0') {
+    return false;
+  }
+  return variant && variant === '1';
+};
 
 export type SingleIntegrationEvent = {
   eventKey:

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -224,7 +224,7 @@ export class OrganizationIntegrations extends AsyncComponent<
     this.getInstallValue(b) - this.getInstallValue(a);
 
   sortIntegrations(integrations: AppOrProviderOrPlugin[]) {
-    if (getSortIntegrationsByWeightActive()) {
+    if (getSortIntegrationsByWeightActive(this.props.organization)) {
       return integrations
         .sort(this.sortByName)
         .sort(this.sortByPopularity)

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -28,6 +28,7 @@ import withOrganization from 'app/utils/withOrganization';
 import SearchInput from 'app/components/forms/searchInput';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import space from 'app/styles/space';
+import {logExperiment} from 'app/utils/analytics';
 
 import {POPULARITY_WEIGHT} from './constants';
 import IntegrationRow from './integrationRow';
@@ -78,6 +79,16 @@ export class OrganizationIntegrations extends AsyncComponent<
   static propTypes = {
     organization: SentryTypes.Organization,
   };
+
+  componentDidMount() {
+    logExperiment({
+      organization: this.props.organization,
+      key: 'IntegrationDirectorySortWeightExperiment',
+      unitName: 'org_id',
+      unitId: parseInt(this.props.organization.id, 10),
+      param: 'variant',
+    });
+  }
 
   getDefaultState() {
     return {


### PR DESCRIPTION
## Objective
Control which version of the sort is used in the Integration Directory with the IntegrationDirectorySortWeightExperiment Planout experiment.

Associate PR in GetSentry: https://github.com/getsentry/getsentry/pull/3658

## UI
Sort by weight view:
<img width="1440" alt="Screen Shot 2020-03-11 at 6 29 50 PM" src="https://user-images.githubusercontent.com/10491193/76478963-7b824c80-63c7-11ea-8147-15f8e479a424.png">
