### PR TITLE
fix(ui): Replace id with barId in attachments's ButtonBar

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
@@ -31,10 +31,14 @@ const GroupEventAttachmentsFilter = (props: WithRouterProps) => {
   return (
     <FilterWrapper>
       <ButtonBar merged active={activeButton}>
-        <Button id="all" size="small" to={{pathname, query: allAttachmentsQuery}}>
+        <Button barId="all" size="small" to={{pathname, query: allAttachmentsQuery}}>
           {t('All Attachments')}
         </Button>
-        <Button id="onlyCrash" size="small" to={{pathname, query: onlyCrashReportsQuery}}>
+        <Button
+          barId="onlyCrash"
+          size="small"
+          to={{pathname, query: onlyCrashReportsQuery}}
+        >
           {t('Only Crash Reports')}
         </Button>
       </ButtonBar>


### PR DESCRIPTION
There has been a typo in our recent refactor.
In order for ButtonBar to work correctly, children Buttons need to have barId specified, not id.