### PR TITLE
fix(ui): Show package status icon only on hover

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/packageLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/packageLink.tsx
@@ -64,7 +64,7 @@ const Package = styled('a')<Partial<Props>>`
   color: ${p => p.theme.foreground};
   cursor: ${p => (p.isClickable ? 'pointer' : 'default')};
   ${PackageStatusIcon} {
-    opacity: 1;
+    opacity: 0;
   }
   &:hover {
     color: ${p => p.theme.foreground};


### PR DESCRIPTION
There has been a regression in our recent stacktrace refactor.
Package status icon needs to be visible only on hover.

