### PR TITLE
feat(performance) Add latency distribution graph to transaction summary

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
 import {SelectValue} from 'app/types';
 import YAxisSelector from 'app/views/events/yAxisSelector';
-import space from 'app/styles/space';
 
-import {ChartControls, InlineContainer, SectionHeading} from './styles';
+import {ChartControls, InlineContainer, SectionHeading, SectionValue} from './styles';
 
 type Props = {
   total: number | null;
@@ -21,11 +19,11 @@ export default function ChartFooter({total, yAxisValue, yAxisOptions, onChange}:
   elements.push(<SectionHeading key="total-label">{t('Total')}</SectionHeading>);
   elements.push(
     total === null ? (
-      <Value data-test-id="loading-placeholder" key="total-value">
+      <SectionValue data-test-id="loading-placeholder" key="total-value">
         -
-      </Value>
+      </SectionValue>
     ) : (
-      <Value key="total-value">{total.toLocaleString()}</Value>
+      <SectionValue key="total-value">{total.toLocaleString()}</SectionValue>
     )
   );
 
@@ -36,9 +34,3 @@ export default function ChartFooter({total, yAxisValue, yAxisOptions, onChange}:
     </ChartControls>
   );
 }
-
-const Value = styled('span')`
-  color: ${p => p.theme.gray3};
-  font-size: ${p => p.theme.fontSizeMedium};
-  margin-right: ${space(1)};
-`;

--- a/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
@@ -10,6 +10,8 @@ import space from 'app/styles/space';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import Card from 'app/components/card';
 
+import {SubHeading} from './styles';
+
 type Props = {
   title?: string;
   subtitle?: string;
@@ -44,7 +46,7 @@ class QueryCard extends React.PureComponent<Props> {
       <Link data-test-id={`card-${title}`} onClick={this.handleClick} to={this.props.to}>
         <StyledQueryCard interactive>
           <QueryCardHeader>
-            <StyledTitle>
+            <CardHeading>
               {title}
               {starred && (
                 <StyledIconBookmark
@@ -53,7 +55,7 @@ class QueryCard extends React.PureComponent<Props> {
                   solid
                 />
               )}
-            </StyledTitle>
+            </CardHeading>
             <StyledQueryDetail>{queryDetail}</StyledQueryDetail>
           </QueryCardHeader>
           <QueryCardBody>{renderGraph()}</QueryCardBody>
@@ -90,12 +92,7 @@ const StyledIconBookmark = styled(IconBookmark)`
   right: ${space(2)};
 `;
 
-const StyledTitle = styled('div')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.gray5};
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+const CardHeading = styled(SubHeading)`
   width: 95%;
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/styles.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/styles.tsx
@@ -13,6 +13,12 @@ export const SectionHeading = styled('h4')`
   line-height: 1.2;
 `;
 
+export const SectionValue = styled('span')`
+  color: ${p => p.theme.gray3};
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin-right: ${space(1)};
+`;
+
 export const Container = styled('div')`
   ${overflowEllipsis};
 `;
@@ -81,4 +87,28 @@ export const InlineContainer = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: center;
+`;
+
+export const SubHeading = styled('h3')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: normal;
+  color: ${p => p.theme.gray5};
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const ErrorPanel = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  flex: 1;
+  flex-shrink: 0;
+  overflow: hidden;
+  height: 200px;
+  position: relative;
+  border-color: transparent;
+  margin-bottom: 0;
 `;

--- a/src/sentry/static/sentry/app/views/performance/transaction_summary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transaction_summary/content.tsx
@@ -3,7 +3,6 @@ import {Location} from 'history';
 import styled from '@emotion/styled';
 
 import {Organization} from 'app/types';
-import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import EventView from 'app/views/eventsV2/eventView';
 import {ContentBox, HeaderBox} from 'app/views/eventsV2/styles';

--- a/src/sentry/static/sentry/app/views/performance/transaction_summary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transaction_summary/content.tsx
@@ -38,7 +38,7 @@ class SummaryContent extends React.Component<Props> {
               transactionName={transactionName}
             />
           </div>
-          <TransactionName transactionName={transactionName} />
+          <StyledTitleHeader>{transactionName}</StyledTitleHeader>
         </HeaderBox>
         <ContentBox>
           <EventsV2
@@ -78,23 +78,15 @@ class SummaryContent extends React.Component<Props> {
   }
 }
 
-const TransactionName = (props: {transactionName: string}) => (
-  <StyledTitleHeader>
-    <StyledTitle>{props.transactionName}</StyledTitle>
-  </StyledTitleHeader>
-);
-
-const StyledTitleHeader = styled('div')`
+const StyledTitleHeader = styled('h2')`
   font-size: ${p => p.theme.headerFontSize};
-  color: ${p => p.theme.gray2};
+  font-weight: normal;
+  line-height: 1.2;
+
+  color: ${p => p.theme.gray4};
   grid-column: 1/2;
   align-self: center;
   ${overflowEllipsis};
-`;
-
-const StyledTitle = styled('span')`
-  color: ${p => p.theme.gray4};
-  margin-right: ${space(1)};
 `;
 
 const Side = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/transaction_summary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transaction_summary/latencyChart.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import {Panel} from 'app/components/panels';
+import {IconQuestion, IconWarning} from 'app/icons';
+import {t} from 'app/locale';
+import BarChart from 'app/components/charts/barChart';
+import Tooltip from 'app/components/tooltip';
+import AsyncComponent from 'app/components/asyncComponent';
+import {
+  ChartControls,
+  InlineContainer,
+  SectionHeading,
+  SectionValue,
+  SubHeading,
+  ErrorPanel,
+} from 'app/views/eventsV2/styles';
+import {OrganizationSummary} from 'app/types';
+import LoadingPanel from 'app/views/events/loadingPanel';
+import EventView from 'app/views/eventsV2/eventView';
+import space from 'app/styles/space';
+import theme from 'app/utils/theme';
+
+type ViewProps = Pick<
+  EventView,
+  'environment' | 'project' | 'query' | 'start' | 'end' | 'statsPeriod'
+>;
+
+type ApiResult = {
+  histogram_transaction_duration_15: number;
+  count: number;
+};
+
+type Props = AsyncComponent['props'] &
+  ViewProps & {
+    organization: OrganizationSummary;
+    location: Location;
+  };
+
+type State = AsyncComponent['state'] & {
+  chartData: {data: ApiResult[]} | null;
+};
+
+/**
+ * Fetch the chart data and then render the chart panel.
+ */
+class LatencyChart extends AsyncComponent<Props, State> {
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {
+      organization,
+      query,
+      start,
+      end,
+      statsPeriod,
+      environment,
+      project,
+      location,
+    } = this.props;
+    const eventView = EventView.fromSavedQuery({
+      id: '',
+      name: '',
+      version: 2,
+      fields: ['histogram(transaction.duration,15)', 'count()'],
+      orderby: 'histogram_transaction_duration_15',
+      projects: project,
+      range: statsPeriod,
+      query,
+      environment,
+      start,
+      end,
+    });
+    const apiPayload = eventView.getEventsAPIPayload(location);
+
+    return [
+      ['chartData', `/organizations/${organization.slug}/eventsv2/`, {query: apiPayload}],
+    ];
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.shouldRefetchData(prevProps)) {
+      this.fetchData();
+    }
+  }
+
+  shouldRefetchData(prevProps: Props) {
+    if (this.state.loading) {
+      return false;
+    }
+    return (
+      prevProps.query !== this.props.query ||
+      prevProps.environment !== this.props.environment ||
+      prevProps.start !== this.props.start ||
+      prevProps.end !== this.props.end ||
+      prevProps.statsPeriod !== this.props.statsPeriod
+    );
+  }
+
+  renderLoading() {
+    return <LoadingPanel data-test-id="histogram-loading" />;
+  }
+
+  renderError() {
+    // Don't call super as we don't really need issues for this.
+    return (
+      <ErrorPanel>
+        <IconWarning color={theme.gray2} size="lg" />
+      </ErrorPanel>
+    );
+  }
+
+  renderBody() {
+    const {chartData} = this.state;
+    if (chartData === null) {
+      return null;
+    }
+    const xAxis = {
+      type: 'category',
+      truncate: true,
+      axisLabel: {
+        margin: 20,
+      },
+      axisTick: {
+        interval: 0,
+        alignWithLabel: true,
+      },
+    };
+
+    return (
+      <BarChart
+        grid={{left: '24px', right: '24px', top: '32px', bottom: '16px'}}
+        xAxis={xAxis}
+        yAxis={{type: 'value'}}
+        series={transformData(chartData.data)}
+        colors={['rgba(140, 79, 189, 0.3)']}
+      />
+    );
+  }
+
+  calculateTotal() {
+    if (this.state.chartData === null) {
+      return '\u2015';
+    }
+    return this.state.chartData.data.reduce((acc, item) => {
+      return acc + item.count;
+    }, 0);
+  }
+
+  render() {
+    return (
+      <Panel>
+        <PaddedSubHeading>
+          <span>{t('Latency Distribution')}</span>
+          <Tooltip
+            position="top"
+            title={t(
+              `This graph shows the volume of transactions that completed within each duration bucket.
+               X-axis values represent the median value of each bucket.
+               `
+            )}
+          >
+            <IconQuestion size="sm" color={theme.gray6} />
+          </Tooltip>
+        </PaddedSubHeading>
+        {super.render()}
+        <ChartControls>
+          <InlineContainer>
+            <SectionHeading key="total-heading">{t('Total Events')}</SectionHeading>
+            <SectionValue key="total-value">{this.calculateTotal()}</SectionValue>
+          </InlineContainer>
+        </ChartControls>
+      </Panel>
+    );
+  }
+}
+
+/**
+ * Convert a discover response into a barchart compatible series
+ */
+function transformData(data: ApiResult[]) {
+  let previous: number = 0;
+
+  const seriesData = data.map(item => {
+    const bucket = item.histogram_transaction_duration_15;
+    const midPoint = previous + Math.ceil((bucket - previous) / 2);
+    const value = {value: item.count, name: `${midPoint}ms`};
+    previous = bucket + 1;
+
+    return value;
+  });
+
+  return [
+    {
+      seriesName: t('Count'),
+      data: seriesData,
+    },
+  ];
+}
+
+const PaddedSubHeading = styled(SubHeading)`
+  display: flex;
+  align-items: flex-start;
+  margin: ${space(2)} 0 ${space(1)} ${space(3)};
+
+  & > span {
+    margin-right: ${space(1)};
+  }
+`;
+
+export default LatencyChart;

--- a/src/sentry/static/sentry/app/views/performance/transaction_summary/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transaction_summary/table.tsx
@@ -30,6 +30,7 @@ import {
   GridBodyCell,
   GridBodyCellNumber,
 } from '../styles';
+import LatencyChart from './latencyChart';
 
 type Props = {
   eventView: EventView;
@@ -158,11 +159,21 @@ class SummaryContentTable extends React.Component<Props> {
   };
 
   render() {
-    const {eventView, organization} = this.props;
+    const {eventView, location, organization} = this.props;
     const columnOrder = eventView.getColumns();
 
     return (
       <div>
+        <LatencyChart
+          organization={organization}
+          location={location}
+          query={eventView.query}
+          project={eventView.project}
+          environment={eventView.environment}
+          start={eventView.start}
+          end={eventView.end}
+          statsPeriod={eventView.statsPeriod}
+        />
         <Header>
           <HeaderTitle>{t('Slowest Requests')}</HeaderTitle>
           <HeaderButtonContainer>

--- a/tests/js/spec/views/eventsV2/queryList.spec.jsx
+++ b/tests/js/spec/views/eventsV2/queryList.spec.jsx
@@ -80,7 +80,7 @@ describe('EventsV2 > QueryList', function() {
       TestStubs.routerContext()
     );
     let card = wrapper.find('QueryCard').last();
-    expect(card.find('StyledTitle').text()).toEqual(savedQueries[1].name);
+    expect(card.find('CardHeading').text()).toEqual(savedQueries[1].name);
 
     openContextMenu(card);
     wrapper.update();
@@ -108,7 +108,7 @@ describe('EventsV2 > QueryList', function() {
       TestStubs.routerContext()
     );
     let card = wrapper.find('QueryCard').last();
-    expect(card.find('StyledTitle').text()).toEqual(savedQueries[1].name);
+    expect(card.find('CardHeading').text()).toEqual(savedQueries[1].name);
 
     openContextMenu(card);
     wrapper.update();
@@ -135,7 +135,7 @@ describe('EventsV2 > QueryList', function() {
       TestStubs.routerContext()
     );
     let card = wrapper.find('QueryCard').last();
-    expect(card.find('StyledTitle').text()).toEqual(savedQueries[1].name);
+    expect(card.find('CardHeading').text()).toEqual(savedQueries[1].name);
 
     // Open the context menu
     openContextMenu(card);


### PR DESCRIPTION
Wire up a latency distribution graph to the transaction summary details view. This is a first pass and will likely have several revisions made to it as we play around with it in production.

![Screen Shot 2020-03-18 at 3 48 13 PM](https://user-images.githubusercontent.com/24086/77001292-18953600-6930-11ea-86f1-ef3e43211cd7.png)
