### PR TITLE
feat(ui): Add footer to discover chart on release detail page

### DIFF
--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -52,8 +52,8 @@ class EventsAreaChart extends React.Component {
 
   render() {
     const {
-      loading, // eslint-disable-line no-unused-vars
-      reloading, // eslint-disable-line no-unused-vars
+      loading: _loading,
+      reloading: _reloading,
       releaseSeries,
       zoomRenderProps,
       timeseriesData,
@@ -115,6 +115,9 @@ class EventsChart extends React.Component {
     router: PropTypes.object,
     showLegend: PropTypes.bool,
     yAxis: PropTypes.string,
+    disablePrevious: PropTypes.bool,
+    currentSeriesName: PropTypes.string,
+    previousSeriesName: PropTypes.string,
   };
 
   render() {
@@ -130,11 +133,17 @@ class EventsChart extends React.Component {
       environments,
       showLegend,
       yAxis,
+      disablePrevious,
+      currentSeriesName: currentName,
+      previousSeriesName: previousName,
       ...props
     } = this.props;
     // Include previous only on relative dates (defaults to relative if no start and end)
-    const includePrevious = !start && !end;
-    const previousSeriesName = yAxis ? t('previous %s', yAxis) : undefined;
+    const includePrevious = !disablePrevious && !start && !end;
+
+    const previousSeriesName =
+      previousName ?? yAxis ? t('previous %s', yAxis) : undefined;
+    const currentSeriesName = currentName ?? yAxis;
 
     const tooltip = {
       valueFormatter(value) {
@@ -171,7 +180,7 @@ class EventsChart extends React.Component {
             showLoading={false}
             query={query}
             includePrevious={includePrevious}
-            currentSeriesName={yAxis}
+            currentSeriesName={currentSeriesName}
             previousSeriesName={previousSeriesName}
             yAxis={yAxis}
           >
@@ -200,7 +209,7 @@ class EventsChart extends React.Component {
                           releaseSeries={releaseSeries}
                           timeseriesData={timeseriesData}
                           previousTimeseriesData={previousTimeseriesData}
-                          currentSeriesName={yAxis}
+                          currentSeriesName={currentSeriesName}
                           previousSeriesName={previousSeriesName}
                         />
                       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/breadcrumbs.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/breadcrumbs.tsx
@@ -18,7 +18,7 @@ type Props = {
 const Breadcrumbs = ({crumbs}: Props) => (
   <BreadcrumbList>
     {crumbs.map((crumb, index) => (
-      <React.Fragment key={crumb.to}>
+      <React.Fragment key={crumb.label}>
         <BreadcrumbItem to={crumb.to || ''}>{crumb.label}</BreadcrumbItem>
         {index < crumbs.length - 1 && <StyledIcon size="xs" direction="right" />}
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/discoverChartContainer.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/discoverChartContainer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {Location} from 'history';
 import * as ReactRouter from 'react-router';
-import * as Sentry from '@sentry/browser';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
@@ -59,16 +58,12 @@ class DiscoverChartContainer extends React.Component<Props, State> {
   async fetchTotalCount() {
     const {api, organization, location} = this.props;
 
-    try {
-      const totalEvents = await fetchTotalCount(
-        api,
-        organization.slug,
-        this.getEventView().getEventsAPIPayload(location)
-      );
-      this.setState({totalEvents});
-    } catch (err) {
-      Sentry.captureException(err);
-    }
+    const totalEvents = await fetchTotalCount(
+      api,
+      organization.slug,
+      this.getEventView().getEventsAPIPayload(location)
+    );
+    this.setState({totalEvents});
   }
 
   getEventView(): EventView {

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/discoverChartContainer.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/discoverChartContainer.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {Location} from 'history';
 import * as ReactRouter from 'react-router';
+import * as Sentry from '@sentry/browser';
 import styled from '@emotion/styled';
+import isEqual from 'lodash/isEqual';
 
 import {Organization, GlobalSelection} from 'app/types';
 import space from 'app/styles/space';
@@ -10,9 +12,16 @@ import {Client} from 'app/api';
 import {formatVersion} from 'app/utils/formatters';
 import EventView from 'app/utils/discover/eventView';
 import {EventsChart} from 'app/views/events/eventsChart';
+import {fetchTotalCount} from 'app/actionCreators/events';
 import {getUtcDateString} from 'app/utils/dates';
 import {Panel} from 'app/components/panels';
 import getDynamicText from 'app/utils/getDynamicText';
+import {
+  ChartControls,
+  InlineContainer,
+  SectionHeading,
+  SectionValue,
+} from 'app/components/charts/styles';
 
 type Props = {
   organization: Organization;
@@ -23,7 +32,45 @@ type Props = {
   version: string;
 };
 
-class DiscoverChartContainer extends React.Component<Props> {
+type State = {
+  totalEvents: null | number;
+};
+
+class DiscoverChartContainer extends React.Component<Props, State> {
+  state: State = {
+    totalEvents: null,
+  };
+
+  componentDidMount() {
+    this.fetchTotalCount();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const {version, organization, selection} = this.props;
+    if (
+      prevProps.version !== version ||
+      !isEqual(prevProps.organization, organization) ||
+      !isEqual(prevProps.selection, selection)
+    ) {
+      this.fetchTotalCount();
+    }
+  }
+
+  async fetchTotalCount() {
+    const {api, organization, location} = this.props;
+
+    try {
+      const totalEvents = await fetchTotalCount(
+        api,
+        organization.slug,
+        this.getEventView().getEventsAPIPayload(location)
+      );
+      this.setState({totalEvents});
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+  }
+
   getEventView(): EventView {
     const {selection, version} = this.props;
     const {projects, environments, datetime} = selection;
@@ -47,28 +94,42 @@ class DiscoverChartContainer extends React.Component<Props> {
   }
 
   render() {
+    const {totalEvents} = this.state;
     const {organization, location, api, router, selection} = this.props;
     const {projects, environments, datetime} = selection;
     const {start, end, period, utc} = datetime;
+    const eventView = this.getEventView();
 
     return (
       <StyledPanel>
         {getDynamicText({
           value: (
-            <EventsChart
-              router={router}
-              organization={organization}
-              showLegend
-              yAxis={undefined}
-              query={this.getEventView().getEventsAPIPayload(location).query}
-              api={api}
-              projects={projects}
-              environments={environments}
-              start={start}
-              end={end}
-              period={period}
-              utc={utc}
-            />
+            <React.Fragment>
+              <EventsChart
+                router={router}
+                organization={organization}
+                showLegend
+                yAxis={eventView.getYAxis()}
+                query={eventView.getEventsAPIPayload(location).query}
+                api={api}
+                projects={projects}
+                environments={environments}
+                start={start}
+                end={end}
+                period={period}
+                utc={utc}
+                disablePrevious
+                currentSeriesName={t('Events')}
+              />
+              <ChartControls>
+                <InlineContainer>
+                  <SectionHeading>{t('Total Events')}</SectionHeading>
+                  <SectionValue>
+                    {totalEvents === null ? '\u2015' : totalEvents.toLocaleString()}
+                  </SectionValue>
+                </InlineContainer>
+              </ChartControls>
+            </React.Fragment>
           ),
           fixed: 'events chart',
         })}

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -12,6 +12,7 @@ import {Client} from 'app/api';
 import withApi from 'app/utils/withApi';
 import {formatVersion} from 'app/utils/formatters';
 import routeTitleGen from 'app/utils/routeTitle';
+import Feature from 'app/components/acl/feature';
 
 import ReleaseChartContainer from './chart';
 import Issues from './issues';
@@ -92,19 +93,21 @@ class ReleaseOverview extends AsyncView<Props> {
                         {...releaseStatsProps}
                       />
                     ) : (
-                      // TODO(releasesV2): feature flag?
-                      <DiscoverChartContainer
-                        organization={organization}
-                        selection={selection}
-                        location={location}
-                        api={api}
-                        router={router}
-                        version={version}
-                      />
+                      <Feature features={['discover-basic']}>
+                        <DiscoverChartContainer
+                          organization={organization}
+                          selection={selection}
+                          location={location}
+                          api={api}
+                          router={router}
+                          version={version}
+                        />
+                      </Feature>
                     )}
+
                     <Issues
                       orgId={organization.slug}
-                      projectId={project.id}
+                      selection={selection}
                       version={version}
                       location={location}
                     />


### PR DESCRIPTION
This PR adds a footer to discover chart on release detail page.
This chart is shown instead of health stats chart when no health data are available.
We also hid this chart behind a feature flag and added new props to the event chart to be able to reuse it.

![image](https://user-images.githubusercontent.com/9060071/78258116-0d7b0200-74fb-11ea-948b-948c19063277.png)

I would like to move `app/views/events/eventsChart.jsx ` to  `app/components/chart` in later PR now that it's being reused.