### PR TITLE
ref(ui): Release project moved to context

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -797,7 +797,7 @@ export type Release = {
   projects: ReleaseProject[];
 } & BaseRelease;
 
-type ReleaseProject = {
+export type ReleaseProject = {
   slug: string;
   name: string;
   id: number;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
@@ -4,45 +4,34 @@ import {Params} from 'react-router/lib/Router';
 import {Location} from 'history';
 
 import {t} from 'app/locale';
-import {GlobalSelection} from 'app/types';
 import Alert from 'app/components/alert';
 import space from 'app/styles/space';
 import ReleaseArtifactsV1 from 'app/views/releases/detail/releaseArtifacts';
-import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 import {ReleaseContext} from '..';
 
 type Props = {
   params: Params;
   location: Location;
-  selection: GlobalSelection;
 };
 
-const ReleaseArtifacts = ({params, location, selection}: Props) => (
+const ReleaseArtifacts = ({params, location}: Props) => (
   <ReleaseContext.Consumer>
-    {release => {
-      const project = release?.projects.find(p => p.id === selection.projects[0]);
-      // TODO(releasesV2): we will handle this later with forced project selector
-      if (!project) {
-        return null;
-      }
+    {({project}) => (
+      <ContentBox>
+        <Alert type="warning">
+          {t(
+            'We are working on improving this experience, therefore Artifacts will be moving to Settings soon.'
+          )}
+        </Alert>
 
-      return (
-        <ContentBox>
-          <Alert type="warning">
-            {t(
-              'We are working on improving this experience, therefore Artifacts will be moving to Settings soon.'
-            )}
-          </Alert>
-
-          <ReleaseArtifactsV1
-            params={params}
-            location={location}
-            projectId={project.slug}
-          />
-        </ContentBox>
-      );
-    }}
+        <ReleaseArtifactsV1
+          params={params}
+          location={location}
+          projectId={project.slug}
+        />
+      </ContentBox>
+    )}
   </ReleaseContext.Consumer>
 );
 
@@ -52,4 +41,4 @@ const ContentBox = styled('div')`
   background-color: ${p => p.theme.white};
 `;
 
-export default withGlobalSelection(ReleaseArtifacts);
+export default ReleaseArtifacts;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/commits/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/commits/index.tsx
@@ -6,12 +6,11 @@ import AsyncComponent from 'app/components/asyncComponent';
 import CommitRow from 'app/components/commitRow';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {Repository, Commit, GlobalSelection} from 'app/types';
+import {Repository, Commit} from 'app/types';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {PanelHeader, Panel, PanelBody} from 'app/components/panels';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import overflowEllipsisLeft from 'app/styles/overflowEllipsisLeft';
-import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 import {getCommitsByRepository, CommitsByRepository} from '../utils';
 import ReleaseNoCommitData from '../releaseNoCommitData';
@@ -24,9 +23,7 @@ type RouteParams = {
   release: string;
 };
 
-type Props = RouteComponentProps<RouteParams, {}> & {
-  selection: GlobalSelection;
-};
+type Props = RouteComponentProps<RouteParams, {}>;
 
 type State = {
   commits: Commit[];
@@ -45,10 +42,10 @@ class ReleaseCommits extends AsyncComponent<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {params, selection} = this.props;
+    const {params} = this.props;
     const {orgId, release} = params;
 
-    const project = this.context.projects.find(p => p.id === selection.projects[0]);
+    const {project} = this.context;
 
     return [
       [
@@ -160,4 +157,4 @@ const RepoLabel = styled('div')`
   ${overflowEllipsisLeft}
 `;
 
-export default withGlobalSelection(ReleaseCommits);
+export default ReleaseCommits;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
@@ -6,7 +6,7 @@ import pick from 'lodash/pick';
 import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
-import {Organization, Release, Deploy} from 'app/types';
+import {Organization, Release, ReleaseProject, Deploy, GlobalSelection} from 'app/types';
 import AsyncView from 'app/views/asyncView';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import NoProjectMessage from 'app/components/noProjectMessage';
@@ -16,16 +16,19 @@ import withOrganization from 'app/utils/withOrganization';
 import routeTitleGen from 'app/utils/routeTitle';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {formatVersion} from 'app/utils/formatters';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 import ReleaseHeader from './releaseHeader';
 
-const ReleaseContext = React.createContext<Release | undefined>(undefined);
+type ReleaseContext = {release: Release; project: ReleaseProject};
+const ReleaseContext = React.createContext<ReleaseContext>({} as ReleaseContext);
 
 type Props = {
   organization: Organization;
   location: Location;
   router: ReactRouter.InjectedRouter;
   params: Params;
+  selection: GlobalSelection;
 } & AsyncView['props'];
 
 type State = {
@@ -33,7 +36,6 @@ type State = {
   deploys: Deploy[];
 } & AsyncView['state'];
 
-// TODO(releasesv2): Handle project selection
 class ReleasesV2Detail extends AsyncView<Props, State> {
   getTitle() {
     const {params, organization} = this.props;
@@ -86,8 +88,14 @@ class ReleasesV2Detail extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {organization, location} = this.props;
+    const {organization, location, selection} = this.props;
     const {release, deploys} = this.state;
+    const project = release.projects.find(p => p.id === selection.projects[0]);
+
+    // TODO(releasesv2): This will be handled later with forced project selector
+    if (!project || !release) {
+      return null;
+    }
 
     return (
       <NoProjectMessage organization={organization}>
@@ -97,9 +105,10 @@ class ReleasesV2Detail extends AsyncView<Props, State> {
             orgId={organization.slug}
             release={release}
             deploys={deploys}
+            project={project}
           />
 
-          <ReleaseContext.Provider value={release}>
+          <ReleaseContext.Provider value={{release, project}}>
             {this.props.children}
           </ReleaseContext.Provider>
         </StyledPageContent>
@@ -120,4 +129,4 @@ const StyledPageContent = styled(PageContent)`
 `;
 
 export {ReleasesV2DetailContainer, ReleaseContext};
-export default withOrganization(ReleasesV2DetailContainer);
+export default withGlobalSelection(withOrganization(ReleasesV2DetailContainer));

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -48,13 +48,9 @@ class ReleaseOverview extends React.Component<Props, State> {
 
     return (
       <ReleaseContext.Consumer>
-        {release => {
-          const {commitCount, version, projects} = release!; // if release is undefined, this will not be rendered at all
-          const project = projects.find(p => p.id === selection.projects[0]);
-          // TODO(releasesV2): we will handle this with locked projects later
-          if (!project) {
-            return null;
-          }
+        {({release, project}) => {
+          const {commitCount, version} = release;
+          const {hasHealthData} = project.healthData || {};
 
           return (
             <ReleaseStatsRequest
@@ -69,7 +65,7 @@ class ReleaseOverview extends React.Component<Props, State> {
               {({crashFreeTimeBreakdown, ...releaseStatsProps}) => (
                 <ContentBox>
                   <Main>
-                    {project.healthData?.hasHealthData && (
+                    {hasHealthData && (
                       <ReleaseChartContainer
                         onYAxisChange={this.handleYAxisChange}
                         selection={selection}
@@ -88,11 +84,11 @@ class ReleaseOverview extends React.Component<Props, State> {
                         projectSlug={project.slug}
                       />
                     )}
-                    <ProjectReleaseDetails release={release!} />
-                    {project.healthData?.hasHealthData && (
+                    <ProjectReleaseDetails release={release} />
+                    {hasHealthData && (
                       <TotalCrashFreeUsers
                         crashFreeTimeBreakdown={crashFreeTimeBreakdown}
-                        startDate={release?.dateReleased ?? release?.dateCreated}
+                        startDate={release.dateReleased ?? release.dateCreated}
                       />
                     )}
                     {/* TODO(releasesV2): hidden for now */}

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
@@ -8,7 +8,7 @@ import Link from 'app/components/links/link';
 import ListLink from 'app/components/links/listLink';
 import ExternalLink from 'app/components/links/externalLink';
 import NavTabs from 'app/components/navTabs';
-import {Release, Deploy, GlobalSelection} from 'app/types';
+import {Release, Deploy, ReleaseProject} from 'app/types';
 import Version from 'app/components/version';
 import Clipboard from 'app/components/clipboard';
 import {IconCopy, IconOpen} from 'app/icons';
@@ -16,7 +16,6 @@ import Tooltip from 'app/components/tooltip';
 import Badge from 'app/components/badge';
 import Count from 'app/components/count';
 import TimeSince from 'app/components/timeSince';
-import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 import ReleaseStat from './releaseStat';
 import Breadcrumbs from './breadcrumbs';
@@ -27,14 +26,12 @@ type Props = {
   orgId: string;
   release: Release;
   deploys: Deploy[];
-  selection: GlobalSelection;
+  project: ReleaseProject;
 };
 
-const ReleaseHeader = ({location, orgId, release, deploys, selection}: Props) => {
+const ReleaseHeader = ({location, orgId, release, deploys, project}: Props) => {
   const {version, newGroups, url} = release;
-
-  const healthData = release.projects.find(p => p.id === selection.projects[0])
-    ?.healthData;
+  const {healthData} = project;
 
   const releasePath = `/organizations/${orgId}/releases-v2/${encodeURIComponent(
     version
@@ -82,12 +79,11 @@ const ReleaseHeader = ({location, orgId, release, deploys, selection}: Props) =>
               </DeploysWrapper>
             </ReleaseStat>
           )}
-          <ReleaseStat label={t('Crashes')}>
-            <Count value={healthData?.sessionsCrashed ?? 0} />
-          </ReleaseStat>
-          {/* <ReleaseStat label={t('Errors')}>
-            <Count value={healthData?.sessionsErrored ?? 0} />
-          </ReleaseStat> */}
+          {healthData?.hasHealthData && (
+            <ReleaseStat label={t('Crashes')}>
+              <Count value={healthData?.sessionsCrashed ?? 0} />
+            </ReleaseStat>
+          )}
           <ReleaseStat label={t('New Issues')}>
             <Count value={newGroups} />
           </ReleaseStat>
@@ -198,4 +194,4 @@ const StyledNavTabs = styled(NavTabs)`
   grid-column: 1 / 2;
 `;
 
-export default withGlobalSelection(ReleaseHeader);
+export default ReleaseHeader;


### PR DESCRIPTION
I realized I was often looking for a project in release object with the ID equal to the currently selected project in the selection header.

I decided to add this to the already existing release context and therefore clean up multiple components.