### PR TITLE
fix(ecosystem): add message about enabling 3rd party cookies for Jira install

### DIFF
--- a/src/sentry/templates/sentry/integrations/jira-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-config.html
@@ -37,7 +37,12 @@
     <h2>Sentry Integration Configuration</h2>
     {% if login_required %}
       <div class="aui-message aui-message-info">
-        <p>Please login to your Sentry account to access the Sentry Add-on configuration</p>
+        <p>Please login to your Sentry account to access the Sentry Add-on configuration.</p>
+        {% if is_safari %}
+          <p>You may also need to <a href="https://www.whatismybrowser.com/guides/how-to-enable-cookies/safari"  target="_blank">enable 3rd-party cookies in your browser.</a></p>
+        {% else %}
+          <p>You may also need to enable 3rd-party cookies in your browser.</p>
+        {% endif %}
         <p>You must disable your ad-blocker to install this integration, as it relies on 3rd-party cookies.</p>
       </div>
       <div class="signin">


### PR DESCRIPTION
This PR seeks to improve the user experience for users who have problems installing Jira. The current error message is not helpful as it doesn't explain to users that they might need to enable 3rd party cookies. It seems that Safari disables 3rd party cookies by default so it's more of a problem there. As a result, I put a link to a webpage that explains how to do it for Safari if we detect the user is using that browser. Otherwise, we just display text saying `You may also need to enable 3rd-party cookies in your browser.`. Here is what it looks like for Safari:

![Screen Shot 2020-03-31 at 5 20 43 PM](https://user-images.githubusercontent.com/8533851/78087269-628d0b80-7375-11ea-833c-af7fd3148f4e.png)
