### PR TITLE
fix(avatar): firefox height

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
@@ -70,7 +70,7 @@ class QueryCard extends React.PureComponent<Props> {
 const AvatarWrapper = styled('span')`
   border: 3px solid ${p => p.theme.offWhite2};
   border-radius: 50%;
-  height: 100%;
+  height: min-content;
 `;
 
 const QueryCardContent = styled('div')`


### PR DESCRIPTION
**Before:**
<img width="773" alt="Screen Shot 2020-04-06 at 11 45 46 AM" src="https://user-images.githubusercontent.com/4830259/78593910-3d2c5180-77fc-11ea-9de1-960aaea7583c.png">

**After:**
<img width="785" alt="Screen Shot 2020-04-06 at 11 45 31 AM" src="https://user-images.githubusercontent.com/4830259/78593912-40274200-77fc-11ea-9a2a-9674e3942a4f.png">
