### PR TITLE
feat(guides): Update guides design and content

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/resolve.tsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.tsx
@@ -8,7 +8,6 @@ import MenuItem from 'app/components/menuItem';
 import DropdownLink from 'app/components/dropdownLink';
 import ActionLink from 'app/components/actions/actionLink';
 import Tooltip from 'app/components/tooltip';
-import GuideAnchor from 'app/components/assistant/guideAnchor';
 import {formatVersion} from 'app/utils/formatters';
 import {
   Release,
@@ -154,83 +153,81 @@ class ResolveActions extends React.Component<Props, State> {
           orgId={orgId}
           projectId={projectId}
         />
-        <GuideAnchor target="resolve">
-          <Tooltip disabled={!projectFetchError} title={t('Error fetching project')}>
-            <div className="btn-group">
-              <ActionLink
-                {...actionLinkProps}
-                title={t('Resolve')}
-                className={buttonClass}
-                onAction={() => onUpdate({status: ResolutionStatus.RESOLVED})}
-              >
-                <span className="icon-checkmark hidden-xs" style={{marginRight: 5}} />
-                {t('Resolve')}
-              </ActionLink>
+        <Tooltip disabled={!projectFetchError} title={t('Error fetching project')}>
+          <div className="btn-group">
+            <ActionLink
+              {...actionLinkProps}
+              title={t('Resolve')}
+              className={buttonClass}
+              onAction={() => onUpdate({status: ResolutionStatus.RESOLVED})}
+            >
+              <span className="icon-checkmark hidden-xs" style={{marginRight: 5}} />
+              {t('Resolve')}
+            </ActionLink>
 
-              <DropdownLink
-                key="resolve-dropdown"
-                caret
-                className={buttonClass}
-                title=""
-                alwaysRenderMenu
-                disabled={disableDropdown || disabled}
-              >
-                <MenuItem header>{t('Resolved In')}</MenuItem>
-                <MenuItem noAnchor>
-                  <Tooltip title={actionTitle} containerDisplayMode="block">
-                    <ActionLink
-                      {...actionLinkProps}
-                      title={t('The next release')}
-                      onAction={() =>
-                        hasRelease &&
-                        onUpdate({
-                          status: ResolutionStatus.RESOLVED,
-                          statusDetails: {
-                            inNextRelease: true,
-                          },
-                        })
-                      }
-                    >
-                      {t('The next release')}
-                    </ActionLink>
-                  </Tooltip>
-                  <Tooltip title={actionTitle} containerDisplayMode="block">
-                    <ActionLink
-                      {...actionLinkProps}
-                      title={t('The current release')}
-                      onAction={() =>
-                        hasRelease &&
-                        onUpdate({
-                          status: ResolutionStatus.RESOLVED,
-                          statusDetails: {
-                            inRelease: latestRelease ? latestRelease.version : 'latest',
-                          },
-                        })
-                      }
-                    >
-                      {latestRelease
-                        ? t(
-                            'The current release (%s)',
-                            formatVersion(latestRelease.version)
-                          )
-                        : t('The current release')}
-                    </ActionLink>
-                  </Tooltip>
-                  <Tooltip title={actionTitle} containerDisplayMode="block">
-                    <ActionLink
-                      {...actionLinkProps}
-                      title={t('Another version')}
-                      onAction={() => hasRelease && this.setState({modal: true})}
-                      shouldConfirm={false}
-                    >
-                      {t('Another version\u2026')}
-                    </ActionLink>
-                  </Tooltip>
-                </MenuItem>
-              </DropdownLink>
-            </div>
-          </Tooltip>
-        </GuideAnchor>
+            <DropdownLink
+              key="resolve-dropdown"
+              caret
+              className={buttonClass}
+              title=""
+              alwaysRenderMenu
+              disabled={disableDropdown || disabled}
+            >
+              <MenuItem header>{t('Resolved In')}</MenuItem>
+              <MenuItem noAnchor>
+                <Tooltip title={actionTitle} containerDisplayMode="block">
+                  <ActionLink
+                    {...actionLinkProps}
+                    title={t('The next release')}
+                    onAction={() =>
+                      hasRelease &&
+                      onUpdate({
+                        status: ResolutionStatus.RESOLVED,
+                        statusDetails: {
+                          inNextRelease: true,
+                        },
+                      })
+                    }
+                  >
+                    {t('The next release')}
+                  </ActionLink>
+                </Tooltip>
+                <Tooltip title={actionTitle} containerDisplayMode="block">
+                  <ActionLink
+                    {...actionLinkProps}
+                    title={t('The current release')}
+                    onAction={() =>
+                      hasRelease &&
+                      onUpdate({
+                        status: ResolutionStatus.RESOLVED,
+                        statusDetails: {
+                          inRelease: latestRelease ? latestRelease.version : 'latest',
+                        },
+                      })
+                    }
+                  >
+                    {latestRelease
+                      ? t(
+                          'The current release (%s)',
+                          formatVersion(latestRelease.version)
+                        )
+                      : t('The current release')}
+                  </ActionLink>
+                </Tooltip>
+                <Tooltip title={actionTitle} containerDisplayMode="block">
+                  <ActionLink
+                    {...actionLinkProps}
+                    title={t('Another version')}
+                    onAction={() => hasRelease && this.setState({modal: true})}
+                    shouldConfirm={false}
+                  >
+                    {t('Another version\u2026')}
+                  </ActionLink>
+                </Tooltip>
+              </MenuItem>
+            </DropdownLink>
+          </div>
+        </Tooltip>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -4,84 +4,166 @@ import {t, tct} from 'app/locale';
 import {GuidesContent} from 'app/components/assistant/types';
 import ExternalLink from 'app/components/links/externalLink';
 
-export default function getGuidesContent(): GuidesContent {
+export default function getGuidesContent(user): GuidesContent {
+  const hasExperiment = user?.experiments?.AssistantGuideExperiment === 1;
+
   return [
-    {
-      guide: 'issue',
-      requiredTargets: ['issue_title', 'exception'],
-      steps: [
-        {
-          title: t('Issue Details'),
-          target: 'issue_title',
-          description: t(
-            "The issue page contains all the details about an issue. Let's get started."
-          ),
-        },
-        {
-          title: t('Stacktrace'),
-          target: 'exception',
-          description: t(
-            `See the sequence of function calls that led to the error, and global/local variables
-            for each stack frame.`
-          ),
-        },
-        {
-          title: t('Breadcrumbs'),
-          target: 'breadcrumbs',
-          description: t(
-            `Breadcrumbs are a trail of events that happened prior to the error. They're similar
-            to traditional logs but can record more rich structured data. When Sentry is used with
-            web frameworks, breadcrumbs are automatically captured for events like database calls and
-            network requests.`
-          ),
-        },
-        {
-          title: t('Tags'),
-          target: 'tags',
-          description: t(
-            `Attach arbitrary key-value pairs to each event which you can search and filter on.
-            View a heatmap of all tags for an issue on the right panel.`
-          ),
-        },
-        {
-          title: t('Resolve'),
-          target: 'resolve',
-          description: tct(
-            `Resolve an issue to remove it from your issue list. Sentry can also [link:alert you]
-            when a new issue occurs or a resolved issue re-occurs.`,
-            {link: <ExternalLink href="/settings/account/notifications/" />}
-          ),
-        },
-        {
-          title: t('Delete and Ignore'),
-          target: 'ignore_delete_discard',
-          description: t(
-            `Delete an issue to remove it from your issue list until it happens again.
-            Ignore an issue to remove it permanently or until certain conditions are met.`
-          ),
-        },
-        {
-          title: t('Issue Number'),
-          target: 'issue_number',
-          description: tct(
-            `Include this unique identifier in your commit message to have Sentry automatically
-            resolve the issue when your code is deployed. [link:Learn more].`,
-            {link: <ExternalLink href="https://docs.sentry.io/learn/releases/" />}
-          ),
-        },
-        {
-          title: t('Ownership Rules'),
-          target: 'owners',
-          description: tct(
-            `Define users or teams responsible for specific file paths or URLs so that alerts can
-            be routed to the right person. [link:Learn more]`,
+    hasExperiment
+      ? {
+          guide: 'issue',
+          requiredTargets: ['issue_title', 'exception'],
+          steps: [
             {
-              link: <ExternalLink href="https://docs.sentry.io/learn/issue-owners/" />,
-            }
-          ),
+              title: t("Let's Get This Over With"),
+              target: 'issue_title',
+              description: t(
+                `No one likes a product tour. But stick with us, and you'll find it a
+                whole lot easier to use Sentry's Issue details page.`
+              ),
+            },
+            {
+              title: t('Resolve Your Issues'),
+              target: 'resolve',
+              description: t(
+                'So you fixed your problem? Congrats. Hit resolve to make it all go away.'
+              ),
+            },
+            {
+              title: t('Deal With It Later, Or Never'),
+              target: 'ignore_delete_discard',
+              description: t(
+                `Just can't deal with this Issue right now? Ignore it. Saving it for later?
+                Star it. Want it gone and out of your life forever?
+                Delete that shi*t.`
+              ),
+            },
+            {
+              title: t('Identify Your Issues'),
+              target: 'issue_number',
+              description: tct(
+                `You've got a lot of Issues. That's fine. Use the Issue number in your commit mesage,
+                and we'll automatically resolve the Issue when your code is deployed. [link:Learn more]`,
+                {link: <ExternalLink href="https://docs.sentry.io/learn/releases/" />}
+              ),
+            },
+            {
+              title: t('Annoy the Right People'),
+              target: 'owners',
+              description: tct(
+                `Notification overload makes it tempting to hurl your phone into the ocean.
+                Define who is responsible for what, so alerts reach the right people and your
+                devices stay on dry land. [link:Learn more]`,
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/learn/issue-owners/" />
+                  ),
+                }
+              ),
+            },
+            {
+              title: t('Find Information You Can Use'),
+              target: 'tags',
+              description: t(
+                `So many bugs, so little time. When you've got bugs as far as the mouse can scroll,
+                search and filter Events with tags or visualize Issues with a heat map.`
+              ),
+            },
+            {
+              title: t('Narrow Down Suspects'),
+              target: 'exception',
+              description: t(
+                `We've got stack trace. See the exact sequence of function calls leading to the error
+                in question, no detective skills necessary.`
+              ),
+            },
+            {
+              title: t('Retrace Your Steps'),
+              target: 'breadcrumbs',
+              description: t(
+                `Not sure how you got here? Sentry automatically captures breadcrumbs for events in web
+                frameworks to lead you straight to your error.`
+              ),
+            },
+          ],
+        }
+      : {
+          guide: 'issue',
+          requiredTargets: ['issue_title', 'exception'],
+          steps: [
+            {
+              title: t('Issue Details'),
+              target: 'issue_title',
+              description: t(
+                "The issue page contains all the details about an issue. Let's get started."
+              ),
+            },
+            {
+              title: t('Stacktrace'),
+              target: 'exception',
+              description: t(
+                `See the sequence of function calls that led to the error, and global/local variables
+                for each stack frame.`
+              ),
+            },
+            {
+              title: t('Breadcrumbs'),
+              target: 'breadcrumbs',
+              description: t(
+                `Breadcrumbs are a trail of events that happened prior to the error. They're similar
+                to traditional logs but can record more rich structured data. When Sentry is used with
+                web frameworks, breadcrumbs are automatically captured for events like database calls and
+                network requests.`
+              ),
+            },
+            {
+              title: t('Tags'),
+              target: 'tags',
+              description: t(
+                `Attach arbitrary key-value pairs to each event which you can search and filter on.
+                View a heatmap of all tags for an issue on the right panel.`
+              ),
+            },
+            {
+              title: t('Resolve'),
+              target: 'resolve',
+              description: tct(
+                `Resolve an issue to remove it from your issue list. Sentry can also [link:alert you]
+                when a new issue occurs or a resolved issue re-occurs.`,
+                {link: <ExternalLink href="/settings/account/notifications/" />}
+              ),
+            },
+            {
+              title: t('Delete and Ignore'),
+              target: 'ignore_delete_discard',
+              description: t(
+                `Delete an issue to remove it from your issue list until it happens again.
+                Ignore an issue to remove it permanently or until certain conditions are met.`
+              ),
+            },
+            {
+              title: t('Issue Number'),
+              target: 'issue_number',
+              description: tct(
+                `Include this unique identifier in your commit message to have Sentry automatically
+                resolve the issue when your code is deployed. [link:Learn more]`,
+                {link: <ExternalLink href="https://docs.sentry.io/learn/releases/" />}
+              ),
+            },
+            {
+              title: t('Ownership Rules'),
+              target: 'owners',
+              description: tct(
+                `Define users or teams responsible for specific file paths or URLs so that alerts can
+                be routed to the right person. [link:Learn more]`,
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/learn/issue-owners/" />
+                  ),
+                }
+              ),
+            },
+          ],
         },
-      ],
-    },
     {
       guide: 'issue_stream',
       requiredTargets: ['issue_stream'],
@@ -91,7 +173,7 @@ export default function getGuidesContent(): GuidesContent {
           target: 'issue_stream',
           description: tct(
             `Sentry automatically groups similar events together into an issue. Similarity is
-            determined by stacktrace and other factors. [link:Learn more].`,
+            determined by stacktrace and other factors. [link:Learn more]`,
             {
               link: (
                 <ExternalLink href="https://docs.sentry.io/data-management/rollups/" />

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -173,7 +173,7 @@ export default function getGuidesContent(user): GuidesContent {
           target: 'issue_stream',
           description: tct(
             `Sentry automatically groups similar events together into an issue. Similarity is
-            determined by stacktrace and other factors. [link:Learn more]`,
+            determined by stacktrace and other factors. [link:Learn more].`,
             {
               link: (
                 <ExternalLink href="https://docs.sentry.io/data-management/rollups/" />

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -145,6 +145,7 @@ const GuideAnchor = createReactClass<Props, State>({
                 <DismissButton
                   priority="primary"
                   size="small"
+                  href="#" // to clear `#assistant` from the url
                   onClick={this.handleDismiss}
                 >
                   {t('Dismiss')}
@@ -158,7 +159,7 @@ const GuideAnchor = createReactClass<Props, State>({
 
           {hasManySteps && (
             <StepCount>
-              {tct('[currentStepCount] OF [totalStepCount]', {
+              {tct('[currentStepCount] of [totalStepCount]', {
                 currentStepCount,
                 totalStepCount,
               })}
@@ -346,6 +347,7 @@ const DismissButton = styled(StyledButton)`
 const StepCount = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: bold;
+  text-transform: uppercase;
 `;
 
 const StyledHovercard = styled(Hovercard)`

--- a/src/sentry/static/sentry/app/components/assistant/types.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/types.tsx
@@ -6,7 +6,7 @@ export type GuideStep = {
    * "invisible", it will not be pinged but will be scrolled to.
    * Otherwise the anchor will be pinged and scrolled to.
    */
-  target: string;
+  target?: string;
   description: React.ReactNode;
 };
 

--- a/src/sentry/static/sentry/app/components/events/eventMessage.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventMessage.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import {Level} from 'app/types';
 import ErrorLevel from 'app/components/events/errorLevel';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 
@@ -13,6 +14,7 @@ type Props = {
   message?: React.ReactNode;
   annotations?: React.ReactNode;
   className?: string;
+  hasGuideAnchor?: boolean;
 };
 
 const EventMessage = ({
@@ -21,6 +23,7 @@ const EventMessage = ({
   levelIndicatorSize,
   message,
   annotations,
+  hasGuideAnchor,
 }: Props) => (
   <div className={className}>
     {level && (
@@ -28,7 +31,13 @@ const EventMessage = ({
         {level}
       </StyledErrorLevel>
     )}
-    {message && <Message>{message}</Message>}
+
+    {message && (
+      <GuideAnchor target="issue_title" disabled={!hasGuideAnchor} position="bottom">
+        <Message>{message}</Message>
+      </GuideAnchor>
+    )}
+
     {annotations}
   </div>
 );

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs.jsx
@@ -168,9 +168,11 @@ class BreadcrumbsInterface extends React.Component {
     const data = this.props.data;
 
     const title = (
-      <GuideAnchor target="breadcrumbs" position="top">
-        <h3>{t('Breadcrumbs')}</h3>
-      </GuideAnchor>
+      <h3>
+        <GuideAnchor target="breadcrumbs" position="bottom">
+          {t('Breadcrumbs')}
+        </GuideAnchor>
+      </h3>
     );
 
     let all = data.values;

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -92,7 +92,7 @@ class CrashHeader extends React.Component {
   render() {
     const {title, beforeTitle, hideGuide, stackView, stackType, newestFirst} = this.props;
 
-    let titleNode = (
+    const titleNode = (
       <h3
         style={{
           marginBottom: 0,
@@ -100,26 +100,20 @@ class CrashHeader extends React.Component {
           whiteSpace: 'nowrap',
         }}
       >
-        {title}
-        <small>
-          (
-          <Tooltip title={t('Toggle stacktrace order')}>
-            <a onClick={this.handleToggleOrder}>
-              {newestFirst ? t('most recent call first') : t('most recent call last')}
-            </a>
-          </Tooltip>
-          )
-        </small>
+        <GuideAnchor target="exception" disabled={hideGuide} position="bottom">
+          {title}
+          <small>
+            (
+            <Tooltip title={t('Toggle stacktrace order')}>
+              <a onClick={this.handleToggleOrder}>
+                {newestFirst ? t('most recent call first') : t('most recent call last')}
+              </a>
+            </Tooltip>
+            )
+          </small>
+        </GuideAnchor>
       </h3>
     );
-
-    if (!hideGuide) {
-      titleNode = (
-        <GuideAnchor target="exception" position="top">
-          {titleNode}
-        </GuideAnchor>
-      );
-    }
 
     return (
       <Wrapper className="crash-title">

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -426,7 +426,7 @@ class DebugMetaInterface extends React.PureComponent {
     const filteredImages = images.filter(image => this.filterImage(image));
 
     const titleElement = (
-      <GuideAnchor target="packages" position="top">
+      <GuideAnchor target="packages" position="bottom">
         <h3>{t('Images Loaded')}</h3>
       </GuideAnchor>
     );

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -12,6 +12,7 @@ import ExternalIssueList from 'app/components/group/externalIssuesList';
 import GroupParticipants from 'app/components/group/participants';
 import GroupReleaseStats from 'app/components/group/releaseStats';
 import GroupTagDistributionMeter from 'app/components/group/tagDistributionMeter';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import LoadingError from 'app/components/loadingError';
 import SentryTypes from 'app/sentryTypes';
 import SubscribeButton from 'app/components/subscribeButton';
@@ -253,7 +254,9 @@ class GroupSidebar extends React.Component {
         {this.renderPluginIssue()}
 
         <h6>
-          <span>{t('Tags')}</span>
+          <GuideAnchor target="tags" position="bottom">
+            <span>{t('Tags')}</span>
+          </GuideAnchor>
         </h6>
         {this.state.tagsWithTopValues &&
           group.tags.map(tag => {

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners.jsx
@@ -207,37 +207,37 @@ class SuggestedOwners extends React.Component {
         )}
         <Access access={['project:write']}>
           <div className="m-b-1">
-            <GuideAnchor target="owners">
-              <OwnerRuleHeading>
-                <span>{t('Ownership Rules')}</span>
-                <ClassNames>
-                  {({css}) => (
-                    <Hovercard
-                      containerClassName={css`
-                        display: inline-flex;
-                        padding: 0 !important;
-                      `}
-                      body={this.getInfoHovercardBody()}
-                    >
-                      <IconInfo size="xs" />
-                    </Hovercard>
-                  )}
-                </ClassNames>
-              </OwnerRuleHeading>
+            <OwnerRuleHeading>
+              <span>{t('Ownership Rules')}</span>
+              <ClassNames>
+                {({css}) => (
+                  <Hovercard
+                    containerClassName={css`
+                      display: inline-flex;
+                      padding: 0 !important;
+                    `}
+                    body={this.getInfoHovercardBody()}
+                  >
+                    <IconInfo size="xs" />
+                  </Hovercard>
+                )}
+              </ClassNames>
+            </OwnerRuleHeading>
+            <GuideAnchor target="owners" position="bottom">
+              <Button
+                onClick={() =>
+                  openCreateOwnershipRule({
+                    project,
+                    organization,
+                    issueId: group.id,
+                  })
+                }
+                size="small"
+                className="btn btn-default btn-sm btn-create-ownership-rule"
+              >
+                {t('Create Ownership Rule')}
+              </Button>
             </GuideAnchor>
-            <Button
-              onClick={() =>
-                openCreateOwnershipRule({
-                  project,
-                  organization,
-                  issueId: group.id,
-                })
-              }
-              size="small"
-              className="btn btn-default btn-sm btn-create-ownership-rule"
-            >
-              {t('Create Ownership Rule')}
-            </Button>
           </div>
         </Access>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -9,8 +9,6 @@ import getGuidesContent from 'app/components/assistant/getGuidesContent';
 import GuideActions from 'app/actions/guideActions';
 import OrganizationsActions from 'app/actions/organizationsActions';
 
-const guidesContent: GuidesContent = getGuidesContent();
-
 type GuideStoreState = {
   /**
    * All tooltip guides
@@ -98,6 +96,9 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
     if (!data || !Array.isArray(data)) {
       return;
     }
+
+    const user = ConfigStore.get('user');
+    const guidesContent: GuidesContent = getGuidesContent(user);
 
     // map server guide state (i.e. seen status) with guide content
     const guides = guidesContent.map(guideContent => ({

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -865,7 +865,9 @@ export type ActiveOrgExperiments = {
   IntegrationDirectorySortWeightExperiment: '1' | '0';
 };
 
-export type ActiveUserExperiments = {};
+export type ActiveUserExperiments = {
+  AssistantGuideExperiment: 0 | 1 | 1;
+};
 
 type SavedQueryVersions = 1 | 2;
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
@@ -91,7 +91,6 @@ class DeleteActions extends React.Component {
   render() {
     return (
       <div className="btn-group">
-        <GuideAnchor target="ignore_delete_discard" />
         <LinkWithConfirmation
           className="group-remove btn btn-default btn-sm"
           title={t('Delete')}
@@ -271,34 +270,38 @@ const GroupDetailsActions = createReactClass({
 
     return (
       <div className="group-actions">
-        <ResolveActions
-          hasRelease={hasRelease}
-          latestRelease={project.latestRelease}
-          onUpdate={this.onUpdate}
-          orgId={organization.slug}
-          projectId={project.slug}
-          isResolved={isResolved}
-          isAutoResolved={isResolved && group.statusDetails.autoResolved}
-        />
+        <GuideAnchor target="resolve" position="bottom">
+          <ResolveActions
+            hasRelease={hasRelease}
+            latestRelease={project.latestRelease}
+            onUpdate={this.onUpdate}
+            orgId={organization.slug}
+            projectId={project.slug}
+            isResolved={isResolved}
+            isAutoResolved={isResolved && group.statusDetails.autoResolved}
+          />
+        </GuideAnchor>
 
-        <IgnoreActions isIgnored={isIgnored} onUpdate={this.onUpdate} />
+        <GuideAnchor target="ignore_delete_discard" position="bottom">
+          <IgnoreActions isIgnored={isIgnored} onUpdate={this.onUpdate} />
 
-        <div className="btn-group">
-          <div
-            className={bookmarkClassName}
-            title={t('Bookmark')}
-            onClick={this.onToggleBookmark}
-          >
-            <span className="icon-star-solid" />
+          <div className="btn-group">
+            <div
+              className={bookmarkClassName}
+              title={t('Bookmark')}
+              onClick={this.onToggleBookmark}
+            >
+              <span className="icon-star-solid" />
+            </div>
           </div>
-        </div>
 
-        <DeleteActions
-          organization={organization}
-          project={project}
-          onDelete={this.onDelete}
-          onDiscard={this.onDiscard}
-        />
+          <DeleteActions
+            organization={organization}
+            project={project}
+            onDelete={this.onDelete}
+            onDiscard={this.onDiscard}
+          />
+        </GuideAnchor>
 
         {orgFeatures.has('shared-issues') && (
           <div className="btn-group">

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/header.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/header.jsx
@@ -102,12 +102,11 @@ class GroupHeader extends React.Component {
         <div className="row">
           <div className="col-sm-7">
             <h3>
-              <GuideAnchor target="issue_title">
-                <EventOrGroupTitle data={group} />
-              </GuideAnchor>
+              <EventOrGroupTitle data={group} />
             </h3>
 
             <EventMessage
+              hasGuideAnchor
               message={message}
               level={group.level}
               annotations={
@@ -138,8 +137,8 @@ class GroupHeader extends React.Component {
           <div className="col-sm-5 stats">
             <div className="flex flex-justify-right">
               {group.shortId && (
-                <div className="short-id-box count align-right">
-                  <GuideAnchor target="issue_number" position="right">
+                <GuideAnchor target="issue_number" position="bottom">
+                  <div className="short-id-box count align-right">
                     <h6 className="nav-header">
                       <Tooltip
                         title={t(
@@ -155,14 +154,14 @@ class GroupHeader extends React.Component {
                         </a>
                       </Tooltip>
                     </h6>
-                  </GuideAnchor>
-                  <ShortId
-                    shortId={group.shortId}
-                    avatar={
-                      <StyledProjectBadge project={project} avatarSize={20} hideName />
-                    }
-                  />
-                </div>
+                    <ShortId
+                      shortId={group.shortId}
+                      avatar={
+                        <StyledProjectBadge project={project} avatarSize={20} hideName />
+                      }
+                    />
+                  </div>
+                </GuideAnchor>
               )}
               <div className="count align-right m-l-1">
                 <h6 className="nav-header">{t('Events')}</h6>

--- a/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
@@ -79,59 +79,80 @@ exports[`ResolveActions with confirmation step renders 1`] = `
         />
       </Modal>
     </CustomResolutionModal>
-    <GuideAnchor
-      target="resolve"
+    <Tooltip
+      containerDisplayMode="inline-block"
+      disabled={true}
+      position="top"
+      title="Error fetching project"
     >
-      <Tooltip
-        containerDisplayMode="inline-block"
-        disabled={true}
-        position="top"
-        title="Error fetching project"
+      <div
+        className="btn-group"
       >
-        <div
-          className="btn-group"
+        <ActionLink
+          className="btn btn-default btn-sm"
+          confirmLabel="Resolve"
+          disabled={false}
+          message="Are you sure???"
+          onAction={[Function]}
+          shouldConfirm={true}
+          title="Resolve"
         >
-          <ActionLink
-            className="btn btn-default btn-sm"
-            confirmLabel="Resolve"
-            disabled={false}
+          <Confirm
+            cancelText="Cancel"
+            confirmText="Resolve"
+            disableConfirmButton={false}
             message="Are you sure???"
-            onAction={[Function]}
-            shouldConfirm={true}
-            title="Resolve"
+            onConfirm={[Function]}
+            priority="primary"
+            stopPropagation={false}
           >
-            <Confirm
-              cancelText="Cancel"
-              confirmText="Resolve"
-              disableConfirmButton={false}
-              message="Are you sure???"
-              onConfirm={[Function]}
-              priority="primary"
-              stopPropagation={false}
+            <a
+              aria-label="Resolve"
+              className="btn btn-default btn-sm"
+              onClick={[Function]}
+              title="Resolve"
             >
-              <a
-                aria-label="Resolve"
-                className="btn btn-default btn-sm"
-                onClick={[Function]}
-                title="Resolve"
-              >
-                 
-                <span
-                  className="icon-checkmark hidden-xs"
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
+               
+              <span
+                className="icon-checkmark hidden-xs"
+                style={
+                  Object {
+                    "marginRight": 5,
                   }
-                />
-                Resolve
-              </a>
+                }
+              />
+              Resolve
+            </a>
+            <Modal
+              animation={false}
+              autoFocus={true}
+              backdrop={true}
+              bsClass="modal"
+              dialogComponentClass={[Function]}
+              enforceFocus={true}
+              keyboard={true}
+              manager={
+                ModalManager {
+                  "add": [Function],
+                  "containers": Array [],
+                  "data": Array [],
+                  "handleContainerOverflow": true,
+                  "hideSiblingNodes": true,
+                  "isTopModal": [Function],
+                  "modals": Array [],
+                  "remove": [Function],
+                }
+              }
+              onHide={[Function]}
+              renderBackdrop={[Function]}
+              restoreFocus={true}
+              show={false}
+            >
               <Modal
-                animation={false}
                 autoFocus={true}
                 backdrop={true}
-                bsClass="modal"
-                dialogComponentClass={[Function]}
+                backdropClassName="modal-backdrop"
+                containerClassName="modal-open"
                 enforceFocus={true}
                 keyboard={true}
                 manager={
@@ -146,158 +167,158 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                     "remove": [Function],
                   }
                 }
+                onEntering={[Function]}
+                onExited={[Function]}
                 onHide={[Function]}
                 renderBackdrop={[Function]}
                 restoreFocus={true}
                 show={false}
-              >
-                <Modal
-                  autoFocus={true}
-                  backdrop={true}
-                  backdropClassName="modal-backdrop"
-                  containerClassName="modal-open"
-                  enforceFocus={true}
-                  keyboard={true}
-                  manager={
-                    ModalManager {
-                      "add": [Function],
-                      "containers": Array [],
-                      "data": Array [],
-                      "handleContainerOverflow": true,
-                      "hideSiblingNodes": true,
-                      "isTopModal": [Function],
-                      "modals": Array [],
-                      "remove": [Function],
-                    }
-                  }
-                  onEntering={[Function]}
-                  onExited={[Function]}
-                  onHide={[Function]}
-                  renderBackdrop={[Function]}
-                  restoreFocus={true}
-                  show={false}
-                />
-              </Modal>
-            </Confirm>
-          </ActionLink>
-          <DropdownLink
+              />
+            </Modal>
+          </Confirm>
+        </ActionLink>
+        <DropdownLink
+          alwaysRenderMenu={true}
+          anchorRight={false}
+          caret={true}
+          className="btn btn-default btn-sm"
+          disabled={false}
+          key="resolve-dropdown"
+          title=""
+        >
+          <DropdownMenu
             alwaysRenderMenu={true}
-            anchorRight={false}
-            caret={true}
-            className="btn btn-default btn-sm"
-            disabled={false}
-            key="resolve-dropdown"
-            title=""
+            closeOnEscape={true}
+            keepMenuOpen={false}
           >
-            <DropdownMenu
-              alwaysRenderMenu={true}
-              closeOnEscape={true}
-              keepMenuOpen={false}
+            <span
+              className="dropdown"
             >
-              <span
-                className="dropdown"
-              >
-                <a
-                  className="dropdown-actor btn btn-default btn-sm dropdown-toggle"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  style={
-                    Object {
-                      "outline": "none",
-                    }
+              <a
+                className="dropdown-actor btn btn-default btn-sm dropdown-toggle"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "outline": "none",
                   }
+                }
+              >
+                <div
+                  className="dropdown-actor-title"
                 >
-                  <div
-                    className="dropdown-actor-title"
-                  >
-                    <span />
-                    <i
-                      className="icon-arrow-down"
-                    />
-                  </div>
-                </a>
-                <ul
-                  className="dropdown-menu"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
+                  <span />
+                  <i
+                    className="icon-arrow-down"
+                  />
+                </div>
+              </a>
+              <ul
+                className="dropdown-menu"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                <MenuItem
+                  header={true}
                 >
-                  <MenuItem
-                    header={true}
+                  <li
+                    className="dropdown-header"
+                    role="presentation"
                   >
-                    <li
-                      className="dropdown-header"
-                      role="presentation"
-                    >
-                      Resolved In
-                    </li>
-                  </MenuItem>
-                  <MenuItem
-                    noAnchor={true}
+                    Resolved In
+                  </li>
+                </MenuItem>
+                <MenuItem
+                  noAnchor={true}
+                >
+                  <li
+                    className=""
+                    role="presentation"
                   >
-                    <li
-                      className=""
-                      role="presentation"
+                    <Tooltip
+                      containerDisplayMode="block"
+                      position="top"
+                      title="Set up release tracking in order to use this feature."
                     >
-                      <Tooltip
-                        containerDisplayMode="block"
-                        position="top"
-                        title="Set up release tracking in order to use this feature."
-                      >
-                        <Manager>
-                          <Reference>
-                            <InnerReference
-                              setReferenceNode={[Function]}
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
+                          >
+                            <Container
+                              aria-describedby="tooltip-123456"
+                              containerDisplayMode="block"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
                             >
-                              <Container
+                              <span
                                 aria-describedby="tooltip-123456"
-                                containerDisplayMode="block"
+                                className="css-11k874n-Container eowlwvy0"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <span
-                                  aria-describedby="tooltip-123456"
-                                  className="css-11k874n-Container eowlwvy0"
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
+                                <ActionLink
+                                  confirmLabel="Resolve"
+                                  disabled={false}
+                                  message="Are you sure???"
+                                  onAction={[Function]}
+                                  shouldConfirm={true}
+                                  title="The next release"
                                 >
-                                  <ActionLink
-                                    confirmLabel="Resolve"
-                                    disabled={false}
+                                  <Confirm
+                                    cancelText="Cancel"
+                                    confirmText="Resolve"
+                                    disableConfirmButton={false}
                                     message="Are you sure???"
-                                    onAction={[Function]}
-                                    shouldConfirm={true}
-                                    title="The next release"
+                                    onConfirm={[Function]}
+                                    priority="primary"
+                                    stopPropagation={false}
                                   >
-                                    <Confirm
-                                      cancelText="Cancel"
-                                      confirmText="Resolve"
-                                      disableConfirmButton={false}
-                                      message="Are you sure???"
-                                      onConfirm={[Function]}
-                                      priority="primary"
-                                      stopPropagation={false}
+                                    <a
+                                      aria-label="The next release"
+                                      onClick={[Function]}
+                                      title="The next release"
                                     >
-                                      <a
-                                        aria-label="The next release"
-                                        onClick={[Function]}
-                                        title="The next release"
-                                      >
-                                         
-                                        The next release
-                                      </a>
+                                       
+                                      The next release
+                                    </a>
+                                    <Modal
+                                      animation={false}
+                                      autoFocus={true}
+                                      backdrop={true}
+                                      bsClass="modal"
+                                      dialogComponentClass={[Function]}
+                                      enforceFocus={true}
+                                      keyboard={true}
+                                      manager={
+                                        ModalManager {
+                                          "add": [Function],
+                                          "containers": Array [],
+                                          "data": Array [],
+                                          "handleContainerOverflow": true,
+                                          "hideSiblingNodes": true,
+                                          "isTopModal": [Function],
+                                          "modals": Array [],
+                                          "remove": [Function],
+                                        }
+                                      }
+                                      onHide={[Function]}
+                                      renderBackdrop={[Function]}
+                                      restoreFocus={true}
+                                      show={false}
+                                    >
                                       <Modal
-                                        animation={false}
                                         autoFocus={true}
                                         backdrop={true}
-                                        bsClass="modal"
-                                        dialogComponentClass={[Function]}
+                                        backdropClassName="modal-backdrop"
+                                        containerClassName="modal-open"
                                         enforceFocus={true}
                                         keyboard={true}
                                         manager={
@@ -312,103 +333,103 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                                             "remove": [Function],
                                           }
                                         }
+                                        onEntering={[Function]}
+                                        onExited={[Function]}
                                         onHide={[Function]}
                                         renderBackdrop={[Function]}
                                         restoreFocus={true}
                                         show={false}
-                                      >
-                                        <Modal
-                                          autoFocus={true}
-                                          backdrop={true}
-                                          backdropClassName="modal-backdrop"
-                                          containerClassName="modal-open"
-                                          enforceFocus={true}
-                                          keyboard={true}
-                                          manager={
-                                            ModalManager {
-                                              "add": [Function],
-                                              "containers": Array [],
-                                              "data": Array [],
-                                              "handleContainerOverflow": true,
-                                              "hideSiblingNodes": true,
-                                              "isTopModal": [Function],
-                                              "modals": Array [],
-                                              "remove": [Function],
-                                            }
-                                          }
-                                          onEntering={[Function]}
-                                          onExited={[Function]}
-                                          onHide={[Function]}
-                                          renderBackdrop={[Function]}
-                                          restoreFocus={true}
-                                          show={false}
-                                        />
-                                      </Modal>
-                                    </Confirm>
-                                  </ActionLink>
-                                </span>
-                              </Container>
-                            </InnerReference>
-                          </Reference>
-                        </Manager>
-                      </Tooltip>
-                      <Tooltip
-                        containerDisplayMode="block"
-                        position="top"
-                        title="Set up release tracking in order to use this feature."
-                      >
-                        <Manager>
-                          <Reference>
-                            <InnerReference
-                              setReferenceNode={[Function]}
+                                      />
+                                    </Modal>
+                                  </Confirm>
+                                </ActionLink>
+                              </span>
+                            </Container>
+                          </InnerReference>
+                        </Reference>
+                      </Manager>
+                    </Tooltip>
+                    <Tooltip
+                      containerDisplayMode="block"
+                      position="top"
+                      title="Set up release tracking in order to use this feature."
+                    >
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
+                          >
+                            <Container
+                              aria-describedby="tooltip-123456"
+                              containerDisplayMode="block"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
                             >
-                              <Container
+                              <span
                                 aria-describedby="tooltip-123456"
-                                containerDisplayMode="block"
+                                className="css-11k874n-Container eowlwvy0"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <span
-                                  aria-describedby="tooltip-123456"
-                                  className="css-11k874n-Container eowlwvy0"
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
+                                <ActionLink
+                                  confirmLabel="Resolve"
+                                  disabled={false}
+                                  message="Are you sure???"
+                                  onAction={[Function]}
+                                  shouldConfirm={true}
+                                  title="The current release"
                                 >
-                                  <ActionLink
-                                    confirmLabel="Resolve"
-                                    disabled={false}
+                                  <Confirm
+                                    cancelText="Cancel"
+                                    confirmText="Resolve"
+                                    disableConfirmButton={false}
                                     message="Are you sure???"
-                                    onAction={[Function]}
-                                    shouldConfirm={true}
-                                    title="The current release"
+                                    onConfirm={[Function]}
+                                    priority="primary"
+                                    stopPropagation={false}
                                   >
-                                    <Confirm
-                                      cancelText="Cancel"
-                                      confirmText="Resolve"
-                                      disableConfirmButton={false}
-                                      message="Are you sure???"
-                                      onConfirm={[Function]}
-                                      priority="primary"
-                                      stopPropagation={false}
+                                    <a
+                                      aria-label="The current release"
+                                      onClick={[Function]}
+                                      title="The current release"
                                     >
-                                      <a
-                                        aria-label="The current release"
-                                        onClick={[Function]}
-                                        title="The current release"
-                                      >
-                                         
-                                        The current release
-                                      </a>
+                                       
+                                      The current release
+                                    </a>
+                                    <Modal
+                                      animation={false}
+                                      autoFocus={true}
+                                      backdrop={true}
+                                      bsClass="modal"
+                                      dialogComponentClass={[Function]}
+                                      enforceFocus={true}
+                                      keyboard={true}
+                                      manager={
+                                        ModalManager {
+                                          "add": [Function],
+                                          "containers": Array [],
+                                          "data": Array [],
+                                          "handleContainerOverflow": true,
+                                          "hideSiblingNodes": true,
+                                          "isTopModal": [Function],
+                                          "modals": Array [],
+                                          "remove": [Function],
+                                        }
+                                      }
+                                      onHide={[Function]}
+                                      renderBackdrop={[Function]}
+                                      restoreFocus={true}
+                                      show={false}
+                                    >
                                       <Modal
-                                        animation={false}
                                         autoFocus={true}
                                         backdrop={true}
-                                        bsClass="modal"
-                                        dialogComponentClass={[Function]}
+                                        backdropClassName="modal-backdrop"
+                                        containerClassName="modal-open"
                                         enforceFocus={true}
                                         keyboard={true}
                                         manager={
@@ -423,113 +444,88 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                                             "remove": [Function],
                                           }
                                         }
+                                        onEntering={[Function]}
+                                        onExited={[Function]}
                                         onHide={[Function]}
                                         renderBackdrop={[Function]}
                                         restoreFocus={true}
                                         show={false}
-                                      >
-                                        <Modal
-                                          autoFocus={true}
-                                          backdrop={true}
-                                          backdropClassName="modal-backdrop"
-                                          containerClassName="modal-open"
-                                          enforceFocus={true}
-                                          keyboard={true}
-                                          manager={
-                                            ModalManager {
-                                              "add": [Function],
-                                              "containers": Array [],
-                                              "data": Array [],
-                                              "handleContainerOverflow": true,
-                                              "hideSiblingNodes": true,
-                                              "isTopModal": [Function],
-                                              "modals": Array [],
-                                              "remove": [Function],
-                                            }
-                                          }
-                                          onEntering={[Function]}
-                                          onExited={[Function]}
-                                          onHide={[Function]}
-                                          renderBackdrop={[Function]}
-                                          restoreFocus={true}
-                                          show={false}
-                                        />
-                                      </Modal>
-                                    </Confirm>
-                                  </ActionLink>
-                                </span>
-                              </Container>
-                            </InnerReference>
-                          </Reference>
-                        </Manager>
-                      </Tooltip>
-                      <Tooltip
-                        containerDisplayMode="block"
-                        position="top"
-                        title="Set up release tracking in order to use this feature."
-                      >
-                        <Manager>
-                          <Reference>
-                            <InnerReference
-                              setReferenceNode={[Function]}
+                                      />
+                                    </Modal>
+                                  </Confirm>
+                                </ActionLink>
+                              </span>
+                            </Container>
+                          </InnerReference>
+                        </Reference>
+                      </Manager>
+                    </Tooltip>
+                    <Tooltip
+                      containerDisplayMode="block"
+                      position="top"
+                      title="Set up release tracking in order to use this feature."
+                    >
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
+                          >
+                            <Container
+                              aria-describedby="tooltip-123456"
+                              containerDisplayMode="block"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
                             >
-                              <Container
+                              <span
                                 aria-describedby="tooltip-123456"
-                                containerDisplayMode="block"
+                                className="css-11k874n-Container eowlwvy0"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <span
-                                  aria-describedby="tooltip-123456"
-                                  className="css-11k874n-Container eowlwvy0"
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
+                                <ActionLink
+                                  confirmLabel="Resolve"
+                                  disabled={false}
+                                  message="Are you sure???"
+                                  onAction={[Function]}
+                                  shouldConfirm={false}
+                                  title="Another version"
                                 >
-                                  <ActionLink
-                                    confirmLabel="Resolve"
+                                  <ActionLinkAnchor
+                                    aria-label="Another version"
+                                    className=""
+                                    data-test-id="action-link-another-version"
                                     disabled={false}
-                                    message="Are you sure???"
-                                    onAction={[Function]}
-                                    shouldConfirm={false}
-                                    title="Another version"
+                                    onClick={[Function]}
                                   >
-                                    <ActionLinkAnchor
+                                    <a
                                       aria-label="Another version"
-                                      className=""
+                                      className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
                                       data-test-id="action-link-another-version"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <a
-                                        aria-label="Another version"
-                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
-                                        data-test-id="action-link-another-version"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                      >
-                                        Another version…
-                                      </a>
-                                    </ActionLinkAnchor>
-                                  </ActionLink>
-                                </span>
-                              </Container>
-                            </InnerReference>
-                          </Reference>
-                        </Manager>
-                      </Tooltip>
-                    </li>
-                  </MenuItem>
-                </ul>
-              </span>
-            </DropdownMenu>
-          </DropdownLink>
-        </div>
-      </Tooltip>
-    </GuideAnchor>
+                                      Another version…
+                                    </a>
+                                  </ActionLinkAnchor>
+                                </ActionLink>
+                              </span>
+                            </Container>
+                          </InnerReference>
+                        </Reference>
+                      </Manager>
+                    </Tooltip>
+                  </li>
+                </MenuItem>
+              </ul>
+            </span>
+          </DropdownMenu>
+        </DropdownLink>
+      </div>
+    </Tooltip>
   </div>
 </ResolveActions>
 `;
@@ -611,293 +607,289 @@ exports[`ResolveActions without confirmation renders 1`] = `
         />
       </Modal>
     </CustomResolutionModal>
-    <GuideAnchor
-      target="resolve"
+    <Tooltip
+      containerDisplayMode="inline-block"
+      disabled={true}
+      position="top"
+      title="Error fetching project"
     >
-      <Tooltip
-        containerDisplayMode="inline-block"
-        disabled={true}
-        position="top"
-        title="Error fetching project"
+      <div
+        className="btn-group"
       >
-        <div
-          className="btn-group"
+        <ActionLink
+          className="btn btn-default btn-sm"
+          confirmLabel="Resolve"
+          disabled={false}
+          onAction={[Function]}
+          shouldConfirm={false}
+          title="Resolve"
         >
-          <ActionLink
+          <ActionLinkAnchor
+            aria-label="Resolve"
             className="btn btn-default btn-sm"
-            confirmLabel="Resolve"
+            data-test-id="action-link-resolve"
             disabled={false}
-            onAction={[Function]}
-            shouldConfirm={false}
-            title="Resolve"
+            onClick={[Function]}
           >
-            <ActionLinkAnchor
+            <a
               aria-label="Resolve"
-              className="btn btn-default btn-sm"
+              className="btn btn-default btn-sm css-1lugp7w-ActionLinkAnchor ehtyk0g0"
               data-test-id="action-link-resolve"
               disabled={false}
               onClick={[Function]}
             >
-              <a
-                aria-label="Resolve"
-                className="btn btn-default btn-sm css-1lugp7w-ActionLinkAnchor ehtyk0g0"
-                data-test-id="action-link-resolve"
-                disabled={false}
-                onClick={[Function]}
-              >
-                <span
-                  className="icon-checkmark hidden-xs"
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                />
-                Resolve
-              </a>
-            </ActionLinkAnchor>
-          </ActionLink>
-          <DropdownLink
-            alwaysRenderMenu={true}
-            anchorRight={false}
-            caret={true}
-            className="btn btn-default btn-sm"
-            disabled={false}
-            key="resolve-dropdown"
-            title=""
-          >
-            <DropdownMenu
-              alwaysRenderMenu={true}
-              closeOnEscape={true}
-              keepMenuOpen={false}
-            >
               <span
-                className="dropdown"
-              >
-                <a
-                  className="dropdown-actor btn btn-default btn-sm dropdown-toggle"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  style={
-                    Object {
-                      "outline": "none",
-                    }
+                className="icon-checkmark hidden-xs"
+                style={
+                  Object {
+                    "marginRight": 5,
                   }
+                }
+              />
+              Resolve
+            </a>
+          </ActionLinkAnchor>
+        </ActionLink>
+        <DropdownLink
+          alwaysRenderMenu={true}
+          anchorRight={false}
+          caret={true}
+          className="btn btn-default btn-sm"
+          disabled={false}
+          key="resolve-dropdown"
+          title=""
+        >
+          <DropdownMenu
+            alwaysRenderMenu={true}
+            closeOnEscape={true}
+            keepMenuOpen={false}
+          >
+            <span
+              className="dropdown"
+            >
+              <a
+                className="dropdown-actor btn btn-default btn-sm dropdown-toggle"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "outline": "none",
+                  }
+                }
+              >
+                <div
+                  className="dropdown-actor-title"
                 >
-                  <div
-                    className="dropdown-actor-title"
-                  >
-                    <span />
-                    <i
-                      className="icon-arrow-down"
-                    />
-                  </div>
-                </a>
-                <ul
-                  className="dropdown-menu"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
+                  <span />
+                  <i
+                    className="icon-arrow-down"
+                  />
+                </div>
+              </a>
+              <ul
+                className="dropdown-menu"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                <MenuItem
+                  header={true}
                 >
-                  <MenuItem
-                    header={true}
+                  <li
+                    className="dropdown-header"
+                    role="presentation"
                   >
-                    <li
-                      className="dropdown-header"
-                      role="presentation"
-                    >
-                      Resolved In
-                    </li>
-                  </MenuItem>
-                  <MenuItem
-                    noAnchor={true}
+                    Resolved In
+                  </li>
+                </MenuItem>
+                <MenuItem
+                  noAnchor={true}
+                >
+                  <li
+                    className=""
+                    role="presentation"
                   >
-                    <li
-                      className=""
-                      role="presentation"
+                    <Tooltip
+                      containerDisplayMode="block"
+                      position="top"
+                      title="Set up release tracking in order to use this feature."
                     >
-                      <Tooltip
-                        containerDisplayMode="block"
-                        position="top"
-                        title="Set up release tracking in order to use this feature."
-                      >
-                        <Manager>
-                          <Reference>
-                            <InnerReference
-                              setReferenceNode={[Function]}
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
+                          >
+                            <Container
+                              aria-describedby="tooltip-123456"
+                              containerDisplayMode="block"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
                             >
-                              <Container
+                              <span
                                 aria-describedby="tooltip-123456"
-                                containerDisplayMode="block"
+                                className="css-11k874n-Container eowlwvy0"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <span
-                                  aria-describedby="tooltip-123456"
-                                  className="css-11k874n-Container eowlwvy0"
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
+                                <ActionLink
+                                  confirmLabel="Resolve"
+                                  disabled={false}
+                                  onAction={[Function]}
+                                  shouldConfirm={false}
+                                  title="The next release"
                                 >
-                                  <ActionLink
-                                    confirmLabel="Resolve"
+                                  <ActionLinkAnchor
+                                    aria-label="The next release"
+                                    className=""
+                                    data-test-id="action-link-the-next-release"
                                     disabled={false}
-                                    onAction={[Function]}
-                                    shouldConfirm={false}
-                                    title="The next release"
+                                    onClick={[Function]}
                                   >
-                                    <ActionLinkAnchor
+                                    <a
                                       aria-label="The next release"
-                                      className=""
+                                      className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
                                       data-test-id="action-link-the-next-release"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <a
-                                        aria-label="The next release"
-                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
-                                        data-test-id="action-link-the-next-release"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                      >
-                                        The next release
-                                      </a>
-                                    </ActionLinkAnchor>
-                                  </ActionLink>
-                                </span>
-                              </Container>
-                            </InnerReference>
-                          </Reference>
-                        </Manager>
-                      </Tooltip>
-                      <Tooltip
-                        containerDisplayMode="block"
-                        position="top"
-                        title="Set up release tracking in order to use this feature."
-                      >
-                        <Manager>
-                          <Reference>
-                            <InnerReference
-                              setReferenceNode={[Function]}
+                                      The next release
+                                    </a>
+                                  </ActionLinkAnchor>
+                                </ActionLink>
+                              </span>
+                            </Container>
+                          </InnerReference>
+                        </Reference>
+                      </Manager>
+                    </Tooltip>
+                    <Tooltip
+                      containerDisplayMode="block"
+                      position="top"
+                      title="Set up release tracking in order to use this feature."
+                    >
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
+                          >
+                            <Container
+                              aria-describedby="tooltip-123456"
+                              containerDisplayMode="block"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
                             >
-                              <Container
+                              <span
                                 aria-describedby="tooltip-123456"
-                                containerDisplayMode="block"
+                                className="css-11k874n-Container eowlwvy0"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <span
-                                  aria-describedby="tooltip-123456"
-                                  className="css-11k874n-Container eowlwvy0"
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
+                                <ActionLink
+                                  confirmLabel="Resolve"
+                                  disabled={false}
+                                  onAction={[Function]}
+                                  shouldConfirm={false}
+                                  title="The current release"
                                 >
-                                  <ActionLink
-                                    confirmLabel="Resolve"
+                                  <ActionLinkAnchor
+                                    aria-label="The current release"
+                                    className=""
+                                    data-test-id="action-link-the-current-release"
                                     disabled={false}
-                                    onAction={[Function]}
-                                    shouldConfirm={false}
-                                    title="The current release"
+                                    onClick={[Function]}
                                   >
-                                    <ActionLinkAnchor
+                                    <a
                                       aria-label="The current release"
-                                      className=""
+                                      className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
                                       data-test-id="action-link-the-current-release"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <a
-                                        aria-label="The current release"
-                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
-                                        data-test-id="action-link-the-current-release"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                      >
-                                        The current release
-                                      </a>
-                                    </ActionLinkAnchor>
-                                  </ActionLink>
-                                </span>
-                              </Container>
-                            </InnerReference>
-                          </Reference>
-                        </Manager>
-                      </Tooltip>
-                      <Tooltip
-                        containerDisplayMode="block"
-                        position="top"
-                        title="Set up release tracking in order to use this feature."
-                      >
-                        <Manager>
-                          <Reference>
-                            <InnerReference
-                              setReferenceNode={[Function]}
+                                      The current release
+                                    </a>
+                                  </ActionLinkAnchor>
+                                </ActionLink>
+                              </span>
+                            </Container>
+                          </InnerReference>
+                        </Reference>
+                      </Manager>
+                    </Tooltip>
+                    <Tooltip
+                      containerDisplayMode="block"
+                      position="top"
+                      title="Set up release tracking in order to use this feature."
+                    >
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
+                          >
+                            <Container
+                              aria-describedby="tooltip-123456"
+                              containerDisplayMode="block"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
                             >
-                              <Container
+                              <span
                                 aria-describedby="tooltip-123456"
-                                containerDisplayMode="block"
+                                className="css-11k874n-Container eowlwvy0"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <span
-                                  aria-describedby="tooltip-123456"
-                                  className="css-11k874n-Container eowlwvy0"
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
+                                <ActionLink
+                                  confirmLabel="Resolve"
+                                  disabled={false}
+                                  onAction={[Function]}
+                                  shouldConfirm={false}
+                                  title="Another version"
                                 >
-                                  <ActionLink
-                                    confirmLabel="Resolve"
+                                  <ActionLinkAnchor
+                                    aria-label="Another version"
+                                    className=""
+                                    data-test-id="action-link-another-version"
                                     disabled={false}
-                                    onAction={[Function]}
-                                    shouldConfirm={false}
-                                    title="Another version"
+                                    onClick={[Function]}
                                   >
-                                    <ActionLinkAnchor
+                                    <a
                                       aria-label="Another version"
-                                      className=""
+                                      className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
                                       data-test-id="action-link-another-version"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <a
-                                        aria-label="Another version"
-                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
-                                        data-test-id="action-link-another-version"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                      >
-                                        Another version…
-                                      </a>
-                                    </ActionLinkAnchor>
-                                  </ActionLink>
-                                </span>
-                              </Container>
-                            </InnerReference>
-                          </Reference>
-                        </Manager>
-                      </Tooltip>
-                    </li>
-                  </MenuItem>
-                </ul>
-              </span>
-            </DropdownMenu>
-          </DropdownLink>
-        </div>
-      </Tooltip>
-    </GuideAnchor>
+                                      Another version…
+                                    </a>
+                                  </ActionLinkAnchor>
+                                </ActionLink>
+                              </span>
+                            </Container>
+                          </InnerReference>
+                        </Reference>
+                      </Manager>
+                    </Tooltip>
+                  </li>
+                </MenuItem>
+              </ul>
+            </span>
+          </DropdownMenu>
+        </DropdownLink>
+      </div>
+    </Tooltip>
   </div>
 </ResolveActions>
 `;

--- a/tests/js/spec/components/assistant/guideAnchor.spec.jsx
+++ b/tests/js/spec/components/assistant/guideAnchor.spec.jsx
@@ -135,4 +135,20 @@ describe('GuideAnchor', function() {
     expect(wrapper.find('GuideTitle').text()).toBe("Let's Get This Over With");
     expect(wrapper.find('Hovercard').prop('tipColor')).toBe(theme.purple);
   });
+
+  it('renders children when disabled', async function() {
+    const wrapper3 = mountWithTheme(
+      <GuideAnchor disabled target="exception">
+        <div data-test-id="child-div" />
+      </GuideAnchor>,
+      routerContext
+    );
+
+    GuideActions.fetchSucceeded(serverGuide);
+    await tick();
+    wrapper3.update();
+
+    expect(wrapper3.find('Hovercard').exists()).toBe(false);
+    expect(wrapper3.find('[data-test-id="child-div"]').exists()).toBe(true);
+  });
 });

--- a/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
@@ -185,13 +185,19 @@ exports[`SharedGroupDetails renders 1`] = `
                               <div
                                 className="css-j0hue0-StyledEventMessage e1vuddz00"
                               >
-                                <Message>
-                                  <span
-                                    className="css-136mfoi-Message e1vuddz02"
-                                  >
-                                    fetchData(app/components/group/suggestedOwners)
-                                  </span>
-                                </Message>
+                                <GuideAnchor
+                                  disabled={true}
+                                  position="bottom"
+                                  target="issue_title"
+                                >
+                                  <Message>
+                                    <span
+                                      className="css-136mfoi-Message e1vuddz02"
+                                    >
+                                      fetchData(app/components/group/suggestedOwners)
+                                    </span>
+                                  </Message>
+                                </GuideAnchor>
                               </div>
                             </EventMessage>
                           </StyledEventMessage>


### PR DESCRIPTION
Updates the onboarding guides design and content behind an experiment, which hasn't been released yet. Also, adds a guide anchor around the `tags` header on the issue details page and updates other anchor positions. Will follow-up with a PR to add a border around the guide anchor text.

Click through: https://cl.ly/3fd56312d941

<img width="1437" alt="Screen Shot 2020-03-17 at 5 00 37 PM" src="https://user-images.githubusercontent.com/16394317/76913305-d8707d80-6873-11ea-947d-fea505cb4663.png">

Previous
<img width="1439" alt="Screen Shot 2020-03-17 at 5 18 26 PM" src="https://user-images.githubusercontent.com/16394317/76913326-e6be9980-6873-11ea-80dd-9bdb26e87944.png">
