### PR TITLE
security: bump pillow to 6.2.2

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -33,7 +33,7 @@ msgpack>=0.6.1,<0.7.0
 parsimonious==0.8.0
 petname>=2.6,<2.7
 phonenumberslite>=8.11.0,<8.12.0
-Pillow>=6.2.1,<7.0.0
+Pillow>=6.2.2,<7.0.0
 progressbar2>=3.32,<3.33
 psycopg2-binary>=2.7.0,<2.9.0
 PyJWT>=1.5.0,<1.6.0


### PR DESCRIPTION
https://pillow.readthedocs.io/en/stable/releasenotes/6.2.2.html#security

```
-> pillow, installed 6.2.1, affected <6.2.2, id 37782

libImaging/FliDecode.c in Pillow before 6.2.2 has an FLI buffer overflow. See: CVE-2020-5313.

--

-> pillow, installed 6.2.1, affected <6.2.2, id 37781

libImaging/PcxDecode.c in Pillow before 6.2.2 has a PCX P mode buffer overflow. See:CVE-2020-5312.

--

-> pillow, installed 6.2.1, affected <6.2.2, id 37780

libImaging/SgiRleDecode.c in Pillow before 6.2.2 has an SGI buffer overflow. See: CVE-2020-5311.

--

-> pillow, installed 6.2.1, affected <6.2.2, id 37779

libImaging/TiffDecode.c in Pillow before 6.2.2 has a TIFF decoding integer overflow, related to realloc. See: CVE-2020-5310.

--

-> pillow, installed 6.2.1, affected >6.0,<6.2.2, id 37772

There is a DoS vulnerability in Pillow before 6.2.2 caused by FpxImagePlugin.py calling the range function on an unvalidated 32-bit integer if the number of bands is large. On Windows running 32-bit Python, this results in an OverflowError or MemoryError due to the 2 GB limit. However, on Linux running 64-bit Python this results in the process being terminated by the OOM killer. See: CVE-2019-19911.
```