### PR TITLE
Create mail sub-project and migrate `get_send_to` out of `MailPlugin`

### DIFF
--- a/src/sentry/mail/__init__.py
+++ b/src/sentry/mail/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -1,0 +1,83 @@
+from __future__ import absolute_import
+
+import logging
+
+from sentry.models import ProjectOwnership, User
+
+from sentry.utils import metrics
+from sentry.utils.cache import cache
+
+logger = logging.getLogger(__name__)
+
+
+class MailAdapter(object):
+    """
+    This class contains generic logic for notifying users via Email. Short term we'll
+    logic into this class from `MailPlugin` and have `MailPlugin` use the Adapter.
+    Once this is complete, we'll update logic in here to handle more cases for mail,
+    and eventually deprecate `MailPlugin` entirely.
+    """
+
+    def get_send_to(self, project, event=None):
+        """
+        Returns a list of user IDs for the users that should receive
+        notifications for the provided project.
+
+        This result may come from cached data.
+        """
+        if not (project and project.teams.exists()):
+            logger.debug("Tried to send notification to invalid project: %r", project)
+            return []
+
+        if event:
+            owners, _ = ProjectOwnership.get_owners(project.id, event.data)
+            if owners != ProjectOwnership.Everyone:
+                if not owners:
+                    metrics.incr(
+                        "features.owners.send_to",
+                        tags={"organization": project.organization_id, "outcome": "empty"},
+                        skip_internal=True,
+                    )
+                    return []
+
+                metrics.incr(
+                    "features.owners.send_to",
+                    tags={"organization": project.organization_id, "outcome": "match"},
+                    skip_internal=True,
+                )
+                send_to_list = set()
+                teams_to_resolve = set()
+                for owner in owners:
+                    if owner.type == User:
+                        send_to_list.add(owner.id)
+                    else:
+                        teams_to_resolve.add(owner.id)
+
+                # get all users in teams
+                if teams_to_resolve:
+                    send_to_list |= set(
+                        User.objects.filter(
+                            is_active=True,
+                            sentry_orgmember_set__organizationmemberteam__team__id__in=teams_to_resolve,
+                        ).values_list("id", flat=True)
+                    )
+
+                alert_settings = project.get_member_alert_settings(self.alert_option_key)
+                disabled_users = set(
+                    user for user, setting in alert_settings.items() if setting == 0
+                )
+                return send_to_list - disabled_users
+            else:
+                metrics.incr(
+                    "features.owners.send_to",
+                    tags={"organization": project.organization_id, "outcome": "everyone"},
+                    skip_internal=True,
+                )
+
+        cache_key = "%s:send_to:%s" % (self.get_conf_key(), project.pk)
+        send_to_list = cache.get(cache_key)
+        if send_to_list is None:
+            send_to_list = [s for s in self.get_sendable_users(project) if s]
+            cache.set(cache_key, send_to_list, 60)  # 1 minute cache
+
+        return send_to_list

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -18,6 +18,15 @@ class MailAdapter(object):
     and eventually deprecate `MailPlugin` entirely.
     """
 
+    alert_option_key = "mail:alert"
+
+    def get_sendable_users(self, project):
+        """
+        Return a collection of user IDs that are eligible to receive
+        notifications for the provided project.
+        """
+        return project.get_notification_recipients(self.alert_option_key)
+
     def get_send_to(self, project, event=None):
         """
         Returns a list of user IDs for the users that should receive
@@ -74,7 +83,7 @@ class MailAdapter(object):
                     skip_internal=True,
                 )
 
-        cache_key = "%s:send_to:%s" % (self.get_conf_key(), project.pk)
+        cache_key = "mail:send_to:{}".format(project.pk)
         send_to_list = cache.get(cache_key)
         if send_to_list is None:
             send_to_list = [s for s in self.get_sendable_users(project) if s]

--- a/tests/sentry/mail/__init__.py
+++ b/tests/sentry/mail/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1,0 +1,155 @@
+from __future__ import absolute_import
+
+from exam import fixture
+
+from sentry.models import (
+    OrganizationMember,
+    OrganizationMemberTeam,
+    ProjectOwnership,
+    User,
+    UserOption,
+)
+from sentry.event_manager import EventManager, get_event_type
+from sentry.mail.adapter import MailAdapter
+from sentry.ownership.grammar import dump_schema, Matcher, Owner, Rule
+from sentry.testutils import TestCase
+
+
+class BaseMailAdapterTest(object):
+    @fixture
+    def adapter(self):
+        return MailAdapter()
+
+
+class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
+    def setUp(self):
+        self.user = self.create_user(email="foo@example.com", is_active=True)
+        self.user2 = self.create_user(email="baz@example.com", is_active=True)
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
+
+        self.project = self.create_project(name="Test", teams=[self.team])
+        OrganizationMemberTeam.objects.create(
+            organizationmember=OrganizationMember.objects.get(
+                user=self.user, organization=self.organization
+            ),
+            team=self.team,
+        )
+        self.create_member(user=self.user2, organization=self.organization, teams=[self.team])
+        ProjectOwnership.objects.create(
+            project_id=self.project.id,
+            schema=dump_schema(
+                [
+                    Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)]),
+                    Rule(Matcher("path", "*.jx"), [Owner("user", self.user2.email)]),
+                    Rule(
+                        Matcher("path", "*.cbl"),
+                        [Owner("user", self.user.email), Owner("user", self.user2.email)],
+                    ),
+                ]
+            ),
+            fallthrough=True,
+        )
+
+    def make_event_data(self, filename, url="http://example.com"):
+        mgr = EventManager(
+            {
+                "tags": [("level", "error")],
+                "stacktrace": {"frames": [{"lineno": 1, "filename": filename}]},
+                "request": {"url": url},
+            }
+        )
+        mgr.normalize()
+        data = mgr.get_data()
+        event_type = get_event_type(data)
+        data["type"] = event_type.key
+        data["metadata"] = event_type.get_metadata(data)
+        return data
+
+    def test_get_send_to_with_team_owners(self):
+        event = self.store_event(data=self.make_event_data("foo.py"), project_id=self.project.id)
+        assert sorted(set([self.user.pk, self.user2.pk])) == sorted(
+            self.adapter.get_send_to(self.project, event.data)
+        )
+
+        # Make sure that disabling mail alerts works as expected
+        UserOption.objects.set_value(
+            user=self.user2, key="mail:alert", value=0, project=self.project
+        )
+        assert set([self.user.pk]) == self.adapter.get_send_to(self.project, event.data)
+
+    def test_get_send_to_with_user_owners(self):
+        event = self.store_event(data=self.make_event_data("foo.cbl"), project_id=self.project.id)
+        assert sorted(set([self.user.pk, self.user2.pk])) == sorted(
+            self.adapter.get_send_to(self.project, event.data)
+        )
+
+        # Make sure that disabling mail alerts works as expected
+        UserOption.objects.set_value(
+            user=self.user2, key="mail:alert", value=0, project=self.project
+        )
+        assert set([self.user.pk]) == self.adapter.get_send_to(self.project, event.data)
+
+    def test_get_send_to_with_user_owner(self):
+        event = self.store_event(data=self.make_event_data("foo.jx"), project_id=self.project.id)
+        assert set([self.user2.pk]) == self.adapter.get_send_to(self.project, event.data)
+
+    def test_get_send_to_with_fallthrough(self):
+        event = self.store_event(data=self.make_event_data("foo.cpp"), project_id=self.project.id)
+        assert set([self.user.pk, self.user2.pk]) == set(
+            self.adapter.get_send_to(self.project, event.data)
+        )
+
+    def test_get_send_to_without_fallthrough(self):
+        ProjectOwnership.objects.get(project_id=self.project.id).update(fallthrough=False)
+        event = self.store_event(data=self.make_event_data("foo.cpp"), project_id=self.project.id)
+        assert [] == self.adapter.get_send_to(self.project, event.data)
+
+
+class MailAdapterGetSendableUsersTest(BaseMailAdapterTest, TestCase):
+    def test_get_sendable_users(self):
+        user = self.create_user(email="foo@example.com", is_active=True)
+        user2 = self.create_user(email="baz@example.com", is_active=True)
+        self.create_user(email="baz2@example.com", is_active=True)
+
+        # user with inactive account
+        self.create_user(email="bar@example.com", is_active=False)
+        # user not in any groups
+        self.create_user(email="bar2@example.com", is_active=True)
+
+        organization = self.create_organization(owner=user)
+        team = self.create_team(organization=organization)
+
+        project = self.create_project(name="Test", teams=[team])
+        OrganizationMemberTeam.objects.create(
+            organizationmember=OrganizationMember.objects.get(user=user, organization=organization),
+            team=team,
+        )
+        self.create_member(user=user2, organization=organization, teams=[team])
+
+        # all members
+        assert sorted(set([user.pk, user2.pk])) == sorted(self.adapter.get_sendable_users(project))
+
+        # disabled user2
+        UserOption.objects.create(key="mail:alert", value=0, project=project, user=user2)
+
+        assert user2.pk not in self.adapter.get_sendable_users(project)
+
+        user4 = User.objects.create(username="baz4", email="bar@example.com", is_active=True)
+        self.create_member(user=user4, organization=organization, teams=[team])
+        assert user4.pk in self.adapter.get_sendable_users(project)
+
+        # disabled by default user4
+        uo1 = UserOption.objects.create(
+            key="subscribe_by_default", value="0", project=project, user=user4
+        )
+
+        assert user4.pk not in self.adapter.get_sendable_users(project)
+
+        uo1.delete()
+
+        UserOption.objects.create(
+            key="subscribe_by_default", value=u"0", project=project, user=user4
+        )
+
+        assert user4.pk not in self.adapter.get_sendable_users(project)


### PR DESCRIPTION
We want to move away from using the deprecated `MailPlugin`, and also merge @jeffkwoh's work from https://github.com/getsentry/sentry/pull/17571. At the moment that PR feels risky, so my plan is to take the `MailAdapter` concept, migrate the existing functionality from `MailPlugin` into it and have `MailPlugin` just use `MailAdapter`. Then when we're confident that work well, we can add in Jeff's changes and move towards deprecating `MailPlugin` entirely.

This first step just adds the `MailAdapter` and ports over `get_send_to` and anything related it needs to work, and has `MailPlugin` start using the adaptor. I've set up this PR so that there are two commits - the first commit just blanket copies things in an unworking state from `MailPlugin`. The second commit has all the modifications needed to make things work, so for easy of review it's probably best to just look at the diff of the second commit.

Tests are duplicated from `MailPlugin`. We'll eventually remove the `MailPlugin` tests once we deprecate, but they help make sure it's still working as expected for the moment.