### PR TITLE
feat(command-palette): Provide hook for additional actions

### DIFF
--- a/src/sentry/static/sentry/app/components/hook.tsx
+++ b/src/sentry/static/sentry/app/components/hook.tsx
@@ -52,12 +52,12 @@ function Hook<H extends HookName>({name, ...props}: Props<H>) {
     render() {
       const {children} = props;
 
-      if (!this.state.hooks || !this.state.hooks.length) {
-        return null;
-      }
-
       if (typeof children === 'function') {
         return children({hooks: this.state.hooks});
+      }
+
+      if (!this.state.hooks || !this.state.hooks.length) {
+        return null;
       }
 
       return this.state.hooks;

--- a/src/sentry/static/sentry/app/components/search/sources/commandSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/commandSource.jsx
@@ -5,6 +5,7 @@ import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import {openSudo, openHelpSearchModal} from 'app/actionCreators/modal';
 import {toggleLocaleDebug} from 'app/locale';
 import Access from 'app/components/acl/access';
+import Hook from 'app/components/hook';
 
 const ACTIONS = [
   {
@@ -54,6 +55,9 @@ class CommandSource extends React.Component {
     // Array of routes to search
     searchMap: PropTypes.array,
 
+    // Array of actions to add
+    actions: PropTypes.array,
+
     isSuperuser: PropTypes.bool,
 
     /**
@@ -79,7 +83,7 @@ class CommandSource extends React.Component {
   }
 
   componentDidMount() {
-    this.createSearch(ACTIONS);
+    this.createSearch(this.props.actions);
   }
 
   async createSearch(searchMap) {
@@ -117,9 +121,19 @@ class CommandSource extends React.Component {
   }
 }
 
+const CommandSourceWithHooks = props => (
+  <Hook name="command-palette:action">
+    {({hooks}) => <CommandSource {...props} actions={[...hooks, ...ACTIONS]} />}
+  </Hook>
+);
+
 const CommandSourceWithFeature = props => (
   <Access isSuperuser>
-    {({hasSuperuser}) => <CommandSource {...props} isSuperuser={hasSuperuser} />}
+    {({hasSuperuser}) => (
+      <React.Fragment>
+        <CommandSourceWithHooks {...props} isSuperuser={hasSuperuser} />
+      </React.Fragment>
+    )}
   </Access>
 );
 

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -105,6 +105,7 @@ export type InterfaceChromeHooks = {
   'sidebar:organization-dropdown-menu': GenericOrganizationComponentHook;
   'sidebar:bottom-items': SidebarBottomItemsHook;
   'sidebar:item-label': SidebarItemLabelHook;
+  'command-palette:action': CommandPaletteAction;
 };
 
 /**
@@ -264,6 +265,14 @@ type SidebarItemLabelHook = () => React.ComponentType<{
    */
   id?: string;
 }>;
+
+// TODO(ts): When we convert search to use typescript we should remove the any
+// here and use the search item type.
+
+/**
+ * Adds a new command to the global command palette search.
+ */
+type CommandPaletteAction = () => any;
 
 /**
  * Returns an additional list of sidebar items.


### PR DESCRIPTION
This allows hooks to provide additional command palette actions via a defined hook.