### PR TITLE
fix(ui): Changed 'key' in release v2 detail breadcrumbs

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/breadcrumbs.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/breadcrumbs.tsx
@@ -7,7 +7,7 @@ import {IconChevron} from 'app/icons';
 import space from 'app/styles/space';
 
 type Crumb = {
-  label: React.ReactNode;
+  label: string;
   to?: string;
 };
 
@@ -18,7 +18,7 @@ type Props = {
 const Breadcrumbs = ({crumbs}: Props) => (
   <BreadcrumbList>
     {crumbs.map((crumb, index) => (
-      <React.Fragment key={crumb.to}>
+      <React.Fragment key={crumb.label}>
         <BreadcrumbItem to={crumb.to}>{crumb.label}</BreadcrumbItem>
         {index < crumbs.length - 1 && <StyledIcon size="xs" direction="right" />}
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
@@ -16,6 +16,7 @@ import Tooltip from 'app/components/tooltip';
 import Badge from 'app/components/badge';
 import Count from 'app/components/count';
 import TimeSince from 'app/components/timeSince';
+import {formatVersion} from 'app/utils/formatters';
 
 import ReleaseStat from './releaseStat';
 import Breadcrumbs from './breadcrumbs';
@@ -53,7 +54,7 @@ const ReleaseHeader = ({location, orgId, release, deploys, project}: Props) => {
               label: t('Releases'),
               to: `/organizations/${orgId}/releases-v2/`,
             },
-            {label: <Version version={version} anchor={false} />},
+            {label: formatVersion(version)},
           ]}
         />
 


### PR DESCRIPTION
This PR fixes problems with duplicate keys in `Breadcrumbs` component on release v2 detail page as `to`  prop can be undefined.