### PR TITLE
fix(integrations): client api logging

### DIFF
--- a/src/sentry/integrations/client.py
+++ b/src/sentry/integrations/client.py
@@ -139,7 +139,7 @@ class ApiClient(object):
 
         extra = {
             "integration": self.integration_name,
-            "status": code,
+            "status_string": six.text_type(code),
             "error": six.text_type(error)[:128] if error else None,
         }
         extra.update(getattr(self, "logging_context", None) or {})

--- a/src/sentry/integrations/client.py
+++ b/src/sentry/integrations/client.py
@@ -140,7 +140,7 @@ class ApiClient(object):
         extra = {
             "integration": self.integration_name,
             "status": code,
-            "error": six.text_type(error[:128]) if error else None,
+            "error": six.text_type(error)[:128] if error else None,
         }
         extra.update(getattr(self, "logging_context", None) or {})
         logger.info("integrations.http_response", extra=extra)

--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -142,7 +142,7 @@ class ApiClient(object):
 
         extra = {
             "plugin": self.plugin_name,
-            "status": code,
+            "status_string": six.text_type(code),
             "error": six.text_type(error)[:128] if error else None,
         }
         extra.update(getattr(self, "logging_context", None) or {})

--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -143,7 +143,7 @@ class ApiClient(object):
         extra = {
             "plugin": self.plugin_name,
             "status": code,
-            "error": six.text_type(error[:128]) if error else None,
+            "error": six.text_type(error)[:128] if error else None,
         }
         extra.update(getattr(self, "logging_context", None) or {})
         logger.info("plugins.http_response", extra=extra)


### PR DESCRIPTION
When we have certain errors that don't have status codes, we are using a string for the status instead of an integer. Elasticsearch is rejecting those log messages.

I also fixed a possible bug where we tried to concatenate the error before converting it to a string.