### PR TITLE
fix(workflow): Change `<ButtonBar>` children to be "primary" when active

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -46,6 +46,7 @@ type State = {
 function getQueryStatus(status: any) {
   return ['open', 'closed', 'all'].includes(status) ? status : DEFAULT_QUERY_STATUS;
 }
+
 class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state']> {
   getEndpoints(): [string, string, any][] {
     const {params, location} = this.props;
@@ -200,6 +201,11 @@ class IncidentsListContainer extends React.Component<Props> {
     const allIncidentsQuery = omit({...query, status: 'all'}, 'cursor');
 
     const status = getQueryStatus(query.status);
+
+    const isOpenActive = status === 'open';
+    const isClosedActive = status === 'closed';
+    const isAllActive = status === 'all';
+
     return (
       <DocumentTitle title={`Alerts- ${orgId} - Sentry`}>
         <PageContent>
@@ -237,21 +243,21 @@ class IncidentsListContainer extends React.Component<Props> {
                 <Button
                   to={{pathname, query: openIncidentsQuery}}
                   size="small"
-                  className={'btn' + (status === 'open' ? ' active' : '')}
+                  priority={isOpenActive ? 'primary' : 'default'}
                 >
                   {t('Active')}
                 </Button>
                 <Button
                   to={{pathname, query: closedIncidentsQuery}}
                   size="small"
-                  className={'btn' + (status === 'closed' ? ' active' : '')}
+                  priority={isClosedActive ? 'primary' : 'default'}
                 >
                   {t('Resolved')}
                 </Button>
                 <Button
                   to={{pathname, query: allIncidentsQuery}}
                   size="small"
-                  className={'btn' + (status === 'all' ? ' active' : '')}
+                  priority={isAllActive ? 'primary' : 'default'}
                 >
                   {t('All')}
                 </Button>

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -243,6 +243,7 @@ class IncidentsListContainer extends React.Component<Props> {
                 <Button
                   to={{pathname, query: openIncidentsQuery}}
                   size="small"
+                  className={isOpenActive ? ' active' : ''}
                   priority={isOpenActive ? 'primary' : 'default'}
                 >
                   {t('Active')}
@@ -250,6 +251,7 @@ class IncidentsListContainer extends React.Component<Props> {
                 <Button
                   to={{pathname, query: closedIncidentsQuery}}
                   size="small"
+                  className={isClosedActive ? ' active' : ''}
                   priority={isClosedActive ? 'primary' : 'default'}
                 >
                   {t('Resolved')}
@@ -257,6 +259,7 @@ class IncidentsListContainer extends React.Component<Props> {
                 <Button
                   to={{pathname, query: allIncidentsQuery}}
                   size="small"
+                  className={isAllActive ? ' active' : ''}
                   priority={isAllActive ? 'primary' : 'default'}
                 >
                   {t('All')}

--- a/tests/js/spec/views/incidents/list/index.spec.jsx
+++ b/tests/js/spec/views/incidents/list/index.spec.jsx
@@ -102,10 +102,10 @@ describe('IncidentsList', function() {
     expect(
       wrapper
         .find('ButtonBar')
-        .find('a')
+        .find('Button')
         .at(0)
-        .hasClass('active')
-    ).toBe(true);
+        .prop('priority')
+    ).toBe('primary');
 
     expect(mock).toHaveBeenCalledTimes(1);
 
@@ -121,8 +121,8 @@ describe('IncidentsList', function() {
         .find('ButtonBar')
         .find('Button')
         .at(2)
-        .hasClass('active')
-    ).toBe(true);
+        .prop('priority')
+    ).toBe('primary');
 
     expect(mock).toHaveBeenCalledTimes(2);
 


### PR DESCRIPTION
This is the proper way to show "active" state. This logic should probably be moved into `<ButtonBar>`