### PR TITLE
fix(workflow): Fix "null" in tooltips for Alert Details charts

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -60,7 +60,11 @@ function getFormatter({
         utc,
         showTimeInTooltip
       );
-      const truncatedName = truncationFormatter(seriesParamsOrParam.seriesName, truncate);
+      // eCharts sets seriesName as null when `componentType` !== 'series'
+      const truncatedName = truncationFormatter(
+        seriesParamsOrParam.data.labelForValue,
+        truncate
+      );
       const formattedValue = valueFormatter(seriesParamsOrParam.data.coord[1]);
       return [
         '<div class="tooltip-series">',

--- a/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
@@ -65,6 +65,7 @@ export default class Chart extends React.PureComponent<Props> {
       closedTs &&
       typeof nearbyClosedTimestampIndex !== 'undefined' &&
       chartData[nearbyClosedTimestampIndex];
+    const seriesName = getDisplayForAlertRuleAggregation(aggregation);
 
     return (
       <LineChart
@@ -73,11 +74,13 @@ export default class Chart extends React.PureComponent<Props> {
         series={[
           {
             // e.g. Events or Users
-            seriesName: getDisplayForAlertRuleAggregation(aggregation),
+            seriesName,
             dataArray: chartData?.slice(0, -1),
             markPoint: MarkPoint({
               data: [
                 {
+                  labelForValue: seriesName,
+                  seriesName,
                   symbol: `image://${detectedSymbol}`,
                   name: t('Incident Started'),
                   coord: detectedCoordinate,
@@ -85,6 +88,8 @@ export default class Chart extends React.PureComponent<Props> {
                 ...(closedTs
                   ? [
                       {
+                        labelForValue: seriesName,
+                        seriesName,
                         symbol: `image://${closedSymbol}`,
                         symbolSize: 24,
                         name: t('Incident Closed'),


### PR DESCRIPTION
`eCharts` does not pass along `seriesName` if the type of series is not "series" (as in the case of a "markPoint"). This is why it was showing "null" in the tooltips