### PR TITLE
fix(search) Trailing backslash in wildcard search

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -46,7 +46,7 @@ def translate(pat):
         # fnmatch.translate has no way to handle escaping metacharacters.
         # Applied this basic patch to handle it:
         # https://bugs.python.org/file27570/issue8402.1.patch
-        if c == "\\":
+        if c == "\\" and i < n:
             res += re.escape(pat[i])
             i += 1
         elif c == "*":

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1049,6 +1049,10 @@ class GetSnubaQueryArgsTest(TestCase):
         ]
         assert _filter.filter_keys == {}
 
+    def test_wildcard_with_trailing_backslash(self):
+        results = get_filter("title:*misgegaan\\")
+        assert results.conditions == [[["match", ["title", u"'(?i)^.*misgegaan\\\\$'"]], "=", 1]]
+
     def test_has(self):
         assert get_filter("has:release").conditions == [[["isNull", ["release"]], "!=", 1]]
 


### PR DESCRIPTION
Having a trailing backslash on a wildcard search would cause an exception.