### PR TITLE
Adding ARCHIVED status

### DIFF
--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -274,6 +274,7 @@ class AlertRuleStatus(Enum):
     TRIGGERED = 1
     PENDING_DELETION = 2
     DELETION_IN_PROGRESS = 3
+    ARCHIVED = 4
 
 
 class AlertRuleThresholdType(Enum):
@@ -296,6 +297,7 @@ class AlertRuleManager(BaseManager):
                 status__in=(
                     AlertRuleStatus.PENDING_DELETION.value,
                     AlertRuleStatus.DELETION_IN_PROGRESS.value,
+                    AlertRuleStatus.ARCHIVED.value,
                 )
             )
         )

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -14,6 +14,7 @@ from sentry.utils.compat.mock import Mock, patch
 from sentry.db.models.manager import BaseManager
 from sentry.incidents.models import (
     AlertRule,
+    AlertRuleStatus,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
     Incident,
@@ -348,6 +349,24 @@ class IncidentDurationTest(unittest.TestCase):
         assert incident.duration == timedelta(minutes=5)
         incident.date_closed = incident.date_started + timedelta(minutes=2)
         assert incident.duration == timedelta(minutes=2)
+
+
+class IncidentAlertRuleRelationTest(TestCase):
+    def test(self):
+        self.alert_rule = self.create_alert_rule()
+        self.trigger = self.create_alert_rule_trigger(self.alert_rule)
+        self.incident = self.create_incident(alert_rule=self.alert_rule, projects=[self.project])
+
+        assert self.incident.alert_rule.id == self.alert_rule.id
+        all_alert_rules = list(AlertRule.objects.all())
+        assert self.alert_rule in all_alert_rules
+
+        self.alert_rule.status = AlertRuleStatus.ARCHIVED.value
+        self.alert_rule.save()
+
+        all_alert_rules = list(AlertRule.objects.all())
+        assert self.alert_rule not in all_alert_rules
+        assert self.incident.alert_rule.id == self.alert_rule.id
 
 
 @freeze_time()


### PR DESCRIPTION
Adds an ARCHIVED status to the enum, and adds it to the manager's filter so it is not included by default.

(Note I didn't remove deletion (enums, functions) with this PR - I will leave it in for now, and likely remove it once we've replaced the functionality of deletion with archival)