### PR TITLE
feat(ecosystem): remove sort by weight experiment

### DIFF
--- a/src/sentry/static/sentry/app/data/experimentConfig.tsx
+++ b/src/sentry/static/sentry/app/data/experimentConfig.tsx
@@ -20,12 +20,6 @@ export const experimentList = [
     assignments: ['controlV1', '2Optionsv1', '3OptionsV2'],
   },
   {
-    key: 'IntegrationDirectorySortWeightExperiment',
-    type: ExperimentType.Organization,
-    parameter: 'variant',
-    assignments: ['1', '0', -1],
-  },
-  {
     key: 'OnboardingSidebarV2Experiment',
     type: ExperimentType.Organization,
     parameter: 'exposed',

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -15,10 +15,8 @@ import {
 } from 'app/types';
 import {Hooks} from 'app/types/hooks';
 import HookStore from 'app/stores/hookStore';
-import {ExperimentAssignment} from 'app/types/experiments';
 
 const INTEGRATIONS_ANALYTICS_SESSION_KEY = 'INTEGRATION_ANALYTICS_SESSION' as const;
-const SORT_INTEGRATIONS_BY_WEIGHT = 'SORT_INTEGRATIONS_BY_WEIGHT' as const;
 const SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT = 'SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT' as const;
 
 export const startAnalyticsSession = () => {
@@ -33,19 +31,6 @@ export const clearAnalyticsSession = () => {
 
 export const getAnalyticsSessionId = () =>
   window.sessionStorage.getItem(INTEGRATIONS_ANALYTICS_SESSION_KEY);
-
-export const getSortIntegrationsByWeightActive = (
-  experimentAssignment: ExperimentAssignment['IntegrationDirectorySortWeightExperiment']
-) => {
-  switch (localStorage.getItem(SORT_INTEGRATIONS_BY_WEIGHT)) {
-    case '1':
-      return true;
-    case '0':
-      return false;
-    default:
-      return experimentAssignment === '1';
-  }
-};
 
 export const getCategorySelectActive = () =>
   localStorage.getItem(SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT) === '1';

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -19,7 +19,6 @@ import {Panel, PanelBody} from 'app/components/panels';
 import {
   trackIntegrationEvent,
   getSentryAppInstallStatus,
-  getSortIntegrationsByWeightActive,
   getCategorySelectActive,
   isSentryApp,
   isPlugin,
@@ -35,8 +34,6 @@ import SearchInput from 'app/components/forms/searchInput';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import space from 'app/styles/space';
 import SelectControl from 'app/components/forms/selectControl';
-import withExperiment from 'app/utils/withExperiment';
-import {ExperimentAssignment} from 'app/types/experiments';
 
 import {POPULARITY_WEIGHT} from './constants';
 import IntegrationRow from './integrationRow';
@@ -44,7 +41,6 @@ import IntegrationRow from './integrationRow';
 type Props = RouteComponentProps<{orgId: string}, {}> & {
   organization: Organization;
   hideHeader: boolean;
-  experimentAssignment: ExperimentAssignment['IntegrationDirectorySortWeightExperiment'];
 };
 
 type State = {
@@ -220,13 +216,10 @@ export class IntegrationListDirectory extends AsyncComponent<
     this.getInstallValue(b) - this.getInstallValue(a);
 
   sortIntegrations(integrations: AppOrProviderOrPlugin[]) {
-    if (getSortIntegrationsByWeightActive(this.props.experimentAssignment)) {
-      return integrations
-        .sort(this.sortByName)
-        .sort(this.sortByPopularity)
-        .sort(this.sortByInstalled);
-    }
-    return integrations.sort(this.sortByName).sort(this.sortByInstalled);
+    return integrations
+      .sort(this.sortByName)
+      .sort(this.sortByPopularity)
+      .sort(this.sortByInstalled);
   }
 
   async componentDidUpdate(_: Props, prevState: State) {
@@ -446,8 +439,4 @@ const EmptyResultsBody = styled('div')`
   padding-bottom: ${space(2)};
 `;
 
-export default withOrganization(
-  withExperiment(IntegrationListDirectory, {
-    experiment: 'IntegrationDirectorySortWeightExperiment',
-  })
-);
+export default withOrganization(IntegrationListDirectory);

--- a/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -43,17 +43,17 @@ describe('IntegrationListDirectory', function() {
       );
     });
 
-    it('shows installed integrations at the top', async function() {
+    it('shows installed integrations at the top in order of weight', async function() {
       expect(wrapper.find('SearchInput').exists()).toBeTruthy();
       expect(wrapper.find('PanelBody').exists()).toBeTruthy();
       expect(wrapper.find('IntegrationRow')).toHaveLength(6);
 
       [
         'bitbucket',
-        'my-headband-washer-289499',
         'pagerduty',
-        'amazon-sqs',
+        'my-headband-washer-289499',
         'clickup',
+        'amazon-sqs',
         'la-croix-monitor',
       ].map((name, index) =>
         expect(


### PR DESCRIPTION
After running the experiment to sort integrations by weight for a few weeks, we saw about a 7% lift in the number of installation starts compared to the baseline with statistical significance meaning the experiment was a success. This PR removes the old behavior so that now 100% of users integrations sorted by weight.


<img width="1142" alt="Screen Shot 2020-04-03 at 9 29 56 AM" src="https://user-images.githubusercontent.com/8533851/78383721-b5411000-758d-11ea-8ea1-8670c7becad6.png">


Must be merged before: https://github.com/getsentry/getsentry/pull/3724