### PR TITLE
test(ui): Add Percy snapshots for releases v2

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -167,7 +167,7 @@ class ReleasesList extends AsyncView<Props, State> {
     const {location} = this.props;
     const {loading, releases, reloading} = this.state;
 
-    if ((loading && !reloading) || (loading && !releases.length)) {
+    if (!releases || (loading && !reloading) || (loading && !releases.length)) {
       return <LoadingIndicator />;
     }
 

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -167,7 +167,7 @@ class ReleasesList extends AsyncView<Props, State> {
     const {location} = this.props;
     const {loading, releases, reloading} = this.state;
 
-    if (!releases || (loading && !reloading) || (loading && !releases.length)) {
+    if ((loading && !reloading) || (loading && !releases?.length)) {
       return <LoadingIndicator />;
     }
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -303,7 +303,7 @@ class Factories(object):
         return project.key_set.get_or_create()[0]
 
     @staticmethod
-    def create_release(project, user=None, version=None, date_added=None):
+    def create_release(project, user=None, version=None, date_added=None, project2=None):
         if version is None:
             version = hexlify(os.urandom(20))
 
@@ -315,6 +315,7 @@ class Factories(object):
         )
 
         release.add_project(project)
+        release.add_project(project2)
 
         Activity.objects.create(
             type=Activity.RELEASE,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -303,19 +303,23 @@ class Factories(object):
         return project.key_set.get_or_create()[0]
 
     @staticmethod
-    def create_release(project, user=None, version=None, date_added=None, project2=None):
+    def create_release(project, user=None, version=None, date_added=None, additional_projects=None):
         if version is None:
             version = hexlify(os.urandom(20))
 
         if date_added is None:
             date_added = timezone.now()
 
+        if additional_projects is None:
+            additional_projects = []
+
         release = Release.objects.create(
             version=version, organization_id=project.organization_id, date_added=date_added
         )
 
         release.add_project(project)
-        release.add_project(project2)
+        for additional_project in additional_projects:
+            release.add_project(additional_project)
 
         Activity.objects.create(
             type=Activity.RELEASE,

--- a/tests/acceptance/test_organization_releases_v2.py
+++ b/tests/acceptance/test_organization_releases_v2.py
@@ -16,6 +16,10 @@ class OrganizationReleasesV2Test(AcceptanceTestCase):
             organization=self.org, name="Mariachi Band", members=[self.user]
         )
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
+        self.project2 = self.create_project(
+            organization=self.org, teams=[self.team], name="Bengal 2"
+        )
+        self.create_project(organization=self.org, teams=[self.team], name="Bengal 3")
         self.login_as(self.user)
         self.path = u"/organizations/{}/releases-v2/".format(self.org.slug)
         self.project.update(first_event=timezone.now())
@@ -25,9 +29,38 @@ class OrganizationReleasesV2Test(AcceptanceTestCase):
         self.browser.wait_until_not(".loading")
         self.browser.snapshot("organization releases v2 - no access")
 
-    def test(self):
+    def test_list(self):
         with self.feature(FEATURE_NAME):
+            release = self.create_release(project=self.project, version="1.0")
+            self.create_group(first_release=release, project=self.project, message="Foo bar")
             self.browser.get(self.path)
             self.browser.wait_until_not(".loading")
-            # TODO(releasesv2): data is for now randomly hardcoded in the UI - this snapshot will always be different, turned off until finished api
-            # self.browser.snapshot("organization releases v2 list")
+            self.browser.snapshot("organization releases v2 - with releases")
+            # TODO(releasesV2): add health data
+
+    def test_detail(self):
+        with self.feature(FEATURE_NAME):
+            release = self.create_release(project=self.project, version="1.0")
+            self.browser.get(self.path + release.version)
+            self.browser.wait_until_not(".loading")
+            self.browser.snapshot("organization releases v2 - detail")
+            # TODO(releasesV2): add health data
+
+    def test_detail_pick_project(self):
+        with self.feature(FEATURE_NAME):
+            release = self.create_release(
+                project=self.project, project2=self.project2, version="1.0"
+            )
+            self.browser.get(self.path + release.version)
+            self.browser.wait_until_not(".loading")
+            self.browser.snapshot("organization releases v2 - detail - pick project")
+
+    def test_detail_global_header(self):
+        with self.feature(FEATURE_NAME):
+            release = self.create_release(
+                project=self.project, project2=self.project2, version="1.0"
+            )
+            self.browser.get(u"{}?project={}".format(self.path + release.version, self.project.id))
+            self.browser.wait_until_not(".loading")
+            self.browser.click('[data-test-id="global-header-project-selector"]')
+            self.browser.snapshot("organization releases v2 - detail - global project header")

--- a/tests/acceptance/test_organization_releases_v2.py
+++ b/tests/acceptance/test_organization_releases_v2.py
@@ -54,6 +54,8 @@ class OrganizationReleasesV2Test(AcceptanceTestCase):
             self.browser.wait_until_not(".loading")
             self.browser.snapshot("organization releases v2 - detail - pick project")
 
+    # This is snapshotting feature of globalSelectionHeader project picker where we see only specified projects
+    # and a custom footer message saying "Only projects with this release are visible."
     def test_detail_global_header(self):
         with self.feature(FEATURE_NAME):
             release = self.create_release(

--- a/tests/acceptance/test_organization_releases_v2.py
+++ b/tests/acceptance/test_organization_releases_v2.py
@@ -48,7 +48,7 @@ class OrganizationReleasesV2Test(AcceptanceTestCase):
     def test_detail_pick_project(self):
         with self.feature(FEATURE_NAME):
             release = self.create_release(
-                project=self.project, project2=self.project2, version="1.0"
+                project=self.project, additional_projects=[self.project2], version="1.0"
             )
             self.browser.get(self.path + release.version)
             self.browser.wait_until_not(".loading")
@@ -57,7 +57,7 @@ class OrganizationReleasesV2Test(AcceptanceTestCase):
     def test_detail_global_header(self):
         with self.feature(FEATURE_NAME):
             release = self.create_release(
-                project=self.project, project2=self.project2, version="1.0"
+                project=self.project, additional_projects=[self.project2], version="1.0"
             )
             self.browser.get(u"{}?project={}".format(self.path + release.version, self.project.id))
             self.browser.wait_until_not(".loading")

--- a/tests/acceptance/test_organization_releases_v2.py
+++ b/tests/acceptance/test_organization_releases_v2.py
@@ -31,8 +31,7 @@ class OrganizationReleasesV2Test(AcceptanceTestCase):
 
     def test_list(self):
         with self.feature(FEATURE_NAME):
-            release = self.create_release(project=self.project, version="1.0")
-            self.create_group(first_release=release, project=self.project, message="Foo bar")
+            self.create_release(project=self.project, version="1.0")
             self.browser.get(self.path)
             self.browser.wait_until_not(".loading")
             self.browser.snapshot("organization releases v2 - with releases")


### PR DESCRIPTION
Add Percy snapshots for releases v2.
We will fill this with health data in a later PR.