### PR TITLE
fix(relay): Invalidate projectconfig in redis properly

### DIFF
--- a/src/sentry/models/organizationoption.py
+++ b/src/sentry/models/organizationoption.py
@@ -28,11 +28,11 @@ class OrganizationOptionManager(OptionManager):
         except self.model.DoesNotExist:
             return
         inst.delete()
-        self.reload_cache(organization.id)
+        self.reload_cache(organization.id, "organizationoption.unset_value")
 
     def set_value(self, organization, key, value):
         self.create_or_update(organization=organization, key=key, values={"value": value})
-        self.reload_cache(organization.id)
+        self.reload_cache(organization.id, "organizationoption.set_value")
 
     def get_all_values(self, organization):
         if isinstance(organization, models.Model):
@@ -44,12 +44,16 @@ class OrganizationOptionManager(OptionManager):
         if cache_key not in self._option_cache:
             result = cache.get(cache_key)
             if result is None:
-                result = self.reload_cache(organization_id)
+                result = self.reload_cache(organization_id, "organizationoption.get_all_values")
             else:
                 self._option_cache[cache_key] = result
         return self._option_cache.get(cache_key, {})
 
-    def reload_cache(self, organization_id):
+    def reload_cache(self, organization_id, update_reason):
+        schedule_update_config_cache(
+            organization_id=organization_id, generate=False, update_reason=update_reason
+        )
+
         cache_key = self._make_key(organization_id)
         result = dict((i.key, i.value) for i in self.filter(organization=organization_id))
         cache.set(cache_key, result)
@@ -57,20 +61,10 @@ class OrganizationOptionManager(OptionManager):
         return result
 
     def post_save(self, instance, **kwargs):
-        schedule_update_config_cache(
-            organization_id=instance.organization_id,
-            generate=False,
-            update_reason="organizationoption.post_save",
-        )
-        self.reload_cache(instance.organization_id)
+        self.reload_cache(instance.organization_id, "organizationoption.post_save")
 
     def post_delete(self, instance, **kwargs):
-        schedule_update_config_cache(
-            organization_id=instance.organization_id,
-            generate=False,
-            update_reason="organizationoption.post_delete",
-        )
-        self.reload_cache(instance.organization_id)
+        self.reload_cache(instance.organization_id, "organizationoption.post_delete")
 
 
 class OrganizationOption(Model):

--- a/src/sentry/models/projectoption.py
+++ b/src/sentry/models/projectoption.py
@@ -32,11 +32,11 @@ class ProjectOptionManager(OptionManager):
 
     def unset_value(self, project, key):
         self.filter(project=project, key=key).delete()
-        self.reload_cache(project.id)
+        self.reload_cache(project.id, "projectoption.unset_value")
 
     def set_value(self, project, key, value):
         inst, created = self.create_or_update(project=project, key=key, values={"value": value})
-        self.reload_cache(project.id)
+        self.reload_cache(project.id, "projectoption.set_value")
         return created or inst > 0
 
     def get_all_values(self, project):
@@ -49,12 +49,15 @@ class ProjectOptionManager(OptionManager):
         if cache_key not in self._option_cache:
             result = cache.get(cache_key)
             if result is None:
-                result = self.reload_cache(project_id)
+                result = self.reload_cache(project_id, "projectoption.get_all_values")
             else:
                 self._option_cache[cache_key] = result
         return self._option_cache.get(cache_key, {})
 
-    def reload_cache(self, project_id):
+    def reload_cache(self, project_id, update_reason):
+        schedule_update_config_cache(
+            project_id=project_id, generate=True, update_reason=update_reason
+        )
         cache_key = self._make_key(project_id)
         result = dict((i.key, i.value) for i in self.filter(project=project_id))
         cache.set(cache_key, result)
@@ -62,16 +65,10 @@ class ProjectOptionManager(OptionManager):
         return result
 
     def post_save(self, instance, **kwargs):
-        schedule_update_config_cache(
-            project_id=instance.project_id, generate=True, update_reason="projectoption.post_save"
-        )
-        self.reload_cache(instance.project_id)
+        self.reload_cache(instance.project_id, "projectoption.post_save")
 
     def post_delete(self, instance, **kwargs):
-        schedule_update_config_cache(
-            project_id=instance.project_id, generate=True, update_reason="projectoption.post_delete"
-        )
-        self.reload_cache(instance.project_id)
+        self.reload_cache(instance.project_id, "projectoption.post_delete")
 
 
 class ProjectOption(Model):

--- a/tests/sentry/projectoptions/test_basic.py
+++ b/tests/sentry/projectoptions/test_basic.py
@@ -30,7 +30,7 @@ def test_defaults(default_project):
 
     with latest_epoch(42):
         default_manager.freeze_option_epoch(default_project, force=True)
-        ProjectOption.objects.reload_cache(default_project.id)
+        ProjectOption.objects.reload_cache(default_project.id, "")
 
     assert default_project.get_option("__sentry_test:test-option") == "latest-value"
 


### PR DESCRIPTION
This didn't hook into all the right places because magic is happening inside of that manager and because I am a fool.

Be careful when rolling out, this can create a lot of load.