### PR TITLE
ref(integrations): Add sentry APM to ApiClient

### DIFF
--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -12,6 +12,8 @@ from sentry.integrations import IntegrationFeatures
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationFormError
 from sentry.models import Activity, ExternalIssue, GroupLink, Integration
 from sentry.signals import integration_issue_created, integration_issue_linked
+from sentry.web.decorators import transaction_start
+
 
 MISSING_FEATURE_MESSAGE = "Your organization does not have access to this feature."
 
@@ -43,6 +45,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             data=issue_information,
         )
 
+    @transaction_start("GroupIntegrationDetailsEndpoint")
     def get(self, request, group, integration_id):
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
@@ -81,6 +84,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             return Response({"detail": six.text_type(e)}, status=400)
 
     # was thinking put for link an existing issue, post for create new issue?
+    @transaction_start("GroupIntegrationDetailsEndpoint")
     def put(self, request, group, integration_id):
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
@@ -169,6 +173,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
+    @transaction_start("GroupIntegrationDetailsEndpoint")
     def post(self, request, group, integration_id):
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
@@ -241,6 +246,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
+    @transaction_start("GroupIntegrationDetailsEndpoint")
     def delete(self, request, group, integration_id):
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)

--- a/src/sentry/integrations/client.py
+++ b/src/sentry/integrations/client.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 
-
 from time import time
-
 
 from sentry.shared_integrations.client import BaseApiClient
 from sentry.exceptions import InvalidIdentity

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import
 
+import sentry_sdk
+
 from django.core.urlresolvers import reverse
+from sentry_sdk.tracing import Span
+
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.integrations.issues import IssueBasicMixin
 from sentry.utils.http import absolute_uri
@@ -28,10 +32,15 @@ class GitHubIssueBasic(IssueBasicMixin):
 
         comment = data.get("comment")
         if comment:
-            try:
-                client.create_comment(repo=repo, issue_id=issue_num, data={"body": comment})
-            except ApiError as e:
-                raise IntegrationError(self.message_from_error(e))
+            with sentry_sdk.start_span(
+                Span(op="GithubIssueBasic", transaction="create_comment", sampled=True)
+            ) as span:
+                try:
+                    client.create_comment(repo=repo, issue_id=issue_num, data={"body": comment})
+                except ApiError as e:
+                    span.set_http_status(e.code)
+                    span.set_data("message", self.message_from_error(e))
+                    raise IntegrationError(self.message_from_error(e))
 
     def get_persisted_default_config_fields(self):
         return ["repo"]
@@ -85,25 +94,30 @@ class GitHubIssueBasic(IssueBasicMixin):
         if not repo:
             raise IntegrationError("repo kwarg must be provided")
 
-        try:
-            issue = client.create_issue(
-                repo=repo,
-                data={
-                    "title": data["title"],
-                    "body": data["description"],
-                    "assignee": data.get("assignee"),
-                },
-            )
-        except ApiError as e:
-            raise IntegrationError(self.message_from_error(e))
+        with sentry_sdk.start_span(
+            Span(op="GithubIssueBasic", transaction="create_issue", sampled=True)
+        ) as span:
+            try:
+                issue = client.create_issue(
+                    repo=repo,
+                    data={
+                        "title": data["title"],
+                        "body": data["description"],
+                        "assignee": data.get("assignee"),
+                    },
+                )
+            except ApiError as e:
+                span.set_http_status(e.code)
+                span.set_data("message", self.message_from_error(e))
+                raise IntegrationError(self.message_from_error(e))
 
-        return {
-            "key": issue["number"],
-            "title": issue["title"],
-            "description": issue["body"],
-            "url": issue["html_url"],
-            "repo": repo,
-        }
+            return {
+                "key": issue["number"],
+                "title": issue["title"],
+                "description": issue["body"],
+                "url": issue["html_url"],
+                "repo": repo,
+            }
 
     def get_link_issue_config(self, group, **kwargs):
         default_repo, repo_choices = self.get_repository_choices(group, **kwargs)

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import logging
 import json
 import requests
+import sentry_sdk
 import six
 
 from collections import OrderedDict
@@ -147,12 +148,15 @@ class BaseApiClient(object):
     def get_cache_prefix(self):
         return u"%s.%s.client:" % (self.integration_type, self.name)
 
-    def track_response_data(self, code, error=None):
+    def track_response_data(self, code, span, error=None):
         metrics.incr(
             u"%s.http_response" % (self.datadog_prefix),
             sample_rate=1.0,
             tags={self.integration_type: self.name, "status": code},
         )
+
+        span.set_http_status(code)
+        span.set_tag(self.integration_type, self.name)
 
         extra = {
             self.integration_type: self.name,
@@ -203,42 +207,47 @@ class BaseApiClient(object):
             sample_rate=1.0,
             tags={self.integration_type: self.name},
         )
-        try:
-            resp = getattr(session, method.lower())(
-                url=full_url,
-                headers=headers,
-                json=data if json else None,
-                data=data if not json else None,
-                params=params,
-                auth=auth,
-                verify=self.verify_ssl,
-                allow_redirects=allow_redirects,
-                timeout=timeout,
-            )
-            resp.raise_for_status()
-        except ConnectionError as e:
-            self.track_response_data("connection_error", e)
-            raise ApiHostError.from_exception(e)
-        except Timeout as e:
-            self.track_response_data("timeout", e)
-            raise ApiTimeoutError.from_exception(e)
-        except HTTPError as e:
-            resp = e.response
-            if resp is None:
-                self.track_response_data("unknown", e)
-                self.logger.exception(
-                    "request.error", extra={self.integration_type: self.name, "url": full_url}
+
+        with sentry_sdk.start_span(
+            op=u"{}.http".format(self.integration_type),
+            transaction=u"{}.http_response.{}".format(self.integration_type, self.name),
+        ) as span:
+            try:
+                resp = getattr(session, method.lower())(
+                    url=full_url,
+                    headers=headers,
+                    json=data if json else None,
+                    data=data if not json else None,
+                    params=params,
+                    auth=auth,
+                    verify=self.verify_ssl,
+                    allow_redirects=allow_redirects,
+                    timeout=timeout,
                 )
-                raise ApiError("Internal Error")
-            self.track_response_data(resp.status_code, e)
-            raise ApiError.from_response(resp)
+                resp.raise_for_status()
+            except ConnectionError as e:
+                self.track_response_data("connection_error", span, e)
+                raise ApiHostError.from_exception(e)
+            except Timeout as e:
+                self.track_response_data("timeout", span, e)
+                raise ApiTimeoutError.from_exception(e)
+            except HTTPError as e:
+                resp = e.response
+                if resp is None:
+                    self.track_response_data("unknown", span, e)
+                    self.logger.exception(
+                        "request.error", extra={self.integration_type: self.name, "url": full_url}
+                    )
+                    raise ApiError("Internal Error")
+                self.track_response_data(resp.status_code, span, e)
+                raise ApiError.from_response(resp)
 
-        self.track_response_data(resp.status_code)
+            self.track_response_data(resp.status_code, span)
 
-        if resp.status_code == 204:
-            return {}
+            if resp.status_code == 204:
+                return {}
 
-        return BaseApiResponse.from_response(resp, allow_text=allow_text)
+            return BaseApiResponse.from_response(resp, allow_text=allow_text)
 
     # subclasses should override ``request``
     def request(self, *args, **kwargs):

--- a/src/sentry/web/decorators.py
+++ b/src/sentry/web/decorators.py
@@ -7,6 +7,8 @@ from django.contrib import messages
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.utils import auth
+from sentry_sdk import Hub
+from sentry_sdk.tracing import Span
 
 ERR_BAD_SIGNATURE = _("The link you followed is invalid or expired.")
 
@@ -37,3 +39,15 @@ def signed_auth_required(func):
         return func(request, *args, **kwargs)
 
     return wrapped
+
+
+def transaction_start(endpoint):
+    def decorator(func):
+        @wraps(func)
+        def wrapped(request, *args, **kwargs):
+            with Hub.current.start_span(Span(op="http.server", transaction=endpoint, sampled=True)):
+                return func(request, *args, **kwargs)
+
+        return wrapped
+
+    return decorator

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -525,7 +525,9 @@ class SentryWsgiRemoteTest(TransactionTestCase):
                     body = "".join(app_iter)
 
         assert status == "200 OK", body
-        assert not events
+        assert set((e.get("type"), e.get("transaction")) for e in events) == {
+            ("transaction", "rule_processor_apply")
+        }
         assert calls == [1]
 
 


### PR DESCRIPTION
**Context**
We want to be able to get insight (via Sentry) into external requests made to integration services using the new Sentry APM work. For a first step we want to be able to:
* See outbound requests and their status codes for integrations
* Create saved queries in Discover for each integration 

**Statuses n' codes**
* **`transaction.status`**: This is the status of the transaction, and can be set by using `span.set_status`. 

* **`http.status_code`** - This is the status code for a http request, and normally is set automatically for you. However, if you want to be able to search on `http.status_code` (and in our case, add it as a column), then it needs to be tagged on the top level span of the transaction. To do this, I'm passing through the `span` in `track_response_data` and then calling `span.set_http_status(code)` which actually sets both the `transaction.status` and the `http.status_code`. (python sdk code [here](https://github.com/getsentry/sentry-python/blob/909ecaa14423afde602d0342846c497501bc4350/sentry_sdk/tracing.py#L280))

<img width="856" alt="Screen Shot 2020-04-01 at 11 00 39 AM" src="https://user-images.githubusercontent.com/15368179/78171294-15f31000-7409-11ea-95bb-3e9e3899265a.png">

**Detailed View**

This is just to demonstrate what the detailed view would look like, clicking through one of the transactions. The `integrations.http` is the transaction we added manually and the `http` transaction is the request that is automatically within the `ApiClient`.

<img width="892" alt="Screen Shot 2020-03-23 at 10 08 40 AM" src="https://user-images.githubusercontent.com/15368179/77343029-4bec1200-6cee-11ea-8a18-e4a8d6539fbd.png">

**Search By Trace**

In a particular transaction you can search by the trace id to see all the other related transactions, including the parent transaction, which is this case is the `GroupIntegrationDetailsEndpoint`:

<img width="861" alt="Screen Shot 2020-04-01 at 11 10 13 AM" src="https://user-images.githubusercontent.com/15368179/78171538-71250280-7409-11ea-816a-b58d0c8f49e2.png">


**The `transaction_start` decorator**

This decorator basically does what's implemented in [here](https://github.com/getsentry/sentry/blob/feat/data-privacy-rules-selector-field-with-search/src/sentry/api/endpoints/relay_projectconfigs.py#L28) in the `RelayProjectConfigsEndpoint`.

<img width="861" alt="Screen Shot 2020-04-01 at 10 25 47 AM" src="https://user-images.githubusercontent.com/15368179/78171447-489d0880-7409-11ea-852f-8a4fa2cac333.png">
