### PR TITLE
fix(icon): error color for navigation

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -2058,13 +2058,15 @@ ul.crumbs {
         background: @red;
       }
 
-      .icon {
-        color: @red;
-        top: 4px;
-        left: 5.5px;
+      .icon-container {
+        .icon {
+          color: @red;
+          top: 4px;
+          left: 5.5px;
 
-        &:before {
-          content: '\e906';
+          &:before {
+            content: '\e906';
+          }
         }
       }
 


### PR DESCRIPTION
**Before:**
<img width="738" alt="Screen Shot 2020-03-19 at 12 24 38 PM" src="https://user-images.githubusercontent.com/4830259/77106623-a3336f00-69dc-11ea-97d2-85bffcc3a3be.png">

**After:** 
<img width="974" alt="Screen Shot 2020-03-19 at 12 18 40 PM" src="https://user-images.githubusercontent.com/4830259/77106633-a6c6f600-69dc-11ea-8ee2-cb9b7c8fd2cb.png">