### PR TITLE
feat(dif): Add sourcebundle to electron server

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1634,7 +1634,7 @@ SENTRY_BUILTIN_SOURCES = {
         "name": "Electron",
         "layout": {"type": "native"},
         "url": "https://electron-symbols.githubapp.com/",
-        "filters": {"filetypes": ["pdb", "breakpad"]},
+        "filters": {"filetypes": ["pdb", "breakpad", "sourcebundle"]},
         "is_public": True,
     },
 }


### PR DESCRIPTION
This requires a change in symbolicator because `sourcebundle` was incorrectly named `source_bundle`.