### PR TITLE
feat(ui): Add FilesChanged tab to releasesV2

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -829,6 +829,16 @@ export type Commit = {
   releases: BaseRelease[];
 };
 
+export type CommitFile = {
+  id: string;
+  author: CommitAuthor;
+  commitMessage: string;
+  filename: string;
+  orgId: number;
+  repoName: string;
+  type: string;
+};
+
 export type MemberRole = {
   id: string;
   name: string;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
@@ -65,6 +65,12 @@ const ContentBox = styled('div')`
   padding: ${space(4)};
   flex: 1;
   background-color: ${p => p.theme.white};
+
+  h5 {
+    color: ${p => p.theme.gray3};
+    font-size: ${p => p.theme.fontSizeMedium};
+    margin-bottom: ${space(1.5)};
+  }
 `;
 
 export default FilesChanged;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
@@ -1,8 +1,70 @@
 import React from 'react';
+import {Params} from 'react-router/lib/Router';
+import styled from '@emotion/styled';
 
-type Props = {};
+import AsyncComponent from 'app/components/asyncComponent';
+import RepositoryFileSummary from 'app/components/repositoryFileSummary';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {CommitFile, Repository} from 'app/types';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
 
-// TODO(releasesV2): finish this component
-const FilesChanged = ({}: Props) => <div>FilesChanged</div>;
+import {getFilesByRepository} from '../utils';
+import ReleaseNoCommitData from '../releaseNoCommitData';
+
+type Props = {
+  params: Params;
+} & AsyncComponent['props'];
+
+type State = {
+  fileList: CommitFile[];
+  repos: Repository[];
+} & AsyncComponent['state'];
+
+class FilesChanged extends AsyncComponent<Props, State> {
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {orgId, release} = this.props.params;
+
+    return [
+      [
+        'fileList',
+        `/organizations/${orgId}/releases/${encodeURIComponent(release)}/commitfiles/`,
+      ],
+      ['repos', `/organizations/${orgId}/repos/`],
+    ];
+  }
+
+  renderBody() {
+    const {orgId} = this.props.params;
+    const {fileList, repos} = this.state;
+    const filesByRepository = getFilesByRepository(fileList);
+
+    if (repos.length === 0) {
+      return <ReleaseNoCommitData orgId={orgId} />;
+    }
+
+    return (
+      <ContentBox>
+        {fileList.length ? (
+          Object.keys(filesByRepository).map(repository => (
+            <RepositoryFileSummary
+              key={repository}
+              repository={repository}
+              fileChangeSummary={filesByRepository[repository]}
+            />
+          ))
+        ) : (
+          <EmptyStateWarning small>{t('There are no changed files.')}</EmptyStateWarning>
+        )}
+      </ContentBox>
+    );
+  }
+}
+
+const ContentBox = styled('div')`
+  padding: ${space(4)};
+  flex: 1;
+  background-color: ${p => p.theme.white};
+`;
 
 export default FilesChanged;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseNoCommitData.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseNoCommitData.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import Button from 'app/components/button';
+import HeroIcon from 'app/components/heroIcon';
+import Well from 'app/components/well';
+
+type Props = {
+  orgId: string;
+};
+
+const ReleaseNoCommitData = ({orgId}: Props) => (
+  <StyledWell centered>
+    <HeroIcon src="icon-commit" />
+    <h5>{t('Releases are better with commit data!')}</h5>
+    <p>
+      {t(
+        'Connect a repository to see commit info, files changed, and authors involved in future releases.'
+      )}
+    </p>
+    <Button priority="primary" to={`/settings/${orgId}/repos/`}>
+      {t('Connect a repository')}
+    </Button>
+  </StyledWell>
+);
+
+const StyledWell = styled(Well)`
+  margin: ${space(4)};
+
+  padding-top: ${space(2)};
+  padding-bottom: ${space(4)};
+`;
+
+export default ReleaseNoCommitData;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/utils.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/utils.tsx
@@ -1,4 +1,5 @@
 import {Client} from 'app/api';
+import {CommitFile} from 'app/types';
 
 export const deleteRelease = (orgId: string, version: string) => {
   const api = new Client();
@@ -10,3 +11,28 @@ export const deleteRelease = (orgId: string, version: string) => {
     }
   );
 };
+
+/**
+ * Convert list of individual file changes into a per-file summary grouped by repository
+ */
+export function getFilesByRepository(fileList: CommitFile[]) {
+  return fileList.reduce((filesByRepository, file) => {
+    const {filename, repoName, author, type} = file;
+
+    if (!filesByRepository.hasOwnProperty(repoName)) {
+      filesByRepository[repoName] = {};
+    }
+
+    if (!filesByRepository[repoName].hasOwnProperty(filename)) {
+      filesByRepository[repoName][filename] = {
+        authors: {},
+        types: new Set(),
+      };
+    }
+
+    filesByRepository[repoName][filename].authors[author.email] = author;
+    filesByRepository[repoName][filename].types.add(type);
+
+    return filesByRepository;
+  }, {});
+}


### PR DESCRIPTION
This PR adds FilesChanged tab to release v2 detail page.

Reusing `RepositoryFileSummary` component, down the road we will probably clean up the design a bit.

![image](https://user-images.githubusercontent.com/9060071/76888262-eb8b4980-6883-11ea-8881-30ae7f3ccaa8.png)
