### PR TITLE
ref(ts) Convert YAxisSelector to typescript and move it

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
+++ b/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
@@ -2,19 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
+import {SelectValue} from 'app/types';
 import DropdownButton from 'app/components/dropdownButton';
-import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
-import {t} from 'app/locale';
-import space from 'app/styles/space';
 import {InlineContainer, SectionHeading} from 'app/components/charts/styles';
+import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
+import space from 'app/styles/space';
 
-const YAxisSelector = props => {
-  const {options, onChange, selected} = props;
+type Props = {
+  options: SelectValue<string>[];
+  selected: string;
+  onChange: (value: string) => void;
+  title: string;
+};
+
+function OptionSelector({options, onChange, selected, title}: Props) {
   const selectedOption = options.find(opt => selected === opt.value) || options[0];
 
   return (
     <InlineContainer>
-      <SectionHeading>{t('Y-Axis')}</SectionHeading>
+      <SectionHeading>{title}</SectionHeading>
       <DropdownControl
         menuWidth="auto"
         alignRight
@@ -37,7 +43,7 @@ const YAxisSelector = props => {
       </DropdownControl>
     </InlineContainer>
   );
-};
+}
 
 const StyledDropdownButton = styled(DropdownButton)`
   padding: ${space(1)} ${space(2)};
@@ -51,10 +57,11 @@ const StyledDropdownButton = styled(DropdownButton)`
   }
 `;
 
-YAxisSelector.propTypes = {
+OptionSelector.propTypes = {
   options: PropTypes.array.isRequired,
   onChange: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
   selected: PropTypes.string,
 };
 
-export default YAxisSelector;
+export default OptionSelector;

--- a/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/chartFooter.tsx
@@ -2,22 +2,27 @@ import React from 'react';
 
 import {t} from 'app/locale';
 import {SelectValue} from 'app/types';
-import YAxisSelector from 'app/views/events/yAxisSelector';
 import {
   ChartControls,
   InlineContainer,
   SectionHeading,
   SectionValue,
 } from 'app/components/charts/styles';
+import OptionSelector from 'app/components/charts/optionSelector';
 
 type Props = {
   total: number | null;
   yAxisValue: string;
   yAxisOptions: SelectValue<string>[];
-  onChange: (value: string) => void;
+  onAxisChange: (value: string) => void;
 };
 
-export default function ChartFooter({total, yAxisValue, yAxisOptions, onChange}: Props) {
+export default function ChartFooter({
+  total,
+  yAxisValue,
+  yAxisOptions,
+  onAxisChange,
+}: Props) {
   const elements: React.ReactNode[] = [];
 
   elements.push(<SectionHeading key="total-label">{t('Total Events')}</SectionHeading>);
@@ -34,7 +39,12 @@ export default function ChartFooter({total, yAxisValue, yAxisOptions, onChange}:
   return (
     <ChartControls>
       <InlineContainer>{elements}</InlineContainer>
-      <YAxisSelector selected={yAxisValue} options={yAxisOptions} onChange={onChange} />
+      <OptionSelector
+        title={t('Y-Axis')}
+        selected={yAxisValue}
+        options={yAxisOptions}
+        onChange={onAxisChange}
+      />
     </ChartControls>
   );
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -127,7 +127,7 @@ class ResultsChartContainer extends React.Component<ResultsChartContainerProps> 
           total={total}
           yAxisValue={yAxisValue}
           yAxisOptions={eventView.getYAxisOptions()}
-          onChange={onAxisChange}
+          onAxisChange={onAxisChange}
         />
       </StyledPanel>
     );

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseChartControls.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseChartControls.tsx
@@ -66,7 +66,7 @@ const ReleaseChartControls = ({summary, yAxis, onYAxisChange}: Props) => {
         <SectionValue key="total-value">{summary}</SectionValue>
       </InlineContainer>
 
-      {/* TODO(releasesV2): this will be down the road replaced with discover's YAxisSelector */}
+      {/* TODO(releasesV2): this will be down the road replaced with discover's OptionSelector */}
       <InlineContainer>
         <SectionHeading>{t('Y-Axis')}</SectionHeading>
         <DropdownControl

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -226,7 +226,7 @@ describe('EventsV2 > Results', function() {
       />,
       initialData.routerContext
     );
-    const selector = wrapper.find('YAxisSelector');
+    const selector = wrapper.find('OptionSelector');
     expect(selector).toHaveLength(1);
 
     // Open the selector


### PR DESCRIPTION
Move & rename the YAxisSelector to have a more generic name as we're going to have more of these components on graphs soon and they won't all be yaxis related.