### PR TITLE
fix(discover2): Update URL that point to new Discover docs

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -118,7 +118,7 @@ GUIDES = {
                 "title": _("Event Pages have moved"),
                 "message": _(
                     "These are now in our powerful new query builder, Discover "
-                    '<a href="https://docs.sentry.io/workflow/discover2/" target="_blank">Learn more about its advanced features</a>. '
+                    '<a href="https://docs.sentry.io/performance/discover/" target="_blank">Learn more about its advanced features</a>. '
                 ),
                 "target": "discover_sidebar",
             }

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -112,7 +112,7 @@ export default function getGuidesContent(): GuidesContent {
             `These are now in our powerful new query builder, Discover.
             [link:Learn more about its advanced features].`,
             {
-              link: <ExternalLink href="https://docs.sentry.io/workflow/discover2/" />,
+              link: <ExternalLink href="https://docs.sentry.io/performance/discover/" />,
             }
           ),
         },

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -253,4 +253,4 @@ export const ORGANIZATION_FETCH_ERROR_TYPES = {
 };
 
 export const CONFIG_DOCS_URL = 'https://docs.sentry.io/server/config/';
-export const DISCOVER2_DOCS_URL = 'https://docs.sentry.io/workflow/discover2/';
+export const DISCOVER2_DOCS_URL = 'https://docs.sentry.io/performance/discover/';

--- a/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
@@ -121,7 +121,7 @@ class ExploreWidget extends React.Component {
     return (
       <ExploreAction
         to={flags.discover2 ? this.getExportToDiscover(query, true) : ''}
-        href={!flags.discover2 ? 'https://docs.sentry.io/workflow/discover2/' : ''}
+        href={!flags.discover2 ? 'https://docs.sentry.io/performance/discover/' : ''}
         target={!flags.discover2 ? '_blank' : ''}
         title={
           flags.discover2

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -208,7 +208,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
         >
           {t('Build a new query')}
         </StarterButton>
-        <StarterButton href="https://docs.sentry.io/workflow/discover2/">
+        <StarterButton href="https://docs.sentry.io/performance/discover/">
           {t('Read the docs')}
         </StarterButton>
       </Banner>


### PR DESCRIPTION
Updating from https://docs.sentry.io/workflow/discover2/ to https://docs.sentry.io/performance/discover/