### PR TITLE
fix(perf-view): Display total number of transactions on the landing page

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
@@ -16,7 +16,7 @@ type Props = {
 export default function ChartFooter({total, yAxisValue, yAxisOptions, onChange}: Props) {
   const elements: React.ReactNode[] = [];
 
-  elements.push(<SectionHeading key="total-label">{t('Total')}</SectionHeading>);
+  elements.push(<SectionHeading key="total-label">{t('Total Events')}</SectionHeading>);
   elements.push(
     total === null ? (
       <SectionValue data-test-id="loading-placeholder" key="total-value">

--- a/src/sentry/static/sentry/app/views/performance/charts/footer.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/footer.tsx
@@ -1,20 +1,93 @@
 import React from 'react';
+import * as Sentry from '@sentry/browser';
+import {Location} from 'history';
 
 import {t} from 'app/locale';
+import {Client} from 'app/api';
+import {fetchTotalCount} from 'app/views/eventsV2/utils';
+import EventView, {isAPIPayloadSimilar} from 'app/views/eventsV2/eventView';
+import {Organization} from 'app/types';
 
-import {ChartControls, SectionHeading} from './styles';
+import {ChartControls, SectionHeading, SectionValue} from './styles';
 
 type Props = {
-  totals: number | null;
+  api: Client;
+  eventView: EventView;
+  organization: Organization;
+  location: Location;
 };
 
-export default function ChartFooter({totals}: Props) {
-  return (
-    <ChartControls>
-      <SectionHeading>
-        {t('Total Events')}
-        {totals}
-      </SectionHeading>
-    </ChartControls>
-  );
+type State = {
+  totalValues: null | number;
+};
+
+class ChartFooter extends React.Component<Props, State> {
+  state: State = {
+    totalValues: null,
+  };
+
+  componentDidMount() {
+    this.mounted = true;
+
+    this.fetchTotalCount();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const orgSlugHasChanged =
+      this.props.organization.slug !== prevProps.organization.slug;
+    const shouldRefetch = this.shouldRefetchData(prevProps);
+
+    if ((orgSlugHasChanged || shouldRefetch) && this.props.eventView.isValid()) {
+      this.fetchTotalCount();
+    }
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
+  shouldRefetchData = (prevProps: Props): boolean => {
+    const thisAPIPayload = this.props.eventView.getEventsAPIPayload(this.props.location);
+    const otherAPIPayload = prevProps.eventView.getEventsAPIPayload(prevProps.location);
+
+    return !isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
+  };
+
+  mounted: boolean = false;
+
+  async fetchTotalCount() {
+    const {api, organization, location, eventView} = this.props;
+    if (!eventView.isValid() || !this.mounted) {
+      return;
+    }
+
+    try {
+      const totals = await fetchTotalCount(
+        api,
+        organization.slug,
+        eventView.getEventsAPIPayload(location)
+      );
+
+      if (this.mounted) {
+        this.setState({totalValues: totals});
+      }
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+  }
+
+  render() {
+    const {totalValues} = this.state;
+
+    const value = typeof totalValues === 'number' ? totalValues.toLocaleString() : '-';
+
+    return (
+      <ChartControls>
+        <SectionHeading>{t('Total Events')}</SectionHeading>
+        <SectionValue>{value}</SectionValue>
+      </ChartControls>
+    );
+  }
 }
+
+export default ChartFooter;

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/browser';
 import {Location} from 'history';
 import * as ReactRouter from 'react-router';
 
@@ -13,7 +12,6 @@ import getDynamicText from 'app/utils/getDynamicText';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel} from 'app/components/panels';
 import EventView from 'app/views/eventsV2/eventView';
-import {fetchTotalCount} from 'app/views/eventsV2/utils';
 import EventsRequest from 'app/views/events/utils/eventsRequest';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import {IconWarning} from 'app/icons';
@@ -36,49 +34,7 @@ type Props = {
   router: ReactRouter.InjectedRouter;
 };
 
-type State = {
-  totalValues: null | number;
-};
-
-class Container extends React.Component<Props, State> {
-  state: State = {
-    totalValues: null,
-  };
-
-  componentDidMount() {
-    this.mounted = true;
-
-    // TODO: implement later
-    // this.fetchTotalCount();
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-  }
-
-  mounted: boolean = false;
-
-  async fetchTotalCount() {
-    const {api, organization, location, eventView} = this.props;
-    if (!eventView.isValid() || !this.mounted) {
-      return;
-    }
-
-    try {
-      const totals = await fetchTotalCount(
-        api,
-        organization.slug,
-        eventView.getEventsAPIPayload(location)
-      );
-
-      if (this.mounted) {
-        this.setState({totalValues: totals});
-      }
-    } catch (err) {
-      Sentry.captureException(err);
-    }
-  }
-
+class Container extends React.Component<Props> {
   render() {
     const {api, organization, location, eventView, router} = this.props;
 
@@ -158,7 +114,12 @@ class Container extends React.Component<Props, State> {
             }}
           </EventsRequest>
         </ChartsContainer>
-        <Footer totals={this.state.totalValues} />
+        <Footer
+          api={api}
+          organization={organization}
+          eventView={eventView}
+          location={location}
+        />
       </Panel>
     );
   }

--- a/src/sentry/static/sentry/app/views/performance/charts/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/styles.tsx
@@ -15,6 +15,12 @@ export const SectionHeading = styled('h4')`
   line-height: 1.2;
 `;
 
+export const SectionValue = styled('span')`
+  color: ${p => p.theme.gray3};
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin-right: ${space(1)};
+`;
+
 export const ChartsContainer = styled('div')`
   padding: ${space(2)} ${space(1.5)};
 `;
@@ -31,7 +37,7 @@ export const ChartContainer = styled('div')`
 
 export const ChartControls = styled('div')`
   display: flex;
-  justify-content: space-between;
+  align-items: center;
   padding: ${space(1)} ${space(3)};
   border-top: 1px solid ${p => p.theme.borderLight};
 `;


### PR DESCRIPTION
<img width="1164" alt="Screen Shot 2020-03-20 at 11 44 33 AM" src="https://user-images.githubusercontent.com/139499/77180476-5a44ee80-6aa0-11ea-9604-a7616835d92e.png">

I also updated copy of chart footer on Discover2 from "Total" to "Total Events" as per Figma mocks.