### PR TITLE
fix: Fix Relay usage for users of ALLOWED_HOSTS

### DIFF
--- a/config/reverse_proxy/nginx.conf
+++ b/config/reverse_proxy/nginx.conf
@@ -63,5 +63,7 @@ http {
         location / {
            proxy_pass http://sentry;
         }
+
+        proxy_set_header Host $host;
     }
 }


### PR DESCRIPTION
Forward the Host header so overwriting ALLOWED_HOSTS actually works (and does not
require the user to add "sentry" explicitly)

This still requires the user to add `host.docker.internal` explicitly,
which we can unlikely fix.