### PR TITLE
ref: Remove IBAN ruletype

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRulesPanel/dataPrivacyRulesPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRulesPanel/dataPrivacyRulesPanel.tsx
@@ -126,7 +126,7 @@ class DataPrivacyRulesPanel extends React.Component<Props, State> {
         ...prevState.rules,
         {
           id: prevState.rules.length + 1,
-          type: RULE_TYPE.IBAN,
+          type: RULE_TYPE.CREDITCARD,
           method: METHOD_TYPE.MASK,
           from: DEFAULT_RULE_FROM_VALUE,
         },

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRulesPanel/utils.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRulesPanel/utils.tsx
@@ -3,7 +3,6 @@ import {t} from 'app/locale';
 enum RULE_TYPE {
   PATTERN = 'pattern',
   CREDITCARD = 'creditcard',
-  IBAN = 'iban',
   PASSWORD = 'password',
   IP = 'ip',
   IMEI = 'imei',
@@ -47,8 +46,6 @@ function getRuleTypeSelectorFieldLabel(labelType: RULE_TYPE): string {
       return t('UUIDs');
     case RULE_TYPE.CREDITCARD:
       return t('Credit Card Number');
-    case RULE_TYPE.IBAN:
-      return t('IBAN bank accounts');
     case RULE_TYPE.PASSWORD:
       return t('Password fields');
     case RULE_TYPE.IP:


### PR DESCRIPTION
Remove IBAN as it is not actually implemented on the serverside, it only existed as part of mockups. Configuring it will do nothing. Also creditcard is probably a better default as more people know what a CC number is.