### PR TITLE
feat(ts): Improve experiment typings

### DIFF
--- a/src/sentry/static/sentry/app/data/experimentConfig.tsx
+++ b/src/sentry/static/sentry/app/data/experimentConfig.tsx
@@ -1,0 +1,45 @@
+import {Experiments} from 'app/types/experiments';
+
+/**
+ * This is the value an experiment will have when the unit of assignment
+ * (organization, user, etc) is not part of any experiment group.
+ *
+ * This likely indicates they should see nothing, or the original version of
+ * what's being tested.
+ */
+export const unassignedValue = -1;
+
+/**
+ * Frontend experiment configuration object
+ */
+export const experimentList = [
+  {
+    key: 'TrialUpgradeV2Experiment',
+    type: 'organization',
+    parameter: 'variant',
+    assignments: ['upgrade', 'trial', -1],
+  },
+  {
+    key: 'AlertDefaultsExperiment',
+    type: 'organization',
+    parameter: 'variant',
+    assignments: ['controlV1', '2Optionsv1', '3OptionsV2'],
+  },
+  {
+    key: 'IntegrationDirectorySortWeightExperiment',
+    type: 'organization',
+    parameter: 'variant',
+    assignments: ['1', '0', -1],
+  },
+  {
+    key: 'AssistantGuideExperiment',
+    type: 'user',
+    parameter: 'variant',
+    assignments: [0, 1, -1],
+  },
+] as const;
+
+export const experimentConfig = experimentList.reduce(
+  (acc, exp) => ({...acc, [exp.key]: exp}),
+  {}
+) as Experiments;

--- a/src/sentry/static/sentry/app/types/experiments.tsx
+++ b/src/sentry/static/sentry/app/types/experiments.tsx
@@ -1,0 +1,73 @@
+import {experimentList, unassignedValue} from 'app/data/experimentConfig';
+
+/**
+ * An experiment configuration object defines an experiment in the frontend.
+ * This drives various logic in experiment helpers.
+ */
+export type ExperimentConfig = {
+  /**
+   * The name of the organization. This maps to the key exposed by the
+   * organization manager on the backend.
+   */
+  key: string;
+  /**
+   * The type of experiment. This configures what group the experiment is
+   * performed on.
+   *
+   * A `organization` experiment assigns the whole organization.
+   * A `user` experiment assigns a single user.
+   */
+  type: 'organization' | 'user';
+  /**
+   * The parameter used to access the assignment value
+   */
+  parameter: string | 'variant' | 'exposed';
+  /**
+   * Possible assignment values of the experiment
+   */
+  assignments: ReadonlyArray<string | number | typeof unassignedValue>;
+};
+
+// NOTE: The code below is mostly type mechanics to provide utility types
+// around experiments for use in experiment helpers. You probably don't need to
+// modify this and likely just need to make changes to the experiment list [0]
+//
+// [0]: app/data/experimentConfig.tsx
+
+type ExperimentList = typeof experimentList[number];
+
+type ExperimentSelect<
+  C extends ExperimentConfig,
+  N extends ExperimentConfig['key']
+> = C extends {key: N} ? C : never;
+
+type TypeSelect<
+  C extends ExperimentConfig,
+  T extends ExperimentConfig['type']
+> = C extends {type: T} ? C : never;
+
+/**
+ * A mapping of experiment key to the experiment configuration.
+ */
+export type Experiments = {
+  [E in ExperimentList['key']]: ExperimentSelect<ExperimentList, E>;
+};
+
+/**
+ * Represents an active experiment key
+ */
+export type ExperimentKey = ExperimentList['key'];
+
+type GetExperimentAssignment<E extends ExperimentList['key']> = {
+  [K in E]: Experiments[K]['assignments'][number];
+};
+
+export type OrgExperiments = GetExperimentAssignment<
+  TypeSelect<ExperimentList, 'organization'>['key']
+>;
+
+export type UserExperiments = GetExperimentAssignment<
+  TypeSelect<ExperimentList, 'user'>['key']
+>;
+
+export type ExperimentAssignment = GetExperimentAssignment<ExperimentList['key']>;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1,12 +1,13 @@
 import {SpanEntry} from 'app/components/events/interfaces/spans/types';
 import {API_ACCESS_SCOPES} from 'app/constants';
 import {Field} from 'app/views/settings/components/forms/type';
+import {PlatformKey} from 'app/data/platformCategories';
+import {OrgExperiments, UserExperiments} from 'app/types/experiments';
 import {
   INSTALLED,
   NOT_INSTALLED,
   PENDING,
 } from 'app/views/organizationIntegrations/constants';
-import {PlatformKey} from 'app/data/platformCategories';
 
 export type IntegrationInstallationStatus =
   | typeof INSTALLED
@@ -69,7 +70,7 @@ export type LightWeightOrganization = OrganizationSummary & {
     maxRate: number | null;
   };
   defaultRole: string;
-  experiments: Partial<ActiveOrgExperiments>;
+  experiments: Partial<OrgExperiments>;
   allowJoinRequests: boolean;
   scrapeJavaScript: boolean;
   isDefault: boolean;
@@ -323,7 +324,7 @@ export type User = AvatarUser & {
   flags: {newsletter_consent_prompt: boolean};
   hasPasswordAuth: boolean;
   permissions: Set<string>;
-  experiments: Partial<ActiveUserExperiments>;
+  experiments: Partial<UserExperiments>;
 };
 
 export type CommitAuthor = {
@@ -858,16 +859,6 @@ export type SentryAppComponent = {
     slug: string;
     name: string;
   };
-};
-
-export type ActiveOrgExperiments = {
-  TrialUpgradeV2Experiment: 'upgrade' | 'trial' | -1;
-  AlertDefaultsExperiment: 'controlV1' | '2OptionsV1' | '3OptionsV2';
-  IntegrationDirectorySortWeightExperiment: '1' | '0';
-};
-
-export type ActiveUserExperiments = {
-  AssistantGuideExperiment: 0 | 1 | -1;
 };
 
 type SavedQueryVersions = 1 | 2;


### PR DESCRIPTION
This introduces a configuration object for active experiments, along
with some type utilities for experiments

They are not all completely in use yet, but an upcoming withExperiment
HoC will make use of them.