### PR TITLE
feat(ui): Add Artifacts tab to releasesV2

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseArtifacts.jsx
@@ -1,7 +1,7 @@
-import {Flex} from 'reflexbox'; // eslint-disable-line no-restricted-imports
 import PropTypes from 'prop-types';
 import React from 'react';
 import omit from 'lodash/omit';
+import styled from '@emotion/styled';
 
 import {Panel, PanelHeader, PanelBody, PanelItem} from 'app/components/panels';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
@@ -21,6 +21,7 @@ import SentryTypes from 'app/sentryTypes';
 import Tooltip from 'app/components/tooltip';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
+import space from 'app/styles/space';
 
 class ReleaseArtifacts extends React.Component {
   static propTypes = {
@@ -123,28 +124,22 @@ class ReleaseArtifacts extends React.Component {
       <div>
         <Panel>
           <PanelHeader>
-            <Flex flex="7" pr={2}>
-              {t('Name')}
-            </Flex>
-            <Flex flex="2">{t('Distribution')}</Flex>
-            <Flex flex="3">{t('Size')}</Flex>
+            <NameColumn>{t('Name')}</NameColumn>
+            <DistributionColumn>{t('Distribution')}</DistributionColumn>
+            <SizeAndActionsColumn>{t('Size')}</SizeAndActionsColumn>
           </PanelHeader>
           <PanelBody>
             {this.state.fileList.map(file => (
               <PanelItem key={file.id}>
-                <Flex
-                  flex="7"
-                  pr={2}
-                  style={{wordWrap: 'break-word', wordBreak: 'break-all'}}
-                >
+                <NameColumn>
                   <strong>{file.name || '(empty)'}</strong>
-                </Flex>
-                <Flex flex="2">
+                </NameColumn>
+                <DistributionColumn>
                   {file.dist || <span className="text-light">{t('None')}</span>}
-                </Flex>
-                <Flex flex="3" justifyContent="space-between">
+                </DistributionColumn>
+                <SizeAndActionsColumn>
                   <FileSize bytes={file.size} />
-                  <Flex alignItems="center">
+                  <AlignCenter>
                     {access.has('project:write') ? (
                       <a
                         href={
@@ -177,8 +172,8 @@ class ReleaseArtifacts extends React.Component {
                         <span className="icon icon-trash" />
                       </LinkWithConfirmation>
                     </div>
-                  </Flex>
-                </Flex>
+                  </AlignCenter>
+                </SizeAndActionsColumn>
               </PanelItem>
             ))}
           </PanelBody>
@@ -188,6 +183,28 @@ class ReleaseArtifacts extends React.Component {
     );
   }
 }
+
+const NameColumn = styled('div')`
+  display: flex;
+  flex: 7;
+  padding-right: ${space(2)};
+  word-wrap: break-word;
+  word-break: break-all;
+`;
+const DistributionColumn = styled('div')`
+  display: flex;
+  flex: 2;
+  padding-right: ${space(2)};
+`;
+const SizeAndActionsColumn = styled('div')`
+  display: flex;
+  flex: 3;
+  justify-content: space-between;
+`;
+const AlignCenter = styled('div')`
+  display: flex;
+  align-items: center;
+`;
 
 export {ReleaseArtifacts};
 export default withOrganization(withApi(ReleaseArtifacts));

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseArtifacts.jsx
@@ -1,4 +1,4 @@
-import {Flex} from 'reflexbox';
+import {Flex} from 'reflexbox'; // eslint-disable-line no-restricted-imports
 import PropTypes from 'prop-types';
 import React from 'react';
 import omit from 'lodash/omit';
@@ -26,6 +26,7 @@ class ReleaseArtifacts extends React.Component {
   static propTypes = {
     organization: SentryTypes.Organization,
     api: PropTypes.object,
+    projectId: PropTypes.string,
   };
 
   constructor() {
@@ -43,11 +44,13 @@ class ReleaseArtifacts extends React.Component {
   }
 
   getFilesEndpoint() {
-    const {orgId, projectId, version} = this.props.params;
-    const encodedVersion = encodeURIComponent(version);
+    // ?? to temporarily support releases V1 and V2
+    const {orgId, projectId, version, release} = this.props.params;
+    const encodedVersion = encodeURIComponent(version ?? release);
+    const project = projectId ?? this.props.projectId;
 
-    return projectId
-      ? `/projects/${orgId}/${projectId}/releases/${encodedVersion}/files/`
+    return project
+      ? `/projects/${orgId}/${project}/releases/${encodedVersion}/files/`
       : `/organizations/${orgId}/releases/${encodedVersion}/files/`;
   }
 

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
@@ -1,8 +1,55 @@
 import React from 'react';
+import styled from '@emotion/styled';
+import {Params} from 'react-router/lib/Router';
+import {Location} from 'history';
 
-type Props = {};
+import {t} from 'app/locale';
+import {GlobalSelection} from 'app/types';
+import Alert from 'app/components/alert';
+import space from 'app/styles/space';
+import ReleaseArtifactsV1 from 'app/views/releases/detail/releaseArtifacts';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
 
-// TODO(releasesV2): finish this component
-const ReleaseArtifacts = ({}: Props) => <div>ReleaseArtifacts</div>;
+import {ReleaseContext} from '..';
 
-export default ReleaseArtifacts;
+type Props = {
+  params: Params;
+  location: Location;
+  selection: GlobalSelection;
+};
+
+const ReleaseArtifacts = ({params, location, selection}: Props) => (
+  <ReleaseContext.Consumer>
+    {release => {
+      const project = release?.projects.find(p => p.id === selection.projects[0]);
+      // TODO(releasesV2): we will handle this later with forced project selector
+      if (!project) {
+        return null;
+      }
+
+      return (
+        <ContentBox>
+          <Alert type="warning">
+            {t(
+              'We are working on improving this experience, therefore Artifacts will be moving to Settings soon.'
+            )}
+          </Alert>
+
+          <ReleaseArtifactsV1
+            params={params}
+            location={location}
+            projectId={project.slug}
+          />
+        </ContentBox>
+      );
+    }}
+  </ReleaseContext.Consumer>
+);
+
+const ContentBox = styled('div')`
+  padding: ${space(4)};
+  flex: 1;
+  background-color: ${p => p.theme.white};
+`;
+
+export default withGlobalSelection(ReleaseArtifacts);


### PR DESCRIPTION
Basically reusing Artifacts v1 for the time being, because they will be moving to settings soon anyway (accompanied by bigger refactor).

Added new prop to Artifacts v1, so I can scope artifacts to specific project.