### PR TITLE
fix(quotas): Use camelCasing in quota API schema

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -124,7 +124,7 @@ class QuotaConfig(object):
         data = {
             "id": six.text_type(self.id) if self.id is not None else None,
             "scope": self.scope.api_name(),
-            "scope_id": self.scope_id,
+            "scopeId": self.scope_id,
             "categories": categories,
             "limit": self.limit,
             "window": self.window,

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -140,7 +140,7 @@ def test_quotas_to_json_legacy(obj, json):
                 window=1,
                 reason_code="go_away",
             ),
-            {"id": "p", "scope": "project", "scope_id": "1", "window": 1, "reasonCode": "go_away"},
+            {"id": "p", "scope": "project", "scopeId": "1", "window": 1, "reasonCode": "go_away"},
         ),
         (
             QuotaConfig(limit=0, reason_code="go_away"),


### PR DESCRIPTION
The initial API schema contained a typo, since we only use _camelCase_ names.