### PR TITLE
fix(ui) Fix wide tooltips overflowing the viewport

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -153,16 +153,23 @@ export default function Tooltip({
       const tipWidth = dom.clientWidth;
       const tipHeight = dom.clientHeight;
 
-      // Determine new left edge.
+      // Get the left offset of the tip container (the chart)
+      // so that we can estimate overflows
+      const chartLeft = dom.parentNode.getBoundingClientRect().left;
+
+      // Determine the new left edge.
       let leftPos = pos[0] - tipWidth / 2;
       let arrowPosition = '50%';
-      const rightEdge = pos[0] + tipWidth;
+
+      // And the right edge taking into account the chart left offset
+      const rightEdge = chartLeft + pos[0] + tipWidth / 2;
 
       // If the tooltip would go off viewport shift the tooltip over with a gap.
-      if (rightEdge >= window.innerWidth - 30) {
-        leftPos -= rightEdge - window.innerWidth + 30;
+      if (rightEdge >= window.innerWidth - 20) {
+        leftPos -= rightEdge - window.innerWidth + 20;
         arrowPosition = `${pos[0] - leftPos}px`;
       }
+
       // Reposition the arrow.
       const arrow = dom.querySelector('.tooltip-arrow');
       if (arrow) {


### PR DESCRIPTION
The previous logic failed to take into account the chart left offset in the page. This corrects that omission and fixes positioning of wide tooltips as we'll have more of those with top5 graphs.

#### Before

![Screen Shot 2020-04-02 at 5 27 38 PM](https://user-images.githubusercontent.com/24086/78324367-7fc30500-7542-11ea-9cd9-eae2924c5a62.png)


#### After
<img width="395" alt="Screen Shot 2020-04-03 at 12 32 08 AM" src="https://user-images.githubusercontent.com/24086/78324401-9ff2c400-7542-11ea-95bd-7e39b7d42f1a.png">
