### PR TITLE
perf(ui): Move old "Events" to lightweight route tree

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1199,6 +1199,22 @@ function routes() {
           />
         </Route>
 
+        <Route
+          path="/organizations/:orgId/events/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "EventsContainer" */ 'app/views/events')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(/* webpackChunkName: "Events" */ 'app/views/events/events')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
+
+        {/* Settings routes */}
         <Route path="/settings/" name="Settings" component={SettingsWrapper}>
           <IndexRoute
             getComponent={(_loc, cb) =>
@@ -1517,20 +1533,6 @@ function routes() {
                 import(
                   /* webpackChunkName: "PerformanceTransactionSummary" */ 'app/views/performance/transactionSummary'
                 )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-          </Route>
-          <Route
-            path="/organizations/:orgId/events/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "EventsContainer" */ 'app/views/events')
-            }
-            component={errorHandler(LazyLoad)}
-          >
-            <IndexRoute
-              componentPromise={() =>
-                import(/* webpackChunkName: "Events" */ 'app/views/events/events')
               }
               component={errorHandler(LazyLoad)}
             />

--- a/src/sentry/static/sentry/app/views/events/index.jsx
+++ b/src/sentry/static/sentry/app/views/events/index.jsx
@@ -9,7 +9,7 @@ import {t} from 'app/locale';
 import BetaTag from 'app/components/betaTag';
 import Feature from 'app/components/acl/feature';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
-import NoProjectMessage from 'app/components/noProjectMessage';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryTypes from 'app/sentryTypes';
 import PageHeading from 'app/components/pageHeading';
 import withApi from 'app/utils/withApi';
@@ -67,7 +67,7 @@ class EventsContainer extends React.Component {
           resetParamsOnChange={['cursor']}
         />
         <PageContent>
-          <NoProjectMessage organization={organization}>
+          <LightWeightNoProjectMessage organization={organization}>
             <Body>
               <PageHeader>
                 <HeaderTitle>
@@ -83,7 +83,7 @@ class EventsContainer extends React.Component {
               </PageHeader>
               {children}
             </Body>
-          </NoProjectMessage>
+          </LightWeightNoProjectMessage>
         </PageContent>
       </Feature>
     );


### PR DESCRIPTION
This moves the old "Events" page to new lightweight route tree to improve perf