### PR TITLE
feat(discover) Add cell based context menu

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -271,7 +271,6 @@ export const Top = styled('div')`
 export const Main = styled('div')<{eventView: EventView}>`
   grid-column: 1/2;
   max-width: 100%;
-  overflow: hidden;
 `;
 export const Side = styled('div')<{eventView: EventView}>`
   grid-column: 2/3;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -226,7 +226,7 @@ const MenuRoot = styled('div')`
 `;
 
 const Menu = styled('div')`
-  margin: 8px 0;
+  margin: ${space(1)} 0;
 
   z-index: ${p => p.theme.zIndex.tooltip};
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -1,0 +1,323 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import styled from '@emotion/styled';
+import {browserHistory} from 'react-router';
+import * as PopperJS from 'popper.js';
+import {Manager, Reference, Popper} from 'react-popper';
+
+import {t} from 'app/locale';
+import {IconEllipsis} from 'app/icons';
+import EventView from 'app/utils/discover/eventView';
+import space from 'app/styles/space';
+import theme from 'app/utils/theme';
+import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {OrganizationSummary} from 'app/types';
+
+import {TableColumn, TableDataRow} from './types';
+
+enum Actions {
+  ADD,
+  EXCLUDE,
+}
+
+type Props = {
+  eventView: EventView;
+  organization: OrganizationSummary;
+  column: TableColumn<keyof TableDataRow>;
+  dataRow: TableDataRow;
+  children: React.ReactNode;
+};
+
+type State = {
+  isHovering: boolean;
+  isOpen: boolean;
+};
+
+export default class CellAction extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    let portal = document.getElementById('cell-action-portal');
+    if (!portal) {
+      portal = document.createElement('div');
+      portal.setAttribute('id', 'cell-action-portal');
+      document.body.appendChild(portal);
+    }
+    this.portalEl = portal;
+    this.menuEl = null;
+  }
+
+  state = {
+    isHovering: false,
+    isOpen: false,
+  };
+
+  componentDidUpdate(_props: Props, prevState: State) {
+    if (this.state.isOpen && prevState.isOpen === false) {
+      document.addEventListener('click', this.handleClickOutside, true);
+    }
+    if (this.state.isOpen === false && prevState.isOpen) {
+      document.removeEventListener('click', this.handleClickOutside, true);
+    }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleClickOutside, true);
+  }
+
+  private portalEl: Element;
+  private menuEl: Element | null;
+
+  handleClickOutside = (event: MouseEvent) => {
+    if (!this.menuEl) {
+      return;
+    }
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+    if (this.menuEl.contains(event.target)) {
+      return;
+    }
+    this.setState({isOpen: false, isHovering: false});
+  };
+
+  handleMouseEnter = () => {
+    this.setState({isHovering: true});
+  };
+
+  handleMouseLeave = () => {
+    this.setState(state => {
+      // Don't hide the button if the menu is open.
+      if (state.isOpen) {
+        return state;
+      }
+      return {...state, isHovering: false};
+    });
+  };
+
+  handleUpdateSearch = (action: Actions, value: React.ReactText) => {
+    const {eventView, column, organization} = this.props;
+    const query = tokenizeSearch(eventView.query);
+    switch (action) {
+      case Actions.ADD:
+        // Remove exclusion if it exists.
+        delete query[`!${column.name}`];
+        query[column.name] = [`${value}`];
+        break;
+      case Actions.EXCLUDE:
+        // Remove positive if it exists.
+        delete query[`${column.name}`];
+        // Negations should stack up.
+        const negation = `!${column.name}`;
+        if (!query.hasOwnProperty(negation)) {
+          query[negation] = [];
+        }
+        query[negation].push(`${value}`);
+        break;
+      default:
+        throw new Error(`Unknown action type. ${action}`);
+    }
+    const nextView = eventView.clone();
+    nextView.query = stringifyQueryObject(query);
+
+    browserHistory.push(nextView.getResultsViewUrlTarget(organization.slug));
+  };
+
+  handleMenuToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    this.setState({isOpen: !this.state.isOpen});
+  };
+
+  renderMenu() {
+    const {dataRow, column} = this.props;
+    const {isOpen} = this.state;
+
+    const value = dataRow[column.name];
+    const modifiers: PopperJS.Modifiers = {
+      hide: {
+        enabled: false,
+      },
+      preventOverflow: {
+        padding: 10,
+        enabled: true,
+        boundariesElement: 'viewport',
+      },
+    };
+    let menu: React.ReactPortal | null = null;
+
+    if (isOpen) {
+      menu = ReactDOM.createPortal(
+        <Popper placement="top" modifiers={modifiers}>
+          {({ref: popperRef, style, placement, arrowProps}) => (
+            <Menu
+              ref={ref => {
+                (popperRef as Function)(ref);
+                this.menuEl = ref;
+              }}
+              style={style}
+            >
+              <MenuArrow
+                ref={arrowProps.ref}
+                data-placement={placement}
+                style={arrowProps.style}
+              />
+              <MenuButtons>
+                <ActionItem
+                  data-test-id="add-to-filter"
+                  onClick={() => this.handleUpdateSearch(Actions.ADD, value)}
+                >
+                  {t('Add to filter')}
+                </ActionItem>
+                <ActionItem
+                  data-test-id="exclude-from-filter"
+                  onClick={() => this.handleUpdateSearch(Actions.EXCLUDE, value)}
+                >
+                  {t('Exclude from filter')}
+                </ActionItem>
+              </MenuButtons>
+            </Menu>
+          )}
+        </Popper>,
+        this.portalEl
+      );
+    }
+
+    return (
+      <MenuRoot>
+        <Manager>
+          <Reference>
+            {({ref}) => (
+              <MenuButton ref={ref} onClick={this.handleMenuToggle}>
+                <IconEllipsis size="sm" data-test-id="cell-action" color={theme.blue} />
+              </MenuButton>
+            )}
+          </Reference>
+          {menu}
+        </Manager>
+      </MenuRoot>
+    );
+  }
+
+  render() {
+    const {children} = this.props;
+    const {isHovering} = this.state;
+
+    return (
+      <Container
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+      >
+        {children}
+        {isHovering && this.renderMenu()}
+      </Container>
+    );
+  }
+}
+
+const Container = styled('div')`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const MenuRoot = styled('div')`
+  position: absolute;
+  top: 0;
+  right: 0;
+`;
+
+const Menu = styled('div')`
+  margin: 8px 0;
+
+  z-index: ${p => p.theme.zIndex.tooltip};
+`;
+
+const MenuButtons = styled('div')`
+  background: ${p => p.theme.white};
+  border: 1px solid ${p => p.theme.borderLight};
+  border-radius: ${p => p.theme.borderRadius};
+  box-shadow: ${p => p.theme.dropShadowHeavy};
+  overflow: hidden;
+`;
+
+const MenuArrow = styled('span')`
+  position: absolute;
+  width: 18px;
+  height: 9px;
+  /* left and top set by popper */
+
+  &[data-placement*='bottom'] {
+    margin-top: -9px;
+    &::before {
+      border-width: 0 9px 9px 9px;
+      border-color: transparent transparent ${p => p.theme.borderLight} transparent;
+    }
+    &::after {
+      top: 1px;
+      left: 1px;
+      border-width: 0 8px 8px 8px;
+      border-color: transparent transparent #fff transparent;
+    }
+  }
+  &[data-placement*='top'] {
+    margin-bottom: -8px;
+    bottom: 0;
+    &::before {
+      border-width: 9px 9px 0 9px;
+      border-color: ${p => p.theme.borderLight} transparent transparent transparent;
+    }
+    &::after {
+      bottom: 1px;
+      left: 1px;
+      border-width: 8px 8px 0 8px;
+      border-color: #fff transparent transparent transparent;
+    }
+  }
+
+  &::before,
+  &::after {
+    width: 0;
+    height: 0;
+    content: '';
+    display: block;
+    position: absolute;
+    border-style: solid;
+  }
+`;
+
+const ActionItem = styled('button')`
+  display: block;
+  width: 100%;
+  padding: ${space(1)} ${space(2)};
+  background: transparent;
+
+  outline: none;
+  border: 0;
+  border-bottom: 1px solid ${p => p.theme.borderLight};
+
+  font-size: ${p => p.theme.fontSizeMedium};
+  text-align: left;
+  line-height: 1.2;
+
+  &:hover {
+    background: ${p => p.theme.offWhite};
+  }
+
+  &:last-child {
+    border-bottom: 0;
+  }
+`;
+
+const MenuButton = styled('button')`
+  display: flex;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  justify-content: center;
+  align-items: center;
+
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid ${p => p.theme.borderLight};
+  cursor: pointer;
+  outline: none;
+`;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -8,7 +8,6 @@ import {trackAnalyticsEvent} from 'app/utils/analytics';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
 import {IconEvent, IconStack} from 'app/icons';
 import {t} from 'app/locale';
-import {assert} from 'app/types/utils';
 import {openModal} from 'app/actionCreators/modal';
 import Link from 'app/components/links/link';
 import Tooltip from 'app/components/tooltip';
@@ -25,6 +24,7 @@ import {generateEventSlug, eventDetailsRouteWithEventView} from '../eventDetails
 import ColumnEditModal from './columnEditModal';
 import {TableColumn, TableData, TableDataRow} from './types';
 import HeaderCell from './headerCell';
+import CellAction from './cellAction';
 
 export type TableViewProps = {
   location: Location;
@@ -166,30 +166,35 @@ class TableView extends React.Component<TableViewProps> {
     if (!tableData || !tableData.meta) {
       return dataRow[column.key];
     }
+    const fieldRenderer = getFieldRenderer(String(column.key), tableData.meta);
+    const aggregation =
+      column.column.kind === 'function' ? column.column.function[0] : undefined;
 
+    // Aggregation columns offer drilldown behavior
+    if (aggregation) {
+      return (
+        <ExpandAggregateRow
+          eventView={eventView}
+          column={column}
+          dataRow={dataRow}
+          location={location}
+          tableMeta={tableData.meta}
+        >
+          {fieldRenderer(dataRow, {organization, location})}
+        </ExpandAggregateRow>
+      );
+    }
+
+    // Scalar fields offer cell actions to build queries.
     return (
-      <ExpandAggregateRow
+      <CellAction
+        organization={organization}
         eventView={eventView}
         column={column}
         dataRow={dataRow}
-        location={location}
-        tableMeta={tableData.meta}
       >
-        {({willExpand}) => {
-          // NOTE: TypeScript cannot detect that tableData.meta is truthy here
-          //       since there was a condition guard to handle it whenever it is
-          //       falsey. So we assert it here.
-          assert(tableData.meta);
-
-          if (!willExpand) {
-            const fieldRenderer = getFieldRenderer(String(column.key), tableData.meta);
-            return fieldRenderer(dataRow, {organization, location});
-          }
-
-          const fieldRenderer = getFieldRenderer(String(column.key), tableData.meta);
-          return fieldRenderer(dataRow, {organization, location});
-        }}
-      </ExpandAggregateRow>
+        {fieldRenderer(dataRow, {organization, location})}
+      </CellAction>
     );
   };
 
@@ -265,14 +270,14 @@ class TableView extends React.Component<TableViewProps> {
   }
 }
 
-const ExpandAggregateRow = (props: {
-  children: ({willExpand: boolean}) => React.ReactNode;
+function ExpandAggregateRow(props: {
+  children: React.ReactNode;
   eventView: EventView;
   column: TableColumn<keyof TableDataRow>;
   dataRow: TableDataRow;
   location: Location;
   tableMeta: MetaType;
-}) => {
+}) {
   const {children, column, dataRow, eventView, location} = props;
   const aggregation =
     column.column.kind === 'function' ? column.column.function[0] : undefined;
@@ -286,7 +291,7 @@ const ExpandAggregateRow = (props: {
       query: nextView.generateQueryStringObject(),
     };
 
-    return <Link to={target}>{children({willExpand: true})}</Link>;
+    return <Link to={target}>{children}</Link>;
   }
 
   // count_unique(column) drilldown
@@ -302,11 +307,11 @@ const ExpandAggregateRow = (props: {
       query: nextView.generateQueryStringObject(),
     };
 
-    return <Link to={target}>{children({willExpand: true})}</Link>;
+    return <Link to={target}>{children}</Link>;
   }
 
-  return <React.Fragment>{children({willExpand: false})}</React.Fragment>;
-};
+  return <React.Fragment>{children}</React.Fragment>;
+}
 
 const HeaderIcon = styled('span')`
   & > svg {

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import {browserHistory} from 'react-router';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import CellAction from 'app/views/eventsV2/table/cellAction';
+import EventView from 'app/utils/discover/eventView';
+
+function makeWrapper(eventView, initial) {
+  const data = {transaction: 'best-transaction', count: 19};
+  return mountWithTheme(
+    <CellAction
+      organization={initial.organization}
+      dataRow={data}
+      eventView={eventView}
+      column={eventView.getColumns()[0]}
+    >
+      <strong>some content</strong>
+    </CellAction>
+  );
+}
+describe('Discover -> CellAction', function() {
+  const location = {
+    query: {
+      id: '42',
+      name: 'best query',
+      field: ['transaction', 'count()'],
+      widths: ['123', '456'],
+      sort: ['title'],
+      query: 'event.type:transaction',
+      project: [123],
+      start: '2019-10-01T00:00:00',
+      end: '2019-10-02T00:00:00',
+      statsPeriod: '14d',
+      environment: ['staging'],
+      yAxis: 'p95',
+    },
+  };
+  const view = EventView.fromLocation(location);
+  const initial = initializeOrg();
+
+  describe('hover menu button', function() {
+    const wrapper = makeWrapper(view, initial);
+
+    it('shows no menu by default', function() {
+      expect(wrapper.find('MenuButton')).toHaveLength(0);
+    });
+
+    it('shows a menu on hover, and hides again', function() {
+      wrapper.find('Container').simulate('mouseEnter');
+      expect(wrapper.find('MenuButton')).toHaveLength(1);
+
+      wrapper.find('Container').simulate('mouseLeave');
+      expect(wrapper.find('MenuButton')).toHaveLength(0);
+    });
+  });
+
+  describe('opening the menu', function() {
+    const wrapper = makeWrapper(view, initial);
+    wrapper.find('Container').simulate('mouseEnter');
+
+    it('toggles the menu on click', function() {
+      // Button should be rendered.
+      expect(wrapper.find('MenuButton')).toHaveLength(1);
+      wrapper.find('MenuButton').simulate('click');
+
+      // Menu should show now.
+      expect(wrapper.find('Menu')).toHaveLength(1);
+    });
+  });
+
+  describe('action buttons basics', function() {
+    let wrapper;
+    beforeEach(function() {
+      wrapper = makeWrapper(view, initial);
+      // Show button and menu.
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+
+      browserHistory.push.mockReset();
+    });
+
+    it('add button appends condition', function() {
+      wrapper.find('button[data-test-id="add-to-filter"]').simulate('click');
+
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/discover/results/',
+        query: expect.objectContaining({
+          query: 'event.type:transaction transaction:best-transaction',
+        }),
+      });
+    });
+
+    it('exclude button adds condition', function() {
+      wrapper.find('button[data-test-id="exclude-from-filter"]').simulate('click');
+
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/discover/results/',
+        query: expect.objectContaining({
+          query: 'event.type:transaction !transaction:best-transaction',
+        }),
+      });
+    });
+
+    it('exclude button appends exclusions', function() {
+      const excludeView = EventView.fromLocation({
+        query: {...location.query, query: '!transaction:nope'},
+      });
+      wrapper = makeWrapper(excludeView, initial);
+      // Show button and menu.
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+      wrapper.find('button[data-test-id="exclude-from-filter"]').simulate('click');
+
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/discover/results/',
+        query: expect.objectContaining({
+          query: '!transaction:nope !transaction:best-transaction',
+        }),
+      });
+    });
+  });
+});


### PR DESCRIPTION
To make it easier to explore data and build queries based on the results you're seeing, we're adding a context menu to each non-aggregate field.

Because the result table uses overflow-x:scroll I was not able to use our existing `Dropdown` component because the context menu would be unable to overflow the table. Instead I had to re-implement a dropdown like behavior. I was also unable to reuse components like `MenuItem` as their styling is all derived from being inside `.dropdown` containers.

![Screen Shot 2020-03-26 at 10 38 57 AM](https://user-images.githubusercontent.com/24086/77664727-01b89a00-6f55-11ea-8d1e-bb35958dd089.png)
