### PR TITLE
feat(perf-views) Add clickable histogram bars

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -148,7 +148,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
                 orderby=self.get_orderby(request),
                 offset=offset,
                 limit=limit,
-                referrer="api.organization-events-v2",
+                referrer=request.GET.get("referrer", "api.organization-events-v2"),
                 auto_fields=True,
                 use_aggregate_conditions=True,
             )

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -40,6 +40,9 @@ export type EventQuery = {
   sort?: string | string[];
   query: string;
   per_page?: number;
+  // Optional value to help distinguish different workloads
+  // that the generic discover endpoint can handle.
+  referrer?: string;
 };
 
 const AGGREGATE_PATTERN = /^([^\(]+)\((.*?)(?:\s*,\s*(.*))?\)$/;


### PR DESCRIPTION
Make histogram bars clickable and go to a discover result for the matching data. Currently the histogram() function has a problem so the results don't line up well, but we'll be fixing the histogram function separately.