### PR TITLE
nodestore: Add flag to upgrade for bootstrapping nodestore

### DIFF
--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -24,6 +24,7 @@ class NodeStorage(local, Service):
         "generate_id",
         "cleanup",
         "validate",
+        "bootstrap",
         "_get_cache_item",
         "_get_cache_items",
         "_set_cache_item",
@@ -92,6 +93,9 @@ class NodeStorage(local, Service):
         return b64encode(uuid4().bytes)
 
     def cleanup(self, cutoff_timestamp):
+        raise NotImplementedError
+
+    def bootstrap(self):
         raise NotImplementedError
 
     def _get_cache_item(self, id):

--- a/src/sentry/nodestore/bigtable/backend.py
+++ b/src/sentry/nodestore/bigtable/backend.py
@@ -277,4 +277,8 @@ class BigtableNodeStorage(NodeStorage):
         else:
             gc_rule = None
 
-        table.create(column_families={self.column_family: gc_rule})
+        from google.api_core import exceptions
+        from google.api_core import retry
+
+        retry_504 = retry.Retry(retry.if_exception_type(exceptions.DeadlineExceeded))
+        retry_504(table.create)(column_families={self.column_family: gc_rule})

--- a/src/sentry/nodestore/django/backend.py
+++ b/src/sentry/nodestore/django/backend.py
@@ -54,3 +54,7 @@ class DjangoNodeStorage(NodeStorage):
         BulkDeleteQuery(model=Node, dtfield="timestamp", days=days).execute()
         if self.cache:
             self.cache.clear()
+
+    def bootstrap(self):
+        # Nothing for Django backend to do during bootstrap
+        pass


### PR DESCRIPTION
~If this doesn't prove to be any unforseen issues, will drop this flag
and just make it always do that behavior since it should be a no-op.~

On second thought, I will most likely make this always opt in since there's no real use for it outside of Single Tenant or the rare chance someone else wants to wrestle BigTable.