### PR TITLE
feat(discover) Format durations in tooltips

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -15,7 +15,7 @@ function defaultFormatAxisLabel(value, isTimestamp, utc, showTimeInTooltip) {
   return getFormattedDate(value, format, {local: !utc});
 }
 
-function valueFormatter(value) {
+function defaultValueFormatter(value) {
   if (typeof value === 'number') {
     return value.toLocaleString();
   }
@@ -30,6 +30,7 @@ function getFormatter({
   truncate,
   formatAxisLabel,
   utc,
+  valueFormatter = defaultValueFormatter,
 }) {
   const getFilter = seriesParam => {
     // Series do not necessarily have `data` defined, e.g. releases don't have `data`, but rather
@@ -113,6 +114,7 @@ export default function Tooltip({
   truncate,
   utc,
   formatAxisLabel,
+  valueFormatter,
   ...props
 } = {}) {
   formatter =
@@ -124,6 +126,7 @@ export default function Tooltip({
       truncate,
       utc,
       formatAxisLabel,
+      valueFormatter,
     });
 
   return {

--- a/src/sentry/static/sentry/app/components/duration.tsx
+++ b/src/sentry/static/sentry/app/components/duration.tsx
@@ -1,50 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {tn} from 'app/locale';
-
-function roundWithFixed(
-  value: number,
-  fixedDigits: number
-): {label: string; result: number} {
-  const label = value.toFixed(fixedDigits);
-  const result = fixedDigits <= 0 ? Math.round(value) : value;
-
-  return {label, result};
-}
-
-function getDuration(
-  seconds: number,
-  fixedDigits: number = 0,
-  abbreviation: boolean = false
-): string {
-  const value = Math.abs(seconds * 1000);
-
-  if (value >= 604800000) {
-    const {label, result} = roundWithFixed(value / 604800000, fixedDigits);
-    return `${label} ${abbreviation ? 'wk' : tn('week', 'weeks', result)}`;
-  }
-  if (value >= 172800000) {
-    const {label, result} = roundWithFixed(value / 86400000, fixedDigits);
-    return `${label} ${abbreviation ? 'd' : tn('day', 'days', result)}`;
-  }
-  if (value >= 7200000) {
-    const {label, result} = roundWithFixed(value / 3600000, fixedDigits);
-    return `${label} ${abbreviation ? 'hr' : tn('hour', 'hours', result)}`;
-  }
-  if (value >= 120000) {
-    const {label, result} = roundWithFixed(value / 60000, fixedDigits);
-    return `${label} ${abbreviation ? 'min' : tn('minute', 'minutes', result)}`;
-  }
-  if (value >= 1000) {
-    const {label, result} = roundWithFixed(value / 1000, fixedDigits);
-    return `${label} ${abbreviation ? 's' : tn('second', 'seconds', result)}`;
-  }
-
-  const {label} = roundWithFixed(value, fixedDigits);
-
-  return `${label}ms`;
-}
+import {getDuration} from 'app/utils/formatters';
 
 type Props = React.HTMLProps<HTMLSpanElement> & {
   seconds: number;

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -1,7 +1,7 @@
 import get from 'lodash/get';
 import {Release} from '@sentry/release-parser';
 
-import {t} from 'app/locale';
+import {t, tn} from 'app/locale';
 import {CommitAuthor, User} from 'app/types';
 
 export function userDisplayName(user: User | CommitAuthor, includeEmail = true): string {
@@ -35,3 +35,46 @@ export const formatVersion = (rawVersion: string, withPackage = false) => {
     return rawVersion;
   }
 };
+
+function roundWithFixed(
+  value: number,
+  fixedDigits: number
+): {label: string; result: number} {
+  const label = value.toFixed(fixedDigits);
+  const result = fixedDigits <= 0 ? Math.round(value) : value;
+
+  return {label, result};
+}
+
+export function getDuration(
+  seconds: number,
+  fixedDigits: number = 0,
+  abbreviation: boolean = false
+): string {
+  const value = Math.abs(seconds * 1000);
+
+  if (value >= 604800000) {
+    const {label, result} = roundWithFixed(value / 604800000, fixedDigits);
+    return `${label} ${abbreviation ? 'wk' : tn('week', 'weeks', result)}`;
+  }
+  if (value >= 172800000) {
+    const {label, result} = roundWithFixed(value / 86400000, fixedDigits);
+    return `${label} ${abbreviation ? 'd' : tn('day', 'days', result)}`;
+  }
+  if (value >= 7200000) {
+    const {label, result} = roundWithFixed(value / 3600000, fixedDigits);
+    return `${label} ${abbreviation ? 'hr' : tn('hour', 'hours', result)}`;
+  }
+  if (value >= 120000) {
+    const {label, result} = roundWithFixed(value / 60000, fixedDigits);
+    return `${label} ${abbreviation ? 'min' : tn('minute', 'minutes', result)}`;
+  }
+  if (value >= 1000) {
+    const {label, result} = roundWithFixed(value / 1000, fixedDigits);
+    return `${label} ${abbreviation ? 's' : tn('second', 'seconds', result)}`;
+  }
+
+  const {label} = roundWithFixed(value, fixedDigits);
+
+  return `${label}ms`;
+}

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -15,8 +15,11 @@ import {IconWarning} from 'app/icons';
 import theme from 'app/utils/theme';
 import TransparentLoadingMask from 'app/components/charts/components/transparentLoadingMask';
 import ErrorPanel from 'app/components/charts/components/errorPanel';
+import {getDuration} from 'app/utils/formatters';
 
 import EventsRequest from './utils/eventsRequest';
+
+const DURATION_AGGREGATE_PATTERN = /^(p75|p95|p99|percentile)|transaction\.duration/;
 
 class EventsAreaChart extends React.Component {
   static propTypes = {
@@ -133,6 +136,19 @@ class EventsChart extends React.Component {
     const includePrevious = !start && !end;
     const previousSeriesName = yAxis ? t('previous %s', yAxis) : undefined;
 
+    const tooltip = {
+      valueFormatter(value) {
+        if (DURATION_AGGREGATE_PATTERN.test(yAxis)) {
+          return getDuration(value / 1000, 2);
+        }
+        if (typeof value === 'number') {
+          return value.toLocaleString();
+        }
+
+        return value;
+      },
+    };
+
     return (
       <ChartZoom
         router={router}
@@ -176,6 +192,7 @@ class EventsChart extends React.Component {
                         <TransparentLoadingMask visible={reloading} />
                         <EventsAreaChart
                           {...zoomRenderProps}
+                          tooltip={tooltip}
                           loading={loading}
                           reloading={reloading}
                           utc={utc}


### PR DESCRIPTION
When the current aggregate function is a duration function we should format the tooltip value the same way we do in the table.

![Screen Shot 2020-03-17 at 5 02 31 PM](https://user-images.githubusercontent.com/24086/76902326-22586400-6872-11ea-8847-597bb3d38e87.png)
