### PR TITLE
feat(sessions): Issue a reject-all quota without feature flag

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -90,6 +90,7 @@ default_manager.add("organizations:sso-saml2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:grouping-info", OrganizationFeature)  # NOQA
 default_manager.add("organizations:tweak-grouping-config", OrganizationFeature)  # NOQA
 default_manager.add("organizations:set-grouping-config", OrganizationFeature)  # NOQA
+default_manager.add("organizations:set-grouping-config", OrganizationFeature)  # NOQA
 
 # Project scoped features
 default_manager.add("projects:custom-inbound-filters", ProjectFeature)  # NOQA

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -6,8 +6,7 @@ from django.conf import settings
 from django.core.cache import cache
 from enum import IntEnum, unique
 
-from sentry import features, options
-from sentry.constants import DataCategory
+from sentry import options
 from sentry.utils.json import prune_empty_keys
 from sentry.utils.services import Service
 
@@ -228,15 +227,7 @@ class Quota(Service):
                         only project and organization quotas are used.
         :param keys:    Similar to ``key``, except for multiple keys.
         """
-        quotas = []
-
-        if not features.has("organizations:releases-v2", project.organization):
-            quota = QuotaConfig(
-                limit=0, categories=[DataCategory.SESSION], reason_code="sessions_unavailable"
-            )
-            quotas.append(quota)
-
-        return quotas
+        return []
 
     def is_rate_limited(self, project, key=None):
         """

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -5,6 +5,7 @@ import six
 
 from time import time
 
+from sentry import features
 from sentry.constants import DataCategory
 from sentry.quotas.base import NotRateLimited, Quota, QuotaConfig, QuotaScope, RateLimited
 from sentry.utils.redis import (
@@ -65,6 +66,16 @@ class RedisQuota(Quota):
             key.project = project
 
         results = []
+
+        if not features.has("organizations:releases-v2", project.organization):
+            results.append(
+                QuotaConfig(
+                    limit=0,
+                    scope=QuotaScope.ORGANIZATION,
+                    categories=[DataCategory.SESSION],
+                    reason_code="sessions_unavailable",
+                )
+            )
 
         pquota = self.get_project_quota(project)
         if pquota[0] is not None:


### PR DESCRIPTION
Emits a reject-all quota for sessions if the organization does not have the feature flag.

cc @nathan-heskia 