### PR TITLE
feat(noise): Ignore failing to load `passwordStrength`

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -107,10 +107,14 @@ const render = (Component: React.ComponentType) => {
 // zxcvbn, a relatively byte-heavy password strength estimation library. Load
 // it on demand.
 async function loadPasswordStrength(callback: Function) {
-  const module = await import(
-    /* webpackChunkName: "passwordStrength" */ 'app/components/passwordStrength'
-  );
-  callback(module);
+  try {
+    const module = await import(
+      /* webpackChunkName: "passwordStrength" */ 'app/components/passwordStrength'
+    );
+    callback(module);
+  } catch (err) {
+    // Ignore if client can't load this, it enhances UX a bit, but is optional
+  }
 }
 
 const globals = {


### PR DESCRIPTION
This is an optional library used on our org login pages to give users feedback on their password strength. Some browsers fail to load the bundle because it is quite large. Catch and kill these errors.