### PR TITLE
feat(Releases): Send failed commit emails to owners of repo on behalf of Sentry Apps

### DIFF
--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -150,13 +150,13 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
                 handle_invalid_identity(identity=e.identity, commit_failure=True)
             elif isinstance(e, (PluginError, InvalidIdentity, IntegrationError)):
                 msg = generate_fetch_commits_error_email(release, six.text_type(e))
-                emails = get_owner_emails(user, release.organization_id)
+                emails = get_emails_for_user_or_org(user, release.organization_id)
                 msg.send_async(to=emails)
             else:
                 msg = generate_fetch_commits_error_email(
                     release, "An internal system error occurred."
                 )
-                emails = get_owner_emails(user, release.organization_id)
+                emails = get_emails_for_user_or_org(user, release.organization_id)
                 msg.send_async(to=emails)
         else:
             logger.info(
@@ -225,14 +225,14 @@ def is_integration_provider(provider):
     return provider and provider.startswith("integrations:")
 
 
-def get_owner_emails(user, orgId):
+def get_emails_for_user_or_org(user, orgId):
     emails = []
     if user.is_sentry_app:
         members = OrganizationMember.objects.filter(
             organization_id=orgId, role="owner", user_id__isnull=False
         ).select_related("user")
         for m in list(members):
-            emails.add(m.user.email)
+            emails.append(m.user.email)
     else:
         emails = [user.email]
 

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -156,8 +156,6 @@ class FetchCommitsTest(TestCase):
 
         release2 = Release.objects.create(organization_id=org.id, version="12345678")
 
-        UserSocialAuth.objects.create(user=self.user, provider="dummy")
-
         mock_compare_commits.side_effect = Exception("secrets")
 
         with self.tasks():

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -137,6 +137,43 @@ class FetchCommitsTest(TestCase):
         assert "secrets" not in msg.body
 
     @patch("sentry.plugins.providers.dummy.repository.DummyRepositoryProvider.compare_commits")
+    def test_fetch_error_plugin_error_for_sentry_app(self, mock_compare_commits):
+        org = self.create_organization(owner=self.user, name="baz")
+        sentry_app = self.create_sentry_app(
+            organization=org, published=True, verify_install=False, name="Super Awesome App"
+        )
+
+        repo = Repository.objects.create(name="example", provider="dummy", organization_id=org.id)
+        release = Release.objects.create(organization_id=org.id, version="abcabcabc")
+
+        commit = Commit.objects.create(organization_id=org.id, repository_id=repo.id, key="a" * 40)
+
+        ReleaseHeadCommit.objects.create(
+            organization_id=org.id, repository_id=repo.id, release=release, commit=commit
+        )
+
+        refs = [{"repository": repo.name, "commit": "b" * 40}]
+
+        release2 = Release.objects.create(organization_id=org.id, version="12345678")
+
+        UserSocialAuth.objects.create(user=self.user, provider="dummy")
+
+        mock_compare_commits.side_effect = Exception("secrets")
+
+        with self.tasks():
+            fetch_commits(
+                release_id=release2.id,
+                user_id=sentry_app.proxy_user_id,
+                refs=refs,
+                previous_release_id=release.id,
+            )
+
+        msg = mail.outbox[-1]
+        assert msg.subject == "Unable to Fetch Commits"
+        assert msg.to == [self.user.email]
+        assert "secrets" not in msg.body
+
+    @patch("sentry.plugins.providers.dummy.repository.DummyRepositoryProvider.compare_commits")
     def test_fetch_error_random_exception(self, mock_compare_commits):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")


### PR DESCRIPTION
## Objective
The proxy user for the sentry app does not have an email, because it's not used as a normal user would be. So, when we attempt to send a "failed to fetch commits" email it will fail.

We should send the `failed fetch commits` email to the owners of that org on behalf of the Sentry App.

## Test Plan
I tested locally by:
1. setting up releases for a mock project with Bitbucket,
2. converting my user into a sentry app in the db,
3. creating multiple owners for the org
4. use `mail.backend: 'sentry.utils.email.PreviewBackend'` setting in `.sentry/config.yml` to capture sent emails and check emails were sent the right users.

Also added a unit test case for `fetch_commits` function.