### PR TITLE
fix(discover) Fix negative user searches

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -854,12 +854,14 @@ def get_filter(query=None, params=None):
                         )
             elif name == USER_ALIAS:
                 # If the key is user, do an OR across all the different possible user fields
-                kwargs["conditions"].append(
-                    [
-                        convert_search_filter_to_snuba_query(term, key=field)
-                        for field in FIELD_ALIASES[USER_ALIAS]["fields"]
-                    ]
-                )
+                user_conditions = [
+                    convert_search_filter_to_snuba_query(term, key=field)
+                    for field in FIELD_ALIASES[USER_ALIAS]["fields"]
+                ]
+                if term.operator == "!=":
+                    kwargs["conditions"].extend(user_conditions)
+                else:
+                    kwargs["conditions"].append(user_conditions)
             elif name in FIELD_ALIASES and name != PROJECT_ALIAS:
                 converted_filter = convert_aggregate_filter_to_snuba_query(term, True)
                 if converted_filter:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -858,7 +858,7 @@ def get_filter(query=None, params=None):
                     convert_search_filter_to_snuba_query(term, key=field)
                     for field in FIELD_ALIASES[USER_ALIAS]["fields"]
                 ]
-                if term.operator == "!=":
+                if term.operator == "!=" and term.value.value != "":
                     kwargs["conditions"].extend(user_conditions)
                 else:
                     kwargs["conditions"].append(user_conditions)

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1213,6 +1213,17 @@ class GetSnubaQueryArgsTest(TestCase):
         assert ["user.email", "=", "123"] in conditions[0]
         assert ["user.ip", "=", "123"] in conditions[0]
 
+    def test_general_negative_user_field(self):
+        conditions = get_filter("!user:123").conditions
+        assert len(conditions) == 4
+        assert [[["isNull", ["user.id"]], "=", 1], ["user.id", "!=", "123"]] == conditions[0]
+        assert [
+            [["isNull", ["user.username"]], "=", 1],
+            ["user.username", "!=", "123"],
+        ] == conditions[1]
+        assert [[["isNull", ["user.email"]], "=", 1], ["user.email", "!=", "123"]] == conditions[2]
+        assert [[["isNull", ["user.ip"]], "=", 1], ["user.ip", "!=", "123"]] == conditions[3]
+
     def test_function_with_default_arguments(self):
         result = get_filter("rpm():>100", {"start": before_now(minutes=5), "end": before_now()})
         assert result.having == [["rpm", ">", 100]]

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -371,7 +371,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             data["transaction"] = "/transactions/{}".format(key)
             data["timestamp"] = iso_format(before_now(minutes=1))
             data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
-            event_data = dict(user_data)
+            event_data = user_data.copy()
             event_data[key] = "undefined"
             data["user"] = event_data
             self.store_event(data, project_id=project.id)


### PR DESCRIPTION
When someone searched for !user:something, that would cause too many layers of
nesting in the snuba query so the schema would reject it.

Change the behaviour to return the opposite of user:something, namely exclude
any users with any fields that are equal to something.