### PR TITLE
feat(workflow): Move Alerts to lightweight org

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1342,7 +1342,31 @@ function routes() {
           />
           {hook('routes:admin')}
         </Route>
+
+        <Route
+          path="/organizations/:orgId/alerts/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "AlertsContainer" */ 'app/views/alerts')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(/* webpackChunkName: "AlertsList" */ 'app/views/alerts/list')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+
+          <Route
+            path=":alertId/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "AlertsDetails" */ 'app/views/alerts/details')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
       </Route>
+
       {/* The heavyweight organization detail views */}
       <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
         <Route component={errorHandler(OrganizationRoot)}>
@@ -1575,28 +1599,6 @@ function routes() {
                 component={errorHandler(LazyLoad)}
               />
             </Route>
-          </Route>
-          <Route
-            path="/organizations/:orgId/alerts/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "AlertsContainer" */ 'app/views/alerts')
-            }
-            component={errorHandler(LazyLoad)}
-          >
-            <IndexRoute
-              componentPromise={() =>
-                import(/* webpackChunkName: "AlertsList" */ 'app/views/alerts/list')
-              }
-              component={errorHandler(LazyLoad)}
-            />
-
-            <Route
-              path=":alertId/"
-              componentPromise={() =>
-                import(/* webpackChunkName: "AlertsDetails" */ 'app/views/alerts/details')
-              }
-              component={errorHandler(LazyLoad)}
-            />
           </Route>
           <Route
             path="/organizations/:orgId/projects/:projectId/getting-started/"


### PR DESCRIPTION
This moves Alerts to the lightweight org so we do not have to serialize all projects when loading an org.