### PR TITLE
fix(ui): Fix React warning for `<Alert>` and `system` prop

### DIFF
--- a/src/sentry/static/sentry/app/components/alert.tsx
+++ b/src/sentry/static/sentry/app/components/alert.tsx
@@ -88,7 +88,15 @@ const StyledTextBlock = styled('div')`
 `;
 
 const Alert = styled(
-  ({type, icon, iconSize, children, className, ...props}: AlertProps) => (
+  ({
+    type,
+    icon,
+    iconSize,
+    children,
+    className,
+    system: _system, // don't forward to `div`
+    ...props
+  }: AlertProps) => (
     <div className={classNames(type ? `ref-${type}` : '', className)} {...props}>
       {icon && (
         <IconWrapper>

--- a/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
+++ b/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
@@ -110,7 +110,6 @@ exports[`ProjectPlugins renders 1`] = `
                     >
                       <div
                         className="ref-warning e1cszazt0 css-utenda-Alert-PanelAlert ejthpj82"
-                        system={true}
                       >
                         <IconWrapper>
                           <span


### PR DESCRIPTION
We were spreading `system` from props into a native element