### PR TITLE
feat(ui): Collapse commit authors in release v2 detail

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/commitAuthorBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/commitAuthorBreakdown.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import round from 'lodash/round';
 
 import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
@@ -52,7 +51,7 @@ class CommitAuthorBreakdown extends AsyncComponent<Props, State> {
   getDisplayPercent(authorCommitCount: number): string {
     const {commits} = this.state;
 
-    const calculatedPercent = round(percent(authorCommitCount, commits.length), 0);
+    const calculatedPercent = Math.round(percent(authorCommitCount, commits.length));
 
     return `${calculatedPercent < 1 ? '<1' : calculatedPercent}%`;
   }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/commitAuthorBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/commitAuthorBreakdown.tsx
@@ -97,8 +97,8 @@ class CommitAuthorBreakdown extends AsyncComponent<Props, State> {
     // collapse them
     const MAX = CommitAuthorBreakdown.MAX_WHEN_COLLAPSED;
     const initialNumberOfAuthors = sortedAuthorsByNumberOfCommits.length;
-    const canCollapse = initialNumberOfAuthors > MAX;
-    if (collapsed && canCollapse) {
+    const canExpand = initialNumberOfAuthors > MAX;
+    if (collapsed && canExpand) {
       sortedAuthorsByNumberOfCommits = sortedAuthorsByNumberOfCommits.slice(0, MAX);
     }
     const collapsedNumberOfAuthors =
@@ -129,7 +129,7 @@ class CommitAuthorBreakdown extends AsyncComponent<Props, State> {
             )}
           </StyledButton>
         )}
-        {collapsedNumberOfAuthors === 0 && canCollapse && (
+        {collapsedNumberOfAuthors === 0 && canExpand && (
           <StyledButton priority="link" onClick={this.onCollapseToggle}>
             {t('Collapse')}
           </StyledButton>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -80,7 +80,6 @@ class ReleaseOverview extends React.Component<Props, State> {
                       <CommitAuthorBreakdown
                         version={version}
                         orgId={organization.slug}
-                        commitCount={commitCount}
                         projectSlug={project.slug}
                       />
                     )}


### PR DESCRIPTION
This PR adds collapsing of commit authors in the release v2 detail page.

![image](https://user-images.githubusercontent.com/9060071/77170112-dcdaa780-6aba-11ea-9537-c008b2824241.png)
