### PR TITLE
fix(icon-update): larger integration icons

### DIFF
--- a/src/sentry/static/sentry/app/components/sentryAppIcon.tsx
+++ b/src/sentry/static/sentry/app/components/sentryAppIcon.tsx
@@ -15,13 +15,13 @@ export default class SentryAppIcon extends React.Component<Props> {
   render() {
     switch (this.props.slug) {
       case 'clickup':
-        return <IconClickup size="xs" />;
+        return <IconClickup size="md" />;
       case 'clubhouse':
-        return <IconClubhouse size="xs" />;
+        return <IconClubhouse size="md" />;
       case 'rookout':
-        return <IconRookout size="xs" />;
+        return <IconRookout size="md" />;
       default:
-        return <IconGeneric size="xs" />;
+        return <IconGeneric size="md" />;
     }
   }
 }


### PR DESCRIPTION
**Before:** 
<img width="245" alt="Screen Shot 2020-03-17 at 5 39 54 PM" src="https://user-images.githubusercontent.com/4830259/76914680-3d2dd700-6878-11ea-9cd0-9c456b49b187.png">
