### PR TITLE
perf: Add more endpoints to metric allowed paths

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1788,4 +1788,6 @@ SENTRY_REQUEST_METRIC_ALLOWED_PATHS = (
     "sentry.web.api",
     "sentry.web.frontend",
     "sentry.api.endpoints",
+    "sentry.discover.endpoints",
+    "sentry.incidents.endpoints",
 )


### PR DESCRIPTION
This variable was added recently, adding some more endpoint paths to it. Ideally it probably makes
sense to switch this to a blacklist and just filter out the endpoints we don't want to log stats
for.