### PR TITLE
feat(perf-view): Display Key Transactions

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -7,7 +7,13 @@ import {canIncludePreviousPeriod} from 'app/views/events/utils/canIncludePreviou
 import {getPeriod} from 'app/utils/getPeriod';
 import {EventsStats, Organization, YAxisEventsStats} from 'app/types';
 
-const getBaseUrl = (org: Organization) => `/organizations/${org.slug}/events-stats/`;
+function getBaseUrl(org: Organization, keyTransactions: boolean | undefined) {
+  if (keyTransactions) {
+    return `/organizations/${org.slug}/key-transactions-stats/`;
+  }
+
+  return `/organizations/${org.slug}/events-stats/`;
+}
 
 type Options = {
   organization: Organization;
@@ -23,6 +29,7 @@ type Options = {
   yAxis?: string | string[];
   field?: string[];
   referenceEvent?: string;
+  keyTransactions?: boolean;
 };
 
 /**
@@ -54,6 +61,7 @@ export const doEventsRequest = (
     yAxis,
     field,
     referenceEvent,
+    keyTransactions,
   }: Options
 ): Promise<EventsStats | YAxisEventsStats> => {
   const shouldDoublePeriod = canIncludePreviousPeriod(includePrevious, period);
@@ -74,7 +82,7 @@ export const doEventsRequest = (
   // the tradeoff for now.
   const periodObj = getPeriod({period, start, end}, {shouldDoublePeriod});
 
-  return api.requestPromise(`${getBaseUrl(organization)}`, {
+  return api.requestPromise(`${getBaseUrl(organization, keyTransactions)}`, {
     query: {
       ...urlQuery,
       ...periodObj,

--- a/src/sentry/static/sentry/app/actionCreators/performance.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/performance.tsx
@@ -20,12 +20,12 @@ export function saveKeyTransaction(
   );
 
   promise.catch(response => {
+    const non_field_errors = response?.responseJSON?.non_field_errors;
+
     if (
-      response &&
-      response.responseJSON &&
-      response.responseJSON.non_field_errors &&
-      response.responseJSON.non_field_errors.length &&
-      response.responseJSON.non_field_errors[0]
+      Array.isArray(non_field_errors) &&
+      non_field_errors.length &&
+      non_field_errors[0]
     ) {
       addErrorMessage(response.responseJSON.non_field_errors[0]);
     } else {
@@ -54,12 +54,12 @@ export function deleteKeyTransaction(
   );
 
   promise.catch(response => {
+    const non_field_errors = response?.responseJSON?.non_field_errors;
+
     if (
-      response &&
-      response.responseJSON &&
-      response.responseJSON.non_field_errors &&
-      response.responseJSON.non_field_errors.length &&
-      response.responseJSON.non_field_errors[0]
+      Array.isArray(non_field_errors) &&
+      non_field_errors.length &&
+      non_field_errors[0]
     ) {
       addErrorMessage(response.responseJSON.non_field_errors[0]);
     } else {

--- a/src/sentry/static/sentry/app/actionCreators/performance.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/performance.tsx
@@ -1,0 +1,71 @@
+import {Client} from 'app/api';
+import {t} from 'app/locale';
+import {addErrorMessage} from 'app/actionCreators/indicator';
+
+export function saveKeyTransaction(
+  api: Client,
+  orgId: string,
+  projects: number[],
+  transactionName: string
+): Promise<undefined> {
+  const promise: Promise<undefined> = api.requestPromise(
+    `/organizations/${orgId}/key-transactions/`,
+    {
+      method: 'POST',
+      query: {
+        project: projects.map(id => String(id)),
+      },
+      data: {transaction: transactionName},
+    }
+  );
+
+  promise.catch(response => {
+    if (
+      response &&
+      response.responseJSON &&
+      response.responseJSON.non_field_errors &&
+      response.responseJSON.non_field_errors.length &&
+      response.responseJSON.non_field_errors[0]
+    ) {
+      addErrorMessage(response.responseJSON.non_field_errors[0]);
+    } else {
+      addErrorMessage(t('Unable to update key transaction'));
+    }
+  });
+
+  return promise;
+}
+
+export function deleteKeyTransaction(
+  api: Client,
+  orgId: string,
+  projects: number[],
+  transactionName: string
+): Promise<undefined> {
+  const promise: Promise<undefined> = api.requestPromise(
+    `/organizations/${orgId}/key-transactions/`,
+    {
+      method: 'DELETE',
+      query: {
+        project: projects.map(id => String(id)),
+      },
+      data: {transaction: transactionName},
+    }
+  );
+
+  promise.catch(response => {
+    if (
+      response &&
+      response.responseJSON &&
+      response.responseJSON.non_field_errors &&
+      response.responseJSON.non_field_errors.length &&
+      response.responseJSON.non_field_errors[0]
+    ) {
+      addErrorMessage(response.responseJSON.non_field_errors[0]);
+    } else {
+      addErrorMessage(t('Unable to update key transaction'));
+    }
+  });
+
+  return promise;
+}

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -60,6 +60,7 @@ type EventsRequestPartialProps = {
   currentSeriesName?: string;
   previousSeriesName?: string;
   children: (renderProps: RenderProps) => React.ReactNode;
+  keyTransactions?: boolean;
 };
 
 type TimeAggregationProps =
@@ -180,6 +181,11 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
 
     field: PropTypes.arrayOf(PropTypes.string),
     referenceEvent: PropTypes.string,
+
+    /**
+     * Determines if the "key transactions" version of the event-stats endpoint should be used
+     */
+    keyTransactions: PropTypes.bool,
   };
 
   static defaultProps: DefaultProps = {

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -41,11 +41,12 @@ type Props = {
   organization: Organization;
   location: Location;
   router: ReactRouter.InjectedRouter;
+  keyTransactions: boolean;
 };
 
 class Container extends React.Component<Props> {
   render() {
-    const {api, organization, location, eventView, router} = this.props;
+    const {api, organization, location, eventView, router, keyTransactions} = this.props;
 
     // construct request parameters for fetching chart data
 
@@ -83,6 +84,7 @@ class Container extends React.Component<Props> {
             query={eventView.getEventsAPIPayload(location).query}
             includePrevious={false}
             yAxis={YAXIS_OPTIONS.map(option => option.value)}
+            keyTransactions={keyTransactions}
           >
             {({loading, reloading, errored, results}) => {
               if (errored) {

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -22,11 +22,12 @@ import {generatePerformanceEventView, DEFAULT_STATS_PERIOD} from './data';
 import Table from './table';
 import Charts from './charts/index';
 
-type FilterViewType = 'ALL_TRANSACTIONS' | 'KEY_TRANSACTIONS';
-const FILTER_VIEWS: Readonly<FilterViewType[]> = [
-  'ALL_TRANSACTIONS',
-  'KEY_TRANSACTIONS',
-] as const;
+enum FilterViews {
+  ALL_TRANSACTIONS = 'ALL_TRANSACTIONS',
+  KEY_TRANSACTIONS = 'KEY_TRANSACTIONS',
+}
+
+const VIEWS = [FilterViews.ALL_TRANSACTIONS, FilterViews.KEY_TRANSACTIONS];
 
 type Props = {
   organization: Organization;
@@ -37,7 +38,7 @@ type Props = {
 type State = {
   eventView: EventView;
   error: string | undefined;
-  currentView: FilterViewType;
+  currentView: FilterViews;
 };
 
 class PerformanceLanding extends React.Component<Props, State> {
@@ -48,7 +49,7 @@ class PerformanceLanding extends React.Component<Props, State> {
   state: State = {
     eventView: generatePerformanceEventView(this.props.location),
     error: undefined,
-    currentView: 'ALL_TRANSACTIONS',
+    currentView: FilterViews.ALL_TRANSACTIONS,
   };
 
   renderError = () => {
@@ -111,11 +112,11 @@ class PerformanceLanding extends React.Component<Props, State> {
     return false;
   };
 
-  getViewLabel(currentView: FilterViewType): string {
+  getViewLabel(currentView: FilterViews): string {
     switch (currentView) {
-      case 'ALL_TRANSACTIONS':
+      case FilterViews.ALL_TRANSACTIONS:
         return t('All Transactions');
-      case 'KEY_TRANSACTIONS':
+      case FilterViews.KEY_TRANSACTIONS:
         return t('My Key Transactions');
       default:
         throw Error(`Unknown view: ${currentView}`);
@@ -123,7 +124,7 @@ class PerformanceLanding extends React.Component<Props, State> {
   }
 
   renderDropdown() {
-    const selectView = (viewKey: FilterViewType) => {
+    const selectView = (viewKey: FilterViews) => {
       return () => {
         this.setState({
           currentView: viewKey,
@@ -133,7 +134,7 @@ class PerformanceLanding extends React.Component<Props, State> {
 
     return (
       <ButtonBar merged active={this.state.currentView}>
-        {FILTER_VIEWS.map(viewKey => {
+        {VIEWS.map(viewKey => {
           return (
             <Button
               key={viewKey}

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -27,7 +27,7 @@ enum FilterViews {
   KEY_TRANSACTIONS = 'KEY_TRANSACTIONS',
 }
 
-const VIEWS = [FilterViews.ALL_TRANSACTIONS, FilterViews.KEY_TRANSACTIONS];
+const VIEWS = Object.values(FilterViews);
 
 type Props = {
   organization: Organization;

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -60,6 +60,7 @@ type Props = {
   organization: Organization;
   location: Location;
   setError: (msg: string | undefined) => void;
+  keyTransactions: boolean;
 
   projects: Project[];
   loadingProjects: boolean;
@@ -240,11 +241,16 @@ class Table extends React.Component<Props> {
   };
 
   render() {
-    const {eventView, organization, location} = this.props;
+    const {eventView, organization, location, keyTransactions} = this.props;
     const columnOrder = eventView.getColumns();
 
     return (
-      <EventsV2 eventView={eventView} organization={organization} location={location}>
+      <EventsV2
+        eventView={eventView}
+        organization={organization}
+        location={location}
+        keyTransactions={keyTransactions}
+      >
         {({pageLinks, isLoading, tableData}) => (
           <div>
             <StyledSearchBar

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -12,6 +12,7 @@ import EventsV2 from 'app/utils/discover/eventsv2';
 import SummaryContentTable from './table';
 import Breadcrumb from './breadcrumb';
 import UserStats from './userStats';
+import KeyTransactionButton from './keyTransactionButton';
 
 const TOP_SLOWEST_TRANSACTIONS = 5;
 
@@ -24,6 +25,18 @@ type Props = {
 };
 
 class SummaryContent extends React.Component<Props> {
+  renderKeyTransactionButton() {
+    const {eventView, organization, transactionName} = this.props;
+
+    return (
+      <KeyTransactionButton
+        transactionName={transactionName}
+        eventView={eventView}
+        organization={organization}
+      />
+    );
+  }
+
   render() {
     const {transactionName, location, eventView, organization, totalValues} = this.props;
 
@@ -38,6 +51,9 @@ class SummaryContent extends React.Component<Props> {
               transactionName={transactionName}
             />
           </div>
+          <KeyTransactionContainer>
+            {this.renderKeyTransactionButton()}
+          </KeyTransactionContainer>
           <StyledTitleHeader>{transactionName}</StyledTitleHeader>
         </HeaderBox>
         <ContentBox>
@@ -90,6 +106,11 @@ const StyledTitleHeader = styled('span')`
 
 const Side = styled('div')`
   grid-column: 2/3;
+`;
+
+const KeyTransactionContainer = styled('div')`
+  display: flex;
+  justify-content: flex-end;
 `;
 
 export default SummaryContent;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import withApi from 'app/utils/withApi';
+import {Client} from 'app/api';
+import Button from 'app/components/button';
+import {IconStar} from 'app/icons';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import theme from 'app/utils/theme';
+import EventView from 'app/utils/discover/eventView';
+import {Organization} from 'app/types';
+import {saveKeyTransaction, deleteKeyTransaction} from 'app/actionCreators/performance';
+
+type Props = {
+  api: Client;
+  eventView: EventView;
+  organization: Organization;
+  transactionName: string;
+};
+
+type State = {
+  isLoading: boolean;
+  keyFetchID: symbol | undefined;
+  error: null | string;
+
+  isKeyTransaction: boolean;
+};
+
+class KeyTransactionButton extends React.Component<Props, State> {
+  state: State = {
+    isLoading: true,
+    keyFetchID: undefined,
+    error: null,
+
+    isKeyTransaction: false,
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const orgSlugChanged = prevProps.organization.slug !== this.props.organization.slug;
+    const projectsChanged =
+      prevProps.eventView.project.length === 1 &&
+      this.props.eventView.project.length === 1 &&
+      prevProps.eventView.project[0] !== this.props.eventView.project[0];
+
+    if (orgSlugChanged || projectsChanged) {
+      this.fetchData();
+    }
+  }
+
+  fetchData = () => {
+    const {organization, eventView, transactionName} = this.props;
+
+    const projects = eventView.project as number[];
+
+    if (projects.length !== 1) {
+      return;
+    }
+
+    const url = `/organizations/${organization.slug}/is-key-transactions/`;
+    const keyFetchID = Symbol('keyFetchID');
+
+    this.setState({isLoading: true, keyFetchID});
+
+    this.props.api
+      .requestPromise(url, {
+        method: 'GET',
+        includeAllArgs: true,
+        query: {
+          project: projects.map(id => String(id)),
+          transaction: transactionName,
+        },
+      })
+      .then(([data, _, _jqXHR]) => {
+        if (this.state.keyFetchID !== keyFetchID) {
+          // invariant: a different request was initiated after this request
+          return;
+        }
+
+        this.setState({
+          isLoading: false,
+          keyFetchID: undefined,
+          error: null,
+          isKeyTransaction: !!data?.isKey,
+        });
+      })
+      .catch(err => {
+        this.setState({
+          isLoading: false,
+          keyFetchID: undefined,
+          error: err.responseJSON.detail,
+          isKeyTransaction: false,
+        });
+      });
+  };
+
+  toggleKeyTransaction = () => {
+    const {eventView, api, organization, transactionName} = this.props;
+    const projects = eventView.project as number[];
+
+    if (!this.state.isKeyTransaction) {
+      saveKeyTransaction(api, organization.slug, projects, transactionName)
+        .then(() => {
+          this.setState({
+            isKeyTransaction: true,
+          });
+        })
+        .catch(() => {
+          this.setState({
+            isKeyTransaction: false,
+          });
+        });
+    } else {
+      deleteKeyTransaction(api, organization.slug, projects, transactionName)
+        .then(() => {
+          this.setState({
+            isKeyTransaction: false,
+          });
+        })
+        .catch(() => {
+          this.setState({
+            isKeyTransaction: true,
+          });
+        });
+    }
+  };
+
+  render() {
+    const {isKeyTransaction, isLoading} = this.state;
+
+    if (this.props.eventView.project.length !== 1 || isLoading) {
+      return null;
+    }
+
+    return (
+      <Button onClick={this.toggleKeyTransaction}>
+        <StyledIconStar
+          size="xs"
+          color={isKeyTransaction ? theme.yellow : undefined}
+          solid={!!isKeyTransaction}
+        />
+        {t('Key Transaction')}
+      </Button>
+    );
+  }
+}
+
+export default withApi(KeyTransactionButton);
+
+const StyledIconStar = styled(IconStar)`
+  margin-right: ${space(1)};
+`;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
@@ -103,29 +103,27 @@ class KeyTransactionButton extends React.Component<Props, State> {
     const projects = eventView.project as number[];
 
     if (!this.state.isKeyTransaction) {
-      saveKeyTransaction(api, organization.slug, projects, transactionName)
-        .then(() => {
-          this.setState({
-            isKeyTransaction: true,
-          });
-        })
-        .catch(() => {
-          this.setState({
-            isKeyTransaction: false,
-          });
+      this.setState({
+        isKeyTransaction: true,
+      });
+
+      saveKeyTransaction(api, organization.slug, projects, transactionName).catch(() => {
+        this.setState({
+          isKeyTransaction: false,
         });
+      });
     } else {
-      deleteKeyTransaction(api, organization.slug, projects, transactionName)
-        .then(() => {
-          this.setState({
-            isKeyTransaction: false,
-          });
-        })
-        .catch(() => {
+      this.setState({
+        isKeyTransaction: false,
+      });
+
+      deleteKeyTransaction(api, organization.slug, projects, transactionName).catch(
+        () => {
           this.setState({
             isKeyTransaction: true,
           });
-        });
+        }
+      );
     }
   };
 

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
 import withApi from 'app/utils/withApi';
 import {Client} from 'app/api';
 import Button from 'app/components/button';
 import {IconStar} from 'app/icons';
 import {t} from 'app/locale';
-import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import EventView from 'app/utils/discover/eventView';
 import {Organization} from 'app/types';
@@ -135,12 +133,16 @@ class KeyTransactionButton extends React.Component<Props, State> {
     }
 
     return (
-      <Button onClick={this.toggleKeyTransaction}>
-        <StyledIconStar
-          size="xs"
-          color={isKeyTransaction ? theme.yellow : undefined}
-          solid={!!isKeyTransaction}
-        />
+      <Button
+        icon={
+          <IconStar
+            size="xs"
+            color={isKeyTransaction ? theme.yellow : undefined}
+            solid={!!isKeyTransaction}
+          />
+        }
+        onClick={this.toggleKeyTransaction}
+      >
         {t('Key Transaction')}
       </Button>
     );
@@ -148,7 +150,3 @@ class KeyTransactionButton extends React.Component<Props, State> {
 }
 
 export default withApi(KeyTransactionButton);
-
-const StyledIconStar = styled(IconStar)`
-  margin-right: ${space(1)};
-`;


### PR DESCRIPTION


Consuming key transactions endpoint added in https://github.com/getsentry/sentry/pull/17511/

## TODO

- [x] need a way to check `(project, transaction_name)` without having to hit snuba; this is for the "my key transaction" button state - https://github.com/getsentry/sentry/pull/17965
- [x] need to convey "my key transactions" on the chart? - https://github.com/getsentry/sentry/pull/17982 https://github.com/getsentry/sentry/pull/18092
- [x] make text search (i.e. query param) work for my key transactions - https://github.com/getsentry/sentry/pull/17965
- [x] list of Key transactions should be empty if there are no key transactions - https://github.com/getsentry/sentry/pull/17965
- [x] move `KeyTransactionButton` into its own file