### PR TITLE
feat(ui): Add session duration formatting

### DIFF
--- a/docs-ui/components/formatters.stories.js
+++ b/docs-ui/components/formatters.stories.js
@@ -58,31 +58,35 @@ storiesOf('Utility|Formatters', module)
   )
   .add(
     'Duration',
-    withInfo('Formats number of seconds into a duration string')(() => (
-      <div>
+    withInfo('Formats number of seconds into a duration string')(() => {
+      const exact = boolean('exact', false);
+      const abbreviation = boolean('abbreviation', false);
+      return (
         <div>
-          <Duration seconds={15} />
+          <div>
+            <Duration seconds={15} exact={exact} abbreviation={abbreviation} />
+          </div>
+          <div>
+            <Duration seconds={60} exact={exact} abbreviation={abbreviation} />
+          </div>
+          <div>
+            <Duration seconds={15000} exact={exact} abbreviation={abbreviation} />
+          </div>
+          <div>
+            <Duration seconds={86400} exact={exact} abbreviation={abbreviation} />
+          </div>
+          <div>
+            <Duration seconds={186400} exact={exact} abbreviation={abbreviation} />
+          </div>
+          <div>
+            <Duration seconds={604800} exact={exact} abbreviation={abbreviation} />
+          </div>
+          <div>
+            <Duration seconds={1500000} exact={exact} abbreviation={abbreviation} />
+          </div>
         </div>
-        <div>
-          <Duration seconds={60} />
-        </div>
-        <div>
-          <Duration seconds={15000} />
-        </div>
-        <div>
-          <Duration seconds={86400} />
-        </div>
-        <div>
-          <Duration seconds={186400} />
-        </div>
-        <div>
-          <Duration seconds={604800} />
-        </div>
-        <div>
-          <Duration seconds={1500000} />
-        </div>
-      </div>
-    ))
+      );
+    })
   )
   .add(
     'Count',

--- a/src/sentry/static/sentry/app/components/duration.tsx
+++ b/src/sentry/static/sentry/app/components/duration.tsx
@@ -1,22 +1,28 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {getDuration} from 'app/utils/formatters';
+import {getDuration, getExactDuration} from 'app/utils/formatters';
 
 type Props = React.HTMLProps<HTMLSpanElement> & {
   seconds: number;
   fixedDigits?: number;
   abbreviation?: boolean;
+  exact?: boolean;
 };
 
-const Duration = ({seconds, fixedDigits, abbreviation, ...props}: Props) => (
-  <span {...props}>{getDuration(seconds, fixedDigits, abbreviation)}</span>
+const Duration = ({seconds, fixedDigits, abbreviation, exact, ...props}: Props) => (
+  <span {...props}>
+    {exact
+      ? getExactDuration(seconds, abbreviation)
+      : getDuration(seconds, fixedDigits, abbreviation)}
+  </span>
 );
 
 Duration.propTypes = {
   seconds: PropTypes.number.isRequired,
   fixedDigits: PropTypes.number,
   abbreviation: PropTypes.bool,
+  exact: PropTypes.bool,
 };
 
 export default Duration;

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -46,6 +46,13 @@ function roundWithFixed(
   return {label, result};
 }
 
+// in milliseconds
+const WEEK = 604800000;
+const DAY = 86400000;
+const HOUR = 3600000;
+const MINUTE = 60000;
+const SECOND = 1000;
+
 export function getDuration(
   seconds: number,
   fixedDigits: number = 0,
@@ -53,28 +60,80 @@ export function getDuration(
 ): string {
   const value = Math.abs(seconds * 1000);
 
-  if (value >= 604800000) {
-    const {label, result} = roundWithFixed(value / 604800000, fixedDigits);
-    return `${label} ${abbreviation ? 'wk' : tn('week', 'weeks', result)}`;
+  if (value >= WEEK) {
+    const {label, result} = roundWithFixed(value / WEEK, fixedDigits);
+    return `${label} ${abbreviation ? t('wk') : tn('week', 'weeks', result)}`;
   }
   if (value >= 172800000) {
-    const {label, result} = roundWithFixed(value / 86400000, fixedDigits);
-    return `${label} ${abbreviation ? 'd' : tn('day', 'days', result)}`;
+    const {label, result} = roundWithFixed(value / DAY, fixedDigits);
+    return `${label} ${abbreviation ? t('d') : tn('day', 'days', result)}`;
   }
   if (value >= 7200000) {
-    const {label, result} = roundWithFixed(value / 3600000, fixedDigits);
-    return `${label} ${abbreviation ? 'hr' : tn('hour', 'hours', result)}`;
+    const {label, result} = roundWithFixed(value / HOUR, fixedDigits);
+    return `${label} ${abbreviation ? t('hr') : tn('hour', 'hours', result)}`;
   }
   if (value >= 120000) {
-    const {label, result} = roundWithFixed(value / 60000, fixedDigits);
-    return `${label} ${abbreviation ? 'min' : tn('minute', 'minutes', result)}`;
+    const {label, result} = roundWithFixed(value / MINUTE, fixedDigits);
+    return `${label} ${abbreviation ? t('min') : tn('minute', 'minutes', result)}`;
   }
-  if (value >= 1000) {
-    const {label, result} = roundWithFixed(value / 1000, fixedDigits);
-    return `${label} ${abbreviation ? 's' : tn('second', 'seconds', result)}`;
+  if (value >= SECOND) {
+    const {label, result} = roundWithFixed(value / SECOND, fixedDigits);
+    return `${label} ${abbreviation ? t('s') : tn('second', 'seconds', result)}`;
   }
 
   const {label} = roundWithFixed(value, fixedDigits);
 
-  return `${label}ms`;
+  return label + t('ms');
+}
+
+export function getExactDuration(seconds: number, abbreviation: boolean = false) {
+  const value = Math.abs(seconds * 1000);
+
+  const divideBy = (time: number) => {
+    return {quotient: Math.floor(value / time), remainder: value % time};
+  };
+
+  if (value >= WEEK) {
+    const {quotient, remainder} = divideBy(WEEK);
+
+    return `${quotient}${
+      abbreviation ? t('wk') : ` ${tn('week', 'weeks', quotient)}`
+    } ${getExactDuration(remainder / 1000, abbreviation)}`;
+  }
+  if (value >= DAY) {
+    const {quotient, remainder} = divideBy(DAY);
+
+    return `${quotient}${
+      abbreviation ? t('d') : ` ${tn('day', 'days', quotient)}`
+    } ${getExactDuration(remainder / 1000, abbreviation)}`;
+  }
+  if (value >= HOUR) {
+    const {quotient, remainder} = divideBy(HOUR);
+
+    return `${quotient}${
+      abbreviation ? t('hr') : ` ${tn('hour', 'hours', quotient)}`
+    } ${getExactDuration(remainder / 1000, abbreviation)}`;
+  }
+  if (value >= MINUTE) {
+    const {quotient, remainder} = divideBy(MINUTE);
+
+    return `${quotient}${
+      abbreviation ? t('min') : ` ${tn('minute', 'minutes', quotient)}`
+    } ${getExactDuration(remainder / 1000, abbreviation)}`;
+  }
+  if (value >= SECOND) {
+    const {quotient, remainder} = divideBy(SECOND);
+
+    return `${quotient}${
+      abbreviation ? t('s') : ` ${tn('second', 'seconds', quotient)}`
+    } ${getExactDuration(remainder / 1000, abbreviation)}`;
+  }
+
+  if (value === 0) {
+    return '';
+  }
+
+  return `${value}${
+    abbreviation ? t('ms') : ` ${tn('millisecond', 'milliseconds', value)}`
+  }`;
 }

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -87,53 +87,61 @@ export function getDuration(
 }
 
 export function getExactDuration(seconds: number, abbreviation: boolean = false) {
-  const value = Math.abs(seconds * 1000);
+  const convertDuration = (secs: number, abbr: boolean) => {
+    const value = Math.abs(secs * 1000);
 
-  const divideBy = (time: number) => {
-    return {quotient: Math.floor(value / time), remainder: value % time};
+    const divideBy = (time: number) => {
+      return {quotient: Math.floor(value / time), remainder: value % time};
+    };
+
+    if (value >= WEEK) {
+      const {quotient, remainder} = divideBy(WEEK);
+
+      return `${quotient}${
+        abbr ? t('wk') : ` ${tn('week', 'weeks', quotient)}`
+      } ${convertDuration(remainder / 1000, abbr)}`;
+    }
+    if (value >= DAY) {
+      const {quotient, remainder} = divideBy(DAY);
+
+      return `${quotient}${
+        abbr ? t('d') : ` ${tn('day', 'days', quotient)}`
+      } ${convertDuration(remainder / 1000, abbr)}`;
+    }
+    if (value >= HOUR) {
+      const {quotient, remainder} = divideBy(HOUR);
+
+      return `${quotient}${
+        abbr ? t('hr') : ` ${tn('hour', 'hours', quotient)}`
+      } ${convertDuration(remainder / 1000, abbr)}`;
+    }
+    if (value >= MINUTE) {
+      const {quotient, remainder} = divideBy(MINUTE);
+
+      return `${quotient}${
+        abbr ? t('min') : ` ${tn('minute', 'minutes', quotient)}`
+      } ${convertDuration(remainder / 1000, abbr)}`;
+    }
+    if (value >= SECOND) {
+      const {quotient, remainder} = divideBy(SECOND);
+
+      return `${quotient}${
+        abbr ? t('s') : ` ${tn('second', 'seconds', quotient)}`
+      } ${convertDuration(remainder / 1000, abbr)}`;
+    }
+
+    if (value === 0) {
+      return '';
+    }
+
+    return `${value}${abbr ? t('ms') : ` ${tn('millisecond', 'milliseconds', value)}`}`;
   };
 
-  if (value >= WEEK) {
-    const {quotient, remainder} = divideBy(WEEK);
+  const result = convertDuration(seconds, abbreviation).trim();
 
-    return `${quotient}${
-      abbreviation ? t('wk') : ` ${tn('week', 'weeks', quotient)}`
-    } ${getExactDuration(remainder / 1000, abbreviation)}`;
-  }
-  if (value >= DAY) {
-    const {quotient, remainder} = divideBy(DAY);
-
-    return `${quotient}${
-      abbreviation ? t('d') : ` ${tn('day', 'days', quotient)}`
-    } ${getExactDuration(remainder / 1000, abbreviation)}`;
-  }
-  if (value >= HOUR) {
-    const {quotient, remainder} = divideBy(HOUR);
-
-    return `${quotient}${
-      abbreviation ? t('hr') : ` ${tn('hour', 'hours', quotient)}`
-    } ${getExactDuration(remainder / 1000, abbreviation)}`;
-  }
-  if (value >= MINUTE) {
-    const {quotient, remainder} = divideBy(MINUTE);
-
-    return `${quotient}${
-      abbreviation ? t('min') : ` ${tn('minute', 'minutes', quotient)}`
-    } ${getExactDuration(remainder / 1000, abbreviation)}`;
-  }
-  if (value >= SECOND) {
-    const {quotient, remainder} = divideBy(SECOND);
-
-    return `${quotient}${
-      abbreviation ? t('s') : ` ${tn('second', 'seconds', quotient)}`
-    } ${getExactDuration(remainder / 1000, abbreviation)}`;
+  if (result.length) {
+    return result;
   }
 
-  if (value === 0) {
-    return '';
-  }
-
-  return `${value}${
-    abbreviation ? t('ms') : ` ${tn('millisecond', 'milliseconds', value)}`
-  }`;
+  return `0${abbreviation ? t('ms') : ` ${t('milliseconds')}`}`;
 }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseChart.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseChart.tsx
@@ -6,7 +6,6 @@ import AreaChart from 'app/components/charts/areaChart';
 import {Series} from 'app/types/echarts';
 import theme from 'app/utils/theme';
 import {defined} from 'app/utils';
-import {t} from 'app/locale';
 import {getExactDuration} from 'app/utils/formatters';
 
 import {YAxis} from './releaseChartControls';
@@ -40,9 +39,7 @@ class ReleaseChart extends React.Component<Props> {
     const {yAxis} = this.props;
     switch (yAxis) {
       case 'sessionDuration':
-        return typeof value === 'number'
-          ? getExactDuration(value, true) || `0${t('s')}`
-          : value;
+        return typeof value === 'number' ? getExactDuration(value, true) : value;
       case 'crashFree':
         return defined(value) ? `${value}%` : '-';
       case 'sessions':

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseChart.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseChart.tsx
@@ -7,6 +7,7 @@ import {Series} from 'app/types/echarts';
 import theme from 'app/utils/theme';
 import {defined} from 'app/utils';
 import {t} from 'app/locale';
+import {getExactDuration} from 'app/utils/formatters';
 
 import {YAxis} from './releaseChartControls';
 
@@ -39,7 +40,9 @@ class ReleaseChart extends React.Component<Props> {
     const {yAxis} = this.props;
     switch (yAxis) {
       case 'sessionDuration':
-        return defined(value) ? `${value}${t('s')}` : '-';
+        return typeof value === 'number'
+          ? getExactDuration(value, true) || `0${t('s')}`
+          : value;
       case 'crashFree':
         return defined(value) ? `${value}%` : '-';
       case 'sessions':

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
@@ -7,14 +7,15 @@ import {Location} from 'history';
 
 import {Client} from 'app/api';
 import {addErrorMessage} from 'app/actionCreators/indicator';
-import {t, tct, tn} from 'app/locale';
+import {t, tct} from 'app/locale';
 import {GlobalSelection, CrashFreeTimeBreakdown} from 'app/types';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {percent, defined} from 'app/utils';
 import {Series} from 'app/types/echarts';
+import {getExactDuration} from 'app/utils/formatters';
 
-import {displayCrashFreePercent, getCrashFreePercent} from '../../../utils';
 import {YAxis} from './releaseChartControls';
+import {displayCrashFreePercent, getCrashFreePercent} from '../../../utils';
 
 const omitIgnoredProps = (props: Props) =>
   omitBy(props, (_, key) =>
@@ -288,7 +289,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         'value'
       )
     );
-    const summary = tn('%s second', '%s seconds', sessionDurationAverage ?? 0);
+    const summary = getExactDuration(sessionDurationAverage ?? 0) || `0 ${t('seconds')}`;
 
     return {chartData: [chartData], chartSummary: summary};
   }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
@@ -289,7 +289,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         'value'
       )
     );
-    const summary = getExactDuration(sessionDurationAverage ?? 0) || `0 ${t('seconds')}`;
+    const summary = getExactDuration(sessionDurationAverage ?? 0);
 
     return {chartData: [chartData], chartSummary: summary};
   }

--- a/tests/js/spec/helpers/formatters.spec.jsx
+++ b/tests/js/spec/helpers/formatters.spec.jsx
@@ -1,4 +1,4 @@
-import {userDisplayName} from 'app/utils/formatters';
+import {userDisplayName, getExactDuration} from 'app/utils/formatters';
 
 describe('formatters', function() {
   describe('userDisplayName', function() {
@@ -47,6 +47,26 @@ describe('formatters', function() {
     it('should show unknown author, if user object is either not an object or incomplete', function() {
       expect(userDisplayName()).toEqual('Unknown author');
       expect(userDisplayName({})).toEqual('Unknown author');
+    });
+  });
+
+  describe('getExactDuration', () => {
+    it('should provide default value', () => {
+      expect(getExactDuration(0)).toEqual('0 milliseconds');
+    });
+
+    it('should format in the right way', () => {
+      expect(getExactDuration(0.2)).toEqual('200 milliseconds');
+      expect(getExactDuration(13)).toEqual('13 seconds');
+      expect(getExactDuration(60)).toEqual('1 minute');
+      expect(getExactDuration(121)).toEqual('2 minutes 1 second');
+      expect(getExactDuration(234235435)).toEqual(
+        '387 weeks 2 days 1 hour 23 minutes 55 seconds'
+      );
+    });
+
+    it('should abbreviate label', () => {
+      expect(getExactDuration(234235435, true)).toEqual('387wk 2d 1hr 23min 55s');
     });
   });
 });


### PR DESCRIPTION
This PR adds session duration formatting in release v2 detail page.

So instead of `243 seconds` we now see `4 minutes 3 seconds` (or `4min 3s` if `abbreviation` prop is true).

You can use this either via `getExactDuration` helper function, or providing `exact` prop to our existing Duration component.