### PR TITLE
ref(experiments): Reduce required logExperiment params

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -84,9 +84,6 @@ class Sidebar extends React.Component {
     logExperiment({
       organization,
       key: 'OnboardingSidebarV2Experiment',
-      unitName: 'org_id',
-      unitId: parseInt(organization?.id, 10),
-      param: 'exposed',
     });
   }
 

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -156,12 +156,7 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
     };
     trackAnalyticsEvent(data);
 
-    logExperiment({
-      key: 'AssistantGuideExperiment',
-      unitName: 'user_id',
-      unitId: parseInt(user.id, 10),
-      param: 'exposed',
-    });
+    logExperiment({key: 'AssistantGuideExperiment'});
   },
 
   updatePrevGuide(nextGuide) {

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -2,6 +2,7 @@ import {Route} from 'react-router';
 
 import {NavigationSection} from 'app/views/settings/types';
 import {User, Organization, Project, IntegrationProvider} from 'app/types';
+import {ExperimentKey} from 'app/types/experiments';
 
 // XXX(epurkhiser): A Note about `_`.
 //
@@ -197,25 +198,13 @@ type AnalyticsTrackAdhocEvent = (
  */
 type AnalyticsLogExperiment = (opts: {
   /**
-   * The organization for org based experiments
+   * The organization. Must be provided for organization experiments.
    */
   organization?: Organization;
   /**
    * The experiment key
    */
-  key: keyof Organization['experiments'] | keyof User['experiments'];
-  /**
-   * The name of the exposed unit
-   */
-  unitName: string;
-  /**
-   * The value of the unit to group by
-   */
-  unitId: string | number;
-  /**
-   * The parameter name used for the exposed key
-   */
-  param: string;
+  key: ExperimentKey;
 }) => void;
 
 /**

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -81,9 +81,6 @@ export class OrganizationIntegrations extends AsyncComponent<
     logExperiment({
       organization: this.props.organization,
       key: 'IntegrationDirectorySortWeightExperiment',
-      unitName: 'org_id',
-      unitId: parseInt(this.props.organization.id, 10),
-      param: 'variant',
     });
   }
 

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -79,9 +79,6 @@ class CreateProject extends React.Component {
       logExperiment({
         organization,
         key: 'AlertDefaultsExperiment',
-        unitName: 'org_id',
-        unitId: parseInt(organization.id, 10),
-        param: 'variant',
       });
     }
 

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -90,9 +90,6 @@ describe('GuideStore', function() {
 
     expect(logExperiment).toHaveBeenCalledWith({
       key: 'AssistantGuideExperiment',
-      unitName: 'user_id',
-      unitId: parseInt(user.id, 10),
-      param: 'exposed',
     });
   });
 


### PR DESCRIPTION
This is a followup to https://github.com/getsentry/getsentry/pull/3688