### PR TITLE
fix(workflow): Read aggregate from incident, not alert rule

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -64,7 +64,7 @@ export default class DetailsBody extends React.Component<Props> {
       fields: ['issue', 'count(id)', 'count_unique(user.id)'],
       widths: ['400', '200', '-1'],
       orderby:
-        incident.alertRule?.aggregation === AlertRuleAggregations.UNIQUE_USERS
+        incident.aggregation === AlertRuleAggregations.UNIQUE_USERS
           ? '-count_unique_user_id'
           : '-count_id',
       query: (incident && incident.query) || '',

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -160,7 +160,7 @@ export default class DetailsBody extends React.Component<Props> {
         <ChartWrapper>
           {incident && stats ? (
             <Chart
-              aggregation={incident.alertRule?.aggregation}
+              aggregation={incident.aggregation}
               data={stats.eventStats.data}
               detected={incident.dateDetected}
               closed={incident.dateClosed}

--- a/src/sentry/static/sentry/app/views/alerts/types.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/types.tsx
@@ -1,4 +1,7 @@
-import {IncidentRule} from 'app/views/settings/incidentRules/types';
+import {
+  AlertRuleAggregations,
+  IncidentRule,
+} from 'app/views/settings/incidentRules/types';
 import {User, Repository} from 'app/types';
 
 type Data = [number, {count: number}[]][];
@@ -28,6 +31,8 @@ export type IncidentStats = {
   };
   totalEvents: number;
   uniqueUsers: number;
+  aggregation: AlertRuleAggregations;
+  alertRule: IncidentRule;
 };
 
 export type IncidentSuspect = {

--- a/src/sentry/static/sentry/app/views/alerts/types.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/types.tsx
@@ -23,6 +23,7 @@ export type Incident = {
   title: string;
   hasSeen: boolean;
   alertRule: IncidentRule;
+  aggregation: AlertRuleAggregations;
 };
 
 export type IncidentStats = {
@@ -31,7 +32,6 @@ export type IncidentStats = {
   };
   totalEvents: number;
   uniqueUsers: number;
-  aggregation: AlertRuleAggregations;
   alertRule: IncidentRule;
 };
 

--- a/src/sentry/static/sentry/app/views/alerts/types.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/types.tsx
@@ -32,7 +32,6 @@ export type IncidentStats = {
   };
   totalEvents: number;
   uniqueUsers: number;
-  alertRule: IncidentRule;
 };
 
 export type IncidentSuspect = {


### PR DESCRIPTION
On the alert details page, we're reading the aggregate from the alert rule. This caused an issue when viewing an alert that had its associated rule deleted. Throughout the UI, we defaulted to a "users" aggregate in this case, which caused confusion when the aggregate was actually "events".

Since we are already storing the aggregate in the incident, this is a good fix for now. Long-term, I believe the plan will be to persist rules associated with an alert, so that even if they rule is altered or deleted, we'll still have an original record of the rule.