### PR TITLE
feat(async-csv): Add new-tag to export all button

### DIFF
--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import {Client} from 'app/api';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import Feature from 'app/components/acl/feature';
-import BetaTag from 'app/components/betaTag';
 import Button from 'app/components/button';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
+import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -73,7 +73,7 @@ class DataExport extends React.Component<Props, State> {
     return (
       <Feature features={['data-export']}>
         {inProgress && dataExportId ? (
-          <StyledBetaButton
+          <NewButton
             size="small"
             priority="default"
             title="You can get on with your life. We'll email you when your data's ready."
@@ -81,9 +81,9 @@ class DataExport extends React.Component<Props, State> {
             disabled
           >
             {t("We're working on it...")}
-          </StyledBetaButton>
+          </NewButton>
         ) : (
-          <StyledBetaButton
+          <NewButton
             onClick={this.startDataExport}
             disabled={disabled || false}
             size="small"
@@ -92,30 +92,27 @@ class DataExport extends React.Component<Props, State> {
             {...this.props}
           >
             {children ? children : t('Export All to CSV')}
-          </StyledBetaButton>
+          </NewButton>
         )}
       </Feature>
     );
   }
 }
 
-const BetaButton = ({children, ...buttonProps}) => (
+const NewButton = ({children, ...buttonProps}) => (
   <Button {...buttonProps}>
     {children}
-    <span id="beta-tag">
-      <BetaTag title="" />
-    </span>
+    <NewTag>{t('NEW')}</NewTag>
   </Button>
 );
 
-const StyledBetaButton = styled(BetaButton)`
-  position: relative;
-  #beta-tag {
-    position: absolute;
-    top: 0;
-    right: 0;
-    margin: -10px -20px 0 0;
-  }
+const NewTag = styled('span')`
+  font-size: 9px;
+  padding: 3px ${space(1)};
+  margin: -3px -3px -3px ${space(0.75)};
+  background: ${p => p.theme.green};
+  color: ${p => p.theme.white};
+  border-radius: 20px;
 `;
 
 export {DataExport};

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -1,8 +1,10 @@
+import styled from '@emotion/styled';
 import React from 'react';
 
 import {Client} from 'app/api';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import Feature from 'app/components/acl/feature';
+import BetaTag from 'app/components/betaTag';
 import Button from 'app/components/button';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
@@ -71,7 +73,7 @@ class DataExport extends React.Component<Props, State> {
     return (
       <Feature features={['data-export']}>
         {inProgress && dataExportId ? (
-          <Button
+          <StyledBetaButton
             size="small"
             priority="default"
             title="You can get on with your life. We'll email you when your data's ready."
@@ -79,9 +81,9 @@ class DataExport extends React.Component<Props, State> {
             disabled
           >
             {t("We're working on it...")}
-          </Button>
+          </StyledBetaButton>
         ) : (
-          <Button
+          <StyledBetaButton
             onClick={this.startDataExport}
             disabled={disabled || false}
             size="small"
@@ -90,12 +92,31 @@ class DataExport extends React.Component<Props, State> {
             {...this.props}
           >
             {children ? children : t('Export All to CSV')}
-          </Button>
+          </StyledBetaButton>
         )}
       </Feature>
     );
   }
 }
+
+const BetaButton = ({children, ...buttonProps}) => (
+  <Button {...buttonProps}>
+    {children}
+    <span id="beta-tag">
+      <BetaTag title="" />
+    </span>
+  </Button>
+);
+
+const StyledBetaButton = styled(BetaButton)`
+  position: relative;
+  #beta-tag {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: -10px -20px 0 0;
+  }
+`;
 
 export {DataExport};
 export default withApi(withOrganization(DataExport));

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -36,7 +36,7 @@ describe('DataExport', function() {
       mockRouterContext(mockAuthorizedOrg)
     );
     expect(wrapper.isEmptyRender()).toBe(false);
-    expect(wrapper.text()).toBe('Export All to CSV');
+    expect(wrapper.text()).toContain('Export All to CSV');
   });
 
   it('should render custom children if provided', function() {
@@ -45,7 +45,7 @@ describe('DataExport', function() {
       <WrappedDataExport payload={mockPayload}>{testString}</WrappedDataExport>,
       mockRouterContext(mockAuthorizedOrg)
     );
-    expect(wrapper.text()).toBe(testString);
+    expect(wrapper.text()).toContain(testString);
   });
 
   it('should respect the disabled prop and not be clickable', function() {
@@ -90,7 +90,7 @@ describe('DataExport', function() {
     });
     await tick();
     wrapper.update();
-    expect(wrapper.text()).toBe("We're working on it...");
+    expect(wrapper.text()).toContain("We're working on it...");
     expect(wrapper.find(Button).prop('disabled')).toBe(true);
     expect(wrapper.find(DataExport).state()).toEqual({
       inProgress: true,


### PR DESCRIPTION
Before we enable the feature for GA or anything like that, we want to add a <s>beta</s> new tag to let people know unexpected errors will be looked at. 👌

Image:
<s>[prev image](https://user-images.githubusercontent.com/35509934/78402919-73ce5600-75c9-11ea-9e25-9e7c924d3567.png)</s>

**Update**:

Changed it over to a 'new' tag instead of 'beta' as per a design spec.

Image:
![image](https://user-images.githubusercontent.com/35509934/78608068-33bbdd00-782e-11ea-968c-321490200e13.png)

