### PR TITLE
feat(workflow): Add analytics for Alert views

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -37,6 +37,7 @@ class IncidentDetails extends React.Component<Props, State> {
       eventKey: 'alert_details.viewed',
       eventName: 'Alert Details: Viewed',
       org_id: parseInt(organization.id, 10),
+      alert_id: parseInt(params.alertId, 10),
     });
 
     fetchOrgMembers(api, params.orgId);

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -36,7 +36,7 @@ class IncidentDetails extends React.Component<Props, State> {
     trackAnalyticsEvent({
       eventKey: 'alert_details.viewed',
       eventName: 'Alert Details: Viewed',
-      org_id: parseInt(organization.id, 10),
+      organization_id: parseInt(organization.id, 10),
       alert_id: parseInt(params.alertId, 10),
     });
 

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -1,20 +1,24 @@
-import React from 'react';
 import {RouteComponentProps} from 'react-router/lib/Router';
+import React from 'react';
 
 import {Client} from 'app/api';
+import {Organization} from 'app/types';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {fetchOrgMembers} from 'app/actionCreators/members';
 import {markIncidentAsSeen} from 'app/actionCreators/incident';
 import {t} from 'app/locale';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
+import withOrganization from 'app/utils/withOrganization';
 
+import {IncidentStatus, Incident} from '../types';
 import {fetchIncident, updateSubscription, updateStatus, isOpen} from '../utils';
 import DetailsBody from './body';
 import DetailsHeader from './header';
-import {IncidentStatus, Incident} from '../types';
 
 type Props = {
   api: Client;
+  organization: Organization;
 } & RouteComponentProps<{alertId: string; orgId: string}, {}>;
 
 type State = {
@@ -27,8 +31,16 @@ class IncidentDetails extends React.Component<Props, State> {
   state: State = {isLoading: false, hasError: false};
 
   componentDidMount() {
-    const {api, params} = this.props;
+    const {api, organization, params} = this.props;
+
+    trackAnalyticsEvent({
+      eventKey: 'alert_details.viewed',
+      eventName: 'Alert Details: Viewed',
+      org_id: parseInt(organization.id, 10),
+    });
+
     fetchOrgMembers(api, params.orgId);
+
     this.fetchData();
   }
 
@@ -129,4 +141,4 @@ class IncidentDetails extends React.Component<Props, State> {
   }
 }
 
-export default withApi(IncidentDetails);
+export default withApi(withOrganization(IncidentDetails));

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -174,6 +174,16 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
 
 class IncidentsListContainer extends React.Component<Props> {
   componentDidMount() {
+    this.trackView();
+  }
+
+  componentDidUpdate(nextProps: Props) {
+    if (nextProps.location.query?.status !== this.props.location.query?.status) {
+      this.trackView();
+    }
+  }
+
+  trackView() {
     const {location, organization} = this.props;
     const status = getQueryStatus(location.query.status);
 

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -174,10 +174,14 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
 
 class IncidentsListContainer extends React.Component<Props> {
   componentDidMount() {
+    const {location, organization} = this.props;
+    const status = getQueryStatus(location.query.status);
+
     trackAnalyticsEvent({
       eventKey: 'alert_stream.viewed',
       eventName: 'Alert Stream: Viewed',
-      org_id: parseInt(this.props.organization.id, 10),
+      status,
+      organization_id: parseInt(organization.id, 10),
     });
   }
 

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -8,10 +8,12 @@ import omit from 'lodash/omit';
 import styled from '@emotion/styled';
 
 import {IconAdd, IconSettings} from 'app/icons';
+import {Organization} from 'app/types';
 import {PageContent, PageHeader} from 'app/styles/organization';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import {navigateTo} from 'app/actionCreators/navigation';
 import {t} from 'app/locale';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import BetaTag from 'app/components/betaTag';
@@ -30,6 +32,7 @@ import Projects from 'app/utils/projects';
 import getDynamicText from 'app/utils/getDynamicText';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
+import withOrganization from 'app/utils/withOrganization';
 
 import {Incident} from '../types';
 import SparkLine from './sparkLine';
@@ -37,7 +40,9 @@ import Status from '../status';
 
 const DEFAULT_QUERY_STATUS = 'open';
 
-type Props = RouteComponentProps<{orgId: string}, {}>;
+type Props = {
+  organization: Organization;
+} & RouteComponentProps<{orgId: string}, {}>;
 
 type State = {
   incidentList: Incident[];
@@ -168,6 +173,14 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
 }
 
 class IncidentsListContainer extends React.Component<Props> {
+  componentDidMount() {
+    trackAnalyticsEvent({
+      eventKey: 'alert_stream.viewed',
+      eventName: 'Alert Stream: Viewed',
+      org_id: parseInt(this.props.organization.id, 10),
+    });
+  }
+
   /**
    * Incidents list is currently at the organization level, but the link needs to
    * go down to a specific project scope.
@@ -328,4 +341,4 @@ const NumericColumn = styled('div')`
   text-align: right;
 `;
 
-export default IncidentsListContainer;
+export default withOrganization(IncidentsListContainer);

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {Organization, Project} from 'app/types';
 import {createDefaultRule} from 'app/views/settings/incidentRules/constants';
 import recreateRoute from 'app/utils/recreateRoute';
-import withProject from 'app/utils/withProject';
 
 import RuleForm from './ruleForm';
 
@@ -42,4 +41,4 @@ class IncidentRulesCreate extends React.Component<Props> {
   }
 }
 
-export default withProject(IncidentRulesCreate);
+export default IncidentRulesCreate;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/create.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/create.tsx
@@ -1,15 +1,17 @@
 import {RouteComponentProps} from 'react-router/lib/Router';
 import React from 'react';
 
-import {Organization} from 'app/types';
+import {Organization, Project} from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import IncidentRulesCreate from 'app/views/settings/incidentRules/create';
 import IssueEditor from 'app/views/settings/projectAlerts/issueEditor';
 import PanelItem from 'app/components/panels/panelItem';
 import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+import withProject from 'app/utils/withProject';
 
 type RouteParams = {
   orgId: string;
@@ -18,6 +20,7 @@ type RouteParams = {
 
 type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
+  project: Project;
   hasMetricAlerts: boolean;
 };
 
@@ -33,6 +36,17 @@ class Create extends React.Component<Props, State> {
       ? 'metric'
       : null,
   };
+
+  componentDidMount() {
+    const {organization, project} = this.props;
+
+    trackAnalyticsEvent({
+      eventKey: 'new_alert_rule.viewed',
+      eventName: 'New Alert Rule: Viewed',
+      org_id: parseInt(organization.id, 10),
+      project_id: parseInt(project.id, 10),
+    });
+  }
 
   handleChangeAlertType = (alertType: string) => {
     // alertType should be `issue` or `metric`
@@ -95,4 +109,4 @@ class Create extends React.Component<Props, State> {
   }
 }
 
-export default Create;
+export default withProject(Create);

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/create.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/create.tsx
@@ -43,7 +43,7 @@ class Create extends React.Component<Props, State> {
     trackAnalyticsEvent({
       eventKey: 'new_alert_rule.viewed',
       eventName: 'New Alert Rule: Viewed',
-      org_id: parseInt(organization.id, 10),
+      organization_id: parseInt(organization.id, 10),
       project_id: parseInt(project.id, 10),
     });
   }


### PR DESCRIPTION
This adds analytics for the follow Alert views:

* Alert Stream
* Alert Details
* New Alert Rule

Requires https://github.com/getsentry/reload/pull/150/files