### PR TITLE
ref(workflow): Change Alert Rules list to use `<PanelTable>`

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/list.tsx
@@ -10,7 +10,6 @@ import {SavedIncidentRule} from 'app/views/settings/incidentRules/types';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
-import EmptyStateWarning from 'app/components/emptyStateWarning';
 import OnboardingHovercard from 'app/views/settings/projectAlerts/onboardingHovercard';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import RuleRow from 'app/views/settings/projectAlerts/ruleRow';
@@ -18,7 +17,6 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import Tooltip from 'app/components/tooltip';
 import routeTitle from 'app/utils/routeTitle';
 import space from 'app/styles/space';
-import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 type Props = {
   canEditRule: boolean;
@@ -46,14 +44,6 @@ class ProjectAlertRules extends AsyncView<Props, State> {
   getTitle() {
     const {projectId} = this.props.params;
     return routeTitle(t('Alert Rules'), projectId);
-  }
-
-  renderEmpty() {
-    return (
-      <EmptyStateWarning>
-        <p />
-      </EmptyStateWarning>
-    );
   }
 
   renderResults() {
@@ -129,12 +119,8 @@ class ProjectAlertRules extends AsyncView<Props, State> {
             headers={[
               <div key="type">{t('Type')}</div>,
               <div key="name">{t('Name')}</div>,
-              <TriggerAndActions key="triggerAndActions">
-                <EllipsisHeader key="conditions">
-                  {t('Conditions/Triggers')}
-                </EllipsisHeader>
-                <EllipsisHeader key="actions">{t('Action(s)')}</EllipsisHeader>
-              </TriggerAndActions>,
+              <div key="conditions">{t('Conditions/Triggers')}</div>,
+              <div key="actions">{t('Action(s)')}</div>,
             ]}
           >
             {() => this.renderResults()}
@@ -152,32 +138,16 @@ const ScrollWrapper = styled('div')`
   overflow-x: auto;
 `;
 
-const LoadingWrapper = styled('div')`
-  border: none;
-  grid-column: auto / span 4;
-`;
-
+/**
+ * TODO(billy): Not sure if this should be default for PanelTable or not
+ */
 const StyledPanelTable = styled(PanelTable)`
   width: fit-content;
   min-width: 100%;
-
-  > ${LoadingWrapper} {
-    border: none;
-  }
-`;
-
-const TriggerAndActions = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: ${space(1)};
 `;
 
 const HeaderActions = styled('div')`
   display: grid;
   grid-auto-flow: column;
   grid-gap: ${space(1)};
-`;
-
-const EllipsisHeader = styled('div')`
-  ${overflowEllipsis};
 `;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/list.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import {IconAdd} from 'app/icons';
 import {IssueAlertRule} from 'app/types/alerts';
 import {Organization} from 'app/types';
-import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import {Panel, PanelBody, PanelHeader, PanelTable} from 'app/components/panels';
 import {SavedIncidentRule} from 'app/views/settings/incidentRules/types';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
@@ -120,36 +120,33 @@ class ProjectAlertRules extends AsyncView<Props, State> {
         />
         <PermissionAlert />
 
-        <Panel>
-          <RuleHeader>
-            <div>{t('Type')}</div>
-            <div>{t('Name')}</div>
-            <TriggerAndActions>
-              <div>{t('Conditions/Triggers')}</div>
-              <div>{t('Action(s)')}</div>
-            </TriggerAndActions>
-          </RuleHeader>
-
-          <PanelBody>
+        <ScrollWrapper>
+          <PanelTable
+            headers={[
+              <div key="type">{t('Type')}</div>,
+              <div key="name">{t('Name')}</div>,
+              <TriggerAndActions key="triggerAndActions">
+                <div>{t('Conditions/Triggers')}</div>
+                <div>{t('Action(s)')}</div>
+              </TriggerAndActions>,
+            ]}
+          >
             {loading
               ? super.renderLoading()
               : !!rules.length
               ? this.renderResults()
               : this.renderEmpty()}
-          </PanelBody>
-        </Panel>
+          </PanelTable>
+        </ScrollWrapper>
       </React.Fragment>
     );
   }
 }
 
 export default ProjectAlertRules;
-
-const RuleHeader = styled(PanelHeader)`
-  display: grid;
-  grid-gap: ${space(1)};
-  grid-template-columns: 1fr 3fr 6fr;
-  grid-auto-flow: column;
+const ScrollWrapper = styled('div')`
+  width: 100%;
+  overflow-x: auto;
 `;
 
 const TriggerAndActions = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/list.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import {IconAdd} from 'app/icons';
 import {IssueAlertRule} from 'app/types/alerts';
 import {Organization} from 'app/types';
-import {Panel, PanelBody, PanelHeader, PanelTable} from 'app/components/panels';
+import {PanelTable} from 'app/components/panels';
 import {SavedIncidentRule} from 'app/views/settings/incidentRules/types';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
@@ -18,6 +18,7 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import Tooltip from 'app/components/tooltip';
 import routeTitle from 'app/utils/routeTitle';
 import space from 'app/styles/space';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 type Props = {
   canEditRule: boolean;
@@ -50,7 +51,7 @@ class ProjectAlertRules extends AsyncView<Props, State> {
   renderEmpty() {
     return (
       <EmptyStateWarning>
-        <p>{t('There are no alerts configured for this project.')}</p>
+        <p />
       </EmptyStateWarning>
     );
   }
@@ -121,22 +122,23 @@ class ProjectAlertRules extends AsyncView<Props, State> {
         <PermissionAlert />
 
         <ScrollWrapper>
-          <PanelTable
+          <StyledPanelTable
+            isLoading={loading}
+            isEmpty={!loading && !rules.length}
+            emptyMessage={t('There are no alerts configured for this project.')}
             headers={[
               <div key="type">{t('Type')}</div>,
               <div key="name">{t('Name')}</div>,
               <TriggerAndActions key="triggerAndActions">
-                <div>{t('Conditions/Triggers')}</div>
-                <div>{t('Action(s)')}</div>
+                <EllipsisHeader key="conditions">
+                  {t('Conditions/Triggers')}
+                </EllipsisHeader>
+                <EllipsisHeader key="actions">{t('Action(s)')}</EllipsisHeader>
               </TriggerAndActions>,
             ]}
           >
-            {loading
-              ? super.renderLoading()
-              : !!rules.length
-              ? this.renderResults()
-              : this.renderEmpty()}
-          </PanelTable>
+            {() => this.renderResults()}
+          </StyledPanelTable>
         </ScrollWrapper>
       </React.Fragment>
     );
@@ -144,19 +146,38 @@ class ProjectAlertRules extends AsyncView<Props, State> {
 }
 
 export default ProjectAlertRules;
+
 const ScrollWrapper = styled('div')`
   width: 100%;
   overflow-x: auto;
 `;
 
+const LoadingWrapper = styled('div')`
+  border: none;
+  grid-column: auto / span 4;
+`;
+
+const StyledPanelTable = styled(PanelTable)`
+  width: fit-content;
+  min-width: 100%;
+
+  > ${LoadingWrapper} {
+    border: none;
+  }
+`;
+
 const TriggerAndActions = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-auto-flow: column;
+  grid-gap: ${space(1)};
 `;
 
 const HeaderActions = styled('div')`
   display: grid;
   grid-auto-flow: column;
   grid-gap: ${space(1)};
+`;
+
+const EllipsisHeader = styled('div')`
+  ${overflowEllipsis};
 `;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
@@ -10,7 +10,6 @@ import {getDisplayName} from 'app/utils/environment';
 import {t, tct} from 'app/locale';
 import recreateRoute from 'app/utils/recreateRoute';
 import space from 'app/styles/space';
-import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 function isIssueAlert(data: IssueAlertRule | SavedIncidentRule): data is IssueAlertRule {
   return !data.hasOwnProperty('triggers');
@@ -62,28 +61,26 @@ class RuleRow extends React.Component<Props, State> {
           </RuleDescription>
         </div>
 
-        <TriggerAndActions>
-          <ConditionsWithHeader>
-            <MatchTypeHeader>
-              {tct('[matchType] of the following:', {
-                matchType: data.actionMatch,
-              })}
-            </MatchTypeHeader>
-            {data.conditions.length !== 0 && (
-              <Conditions>
-                {data.conditions.map((condition, i) => (
-                  <div key={i}>{condition.name}</div>
-                ))}
-              </Conditions>
-            )}
-          </ConditionsWithHeader>
+        <ConditionsWithHeader>
+          <MatchTypeHeader>
+            {tct('[matchType] of the following:', {
+              matchType: data.actionMatch,
+            })}
+          </MatchTypeHeader>
+          {data.conditions.length !== 0 && (
+            <Conditions>
+              {data.conditions.map((condition, i) => (
+                <div key={i}>{condition.name}</div>
+              ))}
+            </Conditions>
+          )}
+        </ConditionsWithHeader>
 
-          <Actions>
-            {data.actions.map((action, i) => (
-              <Action key={i}>{action.name}</Action>
-            ))}
-          </Actions>
-        </TriggerAndActions>
+        <Actions>
+          {data.actions.map((action, i) => (
+            <Action key={i}>{action.name}</Action>
+          ))}
+        </Actions>
       </React.Fragment>
     );
   }
@@ -96,19 +93,22 @@ class RuleRow extends React.Component<Props, State> {
       location,
     });
 
+    const numberOfTriggers = data.triggers.length;
+
     return (
       <React.Fragment>
-        <RuleType>{t('Metric')}</RuleType>
-        <div>
+        <RuleType rowSpans={numberOfTriggers}>{t('Metric')}</RuleType>
+        <RuleNameAndDescription rowSpans={numberOfTriggers}>
           {canEdit ? <RuleName to={editLink}>{data.name}</RuleName> : data.name}
           <RuleDescription />
-        </div>
+        </RuleNameAndDescription>
 
-        <TriggerAndActions>
-          {data.triggers.length !== 0 &&
-            data.triggers.map((trigger, i) => (
+        {numberOfTriggers !== 0 &&
+          data.triggers.map((trigger, i) => {
+            const hideBorder = i !== numberOfTriggers - 1;
+            return (
               <React.Fragment key={i}>
-                <Trigger key={`trigger-${i}`}>
+                <Trigger key={`trigger-${i}`} hideBorder={hideBorder}>
                   <StatusBadge>{trigger.label}</StatusBadge>
                   <TriggerDescription>
                     {data.aggregations[0] === 0 ? t('Events') : t('Users')}{' '}
@@ -117,14 +117,14 @@ class RuleRow extends React.Component<Props, State> {
                     {t('min')}
                   </TriggerDescription>
                 </Trigger>
-                <Actions key={`actions-${i}`}>
+                <Actions key={`actions-${i}`} hideBorder={hideBorder}>
                   {trigger.actions?.map((action, j) => (
                     <Action key={j}>{action.desc}</Action>
                   ))}
                 </Actions>
               </React.Fragment>
-            ))}
-        </TriggerAndActions>
+            );
+          })}
       </React.Fragment>
     );
   }
@@ -138,11 +138,24 @@ class RuleRow extends React.Component<Props, State> {
 
 export default RuleRow;
 
-const RuleType = styled('div')`
+type RowSpansProp = {
+  rowSpans?: number;
+};
+
+type HasBorderProp = {
+  hideBorder?: boolean;
+};
+
+const RuleType = styled('div')<RowSpansProp>`
   color: ${p => p.theme.gray3};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: bold;
   text-transform: uppercase;
+  ${p => p.rowSpans && `grid-row: auto / span ${p.rowSpans}`};
+`;
+
+const RuleNameAndDescription = styled('div')<RowSpansProp>`
+  ${p => p.rowSpans && `grid-row: auto / span ${p.rowSpans}`};
 `;
 
 const RuleName = styled(Link)`
@@ -157,26 +170,18 @@ const Conditions = styled('div')`
 `;
 
 // For tests
-const Actions = styled('div')`
-  overflow: hidden;
+const Actions = styled('div')<HasBorderProp>`
+  font-size: ${p => p.theme.fontSizeSmall};
+
+  ${p => p.hideBorder && `border-bottom: none`};
 `;
 
 const Action = styled('div')`
   line-height: 14px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
-const TriggerAndActions = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  align-items: flex-start;
-  grid-gap: ${space(1)};
-  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const ConditionsWithHeader = styled('div')`
-  overflow: hidden;
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const MatchTypeHeader = styled('div')`
@@ -184,21 +189,24 @@ const MatchTypeHeader = styled('div')`
   text-transform: uppercase;
   color: ${p => p.theme.gray2};
   margin-bottom: ${space(1)};
-  ${overflowEllipsis}
 `;
 
 const RuleDescription = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   margin: ${space(0.5)} 0;
+  white-space: nowrap;
 `;
 
-const Trigger = styled('div')`
+const Trigger = styled('div')<HasBorderProp>`
   display: flex;
-  overflow: hidden;
+  align-items: flex-start;
+  font-size: ${p => p.theme.fontSizeSmall};
+
+  ${p => p.hideBorder && `border-bottom: none`};
 `;
 
 const TriggerDescription = styled('div')`
-  ${overflowEllipsis};
+  white-space: nowrap;
 `;
 
 const StatusBadge = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
@@ -63,7 +63,7 @@ class RuleRow extends React.Component<Props, State> {
         </div>
 
         <TriggerAndActions>
-          <div>
+          <ConditionsWithHeader>
             <MatchTypeHeader>
               {tct('[matchType] of the following:', {
                 matchType: data.actionMatch,
@@ -76,7 +76,7 @@ class RuleRow extends React.Component<Props, State> {
                 ))}
               </Conditions>
             )}
-          </div>
+          </ConditionsWithHeader>
 
           <Actions>
             {data.actions.map((action, i) => (
@@ -175,11 +175,16 @@ const TriggerAndActions = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
+const ConditionsWithHeader = styled('div')`
+  overflow: hidden;
+`;
+
 const MatchTypeHeader = styled('div')`
   font-weight: bold;
   text-transform: uppercase;
   color: ${p => p.theme.gray2};
   margin-bottom: ${space(1)};
+  ${overflowEllipsis}
 `;
 
 const RuleDescription = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
@@ -10,6 +10,7 @@ import {getDisplayName} from 'app/utils/environment';
 import {t, tct} from 'app/locale';
 import recreateRoute from 'app/utils/recreateRoute';
 import space from 'app/styles/space';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 function isIssueAlert(data: IssueAlertRule | SavedIncidentRule): data is IssueAlertRule {
   return !data.hasOwnProperty('triggers');
@@ -79,7 +80,7 @@ class RuleRow extends React.Component<Props, State> {
 
           <Actions>
             {data.actions.map((action, i) => (
-              <div key={i}>{action.name}</div>
+              <Action key={i}>{action.name}</Action>
             ))}
           </Actions>
         </TriggerAndActions>
@@ -103,27 +104,27 @@ class RuleRow extends React.Component<Props, State> {
           <RuleDescription />
         </div>
 
-        <div>
+        <TriggerAndActions>
           {data.triggers.length !== 0 &&
             data.triggers.map((trigger, i) => (
-              <TriggerAndActions key={i}>
-                <Trigger>
+              <React.Fragment key={i}>
+                <Trigger key={`trigger-${i}`}>
                   <StatusBadge>{trigger.label}</StatusBadge>
-                  <div>
+                  <TriggerDescription>
                     {data.aggregations[0] === 0 ? t('Events') : t('Users')}{' '}
                     {trigger.thresholdType === 0 ? t('above') : t('below')}{' '}
                     {trigger.alertThreshold}/{data.timeWindow}
                     {t('min')}
-                  </div>
+                  </TriggerDescription>
                 </Trigger>
-                <Actions>
+                <Actions key={`actions-${i}`}>
                   {trigger.actions?.map((action, j) => (
-                    <div key={j}>{action.desc}</div>
+                    <Action key={j}>{action.desc}</Action>
                   ))}
                 </Actions>
-              </TriggerAndActions>
+              </React.Fragment>
             ))}
-        </div>
+        </TriggerAndActions>
       </React.Fragment>
     );
   }
@@ -156,12 +157,21 @@ const Conditions = styled('div')`
 `;
 
 // For tests
-const Actions = styled('div')``;
+const Actions = styled('div')`
+  overflow: hidden;
+`;
+
+const Action = styled('div')`
+  line-height: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
 const TriggerAndActions = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-auto-flow: column;
+  align-items: flex-start;
+  grid-gap: ${space(1)};
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
@@ -179,7 +189,11 @@ const RuleDescription = styled('div')`
 
 const Trigger = styled('div')`
   display: flex;
-  align-items: center;
+  overflow: hidden;
+`;
+
+const TriggerDescription = styled('div')`
+  ${overflowEllipsis};
 `;
 
 const StatusBadge = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {IssueAlertRule} from 'app/types/alerts';
-import {PanelItem} from 'app/components/panels';
 import {SavedIncidentRule} from 'app/views/settings/incidentRules/types';
 import {getDisplayName} from 'app/utils/environment';
 import {t, tct} from 'app/locale';
@@ -53,7 +52,7 @@ class RuleRow extends React.Component<Props, State> {
       : t('All Environments');
 
     return (
-      <RuleItem>
+      <React.Fragment>
         <RuleType>{t('Issue')}</RuleType>
         <div>
           {canEdit ? <RuleName to={editLink}>{data.name}</RuleName> : data.name}
@@ -84,7 +83,7 @@ class RuleRow extends React.Component<Props, State> {
             ))}
           </Actions>
         </TriggerAndActions>
-      </RuleItem>
+      </React.Fragment>
     );
   }
 
@@ -97,7 +96,7 @@ class RuleRow extends React.Component<Props, State> {
     });
 
     return (
-      <RuleItem>
+      <React.Fragment>
         <RuleType>{t('Metric')}</RuleType>
         <div>
           {canEdit ? <RuleName to={editLink}>{data.name}</RuleName> : data.name}
@@ -125,7 +124,7 @@ class RuleRow extends React.Component<Props, State> {
               </TriggerAndActions>
             ))}
         </div>
-      </RuleItem>
+      </React.Fragment>
     );
   }
 
@@ -137,13 +136,6 @@ class RuleRow extends React.Component<Props, State> {
 }
 
 export default RuleRow;
-
-const RuleItem = styled(PanelItem)`
-  display: grid;
-  grid-gap: ${space(1)};
-  grid-template-columns: 1fr 3fr 6fr;
-  grid-auto-flow: column;
-`;
 
 const RuleType = styled('div')`
   color: ${p => p.theme.gray3};
@@ -171,7 +163,6 @@ const TriggerAndActions = styled('div')`
   grid-template-columns: 1fr 1fr;
   grid-auto-flow: column;
   font-size: ${p => p.theme.fontSizeSmall};
-  margin-bottom: ${space(1)};
 `;
 
 const MatchTypeHeader = styled('div')`

--- a/tests/js/spec/views/settings/projectAlerts/list.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/list.spec.jsx
@@ -42,35 +42,35 @@ describe('ProjectAlertsList', function() {
 
     expect(
       wrapper
-        .find('RuleItem RuleType')
+        .find('RuleType')
         .at(0)
         .text()
     ).toBe('Issue');
 
     expect(
       wrapper
-        .find('RuleItem RuleName')
+        .find('RuleName')
         .at(0)
         .text()
     ).toBe('My alert rule');
 
     expect(
       wrapper
-        .find('RuleItem RuleDescription')
+        .find('RuleDescription')
         .at(0)
         .text()
     ).toBe('Environment: Staging');
 
     expect(
       wrapper
-        .find('RuleItem Conditions')
+        .find('Conditions')
         .at(0)
         .text()
     ).toBe('An alert is first seen');
 
     expect(
       wrapper
-        .find('RuleItem Actions')
+        .find('Actions')
         .at(0)
         .text()
     ).toBe('Send a notification to all services');
@@ -91,7 +91,7 @@ describe('ProjectAlertsList', function() {
     ).toBe(true);
     expect(
       wrapper
-        .find('RuleItem RuleDescription')
+        .find('RuleDescription')
         .at(0)
         .text()
     ).toBe('Environment: Staging');


### PR DESCRIPTION
Uses CSS grid properly for the Panel where previously there was some hackery going on with nested grids and flexbox.

Hopefully this fixes our flakey percy tests too. 

Old:
![image](https://user-images.githubusercontent.com/79684/77585697-243dab00-6ea2-11ea-8996-2accc660d482.png)

New:
![image](https://user-images.githubusercontent.com/79684/77585623-040dec00-6ea2-11ea-84f9-1591b9863a02.png)
