### PR TITLE
feat(ui): Add discover chart to release detail page

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/discoverChartContainer.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/discoverChartContainer.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {Location} from 'history';
+import * as ReactRouter from 'react-router';
+import styled from '@emotion/styled';
+
+import {Organization, GlobalSelection} from 'app/types';
+import space from 'app/styles/space';
+import {t} from 'app/locale';
+import {Client} from 'app/api';
+import {formatVersion} from 'app/utils/formatters';
+import EventView from 'app/utils/discover/eventView';
+import {EventsChart} from 'app/views/events/eventsChart';
+import {getUtcDateString} from 'app/utils/dates';
+import {Panel} from 'app/components/panels';
+import getDynamicText from 'app/utils/getDynamicText';
+
+type Props = {
+  organization: Organization;
+  selection: GlobalSelection;
+  api: Client;
+  location: Location;
+  router: ReactRouter.InjectedRouter;
+  version: string;
+};
+
+class DiscoverChartContainer extends React.Component<Props> {
+  getEventView(): EventView {
+    const {selection, version} = this.props;
+    const {projects, environments, datetime} = selection;
+    const {start, end, period} = datetime;
+
+    const discoverQuery = {
+      id: undefined,
+      version: 2,
+      name: `${t('Release')} ${formatVersion(version)}`,
+      fields: ['title', 'count()', 'event.type', 'issue', 'last_seen()'],
+      query: `release:${version} !event.type:transaction`,
+      orderby: '-last_seen',
+      range: period,
+      environments,
+      projects,
+      start: start ? getUtcDateString(start) : undefined,
+      end: end ? getUtcDateString(end) : undefined,
+    } as const;
+
+    return EventView.fromSavedQuery(discoverQuery);
+  }
+
+  render() {
+    const {organization, location, api, router, selection} = this.props;
+    const {projects, environments, datetime} = selection;
+    const {start, end, period, utc} = datetime;
+
+    return (
+      <StyledPanel>
+        {getDynamicText({
+          value: (
+            <EventsChart
+              router={router}
+              organization={organization}
+              showLegend
+              yAxis={undefined}
+              query={this.getEventView().getEventsAPIPayload(location).query}
+              api={api}
+              projects={projects}
+              environments={environments}
+              start={start}
+              end={end}
+              period={period}
+              utc={utc}
+            />
+          ),
+          fixed: 'events chart',
+        })}
+      </StyledPanel>
+    );
+  }
+}
+
+const StyledPanel = styled(Panel)`
+  margin-bottom: ${space(3)};
+`;
+
+export default DiscoverChartContainer;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -20,6 +20,7 @@ import ProjectReleaseDetails from './projectReleaseDetails';
 import TotalCrashFreeUsers from './totalCrashFreeUsers';
 import ReleaseStatsRequest from './chart/releaseStatsRequest';
 import {YAxis} from './chart/releaseChartControls';
+import DiscoverChartContainer from './chart/discoverChartContainer';
 
 import {ReleaseContext} from '..';
 
@@ -60,7 +61,7 @@ class ReleaseOverview extends AsyncView<Props> {
   }
 
   render() {
-    const {organization, params, selection, location, api, router} = this.props;
+    const {organization, selection, location, api, router} = this.props;
     const yAxis = this.getYAxis();
 
     return (
@@ -82,7 +83,7 @@ class ReleaseOverview extends AsyncView<Props> {
               {({crashFreeTimeBreakdown, ...releaseStatsProps}) => (
                 <ContentBox>
                   <Main>
-                    {hasHealthData && (
+                    {hasHealthData ? (
                       <ReleaseChartContainer
                         onYAxisChange={this.handleYAxisChange}
                         selection={selection}
@@ -90,11 +91,20 @@ class ReleaseOverview extends AsyncView<Props> {
                         router={router}
                         {...releaseStatsProps}
                       />
+                    ) : (
+                      <DiscoverChartContainer
+                        organization={organization}
+                        selection={selection}
+                        location={location}
+                        api={api}
+                        router={router}
+                        version={version}
+                      />
                     )}
                     <Issues
                       orgId={organization.slug}
                       projectId={project.id}
-                      version={params.release}
+                      version={version}
                       location={location}
                     />
                   </Main>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -92,6 +92,7 @@ class ReleaseOverview extends AsyncView<Props> {
                         {...releaseStatsProps}
                       />
                     ) : (
+                      // TODO(releasesV2): feature flag?
                       <DiscoverChartContainer
                         organization={organization}
                         selection={selection}


### PR DESCRIPTION
This is still WIP, but I don't want PRs to get big so this is the first iteration of having events chart on releases v2 page when no health data available.