### PR TITLE
fix(ecosystem): bug where user could not add PagerDuty service

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
@@ -75,13 +75,14 @@ export default class TableField extends React.Component<Props> {
     const valueIsEmpty = this.hasValue(props.value);
     const value = valueIsEmpty ? props.value : [];
 
-    const saveChanges = (nextValue: object) => {
+    const saveChanges = (nextValue: object[]) => {
       onChange(nextValue, []);
 
-      //check for falsy values
-      const validValues = !flatten(Object.values(nextValue).map(Object.values)).some(
-        v => !v
+      //nextValue is an array of ObservableObjectAdministration objects
+      const badValues = flatten(Object.values(nextValue).map(Object.entries)).filter(
+        ([key, val]) => key !== 'id' && !val //don't allow empty values except if it's the ID field
       );
+      const validValues = badValues.length === 0;
 
       if (allowEmpty || validValues) {
         //TOOD: add debouncing or use a form save button

--- a/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
@@ -79,10 +79,9 @@ export default class TableField extends React.Component<Props> {
       onChange(nextValue, []);
 
       //nextValue is an array of ObservableObjectAdministration objects
-      const badValues = flatten(Object.values(nextValue).map(Object.entries)).filter(
+      const validValues = !flatten(Object.values(nextValue).map(Object.entries)).some(
         ([key, val]) => key !== 'id' && !val //don't allow empty values except if it's the ID field
       );
-      const validValues = badValues.length === 0;
 
       if (allowEmpty || validValues) {
         //TOOD: add debouncing or use a form save button


### PR DESCRIPTION
Users cannot manually add PagerDuty service ever since the PR of mine that got merged 6 days ago. The problem is that the value of `id` is falsy so it failed the validation and we don't send a request to the backend to update the rows.