### PR TITLE
test(js): Throw on unmocked API endpoints

### DIFF
--- a/src/sentry/static/sentry/app/__mocks__/api.tsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.tsx
@@ -124,9 +124,9 @@ class Client {
 
       // Mutate stack to drop frames since test file so that we know where in the test
       // this needs to be mocked
-      const lines = err.stack.split('\n');
-      const startIndex = lines.findIndex(line => line.includes('tests/js/spec'));
-      err.stack = ['\n', lines[0], ...lines.slice(startIndex)].join('\n');
+      const lines = err.stack?.split('\n');
+      const startIndex = lines?.findIndex(line => line.includes('tests/js/spec'));
+      err.stack = ['\n', lines?.[0], ...lines?.slice(startIndex)].join('\n');
 
       // Throwing an error here does not do what we want it to do....
       // Because we are mocking an API client, we generally catch errors to show

--- a/src/sentry/static/sentry/app/__mocks__/api.tsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.tsx
@@ -122,12 +122,19 @@ class Client {
         `No mocked response found for request:\n\t${options.method || 'GET'} ${url}`
       );
 
+      // Mutate stack to drop frames since test file so that we know where in the test
+      // this needs to be mocked
+      const lines = err.stack.split('\n');
+      const startIndex = lines.findIndex(line => line.includes('tests/js/spec'));
+      err.stack = ['\n', lines[0], ...lines.slice(startIndex)].join('\n');
+
       // Throwing an error here does not do what we want it to do....
       // Because we are mocking an API client, we generally catch errors to show
       // user-friendly error messages, this means in tests this error gets gobbled
-      // up and developer frustration ensues.
-      console.warn(err.message); // eslint-disable-line no-console
-      throw err;
+      // up and developer frustration ensues. Use `setTimeout` to get around this
+      setTimeout(() => {
+        throw err;
+      });
     } else {
       // has mocked response
 

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -45,7 +45,10 @@ describe('Command Palette Modal', function() {
       url: '/organizations/org-slug/config/integrations/',
       body: [],
     });
-
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/plugins/configs/',
+      body: [],
+    });
     MockApiClient.addMockResponse({
       url: '/internal/health/',
       body: {

--- a/tests/js/spec/components/search/sources/apiSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/apiSource.spec.jsx
@@ -58,6 +58,10 @@ describe('ApiSource', function() {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/plugins/configs/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/config/integrations/',
       body: [],
     });

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -47,7 +47,10 @@ describe('SettingsSearch', function() {
       query: 'foo',
       body: [],
     });
-
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/plugins/configs/',
+      body: [],
+    });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/config/integrations/',
       query: 'foo',


### PR DESCRIPTION
This will cause jest to error when there are unmocked API endpoints, previously we were just using `console.warn`. Throwing inside of the mocked request function does not work as expected since our components generally do error handling, so we need to throw in the next execution loop to get around this. We also change the stack so that jest shows where in the tests we are calling the unmocked endpoint.