### PR TITLE
fix(migrations): Fixes old EventAttachment migration failing

### DIFF
--- a/src/sentry/migrations/0020_auto_20191125_1420.py
+++ b/src/sentry/migrations/0020_auto_20191125_1420.py
@@ -14,7 +14,8 @@ def backfill_group_ids(model):
     for attachment in RangeQuerySetWrapper(query, step=1000):
         event = eventstore.get_event_by_id(attachment.project_id, attachment.event_id)
         if event:
-            attachment.update(group_id=event.group_id)
+            attachment.group_id = event.group_id
+            attachment.save(update_fields=("group_id",))
 
 
 def forwards(apps, schema_editor):
@@ -37,11 +38,8 @@ class Migration(migrations.Migration):
     # - Adding columns to highly active tables, even ones that are NULL.
     is_dangerous = True
 
-
     dependencies = [
-        ('sentry', '0019_auto_20191114_2040'),
+        ("sentry", "0019_auto_20191114_2040"),
     ]
 
-    operations = [
-        migrations.RunPython(forwards, migrations.RunPython.noop)
-    ]
+    operations = [migrations.RunPython(forwards, migrations.RunPython.noop)]

--- a/src/sentry/migrations/0020_auto_20191125_1420.py
+++ b/src/sentry/migrations/0020_auto_20191125_1420.py
@@ -14,8 +14,7 @@ def backfill_group_ids(model):
     for attachment in RangeQuerySetWrapper(query, step=1000):
         event = eventstore.get_event_by_id(attachment.project_id, attachment.event_id)
         if event:
-            attachment.group_id = event.group_id
-            attachment.save(update_fields=("group_id",))
+            model.objects.filter(id=attachment.id).update(group_id=event.group_id)
 
 
 def forwards(apps, schema_editor):


### PR DESCRIPTION
Reported here: https://forum.sentry.io/t/unable-to-update-version-10-to-latest/9193?u=byk

I suspect this is due to the historical version of the model not having our augmented `update` method on the instance as this migration worked on prod when it was first introduced.