### PR TITLE
feat(ingest): Custom subdomains per-organizations

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -848,6 +848,9 @@ SENTRY_FEATURES = {
     "organizations:issue-alerts-targeting": False,
     # Enable org-wide saved searches and user pinned search
     "organizations:org-saved-searches": False,
+    # Prefix host with organization ID when giving users DSNs (can be
+    # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE)
+    "organizations:org-subdomains": False,
     # Enable access to more advanced (alpha) datascrubbing settings.
     "organizations:datascrubbers-v2": False,
     # Enable usage of external relays, for use with Relay. See
@@ -1103,6 +1106,10 @@ SENTRY_METRICS_SKIP_INTERNAL_PREFIXES = []  # Order this by most frequent prefix
 # (Defaults to URL_PREFIX by default)
 SENTRY_ENDPOINT = None
 SENTRY_PUBLIC_ENDPOINT = None
+
+# Hostname prefix to add for organizations that are opted into the
+# `organizations:org-subdomains` feature.
+SENTRY_ORG_SUBDOMAIN_TEMPLATE = "o{organization_id}.ingest"
 
 # Prevent variables (e.g. context locals, http data, etc) from exceeding this
 # size in characters

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -90,6 +90,7 @@ default_manager.add("organizations:sso-saml2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:grouping-info", OrganizationFeature)  # NOQA
 default_manager.add("organizations:tweak-grouping-config", OrganizationFeature)  # NOQA
 default_manager.add("organizations:set-grouping-config", OrganizationFeature)  # NOQA
+default_manager.add("organizations:org-subdomains", OrganizationFeature)  # NOQA
 
 # Project scoped features
 default_manager.add("projects:custom-inbound-filters", ProjectFeature)  # NOQA

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from six.moves.urllib.parse import urlparse
 
-from sentry import options
+from sentry import options, features
 from sentry.db.models import (
     Model,
     BaseManager,
@@ -143,17 +143,12 @@ class ProjectKey(Model):
         super(ProjectKey, self).save(*args, **kwargs)
 
     def get_dsn(self, domain=None, secure=True, public=False):
+        urlparts = urlparse(self.get_endpoint(public=public))
+
         if not public:
             key = "%s:%s" % (self.public_key, self.secret_key)
-            url = settings.SENTRY_ENDPOINT
         else:
             key = self.public_key
-            url = settings.SENTRY_PUBLIC_ENDPOINT or settings.SENTRY_ENDPOINT
-
-        if url:
-            urlparts = urlparse(url)
-        else:
-            urlparts = urlparse(options.get("system.url-prefix"))
 
         # If we do not have a scheme or domain/hostname, dsn is never valid
         if not urlparts.netloc or not urlparts.scheme:
@@ -229,10 +224,27 @@ class ProjectKey(Model):
                 reverse("sentry-js-sdk-loader", args=[self.public_key, ".min"]),
             )
 
-    def get_endpoint(self):
-        endpoint = settings.SENTRY_PUBLIC_ENDPOINT or settings.SENTRY_ENDPOINT
+    def get_endpoint(self, public=True):
+        if public:
+            endpoint = settings.SENTRY_PUBLIC_ENDPOINT or settings.SENTRY_ENDPOINT
+        else:
+            endpoint = settings.SENTRY_ENDPOINT
+
         if not endpoint:
             endpoint = options.get("system.url-prefix")
+
+        if features.has("organizations:org-subdomains", self.project.organization):
+            urlparts = urlparse(endpoint)
+            if urlparts.scheme and urlparts.netloc:
+                endpoint = "%s://%s.%s%s" % (
+                    urlparts.scheme,
+                    settings.SENTRY_ORG_SUBDOMAIN_TEMPLATE.format(
+                        organization_id=self.project.organization_id
+                    ),
+                    urlparts.netloc,
+                    urlparts.path,
+                )
+
         return endpoint
 
     def get_allowed_origins(self):


### PR DESCRIPTION
This adds the abililty to opt some organizations into using subdomains
with org ids in them.

We want to try this out for some organizations that send a lot of
traffic, eventually switching everyone over.