### PR TITLE
fix(ui): Stop polling in `<EventWaiter>` on 404s

### DIFF
--- a/src/sentry/static/sentry/app/utils/eventWaiter.tsx
+++ b/src/sentry/static/sentry/app/utils/eventWaiter.tsx
@@ -74,7 +74,8 @@ class EventWaiter extends React.Component<Props, State> {
       }
 
       // This means org or project does not exist, we need to stop polling
-      if (resp.status === 404) {
+      // Also stop polling on auth-related errors (403/401)
+      if ([404, 403, 401].includes(resp.status)) {
         // TODO: Add some UX around this... redirect? error message?
         this.stopPolling();
         return;

--- a/src/sentry/static/sentry/app/utils/eventWaiter.tsx
+++ b/src/sentry/static/sentry/app/utils/eventWaiter.tsx
@@ -65,9 +65,10 @@ class EventWaiter extends React.Component<Props, State> {
     let firstEvent = null;
 
     try {
-      ({firstEvent} = await api.requestPromise(
+      const resp = await api.requestPromise(
         `/projects/${organization.slug}/${project.slug}/`
-      ));
+      );
+      firstEvent = resp.firstEvent;
     } catch (resp) {
       if (!resp) {
         return;


### PR DESCRIPTION
If a user changes/removes an org or project (or its slug), it will cause this to 404. This can result in hundreds of events an hour. This PR will stop it from polling but it would be great to have a better UX around this case.