### PR TITLE
fix(discover) Handle empty field graciously

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1373,6 +1373,8 @@ def resolve_field_list(fields, snuba_filter, auto_fields=True):
             fields.append("project.id")
 
     for field in fields:
+        if isinstance(field, six.string_types) and field.strip() == "":
+            continue
         column_additions, agg_additions = resolve_field(field, snuba_filter.date_params)
         if column_additions:
             columns.extend(column_additions)

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1257,6 +1257,11 @@ class ResolveFieldListTest(unittest.TestCase):
             resolve_field_list(fields, eventstore.Filter())
         assert "Field names" in six.text_type(err)
 
+    def test_blank_field_ignored(self):
+        fields = ["", "title", "   "]
+        result = resolve_field_list(fields, eventstore.Filter())
+        assert result["selected_columns"] == ["title", "id", "project.id"]
+
     def test_automatic_fields_no_aggregates(self):
         fields = ["event.type", "message"]
         result = resolve_field_list(fields, eventstore.Filter())


### PR DESCRIPTION
Ignore empty or blank fields in requests as they are obviously human error. While we could fail this request and ask the user to fix it, we can also easily identify and ignore this class of mistake.

Fixes SENTRY-FCZ