### PR TITLE
fix(ui): Fix `<Button>` hover styles for link priority

### DIFF
--- a/docs-ui/components/button.stories.js
+++ b/docs-ui/components/button.stories.js
@@ -59,6 +59,12 @@ storiesOf('UI|Buttons', module)
           </Item>
 
           <Item>
+            <Button priority="link" onClick={action('click link')}>
+              Link Button
+            </Button>
+          </Item>
+
+          <Item>
             <Button to="" disabled onClick={action('click disabled')}>
               Disabled Button
             </Button>

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -175,11 +175,9 @@ const button = {
     color: colors.blue,
     colorActive: colors.blue,
     background: 'transparent',
-    border: 'none',
-    borderActive: 'inherit',
-    // border: '#3d328e',
+    border: false,
+    borderActive: false,
     backgroundActive: 'transparent',
-    // borderActive: '#352b7b',
     focusShadow: false,
   },
   disabled: {


### PR DESCRIPTION
Fixes a regression introduced in #17816

Hover/active/focus styles were incorrect for `<Button>` with
`priority="link"`.