### PR TITLE
fix(ecosystem): stop using random names for acceptance tests

### DIFF
--- a/tests/acceptance/test_organization_plugin_detail_view.py
+++ b/tests/acceptance/test_organization_plugin_detail_view.py
@@ -17,8 +17,8 @@ class OrganizationPluginDetailedView(AcceptanceTestCase):
     def setUp(self):
         super(OrganizationPluginDetailedView, self).setUp()
         # need at least two projects
-        self.project = self.create_project(organization=self.organization)
-        self.create_project(organization=self.organization)
+        self.project = self.create_project(organization=self.organization, name="Back end")
+        self.create_project(organization=self.organization, name="Front End")
         self.login_as(self.user)
 
     def load_page(self, slug, configuration_tab=False):

--- a/tests/acceptance/test_organization_sentry_app_detailed_view.py
+++ b/tests/acceptance/test_organization_sentry_app_detailed_view.py
@@ -13,7 +13,10 @@ class OrganizationSentryAppDetailedView(AcceptanceTestCase):
         super(OrganizationSentryAppDetailedView, self).setUp()
         self.create_project(organization=self.organization)
         self.sentry_app = self.create_sentry_app(
-            organization=self.organization, published=True, verify_install=False
+            organization=self.organization,
+            published=True,
+            verify_install=False,
+            name="Super Awesome App",
         )
         self.login_as(self.user)
 


### PR DESCRIPTION
Randomly generated names are causing diffs in Pery