### PR TITLE
fix(discover) Change error rate to ignore unknown

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1099,7 +1099,7 @@ FUNCTIONS = {
     "error_rate": {
         "name": "error_rate",
         "args": [],
-        "transform": "divide(countIf(notEquals(transaction_status, 0)), count())",
+        "transform": "divide(countIf(and(notEquals(transaction_status, 0), notEquals(transaction_status, 2))), count())",
         "result_type": "number",
     },
     # The user facing signature for this function is histogram(<column>, <num_buckets>)

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -529,7 +529,11 @@ class QueryTransformTest(TestCase):
         mock_query.assert_called_with(
             selected_columns=["transaction"],
             aggregations=[
-                ["divide(countIf(notEquals(transaction_status, 0)), count())", None, "error_rate"],
+                [
+                    "divide(countIf(and(notEquals(transaction_status, 0), notEquals(transaction_status, 2))), count())",
+                    None,
+                    "error_rate",
+                ],
                 ["argMax", ["event_id", "timestamp"], "latest_event"],
                 ["argMax", ["project_id", "timestamp"], "projectid"],
                 [

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -681,43 +681,36 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
         project = self.create_project()
         data = load_data("transaction")
-        data["transaction"] = "/error_rate/1"
+        data["transaction"] = "/error_rate/success"
         data["timestamp"] = iso_format(before_now(minutes=1))
         data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
-        event = self.store_event(data, project_id=project.id)
-
-        data = load_data("transaction")
-        data["transaction"] = "/error_rate/1"
-        data["timestamp"] = iso_format(before_now(minutes=1))
-        data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
-        data["contexts"]["trace"]["status"] = "unauthenticated"
         self.store_event(data, project_id=project.id)
 
         data = load_data("transaction")
-        data["transaction"] = "/error_rate/1"
+        data["transaction"] = "/error_rate/unknown"
         data["timestamp"] = iso_format(before_now(minutes=1))
         data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
-        data["contexts"]["trace"]["status"] = "unauthenticated"
+        data["contexts"]["trace"]["status"] = "unknown_error"
         self.store_event(data, project_id=project.id)
 
-        data = load_data("transaction")
-        data["transaction"] = "/error_rate/1"
-        data["timestamp"] = iso_format(before_now(minutes=1))
-        data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
-        data["contexts"]["trace"]["status"] = "unauthenticated"
-        self.store_event(data, project_id=project.id)
+        for i in range(6):
+            data = load_data("transaction")
+            data["transaction"] = "/error_rate/{}".format(i)
+            data["timestamp"] = iso_format(before_now(minutes=1))
+            data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
+            data["contexts"]["trace"]["status"] = "unauthenticated"
+            self.store_event(data, project_id=project.id)
 
         with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
-                data={"field": ["transaction", "error_rate()"], "query": "event.type:transaction"},
+                data={"field": ["error_rate()"], "query": "event.type:transaction"},
             )
 
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         data = response.data["data"]
-        assert data[0]["transaction"] == event.transaction
         assert data[0]["error_rate"] == 0.75
 
     def test_aggregation(self):


### PR DESCRIPTION
Previously we were counting transactions with an unknown status as errors.
Change error rate to count those as successes to avoid cluttering up the
numbers.