### PR TITLE
feat(incidents): Add endpoint to fetch stats for an incident

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -302,6 +302,7 @@ from sentry.incidents.endpoints.project_alert_rule_index import (
     ProjectAlertRuleIndexEndpoint,
     ProjectCombinedRuleIndexEndpoint,
 )
+from sentry.incidents.endpoints.organization_incident_stats import OrganizationIncidentStatsEndpoint
 
 # issues endpoints are available both top level (by numerical ID) as well as coupled
 # to the organization (and queryable via short ID)
@@ -607,6 +608,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/$",
                     OrganizationIncidentDetailsEndpoint.as_view(),
                     name="sentry-api-0-organization-incident-details",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/stats/$",
+                    OrganizationIncidentStatsEndpoint.as_view(),
+                    name="sentry-api-0-organization-incident-stats",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/incidents/$",

--- a/src/sentry/incidents/endpoints/organization_incident_stats.py
+++ b/src/sentry/incidents/endpoints/organization_incident_stats.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
+from sentry.api.serializers.snuba import SnubaTSResultSerializer
+from sentry.incidents.logic import bulk_get_incident_stats
+
+
+class OrganizationIncidentStatsEndpoint(IncidentEndpoint):
+    permission_classes = (IncidentPermission,)
+
+    def get(self, request, organization, incident):
+        """
+        Fetch total event counts, unique user counts and trend graph for an Incident.
+        ``````````````````
+        :auth: required
+        """
+        stats = bulk_get_incident_stats([incident], prewindow=True)[0]
+        event_stats_serializer = SnubaTSResultSerializer(organization, None, request.user)
+        results = {
+            "eventStats": event_stats_serializer.serialize(stats["event_stats"]),
+            "totalEvents": stats["total_events"],
+            "uniqueUsers": stats["unique_users"],
+        }
+        return Response(results)

--- a/tests/sentry/incidents/endpoints/test_organization_incident_stats.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_stats.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+
+from datetime import timedelta
+
+from django.utils import timezone
+from exam import fixture
+from freezegun import freeze_time
+
+from sentry.testutils import APITestCase
+
+
+class OrganizationIncidentDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-incident-stats"
+
+    def setUp(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        self.login_as(self.user)
+
+    @fixture
+    def organization(self):
+        return self.create_organization(owner=self.create_user())
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+    def test_no_perms(self):
+        incident = self.create_incident()
+        self.login_as(self.create_user())
+        with self.feature("organizations:incidents"):
+            resp = self.get_response(incident.organization.slug, incident.id)
+        assert resp.status_code == 403
+
+    def test_no_feature(self):
+        incident = self.create_incident()
+        resp = self.get_response(incident.organization.slug, incident.id)
+        assert resp.status_code == 404
+
+    @freeze_time()
+    def test_simple(self):
+        incident = self.create_incident(date_started=timezone.now() - timedelta(minutes=5))
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(incident.organization.slug, incident.identifier)
+
+        assert resp.data["totalEvents"] == 0
+        assert resp.data["uniqueUsers"] == 0
+        assert [data[1] for data in resp.data["eventStats"]["data"]] == [[]] * 61


### PR DESCRIPTION
Fetching these as part of the serializer is making the alert list extremely slow. We can have the
initial load be much faster if we separate these stats out into a separate call. As well as that,
loading the stats for each incident individually will make the page appear to load faster, since
we're not bottlenecked by the slowest query.