### PR TITLE
fix(sessions): Add a second to end at all times

### DIFF
--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -363,7 +363,7 @@ def get_project_release_stats(project_id, release, stat, rollup, start, end, env
     # since snuba end queries are exclusive of the time and we're bucketing to
     # a full hour, we need to round to the next hour and add an extra second since
     # snuba is exclusive on the end.
-    end = to_datetime(to_timestamp(end) // DATASET_BUCKET + DATASET_BUCKET + 1)
+    end = to_datetime(to_timestamp(end) // DATASET_BUCKET * DATASET_BUCKET + 1)
 
     filter_keys = {"project_id": [project_id]}
     conditions = [["release", "=", release]]

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -8,6 +8,9 @@ from sentry.utils.dates import to_timestamp, to_datetime
 from sentry.snuba.dataset import Dataset
 
 
+DATASET_BUCKET = 3600
+
+
 def _convert_duration(val):
     if val != val:
         return None
@@ -358,8 +361,9 @@ def get_project_release_stats(project_id, release, stat, rollup, start, end, env
     assert stat in ("users", "sessions")
 
     # since snuba end queries are exclusive of the time and we're bucketing to
-    # a full hour, we need to round to the next hour.
-    end = to_datetime((to_timestamp(end) // 3600 + 1) * 3600)
+    # a full hour, we need to round to the next hour and add an extra second since
+    # snuba is exclusive on the end.
+    end = to_datetime(to_timestamp(end) // DATASET_BUCKET + DATASET_BUCKET + 1)
 
     filter_keys = {"project_id": [project_id]}
     conditions = [["release", "=", release]]

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -363,7 +363,7 @@ def get_project_release_stats(project_id, release, stat, rollup, start, end, env
     # since snuba end queries are exclusive of the time and we're bucketing to
     # a full hour, we need to round to the next hour and add an extra second since
     # snuba is exclusive on the end.
-    end = to_datetime(to_timestamp(end) // DATASET_BUCKET * DATASET_BUCKET + 1)
+    end = to_datetime(to_timestamp(end) // DATASET_BUCKET * (DATASET_BUCKET + 1) + 1)
 
     filter_keys = {"project_id": [project_id]}
     conditions = [["release", "=", release]]

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -4,7 +4,7 @@ import pytz
 from datetime import datetime, timedelta
 
 from sentry.utils.snuba import raw_query, parse_snuba_datetime
-from sentry.utils.dates import to_timestamp
+from sentry.utils.dates import to_timestamp, to_datetime
 from sentry.snuba.dataset import Dataset
 
 
@@ -356,6 +356,10 @@ def get_crash_free_breakdown(project_id, release, start, environments=None):
 
 def get_project_release_stats(project_id, release, stat, rollup, start, end, environments=None):
     assert stat in ("users", "sessions")
+
+    # since snuba end queries are exclusive of the time and we're bucketing to
+    # a full hour, we need to round to the next hour.
+    end = to_datetime((to_timestamp(end) // 3600 + 1) * 3600)
 
     filter_keys = {"project_id": [project_id]}
     conditions = [["release", "=", release]]

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -361,9 +361,9 @@ def get_project_release_stats(project_id, release, stat, rollup, start, end, env
     assert stat in ("users", "sessions")
 
     # since snuba end queries are exclusive of the time and we're bucketing to
-    # a full hour, we need to round to the next hour and add an extra second since
-    # snuba is exclusive on the end.
-    end = to_datetime(to_timestamp(end) // DATASET_BUCKET * (DATASET_BUCKET + 1) + 1)
+    # a full hour, we need to round to the next hour since snuba is exclusive
+    # on the end.
+    end = to_datetime(to_timestamp(end) // DATASET_BUCKET * (DATASET_BUCKET + 1))
 
     filter_keys = {"project_id": [project_id]}
     conditions = [["release", "=", release]]

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -363,7 +363,7 @@ def get_project_release_stats(project_id, release, stat, rollup, start, end, env
     # since snuba end queries are exclusive of the time and we're bucketing to
     # a full hour, we need to round to the next hour since snuba is exclusive
     # on the end.
-    end = to_datetime(to_timestamp(end) // DATASET_BUCKET * (DATASET_BUCKET + 1))
+    end = to_datetime((to_timestamp(end) // DATASET_BUCKET + 1) * DATASET_BUCKET)
 
     filter_keys = {"project_id": [project_id]}
     conditions = [["release", "=", release]]

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -490,7 +490,10 @@ class SnubaQueryParams(object):
         # TODO: instead of having events be the default, make dataset required.
         self.dataset = dataset or Dataset.Events
         self.start = start or datetime.utcfromtimestamp(0)  # will be clamped to project retention
-        self.end = end or datetime.utcnow() + timedelta(seconds=1)
+        # Snuba has end exclusive but our UI wants it generally to be inclusive.
+        # Since we also have hourly bucketed data in the session data set.
+        # This also shows up in unittests: https://github.com/getsentry/sentry/pull/15939
+        self.end = (end or datetime.utcnow()) + timedelta(seconds=1)
         self.groupby = groupby or []
         self.conditions = conditions or []
         self.aggregations = aggregations or []

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -491,9 +491,10 @@ class SnubaQueryParams(object):
         self.dataset = dataset or Dataset.Events
         self.start = start or datetime.utcfromtimestamp(0)  # will be clamped to project retention
         # Snuba has end exclusive but our UI wants it generally to be inclusive.
-        # Since we also have hourly bucketed data in the session data set.
-        # This also shows up in unittests: https://github.com/getsentry/sentry/pull/15939
-        self.end = (end or datetime.utcnow()) + timedelta(seconds=1)
+        # This shows up in unittests: https://github.com/getsentry/sentry/pull/15939
+        # We generally however require that the API user is aware of the exclusive
+        # end.
+        self.end = end or datetime.utcnow() + timedelta(seconds=1)
         self.groupby = groupby or []
         self.conditions = conditions or []
         self.aggregations = aggregations or []


### PR DESCRIPTION
This is a continuation of https://github.com/getsentry/sentry/pull/15939

Since our buckets in the release system are full hours an extra fix is needed for sessions where we make sure we're in the next bucket.

I think the right fix longer term is to make snuba inclusive.