### PR TITLE
fix(issues) Fix edge case with cursor estimator

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -542,7 +542,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             # +/-10% @ 95% confidence.
 
             sample_size = options.get("snuba.search.hits-sample-size")
-            snuba_groups, snuba_total = self.snuba_search(
+            kwargs = dict(
                 start=start,
                 end=end,
                 project_ids=[p.id for p in projects],
@@ -553,6 +553,10 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 get_sample=True,
                 search_filters=search_filters,
             )
+            if not too_many_candidates:
+                kwargs["group_ids"] = group_ids
+
+            snuba_groups, snuba_total = self.snuba_search(**kwargs)
             snuba_count = len(snuba_groups)
             if snuba_count == 0:
                 # Maybe check for 0 hits and return EMPTY_RESULT in ::query? self.empty_result

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -7,8 +7,8 @@ from uuid import uuid4
 
 from django.core.urlresolvers import reverse
 from django.utils import timezone
-from sentry.utils.compat.mock import patch, Mock
 
+from sentry import options
 from sentry.models import (
     Activity,
     ApiToken,
@@ -30,6 +30,8 @@ from sentry.models import (
     UserOption,
     Release,
 )
+from sentry.utils.compat.mock import patch, Mock
+
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -488,42 +490,49 @@ class GroupListTest(APITestCase, SnubaTestCase):
                 organization_id=self.organization.id,
             )
 
-    def test_assigned_to_pagination(self):
+    # This seems like a random override, but this test needed a way to override
+    # the orderby being sent to snuba for a certain call. This function has a simple
+    # return value and can be used to set variables in the snuba payload.
+    @patch("sentry.utils.snuba.get_query_params_to_update_for_projects")
+    def test_assigned_to_pagination(self, patched_params_update):
+        old_sample_size = options.get("snuba.search.hits-sample-size")
+        assert options.set("snuba.search.hits-sample-size", 1)
+
+        days = range(4)
+        days.reverse()
+
         self.login_as(user=self.user)
-        group_1 = self.store_event(
-            data={"timestamp": iso_format(before_now(days=29)), "fingerprint": ["group-1"]},
-            project_id=self.project.id,
-        ).group
-        self.store_event(
-            data={"timestamp": iso_format(before_now(days=8)), "fingerprint": ["group-1"]},
-            project_id=self.project.id,
-        )
-        group_2 = self.store_event(
-            data={"timestamp": iso_format(before_now(days=10)), "fingerprint": ["group-2"]},
-            project_id=self.project.id,
-        ).group
-        self.store_event(
-            data={"timestamp": iso_format(before_now(days=29)), "fingerprint": ["group-3"]},
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={"timestamp": iso_format(before_now(days=6)), "fingerprint": ["group-4"]},
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={"timestamp": iso_format(before_now(days=10)), "fingerprint": ["group-5"]},
-            project_id=self.project.id,
-        )
+        groups = []
+        for day in days:
+            group = self.store_event(
+                data={
+                    "timestamp": iso_format(before_now(days=day)),
+                    "fingerprint": ["group-{}".format(day)],
+                },
+                project_id=self.project.id,
+            ).group
+            groups.append(group)
 
-        group_2.update(status=GroupStatus.RESOLVED, resolved_at=before_now(seconds=5))
-        GroupAssignee.objects.assign(group_1, self.user)
-        GroupAssignee.objects.assign(group_2, self.user)
+        assigned_groups = groups[:2]
+        for ag in assigned_groups:
+            ag.update(status=GroupStatus.RESOLVED, resolved_at=before_now(seconds=5))
+            GroupAssignee.objects.assign(ag, self.user)
 
-        response = self.get_response(limit=10, query="assigned:{}".format(self.user.email))
-        assert len(response.data) == 2
+        patched_params_update.side_effect = [
+            (self.organization.id, {"project": [self.project.id]}),
+            (self.organization.id, {"project": [self.project.id]}),
+            (self.organization.id, {"project": [self.project.id]}),
+            (self.organization.id, {"project": [self.project.id]}),
+            (self.organization.id, {"project": [self.project.id], "orderby": ["-last_seen"]}),
+            (self.organization.id, {"project": [self.project.id]}),
+            (self.organization.id, {"project": [self.project.id]}),
+            (self.organization.id, {"project": [self.project.id]}),
+            (self.organization.id, {"project": [self.project.id]}),
+        ]
+
         response = self.get_response(limit=1, query="assigned:{}".format(self.user.email))
         assert len(response.data) == 1
-        assert response.data[0]["id"] == six.text_type(group_1.id)
+        assert response.data[0]["id"] == six.text_type(assigned_groups[1].id)
 
         header_links = parse_link_header(response["Link"])
         cursor = [link for link in header_links.values() if link["rel"] == "next"][0]["cursor"]
@@ -531,7 +540,9 @@ class GroupListTest(APITestCase, SnubaTestCase):
             limit=1, cursor=cursor, query="assigned:{}".format(self.user.email)
         )
         assert len(response.data) == 1
-        assert response.data[0]["id"] == six.text_type(group_2.id)
+        assert response.data[0]["id"] == six.text_type(assigned_groups[0].id)
+
+        assert options.set("snuba.search.hits-sample-size", old_sample_size)
 
 
 class GroupUpdateTest(APITestCase, SnubaTestCase):


### PR DESCRIPTION
If there is a condition on the issues that limits it to a small number, there is
a chance that calculate_hits will return results, but none will overlap with the
limited issues that were selected. Instead, include those issues in the query so
that we can ensure results are returned if there are any.