### PR TITLE
build(docker): Add pip check after installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -186,7 +186,7 @@ RUN set -x \
     && mkdir -p $SENTRY_CONF
 
 COPY --from=sdist /dist/*.whl /tmp/dist/
-RUN pip install /tmp/dist/*.whl
+RUN pip install /tmp/dist/*.whl && pip check
 
 COPY ./docker/sentry.conf.py ./docker/config.yml $SENTRY_CONF/
 COPY ./docker/docker-entrypoint.sh /


### PR DESCRIPTION
The new pip resolver is coming in 2020H2 and the best way to be ready for it is to ensure there are no broken dependencies by using `pip check`. This PR adds it to the Docker image so we get build failures if we introduce broken deps.

See https://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html for more information.