### PR TITLE
feat(ui): Add beta flag to releases v2

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -529,6 +529,7 @@ class Sidebar extends React.Component<Props, State> {
                       label={t('Releases v2')}
                       to={`/organizations/${organization.slug}/releases-v2/`}
                       id="releasesv2"
+                      isBeta
                     />
                   </Feature>
                 </SidebarSection>

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
@@ -59,6 +59,10 @@ type Props = ReactRouter.WithRouterProps & {
    */
   isNew?: boolean;
   /**
+   * Additional badge letting users know a tab is in beta.
+   */
+  isBeta?: boolean;
+  /**
    * Sidebar is at "top" or "left" of screen
    */
   orientation: SidebarOrientation;
@@ -75,6 +79,7 @@ const SidebarItem = ({
   active,
   hasPanel,
   isNew,
+  isBeta,
   collapsed,
   className,
   orientation,
@@ -112,6 +117,11 @@ const SidebarItem = ({
                 {isNew && (
                   <StyledTag priority="beta" size="small">
                     {t('New')}
+                  </StyledTag>
+                )}
+                {isBeta && (
+                  <StyledTag priority="beta" size="small">
+                    {t('Beta')}
                   </StyledTag>
                 )}
               </LabelHook>


### PR DESCRIPTION
Product wanted to have a beta flag in the sidebar for releases v2 while the manually opted in customers are testing it.