### PR TITLE
ref(SentryApps): Update Sentry App Serializer to include features

### DIFF
--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -6,6 +6,9 @@ from sentry.api.serializers import Serializer, register
 from sentry.models import SentryApp
 from sentry.models.sentryapp import MASKED_VALUE
 from sentry.constants import SentryAppStatus
+from sentry.models import IntegrationFeature
+from sentry.api.serializers import serialize
+from sentry.utils.compat import map
 
 
 @register(SentryApp)
@@ -30,10 +33,16 @@ class SentryAppSerializer(Serializer):
             "allowedOrigins": obj.application.get_allowed_origins(),
         }
 
+        data["featureData"] = []
+
+        if obj.status != SentryAppStatus.INTERNAL:
+            features = IntegrationFeature.objects.filter(sentry_app_id=obj.id)
+            data["featureData"] = map(lambda x: serialize(x, user), features)
+
         if obj.status == SentryAppStatus.PUBLISHED and obj.date_published:
             data.update({"datePublished": obj.date_published})
 
-        if is_active_superuser(env.request) or (
+        if (env.request and is_active_superuser(env.request)) or (
             hasattr(user, "get_orgs") and obj.owner in user.get_orgs()
         ):
             client_secret = (

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -54,6 +54,12 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
                     "allowedOrigins": [],
                     "schema": {},
                     "owner": {"id": self.org.id, "slug": self.org.slug},
+                    "featureData": [
+                        {
+                            "featureGate": "integrations-api",
+                            "description": "Testin can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                        }
+                    ],
                 }
             ],
         )

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -122,6 +122,12 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             "allowedOrigins": [],
             "schema": {},
             "owner": {"id": self.org.id, "slug": self.org.slug},
+            "featureData": [
+                {
+                    "description": "Test can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                    "featureGate": "integrations-api",
+                }
+            ],
         }
 
     def test_update_unpublished_app(self):

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -86,6 +86,12 @@ class GetSentryAppsTest(SentryAppsTest):
             "allowedOrigins": [],
             "schema": {},
             "owner": {"id": self.org.id, "slug": self.org.slug},
+            "featureData": [
+                {
+                    "featureGate": "integrations-api",
+                    "description": "Test can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                }
+            ],
         } in json.loads(response.content)
 
     def test_users_filter_on_internal_apps(self):
@@ -112,6 +118,7 @@ class GetSentryAppsTest(SentryAppsTest):
             "clientId": self.internal_app.application.client_id,
             "clientSecret": self.internal_app.application.client_secret,
             "owner": {"id": self.internal_org.id, "slug": self.internal_org.slug},
+            "featureData": [],
         } in json.loads(response.content)
 
         response_uuids = set(o["uuid"] for o in response.data)
@@ -148,6 +155,7 @@ class GetSentryAppsTest(SentryAppsTest):
             "clientId": self.internal_app.application.client_id,
             "clientSecret": self.internal_app.application.client_secret,
             "owner": {"id": self.internal_org.id, "slug": self.internal_org.slug},
+            "featureData": [],
         } in json.loads(response.content)
 
         response_uuids = set(o["uuid"] for o in response.data)
@@ -180,6 +188,12 @@ class GetSentryAppsTest(SentryAppsTest):
             "allowedOrigins": [],
             "schema": {},
             "owner": {"id": self.org.id, "slug": self.org.slug},
+            "featureData": [
+                {
+                    "featureGate": "integrations-api",
+                    "description": "Test can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                }
+            ],
         } in json.loads(response.content)
 
         response_uuids = set(o["uuid"] for o in response.data)
@@ -221,6 +235,12 @@ class GetSentryAppsTest(SentryAppsTest):
             "allowedOrigins": [],
             "schema": {},
             "owner": {"id": self.org.id, "slug": self.org.slug},
+            "featureData": [
+                {
+                    "featureGate": "integrations-api",
+                    "description": "Testin can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                }
+            ],
         } in json.loads(response.content)
 
         response_uuids = set(o["uuid"] for o in response.data)
@@ -266,6 +286,12 @@ class GetSentryAppsTest(SentryAppsTest):
             "allowedOrigins": [],
             "schema": {},
             "owner": {"id": self.org.id, "slug": self.org.slug},
+            "featureData": [
+                {
+                    "featureGate": "integrations-api",
+                    "description": "Boo Far can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                }
+            ],
         } in json.loads(response.content)
 
     def test_users_dont_see_unpublished_apps_their_org_owns(self):

--- a/tests/sentry/api/serializers/test_sentry_app.py
+++ b/tests/sentry/api/serializers/test_sentry_app.py
@@ -6,9 +6,11 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.sentry_app import SentryAppSerializer
 from sentry.testutils import TestCase
 
+# from sentry.constants import SentryAppStatus
+
 
 class SentryAppSerializerTest(TestCase):
-    def test_simple(self):
+    def test_published_app(self):
         user = self.create_user()
         organization = self.create_organization(owner=user)
         sentry_app = self.create_sentry_app(
@@ -26,5 +28,20 @@ class SentryAppSerializerTest(TestCase):
                 "featureGate": "integrations-api",
             }
         ]
-        assert result["author"] == "A Company"
         assert result["scopes"] == ["org:write", "team:admin"]
+        assert result.get("clientSecret") is None
+
+    def test_internal_app(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        self.create_project(organization=org)
+        sentry_app = self.create_internal_integration(
+            name="La Croix App", organization=org, scopes=("org:write", "team:admin")
+        )
+        result = serialize(sentry_app, None, SentryAppSerializer(), access=None)
+
+        assert result["name"] == "La Croix App"
+        assert result["status"] == "internal"
+        assert result["featureData"] == []
+        assert result["scopes"] == ["org:write", "team:admin"]
+        assert result.get("clientSecret") is None

--- a/tests/sentry/api/serializers/test_sentry_app.py
+++ b/tests/sentry/api/serializers/test_sentry_app.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.sentry_app import SentryAppSerializer
+from sentry.testutils import TestCase
+
+
+class SentryAppSerializerTest(TestCase):
+    def test_simple(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+        sentry_app = self.create_sentry_app(
+            name="Tesla App",
+            organization=organization,
+            published=True,
+            scopes=("org:write", "team:admin"),
+        )
+        result = serialize(sentry_app, None, SentryAppSerializer(), access=None)
+
+        assert result["name"] == "Tesla App"
+        assert result["featureData"] == [
+            {
+                "description": "Tesla App can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
+                "featureGate": "integrations-api",
+            }
+        ]
+        assert result["author"] == "A Company"
+        assert result["scopes"] == ["org:write", "team:admin"]


### PR DESCRIPTION
## Objective
Currently, the integration features for a Sentry App are loaded from a separate endpoint. We want to load the integration features of a sentry app anytime we try to serialize it. We will **not** fetch the objects for internal integrations.

Currently with feature gating, you can't install any integration with 0 features. So users would never be able to install their unpublished integration without other changes.

## Test plan

- Added unit tests for the Sentry App Serializer.
- Use Sentry APM on staging to see the performance of the endpoint of loading all the un/published sentry apps in the integration directory home page. Did the change increase the request length?