### PR TITLE
fix(pagerduty): update deletes all PagerDutyService objects for installation

### DIFF
--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -16,6 +16,7 @@ from sentry.integrations.base import (
     IntegrationProvider,
     FeatureDescription,
 )
+from sentry.shared_integrations.exceptions import IntegrationError
 
 from sentry.models import OrganizationIntegration, PagerDutyService
 
@@ -87,11 +88,11 @@ class PagerDutyIntegration(IntegrationInstallation):
                         service_name = matched_row["service"]
                         key = matched_row["integration_key"]
 
-                        # only update the fields if we have a new value
-                        if service_name:
-                            service_item.service_name = service_name
-                        if key:
-                            service_item.integration_key = key
+                        # must provide name and key
+                        if not service_name or not key:
+                            raise IntegrationError("Name and key are required")
+                        service_item.integration_key = key
+                        service_item.service_name = service_name
                         service_item.save()
                     else:
                         service_item.delete()

--- a/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
+import flatten from 'lodash/flatten';
 
 import {defined, objectIsEmpty} from 'app/utils';
 import {t} from 'app/locale';
@@ -21,6 +22,7 @@ const defaultProps = {
 
 type DefaultProps = Readonly<typeof defaultProps>;
 
+//TODO(TS): properly type this since InputField['props'] is type any
 type Props = {
   name?: string;
   columnLabels: object;
@@ -55,6 +57,7 @@ export default class TableField extends React.Component<Props> {
 
   hasValue = value => defined(value) && !objectIsEmpty(value);
 
+  //TODO(TS): should type field props
   renderField = props => {
     const {
       onChange,
@@ -75,11 +78,13 @@ export default class TableField extends React.Component<Props> {
     const saveChanges = (nextValue: object) => {
       onChange(nextValue, []);
 
-      const validValues = !Object.values(nextValue)
-        .map(o => Object.values(o).find(v => v === null))
-        .includes(null);
+      //check for falsy values
+      const validValues = !flatten(
+        Object.values(nextValue).map(o => Object.values(o))
+      ).some(v => !v);
 
       if (allowEmpty || validValues) {
+        //TOOD: add debouncing or use a form save button
         onBlur();
       }
     };

--- a/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
@@ -79,9 +79,9 @@ export default class TableField extends React.Component<Props> {
       onChange(nextValue, []);
 
       //check for falsy values
-      const validValues = !flatten(
-        Object.values(nextValue).map(o => Object.values(o))
-      ).some(v => !v);
+      const validValues = !flatten(Object.values(nextValue).map(Object.values)).some(
+        v => !v
+      );
 
       if (allowEmpty || validValues) {
         //TOOD: add debouncing or use a form save button


### PR DESCRIPTION
This PR fixes a bug when updating the `PagerDutyService` table that caused alert rules to show up as `[removed]`. This is because every UI update would drop every row for a particular integration install and regenerate the rows. The rules that pointed to those rows now fail to load properly.

This PR rectifies the issue by looking up the existing rows of `PagerDutyService` by the id and updating the existing rows with the new data. If there is an existing row in that table associated with the installation that is not sent by the UI, that row is deleted. For rows that don't have an ID being sent, which means it doesn't exist in the DB, we create a new row.

I updated the form so that if there is a missing field, the form won't save. I think that was the original intention but there was a bug in the implementation since it only checked `null` but empty values are empty strings. I also put in backend validation to prevent this case as well.


#sync-getsentry