### PR TITLE
Adding missing functionality for Key Transactions

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -287,7 +287,10 @@ from sentry.data_export.endpoints.data_export_details import DataExportDetailsEn
 from sentry.discover.endpoints.discover_query import DiscoverQueryEndpoint
 from sentry.discover.endpoints.discover_saved_queries import DiscoverSavedQueriesEndpoint
 from sentry.discover.endpoints.discover_saved_query_detail import DiscoverSavedQueryDetailEndpoint
-from sentry.discover.endpoints.discover_key_transactions import KeyTransactionEndpoint
+from sentry.discover.endpoints.discover_key_transactions import (
+    KeyTransactionEndpoint,
+    IsKeyTransactionEndpoint,
+)
 from sentry.incidents.endpoints.organization_alert_rule_available_action_index import (
     OrganizationAlertRuleAvailableActionIndexEndpoint,
 )
@@ -659,6 +662,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/key-transactions/$",
                     KeyTransactionEndpoint.as_view(),
                     name="sentry-api-0-organization-key-transactions",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/is-key-transactions/$",
+                    IsKeyTransactionEndpoint.as_view(),
+                    name="sentry-api-0-organization-is-key-transactions",
                 ),
                 # Dashboards
                 url(

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -73,7 +73,7 @@ class KeyTransactionEndpoint(KeyTransactionBase):
 
         results = query(
             fields,
-            None,
+            request.GET.get("query"),
             params,
             orderby=orderby,
             referrer="discover.key_transactions",

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -56,6 +56,9 @@ class KeyTransactionEndpoint(OrganizationEventsV2EndpointBase):
 
         queryset = KeyTransaction.objects.filter(organization=organization, owner=request.user)
 
+        if not queryset.exists():
+            raise ResourceDoesNotExist
+
         results = query(
             fields,
             None,


### PR DESCRIPTION
- Return nothing when there's no key transactions
   - Right now the endpoint is still querying but with no conditions
   - This change prevents us from querying at all when there's no key transactions
- Adding a `is-key-transactions` endpoint to check if a transaction/project pair is key or not
- Allowing the query param to be passed to key transactions
- TODO: In another PR i'll introduce the ability to hit event-stats and get key transactions back.