### PR TITLE
feat: Split native and non-native processing

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -556,6 +556,10 @@ CELERY_QUEUES = [
     Queue(
         "events.reprocessing.preprocess_event", routing_key="events.reprocessing.preprocess_event"
     ),
+    Queue("events.symbolicate_event", routing_key="events.symbolicate_event"),
+    Queue(
+        "events.reprocessing.symbolicate_event", routing_key="events.reprocessing.symbolicate_event"
+    ),
     Queue("events.process_event", routing_key="events.process_event"),
     Queue("events.reprocessing.process_event", routing_key="events.reprocessing.process_event"),
     Queue("events.reprocess_events", routing_key="events.reprocess_events"),

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -1,13 +1,5 @@
 from __future__ import absolute_import
 
-from sentry.lang.native.processing import (
-    process_applecrashreport,
-    process_minidump,
-    process_payload,
-)
-from sentry.lang.native.minidump import is_minidump_event
-from sentry.lang.native.utils import is_native_event
-from sentry.lang.native.unreal import is_applecrashreport_event
 from sentry.plugins.base.v2 import Plugin2
 
 
@@ -15,9 +7,5 @@ class NativePlugin(Plugin2):
     can_disable = False
 
     def get_event_enhancers(self, data):
-        if is_minidump_event(data):
-            return [process_minidump]
-        elif is_applecrashreport_event(data):
-            return [process_applecrashreport]
-        elif is_native_event(data):
-            return [process_payload]
+        # TODO: graceful rollout
+        return []

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -1,5 +1,13 @@
 from __future__ import absolute_import
 
+from sentry.lang.native.processing import (
+    process_applecrashreport,
+    process_minidump,
+    process_payload,
+)
+from sentry.lang.native.minidump import is_minidump_event
+from sentry.lang.native.utils import is_native_event
+from sentry.lang.native.unreal import is_applecrashreport_event
 from sentry.plugins.base.v2 import Plugin2
 
 
@@ -7,4 +15,9 @@ class NativePlugin(Plugin2):
     can_disable = False
 
     def get_event_enhancers(self, data):
-        return None
+        if is_minidump_event(data):
+            return [process_minidump]
+        elif is_applecrashreport_event(data):
+            return [process_applecrashreport]
+        elif is_native_event(data):
+            return [process_payload]

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -7,5 +7,4 @@ class NativePlugin(Plugin2):
     can_disable = False
 
     def get_event_enhancers(self, data):
-        # TODO: graceful rollout
-        return []
+        return None

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -356,7 +356,7 @@ def process_payload(data):
     return data
 
 
-def get_symbolication_enhancer(data):
+def get_symbolication_function(data):
     if is_minidump_event(data):
         return process_minidump
     elif is_applecrashreport_event(data):
@@ -366,4 +366,4 @@ def get_symbolication_enhancer(data):
 
 
 def should_process_with_symbolicator(data):
-    return bool(get_symbolication_enhancer(data))
+    return bool(get_symbolication_function(data))

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -116,7 +116,9 @@ def _do_preprocess_event(cache_key, data, start_time, event_id, process_task, pr
     from_reprocessing = process_task is process_event_from_reprocessing
 
     if should_process_with_symbolicator(data):
-        submit_process(project, from_reprocessing, cache_key, event_id, start_time, original_data)
+        submit_symbolicate(
+            project, from_reprocessing, cache_key, event_id, start_time, original_data
+        )
         return
 
     if should_process(data):

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -315,6 +315,11 @@ def _do_process_event(
 ):
     from sentry.plugins.base import plugins
 
+    # TODO: remove me after the new symbolicate_event code is deployed
+    if options.get("sentry:call-old-process-event", False):
+        metrics.incr("tasks.store.called-old-process-event")
+        return _do_process_event_OLD(cache_key, start_time, event_id, process_task, data)
+
     if data is None:
         data = default_cache.get(cache_key)
 
@@ -339,16 +344,6 @@ def _do_process_event(
 
     # Fetch the reprocessing revision
     reprocessing_rev = reprocessing.get_reprocessing_revision(project_id)
-
-    # TODO(anton): All enhancers should be empty now, so we can delete this
-    # Event enhancers.  These run before anything else.
-    for plugin in plugins.all(version=2):
-        enhancers = safe_execute(plugin.get_event_enhancers, data=data)
-        for enhancer in enhancers or ():
-            enhanced = safe_execute(enhancer, data, _passthrough_errors=(RetrySymbolication,))
-            if enhanced:
-                data = enhanced
-                has_changed = True
 
     # Stacktrace based event processors.
     new_data = process_stacktraces(data)
@@ -437,6 +432,197 @@ def _do_process_event(
             # processing from the beginning again. This happens when the reprocessing
             # revision changed while we were processing.
             _do_preprocess_event(cache_key, data, start_time, event_id, process_task, project)
+            return
+
+        default_cache.set(cache_key, data, 3600)
+
+    submit_save_event(project, cache_key, event_id, start_time, data)
+
+
+##########################################################################################
+# This is the old version of retry_process_event, meant to be run only during the deploy #
+##########################################################################################
+@instrumented_task(
+    name="sentry.tasks.store.retry_process_event",
+    queue="sleep",
+    time_limit=(60 * 5) + 5,
+    soft_time_limit=60 * 5,
+)
+def retry_process_event(process_task_name, task_kwargs, **kwargs):
+    """
+    The only purpose of this task is be enqueued with some ETA set. This is
+    essentially an implementation of ETAs on top of Celery's existing ETAs, but
+    with the intent of having separate workers wait for those ETAs.
+    """
+    tasks = {
+        "process_event": process_event,
+        "process_event_from_reprocessing": process_event_from_reprocessing,
+    }
+
+    process_task = tasks.get(process_task_name)
+    if not process_task:
+        raise ValueError("Invalid argument for process_task_name: %s" % (process_task_name,))
+
+    process_task.delay(**task_kwargs)
+
+
+########################################################################################
+# This is the old version of _do_process_event, meant to be run only during the deploy #
+########################################################################################
+def _do_process_event_OLD(cache_key, start_time, event_id, process_task, data=None):
+    from sentry.plugins.base import plugins
+
+    if data is None:
+        data = default_cache.get(cache_key)
+
+    if data is None:
+        metrics.incr(
+            "events.failed", tags={"reason": "cache", "stage": "process"}, skip_internal=False
+        )
+        error_logger.error("process.failed.empty", extra={"cache_key": cache_key})
+        return
+
+    data = CanonicalKeyDict(data)
+
+    project_id = data["project"]
+    event_id = data["event_id"]
+
+    project = Project.objects.get_from_cache(id=project_id)
+
+    with configure_scope() as scope:
+        scope.set_tag("project", project_id)
+
+    has_changed = False
+
+    # Fetch the reprocessing revision
+    reprocessing_rev = reprocessing.get_reprocessing_revision(project_id)
+
+    try:
+        # Event enhancers.  These run before anything else.
+        for plugin in plugins.all(version=2):
+            enhancers = safe_execute(plugin.get_event_enhancers, data=data)
+            for enhancer in enhancers or ():
+                enhanced = safe_execute(enhancer, data, _passthrough_errors=(RetrySymbolication,))
+                if enhanced:
+                    data = enhanced
+                    has_changed = True
+
+        # Stacktrace based event processors.
+        new_data = process_stacktraces(data)
+        if new_data is not None:
+            has_changed = True
+            data = new_data
+    except RetrySymbolication as e:
+        if start_time and (time() - start_time) > settings.SYMBOLICATOR_PROCESS_EVENT_WARN_TIMEOUT:
+            error_logger.warning(
+                "process.slow", extra={"project_id": project_id, "event_id": event_id}
+            )
+
+        if start_time and (time() - start_time) > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT:
+            # Do not drop event but actually continue with rest of pipeline
+            # (persisting unsymbolicated event)
+            error_logger.exception(
+                "process.failed.infinite_retry",
+                extra={"project_id": project_id, "event_id": event_id},
+            )
+        else:
+            retry_process_event.apply_async(
+                args=(),
+                kwargs={
+                    "process_task_name": process_task.__name__,
+                    "task_kwargs": {
+                        "cache_key": cache_key,
+                        "event_id": event_id,
+                        "start_time": start_time,
+                    },
+                },
+                countdown=e.retry_after,
+            )
+            return
+
+    # Second round of datascrubbing after stacktrace and language-specific
+    # processing. First round happened as part of ingest.
+    #
+    # *Right now* the only sensitive data that is added in stacktrace
+    # processing are usernames in filepaths, so we run directly after
+    # stacktrace processors and `get_event_enhancers`.
+    #
+    # We do not yet want to deal with context data produced by plugins like
+    # sessionstack or fullstory (which are in `get_event_preprocessors`), as
+    # this data is very unlikely to be sensitive data. This is why scrubbing
+    # happens somewhere in the middle of the pipeline.
+    #
+    # On the other hand, Javascript event error translation is happening after
+    # this block because it uses `get_event_preprocessors` instead of
+    # `get_event_enhancers`.
+    #
+    # We are fairly confident, however, that this should run *before*
+    # re-normalization as it is hard to find sensitive data in partially
+    # trimmed strings.
+    if (
+        has_changed
+        and options.get("processing.can-use-scrubbers")
+        and features.has("organizations:datascrubbers-v2", project.organization, actor=None)
+    ):
+        with metrics.timer("tasks.store.datascrubbers.scrub"):
+            project_config = get_project_config(project)
+
+            new_data = safe_execute(scrub_data, project_config=project_config, event=data.data)
+
+            # XXX(markus): When datascrubbing is finally "totally stable", we might want
+            # to drop the event if it crashes to avoid saving PII
+            if new_data is not None:
+                data.data = new_data
+
+    # TODO(dcramer): ideally we would know if data changed by default
+    # Default event processors.
+    for plugin in plugins.all(version=2):
+        processors = safe_execute(
+            plugin.get_event_preprocessors, data=data, _with_transaction=False
+        )
+        for processor in processors or ():
+            result = safe_execute(processor, data)
+            if result:
+                data = result
+                has_changed = True
+
+    assert data["project"] == project_id, "Project cannot be mutated by plugins"
+
+    # We cannot persist canonical types in the cache, so we need to
+    # downgrade this.
+    if isinstance(data, CANONICAL_TYPES):
+        data = dict(data.items())
+
+    if has_changed:
+        # Run some of normalization again such that we don't:
+        # - persist e.g. incredibly large stacktraces from minidumps
+        # - store event timestamps that are older than our retention window
+        #   (also happening with minidumps)
+        normalizer = StoreNormalizer(
+            remove_other=False, is_renormalize=True, **DEFAULT_STORE_NORMALIZER_ARGS
+        )
+        data = normalizer.normalize_event(dict(data))
+
+        issues = data.get("processing_issues")
+
+        try:
+            if issues and create_failed_event(
+                cache_key,
+                data,
+                project_id,
+                list(issues.values()),
+                event_id=event_id,
+                start_time=start_time,
+                reprocessing_rev=reprocessing_rev,
+            ):
+                return
+        except RetryProcessing:
+            # If `create_failed_event` indicates that we need to retry we
+            # invoke outselves again.  This happens when the reprocessing
+            # revision changed while we were processing.
+            from_reprocessing = process_task is process_event_from_reprocessing
+            submit_process(project, from_reprocessing, cache_key, event_id, start_time, data)
+            process_task.delay(cache_key, start_time=start_time, event_id=event_id)
             return
 
         default_cache.set(cache_key, data, 3600)

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -69,7 +69,9 @@ def submit_process(
     project, from_reprocessing, cache_key, event_id, start_time, data, has_changed=None
 ):
     task = process_event_from_reprocessing if from_reprocessing else process_event
-    task.delay(cache_key=cache_key, start_time=start_time, event_id=event_id)
+    task.delay(
+        cache_key=cache_key, start_time=start_time, event_id=event_id, has_changed=has_changed
+    )
 
 
 def submit_symbolicate(project, from_reprocessing, cache_key, event_id, start_time, data):

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -256,6 +256,10 @@ def _do_symbolicate_event(cache_key, start_time, event_id, symbolicate_task, dat
 def symbolicate_event(cache_key, start_time=None, event_id=None, **kwargs):
     """
     Handles event symbolication using the external service: symbolicator.
+
+    :param string cache_key: the cache key for the event data
+    :param int start_time: the timestamp when the event was ingested
+    :param string event_id: the event identifier
     """
     return _do_symbolicate_event(
         cache_key=cache_key,
@@ -447,6 +451,16 @@ def _do_process_event(
     soft_time_limit=60,
 )
 def process_event(cache_key, start_time=None, event_id=None, data_has_changed=None, **kwargs):
+    """
+    Handles event processing (for those events that need it)
+
+    This excludes symbolication via symbolicator service (see symbolicate_event).
+
+    :param string cache_key: the cache key for the event data
+    :param int start_time: the timestamp when the event was ingested
+    :param string event_id: the event identifier
+    :param boolean data_has_changed: set to True if the event data was changed in previous tasks
+    """
     return _do_process_event(
         cache_key=cache_key,
         start_time=start_time,

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -429,12 +429,10 @@ def _do_process_event(
             ):
                 return
         except RetryProcessing:
-            # If `create_failed_event` indicates that we need to retry we
-            # invoke outselves again.  This happens when the reprocessing
+            # If `create_failed_event` indicates that we need to retry we start
+            # processing from the beginning again. This happens when the reprocessing
             # revision changed while we were processing.
-            from_reprocessing = process_task is process_event_from_reprocessing
-            submit_process(project, from_reprocessing, cache_key, event_id, start_time, data)
-            process_task.delay(cache_key, start_time=start_time, event_id=event_id)
+            _do_preprocess_event(cache_key, data, start_time, event_id, process_task, project)
             return
 
         default_cache.set(cache_key, data, 3600)

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -160,7 +160,7 @@ def test_symbolicate_event_call_process(
 
     assert mock_save_event.delay.call_count == 0
     mock_process_event.delay.assert_called_once_with(
-        cache_key="e:1", start_time=1, event_id=EVENT_ID, has_changed=True
+        cache_key="e:1", start_time=1, event_id=EVENT_ID, data_has_changed=True
     )
 
 

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -64,6 +64,12 @@ def mock_process_event():
 
 
 @pytest.fixture
+def mock_symbolicate_event():
+    with mock.patch("sentry.tasks.store.symbolicate_event") as m:
+        yield m
+
+
+@pytest.fixture
 def mock_default_cache():
     with mock.patch("sentry.tasks.store.default_cache") as m:
         yield m
@@ -91,6 +97,26 @@ def test_move_to_process_event(
     preprocess_event(data=data)
 
     assert mock_process_event.delay.call_count == 1
+    assert mock_save_event.delay.call_count == 0
+
+
+@pytest.mark.django_db
+def test_move_to_symbolicate_event(
+    default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
+):
+    register_plugin(BasicPreprocessorPlugin)
+    data = {
+        "project": default_project.id,
+        "platform": "native",
+        "logentry": {"formatted": "test"},
+        "event_id": EVENT_ID,
+        "extra": {"foo": "bar"},
+    }
+
+    preprocess_event(data=data)
+
+    assert mock_symbolicate_event.delay.call_count == 1
+    assert mock_process_event.delay.call_count == 0
     assert mock_save_event.delay.call_count == 0
 
 

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -8,7 +8,7 @@ from time import time
 from sentry import quotas
 from sentry.event_manager import EventManager, HashDiscarded
 from sentry.plugins.base.v2 import Plugin2
-from sentry.tasks.store import preprocess_event, process_event, save_event
+from sentry.tasks.store import preprocess_event, process_event, save_event, symbolicate_event
 from sentry.testutils.helpers.features import Feature
 
 EVENT_ID = "cc3e6c2bb6b6498097f336d1e6979f4b"
@@ -70,6 +70,12 @@ def mock_symbolicate_event():
 
 
 @pytest.fixture
+def mock_get_symbolication_function():
+    with mock.patch("sentry.lang.native.processing.get_symbolication_function") as m:
+        yield m
+
+
+@pytest.fixture
 def mock_default_cache():
     with mock.patch("sentry.tasks.store.default_cache") as m:
         yield m
@@ -83,7 +89,7 @@ def mock_refund():
 
 @pytest.mark.django_db
 def test_move_to_process_event(
-    default_project, mock_process_event, mock_save_event, register_plugin
+    default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
 ):
     register_plugin(BasicPreprocessorPlugin)
     data = {
@@ -96,6 +102,7 @@ def test_move_to_process_event(
 
     preprocess_event(data=data)
 
+    assert mock_symbolicate_event.delay.call_count == 0
     assert mock_process_event.delay.call_count == 1
     assert mock_save_event.delay.call_count == 0
 
@@ -121,7 +128,46 @@ def test_move_to_symbolicate_event(
 
 
 @pytest.mark.django_db
-def test_move_to_save_event(default_project, mock_process_event, mock_save_event, register_plugin):
+def test_symbolicate_event_call_process(
+    default_project,
+    mock_default_cache,
+    mock_process_event,
+    mock_save_event,
+    mock_get_symbolication_function,
+    register_plugin,
+):
+    register_plugin(BasicPreprocessorPlugin)
+    data = {
+        "project": default_project.id,
+        "platform": "native",
+        "event_id": EVENT_ID,
+        "extra": {"foo": "bar"},
+    }
+    mock_default_cache.get.return_value = data
+
+    symbolicated_data = {"type": "error"}
+
+    mock_get_symbolication_function.return_value = lambda _: symbolicated_data
+
+    symbolicate_event(cache_key="e:1", start_time=1)
+
+    # The event mutated, so make sure we save it back
+    (_, (key, event, duration), _), = mock_default_cache.set.mock_calls
+
+    assert key == "e:1"
+    assert event == symbolicated_data
+    assert duration == 3600
+
+    assert mock_save_event.delay.call_count == 0
+    mock_process_event.delay.assert_called_once_with(
+        cache_key="e:1", start_time=1, event_id=EVENT_ID, has_changed=True
+    )
+
+
+@pytest.mark.django_db
+def test_move_to_save_event(
+    default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
+):
     register_plugin(BasicPreprocessorPlugin)
     data = {
         "project": default_project.id,
@@ -133,6 +179,7 @@ def test_move_to_save_event(default_project, mock_process_event, mock_save_event
 
     preprocess_event(data=data)
 
+    assert mock_symbolicate_event.delay.call_count == 0
     assert mock_process_event.delay.call_count == 0
     assert mock_save_event.delay.call_count == 1
 

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -188,7 +188,7 @@ def test_symbolicate_event_call_process(
         start_time=1,
         event_id=EVENT_ID,
         data_has_changed=True,
-        new_process_behavior=None,
+        new_process_behavior=True,
     )
 
 


### PR DESCRIPTION
We want to run native and non-native processing on different queues/workers so that symbolicator issues do not impact non-native processing (javascript, java).

This PR adds a new task: `symbolicate_event` that runs **before** `process_event` if we detect that the event needs (external) symbolication with the help of Symbolicator.
If symbolication is not needed, `preprocess_event` starts `process_event` task as before.

This is the first step towards modernizing/cleaning-up our processing pipeline.

**Rollout strategy:**
We have a temporary option called `sentry:preprocess-use-new-behavior`, that is False by default, which means that we'll be running the old logic. After everything is deployed, we set it to True, and `preprocess_event` will start spawning `symbolicate_event`, which will tell `process_event` to skip the enhancers.


~The following has to be fixed:~
~* `has_changed` checks with additional normalization and data scrubbing.~