### PR TITLE
fix(charts) Fix left side overflow in chart tooltips.

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -164,9 +164,16 @@ export default function Tooltip({
       // And the right edge taking into account the chart left offset
       const rightEdge = chartLeft + pos[0] + tipWidth / 2;
 
-      // If the tooltip would go off viewport shift the tooltip over with a gap.
-      if (rightEdge >= window.innerWidth - 20) {
-        leftPos -= rightEdge - window.innerWidth + 20;
+      // If the tooltip would leave viewport on the right, pin it.
+      // and adjust the arrow position.
+      if (rightEdge >= window.innerWidth - 30) {
+        leftPos -= rightEdge - window.innerWidth + 30;
+        arrowPosition = `${pos[0] - leftPos}px`;
+      }
+
+      // If the tooltip would leave viewport on the left, pin it.
+      if (leftPos + chartLeft - 20 <= 0) {
+        leftPos = chartLeft * -1 + 20;
         arrowPosition = `${pos[0] - leftPos}px`;
       }
 


### PR DESCRIPTION
Fix overflows on the left side of the screen. Top5 graphs in discover could have _very_ long tooltip contents. Doing some additional positioning math will ensure we keep the tooltip in the viewport. 

#### Before
![Screen Shot 2020-04-03 at 2 20 14 PM](https://user-images.githubusercontent.com/24086/78392771-cf431880-75b6-11ea-88fc-87b054f6838b.png)

#### After
![Screen Shot 2020-04-03 at 2 15 14 PM](https://user-images.githubusercontent.com/24086/78392791-d833ea00-75b6-11ea-95d0-8d994a2ba0a4.png)
