### PR TITLE
feat(ui): Add progressive loading to "Events" table

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1199,6 +1199,21 @@ function routes() {
           />
         </Route>
 
+        <Route
+          path="/organizations/:orgId/events/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "EventsContainer" */ 'app/views/events')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(/* webpackChunkName: "Events" */ 'app/views/events/events')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
+
         {/* Settings routes */}
         <Route path="/settings/" name="Settings" component={SettingsWrapper}>
           <IndexRoute
@@ -1557,21 +1572,6 @@ function routes() {
                 import(
                   /* webpackChunkName: "PerformanceTransactionSummary" */ 'app/views/performance/transactionSummary'
                 )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-          </Route>
-
-          <Route
-            path="/organizations/:orgId/events/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "EventsContainer" */ 'app/views/events')
-            }
-            component={errorHandler(LazyLoad)}
-          >
-            <IndexRoute
-              componentPromise={() =>
-                import(/* webpackChunkName: "Events" */ 'app/views/events/events')
               }
               component={errorHandler(LazyLoad)}
             />

--- a/src/sentry/static/sentry/app/views/events/eventsTable.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsTable.jsx
@@ -3,15 +3,17 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {t} from 'app/locale';
 import {PanelBody, Panel, PanelHeader} from 'app/components/panels';
+import {t} from 'app/locale';
 import DateTime from 'app/components/dateTime';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import IdBadge from 'app/components/idBadge';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import Placeholder from 'app/components/placeholder';
 import SentryTypes from 'app/sentryTypes';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
+import withProjects from 'app/utils/withProjects';
 
 class EventsTableBody extends React.PureComponent {
   static propTypes = {
@@ -27,25 +29,37 @@ class EventsTableBody extends React.PureComponent {
     return events.map((event, eventIdx) => {
       const project = projectsMap.get(event.projectID);
       const trimmedMessage = event.title || event.message.split('\n')[0].substr(0, 100);
-      const eventLink = `/organizations/${organization.slug}/projects/${project.slug}/events/${event.eventID}/`;
+      const eventLink = project
+        ? `/organizations/${organization.slug}/projects/${project?.slug}/events/${event.eventID}/`
+        : '';
 
       return (
-        <TableRow key={`${project.slug}-${event.eventID}`} first={eventIdx === 0}>
+        <TableRow key={`${project?.slug}-${event.eventID}`} first={eventIdx === 0}>
           <TableData>
             <EventTitle>
-              <Link to={eventLink}>{trimmedMessage}</Link>
+              {project ? (
+                <Link disabled={!project} to={eventLink}>
+                  {trimmedMessage}
+                </Link>
+              ) : (
+                trimmedMessage
+              )}
             </EventTitle>
           </TableData>
 
           <TableData>{event['event.type']}</TableData>
 
           <TableData>
-            <IdBadge
-              project={project}
-              avatarSize={16}
-              displayName={<span>{project.slug}</span>}
-              avatarProps={{consistentWidth: true}}
-            />
+            {project ? (
+              <IdBadge
+                project={project}
+                avatarSize={16}
+                displayName={<span>{project?.slug}</span>}
+                avatarProps={{consistentWidth: true}}
+              />
+            ) : (
+              <Placeholder height="16px" width="50px" />
+            )}
           </TableData>
 
           <TableData>
@@ -68,6 +82,8 @@ class EventsTable extends React.Component {
     // Initial loading state
     loading: PropTypes.bool,
 
+    loadingProjects: PropTypes.bool,
+
     // When initial data has been loaded, but params have changed
     reloading: PropTypes.bool,
 
@@ -89,7 +105,8 @@ class EventsTable extends React.Component {
     if (
       this.props.reloading !== nextProps.reloading ||
       this.props.zoomChanged !== nextProps.zoomChanged ||
-      this.props.loading !== nextProps.loading
+      this.props.loading !== nextProps.loading ||
+      this.props.loadingProjects !== nextProps.loadingProjects
     ) {
       return true;
     }
@@ -115,7 +132,7 @@ class EventsTable extends React.Component {
 
   get projectsMap() {
     const {organization, projects} = this.props;
-    const projectList = projects || organization.projects;
+    const projectList = projects || organization.projects || [];
 
     return new Map(projectList.map(project => [project.id, project]));
   }
@@ -157,7 +174,7 @@ class EventsTable extends React.Component {
   }
 }
 
-export default withRouter(EventsTable);
+export default withProjects(withRouter(EventsTable));
 export {EventsTable};
 
 const StyledPanelBody = styled(PanelBody)`

--- a/src/sentry/static/sentry/app/views/events/eventsTable.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsTable.jsx
@@ -82,6 +82,7 @@ class EventsTable extends React.Component {
     // Initial loading state
     loading: PropTypes.bool,
 
+    // projectsStore loading state of projects
     loadingProjects: PropTypes.bool,
 
     // When initial data has been loaded, but params have changed
@@ -131,8 +132,8 @@ class EventsTable extends React.Component {
   }
 
   get projectsMap() {
-    const {organization, projects} = this.props;
-    const projectList = projects || organization.projects || [];
+    const {organization, loadingProjects, projects} = this.props;
+    const projectList = (!loadingProjects && projects) || organization.projects || [];
 
     return new Map(projectList.map(project => [project.id, project]));
   }

--- a/src/sentry/static/sentry/app/views/events/eventsTable.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsTable.jsx
@@ -37,13 +37,7 @@ class EventsTableBody extends React.PureComponent {
         <TableRow key={`${project?.slug}-${event.eventID}`} first={eventIdx === 0}>
           <TableData>
             <EventTitle>
-              {project ? (
-                <Link disabled={!project} to={eventLink}>
-                  {trimmedMessage}
-                </Link>
-              ) : (
-                trimmedMessage
-              )}
+              {project ? <Link to={eventLink}>{trimmedMessage}</Link> : trimmedMessage}
             </EventTitle>
           </TableData>
 

--- a/src/sentry/static/sentry/app/views/events/index.jsx
+++ b/src/sentry/static/sentry/app/views/events/index.jsx
@@ -9,7 +9,7 @@ import {t} from 'app/locale';
 import BetaTag from 'app/components/betaTag';
 import Feature from 'app/components/acl/feature';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
-import NoProjectMessage from 'app/components/noProjectMessage';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryTypes from 'app/sentryTypes';
 import PageHeading from 'app/components/pageHeading';
 import withApi from 'app/utils/withApi';
@@ -67,7 +67,7 @@ class EventsContainer extends React.Component {
           resetParamsOnChange={['cursor']}
         />
         <PageContent>
-          <NoProjectMessage organization={organization}>
+          <LightWeightNoProjectMessage organization={organization}>
             <Body>
               <PageHeader>
                 <HeaderTitle>
@@ -83,7 +83,7 @@ class EventsContainer extends React.Component {
               </PageHeader>
               {children}
             </Body>
-          </NoProjectMessage>
+          </LightWeightNoProjectMessage>
         </PageContent>
       </Feature>
     );

--- a/tests/js/spec/views/events/events.spec.jsx
+++ b/tests/js/spec/views/events/events.spec.jsx
@@ -129,7 +129,9 @@ describe('EventsErrors', function() {
     expect(eventsStatsMock).toHaveBeenCalled();
     expect(eventsMetaMock).not.toHaveBeenCalled();
     expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
-    expect(wrapper.find('IdBadge')).toHaveLength(1);
+
+    // projects and user badges
+    expect(wrapper.find('IdBadge')).toHaveLength(2);
   });
 
   it('renders TotalEventCount with internal flag', async function() {

--- a/tests/js/spec/views/events/events.spec.jsx
+++ b/tests/js/spec/views/events/events.spec.jsx
@@ -30,7 +30,7 @@ const pageTwoLinks = generatePageLinks(100, 100);
 const EventsWithRouter = withRouter(Events);
 
 describe('EventsErrors', function() {
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, projects, router, routerContext} = initializeOrg({
     projects: [{isMember: true}, {isMember: true, slug: 'new-project', id: 3}],
     organization: {
       features: ['events'],
@@ -55,7 +55,7 @@ describe('EventsErrors', function() {
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/projects/`,
-      body: [],
+      body: projects,
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/recent-searches/`,
@@ -129,7 +129,7 @@ describe('EventsErrors', function() {
     expect(eventsStatsMock).toHaveBeenCalled();
     expect(eventsMetaMock).not.toHaveBeenCalled();
     expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
-    expect(wrapper.find('IdBadge')).toHaveLength(2);
+    expect(wrapper.find('IdBadge')).toHaveLength(1);
   });
 
   it('renders TotalEventCount with internal flag', async function() {


### PR DESCRIPTION
This moves "Events" [back] into the lightweight routes tree. Because of the, projects is not guaranteed at time of rendering. Use placeholders for the project avatar and make the link to event text until the projects are loaded. This should make a better experience than waiting until all projects are fully loaded.

![image](https://user-images.githubusercontent.com/79684/78718758-b351b680-78d7-11ea-9f2c-e0b2a187e045.png)
