### PR TITLE
feat(apm): Hide missing instrumentation spans for JS transactions

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -349,9 +349,8 @@ function isJavaScriptSDK(SDKName: string | undefined): boolean {
 
   // based on
   // https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/version.ts
-  // https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/version.ts
 
-  return SDKName === 'sentry.javascript.browser' || SDKName === 'sentry.javascript.node';
+  return SDKName === 'sentry.javascript.browser';
 }
 
 export default SpanTree;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -154,7 +154,7 @@ class SpanTree extends React.Component<PropType> {
 
     const isSpanDisplayed = !isCurrentSpanHidden && !isCurrentSpanFilteredOut;
 
-    const shouldIncludeGap = event.sdk?.name?.includes('javascript') === false;
+    const shouldIncludeGap = isJavaScriptSDK(event.sdk?.name) === false;
 
     const isValidGap =
       typeof previousSiblingEndTimestamp === 'number' &&
@@ -339,5 +339,19 @@ const TraceViewContainer = styled('div')`
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
 `;
+
+function isJavaScriptSDK(SDKName: string | undefined): boolean {
+  if (!SDKName) {
+    return false;
+  }
+
+  SDKName = SDKName.toLowerCase();
+
+  // based on
+  // https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/version.ts
+  // https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/version.ts
+
+  return SDKName === 'sentry.javascript.browser' || SDKName === 'sentry.javascript.node';
+}
 
 export default SpanTree;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -342,17 +342,12 @@ const TraceViewContainer = styled('div')`
   border-bottom-right-radius: 3px;
 `;
 
-function isJavaScriptSDK(sdkName: string | undefined): boolean {
+function isJavaScriptSDK(sdkName?: string): boolean {
   if (!sdkName) {
     return false;
-  }
-
-  sdkName = sdkName.toLowerCase();
-
-  // based on
-  // https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/version.ts
-
-  return sdkName === 'sentry.javascript.browser';
+  }  
+  // based on https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/version.ts
+  return sdkName.toLowerCase() === 'sentry.javascript.browser';
 }
 
 export default SpanTree;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -154,6 +154,8 @@ class SpanTree extends React.Component<PropType> {
 
     const isSpanDisplayed = !isCurrentSpanHidden && !isCurrentSpanFilteredOut;
 
+    // hide gap spans (i.e. "missing instrumentation" spans) for browser js transactions,
+    // since they're not useful to indicate
     const shouldIncludeGap = isJavaScriptSDK(event.sdk?.name) === false;
 
     const isValidGap =

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -340,17 +340,17 @@ const TraceViewContainer = styled('div')`
   border-bottom-right-radius: 3px;
 `;
 
-function isJavaScriptSDK(SDKName: string | undefined): boolean {
-  if (!SDKName) {
+function isJavaScriptSDK(sdkName: string | undefined): boolean {
+  if (!sdkName) {
     return false;
   }
 
-  SDKName = SDKName.toLowerCase();
+  sdkName = sdkName.toLowerCase();
 
   // based on
   // https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/version.ts
 
-  return SDKName === 'sentry.javascript.browser';
+  return sdkName === 'sentry.javascript.browser';
 }
 
 export default SpanTree;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -156,7 +156,7 @@ class SpanTree extends React.Component<PropType> {
 
     // hide gap spans (i.e. "missing instrumentation" spans) for browser js transactions,
     // since they're not useful to indicate
-    const shouldIncludeGap = isJavaScriptSDK(event.sdk?.name) === false;
+    const shouldIncludeGap = !isJavaScriptSDK(event.sdk?.name);
 
     const isValidGap =
       typeof previousSiblingEndTimestamp === 'number' &&

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -345,7 +345,7 @@ const TraceViewContainer = styled('div')`
 function isJavaScriptSDK(sdkName?: string): boolean {
   if (!sdkName) {
     return false;
-  }  
+  }
   // based on https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/version.ts
   return sdkName.toLowerCase() === 'sentry.javascript.browser';
 }

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -213,6 +213,7 @@ class TraceView extends React.PureComponent<Props, State> {
           >
             {this.renderHeader(dragProps, parsedTrace)}
             <SpanTree
+              event={event}
               eventView={eventView}
               trace={parsedTrace}
               dragProps={dragProps}


### PR DESCRIPTION
Hide missing instrumentation spans for JS transactions as they're not useful.