### PR TITLE
feat(onboarding): Pass active user when updating local onboarding task

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/onboardingTasks.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/onboardingTasks.tsx
@@ -1,6 +1,7 @@
 import {Client} from 'app/api';
 import {Organization, OnboardingTask} from 'app/types';
 import OrganizationActions from 'app/actions/organizationActions';
+import ConfigStore from 'app/stores/configStore';
 
 /**
  * Update an onboarding task.
@@ -20,15 +21,16 @@ export async function updateOnboardingTask(
     });
   }
 
-  const hasSkippedTask = organization.onboardingTasks.find(
+  const hasExistingTask = organization.onboardingTasks.find(
     task => task.task === updatedTask.task
   );
 
-  const onboardingTasks = hasSkippedTask
+  const user = ConfigStore.get('user');
+  const onboardingTasks = hasExistingTask
     ? organization.onboardingTasks.map(task =>
         task.task === updatedTask.task ? {...task, ...updatedTask} : task
       )
-    : [...organization.onboardingTasks, updatedTask];
+    : [...organization.onboardingTasks, {...updatedTask, user}];
 
   OrganizationActions.update({onboardingTasks});
 }

--- a/tests/js/spec/actionCreators/onboardingTasks.spec.jsx
+++ b/tests/js/spec/actionCreators/onboardingTasks.spec.jsx
@@ -1,0 +1,96 @@
+import {updateOnboardingTask} from 'app/actionCreators/onboardingTasks';
+import OrganizationActions from 'app/actions/organizationActions';
+import ConfigStore from 'app/stores/configStore';
+
+describe('actionCreators/onboardingTasks', function() {
+  const api = new MockApiClient();
+  const user = ConfigStore.get('user');
+
+  jest.spyOn(OrganizationActions, 'update');
+
+  describe('updateOnboardingTask', function() {
+    it('Adds the task to the organization when task does not exists', async function() {
+      const detailedOrg = TestStubs.Organization({
+        teams: [TestStubs.Team()],
+        projects: [TestStubs.Project()],
+      });
+
+      // User is not passed into the update request
+      const testTask = {
+        task: 'create_project',
+        status: 'complete',
+      };
+
+      const mockUpdate = MockApiClient.addMockResponse({
+        url: `/organizations/${detailedOrg.slug}/onboarding-tasks/`,
+        method: 'POST',
+        body: testTask,
+      });
+
+      updateOnboardingTask(api, detailedOrg, testTask);
+      await tick();
+
+      expect(mockUpdate).toHaveBeenCalled();
+
+      expect(OrganizationActions.update).toHaveBeenCalledWith({
+        onboardingTasks: [{...testTask, user}],
+      });
+    });
+
+    it('Updates existing onboarding task', async function() {
+      const detailedOrg = TestStubs.Organization({
+        teams: [TestStubs.Team()],
+        projects: [TestStubs.Project()],
+        onboardingTasks: [{task: 'first_event', status: 'skipped'}],
+      });
+
+      const testTask = {
+        task: 'first_event',
+        status: 'complete',
+      };
+
+      MockApiClient.clearMockResponses();
+      const mockUpdate = MockApiClient.addMockResponse({
+        url: `/organizations/${detailedOrg.slug}/onboarding-tasks/`,
+        method: 'POST',
+        body: testTask,
+      });
+
+      updateOnboardingTask(api, detailedOrg, testTask);
+      await tick();
+
+      expect(mockUpdate).toHaveBeenCalled();
+
+      // NOTE: user is not passed as it is already associated to the existing
+      // onboarding task.
+      expect(OrganizationActions.update).toHaveBeenCalledWith({
+        onboardingTasks: [testTask],
+      });
+    });
+
+    it('Does not make API request without api object', async function() {
+      const detailedOrg = TestStubs.Organization({
+        teams: [TestStubs.Team()],
+        projects: [TestStubs.Project()],
+      });
+
+      const testTask = {
+        task: 'first_event',
+        status: 'complete',
+      };
+
+      const mockUpdate = MockApiClient.addMockResponse({
+        url: `/organizations/${detailedOrg.slug}/onboarding-tasks/`,
+        method: 'POST',
+      });
+
+      updateOnboardingTask(null, detailedOrg, testTask);
+      await tick();
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+      expect(OrganizationActions.update).toHaveBeenCalledWith({
+        onboardingTasks: [{...testTask, user}],
+      });
+    });
+  });
+});


### PR DESCRIPTION
When using the updateOnboardingTask action creator, it will update the current state of `onboardingTasks` in the organization. Typically when marking an onboarding task as complete a user will be associated with the task. Currently it doesn't associate a user, but the API response will have one.

This corrects the update to associate a user with the task.

This actually requires #17600 to match the expected API.