### PR TITLE
fix: Remove inconsistent CSS

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -244,9 +244,9 @@ class IncidentsListContainer extends React.Component<Props> {
           <Alert type="info" icon="icon-circle-info">
             {t('This feature is in beta and currently shows only metric alerts. ')}
 
-            <FeedbackLink href="mailto:alerting-feedback@sentry.io">
+            <ExternalLink href="mailto:alerting-feedback@sentry.io">
               {t('Please contact us if you have any feedback.')}
-            </FeedbackLink>
+            </ExternalLink>
           </Alert>
           <IncidentsList {...this.props} />
         </PageContent>
@@ -258,11 +258,6 @@ class IncidentsListContainer extends React.Component<Props> {
 const StyledPageHeading = styled(PageHeading)`
   display: flex;
   align-items: center;
-`;
-
-const FeedbackLink = styled(ExternalLink)`
-  font-size: ${p => p.theme.fontSizeMedium};
-  margin-left: ${space(1)};
 `;
 
 const Actions = styled('div')`


### PR DESCRIPTION
Since the link was moved in #17660, it doesn't require the custom CSS in
the new location and we can use an ExternalLink directly.

The custom CSS was making the font-size 14px, whereas the surrounding
text is at 15px, and the margin-left was adding arbitrary spacing
between sentences.

![image](https://user-images.githubusercontent.com/88819/77684605-7d890580-6f9a-11ea-8590-00d906fbe8bd.png)

Fixes #17939.