### PR TITLE
feat(ui): Add crashFreeUserBreakdown + session duration

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1087,3 +1087,12 @@ export type SentryServiceStatus = {
   incidents: SentryServiceIncident[];
   url: string;
 };
+
+export type CrashFreeTimeBreakdown = {
+  [key: string]: {
+    totalSessions: number;
+    crashFreeSessions: number | null;
+    crashFreeUsers: number | null;
+    totalUsers: number;
+  };
+};

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/index.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import {InjectedRouter} from 'react-router/lib/Router';
-import {Location} from 'history';
 import styled from '@emotion/styled';
 
 // import ChartZoom from 'app/components/charts/chartZoom';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
-import {Client} from 'app/api';
 import {IconWarning} from 'app/icons';
 import theme from 'app/utils/theme';
-import withApi from 'app/utils/withApi';
 import {GlobalSelection} from 'app/types';
 import TransitionChart from 'app/components/charts/transitionChart';
 import {Panel} from 'app/components/panels';
@@ -17,107 +13,74 @@ import ErrorPanel from 'app/components/charts/components/errorPanel';
 import space from 'app/styles/space';
 
 import ReleaseChart from './releaseChart';
-import ReleaseChartRequest from './releaseChartRequest';
-import ReleaseChartControls from './releaseChartControls';
+import ReleaseChartControls, {YAxis} from './releaseChartControls';
+import {ReleaseStatsRequestRenderProps} from './releaseStatsRequest';
 
-export type YAxis = 'sessions' | 'users' | 'crashFree';
-
-type Props = {
-  api: Client;
-  router: InjectedRouter;
-  location: Location;
+type Props = Omit<ReleaseStatsRequestRenderProps, 'crashFreeTimeBreakdown'> & {
   selection: GlobalSelection;
-  version: string;
-  orgId: string;
-  projectSlug: string;
-};
-
-type State = {
-  summary: React.ReactNode;
   yAxis: YAxis;
+  onYAxisChange: (yAxis: YAxis) => void;
 };
 
-class ReleaseChartContainer extends React.Component<Props, State> {
-  state: State = {
-    summary: '',
-    yAxis: 'sessions',
-  };
+const ReleaseChartContainer = ({
+  selection,
+  loading,
+  errored,
+  reloading,
+  chartData,
+  chartSummary,
+  yAxis,
+  onYAxisChange,
+}: Props) => {
+  const {datetime, projects} = selection;
+  const {utc} = datetime;
 
-  handleYAxisChange = (value: YAxis) => {
-    this.setState({yAxis: value});
-  };
+  return (
+    <Panel>
+      <ChartWrapper>
+        {/* <ChartZoom router={router} period={period} utc={utc} start={start} end={end}>
+          {zoomRenderProps => ( */}
+        <ReleaseSeries utc={utc} projects={projects}>
+          {({releaseSeries}) => {
+            if (errored) {
+              return (
+                <ErrorPanel>
+                  <IconWarning color={theme.gray2} size="lg" />
+                </ErrorPanel>
+              );
+            }
 
-  handleSummaryChange = (value: React.ReactNode) => {
-    this.setState({summary: value});
-  };
-
-  render() {
-    const {api, location, selection, version, orgId, projectSlug} = this.props;
-    const {summary, yAxis} = this.state;
-    const {datetime, projects} = selection;
-    const {utc} = datetime;
-
-    return (
-      <Panel>
-        <ChartWrapper>
-          {/* <ChartZoom router={router} period={period} utc={utc} start={start} end={end}>
-        {zoomRenderProps => ( */}
-          <ReleaseChartRequest
-            api={api}
-            orgId={orgId}
-            projectSlug={projectSlug}
-            version={version}
-            selection={selection}
-            location={location}
-            yAxis={yAxis}
-            onSummaryChange={this.handleSummaryChange}
-          >
-            {({loading, reloading, errored, timeseriesData}) => (
-              <ReleaseSeries utc={utc} projects={projects}>
-                {({releaseSeries}) => {
-                  if (errored) {
-                    return (
-                      <ErrorPanel>
-                        <IconWarning color={theme.gray2} size="lg" />
-                      </ErrorPanel>
-                    );
-                  }
-
-                  return (
-                    <TransitionChart loading={loading} reloading={reloading}>
-                      <React.Fragment>
-                        <TransparentLoadingMask visible={reloading} />
-                        <ReleaseChart
-                          utc={utc}
-                          releaseSeries={releaseSeries}
-                          timeseriesData={timeseriesData}
-                          // zoomRenderProps={zoomRenderProps}
-                          reloading={reloading}
-                          yAxis={yAxis}
-                        />
-                      </React.Fragment>
-                    </TransitionChart>
-                  );
-                }}
-              </ReleaseSeries>
-            )}
-          </ReleaseChartRequest>
-          {/*   )}
-       </ChartZoom> */}
-        </ChartWrapper>
-
-        <ReleaseChartControls
-          summary={summary}
-          yAxis={yAxis}
-          onYAxisChange={this.handleYAxisChange}
-        />
-      </Panel>
-    );
-  }
-}
+            return (
+              <TransitionChart loading={loading} reloading={reloading}>
+                <React.Fragment>
+                  <TransparentLoadingMask visible={reloading} />
+                  <ReleaseChart
+                    utc={utc}
+                    releaseSeries={releaseSeries}
+                    timeseriesData={chartData}
+                    // zoomRenderProps={zoomRenderProps}
+                    reloading={reloading}
+                    yAxis={yAxis}
+                  />
+                </React.Fragment>
+              </TransitionChart>
+            );
+          }}
+        </ReleaseSeries>
+        {/* )}
+        </ChartZoom> */}
+      </ChartWrapper>
+      <ReleaseChartControls
+        summary={chartSummary}
+        yAxis={yAxis}
+        onYAxisChange={onYAxisChange}
+      />
+    </Panel>
+  );
+};
 
 const ChartWrapper = styled('div')`
   padding: ${space(1)} ${space(2)};
 `;
 
-export default withApi(ReleaseChartContainer);
+export default ReleaseChartContainer;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseChart.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseChart.tsx
@@ -5,8 +5,10 @@ import LineChart from 'app/components/charts/lineChart';
 import AreaChart from 'app/components/charts/areaChart';
 import {Series} from 'app/types/echarts';
 import theme from 'app/utils/theme';
+import {defined} from 'app/utils';
+import {t} from 'app/locale';
 
-import {YAxis} from '.';
+import {YAxis} from './releaseChartControls';
 
 type Props = {
   reloading: boolean;
@@ -33,10 +35,24 @@ class ReleaseChart extends React.Component<Props> {
     return true;
   }
 
+  formatTooltipValue = (value: string | number | null) => {
+    const {yAxis} = this.props;
+    switch (yAxis) {
+      case 'sessionDuration':
+        return defined(value) ? `${value}${t('s')}` : '-';
+      case 'crashFree':
+        return defined(value) ? `${value}%` : '-';
+      case 'sessions':
+      case 'users':
+      default:
+        return typeof value === 'number' ? value.toLocaleString() : value;
+    }
+  };
+
   render() {
     const {utc, releaseSeries, timeseriesData, yAxis} = this.props;
-    const crashFreeChart = yAxis === 'crashFree';
-    const Chart = crashFreeChart ? AreaChart : LineChart;
+    const Chart =
+      yAxis === 'crashFree' || yAxis === 'sessionDuration' ? AreaChart : LineChart;
 
     const legend = {
       right: 16,
@@ -72,7 +88,7 @@ class ReleaseChart extends React.Component<Props> {
           bottom: '12px',
         }}
         yAxis={
-          crashFreeChart
+          yAxis === 'crashFree'
             ? {
                 max: 100,
                 scale: true,
@@ -83,7 +99,7 @@ class ReleaseChart extends React.Component<Props> {
               }
             : undefined
         }
-        tooltip={crashFreeChart ? {valueFormatter: value => `${value}%`} : undefined}
+        tooltip={{valueFormatter: this.formatTooltipValue}}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseChartControls.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseChartControls.tsx
@@ -6,7 +6,7 @@ import space from 'app/styles/space';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 
-import {YAxis} from '.';
+export type YAxis = 'sessions' | 'users' | 'crashFree' | 'sessionDuration';
 
 type Props = {
   summary: React.ReactNode;
@@ -19,6 +19,10 @@ const ReleaseChartControls = ({summary, yAxis, onYAxisChange}: Props) => {
     {
       value: 'sessions',
       label: t('Session Count'),
+    },
+    {
+      value: 'sessionDuration',
+      label: t('Session Duration'),
     },
     {
       value: 'users',
@@ -36,6 +40,8 @@ const ReleaseChartControls = ({summary, yAxis, onYAxisChange}: Props) => {
         return t('Total Active Users');
       case 'crashFree':
         return t('Average Rate');
+      case 'sessionDuration':
+        return t('Average Duration');
       case 'sessions':
       default:
         return t('Total Sessions');

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
@@ -230,7 +230,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
       },
     };
 
-    const calculateDatePercentage = (responseData, subject) => {
+    const calculateDatePercentage = (responseData, subject: YAxis) => {
       const percentageData = responseData.map(entry => {
         const [timeframe, values] = entry;
         const date = timeframe * 1000;
@@ -269,14 +269,14 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
     return {chartData: Object.values(chartData), chartSummary: summary};
   }
 
-  transformSessionDurationData(data): Omit<Data, 'crashFreeTimeBreakdown'> {
+  transformSessionDurationData(responseData): Omit<Data, 'crashFreeTimeBreakdown'> {
     // here we can configure colors of the chart
     const chartData: Series = {
       seriesName: t('Session Duration'),
       data: [],
     };
 
-    data.forEach(entry => {
+    responseData.forEach(entry => {
       const [timeframe, values] = entry;
       const date = timeframe * 1000;
       chartData.data.push({name: date, value: values.duration_p50});

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
@@ -279,12 +279,14 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
     responseData.forEach(entry => {
       const [timeframe, values] = entry;
       const date = timeframe * 1000;
-      chartData.data.push({name: date, value: values.duration_p50});
+      chartData.data.push({name: date, value: Math.round(values.duration_p50)});
     });
 
-    const sessionDurationAverage = meanBy(
-      chartData.data.filter(item => defined(item.value)),
-      'value'
+    const sessionDurationAverage = Math.round(
+      meanBy(
+        chartData.data.filter(item => defined(item.value)),
+        'value'
+      )
     );
     const summary = tn('%s second', '%s seconds', sessionDurationAverage ?? 0);
 

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
@@ -7,14 +7,14 @@ import {Location} from 'history';
 
 import {Client} from 'app/api';
 import {addErrorMessage} from 'app/actionCreators/indicator';
-import {t, tct} from 'app/locale';
-import {GlobalSelection} from 'app/types';
+import {t, tct, tn} from 'app/locale';
+import {GlobalSelection, CrashFreeTimeBreakdown} from 'app/types';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
-import {percent} from 'app/utils';
+import {percent, defined} from 'app/utils';
 import {Series} from 'app/types/echarts';
 
 import {displayCrashFreePercent, getCrashFreePercent} from '../../../utils';
-import {YAxis} from '.';
+import {YAxis} from './releaseChartControls';
 
 const omitIgnoredProps = (props: Props) =>
   omitBy(props, (_, key) =>
@@ -25,11 +25,16 @@ type ChartData = {
   [key: string]: Series;
 };
 
-type RenderProps = {
+type Data = {
+  chartData: Series[];
+  chartSummary: React.ReactNode;
+  crashFreeTimeBreakdown: CrashFreeTimeBreakdown;
+};
+
+export type ReleaseStatsRequestRenderProps = Data & {
   loading: boolean;
   reloading: boolean;
   errored: boolean;
-  timeseriesData: Series[];
 };
 
 type Props = {
@@ -40,17 +45,16 @@ type Props = {
   selection: GlobalSelection;
   location: Location;
   yAxis: YAxis;
-  onSummaryChange: (summary: React.ReactNode) => void;
-  children: (renderProps: RenderProps) => React.ReactNode;
+  children: (renderProps: ReleaseStatsRequestRenderProps) => React.ReactNode;
 };
 type State = {
   reloading: boolean;
   errored: boolean;
-  data: Series[] | null;
+  data: Data | null;
 };
 
-class ReleaseChartRequest extends React.Component<Props, State> {
-  state = {
+class ReleaseStatsRequest extends React.Component<Props, State> {
+  state: State = {
     reloading: false,
     errored: false,
     data: null,
@@ -74,7 +78,7 @@ class ReleaseChartRequest extends React.Component<Props, State> {
   private unmounting: boolean = false;
 
   fetchData = async () => {
-    let data: Series[] | null;
+    let data: Data | null = null;
     const {yAxis} = this.props;
 
     this.setState(state => ({
@@ -83,12 +87,19 @@ class ReleaseChartRequest extends React.Component<Props, State> {
     }));
 
     try {
-      data = await (yAxis === 'crashFree' ? this.fetchRateData : this.fetchCountData)();
+      if (yAxis === 'crashFree') {
+        data = await this.fetchRateData();
+      } else {
+        // session duration uses same endpoint as sessions
+        data = await this.fetchCountData(
+          yAxis === 'sessionDuration' ? 'sessions' : yAxis
+        );
+      }
     } catch {
       addErrorMessage(t('Error loading chart data'));
-      data = null;
       this.setState({
         errored: true,
+        data: null,
       });
     }
 
@@ -102,17 +113,22 @@ class ReleaseChartRequest extends React.Component<Props, State> {
     });
   };
 
-  fetchCountData = async () => {
+  fetchCountData = async (type: YAxis) => {
     const {api, yAxis} = this.props;
 
     const response = await api.requestPromise(this.statsPath, {
       query: {
         ...this.baseQueryParams,
-        type: yAxis,
+        type,
       },
     });
 
-    return this.transformCountData(response.stats, yAxis);
+    const transformedData =
+      yAxis === 'sessionDuration'
+        ? this.transformSessionDurationData(response.stats)
+        : this.transformCountData(response.stats, yAxis);
+
+    return {...transformedData, crashFreeTimeBreakdown: response.usersBreakdown};
   };
 
   fetchRateData = async () => {
@@ -133,7 +149,12 @@ class ReleaseChartRequest extends React.Component<Props, State> {
       }),
     ]);
 
-    return this.transformRateData(userResponse.stats, sessionResponse.stats);
+    const transformedData = this.transformRateData(
+      userResponse.stats,
+      sessionResponse.stats
+    );
+
+    return {...transformedData, crashFreeTimeBreakdown: userResponse.usersBreakdown};
   };
 
   get statsPath() {
@@ -148,7 +169,7 @@ class ReleaseChartRequest extends React.Component<Props, State> {
     return pick(location.query, [...Object.values(URL_PARAM)]);
   }
 
-  transformCountData(data, yAxis: string): Series[] {
+  transformCountData(responseData, yAxis: string): Omit<Data, 'crashFreeTimeBreakdown'> {
     let summary = 0;
     // here we can configure colors of the chart
     const chartData: ChartData = {
@@ -170,7 +191,7 @@ class ReleaseChartRequest extends React.Component<Props, State> {
       },
     };
 
-    data.forEach(entry => {
+    responseData.forEach(entry => {
       const [timeframe, values] = entry;
       const date = timeframe * 1000;
       summary += values[yAxis];
@@ -180,12 +201,13 @@ class ReleaseChartRequest extends React.Component<Props, State> {
       chartData.total.data.push({name: date, value: values[yAxis]});
     });
 
-    this.props.onSummaryChange(summary.toLocaleString());
-
-    return Object.values(chartData);
+    return {chartData: Object.values(chartData), chartSummary: summary.toLocaleString()};
   }
 
-  transformRateData(users, sessions) {
+  transformRateData(
+    responseUsersData,
+    responseSessionsData
+  ): Omit<Data, 'crashFreeTimeBreakdown'> {
     const chartData: ChartData = {
       users: {
         seriesName: t('Crash Free Users'),
@@ -208,37 +230,65 @@ class ReleaseChartRequest extends React.Component<Props, State> {
       },
     };
 
-    const calculateDatePercentage = (data, subject) => {
-      const percentageData = data.map(entry => {
+    const calculateDatePercentage = (responseData, subject) => {
+      const percentageData = responseData.map(entry => {
         const [timeframe, values] = entry;
         const date = timeframe * 1000;
 
-        const crashFreePercent = getCrashFreePercent(
-          100 - percent(values[`${subject}_crashed`], values[subject])
-        );
+        const crashFreePercent =
+          values[subject] !== 0
+            ? getCrashFreePercent(
+                100 - percent(values[`${subject}_crashed`], values[subject])
+              )
+            : null;
 
         return {name: date, value: crashFreePercent};
       });
 
-      const averagePercent = displayCrashFreePercent(meanBy(percentageData, 'value'));
+      const averagePercent = displayCrashFreePercent(
+        meanBy(
+          percentageData.filter(item => defined(item.value)),
+          'value'
+        )
+      );
 
       return {averagePercent, percentageData};
     };
 
-    const usersPercentages = calculateDatePercentage(users, 'users');
+    const usersPercentages = calculateDatePercentage(responseUsersData, 'users');
     chartData.users.data = usersPercentages.percentageData;
 
-    const sessionsPercentages = calculateDatePercentage(sessions, 'sessions');
+    const sessionsPercentages = calculateDatePercentage(responseSessionsData, 'sessions');
     chartData.sessions.data = sessionsPercentages.percentageData;
 
-    this.props.onSummaryChange(
-      tct('[usersPercent] users, [sessionsPercent] sessions', {
-        usersPercent: usersPercentages.averagePercent,
-        sessionsPercent: sessionsPercentages.averagePercent,
-      })
-    );
+    const summary = tct('[usersPercent] users, [sessionsPercent] sessions', {
+      usersPercent: usersPercentages.averagePercent,
+      sessionsPercent: sessionsPercentages.averagePercent,
+    });
 
-    return Object.values(chartData);
+    return {chartData: Object.values(chartData), chartSummary: summary};
+  }
+
+  transformSessionDurationData(data): Omit<Data, 'crashFreeTimeBreakdown'> {
+    // here we can configure colors of the chart
+    const chartData: Series = {
+      seriesName: t('Session Duration'),
+      data: [],
+    };
+
+    data.forEach(entry => {
+      const [timeframe, values] = entry;
+      const date = timeframe * 1000;
+      chartData.data.push({name: date, value: values.duration_p50});
+    });
+
+    const sessionDurationAverage = meanBy(
+      chartData.data.filter(item => defined(item.value)),
+      'value'
+    );
+    const summary = tn('%s second', '%s seconds', sessionDurationAverage ?? 0);
+
+    return {chartData: [chartData], chartSummary: summary};
   }
 
   render() {
@@ -250,9 +300,11 @@ class ReleaseChartRequest extends React.Component<Props, State> {
       loading,
       reloading,
       errored,
-      timeseriesData: data ?? [],
+      chartData: data?.chartData ?? [],
+      chartSummary: data?.chartSummary ?? '',
+      crashFreeTimeBreakdown: data?.crashFreeTimeBreakdown ?? {},
     });
   }
 }
 
-export default ReleaseChartRequest;
+export default ReleaseStatsRequest;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -89,10 +89,12 @@ class ReleaseOverview extends React.Component<Props, State> {
                       />
                     )}
                     <ProjectReleaseDetails release={release!} />
-                    <TotalCrashFreeUsers
-                      crashFreeTimeBreakdown={crashFreeTimeBreakdown}
-                      startDate={release?.dateReleased ?? release?.dateCreated}
-                    />
+                    {project.healthData?.hasHealthData && (
+                      <TotalCrashFreeUsers
+                        crashFreeTimeBreakdown={crashFreeTimeBreakdown}
+                        startDate={release?.dateReleased ?? release?.dateCreated}
+                      />
+                    )}
                     {/* TODO(releasesV2): hidden for now */}
                     {/* <SessionDuration /> */}
                   </Sidebar>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -7,13 +7,16 @@ import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import {Organization, GlobalSelection} from 'app/types';
 import space from 'app/styles/space';
+import {Client} from 'app/api';
+import withApi from 'app/utils/withApi';
 
-import HealthChart from './chart';
+import ReleaseChartContainer from './chart';
 import Issues from './issues';
 import CommitAuthorBreakdown from './commitAuthorBreakdown';
 import ProjectReleaseDetails from './projectReleaseDetails';
 import TotalCrashFreeUsers from './totalCrashFreeUsers';
-import SessionDuration from './sessionDuration';
+import ReleaseStatsRequest from './chart/releaseStatsRequest';
+import {YAxis} from './chart/releaseChartControls';
 
 import {ReleaseContext} from '..';
 
@@ -23,50 +26,85 @@ type Props = {
   location: Location;
   selection: GlobalSelection;
   router: InjectedRouter;
+  api: Client;
 };
 
-const ReleaseOverview = ({organization, params, selection, router, location}: Props) => (
-  <ReleaseContext.Consumer>
-    {release => {
-      const {commitCount, version, projects} = release!; // if release is undefined, this will not be rendered at all
-      const project = projects.find(p => p.id === selection.projects[0]);
-      // TODO(releasesV2): we will handle this with locked projects later
-      if (!project) {
-        return null;
-      }
-      return (
-        <ContentBox>
-          <Main>
-            {project.healthData?.hasHealthData && (
-              <HealthChart
-                version={version}
-                orgId={organization.slug}
-                projectSlug={project.slug}
-                router={router}
-                selection={selection}
-                location={location}
-              />
-            )}
-            <Issues orgId={organization.slug} version={params.release} />
-          </Main>
-          <Sidebar>
-            {commitCount > 0 && (
-              <CommitAuthorBreakdown
-                version={version}
-                orgId={organization.slug}
-                commitCount={commitCount}
-                projectSlug={project.slug}
-              />
-            )}
-            <ProjectReleaseDetails release={release!} />
-            <TotalCrashFreeUsers />
-            <SessionDuration />
-          </Sidebar>
-        </ContentBox>
-      );
-    }}
-  </ReleaseContext.Consumer>
-);
+type State = {
+  yAxis: YAxis;
+};
+
+class ReleaseOverview extends React.Component<Props, State> {
+  state: State = {
+    yAxis: 'sessions',
+  };
+
+  handleYAxisChange = (yAxis: YAxis) => {
+    this.setState({yAxis});
+  };
+
+  render() {
+    const {organization, params, selection, location, api} = this.props;
+    const {yAxis} = this.state;
+
+    return (
+      <ReleaseContext.Consumer>
+        {release => {
+          const {commitCount, version, projects} = release!; // if release is undefined, this will not be rendered at all
+          const project = projects.find(p => p.id === selection.projects[0]);
+          // TODO(releasesV2): we will handle this with locked projects later
+          if (!project) {
+            return null;
+          }
+
+          return (
+            <ReleaseStatsRequest
+              api={api}
+              orgId={organization.slug}
+              projectSlug={project?.slug}
+              version={version}
+              selection={selection}
+              location={location}
+              yAxis={yAxis}
+            >
+              {({crashFreeTimeBreakdown, ...releaseStatsProps}) => (
+                <ContentBox>
+                  <Main>
+                    {project.healthData?.hasHealthData && (
+                      <ReleaseChartContainer
+                        onYAxisChange={this.handleYAxisChange}
+                        selection={selection}
+                        yAxis={yAxis}
+                        {...releaseStatsProps}
+                      />
+                    )}
+                    <Issues orgId={organization.slug} version={params.release} />
+                  </Main>
+                  <Sidebar>
+                    {commitCount > 0 && (
+                      <CommitAuthorBreakdown
+                        version={version}
+                        orgId={organization.slug}
+                        commitCount={commitCount}
+                        projectSlug={project.slug}
+                      />
+                    )}
+                    <ProjectReleaseDetails release={release!} />
+                    <TotalCrashFreeUsers
+                      crashFreeTimeBreakdown={crashFreeTimeBreakdown}
+                      startDate={release?.dateReleased ?? release?.dateCreated}
+                    />
+                    {/* TODO(releasesV2): hidden for now */}
+                    {/* <SessionDuration /> */}
+                  </Sidebar>
+                </ContentBox>
+              )}
+            </ReleaseStatsRequest>
+          );
+        }}
+      </ReleaseContext.Consumer>
+    );
+  }
+}
 
 const ContentBox = styled('div')`
   padding: ${space(4)};
@@ -87,4 +125,4 @@ const Sidebar = styled('div')`
   grid-column: 2 / 3;
 `;
 
-export default withGlobalSelection(withOrganization(ReleaseOverview));
+export default withApi(withGlobalSelection(withOrganization(ReleaseOverview)));

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/totalCrashFreeUsers.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/totalCrashFreeUsers.tsx
@@ -1,36 +1,91 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import moment from 'moment';
 
-import {t} from 'app/locale';
+import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
+import {CrashFreeTimeBreakdown} from 'app/types';
+import {defined} from 'app/utils';
+import Count from 'app/components/count';
 
 import {SectionHeading, Wrapper} from './styles';
 
-type Props = {};
+type Props = {
+  crashFreeTimeBreakdown: CrashFreeTimeBreakdown;
+  startDate?: string;
+};
 
-// TODO(releasesV2): waiting for API
-const TotalCrashFreeUsers = ({}: Props) => (
-  <Wrapper>
-    <SectionHeading>{t('Total Crash Free Users')}</SectionHeading>
-    <Timeline>
-      {[1, 2, 3, 4].map((_, index) => (
-        <Row key={index}>
+const TotalCrashFreeUsers = ({crashFreeTimeBreakdown, startDate}: Props) => {
+  if (!startDate) {
+    return null;
+  }
+
+  const periodToDays = {
+    '1d': 1,
+    '1w': 7,
+    '2w': 14,
+    '4w': 28,
+  };
+
+  const periodToLabels = {
+    '1d': t('Last day'),
+    '1w': t('Last week'),
+    '2w': t('Last 2 weeks'),
+    '4w': t('Last month'),
+  };
+
+  const timeline = Object.entries(crashFreeTimeBreakdown)
+    // convert '1d', '1w', etc. to date objects
+    .map(([period, value]) => {
+      const date = moment().subtract(periodToDays[period], 'days');
+      const crashFreeUserCount = Math.round(
+        ((value.crashFreeUsers ?? 0) * value.totalUsers) / 100
+      );
+      return {...value, crashFreeUserCount, period, date};
+    })
+    // sort them by latest
+    .sort((a, b) => (a.date.isAfter(b.date) ? -1 : 1))
+    // remove those that are before release was created
+    .filter(item => item.date.isAfter(startDate));
+
+  if (!timeline.length) {
+    return null;
+  }
+
+  return (
+    <Wrapper>
+      <SectionHeading>{t('Total Crash Free Users')}</SectionHeading>
+      <Timeline>
+        {timeline.map(row => (
+          <Row key={row.date.toString()}>
+            <InnerRow>
+              <Text bold>{row.date.format('MMMM D')}</Text>
+              <Text bold right>
+                <Count value={row.crashFreeUserCount} />{' '}
+                {tn('user', 'users', row.crashFreeUserCount)}
+              </Text>
+            </InnerRow>
+            <InnerRow>
+              <Text>{periodToLabels[row.period]}</Text>
+              <Text right>
+                {defined(row.crashFreeUsers) ? `${row.crashFreeUsers}%` : '-'}
+              </Text>
+            </InnerRow>
+          </Row>
+        ))}
+        <Row>
           <InnerRow>
-            <Text bold>March 7</Text>
-            <Text bold right>
-              4.8k users
-            </Text>
+            <Text bold>{moment(startDate).format('MMMM D')}</Text>
           </InnerRow>
           <InnerRow>
-            <Text>1 wk later</Text>
-            <Text right>30%</Text>
+            <Text>{t('Release created')}</Text>
           </InnerRow>
         </Row>
-      ))}
-    </Timeline>
-  </Wrapper>
-);
+      </Timeline>
+    </Wrapper>
+  );
+};
 
 const Timeline = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
@@ -67,12 +122,13 @@ const InnerRow = styled('div')`
   grid-auto-flow: column;
   grid-auto-columns: 1fr;
 
-  padding-bottom: ${space(0.75)};
+  padding-bottom: ${space(0.5)};
 `;
 
 const Text = styled('div')<{bold?: boolean; right?: boolean}>`
   font-weight: ${p => (p.bold ? 600 : 400)};
   text-align: ${p => (p.right ? 'right' : 'left')};
+  padding-bottom: ${space(0.25)};
   ${overflowEllipsis};
 `;
 


### PR DESCRIPTION
This PR connects the Total Crash Free Users widget in the sidebar to API and adds new chart type - session duration.