### PR TITLE
fix(discover) Fix missing conditions in drilldowns

### DIFF
--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -76,9 +76,15 @@ export function stringifyQueryObject(results: QueryResults) {
   const {query, ...tags} = results;
 
   const stringTags = flatMap(Object.entries(tags), ([k, values]) =>
-    values.map(
-      tag => `${k}:${/[\s\(\)\\"]/g.test(tag) ? `"${escapeDoubleQuotes(tag)}"` : tag}`
-    )
+    values.map(tag => {
+      if (tag === '' || tag === null) {
+        return `${k}:""`;
+      }
+      if (/[\s\(\)\\"]/g.test(tag)) {
+        return `${k}:"${escapeDoubleQuotes(tag)}"`;
+      }
+      return `${k}:${tag}`;
+    })
   );
 
   return `${query.join(' ')} ${stringTags.join(' ')}`.trim();

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -310,8 +310,9 @@ function generateAdditionalConditions(
     // Or is a simple key in the event. More complex deeply nested fields are
     // more challenging to get at as their location in the structure does not
     // match their name.
-    if (dataRow[dataKey]) {
-      const nextValue = String(dataRow[dataKey]).trim();
+    if (dataRow.hasOwnProperty(dataKey)) {
+      const value = dataRow[dataKey];
+      const nextValue = value === null || value === undefined ? '' : String(value).trim();
 
       switch (column.field) {
         case 'timestamp':

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -91,6 +91,16 @@ describe('utils/tokenizeSearch', function() {
         object: {query: ['bad things'], name: ['Ernest "Papa" Hemingway']},
         string: 'bad things name:"Ernest \\"Papa\\" Hemingway"',
       },
+      {
+        name: 'should include blank strings',
+        object: {query: ['bad things'], name: ['']},
+        string: 'bad things name:""',
+      },
+      {
+        name: 'should include nulls',
+        object: {query: ['bad things'], name: [null]},
+        string: 'bad things name:""',
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -266,6 +266,18 @@ describe('getExpandedResults()', function() {
     // appends to existing conditions
     result = getExpandedResults(view, {'event.type': 'csp'}, {});
     expect(result.query).toEqual('event.type:csp');
+
+    // Includes empty strings
+    result = getExpandedResults(view, {}, {custom_tag: ''});
+    expect(result.query).toEqual('event.type:error custom_tag:""');
+
+    // Includes 0
+    result = getExpandedResults(view, {}, {custom_tag: 0});
+    expect(result.query).toEqual('event.type:error custom_tag:0');
+
+    // Includes null
+    result = getExpandedResults(view, {}, {custom_tag: null});
+    expect(result.query).toEqual('event.type:error custom_tag:""');
   });
 
   it('removes any aggregates in either search conditions or extra conditions', () => {


### PR DESCRIPTION
When generating a drilldown query from an aggregate result we need to include empty values as the user might be drilling into empty values.