### PR TITLE
fix(discover) Fix missing overflow

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -272,6 +272,7 @@ export const Top = styled('div')`
 export const Main = styled('div')<{eventView: EventView}>`
   grid-column: 1/2;
   max-width: 100%;
+  overflow: hidden;
 `;
 export const Side = styled('div')<{eventView: EventView}>`
   grid-column: 2/3;


### PR DESCRIPTION
I accidentally removed this when trying one of the prototypes for cell actions and forgot to put it back. Without this the discover results don't correctly scroll horizontally.