### PR TITLE
test(jest): Throw on React warning...

### DIFF
--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -7,6 +7,7 @@ const BAD_ERRORS = [
   'Failed child context type',
   'Warning: Each child in an array or iterator should have a unique "key" prop',
   'React does not recognize the `[^`]+` prop on a DOM element',
+  'Warning: Received `[^`]+` for a non-boolean attribute `[^`]+`',
 ];
 
 // This is needed because when we throw the captured error message, it will


### PR DESCRIPTION
This will cause jest to fail when it receives Reacts `console.error` warning when passing a boolean to a non-boolean attribute. This usually happens when we spread props into a native element.