### PR TITLE
feat(ui): Add Commits tab to releasesV2

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/commits/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/commits/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router/lib/Router';
 import styled from '@emotion/styled';
 
 import AsyncComponent from 'app/components/asyncComponent';
@@ -17,9 +17,12 @@ import ReleaseNoCommitData from '../releaseNoCommitData';
 
 const ALL_REPOSITORIES_LABEL = t('All Repositories');
 
-type Props = {
-  params: Params;
-} & AsyncComponent['props'];
+type RouteParams = {
+  orgId: string;
+  release: string;
+};
+
+type Props = RouteComponentProps<RouteParams, {}>;
 
 type State = {
   commits: Commit[];

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/commits/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/commits/index.tsx
@@ -1,8 +1,151 @@
 import React from 'react';
+import {Params} from 'react-router/lib/Router';
+import styled from '@emotion/styled';
 
-type Props = {};
+import AsyncComponent from 'app/components/asyncComponent';
+import CommitRow from 'app/components/commitRow';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {Repository, Commit} from 'app/types';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
+import {PanelHeader, Panel, PanelBody} from 'app/components/panels';
+import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
+import overflowEllipsisLeft from 'app/styles/overflowEllipsisLeft';
 
-// TODO(releasesV2): finish this component
-const ReleaseCommits = ({}: Props) => <div>ReleaseCommits</div>;
+import {getCommitsByRepository, CommitsByRepository} from '../utils';
+import ReleaseNoCommitData from '../releaseNoCommitData';
+
+const ALL_REPOSITORIES_LABEL = t('All Repositories');
+
+type Props = {
+  params: Params;
+} & AsyncComponent['props'];
+
+type State = {
+  commits: Commit[];
+  repos: Repository[];
+  activeRepo: string;
+} & AsyncComponent['state'];
+
+class ReleaseCommits extends AsyncComponent<Props, State> {
+  getDefaultState() {
+    return {
+      ...super.getDefaultState(),
+      activeRepo: ALL_REPOSITORIES_LABEL,
+    };
+  }
+
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {orgId, release} = this.props.params;
+
+    // TODO(releasesV2): we want to change this in Q2 2020 to fetch release commits filtered by project
+    // `/projects/${orgId}/myproject/releases/${encodeURIComponent(release)}/commits/`,
+    return [
+      [
+        'commits',
+        `/organizations/${orgId}/releases/${encodeURIComponent(release)}/commits/`,
+      ],
+      ['repos', `/organizations/${orgId}/repos/`],
+    ];
+  }
+
+  handleRepoFilterChange = (repo: string) => {
+    this.setState({activeRepo: repo});
+  };
+
+  renderRepoSwitcher(commitsByRepository: CommitsByRepository) {
+    const repos = Object.keys(commitsByRepository);
+    const {activeRepo} = this.state;
+
+    return (
+      <RepoSwitcher>
+        <DropdownControl
+          label={
+            <React.Fragment>
+              <FilterText>{t('Filter')}: &nbsp; </FilterText>
+              {activeRepo}
+            </React.Fragment>
+          }
+        >
+          {[ALL_REPOSITORIES_LABEL, ...repos].map(repoName => (
+            <DropdownItem
+              key={repoName}
+              onSelect={this.handleRepoFilterChange}
+              eventKey={repoName}
+              isActive={repoName === activeRepo}
+            >
+              <RepoLabel>{repoName}</RepoLabel>
+            </DropdownItem>
+          ))}
+        </DropdownControl>
+      </RepoSwitcher>
+    );
+  }
+
+  renderCommitsForRepo(repo: string, commitsByRepository: CommitsByRepository) {
+    return (
+      <Panel key={repo}>
+        <PanelHeader>{repo}</PanelHeader>
+        <PanelBody>
+          {commitsByRepository[repo].map(commit => (
+            <CommitRow key={commit.id} commit={commit} />
+          ))}
+        </PanelBody>
+      </Panel>
+    );
+  }
+
+  renderBody() {
+    const {orgId} = this.props.params;
+    const {commits, repos, activeRepo} = this.state;
+
+    const commitsByRepository = getCommitsByRepository(commits);
+    const reposToRender =
+      activeRepo === ALL_REPOSITORIES_LABEL
+        ? Object.keys(commitsByRepository)
+        : [activeRepo];
+
+    if (repos.length === 0) {
+      return <ReleaseNoCommitData orgId={orgId} />;
+    }
+
+    return (
+      <ContentBox>
+        {commits.length ? (
+          <React.Fragment>
+            {Object.keys(commitsByRepository).length > 1 &&
+              this.renderRepoSwitcher(commitsByRepository)}
+            {reposToRender.map(repoName =>
+              this.renderCommitsForRepo(repoName, commitsByRepository)
+            )}
+          </React.Fragment>
+        ) : (
+          <EmptyStateWarning small>
+            {t('There are no commits associated with this release.')}
+          </EmptyStateWarning>
+        )}
+      </ContentBox>
+    );
+  }
+}
+
+const ContentBox = styled('div')`
+  padding: ${space(4)};
+  flex: 1;
+  background-color: ${p => p.theme.white};
+`;
+
+const RepoSwitcher = styled('div')`
+  margin-bottom: ${space(1)};
+`;
+
+const FilterText = styled('em')`
+  font-style: normal;
+  color: ${p => p.theme.gray2};
+`;
+
+const RepoLabel = styled('div')`
+  ${overflowEllipsisLeft}
+`;
 
 export default ReleaseCommits;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/commitAuthorBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/commitAuthorBreakdown.tsx
@@ -18,7 +18,7 @@ type GroupedAuthorCommits = {
 };
 
 type Props = {
-  projectId: string;
+  projectSlug: string;
   orgId: string;
   version: string;
   commitCount: number;
@@ -36,10 +36,9 @@ class CommitAuthorBreakdown extends AsyncComponent<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {orgId, version} = this.props;
+    const {orgId, projectSlug, version} = this.props;
 
-    // TODO(releasesV2): we want to change this in Q2 2020 to fetch release commits filtered by project
-    const commitsEndpoint = `/organizations/${orgId}/releases/${encodeURIComponent(
+    const commitsEndpoint = `/projects/${orgId}/${projectSlug}/releases/${encodeURIComponent(
       version
     )}/commits/`;
 

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -24,17 +24,13 @@ type Props = {
 };
 
 const ReleaseOverview = ({organization, params, selection}: Props) => {
-  const projectId = String(selection.projects[0]);
-
-  // TODO(releasesV2): we will handle this later with forced project selector
-  if (!projectId) {
-    return null;
-  }
+  const projectId = selection.projects[0];
 
   return (
     <ReleaseContext.Consumer>
       {release => {
-        const {commitCount, version} = release!; // if release is undefined, this will not be rendered at all
+        const {commitCount, version, projects} = release!; // if release is undefined, this will not be rendered at all
+        const projectSlug = projects.find(p => p.id === projectId)?.slug;
         return (
           <ContentBox>
             <Main>
@@ -42,11 +38,11 @@ const ReleaseOverview = ({organization, params, selection}: Props) => {
               <Issues orgId={organization.slug} version={params.release} />
             </Main>
             <Sidebar>
-              {commitCount > 0 && (
+              {commitCount > 0 && projectSlug && (
                 <CommitAuthorBreakdown
                   version={version}
                   orgId={organization.slug}
-                  projectId={projectId}
+                  projectSlug={projectSlug}
                   commitCount={commitCount}
                 />
               )}

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/utils.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/utils.tsx
@@ -1,5 +1,9 @@
 import {Client} from 'app/api';
-import {CommitFile} from 'app/types';
+import {CommitFile, Commit} from 'app/types';
+
+export type CommitsByRepository = {
+  [key: string]: Commit[];
+};
 
 export const deleteRelease = (orgId: string, version: string) => {
   const api = new Client();
@@ -34,5 +38,22 @@ export function getFilesByRepository(fileList: CommitFile[]) {
     filesByRepository[repoName][filename].types.add(type);
 
     return filesByRepository;
+  }, {});
+}
+
+/**
+ * Convert list of individual commits into a summary grouped by repository
+ */
+export function getCommitsByRepository(commitList: Commit[]): CommitsByRepository {
+  return commitList.reduce((commitsByRepository, commit) => {
+    const repositoryName = commit.repository?.name ?? 'unknown';
+
+    if (!commitsByRepository.hasOwnProperty(repositoryName)) {
+      commitsByRepository[repositoryName] = [];
+    }
+
+    commitsByRepository[repositoryName].push(commit);
+
+    return commitsByRepository;
   }, {});
 }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/utils.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/utils.tsx
@@ -1,5 +1,6 @@
 import {Client} from 'app/api';
 import {CommitFile, Commit} from 'app/types';
+import {t} from 'app/locale';
 
 export type CommitsByRepository = {
   [key: string]: Commit[];
@@ -46,7 +47,7 @@ export function getFilesByRepository(fileList: CommitFile[]) {
  */
 export function getCommitsByRepository(commitList: Commit[]): CommitsByRepository {
   return commitList.reduce((commitsByRepository, commit) => {
-    const repositoryName = commit.repository?.name ?? 'unknown';
+    const repositoryName = commit.repository?.name ?? t('unknown');
 
     if (!commitsByRepository.hasOwnProperty(repositoryName)) {
       commitsByRepository[repositoryName] = [];


### PR DESCRIPTION
This PR adds Commits tab to release v2 detail page.

Reusing CommitRow component, down the road we will probably clean up the design a bit.

![image](https://user-images.githubusercontent.com/9060071/76905676-acb8bc00-68a2-11ea-84fa-cd1a7bcabfdc.png)
