### PR TITLE
change(workflow): Change email verbiage

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -12,6 +12,7 @@ from sentry.incidents.models import (
     QueryAggregations,
     TriggerStatus,
     IncidentStatus,
+    INCIDENT_STATUS,
 )
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
@@ -20,12 +21,6 @@ from sentry.utils.http import absolute_uri
 @six.add_metaclass(abc.ABCMeta)
 class ActionHandler(object):
     status_display = {TriggerStatus.ACTIVE: "Fired", TriggerStatus.RESOLVED: "Resolved"}
-    incident_status = {
-        IncidentStatus.OPEN: "Open",
-        IncidentStatus.CLOSED: "Resolved",
-        IncidentStatus.CRITICAL: "Critical",
-        IncidentStatus.WARNING: "Warning",
-    }
 
     def __init__(self, action, incident, project):
         self.action = action
@@ -147,7 +142,7 @@ class EmailActionHandler(ActionHandler):
             # if alert threshold and threshold type is above then show '>'
             # if resolve threshold and threshold type is *BELOW* then show '>'
             "threshold_direction_string": ">" if show_greater_than_string else "<",
-            "status": self.incident_status[IncidentStatus(self.incident.status)],
+            "status": INCIDENT_STATUS[IncidentStatus(self.incident.status)],
             "is_critical": self.incident.status == IncidentStatus.CRITICAL,
             "is_warning": self.incident.status == IncidentStatus.WARNING,
             "unsubscribe_link": None,

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -140,6 +140,14 @@ class IncidentStatus(Enum):
     CRITICAL = 20
 
 
+INCIDENT_STATUS = {
+    IncidentStatus.OPEN: "Open",
+    IncidentStatus.CLOSED: "Resolved",
+    IncidentStatus.CRITICAL: "Critical",
+    IncidentStatus.WARNING: "Warning",
+}
+
+
 class Incident(Model):
     __core__ = True
 

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -16,6 +16,7 @@ from sentry.incidents.models import (
     IncidentActivity,
     IncidentActivityType,
     IncidentStatus,
+    INCIDENT_STATUS,
 )
 from sentry.models import Project
 from sentry.snuba.query_subscription_consumer import register_subscriber
@@ -61,7 +62,7 @@ def send_subscriber_notifications(activity_id):
 def generate_incident_activity_email(activity, user):
     incident = activity.incident
     return MessageBuilder(
-        subject=u"Activity on Incident {} (#{})".format(incident.title, incident.identifier),
+        subject=u"Activity on Alert {} (#{})".format(incident.title, incident.identifier),
         template=u"sentry/emails/incidents/activity.txt",
         html_template=u"sentry/emails/incidents/activity.html",
         type="incident.activity",
@@ -74,12 +75,12 @@ def build_activity_context(activity, user):
         action = "left a comment"
     else:
         action = "changed status from %s to %s" % (
-            IncidentStatus(int(activity.previous_value)).name.lower(),
-            IncidentStatus(int(activity.value)).name.lower(),
+            INCIDENT_STATUS[IncidentStatus(int(activity.previous_value))],
+            INCIDENT_STATUS[IncidentStatus(int(activity.value))],
         )
     incident = activity.incident
 
-    action = "%s on incident %s (#%s)" % (action, incident.title, incident.identifier)
+    action = "%s on alert %s (#%s)" % (action, incident.title, incident.identifier)
 
     return {
         "user_name": activity.user.name if activity.user else "Sentry",

--- a/src/sentry/templates/sentry/emails/incidents/activity.txt
+++ b/src/sentry/templates/sentry/emails/incidents/activity.txt
@@ -1,6 +1,6 @@
 {% spaceless %}
 {% autoescape off %}
-# New Incident Activity
+# New Alert Activity
 
 {{ user_name }} {{ action }}:
 {% if enhanced_privacy %}
@@ -8,7 +8,7 @@ Details about this activity are not shown in this email since enhanced privacy
 controls are enabled. For more details about this activity, view on Sentry:
 {{ link }}.
 {% else %}
-Incident: {{ link }}
+Alert: {{ link }}
 {% if comment %}
 Comment Details:
 {{ comment }}

--- a/src/sentry/templates/sentry/emails/incidents/trigger.txt
+++ b/src/sentry/templates/sentry/emails/incidents/trigger.txt
@@ -7,7 +7,7 @@ Details about this alert are not shown in this email since enhanced privacy
 controls are enabled. For more details about this alert alert, view on Sentry:
 {{ incident_link }}.
 {% else %}
-Incident: {{ link }}
+Alert: {{ link }}
 Rule: {{ rule_link }}
 Status: {{ status }}
 

--- a/src/sentry/web/frontend/debug/debug_incident_activity_email.py
+++ b/src/sentry/web/frontend/debug/debug_incident_activity_email.py
@@ -20,6 +20,9 @@ class DebugIncidentActivityEmailView(View):
         activity = IncidentActivity(
             incident=incident, user=user, type=IncidentActivityType.COMMENT.value, comment="hi"
         )
+        # activity = IncidentActivity(
+        #     incident=incident, user=user, type=IncidentActivityType.STATUS_CHANGE.value, value=2, previous_value=10
+        # )
         email = generate_incident_activity_email(activity, user)
         return MailPreview(
             html_template=email.html_template, text_template=email.template, context=email.context

--- a/src/sentry/web/frontend/debug/debug_incident_activity_email.py
+++ b/src/sentry/web/frontend/debug/debug_incident_activity_email.py
@@ -20,9 +20,6 @@ class DebugIncidentActivityEmailView(View):
         activity = IncidentActivity(
             incident=incident, user=user, type=IncidentActivityType.COMMENT.value, comment="hi"
         )
-        # activity = IncidentActivity(
-        #     incident=incident, user=user, type=IncidentActivityType.STATUS_CHANGE.value, value=2, previous_value=10
-        # )
         email = generate_incident_activity_email(activity, user)
         return MailPreview(
             html_template=email.html_template, text_template=email.template, context=email.context

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -18,6 +18,7 @@ from sentry.incidents.models import (
     IncidentStatus,
     QueryAggregations,
     TriggerStatus,
+    INCIDENT_STATUS,
 )
 from sentry.integrations.slack.utils import build_incident_attachment
 from sentry.models import Integration, UserOption
@@ -109,7 +110,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             ],
             "query": action.alert_rule_trigger.alert_rule.query,
             "threshold": action.alert_rule_trigger.alert_threshold,
-            "status": handler.incident_status[IncidentStatus(incident.status)],
+            "status": INCIDENT_STATUS[IncidentStatus(incident.status)],
             "environment": "All",
             "is_critical": False,
             "is_warning": False,

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -17,6 +17,7 @@ from sentry.incidents.models import (
     AlertRuleTriggerAction,
     IncidentActivityType,
     IncidentStatus,
+    INCIDENT_STATUS,
     IncidentSubscription,
 )
 from sentry.incidents.tasks import (
@@ -133,7 +134,7 @@ class TestBuildActivityContext(BaseIncidentActivityTest, TestCase):
             activity,
             expected_username=activity.user.name,
             expected_action="changed status from %s to %s"
-            % (IncidentStatus.WARNING.name.lower(), IncidentStatus.CLOSED.name.lower()),
+            % (INCIDENT_STATUS[IncidentStatus.WARNING], INCIDENT_STATUS[IncidentStatus.CLOSED]),
             expected_comment=activity.comment,
             expected_recipient=recipient,
         )

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -93,7 +93,7 @@ class TestBuildActivityContext(BaseIncidentActivityTest, TestCase):
         incident = activity.incident
         context = build_activity_context(activity, expected_recipient)
         assert context["user_name"] == expected_username
-        assert context["action"] == "%s on incident %s (#%s)" % (
+        assert context["action"] == "%s on alert %s (#%s)" % (
             expected_action,
             activity.incident.title,
             activity.incident.identifier,

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -79,7 +79,7 @@ class TestGenerateIncidentActivityEmail(BaseIncidentActivityTest, TestCase):
         incident = activity.incident
         recipient = self.create_user()
         message = generate_incident_activity_email(activity, recipient)
-        assert message.subject == "Activity on Incident {} (#{})".format(
+        assert message.subject == "Activity on Alert {} (#{})".format(
             incident.title, incident.identifier
         )
         assert message.type == "incident.activity"


### PR DESCRIPTION
We now use the word "alert" instead of "incident" and "resolved" instead of "closed".