### PR TITLE
ci(github): Update `eslint` action to use correct list of modified files

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -39,7 +39,7 @@ jobs:
           run: yarn install --frozen-lockfile
 
         - name: eslint + fix
-          uses: getsentry/action-eslint-fix@v1
+          uses: getsentry/action-eslint-fix@master
           with:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This was getting the list of modified files from HEAD of master and HEAD of branch, instead get the first commit of the PR and compare with HEAD of PR. Changing the version to track master since this is our own action.