### PR TITLE
perf(ui): Move `redirectDeprecatedProjectRoute`-related routes to LightweightOrg

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1039,6 +1039,7 @@ function routes() {
           component={errorHandler(LazyLoad)}
         />
       </Route>
+
       <Route component={errorHandler(OrganizationDetails)}>
         <Route path="/settings/" name="Settings" component={SettingsWrapper}>
           <IndexRoute
@@ -1114,6 +1115,7 @@ function routes() {
           }
           component={errorHandler(LazyLoad)}
         />
+
         <Route
           path="/organizations/:orgId/user-feedback/"
           componentPromise={() =>
@@ -1121,6 +1123,7 @@ function routes() {
           }
           component={errorHandler(LazyLoad)}
         />
+
         <Route
           path="/organizations/:orgId/issues/"
           component={errorHandler(IssueListContainer)}
@@ -1129,6 +1132,7 @@ function routes() {
           <IndexRoute component={errorHandler(IssueListOverview)} />
           <Route path="searches/:searchId/" component={errorHandler(IssueListOverview)} />
         </Route>
+
         {/* Once org issues is complete, these routes can be nested under
           /organizations/:orgId/issues */}
         <Route
@@ -1378,47 +1382,6 @@ function routes() {
             }
             component={errorHandler(LazyLoad)}
           />
-        </Route>
-
-        <Route name="Organization" path="/:orgId/">
-          <Route path=":projectId/">
-            {/* Support for deprecated URLs (pre-Sentry 10). We just redirect users to new canonical URLs. */}
-            <IndexRoute
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId}) =>
-                    `/organizations/${orgId}/issues/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="issues/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId}) =>
-                    `/organizations/${orgId}/issues/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="dashboard/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId}) =>
-                    `/organizations/${orgId}/dashboards/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="user-feedback/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId}) =>
-                    `/organizations/${orgId}/user-feedback/?project=${projectId}`
-                )
-              )}
-            />
-          </Route>
         </Route>
       </Route>
 
@@ -1861,63 +1824,108 @@ function routes() {
             component={errorHandler(LazyLoad)}
           />
         </Route>
-        <Route path=":projectId/">
-          {/* Support for deprecated URLs (pre-Sentry 10). We just redirect users to new canonical URLs. */}
-          <Route
-            path="releases/"
-            component={errorHandler(
-              redirectDeprecatedProjectRoute(
-                ({orgId, projectId}) =>
-                  `/organizations/${orgId}/releases/?project=${projectId}`
-              )
-            )}
-          />
-          <Route
-            path="releases/:version/"
-            component={errorHandler(
-              redirectDeprecatedProjectRoute(
-                ({orgId, projectId, router}) =>
-                  `/organizations/${orgId}/releases/${router.params.version}/?project=${projectId}`
-              )
-            )}
-          />
-          <Route
-            path="releases/:version/new-events/"
-            component={errorHandler(
-              redirectDeprecatedProjectRoute(
-                ({orgId, projectId, router}) =>
-                  `/organizations/${orgId}/releases/${router.params.version}/new-events/?project=${projectId}`
-              )
-            )}
-          />
-          <Route
-            path="releases/:version/all-events/"
-            component={errorHandler(
-              redirectDeprecatedProjectRoute(
-                ({orgId, projectId, router}) =>
-                  `/organizations/${orgId}/releases/${router.params.version}/all-events/?project=${projectId}`
-              )
-            )}
-          />
-          <Route
-            path="releases/:version/artifacts/"
-            component={errorHandler(
-              redirectDeprecatedProjectRoute(
-                ({orgId, projectId, router}) =>
-                  `/organizations/${orgId}/releases/${router.params.version}/artifacts/?project=${projectId}`
-              )
-            )}
-          />
-          <Route
-            path="releases/:version/commits/"
-            component={errorHandler(
-              redirectDeprecatedProjectRoute(
-                ({orgId, projectId, router}) =>
-                  `/organizations/${orgId}/releases/${router.params.version}/commits/?project=${projectId}`
-              )
-            )}
-          />
+      </Route>
+
+      {/* A route tree for lightweight organizational detail views.
+          This is strictly for deprecated URLs that we need to maintain */}
+      <Route component={errorHandler(LightWeightOrganizationDetails)}>
+        <Route name="Organization" path="/:orgId/">
+          <Route path=":projectId/">
+            {/* Support for deprecated URLs (pre-Sentry 10). We just redirect users to new canonical URLs. */}
+            <IndexRoute
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId}) =>
+                    `/organizations/${orgId}/issues/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="issues/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId}) =>
+                    `/organizations/${orgId}/issues/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="dashboard/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId}) =>
+                    `/organizations/${orgId}/dashboards/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="user-feedback/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId}) =>
+                    `/organizations/${orgId}/user-feedback/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="releases/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId}) =>
+                    `/organizations/${orgId}/releases/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="releases/:version/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId, router}) =>
+                    `/organizations/${orgId}/releases/${router.params.version}/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="releases/:version/new-events/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId, router}) =>
+                    `/organizations/${orgId}/releases/${router.params.version}/new-events/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="releases/:version/all-events/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId, router}) =>
+                    `/organizations/${orgId}/releases/${router.params.version}/all-events/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="releases/:version/artifacts/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId, router}) =>
+                    `/organizations/${orgId}/releases/${router.params.version}/artifacts/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="releases/:version/commits/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId, router}) =>
+                    `/organizations/${orgId}/releases/${router.params.version}/commits/?project=${projectId}`
+                )
+              )}
+            />
+          </Route>
         </Route>
+      </Route>
+
+      <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
         <Route path=":projectId/settings/">
           <Redirect from="teams/" to="/settings/:orgId/projects/:projectId/teams/" />
           <Redirect from="alerts/" to="/settings/:orgId/projects/:projectId/alerts/" />
@@ -2049,6 +2057,7 @@ function routes() {
           component={errorHandler(ProjectEventRedirect)}
         />
       </Route>
+
       {hook('routes')}
       <Route
         path="*"

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1925,7 +1925,7 @@ function routes() {
         </Route>
       </Route>
 
-      <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
+      <Route path="/:orgId/">
         <Route path=":projectId/settings/">
           <Redirect from="teams/" to="/settings/:orgId/projects/:projectId/teams/" />
           <Redirect from="alerts/" to="/settings/:orgId/projects/:projectId/alerts/" />

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1379,6 +1379,47 @@ function routes() {
             component={errorHandler(LazyLoad)}
           />
         </Route>
+
+        <Route name="Organization" path="/:orgId/">
+          <Route path=":projectId/">
+            {/* Support for deprecated URLs (pre-Sentry 10). We just redirect users to new canonical URLs. */}
+            <IndexRoute
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId}) =>
+                    `/organizations/${orgId}/issues/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="issues/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId}) =>
+                    `/organizations/${orgId}/issues/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="dashboard/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId}) =>
+                    `/organizations/${orgId}/dashboards/?project=${projectId}`
+                )
+              )}
+            />
+            <Route
+              path="user-feedback/"
+              component={errorHandler(
+                redirectDeprecatedProjectRoute(
+                  ({orgId, projectId}) =>
+                    `/organizations/${orgId}/user-feedback/?project=${projectId}`
+                )
+              )}
+            />
+          </Route>
+        </Route>
       </Route>
 
       {/* The heavyweight organization detail views */}
@@ -1822,24 +1863,6 @@ function routes() {
         </Route>
         <Route path=":projectId/">
           {/* Support for deprecated URLs (pre-Sentry 10). We just redirect users to new canonical URLs. */}
-          <IndexRoute
-            component={errorHandler(
-              redirectDeprecatedProjectRoute(
-                ({orgId, projectId}) =>
-                  `/organizations/${orgId}/issues/?project=${projectId}`
-              )
-            )}
-          />
-          <Route
-            path="issues/"
-            component={errorHandler(
-              redirectDeprecatedProjectRoute(
-                ({orgId, projectId}) =>
-                  `/organizations/${orgId}/issues/?project=${projectId}`
-              )
-            )}
-          />
-          <Redirect from="dashboard/" to="/organizations/:orgId/dashboards/" />
           <Route
             path="releases/"
             component={errorHandler(
@@ -1891,15 +1914,6 @@ function routes() {
               redirectDeprecatedProjectRoute(
                 ({orgId, projectId, router}) =>
                   `/organizations/${orgId}/releases/${router.params.version}/commits/?project=${projectId}`
-              )
-            )}
-          />
-          <Route
-            path="user-feedback/"
-            component={errorHandler(
-              redirectDeprecatedProjectRoute(
-                ({orgId, projectId}) =>
-                  `/organizations/${orgId}/user-feedback/?project=${projectId}`
               )
             )}
           />

--- a/src/sentry/static/sentry/app/views/projects/redirectDeprecatedProjectRoute.jsx
+++ b/src/sentry/static/sentry/app/views/projects/redirectDeprecatedProjectRoute.jsx
@@ -1,14 +1,17 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import isString from 'lodash/isString';
+import styled from '@emotion/styled';
 
-import {t} from 'app/locale';
-import withApi from 'app/utils/withApi';
-import LoadingError from 'app/components/loadingError';
 import {analytics} from 'app/utils/analytics';
+import {t} from 'app/locale';
 import Alert from 'app/components/alert';
+import LoadingError from 'app/components/loadingError';
+import LoadingIndicator from 'app/components/loadingIndicator';
 import Redirect from 'app/utils/redirect';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
+import space from 'app/styles/space';
+import withApi from 'app/utils/withApi';
 
 class ProjectDetailsInner extends React.Component {
   static propTypes = {
@@ -123,40 +126,45 @@ const redirectDeprecatedProjectRoute = generateRedirectRoute => {
       const {orgId} = this.props.params;
 
       return (
-        <ProjectDetails orgId={orgId} projectSlug={this.props.params.projectId}>
-          {({loading, error, hasProjectId, projectId, organizationId}) => {
-            if (loading) {
-              return null;
-            }
-
-            if (!hasProjectId) {
-              if (error && error.status === 404) {
-                return (
-                  <Alert type="error">
-                    {t('The project you were looking for was not found.')}
-                  </Alert>
-                );
+        <Wrapper>
+          <ProjectDetails orgId={orgId} projectSlug={this.props.params.projectId}>
+            {({loading, error, hasProjectId, projectId, organizationId}) => {
+              if (loading) {
+                return <LoadingIndicator />;
               }
 
-              return <LoadingError onRetry={this.fetchData} />;
-            }
+              if (!hasProjectId) {
+                if (error && error.status === 404) {
+                  return (
+                    <Alert type="error">
+                      {t('The project you were looking for was not found.')}
+                    </Alert>
+                  );
+                }
 
-            const routeProps = {
-              orgId,
-              projectId,
-              router: {
-                params: this.props.params,
-              },
-            };
+                return <LoadingError onRetry={this.fetchData} />;
+              }
 
-            return (
-              <Redirect
-                router={this.props.router}
-                to={this.trackRedirect(organizationId, generateRedirectRoute(routeProps))}
-              />
-            );
-          }}
-        </ProjectDetails>
+              const routeProps = {
+                orgId,
+                projectId,
+                router: {
+                  params: this.props.params,
+                },
+              };
+
+              return (
+                <Redirect
+                  router={this.props.router}
+                  to={this.trackRedirect(
+                    organizationId,
+                    generateRedirectRoute(routeProps)
+                  )}
+                />
+              );
+            }}
+          </ProjectDetails>
+        </Wrapper>
       );
     }
   }
@@ -165,3 +173,8 @@ const redirectDeprecatedProjectRoute = generateRedirectRoute => {
 };
 
 export default redirectDeprecatedProjectRoute;
+
+const Wrapper = styled('div')`
+  flex: 1;
+  padding: ${space(3)};
+`;


### PR DESCRIPTION
e.g. when you visit `/:orgId/:projectId/` it still goes through normal org details instead of lightweight even though it does not use `projects`. We need to "duplicate" the lightweight org tree because of the order of route matching.

Ordering is very important here, having `/:orgId/:projectId/` too high in the tree will cause issues. At a high level the order we need is somewhat this:

1) Lightweight -> needs to take precedence over old routes
2) Normal
3) `/:orgId/` routes -> since the new routes (`/organizations/orgId/`) can be matched with this too early in the tree



Also adds a loader and a better error screen


![image](https://user-images.githubusercontent.com/79684/78315339-8ab17180-7511-11ea-9417-8f527d050f61.png)
