### PR TITLE
perf(ui): Don't fetch health stats when no health data available

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/releaseStatsRequest.tsx
@@ -50,6 +50,7 @@ type Props = {
   location: Location;
   yAxis: YAxis;
   children: (renderProps: ReleaseStatsRequestRenderProps) => React.ReactNode;
+  disable: boolean;
 };
 type State = {
   reloading: boolean;
@@ -83,7 +84,11 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
 
   fetchData = async () => {
     let data: Data | null = null;
-    const {yAxis} = this.props;
+    const {yAxis, disable} = this.props;
+
+    if (disable) {
+      return;
+    }
 
     this.setState(state => ({
       reloading: state.data !== null,

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -80,6 +80,7 @@ class ReleaseOverview extends AsyncView<Props> {
               selection={selection}
               location={location}
               yAxis={yAxis}
+              disable={!hasHealthData}
             >
               {({crashFreeTimeBreakdown, ...releaseStatsProps}) => (
                 <ContentBox>


### PR DESCRIPTION
This PR prevents fetching health stats on release detail page when no health data are available