### PR TITLE
tests: log the original error for selenium when starting Chrome

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -341,6 +341,7 @@ def browser(request, percy, live_server):
         chrome_args = {"options": options}
         if chromedriver_path:
             chrome_args["executable_path"] = chromedriver_path
+
         driver = start_chrome(**chrome_args)
     elif driver_type == "firefox":
         driver = webdriver.Firefox()

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -315,7 +315,7 @@ def percy(request):
     return percy
 
 
-@TimedRetryPolicy.wrap(timeout=15, exceptions=(WebDriverException,))
+@TimedRetryPolicy.wrap(timeout=15, exceptions=(WebDriverException,), log_original_error=True)
 def start_chrome(**chrome_args):
     return webdriver.Chrome(**chrome_args)
 
@@ -341,7 +341,6 @@ def browser(request, percy, live_server):
         chrome_args = {"options": options}
         if chromedriver_path:
             chrome_args["executable_path"] = chromedriver_path
-
         driver = start_chrome(**chrome_args)
     elif driver_type == "firefox":
         driver = webdriver.Firefox()

--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -55,7 +55,7 @@ class TimedRetryPolicy(RetryPolicy):
     """
 
     def __init__(
-        self, timeout, delay=None, exceptions=(Exception,), metric_instance=None, metric_tags=None
+        self, timeout, delay=None, exceptions=(Exception,), metric_instance=None, metric_tags=None, log_original_error=False
     ):
         if delay is None:
             # 100ms +/- 50ms of randomized jitter
@@ -68,6 +68,7 @@ class TimedRetryPolicy(RetryPolicy):
         self.clock = time
         self.metric_instance = metric_instance
         self.metric_tags = metric_tags or {}
+        self.log_original_error = log_original_error
 
     def __call__(self, function):
         start = self.clock.time()
@@ -76,6 +77,8 @@ class TimedRetryPolicy(RetryPolicy):
                 try:
                     return function()
                 except self.exceptions as error:
+                    if self.log_original_error:
+                        logger.info(error)
                     delay = self.delay(i)
                     now = self.clock.time()
                     if (now + delay) > (start + self.timeout):


### PR DESCRIPTION
I was having issues with running acceptance tests on my machine and the error message for `RetryException` was not helpful in determining the issue. The underlying error is eaten up and not logged. I added an option to `TimedRetryPolicy` called `log_original_error ` so we can log the original error in some circumstances such as running acceptance tests. I decided to do this instead of always logging the error since we probably don't always want it.