### PR TITLE
feat(experiment): Additional support for user based experiments

### DIFF
--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -5,6 +5,7 @@ import six
 from collections import defaultdict
 from django.conf import settings
 
+from sentry import experiments
 from sentry.app import env
 from sentry.api.serializers import Serializer, register
 from sentry.models import (
@@ -64,6 +65,8 @@ class UserSerializer(Serializer):
         return data
 
     def serialize(self, obj, attrs, user):
+        experiment_assignments = experiments.all(user=user)
+
         d = {
             "id": six.text_type(obj.id),
             "name": obj.get_display_name(),
@@ -79,6 +82,7 @@ class UserSerializer(Serializer):
             "lastActive": obj.last_active,
             "isSuperuser": obj.is_superuser,
             "isStaff": obj.is_staff,
+            "experiments": experiment_assignments,
         }
 
         if obj == user:

--- a/src/sentry/experiments/manager.py
+++ b/src/sentry/experiments/manager.py
@@ -17,22 +17,52 @@ class ExperimentManager(object):
         """
         self._experiments[experiment.__name__] = {"experiment": experiment, "param": param}
 
-    def all(self, org, actor=None):
+    def all(self, org=None, actor=None, user=None):
         """
-        Returns an object with all the experiment assignments for the org.
+        Returns an object with all the experiment assignments for an organization or user.
+
+        :param org: The organization for org based experiments
+        :param actor: The actor for org based experiments
+        :param user: The user for user based experiments
         """
+        if not org and not user:
+            return {}
+
         assignments = {}
+
+        if org:
+            kwargs = {"org": org, "actor": actor}
+            unit = "org"
+        else:
+            kwargs = {"user": user}
+            unit = "user"
+
         for k, v in six.iteritems(self._experiments):
             cls = v["experiment"]
-            assignments[k] = cls(org=org, actor=actor).get_variant(v["param"], log_exposure=False)
+            if hasattr(cls, "unit") and cls.unit == unit:
+                assignments[k] = cls(**kwargs).get_variant(v["param"], log_exposure=False)
         return assignments
 
-    def get(self, experiment_name, org, actor=None):
+    def get(self, experiment_name, org=None, actor=None, user=None):
         """
         Returns the assignment for an experiment.
+
+        :param experiment_name:  The name of the experiment
+        :param org: The organization for org based experiments
+        :param actor: The actor for org based experiments
+        :param user: The user for user based experiments
         """
+        if not org and not user:
+            return None
+
         value = self._experiments.get(experiment_name)
         if not value:
             return None
+
+        if org:
+            kwargs = {"org": org, "actor": actor}
+        else:
+            kwargs = {"user": user}
+
         cls = value["experiment"]
-        return cls(org=org, actor=actor).get_variant(value["param"], log_exposure=False)
+        return cls(**kwargs).get_variant(value["param"], log_exposure=False)

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -196,9 +196,9 @@ type AnalyticsTrackAdhocEvent = (
  */
 type AnalyticsLogExperiment = (opts: {
   /**
-   * The organiation with the experiment
+   * The organization for org based experiments
    */
-  organization: Organization;
+  organization?: Organization;
   /**
    * The experiment key
    */

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -68,7 +68,7 @@ export type LightWeightOrganization = OrganizationSummary & {
     maxRate: number | null;
   };
   defaultRole: string;
-  experiments: Partial<ActiveExperiments>;
+  experiments: Partial<ActiveOrgExperiments>;
   allowJoinRequests: boolean;
   scrapeJavaScript: boolean;
   isDefault: boolean;
@@ -321,6 +321,7 @@ export type User = AvatarUser & {
   flags: {newsletter_consent_prompt: boolean};
   hasPasswordAuth: boolean;
   permissions: Set<string>;
+  experiments: Partial<ActiveUserExperiments>;
 };
 
 export type CommitAuthor = {
@@ -840,11 +841,13 @@ export type SentryAppComponent = {
   };
 };
 
-export type ActiveExperiments = {
+export type ActiveOrgExperiments = {
   TrialUpgradeV2Experiment: 'upgrade' | 'trial' | -1;
   AlertDefaultsExperiment: 'controlV1' | '2OptionsV1' | '3OptionsV2';
   IntegrationDirectorySortWeightExperiment: '1' | '0';
 };
+
+export type ActiveUserExperiments = {};
 
 type SavedQueryVersions = 1 | 2;
 

--- a/tests/sentry/api/serializers/test_user.py
+++ b/tests/sentry/api/serializers/test_user.py
@@ -30,6 +30,7 @@ class UserSerializerTest(TestCase):
         assert result["emails"][0]["email"] == user.email
         assert result["emails"][0]["is_verified"]
         assert result["isSuperuser"] is False
+        assert result["experiments"] == {}
 
     def test_no_useremail(self):
         user = self.create_user()


### PR DESCRIPTION
- Filters for organization or user based experiments when fetching `experiments.all`
- Adds an experiments field to the `UserSerializer`, so user based experiments are available on the frontend
- Makes `organization` optional when logging user based experiments with `logExperiment`

Requires [#3660](https://github.com/getsentry/getsentry/pull/3660)