### PR TITLE
fix(ui): Fix org settings when projects/teams 403s

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/organization.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/organization.tsx
@@ -54,16 +54,27 @@ export async function fetchOrganizationDetails(
     } else {
       // create a new client so the request is not cancelled
       const uncancelableApi = new Client();
-      const [projects, teams] = await Promise.all([
-        uncancelableApi.requestPromise(`/organizations/${slug}/projects/`, {
-          query: {
-            all_projects: 1,
-          },
-        }),
-        uncancelableApi.requestPromise(`/organizations/${slug}/teams/`),
-      ]);
-      ProjectActions.loadProjects(projects);
-      TeamActions.loadTeams(teams);
+      try {
+        const [projects, teams] = await Promise.all([
+          uncancelableApi.requestPromise(`/organizations/${slug}/projects/`, {
+            query: {
+              all_projects: 1,
+            },
+          }),
+          uncancelableApi.requestPromise(`/organizations/${slug}/teams/`),
+        ]);
+        ProjectActions.loadProjects(projects);
+        TeamActions.loadTeams(teams);
+      } catch (err) {
+        // It's possible these requests fail with a 403 if the user has a role with insufficient access
+        // to projects and teams, but *can* access org details (e.g. billing).
+        // An example of this is in org settings.
+        //
+        // Ignore 403s and bubble up other API errors
+        if (err.status !== 403) {
+          throw err;
+        }
+      }
     }
   } catch (err) {
     if (!err) {


### PR DESCRIPTION
This fixes a regression in `getsentry` that was caused by https://github.com/getsentry/sentry/pull/18067

There is a possibility the user has access to the org details but not to projects/teams. In this case we need to ignore 403 errors for the projects/teams endpoints and allow the view to render as normal