### PR TITLE
feat(ui): adds project icons to project select

### DIFF
--- a/src/sentry/static/sentry/app/components/contextPickerModal.tsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.tsx
@@ -1,5 +1,5 @@
 import {ModalBody, ModalHeader} from 'react-bootstrap';
-import ReactSelect from 'react-select';
+import ReactSelect, {components} from 'react-select';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Reflux from 'reflux';
@@ -16,6 +16,7 @@ import SelectControl from 'app/components/forms/selectControl';
 import replaceRouterParams from 'app/utils/replaceRouterParams';
 import space from 'app/styles/space';
 import Link from 'app/components/links/link';
+import IdBadge from 'app/components/idBadge';
 
 type Props = {
   /**
@@ -215,6 +216,24 @@ class ContextPickerModal extends React.Component<Props> {
     });
   };
 
+  //TODO(TS): Fix typings
+  customOptionProject = ({label, ...props}: any) => {
+    const project = this.props.projects.find(({slug}) => props.value === slug);
+    if (!project) {
+      return null;
+    }
+    return (
+      <components.Option label={label} {...props}>
+        <IdBadge
+          project={project}
+          avatarSize={20}
+          displayName={label}
+          avatarProps={{consistentWidth: true}}
+        />
+      </components.Option>
+    );
+  };
+
   get headerText() {
     const {needOrg, needProject} = this.props;
     if (needOrg && needProject) {
@@ -253,6 +272,7 @@ class ContextPickerModal extends React.Component<Props> {
         options={projects.map(({slug}) => ({label: slug, value: slug}))}
         onChange={this.handleSelectProject}
         onMenuOpen={this.onProjectMenuOpen}
+        components={{Option: this.customOptionProject}}
       />
     );
   }


### PR DESCRIPTION
This PR adds the project icons to the project select modal. Here is what it looks like:

<img width="650" alt="Screen Shot 2020-03-16 at 4 07 57 PM" src="https://user-images.githubusercontent.com/8533851/76808592-76e1dd80-67a5-11ea-8b7c-bc6b9c33feab.png">

Note I had some trouble with typing the props of `components.Option`. I tried importing `OptionProps` but even though VScode could find the import, pre-commit hooks running tests could not. 