### PR TITLE
feat(ui): Add ability to pass own queryParams to groupList

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/groupList.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/groupList.jsx
@@ -31,6 +31,7 @@ const GroupList = createReactClass({
     orgId: PropTypes.string.isRequired,
     endpointPath: PropTypes.string,
     renderEmptyMessage: PropTypes.func,
+    queryParams: PropTypes.object,
   },
 
   contextTypes: {
@@ -64,7 +65,8 @@ const GroupList = createReactClass({
     return (
       !isEqual(this.state, nextState) ||
       nextProps.endpointPath !== this.props.endpointPath ||
-      nextProps.query !== this.props.query
+      nextProps.query !== this.props.query ||
+      !isEqual(nextProps.queryParams, this.props.queryParams)
     );
   },
 
@@ -72,7 +74,8 @@ const GroupList = createReactClass({
     if (
       prevProps.orgId !== this.props.orgId ||
       prevProps.endpointPath !== this.props.endpointPath ||
-      prevProps.query !== this.props.query
+      prevProps.query !== this.props.query ||
+      !isEqual(prevProps.queryParams, this.props.queryParams)
     ) {
       this.fetchData();
     }
@@ -115,10 +118,11 @@ const GroupList = createReactClass({
   },
 
   getGroupListEndpoint() {
-    const {orgId, endpointPath} = this.props;
+    const {orgId, endpointPath, queryParams} = this.props;
     const path = endpointPath ?? `/organizations/${orgId}/issues/`;
+    const queryParameters = queryParams ?? this.getQueryParams();
 
-    return `${path}?${qs.stringify(this.getQueryParams())}`;
+    return `${path}?${qs.stringify(queryParameters)}`;
   },
 
   getQueryParams() {

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -95,6 +95,7 @@ class ReleaseOverview extends AsyncView<Props, State> {
                       orgId={organization.slug}
                       projectId={project.id}
                       version={params.release}
+                      location={location}
                     />
                   </Main>
                   <Sidebar>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -69,7 +69,7 @@ class Issues extends React.Component<Props, State> {
     const {version, orgId, location} = this.props;
     const {issuesType} = this.state;
     const queryParams = {
-      ...pick(location.query, [...Object.values(URL_PARAM)]),
+      ...pick(location.query, [...Object.values(URL_PARAM), 'cursor']),
       limit: 50,
       sort: 'new',
     };

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import pick from 'lodash/pick';
+import {Location} from 'history';
 
 import {t, tct} from 'app/locale';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
@@ -14,6 +16,7 @@ import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import {GlobalSelection} from 'app/types';
 import Feature from 'app/components/acl/feature';
+import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 
 enum IssuesType {
   NEW = 'new',
@@ -21,11 +24,18 @@ enum IssuesType {
   ALL = 'all',
 }
 
+type IssuesQueryParams = {
+  limit: number;
+  sort: string;
+  query: string;
+};
+
 type Props = {
   orgId: string;
   version: string;
   selection: GlobalSelection;
   projectId: number;
+  location: Location;
 };
 
 type State = {
@@ -55,23 +65,31 @@ class Issues extends React.Component<Props, State> {
     return discoverView.getResultsViewUrlTarget(orgId);
   }
 
-  getIssuesEndpoint(): {path: string; query: string} {
-    const {version, orgId} = this.props;
+  getIssuesEndpoint(): {path: string; queryParams: IssuesQueryParams} {
+    const {version, orgId, location} = this.props;
     const {issuesType} = this.state;
+    const queryParams = {
+      ...pick(location.query, [...Object.values(URL_PARAM)]),
+      limit: 50,
+      sort: 'new',
+    };
 
     switch (issuesType) {
       case IssuesType.ALL:
-        return {path: `/organizations/${orgId}/issues/`, query: `release:"${version}"`};
+        return {
+          path: `/organizations/${orgId}/issues/`,
+          queryParams: {...queryParams, query: `release:"${version}"`},
+        };
       case IssuesType.RESOLVED:
         return {
           path: `/organizations/${orgId}/releases/${version}/resolved/`,
-          query: '',
+          queryParams: {...queryParams, query: ''},
         };
       case IssuesType.NEW:
       default:
         return {
           path: `/organizations/${orgId}/issues/`,
-          query: `first-release:"${version}"`,
+          queryParams: {...queryParams, query: `first-release:"${version}"`},
         };
     }
   }
@@ -121,7 +139,7 @@ class Issues extends React.Component<Props, State> {
   render() {
     const {issuesType} = this.state;
     const {orgId} = this.props;
-    const {path, query} = this.getIssuesEndpoint();
+    const {path, queryParams} = this.getIssuesEndpoint();
     const issuesTypes = [
       {value: 'new', label: t('New Issues')},
       {value: 'resolved', label: t('Resolved Issues')},
@@ -157,7 +175,8 @@ class Issues extends React.Component<Props, State> {
           <GroupList
             orgId={orgId}
             endpointPath={path}
-            query={query}
+            queryParams={queryParams}
+            query=""
             canSelectGroups={false}
             withChart={false}
             renderEmptyMessage={this.renderEmptyMessage}


### PR DESCRIPTION
This PR adds the ability to pass your own queryParams to groupList.

GroupList is a component made for releases v1, but we are currently reusing it in v2.