### PR TITLE
fix(eventstore): Ensure get_unfetched_events never hits nodestore

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -107,6 +107,7 @@ class SnubaEventStorage(EventStorage):
             and filter.project_ids
             and len(filter.event_ids) * len(filter.project_ids) < min(limit, NODESTORE_LIMIT)
             and offset == 0
+            and should_bind_nodes
         ):
             event_list = [
                 Event(project_id=project_id, event_id=event_id)


### PR DESCRIPTION
This came up in the ingest consumer where we want to avoid ever fetching
data from nodestore. https://github.com/getsentry/sentry/blob/accb2706b32004350160a28ebe163e0669f6eb44/src/sentry/ingest/ingest_consumer.py#L228-L234