### PR TITLE
feat(IntegrationDirectory): Implement detailed view UI for Document-based Integrations

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -829,6 +829,19 @@ function routes() {
         />
       </Route>
 
+      <Redirect from="document-integrations/" to="integrations/" />
+      <Route name="Integrations" path="document-integrations/">
+        <Route
+          name="Details"
+          path=":integrationSlug"
+          componentPromise={() =>
+            import(
+              /* webpackChunkName: "ConfigureIntegration" */ 'app/views/organizationIntegrations/docIntegrationDetailedView'
+            )
+          }
+          component={errorHandler(LazyLoad)}
+        />
+      </Route>
       <Route name="Integrations" path="integrations/">
         <IndexRoute
           componentPromise={() =>

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -389,6 +389,16 @@ export type AppOrProviderOrPlugin =
   | IntegrationProvider
   | PluginWithProjectList;
 
+export type DocumentIntegration = {
+  slug: string;
+  name: string;
+  author: string;
+  docUrl: string;
+  description: string;
+  features: IntegrationFeature[];
+  resourceLinks: Array<{title: string; url: string}>;
+};
+
 export type GlobalSelection = {
   projects: number[];
   environments: string[];

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -69,7 +69,7 @@ class AbstractIntegrationDetailedView<
    */
 
   //The analytics type used in analytics which is snake case
-  get integrationType(): 'sentry_app' | 'first_party' | 'plugin' {
+  get integrationType(): 'sentry_app' | 'first_party' | 'plugin' | 'document' {
     // Allow children to implement this
     throw new Error('Not implemented');
   }
@@ -95,7 +95,7 @@ class AbstractIntegrationDetailedView<
     throw new Error('Not implemented');
   }
 
-  get installationStatus(): IntegrationInstallationStatus {
+  get installationStatus(): IntegrationInstallationStatus | null {
     // Allow children to implement this
     throw new Error('Not implemented');
   }
@@ -276,7 +276,9 @@ class AbstractIntegrationDetailedView<
           <Flex>
             <Name>{this.integrationName}</Name>
             <StatusWrapper>
-              <IntegrationStatus status={this.installationStatus} />
+              {this.installationStatus && (
+                <IntegrationStatus status={this.installationStatus} />
+              )}
             </StatusWrapper>
           </Flex>
           <Flex>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
@@ -1,3 +1,5 @@
+import {DocumentIntegration} from 'app/types';
+
 export const INSTALLED = 'Installed' as const;
 export const NOT_INSTALLED = 'Not Installed' as const;
 export const PENDING = 'Pending' as const;
@@ -53,7 +55,9 @@ export const POPULARITY_WEIGHT: {
   splunk: 2,
 } as const;
 
-export const documentIntegrations = {
+export const documentIntegrations: {
+  [key: string]: DocumentIntegration;
+} = {
   datadog: {
     slug: 'datadog',
     name: 'Datadog',
@@ -72,4 +76,4 @@ export const documentIntegrations = {
       {title: 'Report Issue', url: 'https://github.com'},
     ],
   },
-} as const;
+};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
@@ -52,3 +52,15 @@ export const POPULARITY_WEIGHT: {
   'amazon-sqs': 2,
   splunk: 2,
 } as const;
+
+export const documentIntegrations = [
+  {
+    slug: 'datadog',
+    name: 'Datadog',
+    author: 'Datadog',
+    docUrl: 'https://datadog.com',
+    description: 'asdfasdfadfasfdasf',
+    features: [],
+    resourceLinks: [{title: 'github', url: 'http//github.com'}],
+  },
+] as const;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
@@ -53,14 +53,23 @@ export const POPULARITY_WEIGHT: {
   splunk: 2,
 } as const;
 
-export const documentIntegrations = [
-  {
+export const documentIntegrations = {
+  datadog: {
     slug: 'datadog',
     name: 'Datadog',
     author: 'Datadog',
-    docUrl: 'https://datadog.com',
-    description: 'asdfasdfadfasfdasf',
-    features: [],
-    resourceLinks: [{title: 'github', url: 'http//github.com'}],
+    docUrl: 'https://www.datadoghq.com/',
+    description:
+      'Quickly discover relationships between production apps and systems performance. Seeing correlations between Sentry events and metrics from infra services like AWS, Elasticsearch, Docker, and Kafka can save time detecting sources of future spikes.',
+    features: [
+      {
+        featureGate: 'data-forwarding',
+        description: 'Forward any events you choose from Sentry.',
+      },
+    ],
+    resourceLinks: [
+      {title: 'View Source', url: 'https://sentry.io'},
+      {title: 'Report Issue', url: 'https://github.com'},
+    ],
   },
-] as const;
+} as const;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -6,6 +6,7 @@ import space from 'app/styles/space';
 import {t} from 'app/locale';
 import {DocumentIntegration} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
+import ExternalLink from 'app/components/links/externalLink';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 import {documentIntegrations} from './constants';
@@ -61,12 +62,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
 
   renderTopButton() {
     return (
-      <a
-        href={this.integration.docUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={this.trackClick}
-      >
+      <ExternalLink href={this.integration.docUrl} onClick={this.trackClick}>
         <LearnMoreButton
           size="small"
           priority="primary"
@@ -75,11 +71,11 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
         >
           {t('Learn More')}
         </LearnMoreButton>
-      </a>
+      </ExternalLink>
     );
   }
 
-  //no configuraitons
+  //no configuratons
   renderConfigurations() {
     return null;
   }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import Button from 'app/components/button';
+import space from 'app/styles/space';
+import {t} from 'app/locale';
+import {DocumentIntegration} from 'app/types';
+import withOrganization from 'app/utils/withOrganization';
+
+import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
+import {documentIntegrations} from './constants';
+
+type Tab = AbstractIntegrationDetailedView['state']['tab'];
+
+class SentryAppDetailedView extends AbstractIntegrationDetailedView<
+  AbstractIntegrationDetailedView['props'],
+  AbstractIntegrationDetailedView['state']
+> {
+  tabs: Tab[] = ['overview'];
+
+  get integrationType() {
+    return 'document' as const;
+  }
+
+  get integration(): DocumentIntegration {
+    const {integrationSlug} = this.props.params;
+
+    return documentIntegrations[integrationSlug] || {};
+  }
+
+  get description() {
+    return this.integration.description || '';
+  }
+
+  get author() {
+    return this.integration.author || '';
+  }
+
+  get resourceLinks() {
+    return this.integration.resourceLinks;
+  }
+
+  get installationStatus() {
+    return null;
+  }
+
+  get integrationName() {
+    return this.integration.name;
+  }
+
+  get featureData() {
+    return this.integration.features;
+  }
+
+  renderTopButton() {
+    return (
+      <a href={this.integration.docUrl} target="_blank" rel="noopener noreferrer">
+        <LearnMoreButton
+          size="small"
+          priority="primary"
+          style={{marginLeft: space(1)}}
+          data-test-id="learn-more"
+        >
+          {t('Learn More')}
+        </LearnMoreButton>
+      </a>
+    );
+  }
+
+  //no configuraitons
+  renderConfigurations() {
+    return null;
+  }
+}
+
+const LearnMoreButton = styled(Button)`
+  margin-left: ${space(1)};
+`;
+
+export default withOrganization(SentryAppDetailedView);

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -30,11 +30,11 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get description() {
-    return this.integration.description || '';
+    return this.integration.description;
   }
 
   get author() {
-    return this.integration.author || '';
+    return this.integration.author;
   }
 
   get resourceLinks() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -52,9 +52,21 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
     return this.integration.features;
   }
 
+  trackClick = () => {
+    this.trackIntegrationEvent({
+      eventKey: 'integrations.installation_start',
+      eventName: 'Integrations: Installation Start',
+    });
+  };
+
   renderTopButton() {
     return (
-      <a href={this.integration.docUrl} target="_blank" rel="noopener noreferrer">
+      <a
+        href={this.integration.docUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={this.trackClick}
+      >
         <LearnMoreButton
           size="small"
           priority="primary"


### PR DESCRIPTION
## Objective
We want to bring Document-based integrations into the Integration Directory. Currently, document-based integrations do not exist inside the app. Users need to Google for integrations that are on the Sentry marketing site and links to the integration partner docs. 

This branch only covers the detailed view UI in the Integration Directory for document-based integrations. This page is hidden from user, because there is no link within the application for this page.

The content is just a placeholder and will be updated in another PR.

## UI
<img width="1440" alt="Screen Shot 2020-03-26 at 7 12 57 PM" src="https://user-images.githubusercontent.com/10491193/77714444-431d6980-6f96-11ea-82be-600fd0cd72b9.png">


## Test Plan
Visually tested and clicked learn more button and saw that it opens the link in a new tab.
