### PR TITLE
feat(async-csv): Modify data export page design and texts

### DIFF
--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -96,7 +96,7 @@ class ExportedData(Model):
             reverse("sentry-data-export-details", args=[self.organization.slug, self.id])
         )
         msg = MessageBuilder(
-            subject="Your Download is Ready!",
+            subject="Your data is ready.",
             context={"url": url, "expiration": self.format_date(self.date_expired)},
             type="organization.export-data",
             template="sentry/emails/data-export-success.txt",
@@ -109,7 +109,7 @@ class ExportedData(Model):
         from sentry.utils.email import MessageBuilder
 
         msg = MessageBuilder(
-            subject="Unable to Export Data",
+            subject="We couldn't export your data.",
             context={
                 "creation": self.format_date(self.date_added),
                 "error_message": message,

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -69,7 +69,7 @@ class DataExport extends React.Component<Props, State> {
     return (
       <Feature features={['data-export']}>
         {inProgress && dataExportId ? (
-          <Tooltip title="Wait right there. We'll email you.">
+          <Tooltip title="You can get on with your life. We'll email you when your data's ready.">
             <button className="btn btn-default btn-sm" disabled>
               {t("We're working on it...")}
             </button>

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -59,7 +59,7 @@ class DataExport extends React.Component<Props, State> {
       this.setState({inProgress: true, dataExportId});
     } catch (_err) {
       addErrorMessage(
-        t("We tried our hardes, but we couldn't export your data. Give it another go.")
+        t("We tried our hardest, but we couldn't export your data. Give it another go.")
       );
     }
   };
@@ -75,9 +75,9 @@ class DataExport extends React.Component<Props, State> {
             </button>
           </Tooltip>
         ) : (
-          <Tooltip title="Put your data to work. Start your export, and we'll email you when it's finished.">
+          <Tooltip title="Put your data to work. Start your export and we'll email you when it's finished.">
             <button className="btn btn-default btn-sm" onClick={this.startDataExport}>
-              {t('Create CSV')}
+              {t('Export Data')}
             </button>
           </Tooltip>
         )}

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -26,11 +26,6 @@ type State = {
   dataExportId?: number;
 };
 
-const TooltipMessages = {
-  start: "We'll get all your data in one place and email you when it's ready",
-  progress: "We'll email you when it's ready",
-} as const;
-
 class DataExport extends React.Component<Props, State> {
   state: State = {
     inProgress: false,
@@ -53,10 +48,14 @@ class DataExport extends React.Component<Props, State> {
           },
         }
       );
-      addSuccessMessage(t("We'll email you when it's ready for download"));
+      addSuccessMessage(
+        t("Sit tight. We'll shoot you an email when your data is ready for download.")
+      );
       this.setState({inProgress: true, dataExportId});
     } catch (_err) {
-      addErrorMessage(t('Unable to begin bulk data export. Please try again.'));
+      addErrorMessage(
+        t("We tried our hardes, but we couldn't export your data. Give it another go.")
+      );
     }
   };
 
@@ -65,15 +64,15 @@ class DataExport extends React.Component<Props, State> {
     return (
       <Feature features={['data-export']}>
         {inProgress && dataExportId ? (
-          <Tooltip title={TooltipMessages.progress}>
+          <Tooltip title="Wait right there. We'll email you.">
             <button className="btn btn-default btn-sm" disabled>
-              {t('Queued up!')}
+              {t("We're working on it...")}
             </button>
           </Tooltip>
         ) : (
-          <Tooltip title={TooltipMessages.start}>
+          <Tooltip title="Put your data to work. Start your export, and we'll email you when it's finished.">
             <button className="btn btn-default btn-sm" onClick={this.startDataExport}>
-              {t('Export All to CSV')}
+              {t('Create CSV')}
             </button>
           </Tooltip>
         )}

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -9,9 +9,14 @@ import {Organization} from 'app/types';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 
+//! Coordinate with other ExportQueryType (src/sentry/data_export/base.py)
+export enum ExportQueryType {
+  IssuesByTag = 'Issues-by-Tag',
+  Discover = 'Discover',
+}
+
 type DataExportPayload = {
-  // Coordinate with ExportQueryType string (src/sentry/constants.py)
-  queryType: 'Issues-by-Tag' | 'Discover';
+  queryType: ExportQueryType;
   queryInfo: any; // TODO(ts): Formalize different possible payloads
 };
 

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -997,6 +997,16 @@ function routes() {
       />
 
       <Route
+        path="/organizations/:orgId/data-export/:dataExportId"
+        componentPromise={() =>
+          import(
+            /* webpackChunkName: "DataDownloadView" */ 'app/views/dataExport/dataDownload'
+          )
+        }
+        component={errorHandler(LazyLoad)}
+      />
+
+      <Route
         path="/join-request/:orgId/"
         componentPromise={() =>
           import(
@@ -1106,15 +1116,6 @@ function routes() {
           <IndexRoute component={errorHandler(IssueListOverview)} />
           <Route path="searches/:searchId/" component={errorHandler(IssueListOverview)} />
         </Route>
-        <Route
-          path="/organizations/:orgId/data-export/:dataExportId"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "DataDownloadView" */ 'app/views/dataExport/dataDownload'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        />
         {/* Once org issues is complete, these routes can be nested under
           /organizations/:orgId/issues */}
         <Route

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -118,9 +118,9 @@ class DataDownload extends AsyncView<Props, State> {
               'Make a new one with your latest data. Your old download will never see it coming.'
             )}
           </p>
-          <Button href={actionLink} priority="primary">
+          <DownloadButton href={actionLink} priority="primary">
             {t('Start a New Download')}
-          </Button>
+          </DownloadButton>
         </Body>
       </React.Fragment>
     );
@@ -191,6 +191,10 @@ const Body = styled('div')`
   p {
     margin: ${space(1.5)} 0;
   }
+`;
+
+const DownloadButton = styled(Button)`
+  margin-bottom: ${space(1.5)};
 `;
 
 export default DataDownload;

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -5,7 +5,7 @@ import {RouteComponentProps} from 'react-router/lib/Router';
 import Button from 'app/components/button';
 import DateTime from 'app/components/dateTime';
 import AsyncView from 'app/views/asyncView';
-import {PageContent} from 'app/styles/organization';
+import Layout from 'app/views/auth/layout';
 import space from 'app/styles/space';
 import {t} from 'app/locale';
 
@@ -68,15 +68,21 @@ class DataDownload extends AsyncView<Props, State> {
   renderExpired(): React.ReactNode {
     return (
       <React.Fragment>
-        <h3>{t('Sorry!')}</h3>
-        <p>
-          {t('It seems this link has expired, and your download is no longer available.')}
-        </p>
-        <p>
-          {t(
-            'Feel free to start a new export to get the latest and greatest of your Sentry data.'
-          )}
-        </p>
+        <Header>
+          <h3>{t('Sorry!')}</h3>
+        </Header>
+        <Body>
+          <p>
+            {t(
+              'It seems this link has expired, and your download is no longer available.'
+            )}
+          </p>
+          <p>
+            {t(
+              'Feel free to start a new export to get the latest and greatest of your Sentry data.'
+            )}
+          </p>
+        </Body>
       </React.Fragment>
     );
   }
@@ -84,9 +90,13 @@ class DataDownload extends AsyncView<Props, State> {
   renderEarly(): React.ReactNode {
     return (
       <React.Fragment>
-        <h3>{t("You're Early!")}</h3>
-        <p>{t("We're still preparing your download, so check back in a bit!")}</p>
-        <p>{t("You can close this page, we'll email you when were ready")}</p>
+        <Header>
+          <h3>{t("You're Early!")}</h3>
+        </Header>
+        <Body>
+          <p>{t("We're still preparing your download, so check back in a bit!")}</p>
+          <p>{t("You can close this page, we'll email you when were ready")}</p>
+        </Body>
       </React.Fragment>
     );
   }
@@ -98,23 +108,27 @@ class DataDownload extends AsyncView<Props, State> {
     const {orgId, dataExportId} = this.props.params;
     return (
       <React.Fragment>
-        <h3>{t('Finally!')}</h3>
-        <p>
-          {t(
-            'We prepared your data for download, you can access it with the link below.'
-          )}
-        </p>
-        <Button
-          priority="primary"
-          icon="icon-download"
-          size="large"
-          borderless
-          href={`/api/0/organizations/${orgId}/data-export/${dataExportId}/?download=true`}
-        >
-          {t('Download CSV')}
-        </Button>
-        <p>{t('Keep in mind, this link will no longer work after:')}</p>
-        <p>{this.renderDate(dateExpired)}</p>
+        <Header>
+          <h3>{t('Finally!')}</h3>
+        </Header>
+        <Body>
+          <p>
+            {t(
+              'We prepared your data for download, you can access it with the link below.'
+            )}
+          </p>
+          <Button
+            priority="primary"
+            icon="icon-download"
+            size="large"
+            borderless
+            href={`/api/0/organizations/${orgId}/data-export/${dataExportId}/?download=true`}
+          >
+            {t('Download CSV')}
+          </Button>
+          <p>{t('Keep in mind, this link will no longer work after:')}</p>
+          <p>{this.renderDate(dateExpired)}</p>
+        </Body>
       </React.Fragment>
     );
   }
@@ -133,25 +147,26 @@ class DataDownload extends AsyncView<Props, State> {
 
   renderBody() {
     return (
-      <PageContent>
-        <div className="pattern-bg" />
-        <ContentContainer>{this.renderContent()}</ContentContainer>
-      </PageContent>
+      <Layout>
+        <main>{this.renderContent()}</main>
+      </Layout>
     );
   }
 }
 
-const ContentContainer = styled('div')`
-  text-align: center;
-  margin: ${space(4)} auto;
-  width: 350px;
-  padding: ${space(4)};
-  background: ${p => p.theme.whiteDark};
-  border-radius: ${p => p.theme.borderRadius};
-  border: 2px solid ${p => p.theme.borderDark};
-  box-shadow: ${p => p.theme.dropShadowHeavy};
+const Header = styled('header')`
+  border-bottom: 1px solid ${p => p.theme.borderLight};
+  padding: ${space(3)} 40px 0;
+  h3 {
+    font-size: 24px;
+    margin: 0 0 ${space(3)} 0;
+  }
+`;
+
+const Body = styled('div')`
+  padding: ${space(4)} 40px;
   p {
-    margin: ${space(1.5)};
+    margin: ${space(1.5)} 0;
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -78,6 +78,27 @@ class DataDownload extends AsyncView<Props, State> {
     );
   }
 
+  renderEarly(): React.ReactNode {
+    return (
+      <React.Fragment>
+        <Header>
+          <h3>
+            {t('What are')}
+            <i>{t(' you ')}</i>
+            {t('doing here?')}
+          </h3>
+        </Header>
+        <Body>
+          <p>
+            {t(
+              "Not that its any of our business, but were you invited to this page? It's just that we don't exactly remember emailing you about it."
+            )}
+          </p>
+          <p>{t("Close this window and we'll email you when your download is ready.")}</p>
+        </Body>
+      </React.Fragment>
+    );
+  }
   renderExpired(): React.ReactNode {
     const {query} = this.state.download;
     const actionLink = this.getActionLink(query.type);
@@ -100,28 +121,6 @@ class DataDownload extends AsyncView<Props, State> {
           <Button href={actionLink} priority="primary">
             {t('Start a New Download')}
           </Button>
-        </Body>
-      </React.Fragment>
-    );
-  }
-
-  renderEarly(): React.ReactNode {
-    return (
-      <React.Fragment>
-        <Header>
-          <h3>
-            {t('What are')}
-            <i>{t(' you ')}</i>
-            {t('doing here?')}
-          </h3>
-        </Header>
-        <Body>
-          <p>
-            {t(
-              "Not that its any of our business, but were you invited to this page? It's just that we don't exactly remember emailing you about it."
-            )}
-          </p>
-          <p>{t("Close this window and we'll email you when your download is ready.")}</p>
         </Body>
       </React.Fragment>
     );
@@ -159,10 +158,10 @@ class DataDownload extends AsyncView<Props, State> {
   renderContent(): React.ReactNode {
     const {download} = this.state;
     switch (download.status) {
-      case DownloadStatus.Expired:
-        return this.renderExpired();
       case DownloadStatus.Early:
         return this.renderEarly();
+      case DownloadStatus.Expired:
+        return this.renderExpired();
       default:
         return this.renderValid();
     }
@@ -171,7 +170,7 @@ class DataDownload extends AsyncView<Props, State> {
   renderBody() {
     return (
       <Layout>
-        <main>{this.renderValid()}</main>
+        <main>{this.renderContent()}</main>
       </Layout>
     );
   }

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {RouteComponentProps} from 'react-router/lib/Router';
 
 import Button from 'app/components/button';
+import {ExportQueryType} from 'app/components/dataExport';
 import DateTime from 'app/components/dateTime';
 import AsyncView from 'app/views/asyncView';
 import Layout from 'app/views/auth/layout';
@@ -31,7 +32,7 @@ type Download = {
   dateFinished?: string;
   dateExpired?: string;
   query: {
-    type: number;
+    type: ExportQueryType;
     info: object;
   };
   status: DownloadStatus;
@@ -53,6 +54,18 @@ class DataDownload extends AsyncView<Props, State> {
     return [['download', `/organizations/${orgId}/data-export/${dataExportId}/`]];
   }
 
+  getActionLink(queryType): string {
+    const {orgId} = this.props.params;
+    switch (queryType) {
+      case ExportQueryType.IssuesByTag:
+        return `/organizations/${orgId}/issues/`;
+      case ExportQueryType.Discover:
+        return `/organizations/${orgId}/discover/queries/`;
+      default:
+        return '/';
+    }
+  }
+
   renderDate(date: string | undefined): React.ReactNode {
     if (!date) {
       return null;
@@ -66,22 +79,27 @@ class DataDownload extends AsyncView<Props, State> {
   }
 
   renderExpired(): React.ReactNode {
+    const {query} = this.state.download;
+    const actionLink = this.getActionLink(query.type);
     return (
       <React.Fragment>
         <Header>
-          <h3>{t('Sorry!')}</h3>
+          <h3>{t('This is awkward.')}</h3>
         </Header>
         <Body>
           <p>
             {t(
-              'It seems this link has expired, and your download is no longer available.'
+              "That link expired, so your download doesn't live here anymore. Just picked up one day and left town."
             )}
           </p>
           <p>
             {t(
-              'Feel free to start a new export to get the latest and greatest of your Sentry data.'
+              'Make a new one with your latest data. Your old download will never see it coming.'
             )}
           </p>
+          <Button href={actionLink} priority="primary">
+            {t('Start a New Download')}
+          </Button>
         </Body>
       </React.Fragment>
     );
@@ -91,11 +109,19 @@ class DataDownload extends AsyncView<Props, State> {
     return (
       <React.Fragment>
         <Header>
-          <h3>{t("You're Early!")}</h3>
+          <h3>
+            {t('What are')}
+            <i>{t(' you ')}</i>
+            {t('doing here?')}
+          </h3>
         </Header>
         <Body>
-          <p>{t("We're still preparing your download, so check back in a bit!")}</p>
-          <p>{t("You can close this page, we'll email you when were ready")}</p>
+          <p>
+            {t(
+              "Not that its any of our business, but were you invited to this page? It's just that we don't exactly remember emailing you about it."
+            )}
+          </p>
+          <p>{t("Close this window and we'll email you when your download is ready.")}</p>
         </Body>
       </React.Fragment>
     );
@@ -109,25 +135,22 @@ class DataDownload extends AsyncView<Props, State> {
     return (
       <React.Fragment>
         <Header>
-          <h3>{t('Finally!')}</h3>
+          <h3>{t('All done.')}</h3>
         </Header>
         <Body>
-          <p>
-            {t(
-              'We prepared your data for download, you can access it with the link below.'
-            )}
-          </p>
+          <p>{t("See, that wasn't so bad. Your data is all ready for download.")}</p>
           <Button
             priority="primary"
             icon="icon-download"
-            size="large"
-            borderless
             href={`/api/0/organizations/${orgId}/data-export/${dataExportId}/?download=true`}
           >
             {t('Download CSV')}
           </Button>
-          <p>{t('Keep in mind, this link will no longer work after:')}</p>
-          <p>{this.renderDate(dateExpired)}</p>
+          <p>
+            {t("That link won't last forever — it expires:")}
+            <br />
+            {this.renderDate(dateExpired)}
+          </p>
         </Body>
       </React.Fragment>
     );
@@ -148,7 +171,7 @@ class DataDownload extends AsyncView<Props, State> {
   renderBody() {
     return (
       <Layout>
-        <main>{this.renderContent()}</main>
+        <main>{this.renderValid()}</main>
       </Layout>
     );
   }
@@ -164,7 +187,8 @@ const Header = styled('header')`
 `;
 
 const Body = styled('div')`
-  padding: ${space(4)} 40px;
+  padding: ${space(2)} 40px;
+  max-width: 500px;
   p {
     margin: ${space(1.5)} 0;
   }

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -13,7 +13,7 @@ import ExternalLink from 'app/components/links/externalLink';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import Pagination from 'app/components/pagination';
 import TimeSince from 'app/components/timeSince';
-import DataExport from 'app/components/dataExport';
+import DataExport, {ExportQueryType} from 'app/components/dataExport';
 import space from 'app/styles/space';
 import {Group, Tag, TagValue} from 'app/types';
 
@@ -118,7 +118,7 @@ class GroupTagValues extends AsyncComponent<
           </a>
           <DataExport
             payload={{
-              queryType: 'Issues-by-Tag',
+              queryType: ExportQueryType.IssuesByTag,
               queryInfo: {
                 project_id: group.project.id,
                 group_id: group.id,

--- a/src/sentry/templates/sentry/emails/data-export-failure.html
+++ b/src/sentry/templates/sentry/emails/data-export-failure.html
@@ -4,13 +4,13 @@
 {% load i18n %}
 
 {% block main %}
-    <h3>Unable to Export Data</h3>
-    <p>The data export you created at {{creation}} has failed.</p>
-    <p>We were unable to generate your report due to an error:</p>
+    <h3>We couldn't export your data.</h3>
+    <p>Well, this is a little awkward. The data export you created at {{creation}} didn't work. Sorry about that.</p>
+    <p>It looks like there was an error:</p>
     <code><pre>{{error_message}}</pre></code>
-    <p>We received the following payload:</p>
+    <p>This is what you sent us. Maybe it'll help you sort this out.</p>
     <code><pre>{{payload}}</pre></code>
-    <p><strong>Troubleshooting &amp; References</strong></p>
+    <p><strong>Need a little more help?</strong></p>
     <ul>
         <li><a href="https://docs.sentry.io/">Documentation</a></li>
         <li><a href="https://help.sentry.io/">FAQs</a></li>

--- a/src/sentry/templates/sentry/emails/data-export-failure.txt
+++ b/src/sentry/templates/sentry/emails/data-export-failure.txt
@@ -1,15 +1,17 @@
-Unable to Export Data
----------------------
+We couldn't export your data.
+-----------------------------
 
-The data export you created at {{creation}} has failed.
-We were unable to generate your report due to an error:
+Well, this is a little awkward.
+The data export that you created at {{creation}} didn't work. Sorry about that.
+
+It looks like there was an error:
 
     {{error_message}}
 
-We received the following payload:
+This is what you sent us. Maybe it'll help you sort this out.
 
     {{payload}}
 
-Troubleshooting & References:
+Need a little more help?
  - https://docs.sentry.io/ (Documentation)
  - https://help.sentry.io/ (FAQs)

--- a/src/sentry/templates/sentry/emails/data-export-success.html
+++ b/src/sentry/templates/sentry/emails/data-export-success.html
@@ -3,8 +3,8 @@
 {% load i18n %}
 
 {% block main %}
-    <h3>Your Data is Ready!</h3>
-    <p>We've finished assembling your download, check it out by clicking the button below.</p>
-    <p>This download file will expire at {{expiration}}.</p>
-    <a href="{{ url|safe }}" class="btn">Go to Download</a>
+    <h3>Your data is ready.</h3>
+    <p>See, that wasn't so bad. We're all done assembling your download. Now have at it.</p>
+    <a href="{{ url|safe }}" class="btn">Take Me There</a>
+    <p>This download file expires at {{expiration}}. So don't get attached</p>
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/data-export-success.html
+++ b/src/sentry/templates/sentry/emails/data-export-success.html
@@ -5,6 +5,6 @@
 {% block main %}
     <h3>Your data is ready.</h3>
     <p>See, that wasn't so bad. We're all done assembling your download. Now have at it.</p>
-    <a href="{{ url|safe }}" class="btn">Take Me There</a>
-    <p>This download file expires at {{expiration}}. So don't get attached</p>
+    <p><a href="{{ url|safe }}" class="btn">Take Me There</a></p>
+    <p>This download file expires at {{expiration}}. So don't get attached.</p>
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/data-export-success.txt
+++ b/src/sentry/templates/sentry/emails/data-export-success.txt
@@ -1,8 +1,8 @@
-Your Download is Ready!
------------------------
+Your data is ready.
+-------------------
 
-We've finished assembling your download, check it out by clicking the link below:
+See, that wasn't so bad. We're all done assembling your download. Now have at it.
 
 {{url|safe}}
 
-The download file will expire at {{expiration}}
+The download file expires at {{expiration}}. So don't get attached.

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -35,7 +35,7 @@ describe('DataExport', function() {
       mockRouterContext(mockAuthorizedOrg)
     );
     expect(wrapper.isEmptyRender()).toBe(false);
-    expect(wrapper.text()).toBe('Create CSV');
+    expect(wrapper.text()).toBe('Export Data');
   });
 
   it('should send a request and disable itself when clicked', async function() {

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -3,8 +3,7 @@ import React from 'react';
 import {mount} from 'sentry-test/enzyme';
 import WrappedDataExport, {DataExport} from 'app/components/dataExport';
 
-// eslint-disable-next-line
-describe.skip('DataExport', function() {
+describe('DataExport', function() {
   const mockUnauthorizedOrg = TestStubs.Organization({
     features: [],
   });
@@ -36,7 +35,7 @@ describe.skip('DataExport', function() {
       mockRouterContext(mockAuthorizedOrg)
     );
     expect(wrapper.isEmptyRender()).toBe(false);
-    expect(wrapper.text()).toBe('Export All to CSV');
+    expect(wrapper.text()).toBe('Create CSV');
   });
 
   it('should send a request and disable itself when clicked', async function() {
@@ -65,7 +64,7 @@ describe.skip('DataExport', function() {
     });
     await tick();
     wrapper.update();
-    expect(wrapper.text()).toBe('Queued up!');
+    expect(wrapper.text()).toBe("We're working on it...");
     expect(wrapper.find('button').is('[disabled]')).toBe(true);
     expect(wrapper.find(DataExport).state()).toEqual({
       inProgress: true,

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import {mount} from 'sentry-test/enzyme';
 import WrappedDataExport, {DataExport} from 'app/components/dataExport';
 
-describe('DataExport', function() {
+// eslint-disable-next-line
+describe.skip('DataExport', function() {
   const mockUnauthorizedOrg = TestStubs.Organization({
     features: [],
   });

--- a/tests/js/spec/views/dataExport/dataDownload.spec.jsx
+++ b/tests/js/spec/views/dataExport/dataDownload.spec.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
 import DataDownload, {DownloadStatus} from 'app/views/dataExport/dataDownload';
 
-describe('DataDownload', function() {
+// eslint-disable-next-line
+describe.skip('DataDownload', function() {
   beforeEach(MockApiClient.clearMockResponses);
   const dateExpired = new Date();
   const organization = TestStubs.Organization();

--- a/tests/js/spec/views/dataExport/dataDownload.spec.jsx
+++ b/tests/js/spec/views/dataExport/dataDownload.spec.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+import {ExportQueryType} from 'app/components/dataExport';
 import DataDownload, {DownloadStatus} from 'app/views/dataExport/dataDownload';
 
-// eslint-disable-next-line
-describe.skip('DataDownload', function() {
+describe('DataDownload', function() {
   beforeEach(MockApiClient.clearMockResponses);
   const dateExpired = new Date();
   const organization = TestStubs.Organization();
@@ -30,20 +30,21 @@ describe.skip('DataDownload', function() {
     const wrapper = shallow(<DataDownload params={mockRouteParams} />);
     expect(wrapper.state('download')).toEqual({status});
     expect(wrapper.state('download').dateExpired).toBeUndefined();
-    const contentWrapper = wrapper.find('ContentContainer');
-    expect(contentWrapper.children()).toHaveLength(3);
-    expect(contentWrapper.find('h3').text()).toBe("You're Early!");
+    expect(wrapper.find('Header').text()).toBe('What are you doing here?');
   });
 
   it("should render the 'Expired' view when appropriate", function() {
     const status = DownloadStatus.Expired;
-    getDataExportDetails({status});
-    const wrapper = shallow(<DataDownload params={mockRouteParams} />);
-    expect(wrapper.state('download')).toEqual({status});
+    const response = {status, query: {type: ExportQueryType.IssuesByTag}};
+    getDataExportDetails(response);
+    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
+    expect(wrapper.state('download')).toEqual(response);
     expect(wrapper.state('download').dateExpired).toBeUndefined();
-    const contentWrapper = wrapper.find('ContentContainer');
-    expect(contentWrapper.children()).toHaveLength(3);
-    expect(contentWrapper.find('h3').text()).toBe('Sorry!');
+    expect(wrapper.find('Header').text()).toBe('This is awkward.');
+    const buttonWrapper = wrapper.find('a[aria-label="Start a New Download"]');
+    expect(buttonWrapper.prop('href')).toBe(
+      `/organizations/${mockRouteParams.orgId}/issues/`
+    );
   });
 
   it("should render the 'Valid' view when appropriate", function() {
@@ -51,14 +52,12 @@ describe.skip('DataDownload', function() {
     getDataExportDetails({dateExpired, status});
     const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
     expect(wrapper.state('download')).toEqual({dateExpired, status});
-    const contentWrapper = wrapper.find('ContentContainer').childAt(0);
-    expect(contentWrapper.children()).toHaveLength(5);
-    expect(contentWrapper.find('h3').text()).toBe('Finally!');
-    const buttonWrapper = contentWrapper.find('a[aria-label="Download CSV"]');
+    expect(wrapper.find('Header').text()).toBe('All done.');
+    const buttonWrapper = wrapper.find('a[aria-label="Download CSV"]');
     expect(buttonWrapper.text()).toBe('Download CSV');
     expect(buttonWrapper.prop('href')).toBe(
       `/api/0/organizations/${mockRouteParams.orgId}/data-export/${mockRouteParams.dataExportId}/?download=true`
     );
-    expect(contentWrapper.find('DateTime').prop('date')).toEqual(new Date(dateExpired));
+    expect(wrapper.find('DateTime').prop('date')).toEqual(new Date(dateExpired));
   });
 });

--- a/tests/sentry/models/test_exporteddata.py
+++ b/tests/sentry/models/test_exporteddata.py
@@ -125,7 +125,7 @@ class ExportedDataTest(TestCase):
             )
         )
         expected_email_args = {
-            "subject": "Your Download is Ready!",
+            "subject": "Your data is ready.",
             "context": {
                 "url": expected_url,
                 "expiration": ExportedData.format_date(date=self.data_export.date_expired),
@@ -147,7 +147,7 @@ class ExportedDataTest(TestCase):
         with self.tasks():
             self.data_export.email_failure(self.TEST_STRING)
         expected_email_args = {
-            "subject": "Unable to Export Data",
+            "subject": "We couldn't export your data.",
             "context": {
                 "creation": ExportedData.format_date(date=self.data_export.date_added),
                 "error_message": self.TEST_STRING,


### PR DESCRIPTION
### Description

This PR will update the design of the data-export feature including all the text shown to the user at any point in the workflow.

All the text has been written by the team's copywriter (Molly) and redesign was suggested by @ckj. I've attached screenshots to the PR for clarity as well.

### Screenshots

**Button**

---
![image](https://user-images.githubusercontent.com/35509934/77586332-61af3200-6ebc-11ea-971c-b7d6ad27a09a.png)
![image](https://user-images.githubusercontent.com/35509934/77586371-755a9880-6ebc-11ea-9edf-48386e8eb6bb.png)


**Alerts**

---
![image](https://user-images.githubusercontent.com/35509934/77586158-13019800-6ebc-11ea-8c98-6ddedd2b2d96.png)
![image](https://user-images.githubusercontent.com/35509934/77586258-3f1d1900-6ebc-11ea-9ba8-ebadd287df1b.png)


**Emails**

---
![image](https://user-images.githubusercontent.com/35509934/77586442-9622ee00-6ebc-11ea-9855-d0cbd8ad11dd.png)
![image](https://user-images.githubusercontent.com/35509934/77586557-cbc7d700-6ebc-11ea-9782-c0ed25253e60.png)


**Download Page**

---
![image](https://user-images.githubusercontent.com/35509934/77586642-ed28c300-6ebc-11ea-870a-82214896e371.png)
![image](https://user-images.githubusercontent.com/35509934/77586679-fade4880-6ebc-11ea-84e3-a20115f02728.png)
![image](https://user-images.githubusercontent.com/35509934/77586699-03cf1a00-6ebd-11ea-9c1e-dfda44ca8c83.png)




### Testing Plan

A lot of tests had to be modified to be less strict and still useful, but they all should pass now. 

The old UI was removed, not toggled, so as long as you can access the feature, there shouldn't be anything to test, it should just be visible.
