### PR TITLE
fix(withExperiment): Correct comment on injectLogExperiment

### DIFF
--- a/src/sentry/static/sentry/app/utils/withExperiment.tsx
+++ b/src/sentry/static/sentry/app/utils/withExperiment.tsx
@@ -20,9 +20,8 @@ type Options<E extends ExperimentKey, L extends boolean> = {
    */
   experiment: E;
   /**
-   * By default, when the experiment has an assignment value that is not the
-   * `unassignedValue`, this HoC will log the exposure of the experiment upon
-   * mounting of the component.
+   * By default this HoC will log the exposure of the experiment upon mounting
+   * of the component.
    *
    * If this is undesirable, for example if the experiment is hidden behind
    * some user action beyond this component being mounted, then you will want


### PR DESCRIPTION
the unassignedValue will be checked in getsentry, so no need to call
that out here. You should always call log experiment now.