### PR TITLE
fix(ui) Improve country tooltips

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -323,6 +323,9 @@ const ChartContainer = styled('div')`
     padding: ${space(1)} ${space(2)};
     border-radius: ${theme.borderRadius} ${theme.borderRadius} 0 0;
   }
+  .tooltip-series-solo {
+    border-radius: ${theme.borderRadius};
+  }
   .tooltip-label {
     margin-right: ${space(1)};
   }

--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
@@ -112,7 +112,7 @@ export default class WorldMapChart extends React.Component {
             const countryOrCode = this.state.codeToCountryMap[name] || name;
 
             return [
-              `<div class="tooltip-series">
+              `<div class="tooltip-series tooltip-series-solo">
                  <div><span class="tooltip-label">${marker} <strong>${countryOrCode}</strong></span> ${formattedValue}</div>
               </div>`,
               '<div class="tooltip-arrow"></div>',


### PR DESCRIPTION
Add a bottom border radius to the world map tooltips.

### before
![Screen Shot 2020-03-19 at 4 57 25 PM](https://user-images.githubusercontent.com/24086/77114691-5616c380-6a03-11ea-8f8d-6024c6e30170.png)

### after
![Screen Shot 2020-03-19 at 4 58 52 PM](https://user-images.githubusercontent.com/24086/77114710-5dd66800-6a03-11ea-9aee-a66bf13033ce.png)
