### PR TITLE
fix(lint): fixed fixable lint errors

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/projects.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/projects.jsx
@@ -91,7 +91,7 @@ export const _debouncedLoadStats = debounce((api, projectSet, params) => {
         results.reduce((acc, result) => acc.concat(result), [])
       );
     })
-    .catch(err => {
+    .catch(() => {
       addErrorMessage(t('Unable to fetch all project stats'));
     });
 

--- a/src/sentry/static/sentry/app/actionCreators/teams.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/teams.jsx
@@ -101,7 +101,7 @@ export function leaveTeam(api, params, options) {
   });
 }
 
-export function createTeam(api, team, params, options) {
+export function createTeam(api, team, params) {
   TeamActions.createTeam(team);
 
   return api
@@ -133,7 +133,7 @@ export function createTeam(api, team, params, options) {
     );
 }
 
-export function removeTeam(api, params, options) {
+export function removeTeam(api, params) {
   TeamActions.removeTeam(params.teamId);
 
   return api

--- a/src/sentry/static/sentry/app/components/charts/barChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/barChart.jsx
@@ -15,7 +15,7 @@ export default class BarChart extends React.Component {
       <BaseChart
         {...props}
         xAxis={xAxis !== null ? {...(xAxis || {}), boundaryGap: true} : null}
-        series={series.map((s, i) =>
+        series={series.map(s =>
           BarSeries({
             name: s.seriesName,
             stack: stacked ? 'stack1' : null,

--- a/src/sentry/static/sentry/app/components/charts/pieChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/pieChart.jsx
@@ -161,7 +161,7 @@ class PieChart extends React.Component {
             avoidLabelOverlap: false,
             label: {
               normal: {
-                formatter: ({name, percent, dataIndex}) => `${name}\n${percent}%`,
+                formatter: ({name, percent}) => `${name}\n${percent}%`,
                 show: false,
                 position: 'center',
               },

--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
@@ -100,7 +100,7 @@ export default class WorldMapChart extends React.Component {
         xAxis={null}
         series={processedSeries}
         tooltip={{
-          formatter: ({marker, name, value, seriesName}) => {
+          formatter: ({marker, name, value}) => {
             // If value is NaN, don't show anything because we won't have a country code either
             if (isNaN(value)) {
               return '';

--- a/src/sentry/static/sentry/app/components/events/contexts/contextBlock.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/contextBlock.jsx
@@ -39,7 +39,7 @@ class ContextBlock extends React.Component {
     }
 
     if (extraData.length > 0) {
-      data = data.concat(sortBy(extraData, (key, value) => key));
+      data = data.concat(sortBy(extraData, key => key));
     }
 
     return (

--- a/src/sentry/static/sentry/app/components/events/errorItem.jsx
+++ b/src/sentry/static/sentry/app/components/events/errorItem.jsx
@@ -25,7 +25,7 @@ class EventErrorItem extends React.Component {
     };
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate(_nextProps, nextState) {
     return this.state.isOpen !== nextState.isOpen;
   }
 
@@ -54,7 +54,7 @@ class EventErrorItem extends React.Component {
       data.image_path = path.length ? path.join(separator) + separator : '';
     }
 
-    return mapKeys(data, (value, key) => t(keyMapping[key] || startCase(key)));
+    return mapKeys(data, (_value, key) => t(keyMapping[key] || startCase(key)));
   }
 
   renderPath() {

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -96,7 +96,7 @@ class EventSdkUpdateSuggestion extends React.Component {
         {title}
         {t(' so you can')}
         <AlertUl>
-          {suggestion.enables.map((suggestion2, i) => (
+          {suggestion.enables.map(suggestion2 => (
             <li key={getSuggestionComponentKey(suggestion2)}>
               <EventSdkUpdateSuggestion event={event} suggestion={suggestion2} />
             </li>

--- a/src/sentry/static/sentry/app/components/forms/input.jsx
+++ b/src/sentry/static/sentry/app/components/forms/input.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
+import omit from 'lodash/omit';
 
-export default function Input({className, children, ...otherProps}) {
-  return <input className={classNames('form-control', className)} {...otherProps} />;
+export default function Input({className, ...otherProps}) {
+  return (
+    <input
+      className={classNames('form-control', className)}
+      {...omit(otherProps, 'children')}
+    />
+  );
 }

--- a/src/sentry/static/sentry/app/components/forms/numberField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/numberField.jsx
@@ -9,7 +9,7 @@ export default class NumberField extends InputField {
     max: PropTypes.number,
   };
 
-  coerceValue(value, prevValue) {
+  coerceValue(value) {
     const intValue = parseInt(value, 10);
 
     // return previous value if new value is NaN, otherwise, will get recursive error

--- a/src/sentry/static/sentry/app/components/group/pluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/pluginActions.jsx
@@ -46,11 +46,11 @@ class PluginActions extends React.Component {
     // doesn't think the plugin still has an issue linked
     const endpoint = `/issues/${this.props.group.id}/plugins/${plugin.slug}/unlink/`;
     this.props.api.request(endpoint, {
-      success: data => {
+      success: () => {
         this.loadPlugin(plugin);
         addSuccessMessage(t('Successfully unlinked issue.'));
       },
-      error: error => {
+      error: () => {
         addErrorMessage(t('Unable to unlink issue'));
       },
     });

--- a/src/sentry/static/sentry/app/components/lazyLoad.jsx
+++ b/src/sentry/static/sentry/app/components/lazyLoad.jsx
@@ -39,7 +39,7 @@ class LazyLoad extends React.Component {
     this.fetchComponent();
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps, nextState) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // No need to refetch when component does not change
     if (nextProps.component && nextProps.component === this.props.component) {
       return;
@@ -67,7 +67,7 @@ class LazyLoad extends React.Component {
     );
   }
 
-  componentDidCatch(error, info) {
+  componentDidCatch(error) {
     Sentry.captureException(error);
     this.handleError(error);
   }

--- a/src/sentry/static/sentry/app/components/modals/createOwnershipRuleModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/createOwnershipRuleModal.jsx
@@ -15,7 +15,7 @@ class CreateOwnershipRuleModal extends React.Component {
     project: SentryTypes.Project,
   };
 
-  handleSubmit = data => {
+  handleSubmit = () => {
     this.handleSuccess();
   };
 

--- a/src/sentry/static/sentry/app/components/resultGrid.jsx
+++ b/src/sentry/static/sentry/app/components/resultGrid.jsx
@@ -164,7 +164,7 @@ const ResultGrid = createReactClass({
       keyForRow: function(row) {
         return row.id;
       },
-      columnsForRow: function(row) {
+      columnsForRow: function() {
         return [];
       },
       defaultParams: {

--- a/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
 import {css} from '@emotion/core';
 import React from 'react';
+import omit from 'lodash/omit';
 
-const SearchResultWrapper = styled(({highlighted, ...props}) => <div {...props} />)`
+const SearchResultWrapper = styled(props => <div {...omit(props, 'highlighted')} />)`
   cursor: pointer;
   display: block;
   color: ${p => p.theme.gray5};

--- a/src/sentry/static/sentry/app/components/search/sources/apiSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/apiSource.jsx
@@ -351,7 +351,7 @@ class ApiSource extends React.Component {
 
   // Create result objects from API requests that do not require fuzzy search
   // i.e. these responses only return 1 object or they should always be displayed regardless of query input
-  async getDirectResults(requests, query) {
+  async getDirectResults(requests) {
     const [shortIdLookup, eventIdLookup] = requests;
 
     const directResults = (

--- a/src/sentry/static/sentry/app/components/search/sources/commandSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/commandSource.jsx
@@ -98,7 +98,7 @@ class CommandSource extends React.Component {
       (this.state.fuzzy &&
         this.state.fuzzy
           .search(query)
-          .filter(({item, ...rest}) => !item.requiresSuperuser || isSuperuser)
+          .filter(({item}) => !item.requiresSuperuser || isSuperuser)
           .map(({item, ...rest}) => ({
             item: {
               ...item,

--- a/src/sentry/static/sentry/app/components/search/sources/routeSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/routeSource.jsx
@@ -18,7 +18,7 @@ import withLatestContext from 'app/utils/withLatestContext';
 // We need to go through all navigation configurations and get a flattened list of all navigation item objects
 const mapFunc = (config, context = {}) =>
   (Array.isArray(config) ? config : config(context)).map(({items}) =>
-    items.filter(({show, ...rest}) => (typeof show === 'function' ? show(context) : true))
+    items.filter(({show}) => (typeof show === 'function' ? show(context) : true))
   );
 
 class RouteSource extends React.Component {

--- a/src/sentry/static/sentry/app/components/setupWizard.jsx
+++ b/src/sentry/static/sentry/app/components/setupWizard.jsx
@@ -32,13 +32,13 @@ class SetupWizard extends React.Component {
   }
 
   pollFinished() {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this.api.request(`/wizard/${this.props.hash}/`, {
         method: 'GET',
-        success: data => {
+        success: () => {
           setTimeout(() => this.pollFinished(), 1000);
         },
-        error: err => {
+        error: () => {
           resolve();
           this.setState({
             finished: true,

--- a/src/sentry/static/sentry/app/components/splitDiff.jsx
+++ b/src/sentry/static/sentry/app/components/splitDiff.jsx
@@ -34,7 +34,7 @@ class SplitDiff extends React.Component {
       baseLines.length > targetLines.length
         ? [baseLines, targetLines]
         : [targetLines, baseLines];
-    const results = largerArray.map((line, index) =>
+    const results = largerArray.map((_line, index) =>
       diffFn(baseLines[index] || '', targetLines[index] || '', {newlineIsToken: true})
     );
 

--- a/src/sentry/static/sentry/app/components/stream/processingIssueList.jsx
+++ b/src/sentry/static/sentry/app/components/stream/processingIssueList.jsx
@@ -31,7 +31,7 @@ class ProcessingIssueList extends React.Component {
     this.fetchIssues();
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     if (!isEqual(prevProps.projectIds, this.props.projectIds)) {
       this.fetchIssues();
     }
@@ -55,7 +55,7 @@ class ProcessingIssueList extends React.Component {
           this.setState({issues: data});
         }
       },
-      error => {
+      () => {
         // this is okay. it's just a ui hint
       }
     );

--- a/src/sentry/static/sentry/app/components/u2f/u2finterface.jsx
+++ b/src/sentry/static/sentry/app/components/u2f/u2finterface.jsx
@@ -82,7 +82,7 @@ class U2fInterface extends React.Component {
                   response: u2fResponse,
                   challenge,
                 })
-                .catch(err => {
+                .catch(() => {
                   // This is kind of gross but I want to limit the amount of changes to this component
                   this.setState({
                     deviceFailure: 'UNKNOWN_ERROR',

--- a/src/sentry/static/sentry/app/plugins/registry.jsx
+++ b/src/sentry/static/sentry/app/plugins/registry.jsx
@@ -49,7 +49,7 @@ export default class Registry {
       return;
     }
 
-    const onAssetLoaded = function(asset) {
+    const onAssetLoaded = function() {
       remainingAssets--;
       if (remainingAssets === 0) {
         finishLoad();

--- a/src/sentry/static/sentry/app/stores/pluginsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/pluginsStore.jsx
@@ -86,11 +86,11 @@ const PluginsStore = Reflux.createStore({
     this.triggerState();
   },
 
-  onUpdateSuccess(id, updateObj) {
+  onUpdateSuccess(id, _updateObj) {
     this.updating.delete(id);
   },
 
-  onUpdateError(id, updateObj, err) {
+  onUpdateError(id, _updateObj, err) {
     const origPlugin = this.updating.get(id);
     if (!origPlugin) {
       return;

--- a/src/sentry/static/sentry/app/stores/projectsStatsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/projectsStatsStore.jsx
@@ -65,7 +65,7 @@ const ProjectsStatsStore = Reflux.createStore({
    * @param {Object} err Error object
    * @param {Object} data Previous project data
    */
-  onUpdateError(err, projectSlug) {
+  onUpdateError(_err, projectSlug) {
     const project = this.updatingItems.get(projectSlug);
     if (!project) {
       return;

--- a/src/sentry/static/sentry/app/views/admin/adminOverview/apiChart.jsx
+++ b/src/sentry/static/sentry/app/views/admin/adminOverview/apiChart.jsx
@@ -60,7 +60,7 @@ const ApiChart = createReactClass({
             };
           }, this.requestFinished);
         },
-        error: data => {
+        error: () => {
           this.setState({
             error: true,
           });

--- a/src/sentry/static/sentry/app/views/admin/adminOverview/eventChart.jsx
+++ b/src/sentry/static/sentry/app/views/admin/adminOverview/eventChart.jsx
@@ -61,7 +61,7 @@ const EventChart = createReactClass({
             };
           }, this.requestFinished);
         },
-        error: data => {
+        error: () => {
           this.setState({
             error: true,
           });

--- a/src/sentry/static/sentry/app/views/issueList/tagFilter.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/tagFilter.jsx
@@ -8,17 +8,17 @@ import {t, tct} from 'app/locale';
 import SelectControl from 'app/components/forms/selectControl';
 
 class IssueListTagFilter extends React.Component {
+  static tagValueToSelectFormat = ({value}) => ({
+    value,
+    label: value,
+  });
+
   static propTypes = {
     tag: PropTypes.object.isRequired,
     value: PropTypes.string,
     onSelect: PropTypes.func,
     tagValueLoader: PropTypes.func.isRequired,
   };
-
-  static tagValueToSelectFormat = ({value}) => ({
-    value,
-    label: value,
-  });
 
   static defaultProps = {
     tag: {},
@@ -73,7 +73,7 @@ class IssueListTagFilter extends React.Component {
           options: Object.values(resp).map(IssueListTagFilter.tagValueToSelectFormat),
         });
       })
-      .catch(err => {
+      .catch(() => {
         // TODO(billy): This endpoint seems to timeout a lot,
         // should we log these errors into datadog?
 
@@ -156,7 +156,7 @@ class IssueListTagFilter extends React.Component {
           <SelectControl
             deprecatedSelectControl
             clearable
-            filterOptions={(options, filter, currentValues) => options}
+            filterOptions={options => options}
             placeholder="--"
             value={this.state.value}
             onChange={this.handleChangeSelect}

--- a/src/sentry/static/sentry/app/views/organizationStats/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/index.jsx
@@ -84,7 +84,7 @@ class OrganizationStatsContainer extends React.Component {
   fetchProjectData() {
     this.props.api.request(this.getOrganizationProjectsEndpoint(), {
       query: this.props.location.query,
-      success: (data, textStatus, jqxhr) => {
+      success: (data, _textStatus, jqxhr) => {
         const projectMap = {};
         data.forEach(project => {
           projectMap[project.id] = project;

--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -31,7 +31,7 @@ class OrganizationStats extends React.Component {
     organization: PropTypes.object,
   };
 
-  renderTooltip(point, pointIdx, chart) {
+  renderTooltip(point, _pointIdx, chart) {
     const timeLabel = chart.getTimeLabel(point);
     const [accepted, rejected, blacklisted] = point.y;
 

--- a/src/sentry/static/sentry/app/views/settings/account/accountDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountDetails.jsx
@@ -21,7 +21,7 @@ class AccountDetails extends AsyncView {
     this.setState({user});
   };
 
-  handleSubmitError = (resp, model, id) => {};
+  handleSubmitError = () => {};
 
   renderBody() {
     const {user} = this.state;

--- a/src/sentry/static/sentry/app/views/settings/account/passwordForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/passwordForm.jsx
@@ -12,13 +12,13 @@ import accountPasswordFields from 'app/data/forms/accountPassword';
 const ENDPOINT = '/users/me/password/';
 
 class PasswordForm extends React.Component {
-  handleSubmitSuccess = (change, model, id) => {
+  handleSubmitSuccess = (_change, model) => {
     // Reset form on success
     model.resetForm();
     addSuccessMessage('Password has been changed');
   };
 
-  handleSubmitError = (resp, model, id) => {
+  handleSubmitError = () => {
     addErrorMessage('Error changing password');
   };
 
@@ -37,7 +37,7 @@ class PasswordForm extends React.Component {
           location={this.props.location}
           forms={accountPasswordFields}
           additionalFieldProps={{user}}
-          renderFooter={({title, fields}) => (
+          renderFooter={() => (
             <PanelItem justifyContent="flex-end">
               <Button type="submit" priority="primary">
                 {t('Change password')}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/inputField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/inputField.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import omit from 'lodash/omit';
 
 import FormField from 'app/views/settings/components/forms/formField';
 import Input from 'app/views/settings/components/forms/controls/input';
@@ -26,11 +27,7 @@ export default class InputField extends React.Component {
 
     return (
       <FormField className={className} {...this.props}>
-        {({children, ...formFieldProps}) =>
-          field({
-            ...formFieldProps,
-          })
-        }
+        {formFieldProps => field(omit(formFieldProps, 'children'))}
       </FormField>
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/radioBooleanField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/radioBooleanField.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import omit from 'lodash/omit';
 
 import InputField from './inputField';
 import RadioBoolean from './controls/radioBoolean';
@@ -8,7 +9,9 @@ export default class RadioBooleanField extends React.Component {
     return (
       <InputField
         {...this.props}
-        field={({children, onKeyDown, ...fieldProps}) => <RadioBoolean {...fieldProps} />}
+        field={fieldProps => (
+          <RadioBoolean {...omit(fieldProps, ['onKeyDown', 'children'])} />
+        )}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/textareaField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/textareaField.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import omit from 'lodash/omit';
 
 import InputField from 'app/views/settings/components/forms/inputField';
 import Textarea from 'app/views/settings/components/forms/controls/textarea';
@@ -8,7 +9,9 @@ export default class TextareaField extends React.Component {
     return (
       <InputField
         {...this.props}
-        field={({children, onKeyDown, ...fieldProps}) => <Textarea {...fieldProps} />}
+        field={fieldProps => (
+          <Textarea {...omit(fieldProps, ['onKeyDown', 'children'])} />
+        )}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/organizationApiKeys/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationApiKeys/index.jsx
@@ -24,12 +24,12 @@ class OrganizationApiKeys extends AsyncView {
     return `${org.name} API Keys`;
   }
 
-  handleRemove = (id, e) => {
+  handleRemove = id => {
     const api = new Client();
     api.request(`/organizations/${this.props.params.orgId}/api-keys/${id}/`, {
       method: 'DELETE',
       data: {},
-      success: data => {
+      success: () => {
         this.setState(state => ({
           keys: state.keys.filter(({id: existingId}) => existingId !== id),
         }));

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/allTeamsList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/allTeamsList.jsx
@@ -37,7 +37,7 @@ class AllTeamsList extends React.Component {
 
   render() {
     const {access, organization, urlPrefix, openMembership, useCreateModal} = this.props;
-    const teamNodes = this.props.teamList.map((team, teamIdx) => (
+    const teamNodes = this.props.teamList.map(team => (
       <AllTeamsRow
         urlPrefix={urlPrefix}
         access={access}

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -49,13 +49,13 @@ class ProjectTeams extends AsyncView {
   };
 
   handleRemovedTeam = teamSlug => {
-    this.setState(prevState => ({
+    this.setState(() => ({
       projectTeams: this.state.projectTeams.filter(team => team.slug !== teamSlug),
     }));
   };
 
   handleAddedTeam = team => {
-    this.setState(prevState => ({
+    this.setState(() => ({
       projectTeams: this.state.projectTeams.concat([team]),
     }));
   };

--- a/tests/js/sentry-test/fixtures/asana.js
+++ b/tests/js/sentry-test/fixtures/asana.js
@@ -1,4 +1,4 @@
-function AsanaPlugin(params) {
+function AsanaPlugin() {
   return {
     status: 'unknown',
     description: 'Integrate Asana issues by linking a repository to a project.',
@@ -26,7 +26,7 @@ function AsanaPlugin(params) {
   };
 }
 
-function AsanaCreate(params) {
+function AsanaCreate() {
   return [
     {
       name: 'workspace',

--- a/tests/js/sentry-test/fixtures/dashboard.js
+++ b/tests/js/sentry-test/fixtures/dashboard.js
@@ -2,7 +2,7 @@ import {Widget} from './widget';
 
 const DEFAULT_WIDGETS = [Widget()];
 
-export function Dashboard(widgets = DEFAULT_WIDGETS, options) {
+export function Dashboard(widgets = DEFAULT_WIDGETS) {
   return {
     widgets,
     title: 'Dashboard',

--- a/tests/js/sentry-test/fixtures/events.js
+++ b/tests/js/sentry-test/fixtures/events.js
@@ -13,7 +13,7 @@ export function Events(params = []) {
   ];
 }
 
-export function EventsStats(query = {}, params) {
+export function EventsStats(_query = {}, params) {
   return {
     data: [
       [new Date(), [{count: 321}, {count: 79}]],

--- a/tests/js/sentry-test/fixtures/groupingConfigs.js
+++ b/tests/js/sentry-test/fixtures/groupingConfigs.js
@@ -1,4 +1,4 @@
-export function GroupingConfigs(params) {
+export function GroupingConfigs() {
   return [
     {
       id: 'default:XXXX',

--- a/tests/js/sentry-test/fixtures/groupingEnhancements.js
+++ b/tests/js/sentry-test/fixtures/groupingEnhancements.js
@@ -1,4 +1,4 @@
-export function GroupingEnhancements(params) {
+export function GroupingEnhancements() {
   return [
     {
       id: 'default:XXXX',

--- a/tests/js/sentry-test/fixtures/integrationListDirectory.js
+++ b/tests/js/sentry-test/fixtures/integrationListDirectory.js
@@ -1,4 +1,4 @@
-export function ProviderList(params = {}) {
+export function ProviderList() {
   return {
     providers: [
       {
@@ -33,7 +33,7 @@ export function ProviderList(params = {}) {
   };
 }
 
-export function IntegrationConfig(params = {}) {
+export function IntegrationConfig() {
   return [
     {
       accountType: null,
@@ -58,7 +58,7 @@ export function IntegrationConfig(params = {}) {
   ];
 }
 
-export function OrgOwnedApps(params = {}) {
+export function OrgOwnedApps() {
   return [
     {
       allowedOrigins: [],
@@ -122,7 +122,7 @@ export function OrgOwnedApps(params = {}) {
   ];
 }
 
-export function PublishedApps(params = {}) {
+export function PublishedApps() {
   return [
     {
       allowedOrigins: [],
@@ -146,7 +146,7 @@ export function PublishedApps(params = {}) {
   ];
 }
 
-export function SentryAppInstalls(params = {}) {
+export function SentryAppInstalls() {
   return [
     {
       app: {
@@ -161,7 +161,7 @@ export function SentryAppInstalls(params = {}) {
   ];
 }
 
-export function PluginListConfig(params = {}) {
+export function PluginListConfig() {
   return [
     {
       assets: [],

--- a/tests/js/sentry-test/fixtures/phabricator.js
+++ b/tests/js/sentry-test/fixtures/phabricator.js
@@ -1,4 +1,4 @@
-function PhabricatorPlugin(params) {
+function PhabricatorPlugin() {
   return {
     status: 'unknown',
     description:
@@ -35,7 +35,7 @@ function PhabricatorPlugin(params) {
   };
 }
 
-function PhabricatorCreate(params) {
+function PhabricatorCreate() {
   return [
     {
       default: 'ApiException: Authentication failed, token expired!',

--- a/tests/js/sentry-test/fixtures/updateSdkAndEnableIntegrationSuggestion.jsx
+++ b/tests/js/sentry-test/fixtures/updateSdkAndEnableIntegrationSuggestion.jsx
@@ -1,4 +1,4 @@
-export function UpdateSdkAndEnableIntegrationSuggestion(params) {
+export function UpdateSdkAndEnableIntegrationSuggestion() {
   return {
     id: '123',
     sdk: {

--- a/tests/js/sentry-test/fixtures/vsts-old.js
+++ b/tests/js/sentry-test/fixtures/vsts-old.js
@@ -1,4 +1,4 @@
-function VstsPlugin(params) {
+function VstsPlugin() {
   return {
     status: 'unknown',
     description: 'Integrate Visual Studio Team Services work items by linking a project.',
@@ -26,7 +26,7 @@ function VstsPlugin(params) {
   };
 }
 
-function VstsCreate(params) {
+function VstsCreate() {
   return [
     {
       name: 'project',

--- a/tests/js/setupFramework.js
+++ b/tests/js/setupFramework.js
@@ -1,5 +1,5 @@
 /* global process */
-process.on('unhandledRejection', (reason, promise) => {
+process.on('unhandledRejection', reason => {
   // eslint-disable-next-line no-console
   console.error(reason);
 });

--- a/tests/js/spec/components/dropdownMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownMenu.spec.jsx
@@ -178,7 +178,7 @@ describe('DropdownMenu', function() {
 
     wrapper = mount(
       <DropdownMenu alwaysRenderMenu>
-        {({getRootProps, getActorProps, getMenuProps, isOpen}) => (
+        {({getRootProps, getActorProps, getMenuProps}) => (
           <span
             {...getRootProps({
               className: 'root',

--- a/tests/js/spec/components/hook.spec.jsx
+++ b/tests/js/spec/components/hook.spec.jsx
@@ -58,7 +58,7 @@ describe('Hook', function() {
 
     expect(wrapper.find('Wrapper')).toHaveLength(1);
 
-    HookStore.add('footer', ({organization} = {}) => (
+    HookStore.add('footer', () => (
       <Wrapper key="new" organization={null}>
         New Hook
       </Wrapper>
@@ -86,7 +86,7 @@ describe('Hook', function() {
       routerContext
     );
 
-    HookStore.add('footer', ({organization} = {}) => (
+    HookStore.add('footer', () => (
       <Wrapper key="new" organization={null}>
         New Hook
       </Wrapper>

--- a/tests/js/spec/components/modals/integrationDetailsModal.spec.jsx
+++ b/tests/js/spec/components/modals/integrationDetailsModal.spec.jsx
@@ -50,7 +50,7 @@ describe('IntegrationDetailsModal', function() {
 
   it('disables the button via a hookstore IntegrationFeatures component', function() {
     HookStore.add('integrations:feature-gates', () => ({
-      FeatureList: p => null,
+      FeatureList: () => null,
       IntegrationFeatures: p =>
         p.children({
           disabled: true,

--- a/tests/js/spec/utils/retryableImport.spec.jsx
+++ b/tests/js/spec/utils/retryableImport.spec.jsx
@@ -26,7 +26,7 @@ describe('retryableImport', function() {
     const importMock = jest.fn();
 
     importMock.mockReturnValueOnce(
-      new Promise((resolve, reject) => reject(new Error('Another error happened')))
+      new Promise((_resolve, reject) => reject(new Error('Another error happened')))
     );
 
     try {
@@ -42,10 +42,10 @@ describe('retryableImport', function() {
 
     importMock
       .mockReturnValueOnce(
-        new Promise((resolve, reject) => reject(new Error('Loading chunk 123 failed')))
+        new Promise((_resolve, reject) => reject(new Error('Loading chunk 123 failed')))
       )
       .mockReturnValueOnce(
-        new Promise((resolve, reject) => reject(new Error('Loading chunk 123 failed')))
+        new Promise((_resolve, reject) => reject(new Error('Loading chunk 123 failed')))
       )
       .mockReturnValue(
         new Promise(resolve =>
@@ -68,7 +68,7 @@ describe('retryableImport', function() {
   it('only retries 3 times', async function() {
     const importMock = jest.fn(
       () =>
-        new Promise((resolve, reject) => reject(new Error('Loading chunk 123 failed')))
+        new Promise((_resolve, reject) => reject(new Error('Loading chunk 123 failed')))
     );
 
     await expect(retryableImport(() => importMock())).rejects.toThrow(

--- a/tests/js/spec/views/onboarding/platform.spec.jsx
+++ b/tests/js/spec/views/onboarding/platform.spec.jsx
@@ -65,7 +65,7 @@ describe('OnboardingWelcome', function() {
 
     let resolveProjectCreate;
     createProject.mockReturnValue(
-      new Promise((resolve, reject) => (resolveProjectCreate = resolve))
+      new Promise(resolve => (resolveProjectCreate = resolve))
     );
 
     // Create the project

--- a/tests/js/spec/views/projectFilters.spec.jsx
+++ b/tests/js/spec/views/projectFilters.spec.jsx
@@ -79,7 +79,7 @@ describe('ProjectFilters', function() {
   });
 
   it('can toggle filters: localhost, web crawlers', function() {
-    ['localhost', 'web-crawlers'].map((filter, i) => {
+    ['localhost', 'web-crawlers'].map(filter => {
       const mock = createFilterMock(filter);
       const Switch = wrapper.find(`BooleanField[name="${filter}"] Switch`);
 


### PR DESCRIPTION
**Type:** Fix

**Description:**

I noticed that, running `yarn lint --fix`, 151 errors were being displayed, 93 of which could be fixed without problem. This PR fixes these ~~93~~ 89 errors.

I also believe that, for now, we could define `reflexbox` as a warning instead of an error, because it makes difficult to check for errors that could easily be fixed...


because the reflexbox import throws an eslint error, I had to revert the files rangeField, sharedIssue, accountIdentities and organizationApiKeysList for the eslint tests to pass.