### PR TITLE
test(jest): Fix `throw-on-react-error` when arg is not string

### DIFF
--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -36,6 +36,7 @@ jest.spyOn(console, 'error').mockImplementation((message, ...args) => {
     err.stack = ['\n', lines?.[0], ...lines?.slice(startIndex)].join('\n');
 
     // `fail` is a global from jest/jasmine
+    // eslint-disable-next-line jest/no-jasmine-globals
     fail(err);
   }
 });

--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -6,9 +6,13 @@ const originalConsoleError = console.error;
 // List of `console.error` messages to ignore
 // (i.e. don't fail tests when we get these messages)
 const IGNORED_ERRORS = [
-  (message, ...args) => message?.includes('Warning: ') && args[0] === 'CreatableSelect',
+  (message, ...args) =>
+    typeof message === 'string' &&
+    message.includes('Warning: ') &&
+    args[0] === 'CreatableSelect',
   message =>
-    message?.includes(
+    typeof message === 'string' &&
+    message.includes(
       'The pseudo class ":first-child" is potentially unsafe when doing server-side rendering.'
     ),
 ];


### PR DESCRIPTION
`console.error()` can be called with a non-string (e.g. Error object), so
make sure our `IGNORED_ERRORS` functions check for string type when trying
to parse for ignored messages.