### PR TITLE
fix: Fix comma regression for represented data

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1392,6 +1392,8 @@ span.val {
 }
 
 .val-dict {
+  display: inline;
+
   .val-dict-items {
     display: block;
     padding: 0 0 0 15px;
@@ -1415,8 +1417,7 @@ span.val {
     padding: 0 0 0 15px;
 
     .val-array-item {
-      display: flex;
-      flex-direction: row;
+      display: block;
     }
   }
 }


### PR DESCRIPTION
Regression was introduced in https://github.com/getsentry/sentry/pull/16051

**Before:**

![Screen Shot 2020-04-01 at 9 12 22 AM](https://user-images.githubusercontent.com/139499/78142088-6fa00e00-73fa-11ea-8ac9-8e035ff77969.png)


**After:**

![Screen Shot 2020-04-01 at 9 12 14 AM](https://user-images.githubusercontent.com/139499/78142083-6fa00e00-73fa-11ea-8c3d-d953cd5786d8.png)


## TODO

- [ ] add visual regression tests for various array and dict combinations on the Issue details page