### PR TITLE
fix(heroku) Fix KeyError when trying to read user data

### DIFF
--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -17,7 +17,11 @@ logger = logging.getLogger("sentry.plugins.heroku")
 
 class HerokuReleaseHook(ReleaseHook):
     def handle(self, request):
-        email = request.POST["user"]
+        email = None
+        if "user" in request.POST:
+            email = request.POST["user"]
+        elif "actor" in request.POST:
+            email = request.POST["actor"].get("email")
         try:
             user = User.objects.get(
                 email__iexact=email, sentry_orgmember_set__organization__project=self.project


### PR DESCRIPTION
In addition to not failing on the `user` key missing add fallbacks for actor.email as that comes in a lot of our hook events.

Fixes SENTRY-BRW