### PR TITLE
feat(relay): Always expose the organization id

### DIFF
--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -123,16 +123,13 @@ def get_project_config(project, org_options=None, full_config=True, project_keys
                 "piiConfig": _get_pii_config(project),
                 "datascrubbingSettings": _get_datascrubbing_settings(project, org_options),
             },
+            "organizationId": project.organization_id,
             "projectId": project.id,  # XXX: Unused by Relay, required by Python store
         }
 
     if not full_config:
         # This is all we need for external Relay processors
         return ProjectConfig(project, **cfg)
-
-    # The organization id is only required for reporting when processing events
-    # internally. Do not expose it to external Relays.
-    cfg["organizationId"] = project.organization_id
 
     with Hub.current.start_span(op="get_filter_settings"):
         cfg["config"]["filterSettings"] = get_filter_settings(project)

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -224,11 +224,11 @@ def test_trusted_external_relays_should_receive_minimal_configs(
     assert _date_regex.match(last_change) is not None
     last_fetch = safe.get_path(cfg, "lastFetch")
     assert _date_regex.match(last_fetch) is not None
+    assert safe.get_path(cfg, "organizationId") == default_project.organization.id
     assert safe.get_path(cfg, "projectId") == default_project.id
     assert safe.get_path(cfg, "slug") == default_project.slug
     assert safe.get_path(cfg, "rev") is not None
 
-    assert safe.get_path(cfg, "organizationId") is None
     assert safe.get_path(cfg, "config", "trustedRelays") == [relay.public_key]
     assert safe.get_path(cfg, "config", "filterSettings") is None
     assert safe.get_path(cfg, "config", "groupingConfig") is None

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -46,7 +46,6 @@ def test_get_project_config(default_project, insta_snapshot, full):
     # public keys change every time
     assert cfg.pop("projectId") == default_project.id
     assert len(cfg.pop("publicKeys")) == len(keys)
-    if full:
-        assert cfg.pop("organizationId") == default_project.organization.id
+    assert cfg.pop("organizationId") == default_project.organization.id
 
     insta_snapshot(cfg)


### PR DESCRIPTION
Relays will start to enforce organization-wide rate limits. This requires external Relays to know about the organization ids to correlate projects.