### PR TITLE
feat(perf-views) Add interactions to the latency chart

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/barChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/barChart.jsx
@@ -19,7 +19,12 @@ export default class BarChart extends React.Component {
           BarSeries({
             name: s.seriesName,
             stack: stacked ? 'stack1' : null,
-            data: s.data.map(({value, name}) => [name, value]),
+            data: s.data.map(({value, name, itemStyle}) => {
+              if (itemStyle === undefined) {
+                return [name, value];
+              }
+              return {value: [name, value], itemStyle};
+            }),
           })
         )}
       />

--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -1,7 +1,5 @@
 import 'echarts/lib/component/tooltip';
 
-import get from 'lodash/get';
-
 import {getFormattedDate} from 'app/utils/dates';
 
 import {truncationFormatter} from '../utils';
@@ -23,6 +21,17 @@ function defaultValueFormatter(value) {
   return value;
 }
 
+function getSeriesValue(series, offset) {
+  if (Array.isArray(series.data)) {
+    return series.data[offset];
+  }
+  if (Array.isArray(series.data.value)) {
+    return series.data.value[offset];
+  }
+
+  return undefined;
+}
+
 function getFormatter({
   filter,
   isGroupedByDate,
@@ -35,8 +44,9 @@ function getFormatter({
   const getFilter = seriesParam => {
     // Series do not necessarily have `data` defined, e.g. releases don't have `data`, but rather
     // has a series using strictly `markLine`s.
-    // However, real series will have `data` as a tuple of (key, value)
-    const value = seriesParam.data && seriesParam.data.length && seriesParam.data[1];
+    // However, real series will have `data` as a tuple of (label, value) or be
+    // an object with value/label keys.
+    const value = getSeriesValue(seriesParam, 0);
     if (typeof filter === 'function') {
       return filter(value);
     }
@@ -81,10 +91,12 @@ function getFormatter({
 
     const seriesParams = isAxisItem ? seriesParamsOrParam : [seriesParamsOrParam];
 
-    // If axis, timestamp comes from axis, otherwise for a single item it is defined in its data
+    // If axis, timestamp comes from axis, otherwise for a single item it is defined in the data attribute.
+    // The data attribute is usually a list of [name, value] but can also be an object of {name, value} when
+    // there is item specific formatting being used.
     const timestamp = isAxisItem
       ? seriesParams[0].axisValue
-      : get(seriesParams, '[0].data[0]');
+      : getSeriesValue(seriesParams[0], 0);
 
     const label =
       seriesParams.length &&
@@ -96,7 +108,7 @@ function getFormatter({
         .filter(getFilter)
         .map(s => {
           const formattedLabel = truncationFormatter(s.seriesName, truncate);
-          const value = valueFormatter(s.data[1]);
+          const value = valueFormatter(getSeriesValue(s, 1));
           return `<div><span class="tooltip-label">${s.marker} <strong>${formattedLabel}</strong></span> ${value}</div>`;
         })
         .join(''),

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Params} from 'react-router/lib/Router';
-import * as ReactRouter from 'react-router';
+import {browserHistory} from 'react-router';
 import {Location} from 'history';
 import styled from '@emotion/styled';
 
@@ -16,7 +16,6 @@ import {decodeScalar} from 'app/views/eventsV2/utils';
 import {stringifyQueryObject} from 'app/utils/tokenizeSearch';
 import NoProjectMessage from 'app/components/noProjectMessage';
 
-import {generatePerformanceEventView} from '../data';
 import SummaryContent from './content';
 
 type Props = {
@@ -28,7 +27,7 @@ type Props = {
 };
 
 type State = {
-  eventView: EventView;
+  eventView: EventView | undefined;
 };
 
 class TransactionSummary extends React.Component<Props, State> {
@@ -64,13 +63,11 @@ class TransactionSummary extends React.Component<Props, State> {
   render() {
     const {organization, location} = this.props;
     const {eventView} = this.state;
-
     const transactionName = getTransactionName(this.props);
-
-    if (!transactionName) {
+    if (!eventView || transactionName === undefined) {
       // If there is no transaction name, redirect to the Performance landing page
 
-      ReactRouter.browserHistory.replace({
+      browserHistory.replace({
         pathname: `/organizations/${organization.slug}/performance/`,
         query: {
           ...location.query,
@@ -113,45 +110,37 @@ function getTransactionName(props: Props): string | undefined {
 function generateSummaryEventView(
   location: Location,
   transactionName: string | undefined
-): EventView {
-  let eventView = generatePerformanceEventView(location);
-  if (typeof transactionName !== 'string') {
-    return eventView;
+): EventView | undefined {
+  if (transactionName === undefined) {
+    return undefined;
   }
-
-  // narrow the search conditions of the Performance event view
-  eventView.name = transactionName;
-
-  const searchConditions = {
+  const conditions = {
     query: [],
     'event.type': ['transaction'],
     transaction: [transactionName],
   };
-  eventView.query = stringifyQueryObject(searchConditions);
+  // Handle duration filters from the latency chart
+  if (location.query.startDuration || location.query.endDuration) {
+    conditions['transaction.duration'] = [
+      decodeScalar(location.query.startDuration),
+      decodeScalar(location.query.endDuration),
+    ]
+      .filter(item => item)
+      .map((item, index) => (index === 0 ? `>${item}` : `<${item}`));
+  }
 
-  eventView = eventView.withColumns([
+  return EventView.fromNewQueryWithLocation(
     {
-      kind: 'field',
-      field: 'transaction',
+      id: undefined,
+      version: 2,
+      name: transactionName,
+      fields: ['transaction', 'transaction.duration', 'timestamp'],
+      orderby: '-transaction.duration',
+      query: stringifyQueryObject(conditions),
+      projects: [],
     },
-    {
-      kind: 'field',
-      field: 'transaction.duration',
-    },
-    {
-      kind: 'field',
-      field: 'timestamp',
-    },
-  ]);
-
-  eventView.sorts = [
-    {
-      kind: 'desc',
-      field: 'transaction.duration',
-    },
-  ];
-
-  return eventView;
+    location
+  );
 }
 
 export default withProjects(withOrganization(TransactionSummary));


### PR DESCRIPTION
Clicking a bar will update the generated EventView to include additional conditions that constrain the results based on the start and end durations. Clicking the active bar again will remove the conditions.

![graph nav](https://user-images.githubusercontent.com/24086/77363070-6ba02c00-6d28-11ea-8bb4-c00279ead37d.gif)
