### PR TITLE
fix(dashboards) - Fixing the Affected User dashboard

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboards/widgetChart.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/widgetChart.jsx
@@ -37,13 +37,19 @@ class WidgetChart extends React.Component {
     const isDataEqual =
       this.props.results.length &&
       nextProps.results.length &&
-      isEqual(this.props.results[0].data, nextProps.results[0].data);
+      this.props.results.length === nextProps.results.length;
 
-    if (isDataEqual) {
-      return false;
+    if (!isDataEqual) {
+      return true;
     }
 
-    return true;
+    for (let i = 0; i < this.props.results.length; i++) {
+      if (!isEqual(this.props.results[i].data, nextProps.results[i].data)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   renderZoomableChart(ChartComponent, props) {


### PR DESCRIPTION
- When projects change and both have the same number of known users, the
  current comparison thinks that the tables are identical and doesn't
  update.
- This is happening with Affected Users cause it has 2 results, results[0] is Known users, results[1] are unknown.