### PR TITLE
feat(IntegrationDirectory): Add category tags

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -670,6 +670,7 @@ export type SentryApp = {
     id: number;
     slug: string;
   };
+  featureData: IntegrationFeature[];
 };
 
 export type Integration = {

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -8,6 +8,7 @@ import {
   SentryAppInstallation,
   IntegrationInstallationStatus,
   SentryAppStatus,
+  IntegrationFeature,
 } from 'app/types';
 import {Hooks} from 'app/types/hooks';
 import HookStore from 'app/stores/hookStore';
@@ -204,4 +205,28 @@ export const getSentryAppInstallStatus = (install: SentryAppInstallation | undef
     return capitalize(install.status) as IntegrationInstallationStatus;
   }
   return 'Not Installed';
+};
+
+export const getCategories = (features: IntegrationFeature[]): string[] => {
+  const transform = features.map(({featureGate}) => {
+    const feature = featureGate
+      .replace(/integrations/g, '')
+      .replace(/-/g, ' ')
+      .trim();
+    switch (feature) {
+      case 'actionable notification':
+        return 'notification action';
+      case 'issue basic':
+      case 'issue sync':
+        return 'project management';
+      case 'commits':
+        return 'source code management';
+      case 'chat unfurl':
+        return 'chat';
+      default:
+        return feature;
+    }
+  });
+
+  return [...new Set(transform)];
 };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -1,4 +1,3 @@
-import uniq from 'lodash/uniq';
 import React from 'react';
 import styled from '@emotion/styled';
 import {RouteComponentProps} from 'react-router/lib/Router';
@@ -20,6 +19,7 @@ import {
   getIntegrationFeatureGate,
   trackIntegrationEvent,
   SingleIntegrationEvent,
+  getCategories,
 } from 'app/utils/integrationUtil';
 import Alert, {Props as AlertProps} from 'app/components/alert';
 import ExternalLink from 'app/components/links/externalLink';
@@ -231,11 +231,7 @@ class AbstractIntegrationDetailedView<
   }
 
   cleanTags() {
-    return uniq(
-      this.featureData.map(feature =>
-        feature.featureGate.replace(/integrations/g, '').replace(/-/g, ' ')
-      )
-    );
+    return getCategories(this.featureData);
   }
 
   renderAddInstallButton(hideButtonIfDisabled = false) {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -11,13 +11,13 @@ import {
   IntegrationProvider,
   SentryAppInstallation,
   PluginWithProjectList,
-  IntegrationFeature,
 } from 'app/types';
 import {Panel, PanelBody} from 'app/components/panels';
 import {
   trackIntegrationEvent,
   getSentryAppInstallStatus,
   getSortIntegrationsByWeightActive,
+  getCategories,
 } from 'app/utils/integrationUtil';
 import {t, tct} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -289,29 +289,6 @@ export class OrganizationIntegrations extends AsyncComponent<
     });
   };
 
-  getCategories = (features: IntegrationFeature[]): string[] => {
-    const transform = features.map(({featureGate}) => {
-      const feature = featureGate
-        .replace(/integrations/g, '')
-        .replace(/-/g, ' ')
-        .trim();
-      switch (feature) {
-        case 'actionable notification':
-          return 'notification action';
-        case 'issue basic':
-        case 'issue sync':
-          return 'project management';
-        case 'commits':
-          return 'source code management';
-        case 'chat unfurl':
-          return 'chat';
-        default:
-          return feature;
-      }
-    });
-
-    return [...new Set(transform)];
-  };
   // Rendering
   renderProvider = (provider: IntegrationProvider) => {
     const {organization} = this.props;
@@ -331,7 +308,7 @@ export class OrganizationIntegrations extends AsyncComponent<
         status={integrations.length ? 'Installed' : 'Not Installed'}
         publishStatus="published"
         configurations={integrations.length}
-        categories={this.getCategories(provider.metadata.features)}
+        categories={getCategories(provider.metadata.features)}
       />
     );
   };
@@ -356,7 +333,7 @@ export class OrganizationIntegrations extends AsyncComponent<
         status={plugin.projectList.length ? 'Installed' : 'Not Installed'}
         publishStatus="published"
         configurations={plugin.projectList.length}
-        categories={this.getCategories(plugin.featureDescriptions)}
+        categories={getCategories(plugin.featureDescriptions)}
       />
     );
   };
@@ -367,7 +344,7 @@ export class OrganizationIntegrations extends AsyncComponent<
     const status = getSentryAppInstallStatus(this.getAppInstall(app));
     const categories = ['internal', 'unpublished'].includes(app.status)
       ? [app.status]
-      : this.getCategories(app.featureData);
+      : getCategories(app.featureData);
 
     return (
       <IntegrationRow

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -11,6 +11,7 @@ import {
   IntegrationProvider,
   SentryAppInstallation,
   PluginWithProjectList,
+  IntegrationFeature,
 } from 'app/types';
 import {Panel, PanelBody} from 'app/components/panels';
 import {
@@ -288,6 +289,26 @@ export class OrganizationIntegrations extends AsyncComponent<
     });
   };
 
+  getCategories = (features: IntegrationFeature[]): string[] => {
+    const transform = features.map(({featureGate}) => {
+      switch (featureGate) {
+        case 'actionable-notification':
+          return 'notification action';
+        case 'issue-basic':
+          return 'project management';
+        case 'issue-sync':
+          return 'project management';
+        case 'commits':
+          return 'source code management';
+        case 'chat-unfurl':
+          return 'chat';
+        default:
+          return featureGate.replace(/integrations/g, '').replace(/-/g, ' ');
+      }
+    });
+
+    return [...new Set(transform)];
+  };
   // Rendering
   renderProvider = (provider: IntegrationProvider) => {
     const {organization} = this.props;
@@ -307,6 +328,7 @@ export class OrganizationIntegrations extends AsyncComponent<
         status={integrations.length ? 'Installed' : 'Not Installed'}
         publishStatus="published"
         configurations={integrations.length}
+        categories={this.getCategories(provider.metadata.features)}
       />
     );
   };
@@ -331,6 +353,7 @@ export class OrganizationIntegrations extends AsyncComponent<
         status={plugin.projectList.length ? 'Installed' : 'Not Installed'}
         publishStatus="published"
         configurations={plugin.projectList.length}
+        categories={this.getCategories(plugin.featureDescriptions)}
       />
     );
   };
@@ -339,6 +362,10 @@ export class OrganizationIntegrations extends AsyncComponent<
   renderSentryApp = (app: SentryApp) => {
     const {organization} = this.props;
     const status = getSentryAppInstallStatus(this.getAppInstall(app));
+    // console.log(app.featureData);
+    const categories = ['internal', 'unpublished'].includes(app.status)
+      ? [app.status]
+      : this.getCategories(app.featureData);
 
     return (
       <IntegrationRow
@@ -351,6 +378,7 @@ export class OrganizationIntegrations extends AsyncComponent<
         status={status}
         publishStatus={app.status}
         configurations={0}
+        categories={categories}
       />
     );
   };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -291,19 +291,22 @@ export class OrganizationIntegrations extends AsyncComponent<
 
   getCategories = (features: IntegrationFeature[]): string[] => {
     const transform = features.map(({featureGate}) => {
-      switch (featureGate) {
-        case 'actionable-notification':
+      const feature = featureGate
+        .replace(/integrations/g, '')
+        .replace(/-/g, ' ')
+        .trim();
+      switch (feature) {
+        case 'actionable notification':
           return 'notification action';
-        case 'issue-basic':
-          return 'project management';
-        case 'issue-sync':
+        case 'issue basic':
+        case 'issue sync':
           return 'project management';
         case 'commits':
           return 'source code management';
-        case 'chat-unfurl':
+        case 'chat unfurl':
           return 'chat';
         default:
-          return featureGate.replace(/integrations/g, '').replace(/-/g, ' ');
+          return feature;
       }
     });
 
@@ -362,7 +365,6 @@ export class OrganizationIntegrations extends AsyncComponent<
   renderSentryApp = (app: SentryApp) => {
     const {organization} = this.props;
     const status = getSentryAppInstallStatus(this.getAppInstall(app));
-    // console.log(app.featureData);
     const categories = ['internal', 'unpublished'].includes(app.status)
       ? [app.status]
       : this.getCategories(app.featureData);

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -66,7 +66,7 @@ const IntegrationRow = (props: Props) => {
             {renderDetails()}
           </IntegrationDetails>
         </Container>
-        <FlexContainer>
+        <InternalContainer>
           {categories?.map(category => (
             <CategoryTag
               key={category}
@@ -74,7 +74,7 @@ const IntegrationRow = (props: Props) => {
               priority={category === publishStatus}
             />
           ))}
-        </FlexContainer>
+        </InternalContainer>
       </FlexContainer>
     </PanelItem>
   );
@@ -84,6 +84,10 @@ const FlexContainer = styled('div')`
   display: flex;
   align-items: center;
   padding: ${space(2)};
+`;
+
+const InternalContainer = styled(FlexContainer)`
+  padding: 0 ${space(2)};
 `;
 
 const Container = styled('div')`

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -71,7 +71,7 @@ const IntegrationRow = (props: Props) => {
             <CategoryTag
               key={category}
               category={category}
-              publishStatus={publishStatus}
+              priority={category === publishStatus}
             />
           ))}
         </FlexContainer>
@@ -131,18 +131,21 @@ const PublishStatus = styled(({status, ...props}: PublishStatusProps) => (
   }
 `;
 
-const CategoryTag = styled(({category, ...p}) => <div {...p}>{category}</div>)`
+const CategoryTag = styled(
+  ({priority, category, ...p}: {category: string; priority: boolean; theme?: any}) => (
+    <div {...p}>{category}</div>
+  )
+)`
   display: flex;
   flex-direction: row;
   padding: 1px 10px;
-  background: ${p =>
-    p.category === p.publishStatus ? p.theme.purpleLightest : p.theme.offWhite2};
+  background: ${p => (p.priority ? p.theme.purpleLightest : p.theme.offWhite2)};
   border-radius: 20px;
   font-size: ${space(1.5)};
   margin-right: ${space(1)};
   line-height: ${space(3)};
   text-align: center;
-  color: ${p => (p.category === p.publishStatus ? p.theme.white : p.theme.gray4)};
+  color: ${p => (p.priority ? p.theme.white : p.theme.gray4)};
 `;
 
 export default IntegrationRow;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -39,7 +39,6 @@ const IntegrationRow = (props: Props) => {
     categories,
   } = props;
 
-  // console.log({type, slug, categories});
   const baseUrl =
     publishStatus === 'internal'
       ? `/settings/${organization.slug}/developer-settings/${slug}/`
@@ -136,7 +135,10 @@ const CategoryTag = styled(({category, ...p}) => <div {...p}>{category}</div>)`
   display: flex;
   flex-direction: row;
   padding: 1px 10px;
-  background: ${p => (p.category === p.publishStatus ? '#E1567C' : p.theme.offWhite2)};
+  background: ${p =>
+    p.category === p.publishStatus
+      ? /*'#E1567C'*/ p.theme.purpleLightest
+      : p.theme.offWhite2};
   border-radius: 20px;
   font-size: ${space(1.5)};
   margin-right: ${space(1)};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -18,6 +18,7 @@ type Props = {
   status: IntegrationInstallationStatus;
   publishStatus: 'unpublished' | 'published' | 'internal';
   configurations: number;
+  categories?: string[];
 };
 
 const urlMap = {
@@ -35,8 +36,10 @@ const IntegrationRow = (props: Props) => {
     status,
     publishStatus,
     configurations,
+    categories,
   } = props;
 
+  // console.log({type, slug, categories});
   const baseUrl =
     publishStatus === 'internal'
       ? `/settings/${organization.slug}/developer-settings/${slug}/`
@@ -64,6 +67,15 @@ const IntegrationRow = (props: Props) => {
             {renderDetails()}
           </IntegrationDetails>
         </Container>
+        <FlexContainer>
+          {categories?.map(category => (
+            <CategoryTag
+              key={category}
+              category={category}
+              publishStatus={publishStatus}
+            />
+          ))}
+        </FlexContainer>
       </FlexContainer>
     </PanelItem>
   );
@@ -118,6 +130,19 @@ const PublishStatus = styled(({status, ...props}: PublishStatusProps) => (
     margin-right: ${space(0.75)};
     font-weight: normal;
   }
+`;
+
+const CategoryTag = styled(({category, ...p}) => <div {...p}>{category}</div>)`
+  display: flex;
+  flex-direction: row;
+  padding: 1px 10px;
+  background: ${p => (p.category === p.publishStatus ? '#E1567C' : p.theme.offWhite2)};
+  border-radius: 20px;
+  font-size: ${space(1.5)};
+  margin-right: ${space(1)};
+  line-height: ${space(3)};
+  text-align: center;
+  color: ${p => (p.category === p.publishStatus ? p.theme.white : p.theme.gray4)};
 `;
 
 export default IntegrationRow;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -136,9 +136,7 @@ const CategoryTag = styled(({category, ...p}) => <div {...p}>{category}</div>)`
   flex-direction: row;
   padding: 1px 10px;
   background: ${p =>
-    p.category === p.publishStatus
-      ? /*'#E1567C'*/ p.theme.purpleLightest
-      : p.theme.offWhite2};
+    p.category === p.publishStatus ? p.theme.purpleLightest : p.theme.offWhite2};
   border-radius: 20px;
   font-size: ${space(1.5)};
   margin-right: ${space(1)};

--- a/tests/js/sentry-test/fixtures/integrationListDirectory.js
+++ b/tests/js/sentry-test/fixtures/integrationListDirectory.js
@@ -78,6 +78,7 @@ export function OrgOwnedApps() {
       uuid: 'a806ab10-9608-4a4f-8dd9-ca6d6c09f9f5',
       verifyInstall: false,
       webhookUrl: 'https://myheadbandwasher.com',
+      featureData: [],
     },
     {
       allowedOrigins: [],
@@ -99,6 +100,13 @@ export function OrgOwnedApps() {
       uuid: 'a59c8fcc-2f27-49f8-af9e-02661fc3e8d7',
       verifyInstall: false,
       webhookUrl: 'https://lacroix.com',
+      featureData: [
+        {
+          description:
+            'La Croix can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).',
+          featureGate: 'integrations-api',
+        },
+      ],
     },
     {
       allowedOrigins: [],
@@ -118,6 +126,13 @@ export function OrgOwnedApps() {
       uuid: '5d547ecb-7eb8-4ed2-853b-40256177d526',
       verifyInstall: false,
       webhookUrl: 'http://localhost:7000',
+      featureData: [
+        {
+          description:
+            'Clickup can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).',
+          featureGate: 'integrations-api',
+        },
+      ],
     },
   ];
 }
@@ -142,6 +157,13 @@ export function PublishedApps() {
       uuid: '5d547ecb-7eb8-4ed2-853b-40256177d526',
       verifyInstall: false,
       webhookUrl: 'http://localhost:7000',
+      featureData: [
+        {
+          description:
+            'Clickup can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).',
+          featureGate: 'integrations-api',
+        },
+      ],
     },
   ];
 }
@@ -210,7 +232,14 @@ export function PluginListConfig() {
       shortName: 'PagerDuty',
       id: 'pagerduty',
       assets: [],
-      featureDescriptions: [],
+      featureDescriptions: [
+        {
+          description:
+            'Configure rule based PagerDuty alerts to automatically be triggered in a specific\n            service - or in multiple services!',
+          featureGate: 'alert-rule',
+        },
+      ],
+      features: ['alert-rule'],
       name: 'PagerDuty',
       author: {url: 'https://github.com/getsentry/sentry', name: 'Sentry Team'},
       contexts: [],

--- a/tests/js/sentry-test/fixtures/integrationListDirectory.js
+++ b/tests/js/sentry-test/fixtures/integrationListDirectory.js
@@ -228,7 +228,6 @@ export function PluginListConfig() {
       isTestable: true,
       isHidden: true,
       hasConfiguration: true,
-      features: [],
       shortName: 'PagerDuty',
       id: 'pagerduty',
       assets: [],


### PR DESCRIPTION
## Objective
Currently, you cannot see the categories of an integration in the directory. You have to go to the detailed view in order to see the categories of the integration. We are adding the categories to the right side of the row in the home page of the directory.

The categories are pulled from the featureGate of the IntegrationFeature objects associated with the integration (either featureDescriptions or features depending on the type of integration).

## UI
_List view:_
<img width="1440" alt="Screen Shot 2020-03-20 at 4 20 20 PM" src="https://user-images.githubusercontent.com/10491193/77213084-c9353e00-6ac6-11ea-83a8-b2639832d8e1.png">


_Detailed view:_
<img width="1440" alt="Screen Shot 2020-03-20 at 4 19 13 PM" src="https://user-images.githubusercontent.com/10491193/77213028-98ed9f80-6ac6-11ea-8cca-97b8f3e5ffe8.png">

## Test Plan
Created an. internal integration, published app, unpublished app and viewed the results in the UI.