### PR TITLE
feat(alerts): Hide new mail targetting action from projects that haven't been migrated.

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-
 from sentry.api.bases.project import ProjectEndpoint, StrictProjectPermission
 from sentry.rules import rules
 from rest_framework.response import Response
@@ -17,10 +16,19 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         action_list = []
         condition_list = []
 
+        has_issue_alerts_targeting = (
+            project.flags.has_issue_alerts_targeting
+            or request.query_params.get("issue_alerts_targeting") == "1"
+        )
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
             node = rule_cls(project)
             context = {"id": node.id, "label": node.label, "enabled": node.is_enabled()}
+            if (
+                node.id == "sentry.rules.actions.notify_email.NotifyEmailAction"
+                and not has_issue_alerts_targeting
+            ):
+                continue
 
             if hasattr(node, "form_fields"):
                 context["formFields"] = node.form_fields

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -103,13 +103,16 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   }
 
   getEndpoints() {
-    const {
-      params: {ruleId, projectId, orgId},
-    } = this.props;
+    const {params, location} = this.props;
+    const {ruleId, projectId, orgId} = params;
+    const {issue_alerts_targeting = 0} = location.query ?? {};
 
     const endpoints = [
       ['environments', `/projects/${orgId}/${projectId}/environments/`],
-      ['configs', `/projects/${orgId}/${projectId}/rules/configuration/`],
+      [
+        'configs',
+        `/projects/${orgId}/${projectId}/rules/configuration/?issue_alerts_targeting=${issue_alerts_targeting}`,
+      ],
     ];
 
     if (ruleId) {

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -63,7 +63,8 @@ describe('ProjectAlertsCreate', function() {
   beforeEach(async function() {
     browserHistory.replace = jest.fn();
     MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/rules/configuration/',
+      url:
+        '/projects/org-slug/project-slug/rules/configuration/?issue_alerts_targeting=0',
       body: TestStubs.ProjectAlertRuleConfiguration(),
     });
     MockApiClient.addMockResponse({

--- a/tests/js/spec/views/settings/projectAlerts/issueEditor.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/issueEditor.spec.jsx
@@ -54,7 +54,8 @@ describe('ProjectAlerts -> IssueEditor', function() {
   beforeEach(async function() {
     browserHistory.replace = jest.fn();
     MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/rules/configuration/',
+      url:
+        '/projects/org-slug/project-slug/rules/configuration/?issue_alerts_targeting=0',
       body: TestStubs.ProjectAlertRuleConfiguration(),
     });
     MockApiClient.addMockResponse({

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
+from mock import Mock, patch
 
+from sentry.rules.registry import RuleRegistry
 from sentry.testutils import APITestCase
 
 
@@ -22,3 +24,45 @@ class ProjectRuleConfigurationTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data["actions"]) == 4
         assert len(response.data["conditions"]) == 9
+
+    @property
+    def rules(self):
+        rules = RuleRegistry()
+        rule = Mock()
+        rule.id = "sentry.rules.actions.notify_email.NotifyEmailAction"
+        rule.rule_type = "action/lol"
+        node = rule.return_value
+        node.id = "sentry.rules.actions.notify_email.NotifyEmailAction"
+        node.label = "hello"
+        node.is_enabled.return_value = True
+        node.form_fields = {}
+        rules.add(rule)
+        return rules
+
+    def run_mock_rules_test(self, expected_actions, querystring_params):
+        self.login_as(user=self.user)
+        with patch("sentry.api.endpoints.project_rules_configuration.rules", self.rules):
+            url = reverse(
+                "sentry-api-0-project-rules-configuration",
+                kwargs={
+                    "organization_slug": self.organization.slug,
+                    "project_slug": self.project.slug,
+                },
+            )
+            response = self.client.get(url, querystring_params, format="json")
+
+            assert response.status_code == 200, response.content
+            assert len(response.data["actions"]) == expected_actions
+            assert len(response.data["conditions"]) == 0
+
+    def test_filter_out_notify_email_action(self):
+        self.run_mock_rules_test(0, {})
+
+    def test_filter_show_notify_email_action_migrated_project(self):
+        self.project.flags.has_issue_alerts_targeting = True
+        self.project.save()
+        self.run_mock_rules_test(1, {})
+
+    def test_filter_show_notify_email_action_override(self):
+        self.run_mock_rules_test(0, {"issue_alerts_targeting": "0"})
+        self.run_mock_rules_test(1, {"issue_alerts_targeting": "1"})


### PR DESCRIPTION
We'll introduce this action in https://github.com/getsentry/sentry/pull/17571. This is being split
off from that PR in an attempt to break it down into manageable chunks.

This pr hides the new action from any projects that are not migrated, which is indicated by their
`has_issue_alerts_targeting` flag set to `False`. This can also be overriden by passing the
`issue_alerts_targeting` query param.