### PR TITLE
dev: Support exclusion logic on devservices via configuration

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1354,6 +1354,25 @@ SENTRY_USE_RELAY = True
 SENTRY_RELAY_PORT = 3000
 SENTRY_REVERSE_PROXY_PORT = 8000
 
+
+# SENTRY_DEVSERVICES = {
+#     "service-name": {
+#         "image": "image-name:version",
+#         # optional ports to expose
+#         "ports": {"internal-port/tcp": external-port},
+#         # optional command
+#         "command": ["exit 1"],
+#         optional mapping of volumes
+#         "volumes": {"volume-name": {"bind": "/path/in/container"}},
+#         # optional statement to test if service should run
+#         "only_if": lambda settings, options: True,
+#         # optional environment variables
+#         "environment": {
+#             "ENV_VAR": "1",
+#         }
+#     }
+# }
+
 SENTRY_DEVSERVICES = {
     "redis": {
         "image": "redis:5.0-alpine",
@@ -1371,6 +1390,9 @@ SENTRY_DEVSERVICES = {
         "image": "confluentinc/cp-zookeeper:5.1.2",
         "environment": {"ZOOKEEPER_CLIENT_PORT": "2181"},
         "volumes": {"zookeeper": {"bind": "/var/lib/zookeeper"}},
+        "only_if": lambda settings, options: (
+            "kafka" in settings.SENTRY_EVENTSTREAM or settings.SENTRY_USE_RELAY
+        ),
     },
     "kafka": {
         "image": "confluentinc/cp-kafka:5.1.2",
@@ -1385,12 +1407,18 @@ SENTRY_DEVSERVICES = {
             "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "1",
         },
         "volumes": {"kafka": {"bind": "/var/lib/kafka"}},
+        "only_if": lambda settings, options: (
+            "kafka" in settings.SENTRY_EVENTSTREAM or settings.SENTRY_USE_RELAY
+        ),
     },
     "clickhouse": {
         "image": "yandex/clickhouse-server:19.11",
         "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
         "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],
         "volumes": {"clickhouse": {"bind": "/var/lib/clickhouse"}},
+        "only_if": lambda settings, options: (
+            "snuba" in settings.SENTRY_EVENTSTREAM or "kafka" in settings.SENTRY_EVENTSTREAM
+        ),
     },
     "snuba": {
         "image": "getsentry/snuba:latest",
@@ -1409,19 +1437,33 @@ SENTRY_DEVSERVICES = {
             "REDIS_PORT": "6379",
             "REDIS_DB": "1",
         },
+        "only_if": lambda settings, options: (
+            "snuba" in settings.SENTRY_EVENTSTREAM or "kafka" in settings.SENTRY_EVENTSTREAM
+        ),
     },
-    "bigtable": {"image": "mattrobenolt/cbtemulator:0.51.0", "ports": {"8086/tcp": 8086}},
-    "memcached": {"image": "memcached:1.5-alpine", "ports": {"11211/tcp": 11211}},
+    "bigtable": {
+        "image": "mattrobenolt/cbtemulator:0.51.0",
+        "ports": {"8086/tcp": 8086},
+        "only_if": lambda settings, options: "bigtable" in settings.SENTRY_NODESTORE,
+    },
+    "memcached": {
+        "image": "memcached:1.5-alpine",
+        "ports": {"11211/tcp": 11211},
+        "only_if": lambda settings, options: "memcached"
+        in settings.CACHES.get("default", {}).get("BACKEND"),
+    },
     "symbolicator": {
         "image": "us.gcr.io/sentryio/symbolicator:latest",
         "pull": True,
         "ports": {"3021/tcp": 3021},
         "command": ["run"],
+        "only_if": lambda settings, options: options.get("symbolicator.enabled"),
     },
     "reverse_proxy": {
         "image": "nginx:1.16.1",
         "ports": {"80/tcp": SENTRY_REVERSE_PROXY_PORT},
         "volumes": {REVERSE_PROXY_CONFIG: {"bind": "/etc/nginx/nginx.conf"}},
+        "only_if": lambda settings, options: settings.SENTRY_USE_RELAY,
     },
     "relay": {
         "image": "us.gcr.io/sentryio/relay:latest",
@@ -1429,6 +1471,7 @@ SENTRY_DEVSERVICES = {
         "ports": {"3000/tcp": SENTRY_RELAY_PORT},
         "volumes": {RELAY_CONFIG_DIR: {"bind": "/etc/relay"}},
         "command": ["run", "--config", "/etc/relay"],
+        "only_if": lambda settings, options: settings.SENTRY_USE_RELAY,
     },
 }
 


### PR DESCRIPTION
This adds support for the ``only_if`` key on SENTRY_DEVSERVICES configurations, allowing the default-exclusion logic to happen with additional services defined elsewhere.