### PR TITLE
feat(ui): Fix pressing "Enter" in `<SmartSearchBar>` while loading

### DIFF
--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -75,6 +75,46 @@ describe('SmartSearchBar', function() {
     MockApiClient.clearMockResponses();
   });
 
+  it('calls preventDefault when loading and enter is pressed', async function() {
+    jest.useRealTimers();
+    const getTagValuesMock = jest.fn().mockImplementation(() => {
+      return new Promise(() => {});
+    });
+    const onSearch = jest.fn();
+    const props = {
+      orgId: 'org-slug',
+      projectId: '0',
+      query: '',
+      organization,
+      supportedTags,
+      onGetTagValues: getTagValuesMock,
+      onSearch,
+    };
+
+    const searchBar = mountWithTheme(
+      <SmartSearchBar {...props} api={new Client()} />,
+
+      options
+    );
+    searchBar.find('input').simulate('focus');
+    searchBar.find('input').simulate('change', {target: {value: 'bro'}});
+    await tick();
+
+    // Can't select with tab
+    searchBar.find('input').simulate('keyDown', {key: 'ArrowDown'});
+    searchBar.find('input').simulate('keyDown', {key: 'Tab'});
+    expect(onSearch).not.toHaveBeenCalled();
+
+    searchBar.find('input').simulate('change', {target: {value: 'browser:'}});
+    await tick();
+
+    // press enter
+    const preventDefault = jest.fn();
+    searchBar.find('input').simulate('keyDown', {key: 'Enter', preventDefault});
+    expect(onSearch).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
   describe('componentWillReceiveProps()', function() {
     it('should add a space when setting state.query', function() {
       const searchBar = shallow(


### PR DESCRIPTION
This would previously submit the field while the dropdown bar is visible and it is in a loading state -- this action (Tab/Enter) should not do anything while the dropdown is open and in a loading state.