### PR TITLE
ref(ui): Use `<ButtonBar>` prop `active`

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
@@ -79,18 +79,16 @@ class EventDataSection extends React.Component<Props> {
             </Permalink>
             {titleNode}
             {type === 'extra' && (
-              <ButtonBar merged>
+              <ButtonBar merged active={raw ? 'raw' : 'formatted'}>
                 <Button
-                  className={!raw ? 'active' : ''}
-                  priority={!raw ? 'primary' : 'default'}
+                  barId="formatted"
                   size="xsmall"
                   onClick={() => callIfFunction(toggleRaw, false)}
                 >
                   {t('Formatted')}
                 </Button>
                 <Button
-                  className={raw ? 'active' : ''}
-                  priority={raw ? 'primary' : 'default'}
+                  barId="raw"
                   size="xsmall"
                   onClick={() => callIfFunction(toggleRaw, true)}
                 >

--- a/src/sentry/static/sentry/app/components/events/interfaces/csp.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/csp.jsx
@@ -52,29 +52,18 @@ export default class CspInterface extends React.Component {
 
     const title = (
       <div>
-        <ButtonBar merged>
+        <ButtonBar merged active={view}>
           <Button
-            className={view === 'report' ? 'active' : ''}
-            priority={view === 'report' ? 'primary' : 'default'}
+            barId="report"
             size="xsmall"
             onClick={this.toggleView.bind(this, 'report')}
           >
             {t('Report')}
           </Button>
-          <Button
-            className={view === 'raw' ? 'active' : ''}
-            priority={view === 'raw' ? 'primary' : 'default'}
-            size="xsmall"
-            onClick={this.toggleView.bind(this, 'raw')}
-          >
+          <Button barId="raw" size="xsmall" onClick={this.toggleView.bind(this, 'raw')}>
             {t('Raw')}
           </Button>
-          <Button
-            className={view === 'help' ? 'active' : ''}
-            priority={view === 'help' ? 'primary' : 'default'}
-            size="xsmall"
-            onClick={this.toggleView.bind(this, 'help')}
-          >
+          <Button barId="help" size="xsmall" onClick={this.toggleView.bind(this, 'help')}>
             {t('Help')}
           </Button>
         </ButtonBar>

--- a/src/sentry/static/sentry/app/components/events/interfaces/generic.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/generic.jsx
@@ -46,21 +46,15 @@ export default class GenericInterface extends Component {
 
     const title = (
       <div>
-        <ButtonBar merged>
+        <ButtonBar merged active={view}>
           <Button
-            className={view === 'report' ? 'active' : ''}
-            priority={view === 'report' ? 'primary' : 'default'}
+            barId="report"
             size="xsmall"
             onClick={this.toggleView.bind(this, 'report')}
           >
             {t('Report')}
           </Button>
-          <Button
-            className={view === 'raw' ? 'active' : ''}
-            priority={view === 'raw' ? 'primary' : 'default'}
-            size="xsmall"
-            onClick={this.toggleView.bind(this, 'raw')}
-          >
+          <Button barId="raw" size="xsmall" onClick={this.toggleView.bind(this, 'raw')}>
             {t('Raw')}
           </Button>
         </ButtonBar>

--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -66,19 +66,17 @@ class RequestInterface extends React.Component {
     let actions;
     if (!this.isPartial() && fullUrl) {
       actions = (
-        <ButtonBar key="view-buttons" merged>
+        <ButtonBar merged active={view}>
           <Button
-            className={view === 'formatted' ? 'active' : ''}
-            priority={view === 'formatted' ? 'primary' : 'default'}
+            barId="formatted"
             size="xsmall"
             onClick={this.toggleView.bind(this, 'formatted')}
           >
-            {/* Translators: this means "formatted" rendering (fancy tables) */
-            t('Formatted')}
+            {/* Translators: this means "formatted" rendering (fancy tables) */}
+            {t('Formatted')}
           </Button>
           <MonoButton
-            className={view === 'curl' ? 'active' : ''}
-            priority={view === 'curl' ? 'primary' : 'default'}
+            barId="curl"
             size="xsmall"
             onClick={this.toggleView.bind(this, 'curl')}
           >

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -182,10 +182,6 @@ class IncidentsListContainer extends React.Component<Props> {
 
     const status = getQueryStatus(query.status);
 
-    const isOpenActive = status === 'open';
-    const isClosedActive = status === 'closed';
-    const isAllActive = status === 'all';
-
     return (
       <DocumentTitle title={`Alerts- ${orgId} - Sentry`}>
         <PageContent>
@@ -219,28 +215,25 @@ class IncidentsListContainer extends React.Component<Props> {
                 {t('Settings')}
               </Button>
 
-              <ButtonBar merged>
+              <ButtonBar merged active={status}>
                 <Button
                   to={{pathname, query: openIncidentsQuery}}
+                  barId="open"
                   size="small"
-                  className={isOpenActive ? ' active' : ''}
-                  priority={isOpenActive ? 'primary' : 'default'}
                 >
                   {t('Active')}
                 </Button>
                 <Button
                   to={{pathname, query: closedIncidentsQuery}}
+                  barId="closed"
                   size="small"
-                  className={isClosedActive ? ' active' : ''}
-                  priority={isClosedActive ? 'primary' : 'default'}
                 >
                   {t('Resolved')}
                 </Button>
                 <Button
                   to={{pathname, query: allIncidentsQuery}}
+                  barId="all"
                   size="small"
-                  className={isAllActive ? ' active' : ''}
-                  priority={isAllActive ? 'primary' : 'default'}
                 >
                   {t('All')}
                 </Button>

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
@@ -20,21 +20,21 @@ const GroupEventAttachmentsFilter = (props: WithRouterProps) => {
     types: onlyCrashReportTypes,
   };
 
+  let activeButton = '';
+
+  if (types === undefined) {
+    activeButton = 'all';
+  } else if (xor(onlyCrashReportTypes, types).length === 0) {
+    activeButton = 'onlyCrash';
+  }
+
   return (
     <FilterWrapper>
-      <ButtonBar merged>
-        <Button
-          size="small"
-          to={{pathname, query: allAttachmentsQuery}}
-          priority={types === undefined ? 'primary' : 'default'}
-        >
+      <ButtonBar merged active={activeButton}>
+        <Button id="all" size="small" to={{pathname, query: allAttachmentsQuery}}>
           {t('All Attachments')}
         </Button>
-        <Button
-          size="small"
-          to={{pathname, query: onlyCrashReportsQuery}}
-          priority={xor(onlyCrashReportTypes, types).length === 0 ? 'primary' : 'default'}
-        >
+        <Button id="onlyCrash" size="small" to={{pathname, query: onlyCrashReportsQuery}}>
           {t('Only Crash Reports')}
         </Button>
       </ButtonBar>

--- a/tests/js/spec/components/__snapshots__/toggleRawEventData.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/toggleRawEventData.spec.jsx.snap
@@ -19,20 +19,19 @@ exports[`EventDataSection renders formatted 1`] = `
       Additional Data
     </h3>
     <ButtonBar
+      active="formatted"
       merged={true}
     >
       <forwardRef<Button>
-        className="active"
+        barId="formatted"
         onClick={[Function]}
-        priority="primary"
         size="xsmall"
       >
         Formatted
       </forwardRef<Button>>
       <forwardRef<Button>
-        className=""
+        barId="raw"
         onClick={[Function]}
-        priority="default"
         size="xsmall"
       >
         Raw
@@ -62,20 +61,19 @@ exports[`EventDataSection renders raw 1`] = `
       Additional Data
     </h3>
     <ButtonBar
+      active="raw"
       merged={true}
     >
       <forwardRef<Button>
-        className=""
+        barId="formatted"
         onClick={[Function]}
-        priority="default"
         size="xsmall"
       >
         Formatted
       </forwardRef<Button>>
       <forwardRef<Button>
-        className="active"
+        barId="raw"
         onClick={[Function]}
-        priority="primary"
         size="xsmall"
       >
         Raw


### PR DESCRIPTION
This refactors existing usage of `<ButtonBar>` to use `active` prop instead
of manually setting priority and "active" className in the children
`<Button>`s