### PR TITLE
feat(ecosystem): adds doc integration to directory

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -423,7 +423,8 @@ export type PluginWithProjectList = PluginNoProject & {
 export type AppOrProviderOrPlugin =
   | SentryApp
   | IntegrationProvider
-  | PluginWithProjectList;
+  | PluginWithProjectList
+  | DocumentIntegration;
 
 export type DocumentIntegration = {
   slug: string;

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -12,6 +12,7 @@ import {
   AppOrProviderOrPlugin,
   SentryApp,
   PluginWithProjectList,
+  DocumentIntegration,
 } from 'app/types';
 import {Hooks} from 'app/types/hooks';
 import HookStore from 'app/stores/hookStore';
@@ -238,6 +239,9 @@ export const getCategoriesForIntegration = (
   if (isPlugin(integration)) {
     return getCategories(integration.featureDescriptions);
   }
+  if (isDocumentIntegration(integration)) {
+    return getCategories(integration.features);
+  }
   return getCategories(integration.metadata.features);
 };
 
@@ -251,4 +255,10 @@ export function isPlugin(
   integration: AppOrProviderOrPlugin
 ): integration is PluginWithProjectList {
   return integration.hasOwnProperty('shortName');
+}
+
+export function isDocumentIntegration(
+  integration: AppOrProviderOrPlugin
+): integration is DocumentIntegration {
+  return integration.hasOwnProperty('docUrl');
 }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
@@ -3,11 +3,13 @@ import {DocumentIntegration} from 'app/types';
 export const INSTALLED = 'Installed' as const;
 export const NOT_INSTALLED = 'Not Installed' as const;
 export const PENDING = 'Pending' as const;
+export const LEARN_MORE = 'Learn More' as const;
 
 export const COLORS = {
   [INSTALLED]: 'success',
   [NOT_INSTALLED]: 'gray2',
   [PENDING]: 'yellowOrange',
+  [LEARN_MORE]: 'gray2',
 } as const;
 
 /**
@@ -53,27 +55,135 @@ export const POPULARITY_WEIGHT: {
   segment: 2,
   'amazon-sqs': 2,
   splunk: 2,
+
+  //doc integrations
+  fullstory: 8,
+  datadog: 8,
+  msteams: 8,
+  asayer: 8,
+  rocketchat: 8,
 } as const;
 
 export const documentIntegrations: {
   [key: string]: DocumentIntegration;
 } = {
+  fullstory: {
+    slug: 'fullstory',
+    name: 'FullStory',
+    author: 'Sentry',
+    docUrl: 'https://www.npmjs.com/package/@sentry/fullstory',
+    description:
+      'The Sentry-FullStory integration seamlessly integrates the Sentry and FullStory platforms. When you look at a browser error in Sentry, you will see a link to the FullStory session replay at that exact moment in time. When you are watching a FullStory replay and your user experiences an error, you will see a link that will take you to that error in Sentry.',
+    features: [
+      {
+        featureGate: 'session-replay',
+        description:
+          'Links Sentry errors to the FullStory session replay and vice-versa.',
+      },
+    ],
+    resourceLinks: [
+      {
+        title: 'Documentation',
+        url: 'https://www.npmjs.com/package/@sentry/fullstory',
+      },
+      {title: 'View Source', url: 'https://github.com/getsentry/sentry-fullstory'},
+      {
+        title: 'Report Issue',
+        url: 'https://github.com/getsentry/sentry-fullstory/issues',
+      },
+    ],
+  },
   datadog: {
     slug: 'datadog',
     name: 'Datadog',
     author: 'Datadog',
-    docUrl: 'https://www.datadoghq.com/',
+    docUrl: 'https://docs.datadoghq.com/integrations/sentry/',
     description:
-      'Quickly discover relationships between production apps and systems performance. Seeing correlations between Sentry events and metrics from infra services like AWS, Elasticsearch, Docker, and Kafka can save time detecting sources of future spikes.',
+      'Quickly discover relationships between production apps and systems performance. See correlations between Sentry events and metrics from infra services like AWS, Elasticsearch, Docker, and Kafka can save time detecting sources of future spikes.',
     features: [
       {
-        featureGate: 'data-forwarding',
-        description: 'Forward any events you choose from Sentry.',
+        featureGate: 'incident-management',
+        description:
+          'Manage incidents and outages by sending Sentry notifications to DataDog.',
+      },
+      {
+        featureGate: 'alert-rule',
+        description:
+          'Configure Sentry rules to trigger notifications based on conditions you set through the Sentry webhook integration.',
       },
     ],
     resourceLinks: [
-      {title: 'View Source', url: 'https://sentry.io'},
-      {title: 'Report Issue', url: 'https://github.com'},
+      {title: 'Documentation', url: 'https://docs.datadoghq.com/integrations/sentry/'},
+    ],
+  },
+  msteams: {
+    slug: 'msteams',
+    name: 'Microst Teams',
+    author: 'Microsoft',
+    docUrl:
+      'https://appsource.microsoft.com/en-us/product/office/WA104381566?src=office&tab=Overview',
+    description:
+      "Microsoft Teams is a hub for teamwork in Office 365. Keep all your team's chats, meetings, files, and apps together in one place.",
+    features: [
+      {
+        featureGate: 'chat',
+        description: 'Get Sentry notifications in Microsoft Teams.',
+      },
+      {
+        featureGate: 'alert-rule',
+        description:
+          'Configure Sentry rules to trigger notifications based on conditions you set through the Sentry webhook integration.',
+      },
+    ],
+    resourceLinks: [
+      {
+        title: 'Documentation',
+        url:
+          'https://appsource.microsoft.com/en-us/product/office/WA104381566?src=office&tab=Overview',
+      },
+    ],
+  },
+  asayer: {
+    slug: 'asayer',
+    name: 'Asayer',
+    author: 'Sentry',
+    docUrl: 'https://docs.asayer.io/integrations/sentry',
+    description:
+      'Asayer is a session replay tool for developers. Replay each user session alongside your front/backend logs and other data spread across your stack so you can immediately find, reproduce and fix bugs faster.',
+    features: [
+      {
+        featureGate: 'session-replay',
+        description:
+          'By integrating Sentry with Asayer, you can see the moments that precede and that lead up to each problem. You can sync your Sentry logs alongside your session replay, JS console and network activity to gain complete visibility over every issue that affect your users.',
+      },
+    ],
+    resourceLinks: [
+      {title: 'Documentation', url: 'https://docs.asayer.io/integrations/sentry'},
+    ],
+  },
+  rocketchat: {
+    slug: 'rocketchat',
+    name: 'Rocket.Chat',
+    author: 'Rocket.Chat',
+    docUrl: 'https://rocket.chat/docs/administrator-guides/integrations/sentry/',
+    description:
+      'Rocket.Chat is a free and open-source team chat collaboration platform that allows users to communicate securely in real-time across devices on the web, desktop or mobile and to customize their interface with a range of plugins, themes, and integrations with other key software.',
+    features: [
+      {
+        featureGate: 'chat',
+        description: 'Get Sentry notifications in Rocket.Chat.',
+      },
+      {
+        featureGate: 'alert-rule',
+        description:
+          'Configure Sentry rules to trigger notifications based on conditions you set through the Sentry webhook integration.',
+      },
+    ],
+    resourceLinks: [
+      {
+        title: 'Documentation',
+        url: 'https://rocket.chat/docs/administrator-guides/integrations/sentry/',
+      },
     ],
   },
 };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -7,6 +7,7 @@ import {t} from 'app/locale';
 import {DocumentIntegration} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
 import ExternalLink from 'app/components/links/externalLink';
+import {IconOpen} from 'app/icons/iconOpen';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 import {documentIntegrations} from './constants';
@@ -25,8 +26,11 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
 
   get integration(): DocumentIntegration {
     const {integrationSlug} = this.props.params;
-
-    return documentIntegrations[integrationSlug] || {};
+    const documentIntegration = documentIntegrations[integrationSlug];
+    if (!documentIntegration) {
+      throw new Error(`No document integration of slug ${integrationSlug} exists`);
+    }
+    return documentIntegration;
   }
 
   get description() {
@@ -68,6 +72,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
           priority="primary"
           style={{marginLeft: space(1)}}
           data-test-id="learn-more"
+          icon={<StyledIconOpen size="xs" />}
         >
           {t('Learn More')}
         </LearnMoreButton>
@@ -83,6 +88,13 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
 
 const LearnMoreButton = styled(Button)`
   margin-left: ${space(1)};
+`;
+
+const StyledIconOpen = styled(IconOpen)`
+  transition: 0.1s linear color;
+  margin: 0 ${space(0.5)};
+  position: relative;
+  top: 1px;
 `;
 
 export default withOrganization(SentryAppDetailedView);

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -11,6 +11,7 @@ import {
   Integration,
   SentryApp,
   IntegrationProvider,
+  DocumentIntegration,
   SentryAppInstallation,
   PluginWithProjectList,
   AppOrProviderOrPlugin,
@@ -22,6 +23,7 @@ import {
   getCategorySelectActive,
   isSentryApp,
   isPlugin,
+  isDocumentIntegration,
   getCategoriesForIntegration,
 } from 'app/utils/integrationUtil';
 import {t, tct} from 'app/locale';
@@ -35,7 +37,7 @@ import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import space from 'app/styles/space';
 import SelectControl from 'app/components/forms/selectControl';
 
-import {POPULARITY_WEIGHT} from './constants';
+import {POPULARITY_WEIGHT, documentIntegrations} from './constants';
 import IntegrationRow from './integrationRow';
 
 type Props = RouteComponentProps<{orgId: string}, {}> & {
@@ -104,7 +106,8 @@ export class IntegrationListDirectory extends AsyncComponent<
       .concat(published)
       .concat(orgOwned)
       .concat(this.providers)
-      .concat(plugins);
+      .concat(plugins)
+      .concat(Object.values(documentIntegrations));
 
     const list = this.sortIntegrations(combined);
 
@@ -187,24 +190,26 @@ export class IntegrationListDirectory extends AsyncComponent<
       return integration.projectList.length > 0 ? 2 : 0;
     }
 
-    if (!isSentryApp(integration)) {
-      return integrations.find(i => i.provider.key === integration.key) ? 2 : 0;
+    if (isSentryApp(integration)) {
+      const install = this.getAppInstall(integration);
+      if (install) {
+        return install.status === 'pending' ? 1 : 2;
+      }
+      return 0;
     }
 
-    const install = this.getAppInstall(integration);
-
-    if (install) {
-      return install.status === 'pending' ? 1 : 2;
+    if (isDocumentIntegration(integration)) {
+      return 0;
     }
 
-    return 0;
+    return integrations.find(i => i.provider.key === integration.key) ? 2 : 0;
   }
 
   getPopularityWeight = (integration: AppOrProviderOrPlugin) =>
     POPULARITY_WEIGHT[integration.slug] ?? 1;
 
   sortByName = (a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) =>
-    a.name.localeCompare(b.name);
+    a.slug.localeCompare(b.slug);
 
   sortByPopularity = (a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) => {
     const weightA = this.getPopularityWeight(a);
@@ -212,14 +217,26 @@ export class IntegrationListDirectory extends AsyncComponent<
     return weightB - weightA;
   };
 
-  sortByInstalled = (a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) =>
-    this.getInstallValue(b) - this.getInstallValue(a);
+  sortByInstalled = (a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) => {
+    const out = this.getInstallValue(b) - this.getInstallValue(a);
+    return out;
+  };
 
   sortIntegrations(integrations: AppOrProviderOrPlugin[]) {
-    return integrations
-      .sort(this.sortByName)
-      .sort(this.sortByPopularity)
-      .sort(this.sortByInstalled);
+    return integrations.sort((a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) => {
+      //sort by whether installed first
+      const diffWeight = this.sortByInstalled(a, b);
+      if (diffWeight !== 0) {
+        return diffWeight;
+      }
+      //then sort by popularity
+      const diffPop = this.sortByPopularity(a, b);
+      if (diffPop !== 0) {
+        return diffPop;
+      }
+      //then sort by name
+      return this.sortByName(a, b);
+    });
   }
 
   async componentDidUpdate(_: Props, prevState: State) {
@@ -349,11 +366,31 @@ export class IntegrationListDirectory extends AsyncComponent<
     );
   };
 
+  renderDocumentIntegration = (integration: DocumentIntegration) => {
+    const {organization} = this.props;
+    return (
+      <IntegrationRow
+        key={`doc-int-${integration.slug}`}
+        organization={organization}
+        type="documentIntegration"
+        slug={integration.slug}
+        displayName={integration.name}
+        publishStatus="published"
+        configurations={0}
+        categories={getCategoriesForIntegration(integration)}
+      />
+    );
+  };
+
   renderIntegration = (integration: AppOrProviderOrPlugin) => {
     if (isSentryApp(integration)) {
       return this.renderSentryApp(integration);
-    } else if (isPlugin(integration)) {
+    }
+    if (isPlugin(integration)) {
       return this.renderPlugin(integration);
+    }
+    if (isDocumentIntegration(integration)) {
+      return this.renderDocumentIntegration(integration);
     }
     return this.renderProvider(integration);
   };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -217,10 +217,8 @@ export class IntegrationListDirectory extends AsyncComponent<
     return weightB - weightA;
   };
 
-  sortByInstalled = (a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) => {
-    const out = this.getInstallValue(b) - this.getInstallValue(a);
-    return out;
-  };
+  sortByInstalled = (a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) =>
+    this.getInstallValue(b) - this.getInstallValue(a);
 
   sortIntegrations(integrations: AppOrProviderOrPlugin[]) {
     return integrations.sort((a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) => {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -12,19 +12,20 @@ import IntegrationStatus from './integrationStatus';
 
 type Props = {
   organization: Organization;
-  type: 'plugin' | 'firstParty' | 'sentryApp';
+  type: 'plugin' | 'firstParty' | 'sentryApp' | 'documentIntegration';
   slug: string;
   displayName: string;
-  status: IntegrationInstallationStatus;
+  status?: IntegrationInstallationStatus;
   publishStatus: 'unpublished' | 'published' | 'internal';
   configurations: number;
-  categories?: string[];
+  categories: string[];
 };
 
 const urlMap = {
   plugin: 'plugins',
   firstParty: 'integrations',
   sentryApp: 'sentry-apps',
+  documentIntegration: 'document-integrations',
 };
 
 const IntegrationRow = (props: Props) => {
@@ -48,11 +49,20 @@ const IntegrationRow = (props: Props) => {
     if (type === 'sentryApp') {
       return publishStatus !== 'published' && <PublishStatus status={publishStatus} />;
     }
+    //TODO: Use proper translations
     return configurations > 0 ? (
       <StyledLink to={`${baseUrl}?tab=configurations`}>{`${configurations} Configuration${
         configurations > 1 ? 's' : ''
       }`}</StyledLink>
     ) : null;
+  };
+
+  const renderStatus = () => {
+    //status should be undefined for document integrations
+    if (status) {
+      return <IntegrationStatus status={status} />;
+    }
+    return <LearnMore to={baseUrl}>{t('Learn More')}</LearnMore>;
   };
 
   return (
@@ -62,7 +72,7 @@ const IntegrationRow = (props: Props) => {
         <Container>
           <IntegrationName to={baseUrl}>{displayName}</IntegrationName>
           <IntegrationDetails>
-            <IntegrationStatus status={status} />
+            {renderStatus()}
             {renderDetails()}
           </IntegrationDetails>
         </Container>
@@ -117,6 +127,10 @@ const StyledLink = styled(Link)`
   }
 `;
 
+const LearnMore = styled(Link)`
+  color: ${p => p.theme.gray2};
+`;
+
 type PublishStatusProps = {status: SentryApp['status']; theme?: any};
 
 const PublishStatus = styled(({status, ...props}: PublishStatusProps) => (
@@ -136,9 +150,15 @@ const PublishStatus = styled(({status, ...props}: PublishStatusProps) => (
 `;
 
 const CategoryTag = styled(
-  ({priority, category, ...p}: {category: string; priority: boolean; theme?: any}) => (
-    <div {...p}>{category}</div>
-  )
+  ({
+    priority: _priority,
+    category,
+    ...p
+  }: {
+    category: string;
+    priority: boolean;
+    theme?: any;
+  }) => <div {...p}>{category}</div>
 )`
   display: flex;
   flex-direction: row;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationStatus.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationStatus.tsx
@@ -20,6 +20,9 @@ const StatusWrapper = styled('div')`
 
 const IntegrationStatus = styled((props: StatusProps) => {
   const {status, ...p} = props;
+  if (!status) {
+    return null;
+  }
   return (
     <StatusWrapper>
       <CircleIndicator size={6} color={theme[COLORS[status]]} />

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationStatus.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationStatus.tsx
@@ -20,9 +20,6 @@ const StatusWrapper = styled('div')`
 
 const IntegrationStatus = styled((props: StatusProps) => {
   const {status, ...p} = props;
-  if (!status) {
-    return null;
-  }
   return (
     <StatusWrapper>
       <CircleIndicator size={6} color={theme[COLORS[status]]} />

--- a/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -46,13 +46,18 @@ describe('IntegrationListDirectory', function() {
     it('shows installed integrations at the top in order of weight', async function() {
       expect(wrapper.find('SearchInput').exists()).toBeTruthy();
       expect(wrapper.find('PanelBody').exists()).toBeTruthy();
-      expect(wrapper.find('IntegrationRow')).toHaveLength(6);
+      expect(wrapper.find('IntegrationRow')).toHaveLength(11);
 
       [
         'bitbucket',
         'pagerduty',
         'my-headband-washer-289499',
         'clickup',
+        'asayer',
+        'datadog',
+        'fullstory',
+        'msteams',
+        'rocketchat',
         'amazon-sqs',
         'la-croix-monitor',
       ].map((name, index) =>


### PR DESCRIPTION
This PR adds document integrations to the integration directory. Most of the content for descriptions came from Phillip but I made my own adjustments. This PR adds the following document integrations:

- Asayer
- Datadog
- Microsoft Teams
- RocketChat
- FullStory

Here's what it looks like in the directory:

![Screen Shot 2020-04-06 at 10 42 04 AM](https://user-images.githubusercontent.com/8533851/78588539-b07d9580-77f3-11ea-98a9-24025faab521.png)

We also modified the `Learn More` button in the detailed view to have the external link icon:
![Screen Shot 2020-04-06 at 10 42 12 AM](https://user-images.githubusercontent.com/8533851/78588594-c2f7cf00-77f3-11ea-8b0c-a710fdc60911.png)

