### PR TITLE
feat(sessions): add data on single release

### DIFF
--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import six
 from rest_framework.response import Response
+from rest_framework.exceptions import ParseError
 
 from sentry.api.base import DocSection
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
@@ -13,8 +14,13 @@ from sentry.api.serializers.rest_framework import (
     ReleaseHeadCommitSerializer,
     ReleaseHeadCommitSerializerDeprecated,
 )
-from sentry.models import Activity, Group, Release, ReleaseFile
+from sentry.models import Activity, Group, Release, ReleaseFile, Project
 from sentry.utils.apidocs import scenario, attach_scenarios
+from sentry.api.endpoints.organization_releases import (
+    SUMMARY_STATS_PERIOD,
+    HEALTH_STATS_PERIOD,
+    get_stats_period_detail,
+)
 
 ERR_RELEASE_REFERENCED = "This release is referenced by active issues and cannot be removed."
 
@@ -63,6 +69,19 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         :pparam string version: the version identifier of the release.
         :auth: required
         """
+        project_id = request.GET.get("project")
+        with_health = request.GET.get("health") == "1"
+        summary_stats_period = request.GET.get("summaryStatsPeriod") or "48h"
+        health_stats_period = request.GET.get("healthStatsPeriod") or ("24h" if with_health else "")
+        if summary_stats_period not in SUMMARY_STATS_PERIOD:
+            raise ParseError(
+                detail=get_stats_period_detail("summaryStatsPeriod", SUMMARY_STATS_PERIOD)
+            )
+        if health_stats_period not in HEALTH_STATS_PERIOD:
+            raise ParseError(
+                detail=get_stats_period_detail("healthStatsPeriod", HEALTH_STATS_PERIOD)
+            )
+
         try:
             release = Release.objects.get(organization_id=organization.id, version=version)
         except Release.DoesNotExist:
@@ -71,7 +90,23 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        return Response(serialize(release, request.user))
+        if with_health and project_id:
+            try:
+                project = Project.objects.get_from_cache(id=int(project_id))
+            except (ValueError, Project.DoesNotExist):
+                raise ParseError(detail="Invalid project")
+            release._for_project_id = project.id
+
+        return Response(
+            serialize(
+                release,
+                request.user,
+                project=project,
+                with_health_data=with_health,
+                summary_stats_period=summary_stats_period,
+                health_stats_period=health_stats_period,
+            )
+        )
 
     @attach_scenarios([update_organization_release_scenario])
     def put(self, request, organization, version):

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -101,7 +101,6 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
             serialize(
                 release,
                 request.user,
-                project=project,
                 with_health_data=with_health,
                 summary_stats_period=summary_stats_period,
                 health_stats_period=health_stats_period,

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -11,7 +11,6 @@ from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import InvalidRepository
 from sentry.api.paginator import OffsetPaginator, MergingOffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.release import ReleaseSerializer
 from sentry.api.serializers.rest_framework import (
     ReleaseHeadCommitSerializer,
     ReleaseHeadCommitSerializerDeprecated,
@@ -236,16 +235,17 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
                 params=[filter_params["start"], filter_params["end"]],
             )
 
-        serializer = ReleaseSerializer(
-            with_health_data=with_health,
-            health_stats_period=health_stats_period,
-            summary_stats_period=summary_stats_period,
-        )
         return self.paginate(
             request=request,
             queryset=queryset,
             paginator_cls=paginator_cls,
-            on_results=lambda x: serialize(x, request.user, serializer=serializer),
+            on_results=lambda x: serialize(
+                x,
+                request.user,
+                with_health_data=with_health,
+                health_stats_period=health_stats_period,
+                summary_stats_period=summary_stats_period,
+            ),
             **paginator_kwargs
         )
 

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -337,6 +337,7 @@ class ReleaseSerializer(Serializer):
                 "totalUsers": data["total_users"],
                 "adoption": data["adoption"],
                 "stats": data.get("stats"),
+                "hasHealthData": data["has_health_data"],
             }
 
         def expose_project(project):

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -72,12 +72,6 @@ def get_users_for_authors(organization_id, authors, user=None):
 
 @register(Release)
 class ReleaseSerializer(Serializer):
-    def __init__(self, *args, **kwargs):
-        self.with_health_data = kwargs.pop("with_health_data", False)
-        self.health_stats_period = kwargs.pop("health_stats_period", None)
-        self.summary_stats_period = kwargs.pop("summary_stats_period", None)
-        Serializer.__init__(self, *args, **kwargs)
-
     def _get_commit_metadata(self, item_list, user):
         """
         Returns a dictionary of release_id => commit metadata,
@@ -236,6 +230,10 @@ class ReleaseSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
         project = kwargs.get("project")
         environment = kwargs.get("environment")
+        with_health_data = kwargs.get("with_health_data", False)
+        health_stats_period = kwargs.get("health_stats_period")
+        summary_stats_period = kwargs.get("summary_stats_period")
+
         if environment is None:
             first_seen, last_seen, issue_counts_by_release = self.__get_release_data_no_environment(
                 project, item_list
@@ -257,11 +255,11 @@ class ReleaseSerializer(Serializer):
             "release_id", "release__version", "project__slug", "project__name", "project__id"
         )
 
-        if self.with_health_data:
+        if with_health_data:
             health_data = get_release_health_data_overview(
                 [(pr["project__id"], pr["release__version"]) for pr in project_releases],
-                health_stats_period=self.health_stats_period,
-                summary_stats_period=self.summary_stats_period,
+                health_stats_period=health_stats_period,
+                summary_stats_period=summary_stats_period,
             )
         else:
             health_data = None

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -136,6 +136,7 @@ export type Health = {
   sessionsCrashed: number;
   sessionsErrored: number;
   adoption: number | null;
+  hasHealthData: boolean;
 };
 export type HealthGraphData = {
   [key: string]: [number, number][];

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -4,7 +4,8 @@ import {Params} from 'react-router/lib/Router';
 import {Location} from 'history';
 
 import withOrganization from 'app/utils/withOrganization';
-import {Organization} from 'app/types';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
+import {Organization, GlobalSelection} from 'app/types';
 import space from 'app/styles/space';
 
 import HealthChart from './healthChart';
@@ -19,12 +20,13 @@ type Props = {
   organization: Organization;
   params: Params;
   location: Location;
+  selection: GlobalSelection;
 };
 
-const ReleaseOverview = ({organization, params, location}: Props) => {
-  const projectId =
-    typeof location.query.project === 'string' ? location.query.project : undefined;
+const ReleaseOverview = ({organization, params, selection}: Props) => {
+  const projectId = String(selection.projects[0]);
 
+  // TODO(releasesV2): we will handle this later with forced project selector
   if (!projectId) {
     return null;
   }
@@ -44,7 +46,7 @@ const ReleaseOverview = ({organization, params, location}: Props) => {
                 <CommitAuthorBreakdown
                   version={version}
                   orgId={organization.slug}
-                  projectId={location.query.project as string}
+                  projectId={projectId}
                   commitCount={commitCount}
                 />
               )}
@@ -78,4 +80,4 @@ const Sidebar = styled('div')`
   grid-column: 2 / 3;
 `;
 
-export default withOrganization(ReleaseOverview);
+export default withGlobalSelection(withOrganization(ReleaseOverview));

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
@@ -83,7 +83,7 @@ const ReleaseHeader = ({location, orgId, release, deploys, selection}: Props) =>
             </ReleaseStat>
           )}
           <ReleaseStat label={t('Crashes')}>
-            <Count value={healthData?.sessionsCrashed ?? 10} />
+            <Count value={healthData?.sessionsCrashed ?? 0} />
           </ReleaseStat>
           {/* <ReleaseStat label={t('Errors')}>
             <Count value={healthData?.sessionsErrored ?? 0} />

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
@@ -8,7 +8,7 @@ import Link from 'app/components/links/link';
 import ListLink from 'app/components/links/listLink';
 import ExternalLink from 'app/components/links/externalLink';
 import NavTabs from 'app/components/navTabs';
-import {Release, Deploy} from 'app/types';
+import {Release, Deploy, GlobalSelection} from 'app/types';
 import Version from 'app/components/version';
 import Clipboard from 'app/components/clipboard';
 import {IconCopy, IconOpen} from 'app/icons';
@@ -16,6 +16,7 @@ import Tooltip from 'app/components/tooltip';
 import Badge from 'app/components/badge';
 import Count from 'app/components/count';
 import TimeSince from 'app/components/timeSince';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 import ReleaseStat from './releaseStat';
 import Breadcrumbs from './breadcrumbs';
@@ -26,10 +27,14 @@ type Props = {
   orgId: string;
   release: Release;
   deploys: Deploy[];
+  selection: GlobalSelection;
 };
 
-const ReleaseHeader = ({location, orgId, release, deploys}: Props) => {
+const ReleaseHeader = ({location, orgId, release, deploys, selection}: Props) => {
   const {version, newGroups, url} = release;
+
+  const healthData = release.projects.find(p => p.id === selection.projects[0])
+    ?.healthData;
 
   const releasePath = `/organizations/${orgId}/releases-v2/${encodeURIComponent(
     version
@@ -78,10 +83,10 @@ const ReleaseHeader = ({location, orgId, release, deploys}: Props) => {
             </ReleaseStat>
           )}
           <ReleaseStat label={t('Crashes')}>
-            <Count value={release.projects[0].healthData?.sessionsCrashed ?? 0} />
+            <Count value={healthData?.sessionsCrashed ?? 10} />
           </ReleaseStat>
           {/* <ReleaseStat label={t('Errors')}>
-            <Count value={release.projects[0].healthData?.sessionsErrored ?? 0} />
+            <Count value={healthData?.sessionsErrored ?? 0} />
           </ReleaseStat> */}
           <ReleaseStat label={t('New Issues')}>
             <Count value={newGroups} />
@@ -193,4 +198,4 @@ const StyledNavTabs = styled(NavTabs)`
   grid-column: 1 / 2;
 `;
 
-export default ReleaseHeader;
+export default withGlobalSelection(ReleaseHeader);

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
@@ -78,11 +78,10 @@ const ReleaseHeader = ({location, orgId, release, deploys}: Props) => {
             </ReleaseStat>
           )}
           <ReleaseStat label={t('Crashes')}>
-            <Count value={/*release.healthData?.crashes ??*/ 0} />
+            <Count value={release.projects[0].healthData?.sessionsCrashed ?? 0} />
           </ReleaseStat>
-          {/* TODO(releasesV2): waiting for api */}
           {/* <ReleaseStat label={t('Errors')}>
-            <Count value={release.healthData?.errors ?? 0} />
+            <Count value={release.projects[0].healthData?.sessionsErrored ?? 0} />
           </ReleaseStat> */}
           <ReleaseStat label={t('New Issues')}>
             <Count value={newGroups} />

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releaseCard.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releaseCard.tsx
@@ -91,7 +91,9 @@ const ReleaseCard = ({release, project, location}: Props) => (
       </StyledPanelItem>
     </PanelBody>
 
-    {release.healthData && <ReleaseHealth release={release} location={location} />}
+    {release.healthData?.hasHealthData && (
+      <ReleaseHealth release={release} location={location} />
+    )}
   </Panel>
 );
 


### PR DESCRIPTION
This adds session data to the org release endpoint and uses that data on the release detail screen.