### PR TITLE
meta: Add watchman to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -4,6 +4,9 @@ brew 'pyenv'
 brew 'openssl'
 brew 'readline'
 
+# required for yarn test -u
+brew 'watchman'
+
 # required to build some of sentry's dependencies
 brew 'pkgconfig'
 brew 'libxmlsec1'


### PR DESCRIPTION
Before installing watchman I had this:

```
$ which yarn
/Users/rodolfo/.volta/bin/yarn

$ yarn test -u
yarn run v1.21.1
$ node scripts/test.js -u
TypeError: fsevents is not a function
    at new FSEventsWatcher (/Users/rodolfo/sentry/sentry/node_modules/jest-haste-map/build/lib/FSEventsWatcher.js:162:20)
    at createWatcher (/Users/rodolfo/sentry/sentry/node_modules/jest-haste-map/build/index.js:1052:23)
    at Array.map (<anonymous>)
    at HasteMap._watch (/Users/rodolfo/sentry/sentry/node_modules/jest-haste-map/build/index.js:1230:44)
    at /Users/rodolfo/sentry/sentry/node_modules/jest-haste-map/build/index.js:517:21
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/Users/rodolfo/sentry/sentry/node_modules/jest-haste-map/build/index.js:193:24)
    at _next (/Users/rodolfo/sentry/sentry/node_modules/jest-haste-map/build/index.js:213:9)
error Command failed with exit code 1.
```

Searching the web I found that watchman is an indirect dependency of jest.

https://github.com/bbc/simorgh/wiki/Known-setup-issue-when-running-%60npm-test%60#the-cause

Installing watchman fixed the issue, not really obvious from the error above.