### PR TITLE
feat(workflow): Incident rollup calculation

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -67,7 +67,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
             interval = timedelta(hours=1)
 
         date_range = params["end"] - params["start"]
-        if date_range.total_seconds() / interval.total_seconds() > snuba.MAX_DATA_POINTS:
+        if date_range.total_seconds() / interval.total_seconds() > snuba.MAX_TIMESERIES_RESULTS:
             raise InvalidSearchQuery(
                 "Your interval and date range would create too many results. "
                 "Use a larger interval, or a smaller date range."

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -16,11 +16,6 @@ from sentry.utils import snuba
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.compat import zip
 
-# Maximum number of results we are willing to fetch.
-# Clients should adapt the interval width based on their
-# display width.
-MAX_POINTS = 4500
-
 
 class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
@@ -72,7 +67,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
             interval = timedelta(hours=1)
 
         date_range = params["end"] - params["start"]
-        if date_range.total_seconds() / interval.total_seconds() > MAX_POINTS:
+        if date_range.total_seconds() / interval.total_seconds() > snuba.MAX_DATA_POINTS:
             raise InvalidSearchQuery(
                 "Your interval and date range would create too many results. "
                 "Use a larger interval, or a smaller date range."

--- a/src/sentry/api/endpoints/organization_incident_index.py
+++ b/src/sentry/api/endpoints/organization_incident_index.py
@@ -77,14 +77,6 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
             elif query_status == "closed":
                 incidents = incidents.filter(status=IncidentStatus.CLOSED.value)
 
-        projects = request.GET.get("projects")
-        if projects is not None:
-            incidents = incidents.filter(projects__in=projects)
-
-        environments = request.GET.get("environments")
-        if environments is not None:
-            incidents = incidents.filter(environments__in=environments)
-
         return self.paginate(
             request,
             queryset=incidents,

--- a/src/sentry/api/endpoints/organization_incident_index.py
+++ b/src/sentry/api/endpoints/organization_incident_index.py
@@ -77,6 +77,14 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
             elif query_status == "closed":
                 incidents = incidents.filter(status=IncidentStatus.CLOSED.value)
 
+        projects = request.GET.get("projects")
+        if projects is not None:
+            incidents = incidents.filter(projects__in=projects)
+
+        environments = request.GET.get("environments")
+        if environments is not None:
+            incidents = incidents.filter(environments__in=environments)
+
         return self.paginate(
             request,
             queryset=incidents,

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -41,7 +41,12 @@ from sentry.snuba.subscriptions import (
     bulk_update_snuba_subscriptions,
     query_aggregation_to_snuba,
 )
-from sentry.utils.snuba import bulk_raw_query, SnubaQueryParams, SnubaTSResult, MAX_DATA_POINTS
+from sentry.utils.snuba import (
+    bulk_raw_query,
+    SnubaQueryParams,
+    SnubaTSResult,
+    MAX_TIMESERIES_RESULTS,
+)
 from sentry.utils.compat import zip
 
 
@@ -335,7 +340,7 @@ def calculate_incident_rollup(incident):
     stat's on a graph. It prioritized a rollup at the rule's time_window,
     to be consistent with the builder and more easily understand when/where
     thresholds are passed. This works for most cases, except for incidents
-    with a long duration and small time window (Results are more than MAX_DATA_POINTS - bad)
+    with a long duration and small time window (Results are more than MAX_TIMESERIES_RESULTS - bad)
     or a short duration and long time window (Very few to no data points - bad).
     In those cases, we just choose a rollup that results in a reasonable graph.
     Note: time_window is in minutes, rollup is in seconds.
@@ -344,10 +349,10 @@ def calculate_incident_rollup(incident):
     if alert_rule:
         # When we persist a rule's time_window, switch to using the persisted data.
         rollup = alert_rule.time_window * 60
-        while ((incident.duration.total_seconds()) / rollup) > MAX_DATA_POINTS:
+        while ((incident.duration.total_seconds()) / rollup) > MAX_TIMESERIES_RESULTS:
             rollup = rollup * 2
     else:
-        rollup = max(int(incident.duration.total_seconds() / 200), 1)
+        rollup = max(int(incident.duration.total_seconds() / 50), 1)
 
     return rollup
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -342,13 +342,12 @@ def calculate_incident_rollup(incident):
     """
     alert_rule = incident.alert_rule
     if alert_rule:
-        rollup = (
-            alert_rule.time_window * 60
-        )  # When we persist a rule's time_window, switch to using the persisted data.
+        # When we persist a rule's time_window, switch to using the persisted data.
+        rollup = alert_rule.time_window * 60
         while ((incident.duration.total_seconds()) / rollup) > MAX_DATA_POINTS:
             rollup = rollup * 2
     else:
-        rollup = max(int((incident.duration.total_seconds())) / 100, 1)
+        rollup = max(int(incident.duration.total_seconds() / 200), 1)
 
     return rollup
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -361,7 +361,7 @@ def calculate_incident_prewindow(start, end, incident=None):
     return prewindow
 
 
-def get_incident_event_stats(incident, start=None, end=None, data_points=50, prewindow=False):
+def get_incident_event_stats(incident, start=None, end=None, prewindow=False):
     """
     Gets event stats for an incident. If start/end are provided, uses that time
     period, otherwise uses the incident start/current_end.
@@ -369,10 +369,10 @@ def get_incident_event_stats(incident, start=None, end=None, data_points=50, pre
     query_params = bulk_build_incident_query_params(
         [incident], start=start, end=end, prewindow=prewindow
     )
-    return bulk_get_incident_event_stats([incident], query_params, data_points=data_points)[0]
+    return bulk_get_incident_event_stats([incident], query_params)[0]
 
 
-def bulk_get_incident_event_stats(incidents, query_params_list, data_points=50):
+def bulk_get_incident_event_stats(incidents, query_params_list):
     snuba_params_list = [
         SnubaQueryParams(
             aggregations=[

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -347,12 +347,13 @@ def calculate_incident_rollup(incident):
     """
     alert_rule = incident.alert_rule
     if alert_rule:
-        # When we persist a rule's time_window, switch to using the persisted data.
+        # TODO: When we persist a rule's time_window, switch to using the persisted data.
         rollup = alert_rule.time_window * 60
-        while ((incident.duration.total_seconds()) / rollup) > MAX_TIMESERIES_RESULTS:
-            rollup = rollup * 2
     else:
         rollup = max(int(incident.duration.total_seconds() / 50), 1)
+
+    while ((incident.duration.total_seconds()) / rollup) > MAX_TIMESERIES_RESULTS:
+        rollup = rollup * 2
 
     return rollup
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -347,10 +347,10 @@ def calculate_incident_rollup(incident):
     """
     alert_rule = incident.alert_rule
     if alert_rule:
-        # TODO: When we persist a rule's time_window, switch to using the persisted data.
+        # TODO: When we persist a rule's time window, switch to using the persisted data.
         rollup = alert_rule.time_window * 60
     else:
-        rollup = max(int(incident.duration.total_seconds() / 50), 1)
+        rollup = 300  # max(int(incident.duration.total_seconds() / 50), 1)
 
     while ((incident.duration.total_seconds()) / rollup) > MAX_TIMESERIES_RESULTS:
         rollup = rollup * 2

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -350,7 +350,7 @@ def calculate_incident_rollup(incident):
         # TODO: When we persist a rule's time window, switch to using the persisted data.
         rollup = alert_rule.time_window * 60
     else:
-        rollup = 300  # max(int(incident.duration.total_seconds() / 50), 1)
+        rollup = max(int(incident.duration.total_seconds() / 50), 1)
 
     while ((incident.duration.total_seconds()) / rollup) > MAX_TIMESERIES_RESULTS:
         rollup = rollup * 2

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -36,6 +36,19 @@ type Props = {
 } & RouteComponentProps<{alertId: string; orgId: string}, {}>;
 
 export default class DetailsBody extends React.Component<Props> {
+  /**
+   *  Return a string representing the time in seconds between two incident data points
+   */
+  calculateTimeWindowString(incident: Incident) {
+    if (incident.eventStats.data.length >= 2) {
+      return `${incident.eventStats.data[1][0] - incident.eventStats.data[0][0]}s`;
+    } else if (incident.alertRule) {
+      return `${incident.alertRule.timeWindow}m`;
+    } else {
+      return '10m';
+    }
+  }
+
   getDiscoverUrl(projects: Project[]) {
     const {incident, params} = this.props;
     const {orgId} = params;
@@ -44,7 +57,7 @@ export default class DetailsBody extends React.Component<Props> {
       return '';
     }
 
-    const timeWindowString = `${incident.alertRule.timeWindow}m`;
+    const timeWindowString = this.calculateTimeWindowString(incident);
     const timeWindowInMs = intervalToMilliseconds(timeWindowString);
     const startBeforeTimeWindow = moment(incident.dateStarted).subtract(
       timeWindowInMs,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -43,7 +43,7 @@ MAX_HASHES = 5000
 # Maximum number of results we are willing to fetch.
 # Clients should adapt the interval width based on their
 # display width.
-MAX_DATA_POINTS = 4500
+MAX_TIMESERIES_RESULTS = 4500
 
 SAFE_FUNCTION_RE = re.compile(r"-?[a-zA-Z_][a-zA-Z0-9_]*$")
 QUOTED_LITERAL_RE = re.compile(r"^'.*'$")

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -40,6 +40,11 @@ from sentry.utils.compat import map
 MAX_ISSUES = 500
 MAX_HASHES = 5000
 
+# Maximum number of results we are willing to fetch.
+# Clients should adapt the interval width based on their
+# display width.
+MAX_DATA_POINTS = 4500
+
 SAFE_FUNCTION_RE = re.compile(r"-?[a-zA-Z_][a-zA-Z0-9_]*$")
 QUOTED_LITERAL_RE = re.compile(r"^'.*'$")
 

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -21,7 +21,9 @@ class IncidentSerializerTest(TestCase):
     def test_simple(self):
         incident = self.create_incident(date_started=timezone.now() - timedelta(minutes=5))
         result = serialize(incident)
-
+        print ("incident:", incident)
+        print ("incident:", incident.alert_rule)
+        print ("incident:", incident.duration.total_seconds())
         assert result["id"] == six.text_type(incident.id)
         assert result["identifier"] == six.text_type(incident.identifier)
         assert result["organizationId"] == six.text_type(incident.organization_id)

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -21,9 +21,6 @@ class IncidentSerializerTest(TestCase):
     def test_simple(self):
         incident = self.create_incident(date_started=timezone.now() - timedelta(minutes=5))
         result = serialize(incident)
-        print ("incident:", incident)
-        print ("incident:", incident.alert_rule)
-        print ("incident:", incident.duration.total_seconds())
         assert result["id"] == six.text_type(incident.id)
         assert result["identifier"] == six.text_type(incident.identifier)
         assert result["organizationId"] == six.text_type(incident.organization_id)

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -261,8 +261,8 @@ class GetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
             kwargs["end"] = end
 
         result = get_incident_event_stats(incident, **kwargs)
-        # Duration of 300s / 200 data points
-        assert result.rollup == 1
+        # Duration of 300s / 50 data points
+        assert result.rollup == 6
         expected_start = start if start else incident.date_started
         expected_end = end if end else incident.current_end_date
         assert result.start == expected_start
@@ -271,8 +271,8 @@ class GetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
 
         # A prewindow version of the same test:
         result = get_incident_event_stats(incident, prewindow=True, **kwargs)
-        # Duration of 300s / 200 data points
-        assert result.rollup == 1
+        # Duration of 300s / 50 data points
+        assert result.rollup == 6
         expected_start = start if start else incident.date_started
         expected_end = end if end else incident.current_end_date
         expected_start = expected_start - calculate_incident_prewindow(

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -298,8 +298,8 @@ class BulkGetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
         )
         results = bulk_get_incident_event_stats(incidents, query_params_list)
         for incident, result, expected_results in zip(incidents, results, expected_results_list):
-            # Duration of 300s / 200 data points
-            assert result.rollup == 1
+            # Duration of 300s / 50 data points
+            assert result.rollup == 6
             expected_start = start if start else incident.date_started
             expected_end = end if end else incident.current_end_date
             assert result.start == expected_start
@@ -312,8 +312,8 @@ class BulkGetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
         )
         results = bulk_get_incident_event_stats(incidents, query_params_list)
         for incident, result, expected_results in zip(incidents, results, expected_results_list):
-            # Duration of 300s / 200 data points
-            assert result.rollup == 1
+            # Duration of 300s / 50 data points
+            assert result.rollup == 6
             expected_start = start if start else incident.date_started
             expected_end = end if end else incident.current_end_date
             expected_start = expected_start - calculate_incident_prewindow(
@@ -384,8 +384,8 @@ class BulkGetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
             projects=[other_project],
             groups=[],
         )
-        # Should work off duration to provide a rollup with 200 datapoints:
-        assert calculate_incident_rollup(no_rule_incident) == 129600
+        # Should work off duration to provide a rollup with 50 datapoints:
+        assert calculate_incident_rollup(no_rule_incident) == 518400
 
 
 class BaseIncidentAggregatesTest(BaseIncidentsTest):


### PR DESCRIPTION
When viewing an incident's details, the graph often has irregular intervals and strange buckets. This can be hard to read and/or understand. Furthermore, when a user navigates through to discover using our "View on Discover" link, it tends to be appear better (but most notably: _different_) with regular buckets and distribution of data points - thus making our alert's graph feel less than polished.

In addition, the "time ranges" of the graph appeared to be different - one starting at 1:56PM and another at 2:20PM and ending similarly. Upon investigation, this was related to bucketing and the graph's were found to be fed the same start/end times (the graph was simply displaying the nearest bucket).

This PR attempts to resolve this bucketing issue.

It does so by changing the way we're calculating the rollup in the backend. It was previously based on the alerts duration and a number of data points (default=50), but we now attempt to make it equal to the alert rules time window, and only adjust if it would result in too many points (> 4500, same constant as discover uses). 

The frontend has been using the rule's time window as an interval to send to discover, but this can now be inaccurate and result in a different graph. To solve this, we also now calculate the rollup on the front end to send as an `interval` to discover. This calculation happens by finding the difference in time between two data points on the alert.

One caveat, since you can still delete a rule, we fallback to random rollups that create 200 data points if the rule is not available.