### PR TITLE
fix(issue search) Don't allow aggregate filters in issue search

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -7,6 +7,7 @@ from sentry.api.event_search import (
     event_search_grammar,
     InvalidSearchQuery,
     SearchFilter,
+    AggregateFilter,
     SearchKey,
     SearchValue,
     SearchVisitor,
@@ -130,6 +131,12 @@ def convert_query_values(search_filters, projects, user, environments):
             converter = value_converters[search_filter.key.name]
             new_value = converter(search_filter.value.raw_value, projects, user, environments)
             search_filter = search_filter._replace(value=SearchValue(new_value))
+        elif isinstance(search_filter, AggregateFilter):
+            raise InvalidSearchQuery(
+                u"Aggregate filters ({}) are not supported in issue searches.".format(
+                    search_filter.key.name
+                )
+            )
         return search_filter
 
     return map(convert_search_filter, search_filters)

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -2,7 +2,14 @@ from __future__ import absolute_import
 
 import six
 
-from sentry.api.event_search import InvalidSearchQuery, SearchFilter, SearchKey, SearchValue
+from sentry.api.event_search import (
+    InvalidSearchQuery,
+    AggregateFilter,
+    AggregateKey,
+    SearchFilter,
+    SearchKey,
+    SearchValue,
+)
 from sentry.api.issue_search import (
     convert_actor_value,
     convert_query_values,
@@ -147,6 +154,13 @@ class ConvertStatusValueTest(TestCase):
     def test_invalid(self):
         filters = [SearchFilter(SearchKey("status"), "=", SearchValue("wrong"))]
         with self.assertRaises(InvalidSearchQuery, expected_regex="invalid status value"):
+            convert_query_values(filters, [self.project], self.user, None)
+
+        filters = [AggregateFilter(AggregateKey("count_unique(user)"), ">", SearchValue("1"))]
+        with self.assertRaises(
+            InvalidSearchQuery,
+            expected_regex="Aggregate filters (count_unique(user)) are not supported in issue searches.",
+        ):
             convert_query_values(filters, [self.project], self.user, None)
 
 


### PR DESCRIPTION
Allowing aggregate filters in issue search is causing internal errors. I think
we should eventually allow aggregate filters in issue search, but for now just
stop the errors and show a meaningful error message.