### PR TITLE
fix(ui) Use react-router location in sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -626,9 +626,6 @@ class Sidebar extends React.Component {
 
 const SidebarContainer = createReactClass({
   displayName: 'SidebarContainer',
-  contextTypes: {
-    location: PropTypes.any,
-  },
   mixins: [Reflux.listenTo(PreferencesStore, 'onPreferenceChange')],
   getInitialState() {
     return {
@@ -647,9 +644,7 @@ const SidebarContainer = createReactClass({
   },
 
   render() {
-    return (
-      <Sidebar {...this.props} collapsed={this.state.collapsed} location={location} />
-    );
+    return <Sidebar {...this.props} collapsed={this.state.collapsed} />;
   },
 });
 


### PR DESCRIPTION
Don't accidentally pull in the global location object and instead rely on the prop that was passed in. This fixes global selection state being dropped when it should be retained.