### PR TITLE
fix(datascrubbers-v2): Bring back replace and bump relay

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ redis-py-cluster==1.3.4
 redis>=2.10.3,<2.10.6
 requests-oauthlib==1.2.0
 requests[security]>=2.20.0,<2.21.0
-sentry-relay>=0.5.5,<0.6.0
+sentry-relay>=0.5.6,<0.6.0
 sentry-sdk>=0.13.5
 simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRulesPanel/utils.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRulesPanel/utils.tsx
@@ -20,8 +20,7 @@ enum METHOD_TYPE {
   MASK = 'mask',
   REMOVE = 'remove',
   HASH = 'hash',
-  // TODO(Priscila): reactivate METHOD_TYPE.REPLACE
-  // REPLACE = 'replace',
+  REPLACE = 'replace',
 }
 
 function getRuleTypeSelectorFieldLabel(labelType: RULE_TYPE): string {
@@ -65,9 +64,8 @@ function getMethodTypeSelectorFieldLabel(labelType: METHOD_TYPE): string {
       return t('Hash');
     case METHOD_TYPE.REMOVE:
       return t('Remove');
-    // TODO(Priscila): reactivate METHOD_TYPE.REPLACE
-    // case METHOD_TYPE.REPLACE:
-    //   return t('Replace');
+    case METHOD_TYPE.REPLACE:
+      return t('Replace');
     default:
       return '';
   }

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -282,10 +282,7 @@ def test_scrubbing_after_processing(
 
     (_, (key, event, duration), _), = mock_default_cache.set.mock_calls
     assert key == "e:1"
-    assert event["extra"] == {
-        u"aaa": u"[Filtered]" if setting_method == "datascrubbers" else u"[redacted]",
-        u"aaa2": u"event preprocessor",
-    }
+    assert event["extra"] == {u"aaa": u"[Filtered]", u"aaa2": u"event preprocessor"}
     assert duration == 3600
 
     mock_save_event.delay.assert_called_once_with(


### PR DESCRIPTION
Bring back the `replace` setting and bump Relay to make that pass the schema when saving