### PR TITLE
fix(performance-views) - Return nothing instead of 404

### DIFF
--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -113,8 +113,6 @@ class KeyTransactionStatsEndpoint(KeyTransactionBase):
             return self.response(status=404)
 
         queryset = KeyTransaction.objects.filter(organization=organization, owner=request.user)
-        if not queryset.exists():
-            return Response({"data": []}, status=200)
 
         def get_event_stats(query_columns, query, params, rollup, reference_event=None):
             return key_transaction_timeseries_query(

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -68,12 +68,16 @@ class KeyTransactionEndpoint(KeyTransactionBase):
 
         queryset = KeyTransaction.objects.filter(organization=organization, owner=request.user)
 
-        if not queryset.exists():
-            raise ResourceDoesNotExist
-
-        results = key_transaction_query(
-            fields, request.GET.get("query"), params, orderby, "discover.key_transactions", queryset
-        )
+        results = {}
+        if queryset.exists():
+            results = key_transaction_query(
+                fields,
+                request.GET.get("query"),
+                params,
+                orderby,
+                "discover.key_transactions",
+                queryset,
+            )
 
         return Response(
             self.handle_results_with_meta(request, organization, params["project_id"], results),
@@ -110,7 +114,7 @@ class KeyTransactionStatsEndpoint(KeyTransactionBase):
 
         queryset = KeyTransaction.objects.filter(organization=organization, owner=request.user)
         if not queryset.exists():
-            raise ResourceDoesNotExist
+            return Response({"data": []}, status=200)
 
         def get_event_stats(query_columns, query, params, rollup, reference_event=None):
             return key_transaction_timeseries_query(

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -690,21 +690,26 @@ def key_transaction_timeseries_query(selected_columns, query, params, rollup, re
         queryset (QuerySet) Filtered QuerySet of KeyTransactions
     """
     snuba_filter = get_timeseries_snuba_filter(selected_columns, query, params, rollup)
-    snuba_filter.conditions.extend(key_transaction_conditions(queryset))
 
-    result = raw_query(
-        aggregations=snuba_filter.aggregations,
-        conditions=snuba_filter.conditions,
-        filter_keys=snuba_filter.filter_keys,
-        start=snuba_filter.start,
-        end=snuba_filter.end,
-        rollup=rollup,
-        orderby="time",
-        groupby=["time"],
-        dataset=Dataset.Discover,
-        limit=10000,
-        referrer=referrer,
-    )
+    if queryset.exists():
+        snuba_filter.conditions.extend(key_transaction_conditions(queryset))
+
+        result = raw_query(
+            aggregations=snuba_filter.aggregations,
+            conditions=snuba_filter.conditions,
+            filter_keys=snuba_filter.filter_keys,
+            start=snuba_filter.start,
+            end=snuba_filter.end,
+            rollup=rollup,
+            orderby="time",
+            groupby=["time"],
+            dataset=Dataset.Discover,
+            limit=10000,
+            referrer=referrer,
+        )
+    else:
+        result = {"data": []}
+
     result = zerofill(result["data"], snuba_filter.start, snuba_filter.end, rollup, "time")
 
     return SnubaTSResult({"data": result}, snuba_filter.start, snuba_filter.end, rollup)

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -123,7 +123,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
             ]
         }
 
-    def test_get_no_key_transacitons(self):
+    def test_get_no_key_transactions(self):
         event_data = load_data("transaction")
         start_timestamp = iso_format(before_now(minutes=1))
         end_timestamp = iso_format(before_now(minutes=1))
@@ -157,7 +157,8 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
                 },
             )
 
-        assert response.status_code == 404
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 0
 
     def test_is_key_transaciton(self):
         event_data = load_data("transaction")
@@ -592,4 +593,5 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
                 },
             )
 
-        assert response.status_code == 404
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 0

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import pytz
 import six
-from datetime import timedelta
 
 from django.core.urlresolvers import reverse
 
@@ -160,7 +159,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 0
 
-    def test_is_key_transaciton(self):
+    def test_is_key_transaction(self):
         event_data = load_data("transaction")
         start_timestamp = iso_format(before_now(minutes=1))
         end_timestamp = iso_format(before_now(minutes=1))
@@ -181,7 +180,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert response.data["isKey"]
 
-    def test_is_not_key_transaciton(self):
+    def test_is_not_key_transaction(self):
         event_data = load_data("transaction")
         start_timestamp = iso_format(before_now(minutes=1))
         end_timestamp = iso_format(before_now(minutes=1))
@@ -558,24 +557,16 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_key_transaction_stats_with_no_key_transactions(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        prototype = {
-            "type": "transaction",
-            "transaction": "api.issue.delete",
-            "spans": [],
-            "contexts": {"trace": {"op": "foobar", "trace_id": "a" * 32, "span_id": "a" * 16}},
-            "tags": {"important": "yes"},
-        }
-        fixtures = (
-            ("d" * 32, before_now(minutes=32), "yes"),
-            ("e" * 32, before_now(hours=1, minutes=2), "no"),
-            ("f" * 32, before_now(hours=1, minutes=35), "yes"),
+        data = load_data("transaction")
+        event_ids = ["d" * 32, "e" * 32, "f" * 32]
+        data.update(
+            {
+                "timestamp": iso_format(before_now(minutes=30)),
+                "start_timestamp": iso_format(before_now(minutes=31)),
+            }
         )
-        for fixture in fixtures:
-            data = prototype.copy()
-            data["event_id"] = fixture[0]
-            data["timestamp"] = iso_format(fixture[1])
-            data["start_timestamp"] = iso_format(fixture[1] - timedelta(seconds=1))
-            data["tags"]["important"] = fixture[2]
+        for event_id in event_ids:
+            data["event_id"] = event_id
             self.store_event(data=data, project_id=self.project.id)
 
         with self.feature("organizations:performance-view"):
@@ -584,14 +575,110 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
                 url,
                 format="json",
                 data={
-                    "end": iso_format(before_now()),
                     "start": iso_format(before_now(hours=2)),
-                    "interval": "30m",
+                    "end": iso_format(before_now()),
+                    "interval": "1h",
                     "yAxis": "count()",
-                    "query": "tags[important]: yes",
                     "project": [self.project.id],
                 },
             )
 
         assert response.status_code == 200, response.content
-        assert len(response.data["data"]) == 0
+        assert len(response.data["data"]) == 3
+        assert [attrs for time, attrs in response.data["data"]] == [
+            [{"count": 0}],
+            [{"count": 0}],
+            [{"count": 0}],
+        ]
+
+    @patch("django.utils.timezone.now")
+    def test_key_transaction_stats_with_multi_yaxis(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        data = load_data("transaction")
+        event_ids = ["d" * 32, "e" * 32, "f" * 32]
+        data.update(
+            {
+                "timestamp": iso_format(before_now(minutes=30)),
+                "start_timestamp": iso_format(before_now(minutes=31)),
+            }
+        )
+        for event_id in event_ids:
+            data["event_id"] = event_id
+            self.store_event(data=data, project_id=self.project.id)
+
+        KeyTransaction.objects.create(
+            owner=self.user,
+            organization=self.project.organization,
+            transaction=data["transaction"],
+            project=self.project,
+        )
+
+        with self.feature("organizations:performance-view"):
+            url = reverse("sentry-api-0-organization-key-transactions-stats", args=[self.org.slug])
+            response = self.client.get(
+                url,
+                format="json",
+                data={
+                    "start": iso_format(before_now(hours=2)),
+                    "end": iso_format(before_now()),
+                    "interval": "1h",
+                    "yAxis": ["rps()", "rpm()"],
+                    "project": [self.project.id],
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        assert len(response.data["rpm()"]["data"]) == 3
+        assert len(response.data["rps()"]["data"]) == 3
+        assert [{"count": 3.0 / (3600.0 / 60.0)}] in [
+            attrs for time, attrs in response.data["rpm()"]["data"]
+        ]
+        assert [{"count": 3.0 / 3600.0}] in [
+            attrs for time, attrs in response.data["rps()"]["data"]
+        ]
+
+    @patch("django.utils.timezone.now")
+    def test_key_transaction_stats_with_multi_yaxis_no_key_transactions(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        data = load_data("transaction")
+        event_ids = ["d" * 32, "e" * 32, "f" * 32]
+        data.update(
+            {
+                "timestamp": iso_format(before_now(minutes=30)),
+                "start_timestamp": iso_format(before_now(minutes=31)),
+            }
+        )
+        for event_id in event_ids:
+            data["event_id"] = event_id
+            for i in range(5):
+                self.store_event(data=data, project_id=self.project.id)
+
+        with self.feature("organizations:performance-view"):
+            url = reverse("sentry-api-0-organization-key-transactions-stats", args=[self.org.slug])
+            response = self.client.get(
+                url,
+                format="json",
+                data={
+                    "start": iso_format(before_now(hours=2)),
+                    "end": iso_format(before_now()),
+                    "interval": "1h",
+                    "yAxis": ["rps()", "rpm()"],
+                    "project": [self.project.id],
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        assert len(response.data["rpm()"]["data"]) == 3
+        assert len(response.data["rps()"]["data"]) == 3
+        assert [attrs for time, attrs in response.data["rpm()"]["data"]] == [
+            [{"count": 0}],
+            [{"count": 0}],
+            [{"count": 0}],
+        ]
+        assert [attrs for time, attrs in response.data["rps()"]["data"]] == [
+            [{"count": 0}],
+            [{"count": 0}],
+            [{"count": 0}],
+        ]


### PR DESCRIPTION
- When there are no key transactions for a user return nothing with a
  200 instead of a 404