### PR TITLE
fix(discover) Update series labels to match function

### DIFF
--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import isEqual from 'lodash/isEqual';
 import styled from '@emotion/styled';
 
+import {t} from 'app/locale';
 import {getInterval} from 'app/components/charts/utils';
 import ChartZoom from 'app/components/charts/chartZoom';
 import AreaChart from 'app/components/charts/areaChart';
@@ -26,6 +27,8 @@ class EventsAreaChart extends React.Component {
     timeseriesData: PropTypes.array,
     showLegend: PropTypes.bool,
     previousTimeseriesData: PropTypes.object,
+    currentSeriesName: PropTypes.string,
+    previousSeriesName: PropTypes.string,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -53,12 +56,14 @@ class EventsAreaChart extends React.Component {
       timeseriesData,
       previousTimeseriesData,
       showLegend,
+      currentSeriesName,
+      previousSeriesName,
       ...props
     } = this.props;
 
     const legend = showLegend && {
       right: 16,
-      top: 16,
+      top: 12,
       selectedMode: false,
       icon: 'circle',
       itemHeight: 8,
@@ -70,7 +75,7 @@ class EventsAreaChart extends React.Component {
         fontSize: 11,
         fontFamily: 'Rubik',
       },
-      data: ['Current', 'Previous'],
+      data: [currentSeriesName ?? t('Current'), previousSeriesName ?? t('Previous'), ''],
     };
 
     return (
@@ -213,6 +218,7 @@ class EventsChart extends React.Component {
     } = this.props;
     // Include previous only on relative dates (defaults to relative if no start and end)
     const includePrevious = !start && !end;
+    const previousSeriesName = yAxis ? t('previous %s', yAxis) : undefined;
 
     return (
       <ChartZoom
@@ -236,6 +242,8 @@ class EventsChart extends React.Component {
             showLoading={false}
             query={query}
             includePrevious={includePrevious}
+            currentSeriesName={yAxis}
+            previousSeriesName={previousSeriesName}
             yAxis={yAxis}
           >
             {({loading, reloading, errored, timeseriesData, previousTimeseriesData}) => (
@@ -262,6 +270,8 @@ class EventsChart extends React.Component {
                           releaseSeries={releaseSeries}
                           timeseriesData={timeseriesData}
                           previousTimeseriesData={previousTimeseriesData}
+                          currentSeriesName={yAxis}
+                          previousSeriesName={previousSeriesName}
                         />
                       </React.Fragment>
                     </TransitionChart>

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -58,6 +58,7 @@ type EventsRequestPartialProps = {
   showLoading?: boolean;
   yAxis?: string | string[];
   currentSeriesName?: string;
+  previousSeriesName?: string;
   children: (renderProps: RenderProps) => React.ReactNode;
 };
 
@@ -299,7 +300,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     }
 
     return {
-      seriesName: 'Previous',
+      seriesName: this.props.previousSeriesName ?? 'Previous',
       data: this.calculateTotalsPerTimestamp(
         previous,
         (_timestamp, _countArray, i) => current[i][0] * 1000


### PR DESCRIPTION
Show the function name in the series legend and tooltips instead of 'current' and 'previous'. Showing the function name makes it more obvious what value is being plotted.

![Screen Shot 2020-03-16 at 5 02 39 PM](https://user-images.githubusercontent.com/24086/76800067-3c7a3f80-67a9-11ea-9062-d335502e8efc.png)
