### PR TITLE
feat(workflow): Add option for rollout rate

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -216,6 +216,9 @@ register("eventstore.use-nodestore", default=False, flags=FLAG_PRIORITIZE_DISK)
 # Discover2 incremental rollout rate. Tied to feature handlers in getsentry
 register("discover2.rollout-rate", default=0, flags=FLAG_PRIORITIZE_DISK)
 
+# Alerts / Workflow incremental rollout rate. Tied to feature handlers in getsentry
+register("workflow.rollout-rate", default=0, flags=FLAG_PRIORITIZE_DISK)
+
 # Max number of tags to combine in a single query in Discover2 tags facet.
 register("discover2.max_tags_to_combine", default=3, flags=FLAG_PRIORITIZE_DISK)
 


### PR DESCRIPTION
We're adding this as an option that we can scale up later. The feature handler in getsentry will rely on this for rolling out to a percentage of orgs.