### PR TITLE
feat(apm): Display orphan/stray spans

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -18,6 +18,7 @@ import {
   getHumanDuration,
   getSpanID,
   getSpanOperation,
+  isOrphanSpan,
 } from './utils';
 import {ParsedTraceType, ProcessedSpanType} from './types';
 import {
@@ -347,7 +348,11 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     }
 
     return (
-      <SpanTreeConnector isLast={isLast} hasToggler={hasToggler}>
+      <SpanTreeConnector
+        isLast={isLast}
+        hasToggler={hasToggler}
+        orphanBranch={isOrphanSpan(span)}
+      >
         {connectorBars}
       </SpanTreeConnector>
     );
@@ -883,17 +888,31 @@ const SpanTreeTogglerContainer = styled('div')<TogglerTypes>`
   justify-content: flex-end;
 `;
 
-const SpanTreeConnector = styled('div')<TogglerTypes>`
+const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
   height: ${p => (p.isLast ? '80%' : '160%')};
   width: 100%;
-  border-left: 1px solid ${p => p.theme.gray1};
+  border-left: ${p => {
+    if (p.orphanBranch) {
+      return `1px dashed ${p.theme.gray1}`;
+    }
+
+    return `1px solid ${p.theme.gray1}`;
+  }};
+
   position: absolute;
   top: -5px;
 
   &:before {
     content: '';
     height: 1px;
-    background-color: ${p => p.theme.gray1};
+    border-bottom: ${p => {
+      if (p.orphanBranch) {
+        return `1px dashed ${p.theme.gray1}`;
+      }
+
+      return `1px solid ${p.theme.gray1}`;
+    }};
+
     width: 100%;
     position: absolute;
     bottom: ${p => (p.isLast ? '0' : '50%')};

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -327,6 +327,12 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     }
 
     const connectorBars: Array<React.ReactNode> = continuingTreeDepths.map(depth => {
+      if (depth === 0) {
+        // do not render a connector bar at depth 0,
+        // if we did render a connector bar, this bar would be placed at depth -1
+        // which does not exist.
+        return null;
+      }
       const left = ((treeDepth - depth) * (TOGGLE_BORDER_BOX / 2) + 1) * -1;
       return <ConnectorBar style={{left}} key={`${spanID}-${depth}`} />;
     });

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -918,7 +918,7 @@ const SpanTreeTogglerContainer = styled('div')<TogglerTypes>`
 const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
   height: ${p => (p.isLast ? SPAN_ROW_HEIGHT / 2 : SPAN_ROW_HEIGHT)}px;
   width: 100%;
-  border-left: 1px ${p => p.orphanBranch ? 'dashed' : 'solid'} ${p => p.theme.gray1};
+  border-left: 1px ${p => (p.orphanBranch ? 'dashed' : 'solid')} ${p => p.theme.gray1};
   position: absolute;
   top: 0;
 
@@ -953,7 +953,7 @@ const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
 const ConnectorBar = styled('div')<{orphanBranch: boolean}>`
   height: 250%;
 
-  border-left: 1px ${p => p.orphanBranch ? 'dashed' : 'solid'} ${p => p.theme.gray1};
+  border-left: 1px ${p => (p.orphanBranch ? 'dashed' : 'solid')} ${p => p.theme.gray1};
   top: -5px;
   position: absolute;
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -925,13 +925,7 @@ const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
   &:before {
     content: '';
     height: 1px;
-    border-bottom: ${p => {
-      if (p.orphanBranch) {
-        return `1px dashed ${p.theme.gray1}`;
-      }
-
-      return `1px solid ${p.theme.gray1}`;
-    }};
+    border-bottom: 1px ${p => p.orphanBranch ? 'dashed' : 'solid'} ${p => p.theme.gray1};
 
     width: 100%;
     position: absolute;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -346,6 +346,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         return null;
       }
       const left = ((spanTreeDepth - depth) * (TOGGLE_BORDER_BOX / 2) + 1) * -1;
+
       return (
         <ConnectorBar
           style={{left}}
@@ -356,9 +357,16 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     });
 
     if (hasToggler) {
+      // if there is a toggle button, we add a connector bar to create an attachment
+      // between the toggle button and any connector bars below the toggle button
       connectorBars.push(
         <ConnectorBar
-          style={{right: '16px', height: '10px', bottom: '0', top: 'auto'}}
+          style={{
+            right: '16px',
+            height: '10px',
+            bottom: isLast ? `-${SPAN_ROW_HEIGHT / 2}px` : '0',
+            top: 'auto',
+          }}
           key={`${spanID}-last`}
           orphanBranch={false}
         />
@@ -897,17 +905,18 @@ type TogglerTypes = OmitHtmlDivProps<{
 
 const SpanTreeTogglerContainer = styled('div')<TogglerTypes>`
   position: relative;
-  height: 16px;
+  height: ${SPAN_ROW_HEIGHT}px;
   width: ${p => (p.hasToggler ? '40px' : '12px')};
   min-width: ${p => (p.hasToggler ? '40px' : '12px')};
   margin-right: ${p => (p.hasToggler ? space(0.5) : space(1))};
   z-index: ${zIndex.spanTreeToggler};
   display: flex;
   justify-content: flex-end;
+  align-items: center;
 `;
 
 const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
-  height: ${p => (p.isLast ? '80%' : '160%')};
+  height: ${p => (p.isLast ? SPAN_ROW_HEIGHT / 2 : SPAN_ROW_HEIGHT)}px;
   width: 100%;
   border-left: ${p => {
     if (p.orphanBranch) {
@@ -918,7 +927,7 @@ const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
   }};
 
   position: absolute;
-  top: -5px;
+  top: 0;
 
   &:before {
     content: '';
@@ -944,7 +953,7 @@ const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
     width: 3px;
     position: absolute;
     right: 0;
-    top: 11px;
+    top: ${SPAN_ROW_HEIGHT / 2 - 2}px;
   }
 `;
 
@@ -995,6 +1004,7 @@ type SpanTreeTogglerAndDivProps = OmitHtmlDivProps<{
 }>;
 
 const SpanTreeToggler = styled('div')<SpanTreeTogglerAndDivProps>`
+  height: 16px;
   white-space: nowrap;
   min-width: 30px;
   display: flex;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -918,14 +918,7 @@ const SpanTreeTogglerContainer = styled('div')<TogglerTypes>`
 const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
   height: ${p => (p.isLast ? SPAN_ROW_HEIGHT / 2 : SPAN_ROW_HEIGHT)}px;
   width: 100%;
-  border-left: ${p => {
-    if (p.orphanBranch) {
-      return `1px dashed ${p.theme.gray1}`;
-    }
-
-    return `1px solid ${p.theme.gray1}`;
-  }};
-
+  border-left: 1px ${p => p.orphanBranch ? 'dashed' : 'solid'} ${p => p.theme.gray1};
   position: absolute;
   top: 0;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -925,7 +925,7 @@ const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
   &:before {
     content: '';
     height: 1px;
-    border-bottom: 1px ${p => p.orphanBranch ? 'dashed' : 'solid'} ${p => p.theme.gray1};
+    border-bottom: 1px ${p => (p.orphanBranch ? 'dashed' : 'solid')} ${p => p.theme.gray1};
 
     width: 100%;
     position: absolute;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -953,13 +953,7 @@ const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
 const ConnectorBar = styled('div')<{orphanBranch: boolean}>`
   height: 250%;
 
-  border-left: ${p => {
-    if (p.orphanBranch) {
-      return `1px dashed ${p.theme.gray1}`;
-    }
-
-    return `1px solid ${p.theme.gray1}`;
-  }};
+  border-left: 1px ${p => p.orphanBranch ? 'dashed' : 'solid'} ${p => p.theme.gray1};
   top: -5px;
   position: absolute;
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -21,7 +21,7 @@ import {TableDataRow} from 'app/views/eventsV2/table/types';
 import Link from 'app/components/links/link';
 
 import {ProcessedSpanType, RawSpanType, ParsedTraceType} from './types';
-import {isGapSpan, getTraceDateTimeRange} from './utils';
+import {isGapSpan, isOrphanSpan, getTraceDateTimeRange} from './utils';
 
 type TransactionResult = {
   'project.name': string;
@@ -209,6 +209,32 @@ class SpanDetail extends React.Component<Props, State> {
     );
   }
 
+  renderOrphanSpanMessage() {
+    const {span} = this.props;
+
+    if (!isOrphanSpan(span)) {
+      return null;
+    }
+
+    return (
+      <AlertMessage
+        alert={{
+          id: `orphan-span-${span.span_id}`,
+          message: (
+            <span>
+              {t(
+                'This is a span that has no parent span that exists within this transaction, and is attached to the transaction root span by default.'
+              )}
+            </span>
+          ),
+          type: 'info',
+        }}
+        system
+        hideCloseButton
+      />
+    );
+  }
+
   renderSpanErrorMessage() {
     const {orgId, spanErrors, totalNumberOfErrors, span, trace, eventView} = this.props;
 
@@ -310,6 +336,7 @@ class SpanDetail extends React.Component<Props, State> {
           event.stopPropagation();
         }}
       >
+        {this.renderOrphanSpanMessage()}
         {this.renderSpanErrorMessage()}
         <SpanDetails>
           <table className="table key-value">

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -223,7 +223,7 @@ class SpanDetail extends React.Component<Props, State> {
           message: (
             <span>
               {t(
-                'This is a span that has no parent span that exists within this transaction, and is attached to the transaction root span by default.'
+                'This is a span that has no parent span within this transaction. It has been attached to the transaction root span by default.'
               )}
             </span>
           ),

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
@@ -4,7 +4,7 @@ import EventView from 'app/utils/discover/eventView';
 import {TableData, TableDataRow} from 'app/views/eventsV2/table/types';
 
 import {SpanBoundsType, SpanGeneratedBoundsType, isGapSpan, getSpanID} from './utils';
-import {ProcessedSpanType, ParsedTraceType} from './types';
+import {ProcessedSpanType, ParsedTraceType, TreeDepthType} from './types';
 import SpanBar from './spanBar';
 
 type PropType = {
@@ -14,7 +14,7 @@ type PropType = {
   trace: Readonly<ParsedTraceType>;
   generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
   treeDepth: number;
-  continuingTreeDepths: Array<number>;
+  continuingTreeDepths: Array<TreeDepthType>;
   numOfSpanChildren: number;
   renderedSpanChildren: Array<JSX.Element>;
   spanBarColour?: string;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -299,11 +299,9 @@ class SpanTree extends React.Component<PropType> {
       viewEnd: dragProps.viewWindowEnd,
     });
 
-    const hasOrphanSpans = trace.orphanSpans.length > 0;
-
-    const renderedRoot = this.renderSpan({
+    return this.renderSpan({
       isRoot: true,
-      isLast: !hasOrphanSpans,
+      isLast: true,
       spanNumber: 1,
       treeDepth: 0,
       continuingTreeDepths: [],
@@ -314,69 +312,6 @@ class SpanTree extends React.Component<PropType> {
       generateBounds,
       previousSiblingEndTimestamp: undefined,
     });
-
-    // render orphan spans
-
-    type AccType = {
-      renderedSpanChildren: Array<JSX.Element>;
-      nextSpanNumber: number;
-      numOfSpansOutOfViewAbove: number;
-      numOfFilteredSpansAbove: number;
-    };
-
-    const initial: AccType = {
-      renderedSpanChildren: [],
-      nextSpanNumber: renderedRoot.nextSpanNumber,
-      numOfSpansOutOfViewAbove: renderedRoot.numOfSpansOutOfViewAbove,
-      numOfFilteredSpansAbove: renderedRoot.numOfFilteredSpansAbove,
-    };
-
-    const reduced: AccType = trace.orphanSpans.reduce(
-      (acc: AccType, orphanSpan: RawSpanType, currentIndex: number) => {
-        const key = `${orphanSpan.trace_id}${orphanSpan.span_id}`;
-
-        const renderedOrphan = this.renderSpan({
-          isRoot: true,
-          isLast: trace.orphanSpans.length - 1 === currentIndex,
-          spanNumber: acc.nextSpanNumber,
-          treeDepth: 0,
-          continuingTreeDepths: [],
-          numOfSpansOutOfViewAbove: acc.numOfSpansOutOfViewAbove,
-          numOfFilteredSpansAbove: acc.numOfFilteredSpansAbove,
-          span: orphanSpan,
-          childSpans: trace.childSpans,
-          generateBounds,
-          // TODO: is this right?
-          previousSiblingEndTimestamp: undefined,
-        });
-
-        acc.renderedSpanChildren.push(
-          <React.Fragment key={key}>{renderedOrphan.spanTree}</React.Fragment>
-        );
-
-        acc.numOfSpansOutOfViewAbove = renderedOrphan.numOfSpansOutOfViewAbove;
-        acc.numOfFilteredSpansAbove = renderedOrphan.numOfFilteredSpansAbove;
-
-        acc.nextSpanNumber = renderedOrphan.nextSpanNumber;
-
-        return acc;
-      },
-      initial
-    );
-
-    const spanTree = (
-      <React.Fragment>
-        {renderedRoot.spanTree}
-        {reduced.renderedSpanChildren}
-      </React.Fragment>
-    );
-
-    return {
-      spanTree,
-      nextSpanNumber: reduced.nextSpanNumber,
-      numOfSpansOutOfViewAbove: reduced.numOfSpansOutOfViewAbove,
-      numOfFilteredSpansAbove: reduced.numOfFilteredSpansAbove,
-    };
   };
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -299,9 +299,11 @@ class SpanTree extends React.Component<PropType> {
       viewEnd: dragProps.viewWindowEnd,
     });
 
-    return this.renderSpan({
+    const hasOrphanSpans = trace.orphanSpans.length > 0;
+
+    const renderedRoot = this.renderSpan({
       isRoot: true,
-      isLast: true,
+      isLast: !hasOrphanSpans,
       spanNumber: 1,
       treeDepth: 0,
       continuingTreeDepths: [],
@@ -312,6 +314,69 @@ class SpanTree extends React.Component<PropType> {
       generateBounds,
       previousSiblingEndTimestamp: undefined,
     });
+
+    // render orphan spans
+
+    type AccType = {
+      renderedSpanChildren: Array<JSX.Element>;
+      nextSpanNumber: number;
+      numOfSpansOutOfViewAbove: number;
+      numOfFilteredSpansAbove: number;
+    };
+
+    const initial: AccType = {
+      renderedSpanChildren: [],
+      nextSpanNumber: renderedRoot.nextSpanNumber,
+      numOfSpansOutOfViewAbove: renderedRoot.numOfSpansOutOfViewAbove,
+      numOfFilteredSpansAbove: renderedRoot.numOfFilteredSpansAbove,
+    };
+
+    const reduced: AccType = trace.orphanSpans.reduce(
+      (acc: AccType, orphanSpan: RawSpanType, currentIndex: number) => {
+        const key = `${orphanSpan.trace_id}${orphanSpan.span_id}`;
+
+        const renderedOrphan = this.renderSpan({
+          isRoot: true,
+          isLast: trace.orphanSpans.length - 1 === currentIndex,
+          spanNumber: acc.nextSpanNumber,
+          treeDepth: 0,
+          continuingTreeDepths: [],
+          numOfSpansOutOfViewAbove: acc.numOfSpansOutOfViewAbove,
+          numOfFilteredSpansAbove: acc.numOfFilteredSpansAbove,
+          span: orphanSpan,
+          childSpans: trace.childSpans,
+          generateBounds,
+          // TODO: is this right?
+          previousSiblingEndTimestamp: undefined,
+        });
+
+        acc.renderedSpanChildren.push(
+          <React.Fragment key={key}>{renderedOrphan.spanTree}</React.Fragment>
+        );
+
+        acc.numOfSpansOutOfViewAbove = renderedOrphan.numOfSpansOutOfViewAbove;
+        acc.numOfFilteredSpansAbove = renderedOrphan.numOfFilteredSpansAbove;
+
+        acc.nextSpanNumber = renderedOrphan.nextSpanNumber;
+
+        return acc;
+      },
+      initial
+    );
+
+    const spanTree = (
+      <React.Fragment>
+        {renderedRoot.spanTree}
+        {reduced.renderedSpanChildren}
+      </React.Fragment>
+    );
+
+    return {
+      spanTree,
+      nextSpanNumber: reduced.nextSpanNumber,
+      numOfSpansOutOfViewAbove: reduced.numOfSpansOutOfViewAbove,
+      numOfFilteredSpansAbove: reduced.numOfFilteredSpansAbove,
+    };
   };
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -79,13 +79,9 @@ class TraceView extends React.PureComponent<Props, State> {
 
     const {parsedTrace} = this.props;
 
-    const {spans, orphanSpans} = parsedTrace;
+    const {spans} = parsedTrace;
 
-    const transformed: IndexedFusedSpan[] = [
-      generateRootSpan(parsedTrace),
-      ...spans,
-      ...orphanSpans,
-    ].map(
+    const transformed: IndexedFusedSpan[] = [generateRootSpan(parsedTrace), ...spans].map(
       (span): IndexedFusedSpan => {
         const indexed: string[] = [];
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -79,9 +79,13 @@ class TraceView extends React.PureComponent<Props, State> {
 
     const {parsedTrace} = this.props;
 
-    const {spans} = parsedTrace;
+    const {spans, orphanSpans} = parsedTrace;
 
-    const transformed: IndexedFusedSpan[] = [generateRootSpan(parsedTrace), ...spans].map(
+    const transformed: IndexedFusedSpan[] = [
+      generateRootSpan(parsedTrace),
+      ...spans,
+      ...orphanSpans,
+    ].map(
       (span): IndexedFusedSpan => {
         const indexed: string[] = [];
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -25,6 +25,7 @@ export type SpanEntry = {
   data: Array<RawSpanType>;
 };
 
+// map span_id to children whose parent_span_id is equal to span_id
 export type SpanChildrenLookupType = {[span_id: string]: Array<RawSpanType>};
 
 export type ParsedTraceType = {
@@ -37,6 +38,7 @@ export type ParsedTraceType = {
   traceEndTimestamp: number;
   numOfSpans: number;
   spans: RawSpanType[];
+  orphanSpans: RawSpanType[];
 };
 
 export enum TickAlignment {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -18,7 +18,11 @@ export type RawSpanType = {
   tags?: {[key: string]: string};
 };
 
-export type ProcessedSpanType = RawSpanType | GapSpanType;
+export type OrphanSpanType = {
+  type: 'orphan';
+} & RawSpanType;
+
+export type ProcessedSpanType = RawSpanType | GapSpanType | OrphanSpanType;
 
 export type SpanEntry = {
   type: 'spans';

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -42,7 +42,6 @@ export type ParsedTraceType = {
   traceEndTimestamp: number;
   numOfSpans: number;
   spans: RawSpanType[];
-  orphanSpans: RawSpanType[];
 };
 
 export enum TickAlignment {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -22,7 +22,11 @@ export type OrphanSpanType = {
   type: 'orphan';
 } & RawSpanType;
 
-export type ProcessedSpanType = RawSpanType | GapSpanType | OrphanSpanType;
+export type SpanType = RawSpanType | OrphanSpanType;
+
+// this type includes natural spans which are part of the transaction event payload,
+// and as well as pseudo-spans (e.g. gap spans)
+export type ProcessedSpanType = SpanType | GapSpanType;
 
 export type SpanEntry = {
   type: 'spans';
@@ -30,7 +34,7 @@ export type SpanEntry = {
 };
 
 // map span_id to children whose parent_span_id is equal to span_id
-export type SpanChildrenLookupType = {[span_id: string]: Array<RawSpanType>};
+export type SpanChildrenLookupType = {[span_id: string]: Array<SpanType>};
 
 export type ParsedTraceType = {
   op: string;
@@ -41,7 +45,7 @@ export type ParsedTraceType = {
   traceStartTimestamp: number;
   traceEndTimestamp: number;
   numOfSpans: number;
-  spans: RawSpanType[];
+  spans: SpanType[];
 };
 
 export enum TickAlignment {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -3,6 +3,7 @@ export type GapSpanType = {
   start_timestamp: number;
   timestamp: number; // this is essentially end_timestamp
   description?: string;
+  isOrphan: boolean;
 };
 
 export type RawSpanType = {
@@ -61,3 +62,12 @@ export type TraceContextType = {
   trace_id?: string;
   parent_span_id?: string;
 };
+
+type SpanTreeDepth = number;
+
+export type OrphanTreeDepth = {
+  type: 'orphan';
+  depth: number;
+};
+
+export type TreeDepthType = SpanTreeDepth | OrphanTreeDepth;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -350,7 +350,7 @@ export function isGapSpan(span: ProcessedSpanType): span is GapSpanType {
   return span.type === 'gap';
 }
 
-function isOrphanSpan(span: ProcessedSpanType): span is OrphanSpanType {
+export function isOrphanSpan(span: ProcessedSpanType): span is OrphanSpanType {
   // @ts-ignore
   return span.type === 'orphan';
 }

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -4,6 +4,7 @@ import set from 'lodash/set';
 import isNumber from 'lodash/isNumber';
 
 import {SentryTransactionEvent} from 'app/types';
+import {assert} from 'app/types/utils';
 import CHART_PALETTE from 'app/constants/chartPalette';
 
 import {
@@ -472,11 +473,13 @@ export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTrace
       return acc;
     }
 
-    const spanChildren: Array<RawSpanType> = acc.childSpans?.[span.parent_span_id!] ?? [];
+    assert(span.parent_span_id);
+
+    const spanChildren: Array<RawSpanType> = acc.childSpans?.[span.parent_span_id] ?? [];
 
     spanChildren.push(span);
 
-    set(acc.childSpans, span.parent_span_id!, spanChildren);
+    set(acc.childSpans, span.parent_span_id, spanChildren);
 
     if (!acc.traceStartTimestamp || span.start_timestamp < acc.traceStartTimestamp) {
       acc.traceStartTimestamp = span.start_timestamp;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -16,6 +16,8 @@ import {
   SpanType,
   SpanEntry,
   TraceContextType,
+  TreeDepthType,
+  OrphanTreeDepth,
 } from './types';
 
 type Rect = {
@@ -355,7 +357,13 @@ export function isGapSpan(span: ProcessedSpanType): span is GapSpanType {
 
 export function isOrphanSpan(span: ProcessedSpanType): span is OrphanSpanType {
   if ('type' in span) {
-    return span.type === 'orphan';
+    if (span.type === 'orphan') {
+      return true;
+    }
+
+    if (span.type === 'gap') {
+      return span.isOrphan;
+    }
   }
 
   return false;
@@ -548,21 +556,19 @@ function sortSpans(firstSpan: SpanType, secondSpan: SpanType) {
   return 1;
 }
 
-// DEBUG
-// function orphanTheseSpans(spans: Array<RawSpanType>, needleSpanIds: Set<string>) {
-//   const orphanSpans: RawSpanType[] = [];
+export function isOrphanTreeDepth(
+  treeDepth: TreeDepthType
+): treeDepth is OrphanTreeDepth {
+  if (typeof treeDepth === 'number') {
+    return false;
+  }
+  return treeDepth?.type === 'orphan';
+}
 
-//   spans = spans.filter(span => {
-//     if (needleSpanIds.has(span.span_id)) {
-//       orphanSpans.push(span);
-//       return false;
-//     }
+export function unwrapTreeDepth(treeDepth: TreeDepthType): number {
+  if (isOrphanTreeDepth(treeDepth)) {
+    return treeDepth.depth;
+  }
 
-//     return true;
-//   });
-
-//   return {
-//     spans,
-//     orphanSpans,
-//   };
-// }
+  return treeDepth;
+}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -458,17 +458,6 @@ export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTrace
     spans,
   };
 
-  // TODO: DEBUG
-  const orphanMarkers = new Set([
-    // '91bf78ba24c31086',
-    '86620893f627b0a6',
-    // 'a87d8dce1e4d8f88',
-    // 'b8ff4cbcb1aef5fe',
-    // 'b9884f1007035621'
-  ]);
-
-  // console.log('spans', spans);
-
   const reduced: ParsedTraceType = spans.reduce((acc, inputSpan) => {
     let span: SpanType = inputSpan;
 
@@ -476,11 +465,7 @@ export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTrace
 
     const hasParent = parentSpanId && potentialParents.has(parentSpanId);
 
-    if (
-      !isValidSpanID(parentSpanId) ||
-      !hasParent ||
-      (parentSpanId && orphanMarkers.has(span.span_id))
-    ) {
+    if (!isValidSpanID(parentSpanId) || !hasParent) {
       // this span is considered an orphan with respect to the spans within this transaction.
       // although the span is an orphan, it's still a descendant of this transaction,
       // so we set its parent span id to be the root transaction span's id

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -458,6 +458,17 @@ export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTrace
     spans,
   };
 
+  // TODO: DEBUG
+  const orphanMarkers = new Set([
+    // '91bf78ba24c31086',
+    '86620893f627b0a6',
+    // 'a87d8dce1e4d8f88',
+    // 'b8ff4cbcb1aef5fe',
+    // 'b9884f1007035621'
+  ]);
+
+  // console.log('spans', spans);
+
   const reduced: ParsedTraceType = spans.reduce((acc, inputSpan) => {
     let span: SpanType = inputSpan;
 
@@ -465,7 +476,11 @@ export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTrace
 
     const hasParent = parentSpanId && potentialParents.has(parentSpanId);
 
-    if (!isValidSpanID(parentSpanId) || !hasParent) {
+    if (
+      !isValidSpanID(parentSpanId) ||
+      !hasParent ||
+      (parentSpanId && orphanMarkers.has(span.span_id))
+    ) {
       // this span is considered an orphan with respect to the spans within this transaction.
       // although the span is an orphan, it's still a descendant of this transaction,
       // so we set its parent span id to be the root transaction span's id

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -346,13 +346,19 @@ export function getTraceDateTimeRange(input: {
 }
 
 export function isGapSpan(span: ProcessedSpanType): span is GapSpanType {
-  // @ts-ignore
-  return span.type === 'gap';
+  if ('type' in span) {
+    return span.type === 'gap';
+  }
+
+  return false;
 }
 
 export function isOrphanSpan(span: ProcessedSpanType): span is OrphanSpanType {
-  // @ts-ignore
-  return span.type === 'orphan';
+  if ('type' in span) {
+    return span.type === 'orphan';
+  }
+
+  return false;
 }
 
 export function getSpanID(span: ProcessedSpanType, defaultSpanID: string = ''): string {


### PR DESCRIPTION
**WORK IN PROGRESS**

~Branching from https://github.com/getsentry/sentry/pull/17887~

<img width="1308" alt="Screen Shot 2020-04-29 at 5 27 28 AM" src="https://user-images.githubusercontent.com/139499/80580823-2d0e2900-89da-11ea-8627-79dbdcf267fd.png">

Adding "orphaned spans" at the bottom of the span view. Orphaned spans are spans whose parent is either unknown or not one of the spans among the spans within the transaction event.

We know these spans are at least a descendant of the transaction root span; so we attach them as a direct child to the transaction root span. The branch connections are dashed to emphasize this relationship. 

## TODO

- [x] styling
- [x] cherry pick inline error spans
- [x] fix: connect orphaned spans to the transaction root span