### PR TITLE
fix(discover) - Allow user:* queries in Discover

### DIFF
--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1149,6 +1149,14 @@ class GetSnubaQueryArgsTest(TestCase):
         assert "Invalid value" in six.text_type(err)
         assert "cancelled," in six.text_type(err)
 
+    def test_general_user_field(self):
+        conditions = get_filter("user:123").conditions
+        assert len(conditions) == 1
+        assert ["user.id", "=", "123"] in conditions[0]
+        assert ["user.username", "=", "123"] in conditions[0]
+        assert ["user.email", "=", "123"] in conditions[0]
+        assert ["user.ip", "=", "123"] in conditions[0]
+
     def test_function_with_default_arguments(self):
         result = get_filter("rpm():>100", {"start": before_now(minutes=5), "end": before_now()})
         assert result.having == [["rpm", ">", 100]]

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -296,6 +296,65 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             == "Invalid query. Project morty does not exist or is not an actively selected project."
         )
 
+    def test_user_search(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        data = load_data("transaction")
+        data["timestamp"] = iso_format(before_now(minutes=1))
+        data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
+        data["user"] = {
+            "email": "foo@example.com",
+            "id": "123",
+            "ip_address": "127.0.0.1",
+            "username": "foo",
+        }
+        self.store_event(data, project_id=project.id)
+
+        with self.feature(
+            {"organizations:discover-basic": True, "organizations:global-views": True}
+        ):
+            for value in data["user"].values():
+                response = self.client.get(
+                    self.url,
+                    format="json",
+                    data={
+                        "field": ["project", "user"],
+                        "query": "user:{}".format(value),
+                        "statsPeriod": "14d",
+                    },
+                )
+
+                assert response.status_code == 200, response.content
+                assert len(response.data["data"]) == 1
+                assert response.data["data"][0]["user.email"] == data["user"]["email"]
+                assert response.data["data"][0]["user.id"] == data["user"]["id"]
+                assert response.data["data"][0]["user.ip"] == data["user"]["ip_address"]
+                assert response.data["data"][0]["user.username"] == data["user"]["username"]
+
+    def test_has_user(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        data = load_data("transaction")
+        data["timestamp"] = iso_format(before_now(minutes=1))
+        data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
+        self.store_event(data, project_id=project.id)
+
+        with self.feature(
+            {"organizations:discover-basic": True, "organizations:global-views": True}
+        ):
+            for value in data["user"].values():
+                response = self.client.get(
+                    self.url,
+                    format="json",
+                    data={"field": ["project", "user"], "query": "has:user", "statsPeriod": "14d"},
+                )
+
+                assert response.status_code == 200, response.content
+                assert len(response.data["data"]) == 1
+                assert response.data["data"][0]["user.ip"] == data["user"]["ip_address"]
+
     def test_not_project_in_query(self):
         self.login_as(user=self.user)
         project1 = self.create_project()


### PR DESCRIPTION
- This makes `user:` queries become an OR condition across all the user
  aliases.
- Adds `key` param to `convert_search_filter_to_snuba_query` so its  easier to reuse the function
  - can't just do `[field, term.operator, term.value] for field in ..` cause of negations, has etc.