### PR TITLE
refs(mail): Move logic from `MailPlugin.notify` into `MailAdapter`

### DIFF
--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -8,14 +8,12 @@ import sentry
 
 from django.utils import dateformat
 from django.utils.encoding import force_text
-from django.utils.safestring import mark_safe
 
 from sentry.digests.utilities import get_digest_metadata, get_personalized_digests
 from sentry.mail.adapter import MailAdapter
 from sentry.plugins.base.structs import Notification
 from sentry.plugins.bases.notify import NotificationPlugin
-from sentry.utils.committers import get_serialized_event_file_committers
-from sentry.utils.email import MessageBuilder, group_id_to_email
+from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 from sentry.utils.linksign import generate_signed_link
 
@@ -61,110 +59,8 @@ class MailPlugin(NotificationPlugin):
         """
         return self.mail_adapter.get_send_to(project, event)
 
-    def add_unsubscribe_link(self, context, user_id, project, referrer):
-        context["unsubscribe_link"] = generate_signed_link(
-            user_id,
-            "sentry-account-email-unsubscribe-project",
-            referrer,
-            kwargs={"project_id": project.id},
-        )
-
     def notify(self, notification, **kwargs):
-        from sentry.models import Commit, Release
-
-        event = notification.event
-
-        environment = event.get_tag("environment")
-
-        group = event.group
-        project = group.project
-        org = group.organization
-
-        subject = event.get_email_subject()
-
-        query_params = {"referrer": "alert_email"}
-        if environment:
-            query_params["environment"] = environment
-        link = group.get_absolute_url(params=query_params)
-
-        template = "sentry/emails/error.txt"
-        html_template = "sentry/emails/error.html"
-
-        rules = []
-        for rule in notification.rules:
-            rule_link = "/settings/%s/projects/%s/alerts/rules/%s/" % (
-                org.slug,
-                project.slug,
-                rule.id,
-            )
-
-            rules.append((rule.label, rule_link))
-
-        enhanced_privacy = org.flags.enhanced_privacy
-
-        # lets identify possibly suspect commits and owners
-        commits = {}
-        try:
-            committers = get_serialized_event_file_committers(project, event)
-        except (Commit.DoesNotExist, Release.DoesNotExist):
-            pass
-        except Exception as exc:
-            logging.exception(six.text_type(exc))
-        else:
-            for committer in committers:
-                for commit in committer["commits"]:
-                    if commit["id"] not in commits:
-                        commit_data = commit.copy()
-                        commit_data["shortId"] = commit_data["id"][:7]
-                        commit_data["author"] = committer["author"]
-                        commit_data["subject"] = commit_data["message"].split("\n", 1)[0]
-                        commits[commit["id"]] = commit_data
-
-        context = {
-            "project_label": project.get_full_name(),
-            "group": group,
-            "event": event,
-            "link": link,
-            "rules": rules,
-            "enhanced_privacy": enhanced_privacy,
-            "commits": sorted(commits.values(), key=lambda x: x["score"], reverse=True),
-            "environment": environment,
-        }
-
-        # if the organization has enabled enhanced privacy controls we dont send
-        # data which may show PII or source code
-        if not enhanced_privacy:
-            interface_list = []
-            for interface in six.itervalues(event.interfaces):
-                body = interface.to_email_html(event)
-                if not body:
-                    continue
-                text_body = interface.to_string(event)
-                interface_list.append((interface.get_title(), mark_safe(body), text_body))
-
-            context.update({"tags": event.tags, "interfaces": interface_list})
-
-        headers = {
-            "X-Sentry-Logger": group.logger,
-            "X-Sentry-Logger-Level": group.get_level_display(),
-            "X-Sentry-Project": project.slug,
-            "X-Sentry-Reply-To": group_id_to_email(group.id),
-        }
-
-        for user_id in self.get_send_to(project=project, event=event):
-            self.add_unsubscribe_link(context, user_id, project, "alert_email")
-
-            self._send_mail(
-                subject=subject,
-                template=template,
-                html_template=html_template,
-                project=project,
-                reference=group,
-                headers=headers,
-                type="notify.error",
-                context=context,
-                send_to=[user_id],
-            )
+        return self.mail_adapter.notify(notification, **kwargs)
 
     def get_digest_subject(self, group, counts, date):
         return u"{short_id} - {count} new {noun} since {date}".format(
@@ -207,7 +103,7 @@ class MailPlugin(NotificationPlugin):
             group = six.next(iter(counts))
             subject = self.get_digest_subject(group, counts, start)
 
-            self.add_unsubscribe_link(context, user_id, project, "alert_digest")
+            self.mail_adapter.add_unsubscribe_link(context, user_id, project, "alert_digest")
             self._send_mail(
                 subject=subject,
                 template="sentry/emails/digests/body.txt",

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1,6 +1,10 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 
+import mock
 from django.core import mail
+from django.utils import timezone
 from exam import fixture
 
 from sentry.models import (
@@ -8,19 +12,39 @@ from sentry.models import (
     OrganizationMemberTeam,
     ProjectOption,
     ProjectOwnership,
+    Repository,
+    Rule,
     User,
     UserOption,
 )
 from sentry.event_manager import EventManager, get_event_type
 from sentry.mail.adapter import MailAdapter
-from sentry.ownership.grammar import dump_schema, Matcher, Owner, Rule
+from sentry.ownership import grammar
+from sentry.ownership.grammar import dump_schema, Matcher, Owner
+from sentry.plugins.base import Notification
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
 class BaseMailAdapterTest(object):
     @fixture
     def adapter(self):
         return MailAdapter()
+
+    def make_event_data(self, filename, url="http://example.com"):
+        mgr = EventManager(
+            {
+                "tags": [("level", "error")],
+                "stacktrace": {"frames": [{"lineno": 1, "filename": filename}]},
+                "request": {"url": url},
+            }
+        )
+        mgr.normalize()
+        data = mgr.get_data()
+        event_type = get_event_type(data)
+        data["type"] = event_type.key
+        data["metadata"] = event_type.get_metadata(data)
+        return data
 
 
 class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
@@ -42,9 +66,9 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
             project_id=self.project.id,
             schema=dump_schema(
                 [
-                    Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)]),
-                    Rule(Matcher("path", "*.jx"), [Owner("user", self.user2.email)]),
-                    Rule(
+                    grammar.Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)]),
+                    grammar.Rule(Matcher("path", "*.jx"), [Owner("user", self.user2.email)]),
+                    grammar.Rule(
                         Matcher("path", "*.cbl"),
                         [Owner("user", self.user.email), Owner("user", self.user2.email)],
                     ),
@@ -52,21 +76,6 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
             ),
             fallthrough=True,
         )
-
-    def make_event_data(self, filename, url="http://example.com"):
-        mgr = EventManager(
-            {
-                "tags": [("level", "error")],
-                "stacktrace": {"frames": [{"lineno": 1, "filename": filename}]},
-                "request": {"url": url},
-            }
-        )
-        mgr.normalize()
-        data = mgr.get_data()
-        event_type = get_event_type(data)
-        data["type"] = event_type.key
-        data["metadata"] = event_type.get_metadata(data)
-        return data
 
     def test_get_send_to_with_team_owners(self):
         event = self.store_event(data=self.make_event_data("foo.py"), project_id=self.project.id)
@@ -192,3 +201,220 @@ class MailAdapterSendMailTest(BaseMailAdapterTest, TestCase):
             msg = mail.outbox[0]
             assert msg.subject.endswith(subject)
             assert msg.recipients() == [self.user.email]
+
+
+class MailAdapterNotifyTest(BaseMailAdapterTest, TestCase):
+    def test_simple_notification(self):
+        event = self.store_event(
+            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
+        )
+
+        rule = Rule.objects.create(project=self.project, label="my rule")
+
+        notification = Notification(event=event, rule=rule)
+
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
+            self.adapter.notify(notification)
+
+        msg = mail.outbox[0]
+        assert msg.subject == "[Sentry] BAR-1 - Hello world"
+        assert "my rule" in msg.alternatives[0][0]
+
+    @mock.patch("sentry.interfaces.stacktrace.Stacktrace.get_title")
+    @mock.patch("sentry.interfaces.stacktrace.Stacktrace.to_email_html")
+    @mock.patch("sentry.plugins.sentry_mail.models.MailPlugin._send_mail")
+    def test_notify_users_renders_interfaces_with_utf8(
+        self, _send_mail, _to_email_html, _get_title
+    ):
+        _to_email_html.return_value = u"רונית מגן"
+        _get_title.return_value = "Stacktrace"
+
+        event = self.store_event(
+            data={"message": "Soubor ji\xc5\xbe existuje", "stacktrace": {"frames": [{}]}},
+            project_id=self.project.id,
+        )
+
+        notification = Notification(event=event)
+
+        with self.options({"system.url-prefix": "http://example.com"}):
+            self.adapter.notify(notification)
+
+        _get_title.assert_called_once_with()
+        _to_email_html.assert_called_once_with(event)
+
+    @mock.patch("sentry.mail.adapter.MailAdapter._send_mail")
+    def test_notify_users_does_email(self, _send_mail):
+        event_manager = EventManager({"message": "hello world", "level": "error"})
+        event_manager.normalize()
+        event_data = event_manager.get_data()
+        event_type = get_event_type(event_data)
+        event_data["type"] = event_type.key
+        event_data["metadata"] = event_type.get_metadata(event_data)
+
+        event = event_manager.save(self.project.id)
+        group = event.group
+
+        notification = Notification(event=event)
+
+        with self.options({"system.url-prefix": "http://example.com"}):
+            self.adapter.notify(notification)
+
+        assert _send_mail.call_count == 1
+        args, kwargs = _send_mail.call_args
+        self.assertEquals(kwargs.get("project"), self.project)
+        self.assertEquals(kwargs.get("reference"), group)
+        assert kwargs.get("subject") == u"BAR-1 - hello world"
+
+    @mock.patch("sentry.mail.adapter.MailAdapter._send_mail")
+    def test_multiline_error(self, _send_mail):
+        event_manager = EventManager({"message": "hello world\nfoo bar", "level": "error"})
+        event_manager.normalize()
+        event_data = event_manager.get_data()
+        event_type = get_event_type(event_data)
+        event_data["type"] = event_type.key
+        event_data["metadata"] = event_type.get_metadata(event_data)
+
+        event = event_manager.save(self.project.id)
+
+        notification = Notification(event=event)
+
+        with self.options({"system.url-prefix": "http://example.com"}):
+            self.adapter.notify(notification)
+
+        assert _send_mail.call_count == 1
+        args, kwargs = _send_mail.call_args
+        assert kwargs.get("subject") == u"BAR-1 - hello world"
+
+    def test_notify_users_with_utf8_subject(self):
+        event = self.store_event(
+            data={"message": "רונית מגן", "level": "error"}, project_id=self.project.id
+        )
+
+        notification = Notification(event=event)
+
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
+            self.adapter.notify(notification)
+
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert msg.subject == u"[Sentry] BAR-1 - רונית מגן"
+
+    def test_notify_with_suspect_commits(self):
+        repo = Repository.objects.create(
+            organization_id=self.organization.id, name=self.organization.id
+        )
+        release = self.create_release(project=self.project, version="v12")
+        release.set_commits(
+            [
+                {
+                    "id": "a" * 40,
+                    "repository": repo.name,
+                    "author_email": "bob@example.com",
+                    "author_name": "Bob",
+                    "message": "i fixed a bug",
+                    "patch_set": [{"path": "src/sentry/models/release.py", "type": "M"}],
+                }
+            ]
+        )
+
+        event = self.store_event(
+            data={
+                "message": "Kaboom!",
+                "platform": "python",
+                "timestamp": iso_format(before_now(seconds=1)),
+                "stacktrace": {
+                    "frames": [
+                        {
+                            "function": "handle_set_commits",
+                            "abs_path": "/usr/src/sentry/src/sentry/tasks.py",
+                            "module": "sentry.tasks",
+                            "in_app": True,
+                            "lineno": 30,
+                            "filename": "sentry/tasks.py",
+                        },
+                        {
+                            "function": "set_commits",
+                            "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
+                            "module": "sentry.models.release",
+                            "in_app": True,
+                            "lineno": 39,
+                            "filename": "sentry/models/release.py",
+                        },
+                    ]
+                },
+                "tags": {"sentry:release": release.version},
+            },
+            project_id=self.project.id,
+        )
+
+        with self.tasks():
+            notification = Notification(event=event)
+
+            self.adapter.notify(notification)
+
+        assert len(mail.outbox) >= 1
+
+        msg = mail.outbox[-1]
+
+        assert "Suspect Commits" in msg.body
+
+    def assert_notify(self, event, emails_sent_to):
+        mail.outbox = []
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
+            self.adapter.notify(Notification(event=event))
+        assert len(mail.outbox) == len(emails_sent_to)
+        assert sorted(email.to[0] for email in mail.outbox) == sorted(emails_sent_to)
+
+    def test_notify_users_with_owners(self):
+        user = self.create_user(email="foo@example.com", is_active=True)
+        user2 = self.create_user(email="baz@example.com", is_active=True)
+
+        organization = self.create_organization(owner=user)
+        team = self.create_team(organization=organization)
+        project = self.create_project(name="Test", teams=[team])
+        OrganizationMemberTeam.objects.create(
+            organizationmember=OrganizationMember.objects.get(user=user, organization=organization),
+            team=team,
+        )
+        self.create_member(user=user2, organization=organization, teams=[team])
+        self.group = self.create_group(
+            first_seen=timezone.now(),
+            last_seen=timezone.now(),
+            project=project,
+            message="hello  world",
+            logger="root",
+        )
+        ProjectOwnership.objects.create(
+            project_id=project.id,
+            schema=dump_schema(
+                [
+                    grammar.Rule(Matcher("path", "*.py"), [Owner("team", team.slug)]),
+                    grammar.Rule(Matcher("path", "*.jx"), [Owner("user", user2.email)]),
+                    grammar.Rule(
+                        Matcher("path", "*.cbl"),
+                        [Owner("user", user.email), Owner("user", user2.email)],
+                    ),
+                ]
+            ),
+            fallthrough=True,
+        )
+
+        event_all_users = self.store_event(
+            data=self.make_event_data("foo.cbl"), project_id=project.id
+        )
+        self.assert_notify(event_all_users, [user.email, user2.email])
+
+        event_team = self.store_event(data=self.make_event_data("foo.py"), project_id=project.id)
+        self.assert_notify(event_team, [user.email, user2.email])
+
+        event_single_user = self.store_event(
+            data=self.make_event_data("foo.jx"), project_id=project.id
+        )
+        self.assert_notify(event_single_user, [user2.email])
+
+        # Make sure that disabling mail alerts works as expected
+        UserOption.objects.set_value(user=user2, key="mail:alert", value=0, project=project)
+        event_all_users = self.store_event(
+            data=self.make_event_data("foo.cbl"), project_id=project.id
+        )
+        self.assert_notify(event_all_users, [user.email])

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -93,7 +93,7 @@ class MailPluginTest(TestCase):
         _get_title.assert_called_once_with()
         _to_email_html.assert_called_once_with(event)
 
-    @mock.patch("sentry.plugins.sentry_mail.models.MailPlugin._send_mail")
+    @mock.patch("sentry.mail.adapter.MailAdapter._send_mail")
     def test_notify_users_does_email(self, _send_mail):
         event_manager = EventManager({"message": "hello world", "level": "error"})
         event_manager.normalize()
@@ -116,7 +116,7 @@ class MailPluginTest(TestCase):
         self.assertEquals(kwargs.get("reference"), group)
         assert kwargs.get("subject") == u"BAR-1 - hello world"
 
-    @mock.patch("sentry.plugins.sentry_mail.models.MailPlugin._send_mail")
+    @mock.patch("sentry.mail.adapter.MailAdapter._send_mail")
     def test_multiline_error(self, _send_mail):
         event_manager = EventManager({"message": "hello world\nfoo bar", "level": "error"})
         event_manager.normalize()


### PR DESCRIPTION
This continues work done in https://github.com/getsentry/sentry/pull/18060 to move the core logic from MailPlugin into MailAdapter. As in the previous pr, I just copied the code exactly in the first commit, and then all modifications to get it working, add tests, etc are in the 2nd commit, so it's likely most useful for review.

This PR moves the notify method over to `MailAdapter`.