### PR TITLE
fix(settings): Update copy in Data Privacy settings page

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRulesPanel/dataPrivacyRulesPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRulesPanel/dataPrivacyRulesPanel.tsx
@@ -230,7 +230,7 @@ class DataPrivacyRulesPanel extends React.Component<Props, State> {
   };
 
   handleCancelForm = () => {
-    addLoadingMessage(t('Cancelling...'));
+    addLoadingMessage(t('Canceling...'));
     this.setState(prevState => ({
       rules: prevState.savedRules,
     }));
@@ -245,14 +245,14 @@ class DataPrivacyRulesPanel extends React.Component<Props, State> {
         <Panel>
           <StyledPanelHeader>{t('Data Privacy Rules')}</StyledPanelHeader>
           <PanelAlert type="info">
-            {additionalContext}
-            {tct('To learn more about datascubbing, [linkToDocs].', {
+            {additionalContext}{' '}
+            {tct('For more details, see [linkToDocs].', {
               linkToDocs: (
                 <Link
                   href="https://docs.sentry.io/data-management/advanced-datascrubbing/"
                   target="_blank"
                 >
-                  {t('read the docs.')}
+                  {t('full documentation on data scrubbing')}
                 </Link>
               ),
             })}

--- a/src/sentry/static/sentry/app/views/settings/organizationSecurityAndPrivacy/organizationSecurityAndPrivacyContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationSecurityAndPrivacy/organizationSecurityAndPrivacyContent.tsx
@@ -77,7 +77,7 @@ class OrganizationSecurityAndPrivacyContent extends AsyncView<Props> {
           />
         </Form>
         <DataPrivacyRulesPanel
-          additionalContext={t('These rules can be configured for each project. ')}
+          additionalContext={t('These rules can be configured for each project.')}
           endpoint={endpoint}
           relayPiiConfig={relayPiiConfig}
           disabled={!access.has('org:write')}

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
@@ -79,11 +79,11 @@ class ProjectDataPrivacyContent extends AsyncView<Props> {
           additionalContext={
             <span>
               {tct(
-                'These rules can be configured at the organization level in [linkToOrganizationSecurityAndPrivacy]',
+                'These rules can be configured at the organization level in [linkToOrganizationSecurityAndPrivacy].',
                 {
                   linkToOrganizationSecurityAndPrivacy: (
                     <Link to={`/settings/${orgId}/security-and-privacy/`}>
-                      {t('Security and Privacy. ')}
+                      {t('Security and Privacy')}
                     </Link>
                   ),
                 }


### PR DESCRIPTION
- Fix double '.' at the end of sentence;
- Do not include punctuation in hyperlinks;
- Instead of requiring `additionalContext` values to have a space as
  suffix, explicitly add the space when concatenating sentences.

Since touching the file, replace Cancelling => Canceling (en-US spelling)

**BEFORE**

<img width="962" alt="image" src="https://user-images.githubusercontent.com/88819/77184454-2a154400-6ad0-11ea-9f90-c7a6c660ccc6.png">

**AFTER**

![image](https://user-images.githubusercontent.com/88819/77195906-b597d080-6ae2-11ea-82e0-0c49888cabdd.png)
