### PR TITLE
feat(devserver): Add parameter to not start individual daemons

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -63,6 +63,11 @@ def devserver(
     reload, watchers, workers, experimental_spa, styleguide, prefix, environment, skip_daemons, bind
 ):
     "Starts a lightweight web server for development."
+    skip_daemons = set(skip_daemons.split(",")) if skip_daemons else set()
+    if skip_daemons.difference(_DEFAULT_DAEMONS.keys()):
+        unrecognized_daemons = skip_daemons.difference(_DEFAULT_DAEMONS.keys())
+        raise click.ClickException("Not a daemon name: {}".format(", ".join(unrecognized_daemons)))
+
     if bind is None:
         # default configuration, the dev server address depends on weather we have a reverse proxy
         # in front that splits the requests between Relay and the dev server or we pass everything
@@ -246,12 +251,6 @@ def devserver(
 
     if styleguide:
         daemons += [_get_daemon("storybook")]
-
-    skip_daemons = set(skip_daemons.split(",")) if skip_daemons else set()
-    valid_daemon_names = set(name for (name, cmd) in daemons).union(_DEFAULT_DAEMONS.keys())
-    unrecognized_skips = skip_daemons.difference(valid_daemon_names)
-    if unrecognized_skips:
-        raise click.ClickException("Not a daemon name: {}".format(", ".join(unrecognized_skips)))
 
     cwd = os.path.realpath(os.path.join(settings.PROJECT_ROOT, os.pardir, os.pardir))
 

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -250,7 +250,12 @@ def devserver(
     if styleguide:
         daemons += [("storybook", ["./bin/yarn", "storybook"])]
 
-    skip_daemons = set(skip_daemons.split(",")) if skip_daemons else ()
+    skip_daemons = set(skip_daemons.split(",")) if skip_daemons else set()
+    valid_daemon_names = set(name for (name, cmd) in daemons).union(_DEFAULT_DAEMONS.keys())
+    unrecognized_skips = skip_daemons.difference(valid_daemon_names)
+    if unrecognized_skips:
+        raise click.ClickException("Not a daemon name: {}".format(", ".join(unrecognized_skips)))
+
     cwd = os.path.realpath(os.path.join(settings.PROJECT_ROOT, os.pardir, os.pardir))
 
     manager = Manager(Printer(prefix=prefix))

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -256,9 +256,8 @@ def devserver(
 
     manager = Manager(Printer(prefix=prefix))
     for name, cmd in daemons:
-        cmdline = list2cmdline(cmd)
         if name not in skip_daemons:
-            manager.add_process(name, cmdline, quiet=False, cwd=cwd)
+            manager.add_process(name, list2cmdline(cmd), quiet=False, cwd=cwd)
 
     manager.loop()
     sys.exit(manager.returncode)

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -9,16 +9,8 @@ from sentry.runner.decorators import configuration, log_options
 _DEFAULT_DAEMONS = {
     "worker": ["sentry", "run", "worker", "-c", "1", "--autoreload"],
     "cron": ["sentry", "run", "cron", "--autoreload"],
-    "post-process-forwarder": [
-        "sentry",
-        "run",
-        "post-process-forwarder",
-        "--loglevel=debug",
-        "--commit-batch-size=1",
-    ],
     "ingest": ["sentry", "run", "ingest-consumer", "--all-consumer-types"],
     "server": ["sentry", "run", "web"],
-    "storybook": ["./bin/yarn", "storybook"],
 }
 
 
@@ -195,7 +187,18 @@ def devserver(
         from sentry import eventstream
 
         if eventstream.requires_post_process_forwarder():
-            daemons += [_get_daemon("post-process-forwarder")]
+            daemons += [
+                (
+                    "post-process-forwarder",
+                    [
+                        "sentry",
+                        "run",
+                        "post-process-forwarder",
+                        "--loglevel=debug",
+                        "--commit-batch-size=1",
+                    ],
+                )
+            ]
 
     if settings.SENTRY_USE_RELAY:
         daemons += [_get_daemon("ingest")]
@@ -245,7 +248,7 @@ def devserver(
     daemons += [_get_daemon("server")]
 
     if styleguide:
-        daemons += [_get_daemon("storybook")]
+        daemons += [("storybook", ["./bin/yarn", "storybook"])]
 
     skip_daemons = set(skip_daemons.split(",")) if skip_daemons else ()
     cwd = os.path.realpath(os.path.join(settings.PROJECT_ROOT, os.pardir, os.pardir))

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -23,7 +23,10 @@ from sentry.runner.decorators import configuration, log_options
 )
 @click.option("--environment", default="development", help="The environment name.")
 @click.option(
-    "--skip", default=None, required=False, help="Names of daemons not to start (comma-delimited)"
+    "--skip-daemons",
+    default=None,
+    required=False,
+    help="Names of daemons not to start (comma-delimited)",
 )
 @click.option(
     "--experimental-spa/--no-experimental-spa",
@@ -36,7 +39,7 @@ from sentry.runner.decorators import configuration, log_options
 @log_options()
 @configuration
 def devserver(
-    reload, watchers, workers, experimental_spa, styleguide, prefix, environment, skip, bind
+    reload, watchers, workers, experimental_spa, styleguide, prefix, environment, skip_daemons, bind
 ):
     "Starts a lightweight web server for development."
     if bind is None:
@@ -237,13 +240,13 @@ def devserver(
     if styleguide:
         daemons += [("storybook", ["./bin/yarn", "storybook"])]
 
-    daemons_to_skip = set(skip.split(",")) if skip else ()
+    skip_daemons = set(skip_daemons.split(",")) if skip_daemons else ()
     cwd = os.path.realpath(os.path.join(settings.PROJECT_ROOT, os.pardir, os.pardir))
 
     manager = Manager(Printer(prefix=prefix))
     for name, cmd in daemons:
         cmdline = list2cmdline(cmd)
-        if name not in daemons_to_skip:
+        if name not in skip_daemons:
             click.echo("Adding daemon '{}' with command: {}".format(name, cmdline))
             manager.add_process(name, cmdline, quiet=False, cwd=cwd)
 


### PR DESCRIPTION
By default, the `devserver` command runs its components in external
processes, which precludes attaching a debugger to them conveniently.

The `--skip` parameter allows a developer to suppress certain daemons
but preserve the remainder of devserver's behavior. The developer may
then launch the suppressed daemons with separate `run` commands, so as
to debug them in stand-alone processes.