### PR TITLE
ref(tooltip): Remove proptypes on containerDisplayMode

### DIFF
--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -71,12 +71,7 @@ class Tooltip extends React.Component<Props, State> {
     /**
      * Display mode for the container element
      */
-    containerDisplayMode: PropTypes.oneOf([
-      'block',
-      'inline-block',
-      'inline',
-      'inline-flex',
-    ]),
+    containerDisplayMode: PropTypes.string,
 
     /**
      * Time to wait (in milliseconds) before showing the tooltip


### PR DESCRIPTION
There are more than these, lets not try and get it right, we'll move to
full typescript soon enough anyway.