### PR TITLE
feat(plugin): Make Mail Plugin non-configurable

### DIFF
--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -29,8 +29,12 @@ class PluginManager(InstanceManager):
                 yield plugin
 
     def configurable_for_project(self, project, version=1):
+        from sentry.plugins.sentry_mail.models import MailPlugin
+
         for plugin in self.all(version=version):
             if not safe_execute(plugin.can_configure_for_project, project, _with_transaction=False):
+                continue
+            if plugin.slug == MailPlugin.slug and project.flags.has_issue_alerts_targeting:
                 continue
             yield plugin
 

--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -29,12 +29,8 @@ class PluginManager(InstanceManager):
                 yield plugin
 
     def configurable_for_project(self, project, version=1):
-        from sentry.plugins.sentry_mail.models import MailPlugin
-
         for plugin in self.all(version=version):
             if not safe_execute(plugin.can_configure_for_project, project, _with_transaction=False):
-                continue
-            if plugin.slug == MailPlugin.slug and project.flags.has_issue_alerts_targeting:
                 continue
             yield plugin
 

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -418,6 +418,12 @@ class MailPlugin(NotificationPlugin):
         if name == "user-reports.created":
             self.handle_user_report(payload, **kwargs)
 
+    def can_configure_for_project(self, project):
+        return (
+            super(MailPlugin, self).can_configure_for_project(project)
+            and not project.flags.has_issue_alerts_targeting
+        )
+
 
 # Legacy compatibility
 MailProcessor = MailPlugin

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -662,3 +662,17 @@ class MailPluginOwnersTest(TestCase):
             data=self.make_event_data("foo.cbl"), project_id=self.project.id
         )
         self.assert_notify(event_all_users, [self.user.email])
+
+
+class TestCanConfigureForProject(TestCase):
+    @fixture
+    def plugin(self):
+        return MailPlugin()
+
+    def test_does_not_have_alerts_targeting(self):
+        self.project.flags.has_issue_alerts_targeting = False
+        assert self.plugin.can_configure_for_project(self.project)
+
+    def test_has_alerts_targeting(self):
+        self.project.flags.has_issue_alerts_targeting = True
+        assert not self.plugin.can_configure_for_project(self.project)


### PR DESCRIPTION
Disallow configuration of mail plugins.

This will likely require a migration in propagating the effects of these configurations into rules (or the lack thereof) for each project.