### PR TITLE
fix(Integrations): Center the disabled Add button

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -464,7 +464,7 @@ const DisableWrapper = styled('div')`
   align-self: center;
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
 `;
 
 const CreatedContainer = styled('div')`

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -159,7 +159,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     const priority = 'primary' as const;
 
     const buttonProps = {
-      style: {marginLeft: space(1)},
+      style: {marginBottom: space(1)},
       size,
       priority,
       'data-test-id': 'install-button',

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -193,7 +193,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
         </Button>
       );
     }
-    //should never happen but we can't return undefined without some refactoring
+    // should never happen but we can't return undefined without some refactoring
     return <span />;
   }
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -173,7 +173,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
 }
 
 const AddButton = styled(Button)`
-  margin-left: ${space(1)};
+  margin-bottom: ${space(1)};
 `;
 
 export default withOrganization(PluginDetailedView);


### PR DESCRIPTION
## Objective
Center the disabled Add Project button when user doesn't have a sufficient plan.

## UI
_Before_
<img width="1440" alt="Screen Shot 2020-03-25 at 3 24 41 PM" src="https://user-images.githubusercontent.com/10491193/78707980-3e29b580-78c6-11ea-9303-80927112f96d.png">

_After_
<img width="1437" alt="Screen Shot 2020-04-07 at 11 52 36 AM" src="https://user-images.githubusercontent.com/10491193/78708053-5ac5ed80-78c6-11ea-8d82-51e2388c3863.png">
<img width="1438" alt="Screen Shot 2020-04-07 at 11 52 51 AM" src="https://user-images.githubusercontent.com/10491193/78708064-60233800-78c6-11ea-964a-782ba2b4ff0c.png">

## Test Plan
Visually checked that the disabled Add Project button for SQS is centered.

