### PR TITLE
ref(workflow): Use `<ButtonBar>`

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -12,6 +12,7 @@ import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
 import BetaTag from 'app/components/betaTag';
 import Button from 'app/components/button';
+import ButtonBar from 'app/components/buttonBar';
 import Count from 'app/components/count';
 import Duration from 'app/components/duration';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
@@ -183,7 +184,7 @@ class IncidentsListContainer extends React.Component<Props> {
                 {t('Settings')}
               </Button>
 
-              <div className="btn-group">
+              <ButtonBar merged>
                 <Button
                   to={{pathname, query: openIncidentsQuery}}
                   size="small"
@@ -205,7 +206,7 @@ class IncidentsListContainer extends React.Component<Props> {
                 >
                   {t('All')}
                 </Button>
-              </div>
+              </ButtonBar>
             </Actions>
           </PageHeader>
 

--- a/tests/js/spec/views/incidents/list/index.spec.jsx
+++ b/tests/js/spec/views/incidents/list/index.spec.jsx
@@ -64,7 +64,7 @@ describe('IncidentsList', function() {
 
     expect(
       wrapper
-        .find('.btn-group')
+        .find('ButtonBar')
         .find('a')
         .at(0)
         .hasClass('active')
@@ -81,7 +81,7 @@ describe('IncidentsList', function() {
 
     expect(
       wrapper
-        .find('.btn-group')
+        .find('ButtonBar')
         .find('Button')
         .at(2)
         .hasClass('active')


### PR DESCRIPTION
Use `<ButtonBar>` instead of `btn-group`. This makes active state more subtle, but we want to get away from bootstrap styles.

![image](https://user-images.githubusercontent.com/79684/76647139-6e757280-6519-11ea-8fbe-bd0deed938e4.png)
