### PR TITLE
fix(ui): Small improvements on releases v2

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -80,6 +80,10 @@ class ReleasesList extends AsyncView<Props, State> {
        * Manually trigger checking for elements in viewport.
        * Helpful when LazyLoad components enter the viewport without resize or scroll events,
        * https://github.com/twobin/react-lazyload#forcecheck
+       *
+       * HealthStatsCharts are being rendered only when they are scrolled into viewport.
+       * This is how we re-check them without scrolling once releases change as this view
+       * uses shouldReload=true and there is no reloading happening.
        */
       forceCheck();
     }

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router/lib/Router';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
+import {forceCheck} from 'react-lazyload';
 
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -69,6 +70,14 @@ class ReleasesList extends AsyncView<Props, State> {
     };
 
     return [['releases', `/organizations/${organization.slug}/releases/`, {query}]];
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    super.componentDidUpdate(prevProps, prevState);
+
+    if (prevState.releases !== this.state.releases) {
+      forceCheck();
+    }
   }
 
   getQuery() {
@@ -159,7 +168,7 @@ class ReleasesList extends AsyncView<Props, State> {
       );
     }
 
-    return t('There are no releases.');
+    return <EmptyStateWarning small>{t('There are no releases.')}</EmptyStateWarning>;
   }
 
   renderInnerBody() {

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -76,6 +76,11 @@ class ReleasesList extends AsyncView<Props, State> {
     super.componentDidUpdate(prevProps, prevState);
 
     if (prevState.releases !== this.state.releases) {
+      /**
+       * Manually trigger checking for elements in viewport.
+       * Helpful when LazyLoad components enter the viewport without resize or scroll events,
+       * https://github.com/twobin/react-lazyload#forcecheck
+       */
       forceCheck();
     }
   }

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releaseCard.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releaseCard.tsx
@@ -69,7 +69,9 @@ const ReleaseCard = ({release, project, location, reloading}: Props) => (
           </VersionColumn>
 
           <ProjectsColumn>
-            <ProjectBadge project={project} avatarSize={14} key={project?.slug} />
+            {project && (
+              <ProjectBadge project={project} avatarSize={14} key={project?.slug} />
+            )}
           </ProjectsColumn>
 
           <CommitsColumn>


### PR DESCRIPTION
- reevaluate whether lazy histograms should become visible on releases change
- wrapped empty message with EmptyStateWarning
- conditionally render project badge