### PR TITLE
feat(ui): Change `<ButtonBar>` to control "active" `<Button>`

### DIFF
--- a/docs-ui/components/button.stories.js
+++ b/docs-ui/components/button.stories.js
@@ -222,24 +222,20 @@ storiesOf('UI|Buttons', module)
         </Section>
 
         <Section>
-          <h3>Merged Buttons</h3>
-          <ButtonBar merged>
-            <Button priority="primary" className="active">
-              Left Button
-            </Button>
-            <Button>Right Button</Button>
+          <h3>Merged Buttons with "active" button</h3>
+          <ButtonBar active="left" merged>
+            <Button id="left">Left Button</Button>
+            <Button id="right">Right Button</Button>
           </ButtonBar>
         </Section>
 
         <Section>
-          <h3>Multiple Merged Buttons</h3>
-          <ButtonBar merged>
-            <Button>First Button</Button>
-            <Button priority="primary" className="active">
-              Second Button
-            </Button>
-            <Button>Third Button</Button>
-            <Button>Fourth Button</Button>
+          <h3>Multiple Merged Buttons with "active" button</h3>
+          <ButtonBar active={2} merged>
+            <Button id={1}>First Button</Button>
+            <Button id={2}>Second Button</Button>
+            <Button id={3}>Third Button</Button>
+            <Button id={4}>Fourth Button</Button>
           </ButtonBar>
         </Section>
       </div>

--- a/docs-ui/components/button.stories.js
+++ b/docs-ui/components/button.stories.js
@@ -224,18 +224,18 @@ storiesOf('UI|Buttons', module)
         <Section>
           <h3>Merged Buttons with "active" button</h3>
           <ButtonBar active="left" merged>
-            <Button id="left">Left Button</Button>
-            <Button id="right">Right Button</Button>
+            <Button barId="left">Left Button</Button>
+            <Button barId="right">Right Button</Button>
           </ButtonBar>
         </Section>
 
         <Section>
           <h3>Multiple Merged Buttons with "active" button</h3>
-          <ButtonBar active={2} merged>
-            <Button id={1}>First Button</Button>
-            <Button id={2}>Second Button</Button>
-            <Button id={3}>Third Button</Button>
-            <Button id={4}>Fourth Button</Button>
+          <ButtonBar active="2" merged>
+            <Button barId="1">First Button</Button>
+            <Button barId="2">Second Button</Button>
+            <Button barId="3">Third Button</Button>
+            <Button barId="4">Fourth Button</Button>
           </ButtonBar>
         </Section>
       </div>

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -35,6 +35,9 @@ type Props = {
   onClick?: (e: React.MouseEvent) => void;
   forwardRef?: React.Ref<ButtonElement>;
   name?: string;
+
+  // This is only used with `<ButtonBar>`
+  barId?: string;
 };
 
 type ButtonProps = Omit<React.HTMLProps<ButtonElement>, keyof Props> & Props;

--- a/src/sentry/static/sentry/app/components/buttonBar.tsx
+++ b/src/sentry/static/sentry/app/components/buttonBar.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import classNames from 'classnames';
 import styled from '@emotion/styled';
 
+import Button from 'app/components/button';
 import space, {ValidSize} from 'app/styles/space';
 
 type ButtonBarProps = {
   className?: string;
   gap?: ValidSize;
   merged?: boolean;
-  active?: string | number;
+  active?: React.ComponentProps<typeof Button>['barId'];
   children: React.ReactNode;
 };
 
@@ -31,15 +32,17 @@ function ButtonBar({
 
             const {props: childProps, ...childWithoutProps} = child;
 
-            // We do not want to pass `id` to <Button>`
-            const {id, ...props} = childProps;
-            const isActive = active === id;
+            // We do not want to pass `barId` to <Button>`
+            const {barId, ...props} = childProps;
+            const isActive = active === barId;
+
+            // This ["primary"] could be customizable with a prop,
+            // but let's just enforce one "active" type for now
             const priority = isActive ? 'primary' : childProps.priority || 'default';
 
             return React.cloneElement(childWithoutProps as React.ReactElement, {
               ...props,
               className: classNames(className, {active: isActive}),
-              // This could be customizable with a prop, but let's just enforce one "active" type for now
               priority,
             });
           })}

--- a/src/sentry/static/sentry/app/components/buttonBar.tsx
+++ b/src/sentry/static/sentry/app/components/buttonBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import styled from '@emotion/styled';
 
 import space, {ValidSize} from 'app/styles/space';
@@ -7,13 +8,41 @@ type ButtonBarProps = {
   className?: string;
   gap?: ValidSize;
   merged?: boolean;
+  active?: string | number;
   children: React.ReactNode;
 };
 
-function ButtonBar({children, className, merged = false, gap = 0}: ButtonBarProps) {
+function ButtonBar({
+  children,
+  className,
+  active,
+  merged = false,
+  gap = 0,
+}: ButtonBarProps) {
+  const shouldCheckActive = typeof active !== 'undefined';
   return (
     <ButtonGrid merged={merged} gap={gap} className={className}>
-      {children}
+      {!shouldCheckActive
+        ? children
+        : React.Children.map(children, child => {
+            if (!React.isValidElement(child)) {
+              return child;
+            }
+
+            const {props: childProps, ...childWithoutProps} = child;
+
+            // We do not want to pass `id` to <Button>`
+            const {id, ...props} = childProps;
+            const isActive = active === id;
+            const priority = isActive ? 'primary' : childProps.priority || 'default';
+
+            return React.cloneElement(childWithoutProps as React.ReactElement, {
+              ...props,
+              className: classNames(className, {active: isActive}),
+              // This could be customizable with a prop, but let's just enforce one "active" type for now
+              priority,
+            });
+          })}
     </ButtonGrid>
   );
 }

--- a/tests/js/spec/components/buttonBar.spec.jsx
+++ b/tests/js/spec/components/buttonBar.spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+import Button from 'app/components/button';
+import ButtonBar from 'app/components/buttonBar';
+
+describe('ButtonBar', function() {
+  const createWrapper = () =>
+    mountWithTheme(
+      <ButtonBar active="2" merged>
+        <Button barId="1">First Button</Button>
+        <Button barId="2">Second Button</Button>
+        <Button barId="3">Third Button</Button>
+        <Button barId="4">Fourth Button</Button>
+      </ButtonBar>
+    );
+
+  it('has "Second Button" as the active button in the bar', function() {
+    const wrapper = createWrapper();
+    expect(
+      wrapper
+        .find('Button')
+        .at(1)
+        .prop('priority')
+    ).toBe('primary');
+  });
+
+  it('does not pass `barId` down to the button', function() {
+    const wrapper = createWrapper();
+    expect(
+      wrapper
+        .find('Button')
+        .at(1)
+        .prop('barId')
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This changes `<ButtonBar>` to support an `active` prop whose value should correspond to a child `<Button>` `id` value. This makes it so you do not need to have separate logic to set the `priority` property on the "active" `<Button>`