### PR TITLE
fix(perf) Histogram off by one error

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -231,16 +231,17 @@ def zerofill_histogram(results, column_meta, orderby, sentry_function_alias, snu
                 break
 
     for i in range(num_buckets):
-        bucket = bucket_size * (i + 1)
+        bucket = bucket_size * i
         if bucket not in bucket_map:
             bucket_map[bucket] = build_new_bucket_row(bucket)
 
     # If the list was sorted, pull results out in sorted order, else concat the results
     if is_sorted:
-        i, diff, end = (0, 1, num_buckets - 1) if not is_reversed else (num_buckets - 1, -1, 0)
+        i, diff, end = (0, 1, num_buckets) if not is_reversed else (num_buckets, -1, 0)
         while i <= end:
-            bucket = bucket_size * (i + 1)
-            new_results.append(bucket_map[bucket])
+            bucket = bucket_size * i
+            if bucket in bucket_map:
+                new_results.append(bucket_map[bucket])
             i += diff
     else:
         new_results = results

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1213,7 +1213,7 @@ class QueryTransformTest(TestCase):
             {"data": [{"max_transaction.duration": 10000}]},
             {
                 "meta": [{"name": "histogram_transaction_duration_10_1000"}, {"name": "count"}],
-                "data": [],
+                "data": [{"histogram_transaction_duration_10_1000": 10000, "count": 1}],
             },
         ]
 
@@ -1226,7 +1226,7 @@ class QueryTransformTest(TestCase):
             use_aggregate_conditions=False,
         )
 
-        expected = [i * 1000 for i in range(1, 10)]
+        expected = [i * 1000 for i in range(10)]
         for result, exp in zip(results["data"], expected):
             assert result["histogram_transaction_duration_10"] == exp
 
@@ -1238,7 +1238,7 @@ class QueryTransformTest(TestCase):
                 "meta": [{"name": "histogram_transaction_duration_10_1000"}, {"name": "count"}],
                 "data": [
                     {"histogram_transaction_duration_10_1000": i * 1000, "count": i}
-                    for i in range(1, 10)
+                    for i in range(11)
                 ],
             },
         ]
@@ -1252,7 +1252,7 @@ class QueryTransformTest(TestCase):
             use_aggregate_conditions=False,
         )
 
-        expected = [i * 1000 for i in range(1, 10)]
+        expected = [i * 1000 for i in range(11)]
         for result, exp in zip(results["data"], expected):
             assert result["histogram_transaction_duration_10"] == exp
             assert result["count"] == exp / 1000
@@ -1265,7 +1265,7 @@ class QueryTransformTest(TestCase):
                 "meta": [{"name": "histogram_transaction_duration_10_1000"}, {"name": "count"}],
                 "data": [
                     {"histogram_transaction_duration_10_1000": i * 1000, "count": i}
-                    for i in range(1, 10, 2)
+                    for i in range(0, 11, 2)
                 ],
             },
         ]
@@ -1279,14 +1279,14 @@ class QueryTransformTest(TestCase):
             use_aggregate_conditions=False,
         )
 
-        expected = [i * 1000 for i in range(1, 10)]
+        expected = [i * 1000 for i in range(11)]
         for result, exp in zip(results["data"], expected):
             assert result["histogram_transaction_duration_10"] == exp
-            assert result["count"] == (exp / 1000 if (exp / 1000) % 2 == 1 else 0)
+            assert result["count"] == (exp / 1000 if (exp / 1000) % 2 == 0 else 0)
 
     @patch("sentry.snuba.discover.raw_query")
     def test_histogram_zerofill_missing_results_desc_sort(self, mock_query):
-        seed = range(1, 10, 2)
+        seed = range(0, 11, 2)
         seed.reverse()
         mock_query.side_effect = [
             {"data": [{"max_transaction.duration": 10000}]},
@@ -1307,11 +1307,11 @@ class QueryTransformTest(TestCase):
             use_aggregate_conditions=False,
         )
 
-        expected = [i * 1000 for i in range(1, 10)]
+        expected = [i * 1000 for i in range(11)]
         expected.reverse()
         for result, exp in zip(results["data"], expected):
             assert result["histogram_transaction_duration_10"] == exp
-            assert result["count"] == (exp / 1000 if (exp / 1000) % 2 == 1 else 0)
+            assert result["count"] == (exp / 1000 if (exp / 1000) % 2 == 0 else 0)
 
     @patch("sentry.snuba.discover.raw_query")
     def test_histogram_zerofill_missing_results_no_sort(self, mock_query):
@@ -1321,7 +1321,7 @@ class QueryTransformTest(TestCase):
                 "meta": [{"name": "histogram_transaction_duration_10_1000"}, {"name": "count"}],
                 "data": [
                     {"histogram_transaction_duration_10_1000": i * 1000, "count": i}
-                    for i in range(1, 10, 2)
+                    for i in range(0, 10, 2)
                 ],
             },
         ]
@@ -1335,12 +1335,12 @@ class QueryTransformTest(TestCase):
             use_aggregate_conditions=False,
         )
 
-        expected = [1000, 3000, 5000, 7000, 9000]
+        expected = [0, 2000, 4000, 6000, 8000]
         for result, exp in zip(results["data"], expected):
             assert result["histogram_transaction_duration_10"] == exp
             assert result["count"] == exp / 1000
 
-        expected_extra_buckets = set([2000, 4000, 6000, 8000, 10000])
+        expected_extra_buckets = set([1000, 3000, 5000, 7000, 9000])
         extra_buckets = set(r["histogram_transaction_duration_10"] for r in results["data"][5:])
         assert expected_extra_buckets == extra_buckets
 
@@ -1366,7 +1366,7 @@ class QueryTransformTest(TestCase):
             use_aggregate_conditions=False,
         )
 
-        expected = [i * 87 for i in range(1, 10)]
+        expected = [i * 87 for i in range(11)]
         for result, exp in zip(results["data"], expected):
             assert result["histogram_transaction_duration_10"] == exp
             assert result["count"] == (exp / 87 if (exp / 87) % 2 == 1 else 0)

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2172,7 +2172,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 data = load_data("transaction")
                 data["transaction"] = "/error_rate/{}".format(milliseconds)
                 data["timestamp"] = iso_format(start)
-                data["start_timestamp"] = iso_format(start - timedelta(milliseconds=milliseconds))
+                data["start_timestamp"] = (start - timedelta(milliseconds=milliseconds)).isoformat()
                 self.store_event(data, project_id=project.id)
 
         with self.feature(
@@ -2190,15 +2190,16 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        assert len(data) == 10
+        assert len(data) == 11
         expected = [
-            (1000, 5),
-            (2000, 4),
-            (3000, 0),
-            (4000, 3),
+            (0, 5),
+            (1000, 4),
+            (2000, 0),
+            (3000, 3),
+            (4000, 0),
             (5000, 0),
-            (6000, 0),
-            (7000, 2),
+            (6000, 2),
+            (7000, 0),
             (8000, 0),
             (9000, 0),
             (10000, 1),
@@ -2224,7 +2225,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 data = load_data("transaction")
                 data["transaction"] = "/error_rate/sleepy_gary/{}".format(milliseconds)
                 data["timestamp"] = iso_format(start)
-                data["start_timestamp"] = iso_format(start - timedelta(milliseconds=milliseconds))
+                data["start_timestamp"] = (start - timedelta(milliseconds=milliseconds)).isoformat()
                 self.store_event(data, project_id=project.id)
 
         # Add a transaction that totally throws off the buckets
@@ -2250,15 +2251,16 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        assert len(data) == 10
+        assert len(data) == 11
         expected = [
-            (1000, 5),
-            (2000, 4),
-            (3000, 0),
-            (4000, 3),
+            (0, 5),
+            (1000, 4),
+            (2000, 0),
+            (3000, 3),
+            (4000, 0),
             (5000, 0),
-            (6000, 0),
-            (7000, 2),
+            (6000, 2),
+            (7000, 0),
             (8000, 0),
             (9000, 0),
             (10000, 1),


### PR DESCRIPTION
There was an off by one error that meant the 0th bucket wouldn't be added by the
zerofill function if it wasn't there. There's also an off by one if the max
transaction lands exactly on the max bucket value.