### PR TITLE
chore(ts): Convert SplitLayout

### DIFF
--- a/src/sentry/static/sentry/app/components/splitLayout.tsx
+++ b/src/sentry/static/sentry/app/components/splitLayout.tsx
@@ -1,42 +1,46 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
 import SpreadLayout from 'app/components/spreadLayout';
 
+type Props<T extends HTMLElement> = React.ComponentProps<typeof SpreadLayout> & {
+  children: Omit<React.ReactHTMLElement<T>, 'ref'>[];
+  /**
+   * Distance in number of pixels to separate the children
+   */
+  splitWidth: number;
+};
+
 // Flexbox, use when you want your children to be equal sizes
-const SplitLayout = ({children, className, responsive, splitWidth, ...props}) => {
-  const cx = classNames('split-layout', className, {
-    'allow-responsive': responsive,
-  });
+const SplitLayout = <T extends HTMLElement>({
+  children,
+  className,
+  responsive,
+  splitWidth,
+  ...props
+}: Props<T>) => {
+  const cx = classNames('split-layout', className, {'allow-responsive': responsive});
+
   let childCount = 0;
   const totalChildren = React.Children.count(children);
 
   return (
     <SpreadLayout {...props} className={cx}>
       {React.Children.map(children, child => {
-        const childProps = (child && child.props) || {};
         childCount++;
+        const childProps = child?.props ?? {};
         const isLastChild = childCount === totalChildren;
 
         return React.cloneElement(child, {
           style: {
             marginRight: isLastChild ? undefined : splitWidth,
-            ...((child.props && child.props.style) || {}),
+            ...(child?.props?.style ?? {}),
           },
           className: classNames(childProps.className, 'split-layout-child'),
         });
       })}
     </SpreadLayout>
   );
-};
-
-SplitLayout.propTypes = {
-  children: PropTypes.node,
-  /** Distance in # of pixels to separate children */
-  splitWidth: PropTypes.number,
-  /** Changes flex-direction to be column on smaller widths */
-  responsive: PropTypes.bool,
 };
 
 export default SplitLayout;


### PR DESCRIPTION
I won't lie I'm not 100% positive this is completely right in the generic sense. I don't know why I needed to omit the `ref` prop for the children, since my test was just two `div`s inside of this component, it was complaining they didn't have the ref prop (which they do :/)