### PR TITLE
build(jest): Ignore `dist` as a modulePath for jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
       '<rootDir>/tests/fixtures/integration-docs/_platforms.json',
   },
   modulePaths: ['<rootDir>/src/sentry/static/sentry'],
+  modulePathIgnorePatterns: ['<rootDir>/src/sentry/static/sentry/dist'],
   setupFiles: [
     '<rootDir>/src/sentry/static/sentry/app/utils/silence-react-unsafe-warnings.js',
     '<rootDir>/tests/js/throw-on-react-error.js',


### PR DESCRIPTION
`jest` will pickup duplicated mock modules if you have recently run a webpack build. This ignores the `dist` directory for jest modules.