### PR TITLE
feat(plugins): updates plugin search results in old search

### DIFF
--- a/src/sentry/static/sentry/app/components/search/sources/apiSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/apiSource.jsx
@@ -81,16 +81,21 @@ async function createMemberResults(membersPromise, orgId) {
   }));
 }
 
-async function createLegacyIntegrationResults(pluginsPromise, orgId) {
+async function createPluginResults(pluginsPromise, orgId) {
   const plugins = (await pluginsPromise) || [];
-  return plugins.map(plugin => ({
-    title: `${plugin.name} (Legacy)`,
-    description: plugin.description,
-    model: plugin,
-    sourceType: 'plugin',
-    resultType: 'integration',
-    to: `/settings/${orgId}/projects/:projectId/plugins/${plugin.id}/`,
-  }));
+  return plugins
+    .filter(plugin => {
+      //show a plugin if it is not hidden (aka legacy) or if we have projects with it configured
+      return !plugin.isHidden || !!plugin.projectList.length;
+    })
+    .map(plugin => ({
+      title: plugin.isHidden ? `${plugin.name} (Legacy)` : plugin.name,
+      description: plugin.description,
+      model: plugin,
+      sourceType: 'plugin',
+      resultType: 'integration',
+      to: `/settings/${orgId}/plugins/${plugin.id}/`,
+    }));
 }
 
 async function createIntegrationResults(integrationsPromise, orgId) {
@@ -225,7 +230,7 @@ class ApiSource extends React.Component {
         `/organizations/${orgId}/projects/`,
         `/organizations/${orgId}/teams/`,
         `/organizations/${orgId}/members/`,
-        `/organizations/${orgId}/plugins/?plugins=_all`,
+        `/organizations/${orgId}/plugins/configs/`,
         `/organizations/${orgId}/config/integrations/`,
       ];
 
@@ -317,6 +322,7 @@ class ApiSource extends React.Component {
       this.getDirectResults([shortIdLookup, eventIdLookup]),
     ]);
 
+    //TODO(XXX): Might consider adding logic to maintain consistent ordering of results so things don't switch positions
     const fuzzy = createFuzzySearch(searchResults, {
       ...searchOptions,
       keys: ['title', 'description'],
@@ -341,8 +347,8 @@ class ApiSource extends React.Component {
         createProjectResults(projects, orgId),
         createTeamResults(teams, orgId),
         createMemberResults(members, orgId),
-        createLegacyIntegrationResults(plugins, orgId),
         createIntegrationResults(integrations, orgId),
+        createPluginResults(plugins, orgId),
       ])
     );
 


### PR DESCRIPTION
This PR updates search results in the old search bar with plugins to do the following:
1. Updates the URL to the new plugin detail view instead of the old project-specific plugin page
2. Hides legacy plugins such as BitBucket or Jira unless the user has a project where it is configured
3. Only show "Legacy" in the title if it is truly a legacy plugin

The logic for items 2 and 3 are the same as in the new integration directory.


New look without Legacy:
![Screen Shot 2020-03-23 at 9 26 07 AM](https://user-images.githubusercontent.com/8533851/77340085-03caf080-6cea-11ea-930d-3ddb392d5301.png)
