### PR TITLE
fix(ui): Add guidestore fixes

### DIFF
--- a/src/sentry/static/sentry/app/components/assistant/types.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/types.tsx
@@ -14,7 +14,7 @@ export type Guide = {
   guide: string;
   requiredTargets: string[];
   steps: GuideStep[];
-  seen?: boolean;
+  seen: boolean;
 };
 
 export type GuidesContent = {

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -103,12 +103,11 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
     // map server guide state (i.e. seen status) with guide content
     const guides = guidesContent.reduce((acc: Guide[], content) => {
       const serverGuide = data.find(guide => guide.guide === content.guide);
-      if (serverGuide) {
+      serverGuide &&
         acc.push({
           ...content,
           ...serverGuide,
         });
-      }
       return acc;
     }, []);
 
@@ -153,7 +152,7 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
       eventKey: 'assistant.guide_cued',
       eventName: 'Assistant Guide Cued',
       organization_id: this.state.orgId,
-      user_id: user.id,
+      user_id: parseInt(user.id, 10),
     };
     trackAnalyticsEvent(data);
 

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -101,10 +101,16 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
     const guidesContent: GuidesContent = getGuidesContent(user);
 
     // map server guide state (i.e. seen status) with guide content
-    const guides = guidesContent.map(guideContent => ({
-      ...guideContent,
-      ...data.find(serverGuide => serverGuide.guide === guideContent.guide),
-    }));
+    const guides = guidesContent.reduce((acc: Guide[], content) => {
+      const serverGuide = data.find(guide => guide.guide === content.guide);
+      if (serverGuide) {
+        acc.push({
+          ...content,
+          ...serverGuide,
+        });
+      }
+      return acc;
+    }, []);
 
     this.state.guides = guides;
     this.updateCurrentGuide();
@@ -186,24 +192,31 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
       .sort((a, b) => a.guide.localeCompare(b.guide))
       .filter(guide => guide.requiredTargets.every(target => anchors.has(target)));
 
-    if (!forceShow) {
-      const user = ConfigStore.get('user');
-      const assistantThreshold = new Date(2019, 6, 1);
-      const discoverDate = new Date(2020, 1, 6);
-      const userDateJoined = new Date(user?.dateJoined);
+    const user = ConfigStore.get('user');
+    const assistantThreshold = new Date(2019, 6, 1);
+    const discoverDate = new Date(2020, 1, 6);
+    const userDateJoined = new Date(user?.dateJoined);
 
-      guideOptions = guideOptions.filter(({guide, seen}) => {
-        if (seen !== false) {
-          return false;
-        }
-        if (user?.isSuperuser) {
-          return true;
-        }
-        if (guide === 'discover_sidebar' && userDateJoined >= discoverDate) {
-          return false;
-        }
-        return userDateJoined > assistantThreshold;
-      });
+    if (!forceShow) {
+      guideOptions = guideOptions.filter(({guide, seen}) =>
+        seen
+          ? false
+          : user?.isSuperuser
+          ? true
+          : guide === 'discover_sidebar' && userDateJoined >= discoverDate
+          ? false
+          : userDateJoined > assistantThreshold
+      );
+    }
+
+    // do not force show the "events moved" guide
+    // since it's not relevant for new users
+    if (forceShow) {
+      guideOptions = guideOptions.filter(({guide, seen}) =>
+        guide === 'discover_sidebar' && (seen || userDateJoined >= discoverDate)
+          ? false
+          : true
+      );
     }
 
     const nextGuide =

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -76,7 +76,7 @@ describe('GuideStore', function() {
       eventKey: 'assistant.guide_cued',
       eventName: 'Assistant Guide Cued',
       organization_id: null,
-      user_id: user.id,
+      user_id: parseInt(user.id, 10),
     });
 
     expect(spy).toHaveBeenCalledTimes(1);

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -96,6 +96,23 @@ describe('GuideStore', function() {
     });
   });
 
+  it('only shows guides with server data and content', function() {
+    data = [
+      {
+        guide: 'issue',
+        seen: true,
+      },
+      {
+        guide: 'has_no_content',
+        seen: false,
+      },
+    ];
+
+    GuideStore.onFetchSucceeded(data);
+    expect(GuideStore.state.guides.length).toBe(1);
+    expect(GuideStore.state.guides[0].guide).toBe(data[0].guide);
+  });
+
   describe('discover sidebar guide', function() {
     beforeEach(function() {
       data = [
@@ -156,6 +173,21 @@ describe('GuideStore', function() {
         },
       };
       GuideStore.onFetchSucceeded(data);
+      expect(GuideStore.state.currentGuide).toBe(null);
+    });
+
+    it('does not force show the discover sidebar guide once seen', function() {
+      data[0].seen = true;
+      // previous user
+      ConfigStore.config = {
+        user: {
+          isSuperuser: false,
+          dateJoined: new Date(2020, 0, 1),
+        },
+      };
+      GuideStore.onFetchSucceeded(data);
+      window.location.hash = '#assistant';
+      GuideStore.onURLChange();
       expect(GuideStore.state.currentGuide).toBe(null);
     });
   });


### PR DESCRIPTION
Only render guide content if the guide exists on the backend. Also, no longer force show the discover guide by adding `#assistant` to the end of the URL, since the guide isn't relevant to users that joined after the release date.