### PR TITLE
fix(ingest): Do not crash when chunks are missing in attachments

### DIFF
--- a/src/sentry/attachments/__init__.py
+++ b/src/sentry/attachments/__init__.py
@@ -6,7 +6,7 @@ from django.conf import settings
 
 from sentry.utils.imports import import_string
 
-from .base import CachedAttachment, MissingChunks  # noqa
+from .base import CachedAttachment, MissingAttachmentChunks  # noqa
 
 
 attachment_cache = import_string(settings.SENTRY_ATTACHMENTS)(**settings.SENTRY_ATTACHMENTS_OPTIONS)

--- a/src/sentry/attachments/__init__.py
+++ b/src/sentry/attachments/__init__.py
@@ -6,7 +6,7 @@ from django.conf import settings
 
 from sentry.utils.imports import import_string
 
-from .base import CachedAttachment
+from .base import CachedAttachment, MissingChunks  # noqa
 
 
 attachment_cache = import_string(settings.SENTRY_ATTACHMENTS)(**settings.SENTRY_ATTACHMENTS_OPTIONS)

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import logging
 from six import string_types
 import zlib
 
@@ -13,8 +12,6 @@ ATTACHMENT_UNCHUNKED_DATA_KEY = u"{key}:a:{id}"
 ATTACHMENT_DATA_CHUNK_KEY = u"{key}:a:{id}:{chunk_index}"
 
 UNINITIALIZED_DATA = object()
-
-logger = logging.getLogger(__name__)
 
 
 class MissingChunks(Exception):

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -14,7 +14,7 @@ ATTACHMENT_DATA_CHUNK_KEY = u"{key}:a:{id}:{chunk_index}"
 UNINITIALIZED_DATA = object()
 
 
-class MissingChunks(Exception):
+class MissingAttachmentChunks(Exception):
     pass
 
 
@@ -148,7 +148,7 @@ class BaseAttachmentCache(object):
         for key in attachment.chunk_keys:
             raw_data = self.inner.get(key, raw=True)
             if raw_data is None:
-                raise MissingChunks()
+                raise MissingAttachmentChunks()
             data.append(zlib.decompress(raw_data))
 
         return b"".join(data)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -604,13 +604,14 @@ class EventManager(object):
         attachments = []
         for attachment in get_attachments(cache_key, job["event"]):
             try:
-                key = "bytes.stored.%s" % (attachment.type,)
-                job["event_metrics"][key] = (job["event_metrics"].get(key) or 0) + len(
-                    attachment.data
-                )
+                attachment_data = attachment.data
             except MissingAttachmentChunks:
                 logger.exception("Missing chunks for cache_key=%s", cache_key)
             else:
+                key = "bytes.stored.%s" % (attachment.type,)
+                job["event_metrics"][key] = (job["event_metrics"].get(key) or 0) + len(
+                    attachment_data
+                )
                 attachments.append(attachment)
 
         _nodestore_save_many(jobs)

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -21,7 +21,7 @@ from sentry.utils.dates import to_datetime
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.kafka import create_batching_kafka_consumer
 from sentry.utils.batching_kafka_consumer import AbstractBatchWorker
-from sentry.attachments import CachedAttachment, MissingChunks, attachment_cache
+from sentry.attachments import CachedAttachment, MissingAttachmentChunks, attachment_cache
 from sentry.ingest.userreport import Conflict, save_userreport
 from sentry.event_manager import save_transaction_events
 
@@ -247,7 +247,7 @@ def process_individual_attachment(message, projects):
 
     try:
         data = attachment.data
-    except MissingChunks:
+    except MissingAttachmentChunks:
         logger.exception("Missing chunks for cache_key=%s", cache_key)
         return
 


### PR DESCRIPTION
Generally speaking we want to stop the consumers when processing a message fails, so we can fix the issue and continue processing from the same offset (for as long as we don't have a dead letter queue at least).

In this case however there's nothing we can fix post-mortem because we are somewhat sure we just lost the data.

Fix SENTRY-FK9