### PR TITLE
feat(migrations): Require name to be passed when creating a migration

### DIFF
--- a/src/sentry/management/commands/makemigrations.py
+++ b/src/sentry/management/commands/makemigrations.py
@@ -26,6 +26,12 @@ class Command(makemigrations.Command):
     """
 
     def handle(self, *app_labels, **options):
+        if not options["name"]:
+            self.stderr.write(
+                "Please name your migrations using `-n <migration_name>`. "
+                "For example, `-n backfill_my_new_table`"
+            )
+            return
         super(Command, self).handle(*app_labels, **options)
         loader = MigrationLoader(None, ignore_no_migrations=True)
 


### PR DESCRIPTION
We have a lot of migrations named with random timestamps, which isn't all that descriptive. Require
users to pass a name explicitly when creating a migration.

![Screenshot 2020-03-12 11 11 05](https://user-images.githubusercontent.com/6288560/76553932-322b0f00-6452-11ea-8402-476b66bc9eb6.png)