### PR TITLE
feat(symbolicate): Run process_event inline

### DIFF
--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -193,6 +193,7 @@ def test_symbolicate_event_call_process_inline(
         data=symbolicated_data,
         data_has_changed=True,
         new_process_behavior=True,
+        from_symbolicate=True,
     )
 
 


### PR DESCRIPTION
This change inlines `process_event` call inside `symbolicate_event` task.
After this, the impact of native events should not be visible to "regular" `process_event` task at all.
