### PR TITLE
fix(charts) Constrain tooltips to viewport width

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -342,7 +342,7 @@ const ChartContainer = styled('div')`
     width: auto;
     border-radius: ${theme.borderRadiusBottom};
   }
-  .tooltip-date:after {
+  .tooltip-arrow {
     top: 100%;
     left: 50%;
     border: solid transparent;

--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -102,6 +102,7 @@ function getFormatter({
         .join(''),
       '</div>',
       `<div class="tooltip-date">${label}</div>`,
+      `<div class="tooltip-arrow"></div>`,
     ].join('');
   };
 }
@@ -134,11 +135,29 @@ export default function Tooltip({
     trigger: 'item',
     backgroundColor: 'transparent',
     transitionDuration: 0,
+    padding: 0,
     position(pos, _params, dom, _rec, _size) {
       // Center the tooltip slightly above the cursor.
       const tipWidth = dom.clientWidth;
       const tipHeight = dom.clientHeight;
-      return [pos[0] - tipWidth / 2, pos[1] - tipHeight - 16];
+
+      // Determine new left edge.
+      let leftPos = pos[0] - tipWidth / 2;
+      let arrowPosition = '50%';
+      const rightEdge = pos[0] + tipWidth;
+
+      // If the tooltip would go off viewport shift the tooltip over with a gap.
+      if (rightEdge >= window.innerWidth - 30) {
+        leftPos -= rightEdge - window.innerWidth + 30;
+        arrowPosition = `${pos[0] - leftPos}px`;
+      }
+      // Reposition the arrow.
+      const arrow = dom.querySelector('.tooltip-arrow');
+      if (arrow) {
+        arrow.style.left = arrowPosition;
+      }
+
+      return {left: leftPos, top: pos[1] - tipHeight - 20};
     },
     formatter,
     ...props,

--- a/src/sentry/static/sentry/app/components/charts/percentageAreaChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/percentageAreaChart.jsx
@@ -84,6 +84,7 @@ export default class PercentageAreaChart extends React.Component {
                 .join(''),
               '</div>',
               `<div class="tooltip-date">${date}</div>`,
+              '<div class="tooltip-arrow"></div>',
             ].join('');
           },
         }}

--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -115,6 +115,7 @@ class ReleaseSeries extends React.Component {
               time,
               '</div>',
               '</div>',
+              '<div class="tooltip-arrow"></div>',
             ].join('');
           },
         },

--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
@@ -111,7 +111,12 @@ export default class WorldMapChart extends React.Component {
               typeof value === 'number' ? value.toLocaleString() : '';
             const countryOrCode = this.state.codeToCountryMap[name] || name;
 
-            return `<div>${marker} ${countryOrCode}: ${formattedValue}</div>`;
+            return [
+              `<div class="tooltip-series">
+                 <div><span class="tooltip-label">${marker} <strong>${countryOrCode}</strong></span> ${formattedValue}</div>
+              </div>`,
+              '<div class="tooltip-arrow"></div>',
+            ].join('');
           },
         }}
       />


### PR DESCRIPTION
If the tooltip would overflow from the viewport on the right side move it back into the viewport. We don't have to worry about the leftside as most of our graphs are inset on the page and the sidebar gives us some more padding.

I've also fixed up the worldmap tooltips as I missed those before.

![tooltip](https://user-images.githubusercontent.com/24086/77091266-b6dfd500-69de-11ea-8369-91e0a3b71c17.gif)
