### PR TITLE
ref(emptyMessage): take in icon component

### DIFF
--- a/docs-ui/components/emptyMessage.stories.js
+++ b/docs-ui/components/emptyMessage.stories.js
@@ -4,7 +4,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
 import {Panel, PanelHeader} from 'app/components/panels';
-import {IconUser} from 'app/icons/iconUser';
+import {IconTelescope, IconUser} from 'app/icons';
 import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import space from 'app/styles/space';
@@ -92,7 +92,7 @@ storiesOf('UI|EmptyMessage', module)
     withInfo('Put this in a panel for maximum effect')(() => (
       <Panel dashedBorder>
         <EmptyMessage
-          icon={<IconUser size="xl" />}
+          icon={<IconTelescope size="xl" />}
           title="You're missing out on crucial functionality!"
           description="Enable this feature now to get the most out of Sentry. What are you waiting for? Do it!"
           action={

--- a/docs-ui/components/emptyMessage.stories.js
+++ b/docs-ui/components/emptyMessage.stories.js
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 import React from 'react';
-
-import {Panel, PanelHeader} from 'app/components/panels';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
+
+import {Panel, PanelHeader} from 'app/components/panels';
+import {IconUser} from 'app/icons/iconUser';
 import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import space from 'app/styles/space';
@@ -31,7 +32,7 @@ storiesOf('UI|EmptyMessage', module)
     withInfo('Put this in a panel for maximum effect')(() => (
       <Panel>
         <PanelHeader>Members</PanelHeader>
-        <EmptyMessage icon="icon-user" size="large">
+        <EmptyMessage icon={<IconUser size="xl" />} size="large">
           Sentry is better with friends
         </EmptyMessage>
       </Panel>
@@ -43,7 +44,7 @@ storiesOf('UI|EmptyMessage', module)
       <Panel>
         <PanelHeader>Members</PanelHeader>
         <EmptyMessage
-          icon="icon-user"
+          icon={<IconUser size="xl" />}
           action={<Button priority="primary">Invite Members</Button>}
         >
           Sentry is better with friends
@@ -69,7 +70,7 @@ storiesOf('UI|EmptyMessage', module)
       <Panel>
         <PanelHeader>Members</PanelHeader>
         <EmptyMessage
-          icon="icon-user"
+          icon={<IconUser size="xl" />}
           title="Sentry is better with friends!"
           description="When you use sentry with friends, you'll find your world of possibilities expands!"
           action={
@@ -91,7 +92,7 @@ storiesOf('UI|EmptyMessage', module)
     withInfo('Put this in a panel for maximum effect')(() => (
       <Panel dashedBorder>
         <EmptyMessage
-          icon="icon-discover"
+          icon={<IconUser size="xl" />}
           title="You're missing out on crucial functionality!"
           description="Enable this feature now to get the most out of Sentry. What are you waiting for? Do it!"
           action={

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
@@ -57,7 +57,7 @@ const IconWrapper = styled('div')`
 `;
 
 const Title = styled('h1')`
-  font-size: ${p => p.theme.headerFontSize};
+  font-size: ${p => p.theme.fontSizeExtraLarge};
   margin-bottom: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
@@ -6,42 +6,10 @@ import InlineSvg from 'app/components/inlineSvg';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import space from 'app/styles/space';
 
-const MarginStyles = `
-  margin-bottom: ${space(2)};
-  &:last-child {
-    margin: 0;
-  }
-`;
-
-const Description = styled(TextBlock)`
-  ${MarginStyles};
-`;
-
-const Title = styled('div')`
-  font-weight: bold;
-  font-size: 20px;
-  line-height: 1.2;
-  ${MarginStyles};
-
-  & + ${Description} {
-    margin-top: -${space(0.5)}; /* Remove the illusion of bad padding by offsetting line-height */
-  }
-`;
-
-const StyledInlineSvg = styled(InlineSvg)`
-  display: block;
-  color: ${p => p.theme.gray1};
-  ${MarginStyles};
-`;
-
-const Action = styled('div')`
-  ${MarginStyles};
-`;
-
 type Props = {
   title?: React.ReactNode;
   description?: React.ReactNode;
-  icon?: string;
+  icon?: string | React.ReactNode;
   action?: React.ReactElement;
   size?: 'large' | 'medium';
 };
@@ -52,7 +20,11 @@ type WrapperProps = Pick<EmptyMessageProps, 'size'>;
 const EmptyMessage = styled(
   ({title, description, icon, children, action, ...props}: EmptyMessageProps) => (
     <div data-test-id="empty-message" {...props}>
-      {icon && <StyledInlineSvg src={icon} size="36px" />}
+      {icon && (
+        <IconWrapper>
+          {typeof icon === 'string' ? <InlineSvg src={icon} size="32px" /> : icon}
+        </IconWrapper>
+      )}
       {title && <Title>{title}</Title>}
       {description && <Description>{description}</Description>}
       {children && <Description noMargin>{children}</Description>}
@@ -73,10 +45,31 @@ const EmptyMessage = styled(
 EmptyMessage.propTypes = {
   title: PropTypes.node,
   description: PropTypes.node,
-  icon: PropTypes.string,
+  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   action: PropTypes.element,
   // Currently only the `large` option changes the size - can add more size options as necessary
   size: PropTypes.oneOf(['large', 'medium']),
 };
+
+const IconWrapper = styled('div')`
+  color: ${p => p.theme.gray1};
+  display: block;
+  margin-bottom: ${space(1)};
+`;
+
+const Title = styled('div')`
+  font-weight: bold;
+  font-size: 20px;
+  line-height: 1.2;
+  margin-bottom: ${space(1)};
+`;
+
+const Description = styled(TextBlock)`
+  margin: 0;
+`;
+
+const Action = styled('div')`
+  margin-top: ${space(2)};
+`;
 
 export default EmptyMessage;

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
@@ -53,14 +53,11 @@ EmptyMessage.propTypes = {
 
 const IconWrapper = styled('div')`
   color: ${p => p.theme.gray1};
-  display: block;
   margin-bottom: ${space(1)};
 `;
 
-const Title = styled('div')`
-  font-weight: bold;
-  font-size: 20px;
-  line-height: 1.2;
+const Title = styled('h1')`
+  font-size: ${p => p.theme.headerFontSize};
   margin-bottom: ${space(1)};
 `;
 

--- a/tests/js/spec/components/events/interfaces/__snapshots__/exceptionStacktraceContent.spec.jsx.snap
+++ b/tests/js/spec/components/events/interfaces/__snapshots__/exceptionStacktraceContent.spec.jsx.snap
@@ -142,39 +142,45 @@ exports[`ExceptionStacktraceContent default behaviour 1`] = `
           title="No app only stacktrace has been found!"
         >
           <Component
-            className="css-13mk16x-EmptyMessage e1h3yfdx4"
+            className="css-13mk16x-EmptyMessage e1h3yfdx0"
             icon="icon-warning-sm"
             title="No app only stacktrace has been found!"
           >
             <div
-              className="css-13mk16x-EmptyMessage e1h3yfdx4"
+              className="css-13mk16x-EmptyMessage e1h3yfdx0"
               data-test-id="empty-message"
             >
-              <StyledInlineSvg
-                size="36px"
-                src="icon-warning-sm"
-              >
-                <ForwardRef
-                  className="css-1o8w9c2-InlineSvg-StyledInlineSvg e1h3yfdx2"
-                  size="36px"
-                  src="icon-warning-sm"
+              <IconWrapper>
+                <div
+                  className="css-lylc6f-IconWrapper e1h3yfdx1"
                 >
-                  <svg
-                    className="css-1o8w9c2-InlineSvg-StyledInlineSvg e1h3yfdx2"
-                    height="36px"
-                    viewBox={Object {}}
-                    width="36px"
+                  <InlineSvg
+                    size="32px"
+                    src="icon-warning-sm"
                   >
-                    <use
-                      href="#test"
-                      xlinkHref="#test"
-                    />
-                  </svg>
-                </ForwardRef>
-              </StyledInlineSvg>
+                    <ForwardRef
+                      className="css-tbsmsq-InlineSvg enyz4ql0"
+                      size="32px"
+                      src="icon-warning-sm"
+                    >
+                      <svg
+                        className="css-tbsmsq-InlineSvg enyz4ql0"
+                        height="32px"
+                        viewBox={Object {}}
+                        width="32px"
+                      >
+                        <use
+                          href="#test"
+                          xlinkHref="#test"
+                        />
+                      </svg>
+                    </ForwardRef>
+                  </InlineSvg>
+                </div>
+              </IconWrapper>
               <Title>
                 <div
-                  className="css-1p115wf-Title e1h3yfdx1"
+                  className="css-ke0noi-Title e1h3yfdx2"
                 >
                   No app only stacktrace has been found!
                 </div>

--- a/tests/js/spec/components/events/interfaces/__snapshots__/exceptionStacktraceContent.spec.jsx.snap
+++ b/tests/js/spec/components/events/interfaces/__snapshots__/exceptionStacktraceContent.spec.jsx.snap
@@ -152,7 +152,7 @@ exports[`ExceptionStacktraceContent default behaviour 1`] = `
             >
               <IconWrapper>
                 <div
-                  className="css-lylc6f-IconWrapper e1h3yfdx1"
+                  className="css-9jue1w-IconWrapper e1h3yfdx1"
                 >
                   <InlineSvg
                     size="32px"
@@ -179,11 +179,11 @@ exports[`ExceptionStacktraceContent default behaviour 1`] = `
                 </div>
               </IconWrapper>
               <Title>
-                <div
-                  className="css-ke0noi-Title e1h3yfdx2"
+                <h1
+                  className="css-wtohiw-Title e1h3yfdx2"
                 >
                   No app only stacktrace has been found!
-                </div>
+                </h1>
               </Title>
             </div>
           </Component>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -733,17 +733,17 @@ exports[`InviteMember should render roles when available and allowed, and handle
                     >
                       <EmptyMessage>
                         <Component
-                          className="css-1scmenn-EmptyMessage e1h3yfdx4"
+                          className="css-1scmenn-EmptyMessage e1h3yfdx0"
                         >
                           <div
-                            className="css-1scmenn-EmptyMessage e1h3yfdx4"
+                            className="css-1scmenn-EmptyMessage e1h3yfdx0"
                             data-test-id="empty-message"
                           >
                             <Description
                               noMargin={true}
                             >
                               <div
-                                className="css-1y44za3-TextBlock-Description e1h3yfdx0"
+                                className="css-iex7sn-TextBlock-Description e1h3yfdx3"
                               >
                                 No Teams assigned
                               </div>

--- a/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -328,17 +328,17 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
               >
                 <EmptyMessage>
                   <Component
-                    className="css-1scmenn-EmptyMessage e1h3yfdx4"
+                    className="css-1scmenn-EmptyMessage e1h3yfdx0"
                   >
                     <div
-                      className="css-1scmenn-EmptyMessage e1h3yfdx4"
+                      className="css-1scmenn-EmptyMessage e1h3yfdx0"
                       data-test-id="empty-message"
                     >
                       <Description
                         noMargin={true}
                       >
                         <div
-                          className="css-1y44za3-TextBlock-Description e1h3yfdx0"
+                          className="css-iex7sn-TextBlock-Description e1h3yfdx3"
                         >
                           You don't have any environments yet.
                         </div>
@@ -684,17 +684,17 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
               >
                 <EmptyMessage>
                   <Component
-                    className="css-1scmenn-EmptyMessage e1h3yfdx4"
+                    className="css-1scmenn-EmptyMessage e1h3yfdx0"
                   >
                     <div
-                      className="css-1scmenn-EmptyMessage e1h3yfdx4"
+                      className="css-1scmenn-EmptyMessage e1h3yfdx0"
                       data-test-id="empty-message"
                     >
                       <Description
                         noMargin={true}
                       >
                         <div
-                          className="css-1y44za3-TextBlock-Description e1h3yfdx0"
+                          className="css-iex7sn-TextBlock-Description e1h3yfdx3"
                         >
                           You don't have any hidden environments.
                         </div>

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -326,17 +326,17 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                     >
                       <EmptyMessage>
                         <Component
-                          className="css-1scmenn-EmptyMessage e1h3yfdx4"
+                          className="css-1scmenn-EmptyMessage e1h3yfdx0"
                         >
                           <div
-                            className="css-1scmenn-EmptyMessage e1h3yfdx4"
+                            className="css-1scmenn-EmptyMessage e1h3yfdx0"
                             data-test-id="empty-message"
                           >
                             <Description
                               noMargin={true}
                             >
                               <div
-                                className="css-1y44za3-TextBlock-Description e1h3yfdx0"
+                                className="css-iex7sn-TextBlock-Description e1h3yfdx3"
                               >
                                 No public integrations have been created yet.
                               </div>
@@ -494,17 +494,17 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                     >
                       <EmptyMessage>
                         <Component
-                          className="css-1scmenn-EmptyMessage e1h3yfdx4"
+                          className="css-1scmenn-EmptyMessage e1h3yfdx0"
                         >
                           <div
-                            className="css-1scmenn-EmptyMessage e1h3yfdx4"
+                            className="css-1scmenn-EmptyMessage e1h3yfdx0"
                             data-test-id="empty-message"
                           >
                             <Description
                               noMargin={true}
                             >
                               <div
-                                className="css-1y44za3-TextBlock-Description e1h3yfdx0"
+                                className="css-iex7sn-TextBlock-Description e1h3yfdx3"
                               >
                                 No internal integrations have been created yet.
                               </div>


### PR DESCRIPTION
**Before:**
![Screen Shot 2020-04-03 at 10 56 50 AM](https://user-images.githubusercontent.com/4830259/78390742-efb0aa00-7599-11ea-8802-1a596787e3ca.png)
![Screen Shot 2020-04-03 at 10 56 58 AM](https://user-images.githubusercontent.com/4830259/78390747-f0e1d700-7599-11ea-9981-217f0bc0d959.png)
![Screen Shot 2020-04-03 at 10 57 05 AM](https://user-images.githubusercontent.com/4830259/78390749-f2130400-7599-11ea-9e95-5d41fe003ded.png)
![Screen Shot 2020-04-03 at 10 57 11 AM](https://user-images.githubusercontent.com/4830259/78390751-f2ab9a80-7599-11ea-97ac-756f22d4e538.png)
![Screen Shot 2020-04-03 at 10 57 18 AM](https://user-images.githubusercontent.com/4830259/78390752-f3443100-7599-11ea-8537-df6682db7f55.png)

**After:**
![Screen Shot 2020-04-03 at 12 19 43 PM](https://user-images.githubusercontent.com/4830259/78397969-17f2d580-75a7-11ea-8115-2a59e66b3778.png)
![Screen Shot 2020-04-03 at 12 19 35 PM](https://user-images.githubusercontent.com/4830259/78397973-188b6c00-75a7-11ea-9ac1-c9e168c1b512.png)
![Screen Shot 2020-04-03 at 12 19 14 PM](https://user-images.githubusercontent.com/4830259/78397975-19bc9900-75a7-11ea-8b28-c2f0e063d519.png)
![Screen Shot 2020-04-03 at 12 19 03 PM](https://user-images.githubusercontent.com/4830259/78397976-1a552f80-75a7-11ea-9b44-187df5f7001d.png)
![Screen Shot 2020-04-03 at 12 18 56 PM](https://user-images.githubusercontent.com/4830259/78397988-217c3d80-75a7-11ea-804d-b7b470071af4.png)
