### PR TITLE
feat(workflow): Rename actions in UI

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -24,6 +24,9 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         for rule_type, rule_cls in rules:
             node = rule_cls(project)
             context = {"id": node.id, "label": node.label, "enabled": node.is_enabled()}
+            if hasattr(node, "prompt"):
+                context["prompt"] = node.prompt
+
             if (
                 node.id == "sentry.mail.actions.NotifyEmailAction"
                 and not has_issue_alerts_targeting

--- a/src/sentry/integrations/pagerduty/notify_action.py
+++ b/src/sentry/integrations/pagerduty/notify_action.py
@@ -65,6 +65,7 @@ class PagerDutyNotifyServiceForm(forms.Form):
 class PagerDutyNotifyServiceAction(EventAction):
     form_cls = PagerDutyNotifyServiceForm
     label = "Send a notification to PagerDuty account {account} and service {service}"
+    prompt = "Send a PagerDuty notification"
 
     def __init__(self, *args, **kwargs):
         super(PagerDutyNotifyServiceAction, self).__init__(*args, **kwargs)

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -72,6 +72,7 @@ class SlackNotifyServiceForm(forms.Form):
 class SlackNotifyServiceAction(EventAction):
     form_cls = SlackNotifyServiceForm
     label = u"Send a notification to the {workspace} Slack workspace to {channel} and show tags {tags} in notification"
+    prompt = "Send a Slack notification"
 
     def __init__(self, *args, **kwargs):
         super(SlackNotifyServiceAction, self).__init__(*args, **kwargs)

--- a/src/sentry/rules/actions/notify_event.py
+++ b/src/sentry/rules/actions/notify_event.py
@@ -12,6 +12,7 @@ from sentry.utils.safe import safe_execute
 
 class NotifyEventAction(EventAction):
     label = "Send a notification (for all legacy integrations)"
+    prompt = "Send a notification to all legacy integrations"
 
     def get_plugins(self):
         from sentry.plugins.bases.notify import NotificationPlugin

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -29,6 +29,7 @@ class NotifyEventServiceForm(forms.Form):
 class NotifyEventServiceAction(EventAction):
     form_cls = NotifyEventServiceForm
     label = "Send a notification via {service}"
+    prompt = "Send a notification to one legacy integration"
 
     def __init__(self, *args, **kwargs):
         super(NotifyEventServiceAction, self).__init__(*args, **kwargs)

--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -23,6 +23,7 @@ export type IssueAlertRuleFormField =
 export type IssueAlertRuleActionTemplate = {
   id: string;
   label: string;
+  prompt: string;
   enabled: boolean;
   formFields?: {
     [key: string]: IssueAlertRuleFormField;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -58,12 +58,13 @@ class RuleNodeList extends React.Component<Props> {
       project,
     } = this.props;
 
+    const shouldUsePrompt = project.features?.includes?.('issue-alerts-targeting');
     const options = nodes
       ? nodes
           .filter(({enabled}) => enabled)
           .map(node => ({
             value: node.id,
-            label: node.label,
+            label: shouldUsePrompt && node.prompt?.length > 0 ? node.prompt : node.label,
           }))
       : [];
 

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -34,6 +34,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         node = rule.return_value
         node.id = "sentry.mail.actions.NotifyEmailAction"
         node.label = "hello"
+        node.prompt = "hello"
         node.is_enabled.return_value = True
         node.form_fields = {}
         rules.add(rule)


### PR DESCRIPTION
Add frontend rendering of a better description of actions.

Also introduces additional strings.

### Strings introduced in other PRs:
- Send an email (Added in #17966)

### Strings introduced in this PRs:
- Send a Slack notification
- Send a PagerDuty notification
- Send a notification to all legacy integrations
- Send a notification to one legacy integration

![image](https://user-images.githubusercontent.com/23180853/76588699-e05fa480-64a4-11ea-820b-0adbab29c83a.png)

### New actions label (from specs):
- Send an email 
- Send a Slack notification
- Send a PagerDuty notification
- Send a notification to all legacy integrations
- Send a notification to one legacy integration

Changes the labels for actions as per https://www.notion.so/sentry/Issue-Alert-Targeting-30805fa4d233467ab2edb3eb98fce25e