### PR TITLE
feat(ui): Changed warning message when trying to delete release v2

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseActions.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseActions.tsx
@@ -41,7 +41,7 @@ const ReleaseActions = ({orgId, version}: Props) => {
       <Confirm
         onConfirm={handleDelete}
         message={t(
-          'Deleting this release is permanent. Are you sure you wish to continue?'
+          'Deleting this release is permanent and will affect other projects associated with it. Are you sure you wish to continue?'
         )}
       >
         <Button>


### PR DESCRIPTION
Changed warning message when trying to delete release v2.

Because now every project has its own release detail page (even though it's the same release).