### PR TITLE
build(storybook): Fix running storybook locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver",
     "dev-server": "webpack-dev-server",
     "dev-acceptance": "NO_DEV_SERVER=1 NODE_ENV=development yarn webpack --watch",
-    "storybook": "start-storybook -p 9001 -c .storybook",
+    "storybook": "SENTRY_UI_HOT_RELOAD='' start-storybook -p 9001 -c .storybook",
     "storybook-build": "build-storybook -c .storybook -o .storybook-out && sed -i -e 's/\\/sb_dll/sb_dll/g' .storybook-out/index.html",
     "snapshot": "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=1280",
     "webpack-profile": "yarn -s webpack --profile --json > stats.json",


### PR DESCRIPTION
`react-refresh` causes issues with running storybook locally. Disable it via env vars. Alternatively, we could have cleaned out `plugins` in storybooks own babel config since it extends the main config, but this seems a bit cleaner