### PR TITLE
feat(IntegrationDirectory): Add category selector to filter integrations

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -381,6 +381,11 @@ export type PluginWithProjectList = PluginNoProject & {
   projectList: PluginProjectItem[];
 };
 
+export type AppOrProviderOrPlugin =
+  | SentryApp
+  | IntegrationProvider
+  | PluginWithProjectList;
+
 export type GlobalSelection = {
   projects: number[];
   environments: string[];

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -9,6 +9,9 @@ import {
   IntegrationInstallationStatus,
   SentryAppStatus,
   IntegrationFeature,
+  AppOrProviderOrPlugin,
+  SentryApp,
+  PluginWithProjectList,
 } from 'app/types';
 import {Hooks} from 'app/types/hooks';
 import HookStore from 'app/stores/hookStore';
@@ -237,3 +240,30 @@ export const getCategories = (features: IntegrationFeature[]): string[] => {
 
   return [...new Set(transform)];
 };
+
+export const getCategoriesForIntegration = (
+  integration: AppOrProviderOrPlugin
+): string[] => {
+  if (isSentryApp(integration)) {
+    const features = ['internal', 'unpublished'].includes(integration.status)
+      ? [{featureGate: integration.status, description: ''}]
+      : integration.featureData;
+    return getCategories(features);
+  }
+  if (isPlugin(integration)) {
+    return getCategories(integration.featureDescriptions);
+  }
+  return getCategories(integration.metadata.features);
+};
+
+export function isSentryApp(
+  integration: AppOrProviderOrPlugin
+): integration is SentryApp {
+  return !!(integration as SentryApp).uuid;
+}
+
+export function isPlugin(
+  integration: AppOrProviderOrPlugin
+): integration is PluginWithProjectList {
+  return integration.hasOwnProperty('shortName');
+}

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -245,10 +245,9 @@ export const getCategoriesForIntegration = (
   integration: AppOrProviderOrPlugin
 ): string[] => {
   if (isSentryApp(integration)) {
-    const features = ['internal', 'unpublished'].includes(integration.status)
-      ? [{featureGate: integration.status, description: ''}]
-      : integration.featureData;
-    return getCategories(features);
+    return ['internal', 'unpublished'].includes(integration.status)
+      ? [integration.status]
+      : getCategories(integration.featureData);
   }
   if (isPlugin(integration)) {
     return getCategories(integration.featureDescriptions);

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -15,6 +15,7 @@ import HookStore from 'app/stores/hookStore';
 
 const INTEGRATIONS_ANALYTICS_SESSION_KEY = 'INTEGRATION_ANALYTICS_SESSION' as const;
 const SORT_INTEGRATIONS_BY_WEIGHT = 'SORT_INTEGRATIONS_BY_WEIGHT' as const;
+const SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT = 'SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT' as const;
 
 export const startAnalyticsSession = () => {
   const sessionId = uniqueId();
@@ -40,6 +41,9 @@ export const getSortIntegrationsByWeightActive = (organization?: Organization) =
       return variant && variant === '1';
   }
 };
+
+export const getCategorySelectActive = () =>
+  localStorage.getItem(SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT) === '1';
 
 export type SingleIntegrationEvent = {
   eventKey:

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -135,20 +135,24 @@ export class OrganizationIntegrations extends AsyncComponent<
 
     const list = this.sortIntegrations(combined);
 
-    const allFeatureDescriptions: IntegrationFeature[] = list
-      .map(integration => {
+    const allFeatureDescriptions: IntegrationFeature[] = list.reduce(
+      (acc, integration) => {
         if (isSentryApp(integration)) {
           const array = ['internal', 'unpublished'].includes(integration.status)
             ? [{featureGate: integration.status, description: ''}]
             : integration.featureData;
-          return array;
+          acc.push(...array);
+          return acc;
         }
         if (isPlugin(integration)) {
-          return integration.featureDescriptions;
+          acc.push(...integration.featureDescriptions);
+          return acc;
         }
-        return integration.metadata.features;
-      })
-      .flat(1);
+        acc.push(...integration.metadata.features);
+        return acc;
+      },
+      [] as IntegrationFeature[]
+    );
 
     const categoriesList = getCategories(allFeatureDescriptions);
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -20,7 +20,6 @@ import {
   trackIntegrationEvent,
   getSentryAppInstallStatus,
   getSortIntegrationsByWeightActive,
-  getCategories,
   getCategorySelectActive,
   isSentryApp,
   isPlugin,
@@ -318,7 +317,7 @@ export class OrganizationIntegrations extends AsyncComponent<
         status={integrations.length ? 'Installed' : 'Not Installed'}
         publishStatus="published"
         configurations={integrations.length}
-        categories={getCategories(provider.metadata.features)}
+        categories={getCategoriesForIntegration(provider)}
       />
     );
   };
@@ -343,7 +342,7 @@ export class OrganizationIntegrations extends AsyncComponent<
         status={plugin.projectList.length ? 'Installed' : 'Not Installed'}
         publishStatus="published"
         configurations={plugin.projectList.length}
-        categories={getCategories(plugin.featureDescriptions)}
+        categories={getCategoriesForIntegration(plugin)}
       />
     );
   };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -141,15 +141,12 @@ export class OrganizationIntegrations extends AsyncComponent<
           const array = ['internal', 'unpublished'].includes(integration.status)
             ? [{featureGate: integration.status, description: ''}]
             : integration.featureData;
-          acc.push(...array);
-          return acc;
+          return acc.concat(...array);
         }
         if (isPlugin(integration)) {
-          acc.push(...integration.featureDescriptions);
-          return acc;
+          return acc.concat(...integration.featureDescriptions);
         }
-        acc.push(...integration.metadata.features);
-        return acc;
+        return acc.concat(...integration.metadata.features);
       },
       [] as IntegrationFeature[]
     );
@@ -438,7 +435,7 @@ export class OrganizationIntegrations extends AsyncComponent<
                 {getCategorySelectActive() ? (
                   <StyledSelectControl
                     name="select-categories"
-                    onChange={this.onCategorySelect} // {v => console.log(v)} //
+                    onChange={this.onCategorySelect}
                     value={selectedCategory}
                     choices={[
                       ['', 'All categories'],

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -3,6 +3,8 @@ import debounce from 'lodash/debounce';
 import React from 'react';
 import styled from '@emotion/styled';
 import {RouteComponentProps} from 'react-router/lib/Router';
+import flatten from 'lodash/flatten';
+import uniq from 'lodash/uniq';
 
 import {
   Organization,
@@ -382,10 +384,7 @@ export class OrganizationIntegrations extends AsyncComponent<
     const {displayedList, selectedCategory, list} = this.state;
 
     const title = t('Integrations');
-    const categoryList = list.reduce<string[]>(
-      (acc, curr) => [...new Set([...acc, ...getCategoriesForIntegration(curr)])],
-      []
-    );
+    const categoryList = uniq(flatten(list.map(getCategoriesForIntegration)));
     return (
       <React.Fragment>
         <SentryDocumentTitle title={title} objSlug={orgId} />
@@ -409,7 +408,7 @@ export class OrganizationIntegrations extends AsyncComponent<
                 <SearchInput
                   value={this.state.searchInput || ''}
                   onChange={this.onSearchChange}
-                  placeholder="Filter Integrations..."
+                  placeholder={t('Filter Integrations...')}
                   width="25em"
                 />
               </ActionContainer>


### PR DESCRIPTION
## Objective
Add category filtering to make it easier for users to find a particular kind of integration.

The category selector will eventually be A/B tested. This PR does NOT cover setting up the A/B test. It only covers setting up the feature behind a local storage variable (SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT). If that value is “1”, show the category selector. If not, don’t show it.

## UI
_Initial view_
<img width="1440" alt="Screen Shot 2020-03-23 at 8 59 43 PM" src="https://user-images.githubusercontent.com/10491193/77387005-74edc080-6d49-11ea-8319-90d3b31adbdf.png">

_Filtered view_
<img width="1440" alt="Screen Shot 2020-03-23 at 8 59 54 PM" src="https://user-images.githubusercontent.com/10491193/77387021-7d45fb80-6d49-11ea-976e-fa377a6cbdb0.png">

_Dropdown view_
<img width="1440" alt="Screen Shot 2020-03-23 at 9 02 09 PM" src="https://user-images.githubusercontent.com/10491193/77387069-9babf700-6d49-11ea-9452-2fa142bc3749.png">

## Test plan
I tested by clicking through the different category options and checking if the correct list of integrations was displayed.