### PR TITLE
feat(api): allow the configuration of a provider

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -147,6 +147,7 @@ class OrganizationSerializer(serializers.Serializer):
     allowJoinRequests = serializers.BooleanField(required=False)
     relayPiiConfig = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     apdexThreshold = serializers.IntegerField(min_value=1, required=False)
+    provider = serializers.CharField(required=False, allow_blank=True, allow_null=True)
 
     @memoize
     def _has_legacy_rate_limits(self):
@@ -358,6 +359,16 @@ class OrganizationSerializer(serializers.Serializer):
             org.name = self.initial_data["name"]
         if "slug" in self.initial_data:
             org.slug = self.initial_data["slug"]
+        if "provider" in self.initial_data:
+            provider_name = self.initial_data["provider"]
+            try:
+                provider = AuthProvider.objects.get(organization=org)
+                provider.provider = provider_name
+                provider.save()
+            except AuthProvider.DoesNotExist:
+                AuthProvider.objects.create(
+                    provider=provider_name, organization=org, organization_id=org.id
+                )
 
         org_tracked_field = {
             "name": org.name,

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -273,6 +273,7 @@ class OrganizationUpdateTest(APITestCase):
             "require2FA": True,
             "allowJoinRequests": False,
             "apdexThreshold": 450,
+            "provider": "github",
         }
 
         # needed to set require2FA
@@ -683,6 +684,13 @@ class OrganizationUpdateTest(APITestCase):
         assert resp.status_code == 200, resp.content
         assert org.get_option("sentry:relay_pii_config") == value
         assert resp.data["relayPiiConfig"] == value
+
+    def test_provider_config(self):
+        org = self.create_organization(owner=self.user)
+        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
+        self.login_as(user=self.user)
+        resp = self.client.put(url, data={"provider": "dummy"})
+        assert resp.status_code == 200, resp.content
 
 
 class OrganizationDeleteTest(APITestCase):


### PR DESCRIPTION
This MR fixes the ability to provide boolean values to the organization detail API and also adds the ablity to add a provider to the organization via API.

It's working. I know that it's not the prettiest way (probably) to solve this, but I'm very much open to improvements and changes!