### PR TITLE
fix(ui): Fix `<SmartSearchBar>` again when pressing "Enter"

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -332,12 +332,20 @@ class SmartSearchBar extends React.Component {
   };
 
   onKeyDown = evt => {
+    const {key} = evt;
+
+    // If tab or enter is pressed while the search bar is in a loading state then
+    // we should prevent any the form from submitting from this component
+    //
+    if ((key === 'Tab' || key === 'Enter') && this.state.loading) {
+      evt.preventDefault();
+    }
+
     if (!this.state.searchItems.length) {
       return;
     }
 
     const {useFormWrapper} = this.props;
-    const {key} = evt;
     const isSelectingDropdownItems = this.state.activeSearchItem !== -1;
 
     if (key === 'ArrowDown' || key === 'ArrowUp') {
@@ -412,9 +420,7 @@ class SmartSearchBar extends React.Component {
 
     if (key === 'Enter') {
       // If we are still loading dropdown, do nothing
-      // Otherwise, this will propagate up to form and submit
       if (this.state.loading) {
-        evt.preventDefault();
         return;
       }
 

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -336,7 +336,6 @@ class SmartSearchBar extends React.Component {
 
     // If tab or enter is pressed while the search bar is in a loading state then
     // we should prevent any the form from submitting from this component
-    //
     if ((key === 'Tab' || key === 'Enter') && this.state.loading) {
       evt.preventDefault();
     }

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -75,7 +75,39 @@ describe('SmartSearchBar', function() {
     MockApiClient.clearMockResponses();
   });
 
-  it('calls preventDefault when loading and enter is pressed', async function() {
+  it('calls preventDefault when there are no search items and is loading and enter is pressed', async function() {
+    jest.useRealTimers();
+    const getTagValuesMock = jest.fn().mockImplementation(() => {
+      return new Promise(() => {});
+    });
+    const onSearch = jest.fn();
+    const props = {
+      orgId: 'org-slug',
+      projectId: '0',
+      query: '',
+      organization,
+      supportedTags,
+      onGetTagValues: getTagValuesMock,
+      onSearch,
+    };
+
+    const searchBar = mountWithTheme(
+      <SmartSearchBar {...props} api={new Client()} />,
+
+      options
+    );
+    searchBar.find('input').simulate('focus');
+    searchBar.find('input').simulate('change', {target: {value: 'browser:'}});
+    await tick();
+
+    // press enter
+    const preventDefault = jest.fn();
+    searchBar.find('input').simulate('keyDown', {key: 'Enter', preventDefault});
+    expect(onSearch).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('calls preventDefault when there are existing search items and is loading and enter is pressed', async function() {
     jest.useRealTimers();
     const getTagValuesMock = jest.fn().mockImplementation(() => {
       return new Promise(() => {});


### PR DESCRIPTION
The previous PR (https://github.com/getsentry/sentry/pull/17799) fixed a scenario where you selected the "key" and it was loading the values, e.g.

You entered `brow` and selected the option `browser` -- dropdown tries to load values for `browser`, if you pressed "Enter" it would capture it and not submit.

However, there was another state where if you typed the entire key, e.g. `browser:`, it would also load values for `browser` but in this case, there are no existing `this.state.searchItems`, and does not hit any condition to call `preventDefault()` on the event, and so it would bubble up to the form.