### PR TITLE
fix(perf) Fix decimal bucket values

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -5,6 +5,7 @@ import six
 from collections import namedtuple
 from copy import deepcopy
 from datetime import timedelta
+from math import ceil
 
 from sentry import options
 from sentry.api.event_search import (
@@ -196,7 +197,7 @@ def find_histogram_buckets(field, params, conditions):
     if bucket_max == 0:
         raise InvalidSearchQuery(u"Cannot calculate histogram for {}".format(field))
 
-    bucket_number = bucket_max / float(num_buckets)
+    bucket_number = ceil(bucket_max / float(num_buckets))
 
     return "histogram({}, {:g}, {:g})".format(column, num_buckets, bucket_number)
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1124,13 +1124,6 @@ class QueryTransformTest(TestCase):
             in six.text_type(err)
         )
 
-    # empty results
-    # full results
-    # missing results
-    # missing results sorted asc
-    # missing results sorted desc
-    # missing results sorted otherwise
-
     @patch("sentry.snuba.discover.raw_query")
     def test_histogram_zerofill_empty_results(self, mock_query):
         mock_query.side_effect = [
@@ -1267,6 +1260,33 @@ class QueryTransformTest(TestCase):
         expected_extra_buckets = set([2000, 4000, 6000, 8000, 10000])
         extra_buckets = set(r["histogram_transaction_duration_10"] for r in results["data"][5:])
         assert expected_extra_buckets == extra_buckets
+
+    @patch("sentry.snuba.discover.raw_query")
+    def test_histogram_zerofill_on_weird_bucket(self, mock_query):
+        mock_query.side_effect = [
+            {"data": [{"max_transaction.duration": 869}]},
+            {
+                "meta": [{"name": "histogram_transaction_duration_10_87"}, {"name": "count"}],
+                "data": [
+                    {"histogram_transaction_duration_10_87": i * 87, "count": i}
+                    for i in range(1, 10, 2)
+                ],
+            },
+        ]
+
+        results = discover.query(
+            selected_columns=["histogram(transaction.duration, 10)", "count()"],
+            query="",
+            params={"project_id": [self.project.id]},
+            orderby="histogram_transaction_duration_10",
+            auto_fields=True,
+            use_aggregate_conditions=False,
+        )
+
+        expected = [i * 87 for i in range(1, 10)]
+        for result, exp in zip(results["data"], expected):
+            assert result["histogram_transaction_duration_10"] == exp
+            assert result["count"] == (exp / 87 if (exp / 87) % 2 == 1 else 0)
 
 
 class TimeseriesQueryTest(SnubaTestCase, TestCase):


### PR DESCRIPTION
If the max duration value divided by the buckets was a decimal, it would throw
off the zerofill function and cause the wrong buckets to be returned. Fix this
by only using ints for bucket sizes.