### PR TITLE
feat(apm): Indicate errors in-line in the span view

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -187,7 +187,7 @@ function filterSpansWithErrors(
   tableData: TableData | null | undefined
 ): TableData | null | undefined {
   if (!tableData) {
-    return tableData;
+    return undefined;
   }
 
   const data = tableData?.data ?? [];

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -80,7 +80,7 @@ class SpansInterface extends React.Component<Props, State> {
       <AlertMessageContainer>
         <AlertMessage
           alert={{
-            id: 'id',
+            id: 'transaction-alert',
             message: <span>{label}</span>,
             type: 'error',
           }}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -9,20 +9,22 @@ import {Panel} from 'app/components/panels';
 import space from 'app/styles/space';
 import EventView from 'app/utils/discover/eventView';
 
-import {SentryTransactionEvent} from './types';
+import {SentryTransactionEvent, ParsedTraceType} from './types';
+import {parseTrace} from './utils';
 import TraceView from './traceView';
 
-type PropType = {
+type Props = {
   orgId: string;
   event: SentryTransactionEvent;
   eventView: EventView;
 };
 
 type State = {
+  parsedTrace: ParsedTraceType;
   searchQuery: string | undefined;
 };
 
-class SpansInterface extends React.Component<PropType, State> {
+class SpansInterface extends React.Component<Props, State> {
   static propTypes = {
     event: SentryTypes.Event.isRequired,
     orgId: PropTypes.string.isRequired,
@@ -30,7 +32,15 @@ class SpansInterface extends React.Component<PropType, State> {
 
   state: State = {
     searchQuery: undefined,
+    parsedTrace: parseTrace(this.props.event),
   };
+
+  static getDerivedStateFromProps(props: Props, state: State): State {
+    return {
+      ...state,
+      parsedTrace: parseTrace(props.event),
+    };
+  }
 
   handleSpanFilter = (searchQuery: string) => {
     this.setState({
@@ -55,6 +65,7 @@ class SpansInterface extends React.Component<PropType, State> {
             searchQuery={this.state.searchQuery}
             orgId={orgId}
             eventView={eventView}
+            parsedTrace={this.state.parsedTrace}
           />
         </Panel>
       </div>

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -193,19 +193,19 @@ function filterSpansWithErrors(
   const data = tableData?.data ?? [];
 
   const filtered = data.filter(row => {
-    const spanID = row['trace.span'] || '';
+    const spanId = row['trace.span'] || '';
 
-    if (!spanID) {
+    if (!spanId) {
       return false;
     }
 
-    if (spanID === parsedTrace.rootSpanID) {
+    if (spanId === parsedTrace.rootSpanID) {
       return true;
     }
 
     const hasSpan =
       parsedTrace.spans.findIndex(span => {
-        return spanID === span.span_id;
+        return spanId === span.span_id;
       }) >= 0;
 
     return hasSpan;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import * as ReactRouter from 'react-router';
 
+import {SentryTransactionEvent} from 'app/types';
 import {t} from 'app/locale';
 import SearchBar from 'app/components/searchBar';
 import SentryTypes from 'app/sentryTypes';
@@ -14,7 +15,7 @@ import {stringifyQueryObject, QueryResults} from 'app/utils/tokenizeSearch';
 import AlertMessage from 'app/components/alertMessage';
 import {TableData} from 'app/views/eventsV2/table/types';
 
-import {SentryTransactionEvent, ParsedTraceType} from './types';
+import {ParsedTraceType} from './types';
 import {parseTrace, getTraceDateTimeRange} from './utils';
 import TraceView from './traceView';
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
+import * as ReactRouter from 'react-router';
 
 import {t} from 'app/locale';
 import SearchBar from 'app/components/searchBar';
@@ -8,16 +9,20 @@ import SentryTypes from 'app/sentryTypes';
 import {Panel} from 'app/components/panels';
 import space from 'app/styles/space';
 import EventView from 'app/utils/discover/eventView';
+import DiscoverQuery from 'app/utils/discover/discoverQuery';
+import {stringifyQueryObject, QueryResults} from 'app/utils/tokenizeSearch';
+import AlertMessage from 'app/components/alertMessage';
+import {TableData} from 'app/views/eventsV2/table/types';
 
 import {SentryTransactionEvent, ParsedTraceType} from './types';
-import {parseTrace} from './utils';
+import {parseTrace, getTraceDateTimeRange} from './utils';
 import TraceView from './traceView';
 
 type Props = {
   orgId: string;
   event: SentryTransactionEvent;
   eventView: EventView;
-};
+} & ReactRouter.WithRouterProps;
 
 type State = {
   parsedTrace: ParsedTraceType;
@@ -48,26 +53,122 @@ class SpansInterface extends React.Component<Props, State> {
     });
   };
 
+  renderTraceErrorsAlert({
+    isLoading,
+    numOfErrors,
+  }: {
+    isLoading: boolean;
+    numOfErrors: number;
+  }) {
+    if (isLoading) {
+      return null;
+    }
+
+    if (numOfErrors === 0) {
+      return null;
+    }
+
+    const label =
+      numOfErrors > 1
+        ? t(
+            `There are %d error events associated with this transaction event.`,
+            numOfErrors
+          )
+        : t(`There is an error event associated with this transaction event.`);
+
+    return (
+      <AlertMessageContainer>
+        <AlertMessage
+          alert={{
+            id: 'id',
+            message: <span>{label}</span>,
+            type: 'error',
+          }}
+          system={false}
+          hideCloseButton
+        />
+      </AlertMessageContainer>
+    );
+  }
+
   render() {
-    const {event, orgId, eventView} = this.props;
+    const {event, orgId, eventView, location} = this.props;
+    const {parsedTrace} = this.state;
+
+    // construct discover query to fetch error events associated with this transaction
+
+    const {start, end} = getTraceDateTimeRange({
+      start: parsedTrace.traceStartTimestamp,
+      end: parsedTrace.traceEndTimestamp,
+    });
+
+    const conditions: QueryResults = {
+      query: [],
+      'event.type': ['error'],
+      trace: [parsedTrace.traceID],
+    };
+
+    if (typeof event.title === 'string') {
+      conditions.transaction = [event.title];
+    }
+
+    const traceErrorsEventView = EventView.fromSavedQuery({
+      id: undefined,
+      name: `Errors related to transaction ${parsedTrace.rootSpanID}`,
+      fields: [
+        'title',
+        'project',
+        'timestamp',
+        'trace',
+        'trace.span',
+        'trace.parent_span',
+      ],
+      orderby: '-timestamp',
+      query: stringifyQueryObject(conditions),
+      projects: [],
+      version: 2,
+      start,
+      end,
+    });
 
     return (
       <div>
-        <StyledSearchBar
-          defaultQuery=""
-          query={this.state.searchQuery || ''}
-          placeholder={t('Search for spans')}
-          onSearch={this.handleSpanFilter}
-        />
-        <Panel>
-          <TraceView
-            event={event}
-            searchQuery={this.state.searchQuery}
-            orgId={orgId}
-            eventView={eventView}
-            parsedTrace={this.state.parsedTrace}
-          />
-        </Panel>
+        <DiscoverQuery
+          location={location}
+          eventView={traceErrorsEventView}
+          orgSlug={orgId}
+        >
+          {({isLoading, tableData}) => {
+            const spansWithErrors = filterSpansWithErrors(parsedTrace, tableData);
+
+            const numOfErrors = spansWithErrors?.data.length || 0;
+
+            return (
+              <React.Fragment>
+                {this.renderTraceErrorsAlert({
+                  isLoading,
+                  numOfErrors,
+                })}
+                <StyledSearchBar
+                  defaultQuery=""
+                  query={this.state.searchQuery || ''}
+                  placeholder={t('Search for spans')}
+                  onSearch={this.handleSpanFilter}
+                />
+                <Panel>
+                  <TraceView
+                    event={event}
+                    searchQuery={this.state.searchQuery}
+                    orgId={orgId}
+                    eventView={eventView}
+                    parsedTrace={parsedTrace}
+                    spansWithErrors={spansWithErrors}
+                  />
+                </Panel>
+              </React.Fragment>
+            );
+          }}
+        </DiscoverQuery>
       </div>
     );
   }
@@ -77,4 +178,43 @@ const StyledSearchBar = styled(SearchBar)`
   margin-bottom: ${space(1)};
 `;
 
-export default SpansInterface;
+const AlertMessageContainer = styled('div')`
+  margin-bottom: ${space(1)};
+`;
+
+function filterSpansWithErrors(
+  parsedTrace: ParsedTraceType,
+  tableData: TableData | null | undefined
+): TableData | null | undefined {
+  if (!tableData) {
+    return tableData;
+  }
+
+  const data = tableData?.data ?? [];
+
+  const filtered = data.filter(row => {
+    const spanID = row['trace.span'] || '';
+
+    if (!spanID) {
+      return false;
+    }
+
+    if (spanID === parsedTrace.rootSpanID) {
+      return true;
+    }
+
+    const hasSpan =
+      parsedTrace.spans.findIndex(span => {
+        return spanID === span.span_id;
+      }) >= 0;
+
+    return hasSpan;
+  });
+
+  return {
+    ...tableData,
+    data: filtered,
+  };
+}
+
+export default ReactRouter.withRouter(SpansInterface);

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import * as ReactRouter from 'react-router';
 
 import {SentryTransactionEvent, Organization} from 'app/types';
-import {t} from 'app/locale';
+import {t, tn} from 'app/locale';
 import SearchBar from 'app/components/searchBar';
 import SentryTypes from 'app/sentryTypes';
 import {Panel} from 'app/components/panels';
@@ -71,13 +71,11 @@ class SpansInterface extends React.Component<Props, State> {
       return null;
     }
 
-    const label =
-      numOfErrors > 1
-        ? t(
-            `There are %d error events associated with this transaction event.`,
-            numOfErrors
-          )
-        : t(`There is an error event associated with this transaction event.`);
+    const label = tn(
+      'There is an error event associated with this transaction event.',
+      `There are %d error events associated with this transaction event.`,
+      numOfErrors
+    );
 
     return (
       <AlertMessageContainer>

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -9,6 +9,7 @@ import Count from 'app/components/count';
 import Tooltip from 'app/components/tooltip';
 import InlineSvg from 'app/components/inlineSvg';
 import EventView from 'app/utils/discover/eventView';
+import {TableDataRow} from 'app/views/eventsV2/table/types';
 
 import {
   toPercent,
@@ -182,6 +183,8 @@ type SpanBarProps = {
   toggleSpanTree: () => void;
   isCurrentSpanFilteredOut: boolean;
   eventView: EventView;
+  totalNumberOfErrors: number;
+  spanErrors: TableDataRow[];
 };
 
 type SpanBarState = {
@@ -221,7 +224,15 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       return null;
     }
 
-    const {span, orgId, isRoot, eventView, trace} = this.props;
+    const {
+      span,
+      orgId,
+      isRoot,
+      eventView,
+      trace,
+      totalNumberOfErrors,
+      spanErrors,
+    } = this.props;
 
     return (
       <SpanDetail
@@ -230,6 +241,8 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         isRoot={!!isRoot}
         eventView={eventView}
         trace={trace}
+        totalNumberOfErrors={totalNumberOfErrors}
+        spanErrors={spanErrors}
       />
     );
   };
@@ -374,10 +387,13 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
   };
 
   renderTitle = () => {
-    const {span, treeDepth} = this.props;
+    const {span, treeDepth, spanErrors} = this.props;
 
-    const op = getSpanOperation(span) ? (
-      <strong>{`${getSpanOperation(span)} \u2014 `}</strong>
+    const operationName = getSpanOperation(span) ? (
+      <strong>
+        <OperationName spanErrors={spanErrors}>{getSpanOperation(span)}</OperationName>
+        {` \u2014 `}
+      </strong>
     ) : (
       ''
     );
@@ -395,7 +411,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           }}
         >
           <span>
-            {op}
+            {operationName}
             {description}
           </span>
         </SpanBarTitle>
@@ -1015,6 +1031,16 @@ const WarningIcon = styled(InlineSvg)`
 const Chevron = styled(InlineSvg)`
   width: 7px;
   margin-left: ${space(0.25)};
+`;
+
+const OperationName = styled('span')<{spanErrors: TableDataRow[]}>`
+  color: ${props => {
+    if (props.spanErrors.length > 0) {
+      return props.theme.error;
+    }
+
+    return 'inherit';
+  }};
 `;
 
 export default SpanBar;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -1034,7 +1034,7 @@ const Chevron = styled(InlineSvg)`
 `;
 
 const OperationName = styled('span')<{spanErrors: TableDataRow[]}>`
-color: ${p => p.spanErrors.length ? p.theme.error : 'inherit'};
+  color: ${p => (p.spanErrors.length ? p.theme.error : 'inherit')};
 `;
 
 export default SpanBar;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -1034,13 +1034,7 @@ const Chevron = styled(InlineSvg)`
 `;
 
 const OperationName = styled('span')<{spanErrors: TableDataRow[]}>`
-  color: ${props => {
-    if (props.spanErrors.length > 0) {
-      return props.theme.error;
-    }
-
-    return 'inherit';
-  }};
+color: ${p => p.spanErrors.length ? p.theme.error : 'inherit'};
 `;
 
 export default SpanBar;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import map from 'lodash/map';
 
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import DateTime from 'app/components/dateTime';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -254,17 +254,25 @@ class SpanDetail extends React.Component<Props, State> {
         </Link>
       ) : spanErrors.length === totalNumberOfErrors ? (
         <div>
-          <Link to={target}>
-            <span>{t('%d error events', totalNumberOfErrors)}</span>
-          </Link>
-          <span>{' occurred in this span.'}</span>
+          {tct('[link] occurred in this span.', {
+            link: (
+              <Link to={target}>
+                <span>{t('%d error events', totalNumberOfErrors)}</span>
+              </Link>
+            ),
+          })}
         </div>
       ) : (
         <div>
-          <Link to={target}>
-            <span>{`${spanErrors.length} out of the ${totalNumberOfErrors} error events`}</span>
-          </Link>
-          <span>{' occurred in this span.'}</span>
+          {tct('[link] occurred in this span.', {
+            link: (
+              <Link to={target}>
+                <span>
+                  {t('%d out of %d error events', spanErrors.length, totalNumberOfErrors)}
+                </span>
+              </Link>
+            ),
+          })}
         </div>
       );
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -16,6 +16,9 @@ import {generateEventSlug, eventDetailsRoute} from 'app/utils/discover/urls';
 import EventView from 'app/utils/discover/eventView';
 import getDynamicText from 'app/utils/getDynamicText';
 import {assert} from 'app/types/utils';
+import AlertMessage from 'app/components/alertMessage';
+import {TableDataRow} from 'app/views/eventsV2/table/types';
+import Link from 'app/components/links/link';
 
 import {ProcessedSpanType, RawSpanType, ParsedTraceType} from './types';
 import {isGapSpan, getTraceDateTimeRange} from './utils';
@@ -33,6 +36,8 @@ type Props = {
   isRoot: boolean;
   eventView: EventView;
   trace: Readonly<ParsedTraceType>;
+  totalNumberOfErrors: number;
+  spanErrors: TableDataRow[];
 };
 
 type State = {
@@ -204,6 +209,78 @@ class SpanDetail extends React.Component<Props, State> {
     );
   }
 
+  renderSpanErrorMessage() {
+    const {orgId, spanErrors, totalNumberOfErrors, span, trace, eventView} = this.props;
+
+    if (spanErrors.length === 0 || totalNumberOfErrors === 0 || isGapSpan(span)) {
+      return null;
+    }
+
+    // invariant: spanErrors.length <= totalNumberOfErrors
+
+    const eventSlug = generateEventSlug(spanErrors[0]);
+
+    const {start, end} = getTraceDateTimeRange({
+      start: trace.traceStartTimestamp,
+      end: trace.traceEndTimestamp,
+    });
+
+    const errorsEventView = EventView.fromSavedQuery({
+      id: undefined,
+      name: `Error events associated with span ${span.span_id}`,
+      fields: ['title', 'project', 'issue', 'timestamp'],
+      orderby: '-timestamp',
+      query: `event.type:error trace:${span.trace_id} trace.span:${span.span_id}`,
+      projects: eventView.project,
+      version: 2,
+      start,
+      end,
+    });
+
+    const target =
+      spanErrors.length === 1
+        ? {
+            pathname: eventDetailsRoute({
+              orgSlug: orgId,
+              eventSlug,
+            }),
+          }
+        : errorsEventView.getResultsViewUrlTarget(orgId);
+
+    const message =
+      totalNumberOfErrors === 1 ? (
+        <Link to={target}>
+          <span>{t('An error event occurred in this span.')}</span>
+        </Link>
+      ) : spanErrors.length === totalNumberOfErrors ? (
+        <div>
+          <Link to={target}>
+            <span>{`${totalNumberOfErrors} error events`}</span>
+          </Link>
+          <span>{' occurred in this span.'}</span>
+        </div>
+      ) : (
+        <div>
+          <Link to={target}>
+            <span>{`${spanErrors.length} out of the ${totalNumberOfErrors} error events`}</span>
+          </Link>
+          <span>{' occurred in this span.'}</span>
+        </div>
+      );
+
+    return (
+      <AlertMessage
+        alert={{
+          id: `span-error-${span.span_id}`,
+          message,
+          type: 'error',
+        }}
+        system
+        hideCloseButton
+      />
+    );
+  }
+
   render() {
     const {span} = this.props;
 
@@ -225,51 +302,54 @@ class SpanDetail extends React.Component<Props, State> {
           event.stopPropagation();
         }}
       >
-        <table className="table key-value">
-          <tbody>
-            <Row title="Span ID" extra={this.renderTraversalButton()}>
-              {span.span_id}
-            </Row>
-            <Row title="Trace ID" extra={this.renderTraceButton()}>
-              {span.trace_id}
-            </Row>
-            <Row title="Parent Span ID">{span.parent_span_id || ''}</Row>
-            <Row title="Description">{span?.description ?? ''}</Row>
-            <Row title="Start Date">
-              {getDynamicText({
-                fixed: 'Mar 16, 2020 9:10:12 AM UTC',
-                value: (
-                  <React.Fragment>
-                    <DateTime date={startTimestamp * 1000} />
-                    {` (${startTimestamp})`}
-                  </React.Fragment>
-                ),
-              })}
-            </Row>
-            <Row title="End Date">
-              {getDynamicText({
-                fixed: 'Mar 16, 2020 9:10:13 AM UTC',
-                value: (
-                  <React.Fragment>
-                    <DateTime date={endTimestamp * 1000} />
-                    {` (${endTimestamp})`}
-                  </React.Fragment>
-                ),
-              })}
-            </Row>
-            <Row title="Duration">{durationString}</Row>
-            <Row title="Operation">{span.op || ''}</Row>
-            <Row title="Same Process as Parent">
-              {String(!!span.same_process_as_parent)}
-            </Row>
-            <Tags span={span} />
-            {map(span?.data ?? {}, (value, key) => (
-              <Row title={key} key={key}>
-                {JSON.stringify(value, null, 4) || ''}
+        {this.renderSpanErrorMessage()}
+        <SpanDetails>
+          <table className="table key-value">
+            <tbody>
+              <Row title="Span ID" extra={this.renderTraversalButton()}>
+                {span.span_id}
               </Row>
-            ))}
-          </tbody>
-        </table>
+              <Row title="Trace ID" extra={this.renderTraceButton()}>
+                {span.trace_id}
+              </Row>
+              <Row title="Parent Span ID">{span.parent_span_id || ''}</Row>
+              <Row title="Description">{span?.description ?? ''}</Row>
+              <Row title="Start Date">
+                {getDynamicText({
+                  fixed: 'Mar 16, 2020 9:10:12 AM UTC',
+                  value: (
+                    <React.Fragment>
+                      <DateTime date={startTimestamp * 1000} />
+                      {` (${startTimestamp})`}
+                    </React.Fragment>
+                  ),
+                })}
+              </Row>
+              <Row title="End Date">
+                {getDynamicText({
+                  fixed: 'Mar 16, 2020 9:10:13 AM UTC',
+                  value: (
+                    <React.Fragment>
+                      <DateTime date={endTimestamp * 1000} />
+                      {` (${endTimestamp})`}
+                    </React.Fragment>
+                  ),
+                })}
+              </Row>
+              <Row title="Duration">{durationString}</Row>
+              <Row title="Operation">{span.op || ''}</Row>
+              <Row title="Same Process as Parent">
+                {String(!!span.same_process_as_parent)}
+              </Row>
+              <Tags span={span} />
+              {map(span?.data ?? {}, (value, key) => (
+                <Row title={key} key={key}>
+                  {JSON.stringify(value, null, 4) || ''}
+                </Row>
+              ))}
+            </tbody>
+          </table>
+        </SpanDetails>
       </SpanDetailContainer>
     );
   }
@@ -283,8 +363,11 @@ const StyledButton = styled(Button)`
 
 const SpanDetailContainer = styled('div')`
   border-bottom: 1px solid ${p => p.theme.gray1};
-  padding: ${space(2)};
   cursor: auto;
+`;
+
+const SpanDetails = styled('div')`
+  padding: ${space(2)};
 `;
 
 const ValueTd = styled('td')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -255,7 +255,7 @@ class SpanDetail extends React.Component<Props, State> {
       ) : spanErrors.length === totalNumberOfErrors ? (
         <div>
           <Link to={target}>
-            <span>{`${totalNumberOfErrors} error events`}</span>
+            <span>{t('%d error events', totalNumberOfErrors)}</span>
           </Link>
           <span>{' occurred in this span.'}</span>
         </div>

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import EventView from 'app/utils/discover/eventView';
+import {TableData, TableDataRow} from 'app/views/eventsV2/table/types';
 
-import {SpanBoundsType, SpanGeneratedBoundsType} from './utils';
+import {SpanBoundsType, SpanGeneratedBoundsType, isGapSpan, getSpanID} from './utils';
 import {ProcessedSpanType, ParsedTraceType} from './types';
 import SpanBar from './spanBar';
 
@@ -22,6 +23,7 @@ type PropType = {
   isLast: boolean;
   isRoot?: boolean;
   isCurrentSpanFilteredOut: boolean;
+  spansWithErrors: TableData | null | undefined;
 };
 
 type State = {
@@ -46,6 +48,32 @@ class SpanGroup extends React.Component<PropType, State> {
 
     return this.props.renderedSpanChildren;
   };
+
+  getSpanErrors(): TableDataRow[] {
+    const {span, spansWithErrors} = this.props;
+
+    const spanID = getSpanID(span);
+
+    if (isGapSpan(span) || !spansWithErrors?.data || !spanID) {
+      return [];
+    }
+
+    return spansWithErrors.data.filter(row => {
+      return row['trace.span'] === spanID;
+    });
+  }
+
+  getTotalNumberOfErrors(): number {
+    const {spansWithErrors} = this.props;
+
+    const data = spansWithErrors?.data;
+
+    if (Array.isArray(data)) {
+      return data.length;
+    }
+
+    return 0;
+  }
 
   render() {
     const {
@@ -84,6 +112,8 @@ class SpanGroup extends React.Component<PropType, State> {
           isLast={isLast}
           isRoot={isRoot}
           isCurrentSpanFilteredOut={isCurrentSpanFilteredOut}
+          totalNumberOfErrors={this.getTotalNumberOfErrors()}
+          spanErrors={this.getSpanErrors()}
         />
         {this.renderSpanChildren()}
       </React.Fragment>

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import {SentryTransactionEvent} from 'app/types';
 import {t} from 'app/locale';
 import EventView from 'app/utils/discover/eventView';
 import {TableData} from 'app/views/eventsV2/table/types';
@@ -11,7 +12,6 @@ import {
   SpanChildrenLookupType,
   ParsedTraceType,
   GapSpanType,
-  SentryTransactionEvent,
 } from './types';
 import {
   boundsGenerator,

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
 import EventView from 'app/utils/discover/eventView';
+import {TableData} from 'app/views/eventsV2/table/types';
 
 import {
   ProcessedSpanType,
@@ -43,6 +44,7 @@ type PropType = {
   dragProps: DragManagerChildrenProps;
   filterSpans: FilterSpans | undefined;
   event: SentryTransactionEvent;
+  spansWithErrors: TableData | null | undefined;
 };
 
 class SpanTree extends React.Component<PropType> {
@@ -136,7 +138,7 @@ class SpanTree extends React.Component<PropType> {
     generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
     previousSiblingEndTimestamp: undefined | number;
   }): RenderedSpanTree => {
-    const {orgId, eventView, event} = this.props;
+    const {orgId, eventView, event, spansWithErrors} = this.props;
 
     const spanBarColour: string = pickSpanBarColour(getSpanOperation(span));
     const spanChildren: Array<RawSpanType> = childSpans?.[getSpanID(span)] ?? [];
@@ -249,6 +251,7 @@ class SpanTree extends React.Component<PropType> {
           numOfSpanChildren={0}
           renderedSpanChildren={[]}
           isCurrentSpanFilteredOut={isCurrentSpanFilteredOut}
+          spansWithErrors={spansWithErrors}
           spanBarHatch
         />
       ) : null;
@@ -277,6 +280,7 @@ class SpanTree extends React.Component<PropType> {
             spanBarColour={spanBarColour}
             isCurrentSpanFilteredOut={isCurrentSpanFilteredOut}
             spanBarHatch={false}
+            spansWithErrors={spansWithErrors}
           />
         </React.Fragment>
       ),

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -6,10 +6,11 @@ import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import EventView from 'app/utils/discover/eventView';
 import {TableData} from 'app/views/eventsV2/table/types';
+import {SentryTransactionEvent} from 'app/types';
 
 import DragManager, {DragManagerChildrenProps} from './dragManager';
 import SpanTree from './spanTree';
-import {RawSpanType, SentryTransactionEvent, ParsedTraceType} from './types';
+import {RawSpanType, ParsedTraceType} from './types';
 import {generateRootSpan, getSpanID, getTraceContext} from './utils';
 import TraceViewHeader from './header';
 import * as CursorGuideHandler from './cursorGuideHandler';

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -5,6 +5,7 @@ import {t} from 'app/locale';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import EventView from 'app/utils/discover/eventView';
+import {TableData} from 'app/views/eventsV2/table/types';
 
 import DragManager, {DragManagerChildrenProps} from './dragManager';
 import SpanTree from './spanTree';
@@ -38,6 +39,7 @@ type Props = {
   parsedTrace: ParsedTraceType;
   searchQuery: string | undefined;
   eventView: EventView;
+  spansWithErrors: TableData | null | undefined;
 };
 
 type State = {
@@ -181,7 +183,7 @@ class TraceView extends React.PureComponent<Props, State> {
       );
     }
 
-    const {orgId, eventView} = this.props;
+    const {orgId, eventView, spansWithErrors} = this.props;
 
     return (
       <DragManager interactiveLayerRef={this.minimapInteractiveRef}>
@@ -199,6 +201,7 @@ class TraceView extends React.PureComponent<Props, State> {
               dragProps={dragProps}
               filterSpans={this.state.filterSpans}
               orgId={orgId}
+              spansWithErrors={spansWithErrors}
             />
           </CursorGuideHandler.Provider>
         )}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -59,3 +59,11 @@ export enum TickAlignment {
   Right,
   Center,
 }
+
+export type TraceContextType = {
+  op?: string;
+  type?: 'trace';
+  span_id?: string;
+  trace_id?: string;
+  parent_span_id?: string;
+};

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -26,6 +26,7 @@ export type SpanEntry = {
 };
 
 export type SentryTransactionEvent = {
+  title?: string;
   entries: Array<SpanEntry>;
   startTimestamp: number;
   endTimestamp: number;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -25,22 +25,6 @@ export type SpanEntry = {
   data: Array<RawSpanType>;
 };
 
-export type SentryTransactionEvent = {
-  title?: string;
-  entries: Array<SpanEntry>;
-  startTimestamp: number;
-  endTimestamp: number;
-  sdk?: {
-    name?: string;
-  };
-
-  // TODO(alberto):
-  // TODO(ts): type this
-  contexts?: {
-    trace?: any;
-  };
-};
-
 export type SpanChildrenLookupType = {[span_id: string]: Array<RawSpanType>};
 
 export type ParsedTraceType = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import set from 'lodash/set';
 import isNumber from 'lodash/isNumber';
 
+import {SentryTransactionEvent} from 'app/types';
 import CHART_PALETTE from 'app/constants/chartPalette';
 
 import {
@@ -11,7 +12,6 @@ import {
   GapSpanType,
   RawSpanType,
   SpanEntry,
-  SentryTransactionEvent,
   TraceContextType,
 } from './types';
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -382,7 +382,7 @@ export function getSpanParentSpanID(span: ProcessedSpanType): string | undefined
 export function getTraceContext(
   event: Readonly<SentryTransactionEvent>
 ): TraceContextType | undefined {
- return event?.contexts?.trace;
+  return event?.contexts?.trace;
 }
 
 export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTraceType {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -382,9 +382,7 @@ export function getSpanParentSpanID(span: ProcessedSpanType): string | undefined
 export function getTraceContext(
   event: Readonly<SentryTransactionEvent>
 ): TraceContextType | undefined {
-  const traceContext: TraceContextType | undefined = event?.contexts?.trace;
-
-  return traceContext;
+ return event?.contexts?.trace;
 }
 
 export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTraceType {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1,4 +1,4 @@
-import {SpanEntry} from 'app/components/events/interfaces/spans/types';
+import {SpanEntry, TraceContextType} from 'app/components/events/interfaces/spans/types';
 import {API_ACCESS_SCOPES} from 'app/constants';
 import {Field} from 'app/views/settings/components/forms/type';
 import {PlatformKey} from 'app/data/platformCategories';
@@ -286,15 +286,22 @@ type SentryEventBase = {
   latestEventID: string | null;
 };
 
+export type SentryTransactionEvent = {
+  type: 'transaction';
+  title?: string;
+  entries: SpanEntry[];
+  startTimestamp: number;
+  endTimestamp: number;
+  sdk?: {
+    name?: string;
+  };
+  contexts?: {
+    trace?: TraceContextType;
+  };
+} & SentryEventBase;
+
 // This type is incomplete
-export type Event =
-  | ({type: string} & SentryEventBase)
-  | ({
-      type: 'transaction';
-      entries: SpanEntry[];
-      startTimestamp: number;
-      endTimestamp: number;
-    } & SentryEventBase);
+export type Event = ({type: string} & SentryEventBase) | SentryTransactionEvent;
 
 export type EventsStatsData = [number, {count: number}[]][];
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
@@ -7,10 +7,10 @@ import {
   SentryTransactionEvent,
   SpanEntry,
   RawSpanType,
+  TraceContextType,
 } from 'app/components/events/interfaces/spans/types';
 import {SectionHeading} from 'app/components/charts/styles';
 import {pickSpanBarColour} from 'app/components/events/interfaces/spans/utils';
-import {TraceContextType} from 'app/components/events/interfaces/spans/traceView';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import styled from '@emotion/styled';
 import isFinite from 'lodash/isFinite';
 
-import {Event} from 'app/types';
+import {Event, SentryTransactionEvent} from 'app/types';
 import {
-  SentryTransactionEvent,
   SpanEntry,
   RawSpanType,
   TraceContextType,


### PR DESCRIPTION
![Screen Shot 2020-04-08 at 8 53 05 PM](https://user-images.githubusercontent.com/139499/78846945-68b96280-79db-11ea-87e4-56692a1aea48.png)

I'm going to create some acceptance tests for this feature in a new PR.

## TODO

- [x] `hideCloseButton` prop for AlertMessage component - https://github.com/getsentry/sentry/pull/18173
- [x] https://github.com/getsentry/sentry/pull/18171
- [x] https://github.com/getsentry/sentry/pull/18260