### PR TITLE
perf(incidents): Remove stats from incident serializer

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_details.py
@@ -67,7 +67,6 @@ class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest, APITestCase):
         assert resp.data["dateDetected"] == expected["dateDetected"]
         assert resp.data["dateCreated"] == expected["dateCreated"]
         assert resp.data["projects"] == expected["projects"]
-        assert resp.data["eventStats"] == expected["eventStats"]
         assert resp.data["seenBy"] == seen_by
 
 

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -35,10 +35,6 @@ class IncidentSerializerTest(TestCase):
         assert result["dateDetected"] == incident.date_detected
         assert result["dateCreated"] == incident.date_added
         assert result["dateClosed"] == incident.date_closed
-        assert len(result["eventStats"]["data"]) == 61
-        assert [data[1] for data in result["eventStats"]["data"]] == [[]] * 61
-        assert result["totalEvents"] == 0
-        assert result["uniqueUsers"] == 0
 
 
 class DetailedIncidentSerializerTest(TestCase):


### PR DESCRIPTION
These make loading the incident list slow, removing them so that we can load them separately in
another endpoint. This will be merged after the frontend changes are made