### PR TITLE
fix(ingest): Do not crash the consumer on minidump attachments

### DIFF
--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -217,7 +217,9 @@ def process_individual_attachment(message, projects):
     attachment = attachment_cache.get_from_chunks(
         key=cache_key, type=attachment.pop("attachment_type"), **attachment
     )
-    assert attachment.type == "event.attachment", attachment.type
+    if attachment.type != "event.attachment":
+        logger.exception("invalid individual attachment type: %s", attachment.type)
+        return
 
     file = File.objects.create(
         name=attachment.name,


### PR DESCRIPTION
The events consumer crashes when minidumps are ingested as individual attachments. This is a Relay bug, but should not crash the consumer and instead skip the messages.

Fixes SENTRY-FT0