### PR TITLE
fix: Remove additional dot from docs link

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRulesPanel/dataPrivacyRulesPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRulesPanel/dataPrivacyRulesPanel.tsx
@@ -246,7 +246,7 @@ class DataPrivacyRulesPanel extends React.Component<Props, State> {
           <StyledPanelHeader>{t('Data Privacy Rules')}</StyledPanelHeader>
           <PanelAlert type="info">
             {additionalContext}
-            {tct('To learn more about datascubbing, [linkToDocs].', {
+            {tct('To learn more about datascubbing, [linkToDocs]', {
               linkToDocs: (
                 <Link
                   href="https://docs.sentry.io/data-management/advanced-datascrubbing/"


### PR DESCRIPTION
![Screenshot 2020-03-20 at 14 50 04](https://user-images.githubusercontent.com/837573/77169798-5faf3280-6aba-11ea-86d1-b8086f643140.png)

Assuming that we want to have the dot inside the link based on screenshots from https://github.com/getsentry/sentry/pull/17783