### PR TITLE
fix(search) Don't double wrap tags expressions.

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -264,7 +264,7 @@ def get_snuba_column_name(name, dataset=Dataset.Events):
     if name in no_conversion:
         return name
 
-    if not name or QUOTED_LITERAL_RE.match(name):
+    if not name or name.startswith("tags[") or QUOTED_LITERAL_RE.match(name):
         return name
 
     return DATASETS[dataset].get(name, u"tags[{}]".format(name))

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -158,9 +158,9 @@ class SnubaUtilsTest(TestCase):
         assert get_snuba_column_name("'thing'") == "'thing'"
         assert get_snuba_column_name("id") == "event_id"
         assert get_snuba_column_name("geo.region") == "geo_region"
-        # This is odd behavior but captures what we do currently.
-        assert get_snuba_column_name("tags[sentry:user]") == "tags[tags[sentry:user]]"
+        assert get_snuba_column_name("tags[sentry:user]") == "tags[sentry:user]"
         assert get_snuba_column_name("organization") == "tags[organization]"
+        assert get_snuba_column_name("unknown-key") == "tags[unknown-key]"
 
 
 class PrepareQueryParamsTest(TestCase):


### PR DESCRIPTION
When we get a `tags[foo]` from the user we shouldn't wrap it again.