### PR TITLE
ref: remove isort

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ docker>=3.7.0,<3.8.0
 exam>=0.5.1
 freezegun==0.3.11
 honcho>=1.0.0,<1.1.0
-isort>=4.3.4,<4.4.0
 pytest==4.6.5
 pytest-cov==2.5.1
 pytest-django==3.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,13 +28,3 @@ omit =
 source =
     src
     tests
-
-[isort]
-line_length=100
-lines_between_sections=1
-multi_line_output=5
-known_first_party=sentry
-default_section=THIRDPARTY
-forced_separate=django.contrib,django.utils
-indent='    '
-skip=setup.py


### PR DESCRIPTION
We don't use isort, so remove it. I don't think it's worth keeping around until we have a successful blanket apply + enforce in CI.

I investigated this a while back, and it's definitely nontrivial to blanket reapply isort: https://github.com/getsentry/sentry/pull/17563#issuecomment-597367500

Someday though.