### PR TITLE
chore(ui): Minor style cleanup in the integrationDetailedView

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -2,12 +2,6 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {RouteComponentProps} from 'react-router/lib/Router';
 
-import {
-  Organization,
-  IntegrationFeature,
-  IntegrationInstallationStatus,
-  SentryAppStatus,
-} from 'app/types';
 import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
 import space from 'app/styles/space';
@@ -15,16 +9,22 @@ import Tag from 'app/views/settings/components/tag';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import Access from 'app/components/acl/access';
 import Tooltip from 'app/components/tooltip';
+import Alert, {Props as AlertProps} from 'app/components/alert';
+import ExternalLink from 'app/components/links/externalLink';
+import marked, {singleLineRenderer} from 'app/utils/marked';
+import {IconClose, IconGithub, IconGeneric, IconDocs, IconProject} from 'app/icons';
+import {
+  Organization,
+  IntegrationFeature,
+  IntegrationInstallationStatus,
+  SentryAppStatus,
+} from 'app/types';
 import {
   getIntegrationFeatureGate,
   trackIntegrationEvent,
   SingleIntegrationEvent,
   getCategories,
 } from 'app/utils/integrationUtil';
-import Alert, {Props as AlertProps} from 'app/components/alert';
-import ExternalLink from 'app/components/links/externalLink';
-import marked, {singleLineRenderer} from 'app/utils/marked';
-import {IconClose, IconGithub, IconGeneric, IconDocs} from 'app/icons';
 
 import IntegrationStatus from './integrationStatus';
 
@@ -115,17 +115,15 @@ class AbstractIntegrationDetailedView<
   getIcon(title: string) {
     switch (title) {
       case 'View Source':
-        return <StyledIconCode />;
+        return <IconProject />;
       case 'Report Issue':
-        return <StyledIconGithub />;
+        return <IconGithub />;
       case 'Documentation':
-        return <StyledIconDocs />;
       case 'Splunk Setup Instructions':
-        return <StyledIconDocs />;
       case 'Trello Setup Instructions':
-        return <StyledIconDocs />;
+        return <IconDocs />;
       default:
-        return <StyledIconGeneric />;
+        return <IconGeneric />;
     }
   }
 
@@ -334,10 +332,10 @@ class AbstractIntegrationDetailedView<
           </FlexContainer>
           <Metadata>
             {!!this.author && (
-              <div>
+              <AuthorInfo>
                 <CreatedContainer>{t('Created By')}</CreatedContainer>
-                <AuthorName>{this.author}</AuthorName>
-              </div>
+                <div>{this.author}</div>
+              </AuthorInfo>
             )}
             {this.resourceLinks.map(({title, url}) => (
               <ExternalLinkContainer key={url}>
@@ -432,15 +430,24 @@ const Description = styled('div')`
 `;
 
 const Metadata = styled(Flex)`
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-auto-rows: max-content;
+  grid-auto-flow: row;
+  grid-gap: ${space(2)};
   font-size: 0.9em;
   margin-left: ${space(4)};
   margin-right: 100px;
 `;
 
-const AuthorName = styled('div')`
-  margin-bottom: ${space(4)};
+const AuthorInfo = styled('div')`
+  margin-bottom: ${space(3)};
+`;
+
+const ExternalLinkContainer = styled('div')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  grid-gap: ${space(1)};
+  align-items: center;
 `;
 
 const StatusWrapper = styled('div')`
@@ -491,23 +498,4 @@ const EmptyConfigurationBody = styled('div')`
   padding-bottom: ${space(2)};
 `;
 
-const StyledIconCode = () => (
-  <span className="icon-code2" style={{fontWeight: 'bold', marginRight: space(1)}} />
-);
-
-const StyledIconGithub = styled(IconGithub)`
-  margin-right: ${space(1)};
-`;
-
-const StyledIconGeneric = styled(IconGeneric)`
-  margin-right: ${space(1)};
-`;
-const StyledIconDocs = styled(IconDocs)`
-  margin-right: ${space(1)};
-`;
-
-const ExternalLinkContainer = styled('div')`
-  margin-bottom: ${space(2)};
-  display: flex;
-`;
 export default AbstractIntegrationDetailedView;


### PR DESCRIPTION
I did switch the `code` icon (since we don't have a svg one) with the project icon, which I think conveys the same thing.