### PR TITLE
fix(ui): Add better missing messages to Debug Images

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryDevice.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryDevice.tsx
@@ -8,6 +8,7 @@ import {getMeta} from 'app/components/events/meta/metaProxy';
 import AnnotatedText from 'app/components/events/meta/annotatedText';
 import DeviceName from 'app/components/deviceName';
 import space from 'app/styles/space';
+import {ParagraphOverflow} from 'app/components/textOverflow';
 
 import generateClassName from './generateClassName';
 import ContextSummaryNoSummary from './contextSummaryNoSummary';
@@ -88,7 +89,7 @@ const ContextSummaryDevice = ({data}: Props) => {
       <span className="context-item-icon" />
       <h3>{renderName()}</h3>
       {subTitle && (
-        <p>
+        <ParagraphOverflow>
           <Subject>{subTitle.subject}</Subject>
           {subTitle.meta ? (
             <AnnotatedText
@@ -100,7 +101,7 @@ const ContextSummaryDevice = ({data}: Props) => {
           ) : (
             subTitle.value
           )}
-        </p>
+        </ParagraphOverflow>
       )}
     </div>
   );

--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryGPU.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryGPU.tsx
@@ -7,6 +7,7 @@ import {Meta} from 'app/types';
 import {getMeta} from 'app/components/events/meta/metaProxy';
 import AnnotatedText from 'app/components/events/meta/annotatedText';
 import space from 'app/styles/space';
+import {ParagraphOverflow} from 'app/components/textOverflow';
 
 import ContextSummaryNoSummary from './contextSummaryNoSummary';
 import generateClassName from './generateClassName';
@@ -71,7 +72,7 @@ const ContextSummaryGPU = ({data}: Props) => {
     <div className={`context-item ${className}`}>
       <span className="context-item-icon" />
       <h3>{renderName()}</h3>
-      <p>
+      <ParagraphOverflow>
         <Subject>{versionElement.subject}</Subject>
         {versionElement.meta ? (
           <AnnotatedText
@@ -83,7 +84,7 @@ const ContextSummaryGPU = ({data}: Props) => {
         ) : (
           versionElement.value
         )}
-      </p>
+      </ParagraphOverflow>
     </div>
   );
 };

--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryGeneric.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryGeneric.tsx
@@ -5,6 +5,7 @@ import {t} from 'app/locale';
 import {getMeta} from 'app/components/events/meta/metaProxy';
 import AnnotatedText from 'app/components/events/meta/annotatedText';
 import space from 'app/styles/space';
+import {ParagraphOverflow} from 'app/components/textOverflow';
 
 import ContextSummaryNoSummary from './contextSummaryNoSummary';
 import generateClassName from './generateClassName';
@@ -46,10 +47,10 @@ const ContextSummaryGeneric = ({data, unknownTitle}: Props) => {
     <div className={`context-item ${className}`}>
       <span className="context-item-icon" />
       <h3>{renderValue('name')}</h3>
-      <p>
+      <ParagraphOverflow>
         <Subject>{t('Version:')}</Subject>
         {!data.version ? t('Unknown') : renderValue('version')}
-      </p>
+      </ParagraphOverflow>
     </div>
   );
 };

--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryOS.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryOS.tsx
@@ -7,6 +7,7 @@ import {Meta} from 'app/types';
 import {getMeta} from 'app/components/events/meta/metaProxy';
 import AnnotatedText from 'app/components/events/meta/annotatedText';
 import space from 'app/styles/space';
+import {ParagraphOverflow} from 'app/components/textOverflow';
 
 import ContextSummaryNoSummary from './contextSummaryNoSummary';
 import generateClassName from './generateClassName';
@@ -78,7 +79,7 @@ const ContextSummaryOS = ({data}: Props) => {
     <div className={`context-item ${className}`}>
       <span className="context-item-icon" />
       <h3>{renderName()}</h3>
-      <p>
+      <ParagraphOverflow>
         <Subject>{versionElement.subject}</Subject>
         {versionElement.meta ? (
           <AnnotatedText
@@ -90,7 +91,7 @@ const ContextSummaryOS = ({data}: Props) => {
         ) : (
           versionElement.value
         )}
-      </p>
+      </ParagraphOverflow>
     </div>
   );
 };

--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryUser.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryUser.tsx
@@ -8,6 +8,7 @@ import UserAvatar from 'app/components/avatar/userAvatar';
 import {getMeta} from 'app/components/events/meta/metaProxy';
 import AnnotatedText from 'app/components/events/meta/annotatedText';
 import space from 'app/styles/space';
+import {ParagraphOverflow} from 'app/components/textOverflow';
 
 import ContextSummaryNoSummary from './contextSummaryNoSummary';
 
@@ -47,7 +48,7 @@ const ContextSummaryUser = ({data}: Props) => {
     }
 
     return (
-      <p>
+      <ParagraphOverflow>
         <Subject>{userDetails.subject}</Subject>
         {userDetails.meta ? (
           <AnnotatedText
@@ -59,7 +60,7 @@ const ContextSummaryUser = ({data}: Props) => {
         ) : (
           userDetails.value
         )}
-      </p>
+      </ParagraphOverflow>
     );
   };
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -21,7 +21,7 @@ import {
   getImageRange,
 } from 'app/components/events/interfaces/utils';
 import ImageForBar from 'app/components/events/interfaces/imageForBar';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 
 const IMAGE_ADDR_LEN = 12;
@@ -348,6 +348,10 @@ class DebugMetaInterface extends React.PureComponent {
     this.setState({showUnused});
   };
 
+  handleShowUnused = () => {
+    this.setState({showUnused: true});
+  };
+
   handleChangeShowDetails = e => {
     const showDetails = e.target.checked;
     this.setState({showDetails});
@@ -387,6 +391,25 @@ class DebugMetaInterface extends React.PureComponent {
     return filtered;
   }
 
+  getNoImagesMessage(images) {
+    const {filter, showUnused} = this.state;
+
+    if (images.length === 0) {
+      return t('No loaded images available.');
+    }
+
+    if (!showUnused && !filter) {
+      return tct(
+        'No images are referenced in the stack trace. [toggle: Show Unreferenced]',
+        {
+          toggle: <Button size="large" priority="link" onClick={this.handleShowUnused} />,
+        }
+      );
+    }
+
+    return t('Sorry, no images match your query.');
+  }
+
   renderToolbar() {
     const {filter, showDetails, showUnused} = this.state;
     return (
@@ -419,9 +442,6 @@ class DebugMetaInterface extends React.PureComponent {
   render() {
     // skip null values indicating invalid debug images
     const images = this.getDebugImages();
-    if (images.length === 0) {
-      return null;
-    }
 
     const filteredImages = images.filter(image => this.filterImage(image));
 
@@ -465,7 +485,7 @@ class DebugMetaInterface extends React.PureComponent {
             ) : (
               <EmptyItem>
                 <ImageIcon type="muted" src="icon-circle-exclamation" />{' '}
-                {t('Sorry, no images match your query.')}
+                {this.getNoImagesMessage(images)}
               </EmptyItem>
             )}
           </PanelBody>

--- a/src/sentry/static/sentry/app/components/textOverflow.tsx
+++ b/src/sentry/static/sentry/app/components/textOverflow.tsx
@@ -1,9 +1,18 @@
 import styled from '@emotion/styled';
 
-const TextOverflow = styled('div')`
+const overflow = `
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
 `;
 
+const TextOverflow = styled('div')`
+  ${overflow}
+`;
+
+const ParagraphOverflow = styled('p')`
+  ${overflow}
+`;
+
+export {TextOverflow, ParagraphOverflow};
 export default TextOverflow;

--- a/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
@@ -286,12 +286,12 @@ exports[`GpuSummary render() renders name and vendor 1`] = `
   <h3>
     Mali-T880
   </h3>
-  <p>
+  <ParagraphOverflow>
     <Subject>
       Vendor:
     </Subject>
     ARM
-  </p>
+  </ParagraphOverflow>
 </div>
 `;
 
@@ -305,12 +305,12 @@ exports[`GpuSummary render() renders unknown when no vendor 1`] = `
   <h3>
     Apple A8 GPU
   </h3>
-  <p>
+  <ParagraphOverflow>
     <Subject>
       Vendor:
     </Subject>
     Unknown
-  </p>
+  </ParagraphOverflow>
 </div>
 `;
 
@@ -324,12 +324,12 @@ exports[`OsSummary render() renders the kernel version when no version 1`] = `
   <h3>
     Mac OS X
   </h3>
-  <p>
+  <ParagraphOverflow>
     <Subject>
       Kernel:
     </Subject>
     17.5.0
-  </p>
+  </ParagraphOverflow>
 </div>
 `;
 
@@ -343,12 +343,12 @@ exports[`OsSummary render() renders the version string 1`] = `
   <h3>
     Mac OS X
   </h3>
-  <p>
+  <ParagraphOverflow>
     <Subject>
       Version:
     </Subject>
     10.13.4
-  </p>
+  </ParagraphOverflow>
 </div>
 `;
 
@@ -362,11 +362,11 @@ exports[`OsSummary render() renders unknown when no version 1`] = `
   <h3>
     Mac OS X
   </h3>
-  <p>
+  <ParagraphOverflow>
     <Subject>
       Version:
     </Subject>
     Unknown
-  </p>
+  </ParagraphOverflow>
 </div>
 `;

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -1266,7 +1266,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
           </StyledIconAdd>
           <StyledTextOverflow>
             <div
-              className="css-usqo6f-TextOverflow-StyledTextOverflow e1hyuoc72"
+              className="css-hmonbk-TextOverflow-StyledTextOverflow e1hyuoc72"
             >
               a/bar
             </div>
@@ -1318,7 +1318,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
           </StyledIconAdd>
           <StyledTextOverflow>
             <div
-              className="css-usqo6f-TextOverflow-StyledTextOverflow e1hyuoc72"
+              className="css-hmonbk-TextOverflow-StyledTextOverflow e1hyuoc72"
             >
               a/foo
             </div>
@@ -1370,7 +1370,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
           </StyledIconAdd>
           <StyledTextOverflow>
             <div
-              className="css-usqo6f-TextOverflow-StyledTextOverflow e1hyuoc72"
+              className="css-hmonbk-TextOverflow-StyledTextOverflow e1hyuoc72"
             >
               example.com/a
             </div>
@@ -1422,7 +1422,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
           </StyledIconAdd>
           <StyledTextOverflow>
             <div
-              className="css-usqo6f-TextOverflow-StyledTextOverflow e1hyuoc72"
+              className="css-hmonbk-TextOverflow-StyledTextOverflow e1hyuoc72"
             >
               example.com/a/foo
             </div>

--- a/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
+++ b/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
@@ -311,14 +311,14 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                             >
                               <Message>
                                 <div
-                                  className="css-11irdn4-TextOverflow-Message eyce8w25"
+                                  className="css-b2zdm8-TextOverflow-Message eyce8w25"
                                 >
                                   (improve) Add Links to Spike-Protection Email (#2408)
                                 </div>
                               </Message>
                               <Meta>
                                 <div
-                                  className="css-1dy4vp6-TextOverflow-Meta eyce8w26"
+                                  className="css-14ujho6-TextOverflow-Meta eyce8w26"
                                 >
                                   <span
                                     key="4"
@@ -697,14 +697,14 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                             >
                               <Message>
                                 <div
-                                  className="css-11irdn4-TextOverflow-Message eyce8w25"
+                                  className="css-b2zdm8-TextOverflow-Message eyce8w25"
                                 >
                                   (improve) Add Links to Spike-Protection Email (#2408)
                                 </div>
                               </Message>
                               <Meta>
                                 <div
-                                  className="css-1dy4vp6-TextOverflow-Meta eyce8w26"
+                                  className="css-14ujho6-TextOverflow-Meta eyce8w26"
                                 >
                                   <span
                                     key="4"


### PR DESCRIPTION
This PR adds more informative empty messages to Images Loaded section of issue group detail.

Also, while I was in there, I fixed the overflowing issue I noticed on the same page:

![image](https://user-images.githubusercontent.com/9060071/76997879-586e1480-6954-11ea-83a6-d49f8f18ce91.png)
