### PR TITLE
fix(search) - Duration like values break on non duration fields

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -450,7 +450,7 @@ class SearchVisitor(NodeVisitor):
                 raise InvalidSearchQuery(six.text_type(exc))
             return SearchFilter(search_key, operator, SearchValue(search_value))
         else:
-            search_value = operator + search_value if operator != "=" else search_value
+            search_value = operator + search_value.text if operator != "=" else search_value.text
             return self._handle_basic_filter(search_key, "=", SearchValue(search_value))
 
     def visit_rel_time_filter(self, node, children):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -556,6 +556,20 @@ class ParseSearchQueryTest(unittest.TestCase):
             with self.assertRaisesRegexp(InvalidSearchQuery, "Invalid format for numeric search"):
                 parse_search_query(invalid_query)
 
+    def test_duration_on_non_duration_field(self):
+        assert parse_search_query("user.id:500s") == [
+            SearchFilter(
+                key=SearchKey(name="user.id"), operator="=", value=SearchValue(raw_value="500s")
+            )
+        ]
+
+    def test_negated_duration_on_non_duration_field(self):
+        assert parse_search_query("!user.id:500s") == [
+            SearchFilter(
+                key=SearchKey(name="user.id"), operator="!=", value=SearchValue(raw_value="500s")
+            )
+        ]
+
     def test_duration_filter(self):
         assert parse_search_query("transaction.duration:>500s") == [
             SearchFilter(


### PR DESCRIPTION
- user.id:400d is being treated as a duration, they needed to be treated
  as text fields
- Fixes [SENTRY-FNC](https://sentry.io/organizations/sentry/issues/1574925713/?environment=prod&project=1&referrer=alert_email)