### PR TITLE
chore(ts): Improve acl/feature typing

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/feature.tsx
+++ b/src/sentry/static/sentry/app/components/acl/feature.tsx
@@ -11,84 +11,96 @@ import withProject from 'app/utils/withProject';
 
 import ComingSoon from './comingSoon';
 
-type FeatureProps = {
+type Props = {
+  /**
+   * The following properties will be set by the HoCs
+   */
+
   organization: Organization;
   project: Project;
   config: Config;
+  /**
+   * List of required feature tags. Note we do not enforce uniqueness of tags anywhere.
+   * On the backend end, feature tags have a scope prefix string that is stripped out on the
+   * frontend (since feature tags are attached to a context object).
+   *
+   * Use `organizations:` or `projects:` prefix strings to specify a feature with context.
+   */
   features: string[];
+  /**
+   * Should the component require all features or just one or more.
+   */
   requireAll?: boolean;
-  renderDisabled?: Function | boolean;
+  /**
+   * Custom renderer function for when the feature is not enabled.
+   *
+   *  - [default] Set this to false to disable rendering anything. If the
+   *    feature is not enabled no children will be rendererd.
+   *
+   *  - Set this to `true` to use the default `ComingSoon` alert component.
+   *
+   *  - Provide a custom render function to customize the rendered component.
+   *
+   * When a custom render function is used, the same object that would be
+   * passed to `children` if a func is provided there, will be used here,
+   * aditionally `children` will also be passed.
+   */
+  renderDisabled?:
+    | ((props: FeatureRenderProps & Pick<Props, 'children'>) => React.ReactNode)
+    | boolean;
+  /**
+   * Specify the key to use for hookstore functionality.
+   *
+   * The hookName should be prefixed with `feature-disabled`.
+   *
+   * When specified, the hookstore will be checked if the feature is
+   * disabled, and the first available hook will be used as the render
+   * function.
+   */
   hookName?: keyof FeatureDisabledHooks;
-  children: React.ReactNode;
+  /**
+   * If children is a function then will be treated as a render prop and
+   * passed FeatureRenderProps.
+   *
+   * The other interface is more simple, only show `children` if org/project has
+   * all the required feature.
+   */
+  children: React.ReactNode | ChildrenRenderFn;
 };
+
+type ChildrenRenderFn = (
+  props: FeatureRenderProps & Pick<Props, 'renderDisabled'>
+) => React.ReactNode;
+
+type FeatureRenderProps = {
+  organization: Organization;
+  project: Project;
+  features: string[];
+  hasFeature: boolean;
+};
+
+type AllFeatures = {
+  configFeatures: string[];
+  organization: string[];
+  project: string[];
+};
+
+function childrenIsRenderProp(children: Props['children']): children is ChildrenRenderFn {
+  return typeof children === 'function';
+}
 
 /**
  * Component to handle feature flags.
  */
-class Feature extends React.Component<FeatureProps> {
+class Feature extends React.Component<Props> {
   static propTypes = {
-    /**
-     * The following properties will be set by the HoCs
-     */
     organization: SentryTypes.Organization,
     project: SentryTypes.Project,
     config: SentryTypes.Config.isRequired,
-
-    /**
-     * List of required feature tags. Note we do not enforce uniqueness of tags anywhere.
-     * On the backend end, feature tags have a scope prefix string that is stripped out on the
-     * frontend (since feature tags are attached to a context object).
-     *
-     * Use `organizations:` or `projects:` prefix strings to specify a feature with context.
-     */
     features: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
-
-    /**
-     * Should the component require all features or just one or more.
-     */
     requireAll: PropTypes.bool,
-
-    /**
-     * Custom renderer function for when the feature is not enabled.
-     *
-     *  - [default] Set this to false to disable rendering anything. If the
-     *    feature is not enabled no children will be rendererd.
-     *
-     *  - Set this to `true` to use the default `ComingSoon` alert component.
-     *
-     *  - Provide a custom render function to customize the rendered component.
-     *
-     * When a custom render function is used, the same object that would be
-     * passed to `children` if a func is provided there, will be used here,
-     * aditionally `children` will also be passed.
-     */
     renderDisabled: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
-
-    /**
-     * Specify the key to use for hookstore functionality.
-     *
-     * The hookName should be prefixed with `feature-disabled`.
-     *
-     * When specified, the hookstore will be checked if the feature is
-     * disabled, and the first available hook will be used as the render
-     * function.
-     */
     hookName: PropTypes.string as any,
-
-    /**
-     * If children is a function then will be treated as a render prop and
-     * passed this object:
-     *
-     *   {
-     *     organization,
-     *     project,
-     *     features: [],
-     *     hasFeature: bool,
-     *   }
-     *
-     * The other interface is more simple, only show `children` if org/project has
-     * all the required feature.
-     */
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   };
 
@@ -97,11 +109,7 @@ class Feature extends React.Component<FeatureProps> {
     requireAll: true,
   };
 
-  getAllFeatures(): {
-    configFeatures: string[];
-    organization: string[];
-    project: string[];
-  } {
+  getAllFeatures(): AllFeatures {
     const {organization, project, config} = this.props;
 
     return {
@@ -111,7 +119,7 @@ class Feature extends React.Component<FeatureProps> {
     };
   }
 
-  hasFeature(feature, features) {
+  hasFeature(feature: string, features: AllFeatures) {
     const shouldMatchOnlyProject = feature.match(/^projects:(.+)/);
     const shouldMatchOnlyOrg = feature.match(/^organizations:(.+)/);
 
@@ -181,8 +189,8 @@ class Feature extends React.Component<FeatureProps> {
       return customDisabledRender({children, ...renderProps});
     }
 
-    if (typeof children === 'function') {
-      return children(renderProps);
+    if (childrenIsRenderProp(children)) {
+      return children({renderDisabled, ...renderProps});
     }
 
     return hasFeature && children ? children : null;

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -3,6 +3,7 @@ import {Route} from 'react-router';
 import {NavigationSection} from 'app/views/settings/types';
 import {User, Organization, Project, IntegrationProvider} from 'app/types';
 import {ExperimentKey} from 'app/types/experiments';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
 
 // XXX(epurkhiser): A Note about `_`.
 //
@@ -161,6 +162,8 @@ type FeatureDisabledHook = (opts: {
    * Weather the feature is or is not enabled.
    */
   hasFeature: boolean;
+
+  children: FeatureDisabled['props']['children'];
 }) => React.ReactNode;
 
 /**

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -81,6 +81,7 @@ class KeyRateLimitsForm extends React.Component<Props> {
           features={['projects:rate-limits']}
           hookName="feature-disabled:rate-limits"
           renderDisabled={({children, ...props}) =>
+            typeof children === 'function' &&
             children({...props, renderDisabled: disabledAlert})
           }
         >
@@ -97,7 +98,15 @@ class KeyRateLimitsForm extends React.Component<Props> {
                       number of events processed.`
                   )}
                 </PanelAlert>
-                {!hasFeature && renderDisabled({organization, project, features})}
+                {!hasFeature &&
+                  typeof renderDisabled === 'function' &&
+                  renderDisabled({
+                    organization,
+                    project,
+                    features,
+                    hasFeature,
+                    children: null,
+                  })}
                 <FormField
                   className="rate-limit-group"
                   name="rateLimit"

--- a/tests/js/spec/components/acl/feature.spec.jsx
+++ b/tests/js/spec/components/acl/feature.spec.jsx
@@ -35,6 +35,7 @@ describe('Feature', function() {
         features,
         organization,
         project,
+        renderDisabled: false,
       });
     });
 
@@ -53,6 +54,7 @@ describe('Feature', function() {
         organization,
         project,
         features,
+        renderDisabled: false,
       });
     });
 
@@ -64,6 +66,7 @@ describe('Feature', function() {
         organization,
         project,
         features: ['org-baz'],
+        renderDisabled: false,
       });
     });
 
@@ -100,6 +103,7 @@ describe('Feature', function() {
         organization: customOrg,
         project,
         features: ['org-bazar'],
+        renderDisabled: false,
       });
     });
 
@@ -117,6 +121,7 @@ describe('Feature', function() {
         organization,
         project: customProject,
         features: ['project-baz'],
+        renderDisabled: false,
       });
     });
 
@@ -134,6 +139,7 @@ describe('Feature', function() {
         organization: null,
         project: null,
         features,
+        renderDisabled: false,
       });
     });
 
@@ -148,6 +154,7 @@ describe('Feature', function() {
         organization,
         project,
         features: ['organizations:org-bar'],
+        renderDisabled: false,
       });
 
       mount(<Feature features={['projects:bar']}>{childrenMock}</Feature>, routerContext);
@@ -157,6 +164,7 @@ describe('Feature', function() {
         organization,
         project,
         features: ['projects:bar'],
+        renderDisabled: false,
       });
     });
 
@@ -174,6 +182,7 @@ describe('Feature', function() {
         organization,
         project,
         features: ['organizations:create'],
+        renderDisabled: false,
       });
     });
   });


### PR DESCRIPTION
This component was missing some type information which makes some hook typing a bit harder.

I simplified things a wee bit by also passing the `renderDisabled` prop down as a render prop, since some usages were using this component in such a way that the disabled renderer would default to rendering children and passing down a custom render disabled.