### PR TITLE
fix(workflow): Alert builder should query for event.type = error

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -100,6 +100,12 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     ];
   }
 
+  getEventType() {
+    // XXX: This is hardcoded for now, this will need to change when we add
+    // metric types that require different `event.type` (e.g. transactions)
+    return 'event.type:error';
+  }
+
   goBack() {
     const {router, routes, params, location} = this.props;
 
@@ -382,6 +388,10 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const {organization, ruleId, rule, params, onSubmitSuccess} = this.props;
     const {query, aggregation, timeWindow, triggers} = this.state;
 
+    const queryAndAlwaysErrorEvents = !query.includes(this.getEventType())
+      ? `${query} ${this.getEventType()}`
+      : query;
+
     return (
       <Access access={['project:write']}>
         {({hasAccess}) => (
@@ -426,7 +436,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
               organization={organization}
               projects={this.state.projects}
               triggers={triggers}
-              query={query}
+              query={queryAndAlwaysErrorEvents}
               aggregation={aggregation}
               timeWindow={timeWindow}
             />

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -103,7 +103,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   getEventType() {
     // XXX: This is hardcoded for now, this will need to change when we add
     // metric types that require different `event.type` (e.g. transactions)
-    return 'event.type:error';
+    return '!event.type:transaction';
   }
 
   goBack() {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -388,7 +388,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const {organization, ruleId, rule, params, onSubmitSuccess} = this.props;
     const {query, aggregation, timeWindow, triggers} = this.state;
 
-    const queryAndAlwaysErrorEvents = !query.includes(this.getEventType())
+    const queryAndAlwaysErrorEvents = !query.includes('event.type')
       ? `${query} ${this.getEventType()}`.trim()
       : query;
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -389,7 +389,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const {query, aggregation, timeWindow, triggers} = this.state;
 
     const queryAndAlwaysErrorEvents = !query.includes(this.getEventType())
-      ? `${query} ${this.getEventType()}`
+      ? `${query} ${this.getEventType()}`.trim()
       : query;
 
     return (

--- a/tests/js/spec/views/settings/incidentRules/create.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/create.spec.jsx
@@ -5,6 +5,8 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import IncidentRulesCreate from 'app/views/settings/incidentRules/create';
 
 describe('Incident Rules Create', function() {
+  let eventStatsMock;
+
   beforeEach(function() {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
@@ -19,7 +21,7 @@ describe('Incident Rules Create', function() {
       url: '/projects/org-slug/project-slug/environments/',
       body: [],
     });
-    MockApiClient.addMockResponse({
+    eventStatsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: TestStubs.EventsStats(),
     });
@@ -45,6 +47,19 @@ describe('Incident Rules Create', function() {
         project={project}
       />,
       routerContext
+    );
+
+    expect(eventStatsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {
+          interval: '1m',
+          project: [2],
+          query: 'event.type:error',
+          statsPeriod: '12h',
+          yAxis: 'event_count',
+        },
+      })
     );
   });
 });

--- a/tests/js/spec/views/settings/incidentRules/create.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/create.spec.jsx
@@ -55,7 +55,7 @@ describe('Incident Rules Create', function() {
         query: {
           interval: '1m',
           project: [2],
-          query: 'event.type:error',
+          query: '!event.type:transaction',
           statsPeriod: '12h',
           yAxis: 'event_count',
         },


### PR DESCRIPTION
Alert builder should always (for now) query for only error events