### PR TITLE
fix(visibility) - Fixing tracing context when description is long

### DIFF
--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -74,7 +74,7 @@ def trim(
     elif isinstance(value, dict):
         result = {}
         _size += 2
-        for k in sorted(value.keys(), key=lambda x: (len(value[x]), x)):
+        for k in sorted(value.keys(), key=lambda x: (len(force_text(value[x])), x)):
             v = value[k]
             trim_v = trim(v, _size=_size, **options)
             result[k] = trim_v

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -74,7 +74,7 @@ def trim(
     elif isinstance(value, dict):
         result = {}
         _size += 2
-        for k in sorted(value.keys()):
+        for k in sorted(value.keys(), key=lambda x: (len(value[x]), x)):
             v = value[k]
             trim_v = trim(v, _size=_size, **options)
             result[k] = trim_v

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -527,3 +527,5 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         assert trace["trace_id"] == original_trace["trace_id"]
         assert trace["span_id"] == original_trace["span_id"]
         assert trace["parent_span_id"] == original_trace["parent_span_id"]
+        assert trace["description"].endswith("...")
+        assert trace["description"][:-3] in original_trace["description"]


### PR DESCRIPTION
- When a description is too long, during the ContextType init in
  sentry.interfaces.contexts we trim the data.
  - Based on this issue: https://github.com/getsentry/sentry/issues/5303
    we trim "because otherwise payloads are have no realistic max size."
- So to fix this the orders in which we trim from a dictionary is being
  changed so that we try to keep more keys
  - This is done by sorting by the length of the dictionary value
  - To match existing functionality as much as possible the dictionary
    key is used to sort on a value length tie.