### PR TITLE
ref: remove unnecessary trailing commas in unpacks

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,6 +7,8 @@
 # chore: blacken take 2 (#14360)
 95767d455b8004ec4b4c5026d84b64b6348e6d37
 
+# ref: remove unnecessary trailing commas in unpacks
+10e7add4a1244e36d8652a5a12017954c2715dbb
 
 # feat(lint): Update prettier (#16505)
 # Required to properly support nullish coalescence operator and optional chaining.
@@ -24,7 +26,6 @@ d467e8894478662e0ceee9b5137be4ee6620b60d
 # chore: Run prettier on .eslintrc #10433
 # https://github.com/getsentry/sentry/pull/10433
 a2df8eab9b802966c8af6d0d61e6f97b5fbd3882
-
 
 # build(prettier): Upgrade prettier to 1.7.4 #6459
 # https://github.com/getsentry/sentry/pull/6459

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -147,7 +147,7 @@ class OwnershipVisitor(NodeVisitor):
     def visit_matcher_tag(self, node, children):
         if not children:
             return "path"
-        tag, = children
+        tag = children
         type, _ = tag
         return type[0].text
 

--- a/src/sentry/utils/kafka.py
+++ b/src/sentry/utils/kafka.py
@@ -62,7 +62,7 @@ def create_batching_kafka_consumer(topic_names, worker, **options):
             )
         )
 
-    cluster_name, = cluster_names
+    cluster_name = cluster_names
 
     bootstrap_servers = settings.KAFKA_CLUSTERS[cluster_name]["bootstrap.servers"]
     if not isinstance(bootstrap_servers, (list, tuple)):

--- a/tests/sentry/api/endpoints/test_debug_files.py
+++ b/tests/sentry/api/endpoints/test_debug_files.py
@@ -190,7 +190,7 @@ class DebugFilesUploadTest(APITestCase):
 
         assert response.status_code == 200, response.content
 
-        dsym, = response.data
+        dsym = response.data
         assert dsym["cpuName"] == "any"
         assert dsym["headers"] == {"Content-Type": "text/x-proguard+plain"}
         assert dsym["objectName"] == "proguard-mapping"

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -278,7 +278,7 @@ class OrganizationUpdateTest(APITestCase):
             response = self.client.put(url, data=data)
             assert response.status_code == 200
 
-        option, = OrganizationOption.objects.filter(organization=org, key="sentry:trusted-relays")
+        option = OrganizationOption.objects.filter(organization=org, key="sentry:trusted-relays")
 
         assert option.value == data["trustedRelays"]
         log = AuditLogEntry.objects.get(organization=org)

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -126,7 +126,7 @@ def test_internal_relays_should_receive_full_configs(
     cfg = safe.get_path(result, "configs", six.text_type(default_project.id))
     assert safe.get_path(cfg, "disabled") is False
 
-    public_key, = cfg["publicKeys"]
+    public_key = cfg["publicKeys"]
     assert public_key["publicKey"] == default_projectkey.public_key
     assert public_key["isEnabled"]
     assert "quotas" in public_key
@@ -214,7 +214,7 @@ def test_trusted_external_relays_should_receive_minimal_configs(
 
     cfg = safe.get_path(result, "configs", six.text_type(default_project.id))
     assert safe.get_path(cfg, "disabled") is False
-    public_key, = cfg["publicKeys"]
+    public_key = cfg["publicKeys"]
     assert public_key["publicKey"] == default_projectkey.public_key
     assert public_key["isEnabled"]
     assert "quotas" not in public_key
@@ -289,8 +289,8 @@ def test_relay_projectconfig_cache_full_config(
         result, status_code = call_endpoint(full_config=True)
         assert status_code < 400
 
-    http_cfg, = six.itervalues(result["configs"])
-    call, = projectconfig_cache_set
+    http_cfg = six.itervalues(result["configs"])
+    call = projectconfig_cache_set
     assert len(call) == 1
     redis_cfg = call[six.text_type(default_project.id)]
 
@@ -310,7 +310,7 @@ def test_relay_nonexistent_project(call_endpoint, projectconfig_cache_set, task_
         result, status_code = call_endpoint(full_config=True, projects=[wrong_id])
         assert status_code < 400
 
-    http_cfg, = six.itervalues(result["configs"])
+    http_cfg = six.itervalues(result["configs"])
     assert http_cfg == {"disabled": True}
 
     assert projectconfig_cache_set == [{six.text_type(wrong_id): http_cfg}]
@@ -328,7 +328,7 @@ def test_relay_disabled_project(
         result, status_code = call_endpoint(full_config=True, projects=[wrong_id])
         assert status_code < 400
 
-    http_cfg, = six.itervalues(result["configs"])
+    http_cfg = six.itervalues(result["configs"])
     assert http_cfg == {"disabled": True}
 
     assert projectconfig_cache_set == [{six.text_type(wrong_id): http_cfg}]

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -42,7 +42,7 @@ def test_basic_chunked():
     att = CachedAttachment(key="c:foo", id=123, name="lol.txt", content_type="text/plain", chunks=3)
     cache.set("c:foo", [att])
 
-    att2, = cache.get("c:foo")
+    att2 = cache.get("c:foo")
     assert att2.key == att.key == "c:foo"
     assert att2.id == att.id == 123
     assert att2.data == att.data == b"Hello World! Bye."
@@ -58,7 +58,7 @@ def test_basic_unchunked():
     att = CachedAttachment(name="lol.txt", content_type="text/plain", data=b"Hello World! Bye.")
     cache.set("c:foo", [att])
 
-    att2, = cache.get("c:foo")
+    att2 = cache.get("c:foo")
     assert att2.key == att.key == "c:foo"
     assert att2.id == att.id == 0
     assert att2.data == att.data == b"Hello World! Bye."

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -58,7 +58,7 @@ def test_process_pending_one_batch(mocked_attachment_cache, mock_client):
     mock_client.data["c:1:foo:a"] = '[{"name":"foo.txt","content_type":"text/plain"}]'
     mock_client.data["c:1:foo:a:0"] = zlib.compress(b"Hello World!")
 
-    attachment, = mocked_attachment_cache.get("foo")
+    attachment = mocked_attachment_cache.get("foo")
     assert attachment.meta() == {
         "id": 0,
         "type": "event.attachment",
@@ -74,7 +74,7 @@ def test_chunked(mocked_attachment_cache, mock_client):
     mock_client.data["c:1:foo:a:0:1"] = zlib.compress(b" This attachment is ")
     mock_client.data["c:1:foo:a:0:2"] = zlib.compress(b"chunked up.")
 
-    attachment, = mocked_attachment_cache.get("foo")
+    attachment = mocked_attachment_cache.get("foo")
     assert attachment.meta() == {
         "id": 0,
         "chunks": 3,

--- a/tests/sentry/event_manager/test_validate_data.py
+++ b/tests/sentry/event_manager/test_validate_data.py
@@ -250,7 +250,7 @@ def test_environment_too_long():
 def test_environment_invalid():
     data = validate_and_normalize({"environment": "a/b"})
     assert not data.get("environment")
-    error, = data["errors"]
+    error = data["errors"]
     error["type"] == "invalid_data"
 
     assert error["name"] == "environment"

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -51,7 +51,7 @@ def test_deduplication_works(default_project, task_runner, preprocess_event):
             projects={default_project.id: default_project},
         )
 
-    kwargs, = preprocess_event
+    kwargs = preprocess_event
     assert kwargs == {
         "cache_key": u"e:{event_id}:{project_id}".format(event_id=event_id, project_id=project_id),
         "data": payload,
@@ -123,7 +123,7 @@ def test_with_attachments(default_project, task_runner, missing_chunks, monkeypa
     )
 
     if not missing_chunks:
-        attachment, = persisted_attachments
+        attachment = persisted_attachments
         assert attachment.file.type == "custom.attachment"
         assert attachment.file.headers == {"Content-Type": "text/plain"}
         file = attachment.file.getfile()
@@ -196,7 +196,7 @@ def test_individual_attachments(
     if not event_attachments:
         assert not attachments
     else:
-        attachment, = attachments
+        attachment = attachments
         assert attachment.file.type == "event.attachment"
         assert attachment.file.headers == {"Content-Type": "application/octet-stream"}
         assert attachment.group_id == group_id
@@ -220,7 +220,7 @@ def test_userreport(default_project, monkeypatch):
     mgr.normalize()
     mgr.save(default_project.id)
 
-    evtuser, = EventUser.objects.all()
+    evtuser = EventUser.objects.all()
     assert not evtuser.name
 
     assert not UserReport.objects.all()
@@ -242,10 +242,10 @@ def test_userreport(default_project, monkeypatch):
         projects={default_project.id: default_project},
     )
 
-    report, = UserReport.objects.all()
+    report = UserReport.objects.all()
     assert report.comments == "hello world"
 
-    evtuser, = EventUser.objects.all()
+    evtuser = EventUser.objects.all()
     assert evtuser.name == "Hans Gans"
 
 
@@ -281,10 +281,10 @@ def test_userreport_reverse_order(default_project, monkeypatch):
     mgr.normalize()
     mgr.save(default_project.id)
 
-    report, = UserReport.objects.all()
+    report = UserReport.objects.all()
     assert report.comments == "hello world"
 
-    evtuser, = EventUser.objects.all()
+    evtuser = EventUser.objects.all()
     # Event got saved after user report, and the sync only works in the
     # opposite direction. That's fine, we just accept it.
     assert evtuser.name is None

--- a/tests/sentry/lang/native/test_processing.py
+++ b/tests/sentry/lang/native/test_processing.py
@@ -104,7 +104,7 @@ def test_merge_symbolicator_image_errors(code_file, error):
 
     _merge_image(raw_image, complete_image, sdk_info, errors.append)
 
-    e, = errors
+    e = errors
 
     assert e.image_name == "foo"
     assert e.type == error

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -177,7 +177,7 @@ def test_symbolicate_event_call_process_inline(
         symbolicate_event(cache_key="e:1", start_time=1)
 
     # The event mutated, so make sure we save it back
-    (_, (key, event, duration), _), = mock_default_cache.set.mock_calls
+    (_, (key, event, duration), _) = mock_default_cache.set.mock_calls
 
     assert key == "e:1"
     assert event == symbolicated_data
@@ -236,7 +236,7 @@ def test_process_event_mutate_and_save(
     process_event(cache_key="e:1", start_time=1)
 
     # The event mutated, so make sure we save it back
-    (_, (key, event, duration), _), = mock_default_cache.set.mock_calls
+    (_, (key, event, duration), _) = mock_default_cache.set.mock_calls
 
     assert key == "e:1"
     assert "extra" not in event
@@ -291,7 +291,7 @@ def test_process_event_unprocessed(
 
     process_event(cache_key="e:1", start_time=1)
 
-    (_, (key, event, duration), _), = mock_default_cache.set.mock_calls
+    (_, (key, event, duration), _) = mock_default_cache.set.mock_calls
     assert key == "e:1"
     assert event["unprocessed"] is True
     assert duration == 3600
@@ -386,7 +386,7 @@ def test_scrubbing_after_processing(
     with Feature({"organizations:datascrubbers-v2": True}):
         process_event(cache_key="e:1", start_time=1)
 
-    (_, (key, event, duration), _), = mock_default_cache.set.mock_calls
+    (_, (key, event, duration), _) = mock_default_cache.set.mock_calls
     assert key == "e:1"
     assert event["extra"] == {u"aaa": u"[Filtered]", u"aaa2": u"event preprocessor"}
     assert duration == 3600

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -198,7 +198,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             )
 
         # Asserts that all are in the same group
-        group_id, = set(e.group.id for e in events.values())
+        group_id = set(e.group.id for e in events.values())
 
         url = u"/api/0/issues/{}/events/".format(group_id)
         response = self.client.get(url + "?environment=production", format="json")

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -301,7 +301,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
             )
 
         # Assert all events are in the same group
-        group_id, = set(e.group.id for e in events)
+        group_id = set(e.group.id for e in events)
 
         group = Group.objects.get(id=group_id)
         group.times_seen = 3


### PR DESCRIPTION
[Black 19.10b is going to want to wrap these in parens](https://github.com/getsentry/sentry/pull/18114/commits/1067547723765fd3cc480dd8d502612875fb39ae). It looks pretty ugly, and these shouldn't be here in the first place.

Note to self: don't squash merge this since I added it to ignore-revs.
