### PR TITLE
ref(config) adding "sentry.web.frontend" to the allowed path 

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1783,4 +1783,4 @@ SYMBOLICATOR_PROCESS_EVENT_WARN_TIMEOUT = 120
 # process_event might backlog and affect events from other platforms.
 SYMBOLICATOR_POLL_TIMEOUT = 4
 
-SENTRY_REQUEST_METRIC_ALLOWED_PATHS = ("sentry.web.api", "sentry.api.endpoints")
+SENTRY_REQUEST_METRIC_ALLOWED_PATHS = ("sentry.web.api", "sentry.web.frontend", "sentry.api.endpoints")


### PR DESCRIPTION
adding "sentry.web.frontend" to the allowed path so we can track sentry.web.frontend.auth_login.AuthLoginView (login)