### PR TITLE
test(js): Fix flakey IssueList test due to `<NoGroupsHandler>`

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/noGroupsHandler/index.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/noGroupsHandler/index.tsx
@@ -7,6 +7,7 @@ import {t} from 'app/locale';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import ErrorRobot from 'app/components/errorRobot';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import withApi from 'app/utils/withApi';
 
 import NoUnresolvedIssues from './noUnresolvedIssues';
 
@@ -126,4 +127,4 @@ class NoGroupsHandler extends React.Component<Props, State> {
   }
 }
 
-export default NoGroupsHandler;
+export default withApi(NoGroupsHandler);

--- a/src/sentry/static/sentry/app/views/issueList/noGroupsHandler/index.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/noGroupsHandler/index.tsx
@@ -7,7 +7,6 @@ import {t} from 'app/locale';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import ErrorRobot from 'app/components/errorRobot';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import withApi from 'app/utils/withApi';
 
 import NoUnresolvedIssues from './noUnresolvedIssues';
 
@@ -40,7 +39,26 @@ class NoGroupsHandler extends React.Component<Props, State> {
 
   componentDidMount() {
     this.fetchSentFirstEvent();
+    this._isMounted = true;
   }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  /**
+   * This is a bit hacky, but this is causing flakiness in frontend tests
+   * `issueList/overview` is being unmounted during tests before the requests
+   * in `this.fetchSentFirstEvent` are completed and causing this React warning:
+   *
+   * Warning: Can't perform a React state update on an unmounted component.
+   * This is a no-op, but it indicates a memory leak in your application.
+   * To fix, cancel all subscriptions and asynchronous tasks in the
+   * componentWillUnmount method.
+   *
+   * This is something to revisit if we refactor API client
+   */
+  private _isMounted: boolean = false;
 
   async fetchSentFirstEvent() {
     this.setState({
@@ -73,6 +91,12 @@ class NoGroupsHandler extends React.Component<Props, State> {
         query: projectsQuery,
       }),
     ]);
+
+    // See comment where this property is initialized
+    // FIXME
+    if (!this._isMounted) {
+      return;
+    }
 
     this.setState({
       fetchingSentFirstEvent: false,
@@ -127,4 +151,4 @@ class NoGroupsHandler extends React.Component<Props, State> {
   }
 }
 
-export default withApi(NoGroupsHandler);
+export default NoGroupsHandler;

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -545,7 +545,6 @@ const IssueListOverview = createReactClass({
     } else {
       body = (
         <NoGroupsHandler
-          api={this.api}
           organization={this.props.organization}
           query={this.getQuery()}
           selectedProjectIds={this.props.selection.projects}

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -545,6 +545,7 @@ const IssueListOverview = createReactClass({
     } else {
       body = (
         <NoGroupsHandler
+          api={this.api}
           organization={this.props.organization}
           query={this.getQuery()}
           selectedProjectIds={this.props.selection.projects}


### PR DESCRIPTION
This is a bit hacky, but this is causing flakiness in frontend tests
`issueList/overview` is being unmounted during tests before the requests
in `NoGroupsHandler.fetchSentFirstEvent` are completed and causing this React warning:

```
Warning: Can't perform a React state update on an unmounted component.
This is a no-op, but it indicates a memory leak in your application.
To fix, cancel all subscriptions and asynchronous tasks in the
componentWillUnmount method.
```