### PR TITLE
fix(ui): Properly pass shouldForceProject on component update

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -281,6 +281,7 @@ class GlobalSelectionHeader extends React.Component {
       selection,
       forceUrlSync,
       forceProject,
+      shouldForceProject,
     } = this.props;
 
     if (hasCustomRouting) {
@@ -300,7 +301,7 @@ class GlobalSelectionHeader extends React.Component {
       const {project} = getStateFromQuery(location.query);
       if (!project) {
         singleProjectIsEnforced = true;
-        this.enforceSingleProject({forceProject});
+        this.enforceSingleProject({shouldForceProject, forceProject});
       }
     }
 
@@ -313,7 +314,7 @@ class GlobalSelectionHeader extends React.Component {
     ) {
       const {project} = getStateFromQuery(location.query);
       if (!project) {
-        this.enforceSingleProject({forceProject});
+        this.enforceSingleProject({shouldForceProject, forceProject});
       }
     }
 


### PR DESCRIPTION
This fixes an issue where the `project` query parameter was unintentionally being set to the first project in the organisation when no query parameter was provided.

This manifested itself for example when opening a link to an issue from an email and then going back by clicking 'Back to Issues Stream', which would previously return the user to the first project in the organisation.

Fixes #16776, fixes #17560 