### PR TITLE
feat(ui): Add titles to individual tabs in release v2 detail

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
@@ -7,17 +7,37 @@ import {t} from 'app/locale';
 import Alert from 'app/components/alert';
 import space from 'app/styles/space';
 import ReleaseArtifactsV1 from 'app/views/releases/detail/releaseArtifacts';
+import AsyncView from 'app/views/asyncView';
+import routeTitleGen from 'app/utils/routeTitle';
+import {formatVersion} from 'app/utils/formatters';
+import withOrganization from 'app/utils/withOrganization';
+import {Organization} from 'app/types';
 
 import {ReleaseContext} from '..';
 
 type Props = {
   params: Params;
   location: Location;
+  organization: Organization;
 };
 
-const ReleaseArtifacts = ({params, location}: Props) => (
-  <ReleaseContext.Consumer>
-    {({project}) => (
+class ReleaseArtifacts extends AsyncView<Props> {
+  static contextType = ReleaseContext;
+
+  getTitle() {
+    const {params, organization} = this.props;
+    return routeTitleGen(
+      t('Artifacts - Release %s', formatVersion(params.release)),
+      organization.slug,
+      false
+    );
+  }
+
+  renderBody() {
+    const {project} = this.context;
+    const {params, location} = this.props;
+
+    return (
       <ContentBox>
         <Alert type="warning">
           {t(
@@ -31,9 +51,9 @@ const ReleaseArtifacts = ({params, location}: Props) => (
           projectId={project.slug}
         />
       </ContentBox>
-    )}
-  </ReleaseContext.Consumer>
-);
+    );
+  }
+}
 
 const ContentBox = styled('div')`
   padding: ${space(4)};
@@ -41,4 +61,4 @@ const ContentBox = styled('div')`
   background-color: ${p => p.theme.white};
 `;
 
-export default ReleaseArtifacts;
+export default withOrganization(ReleaseArtifacts);

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {Params} from 'react-router/lib/Router';
-import {Location} from 'history';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {t} from 'app/locale';
 import Alert from 'app/components/alert';
@@ -15,9 +14,12 @@ import {Organization} from 'app/types';
 
 import {ReleaseContext} from '..';
 
-type Props = {
-  params: Params;
-  location: Location;
+type RouteParams = {
+  orgId: string;
+  release: string;
+};
+
+type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
 };
 

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/commits/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/commits/index.tsx
@@ -6,11 +6,15 @@ import AsyncComponent from 'app/components/asyncComponent';
 import CommitRow from 'app/components/commitRow';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {Repository, Commit} from 'app/types';
+import {Repository, Commit, Organization} from 'app/types';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {PanelHeader, Panel, PanelBody} from 'app/components/panels';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import overflowEllipsisLeft from 'app/styles/overflowEllipsisLeft';
+import AsyncView from 'app/views/asyncView';
+import routeTitleGen from 'app/utils/routeTitle';
+import {formatVersion} from 'app/utils/formatters';
+import withOrganization from 'app/utils/withOrganization';
 
 import {getCommitsByRepository, CommitsByRepository} from '../utils';
 import ReleaseNoCommitData from '../releaseNoCommitData';
@@ -23,7 +27,9 @@ type RouteParams = {
   release: string;
 };
 
-type Props = RouteComponentProps<RouteParams, {}>;
+type Props = RouteComponentProps<RouteParams, {}> & {
+  organization: Organization;
+};
 
 type State = {
   commits: Commit[];
@@ -31,8 +37,17 @@ type State = {
   activeRepo: string;
 } & AsyncComponent['state'];
 
-class ReleaseCommits extends AsyncComponent<Props, State> {
+class ReleaseCommits extends AsyncView<Props, State> {
   static contextType = ReleaseContext;
+
+  getTitle() {
+    const {params, organization} = this.props;
+    return routeTitleGen(
+      t('Commits - Release %s', formatVersion(params.release)),
+      organization.slug,
+      false
+    );
+  }
 
   getDefaultState() {
     return {
@@ -157,4 +172,4 @@ const RepoLabel = styled('div')`
   ${overflowEllipsisLeft}
 `;
 
-export default ReleaseCommits;
+export default withOrganization(ReleaseCommits);

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router/lib/Router';
 import styled from '@emotion/styled';
 
 import AsyncComponent from 'app/components/asyncComponent';
@@ -16,10 +16,14 @@ import {formatVersion} from 'app/utils/formatters';
 import {getFilesByRepository} from '../utils';
 import ReleaseNoCommitData from '../releaseNoCommitData';
 
-type Props = {
-  params: Params;
+type RouteParams = {
+  orgId: string;
+  release: string;
+};
+
+type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
-} & AsyncComponent['props'];
+};
 
 type State = {
   fileList: CommitFile[];

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
@@ -6,14 +6,19 @@ import AsyncComponent from 'app/components/asyncComponent';
 import RepositoryFileSummary from 'app/components/repositoryFileSummary';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {CommitFile, Repository} from 'app/types';
+import {CommitFile, Repository, Organization} from 'app/types';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
+import AsyncView from 'app/views/asyncView';
+import withOrganization from 'app/utils/withOrganization';
+import routeTitleGen from 'app/utils/routeTitle';
+import {formatVersion} from 'app/utils/formatters';
 
 import {getFilesByRepository} from '../utils';
 import ReleaseNoCommitData from '../releaseNoCommitData';
 
 type Props = {
   params: Params;
+  organization: Organization;
 } & AsyncComponent['props'];
 
 type State = {
@@ -21,7 +26,16 @@ type State = {
   repos: Repository[];
 } & AsyncComponent['state'];
 
-class FilesChanged extends AsyncComponent<Props, State> {
+class FilesChanged extends AsyncView<Props, State> {
+  getTitle() {
+    const {params, organization} = this.props;
+    return routeTitleGen(
+      t('Files Changed - Release %s', formatVersion(params.release)),
+      organization.slug,
+      false
+    );
+  }
+
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {orgId, release} = this.props.params;
 
@@ -73,4 +87,4 @@ const ContentBox = styled('div')`
   }
 `;
 
-export default FilesChanged;
+export default withOrganization(FilesChanged);

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import * as ReactRouter from 'react-router';
-import {Params} from 'react-router/lib/Router';
-import {Location} from 'history';
+import {RouteComponentProps} from 'react-router/lib/Router';
 import pick from 'lodash/pick';
 import styled from '@emotion/styled';
 
@@ -23,13 +21,15 @@ import ReleaseHeader from './releaseHeader';
 type ReleaseContext = {release: Release; project: ReleaseProject};
 const ReleaseContext = React.createContext<ReleaseContext>({} as ReleaseContext);
 
-type Props = {
+type RouteParams = {
+  orgId: string;
+  release: string;
+};
+
+type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
-  location: Location;
-  router: ReactRouter.InjectedRouter;
-  params: Params;
   selection: GlobalSelection;
-} & AsyncView['props'];
+};
 
 type State = {
   release: Release;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -3,12 +3,16 @@ import styled from '@emotion/styled';
 import {Params, InjectedRouter} from 'react-router/lib/Router';
 import {Location} from 'history';
 
+import {t} from 'app/locale';
+import AsyncView from 'app/views/asyncView';
 import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import {Organization, GlobalSelection} from 'app/types';
 import space from 'app/styles/space';
 import {Client} from 'app/api';
 import withApi from 'app/utils/withApi';
+import {formatVersion} from 'app/utils/formatters';
+import routeTitleGen from 'app/utils/routeTitle';
 
 import ReleaseChartContainer from './chart';
 import Issues from './issues';
@@ -27,16 +31,28 @@ type Props = {
   selection: GlobalSelection;
   router: InjectedRouter;
   api: Client;
-};
+} & AsyncView['props'];
 
 type State = {
   yAxis: YAxis;
-};
+} & AsyncView['state'];
 
-class ReleaseOverview extends React.Component<Props, State> {
-  state: State = {
-    yAxis: 'sessions',
-  };
+class ReleaseOverview extends AsyncView<Props, State> {
+  getTitle() {
+    const {params, organization} = this.props;
+    return routeTitleGen(
+      t('Release %s', formatVersion(params.release)),
+      organization.slug,
+      false
+    );
+  }
+
+  getDefaultState() {
+    return {
+      ...super.getDefaultState(),
+      yAxis: 'sessions',
+    };
+  }
 
   handleYAxisChange = (yAxis: YAxis) => {
     this.setState({yAxis});

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {Params, InjectedRouter} from 'react-router/lib/Router';
-import {Location} from 'history';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
@@ -24,14 +23,16 @@ import {YAxis} from './chart/releaseChartControls';
 
 import {ReleaseContext} from '..';
 
-type Props = {
+type RouteParams = {
+  orgId: string;
+  release: string;
+};
+
+type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
-  params: Params;
-  location: Location;
   selection: GlobalSelection;
-  router: InjectedRouter;
   api: Client;
-} & AsyncView['props'];
+};
 
 type State = {
   yAxis: YAxis;

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {Location} from 'history';
-import * as ReactRouter from 'react-router';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router/lib/Router';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
@@ -28,12 +26,13 @@ import {DEFAULT_STATS_PERIOD} from 'app/constants';
 
 import ReleaseListSortOptions from './releaseListSortOptions';
 
-type Props = {
-  params: Params;
-  location: Location;
+type RouteParams = {
+  orgId: string;
+};
+
+type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
-  router: ReactRouter.InjectedRouter;
-} & AsyncView['props'];
+};
 
 type State = AsyncView['state'];
 


### PR DESCRIPTION
This PR adds browser titles to all tabs in releases v2 detail page.

Also while I was in there I changed all of them to use `RouteComponentProps`