### PR TITLE
fix(discover) Improve the column editor for tags

### DIFF
--- a/docs-ui/components/columnEditor.stories.js
+++ b/docs-ui/components/columnEditor.stories.js
@@ -6,7 +6,7 @@ import {action} from '@storybook/addon-actions';
 import {openModal} from 'app/actionCreators/modal';
 import Button from 'app/components/button';
 import GlobalModal from 'app/components/globalModal';
-import ColumnEditModal from 'app/views/eventsV2/table/columnEditModal';
+import ColumnEditModal, {modalCss} from 'app/views/eventsV2/table/columnEditModal';
 
 storiesOf('Discover|ColumnEditor', module).add(
   'all',
@@ -17,51 +17,59 @@ storiesOf('Discover|ColumnEditor', module).add(
       slug: 'test-org',
       features: ['transaction-events'],
     };
-    const tags = ['browser.name', 'custom-field'];
+    const tags = ['browser.name', 'custom-field', 'project'];
     const columns = [
       {
+        kind: 'field',
         field: 'event.type',
       },
       {
+        kind: 'field',
         field: 'browser.name',
       },
       {
-        field: 'id',
-        aggregation: 'count',
+        kind: 'function',
+        function: ['count', 'id'],
       },
       {
-        field: 'title',
-        aggregation: 'count_unique',
+        kind: 'function',
+        function: ['count_unique', 'title'],
       },
       {
-        field: '',
-        aggregation: 'p95',
+        kind: 'function',
+        function: ['p95'],
       },
       {
+        kind: 'field',
         field: 'issue.id',
-        aggregation: '',
       },
       {
-        field: 'issue.id',
-        aggregation: 'count_unique',
+        kind: 'function',
+        function: ['count_unique', 'issue.id'],
       },
       {
-        refinement: '0.81',
-        field: 'transaction.duration',
-        aggregation: 'percentile',
+        kind: 'function',
+        function: ['percentile', 'transaction.duration', '0.81'],
+      },
+      {
+        kind: 'field',
+        field: 'tags[project]',
       },
     ];
 
     const showModal = () => {
-      openModal(modalProps => (
-        <ColumnEditModal
-          {...modalProps}
-          organization={organization}
-          tagKeys={tags}
-          columns={columns}
-          onApply={action('onApply')}
-        />
-      ));
+      openModal(
+        modalProps => (
+          <ColumnEditModal
+            {...modalProps}
+            organization={organization}
+            tagKeys={tags}
+            columns={columns}
+            onApply={action('onApply')}
+          />
+        ),
+        {modalCss}
+      );
     };
 
     return (

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -134,11 +134,15 @@ class ColumnEditCollection extends React.Component<Props, State> {
 
     if (tagKeys !== null) {
       tagKeys.forEach(tag => {
+        const tagValue =
+          FIELDS.hasOwnProperty(tag) || AGGREGATIONS.hasOwnProperty(tag)
+            ? `tags[${tag}]`
+            : tag;
         fieldOptions[`tag:${tag}`] = {
           label: tag,
           value: {
             kind: FieldValueKind.TAG,
-            meta: {name: tag, dataType: 'string'},
+            meta: {name: tagValue, dataType: 'string'},
           },
         };
       });

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 
 import Button from 'app/components/button';
@@ -8,6 +9,7 @@ import {ModalRenderProps} from 'app/actionCreators/modal';
 import {t} from 'app/locale';
 import {OrganizationSummary} from 'app/types';
 import space from 'app/styles/space';
+import theme from 'app/utils/theme';
 import {Column} from 'app/utils/discover/fields';
 
 import ColumnEditCollection from './columnEditCollection';
@@ -77,4 +79,15 @@ const Instruction = styled('div')`
   margin-bottom: ${space(3)};
 `;
 
+const modalCss = css`
+  @media (min-width: ${theme.breakpoints[0]}) {
+    .modal-dialog {
+      width: auto;
+      max-width: 875px;
+      margin-left: -437px;
+    }
+  }
+`;
+
 export default ColumnEditModal;
+export {modalCss};

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -21,7 +21,7 @@ import {generateEventSlug, eventDetailsRouteWithEventView} from 'app/utils/disco
 
 import {downloadAsCsv, getExpandedResults, pushEventViewToLocation} from '../utils';
 import SortLink from '../sortLink';
-import ColumnEditModal from './columnEditModal';
+import ColumnEditModal, {modalCss} from './columnEditModal';
 import {TableColumn, TableData, TableDataRow} from './types';
 import HeaderCell from './headerCell';
 import CellAction from './cellAction';
@@ -203,15 +203,18 @@ class TableView extends React.Component<TableViewProps> {
     const {organization, eventView, tagKeys} = this.props;
     this.trackEditAnalytics(organization, true);
 
-    openModal(modalProps => (
-      <ColumnEditModal
-        {...modalProps}
-        organization={organization}
-        tagKeys={tagKeys}
-        columns={eventView.getColumns().map(col => col.column)}
-        onApply={this.handleUpdateColumns}
-      />
-    ));
+    openModal(
+      modalProps => (
+        <ColumnEditModal
+          {...modalProps}
+          organization={organization}
+          tagKeys={tagKeys}
+          columns={eventView.getColumns().map(col => col.column)}
+          onApply={this.handleUpdateColumns}
+        />
+      ),
+      {modalCss}
+    );
   };
 
   handleUpdateColumns = (columns: Column[]): void => {

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -102,18 +102,49 @@ describe('EventsV2 -> ColumnEditModal', function() {
 
     it('renders unknown fields in field and field parameter controls', function() {
       const funcRow = wrapper.find('ColumnEditRow').first();
-      expect(funcRow.find('SelectControl[name="field"] SingleValue').text()).toBe(
-        'count_unique(\u2026)'
-      );
+      expect(
+        funcRow.find('SelectControl[name="field"] [data-test-id="label"]').text()
+      ).toBe('count_unique(\u2026)');
       expect(funcRow.find('SelectControl[name="parameter"] SingleValue').text()).toBe(
         'user-defined'
       );
 
       const fieldRow = wrapper.find('ColumnEditRow').last();
-      expect(fieldRow.find('SelectControl[name="field"] SingleValue').text()).toBe(
-        'user-def'
-      );
+      expect(
+        fieldRow.find('SelectControl[name="field"] span[data-test-id="label"]').text()
+      ).toBe('user-def');
+      expect(fieldRow.find('SelectControl[name="field"] Badge')).toHaveLength(1);
       expect(fieldRow.find('StyledInput[disabled]')).toHaveLength(1);
+    });
+  });
+
+  describe('rendering tags that overlap fields & functions', function() {
+    const wrapper = mountModal(
+      {
+        columns: [
+          {kind: 'field', field: 'tags[project]'},
+          {kind: 'field', field: 'tags[count]'},
+        ],
+        onApply: () => void 0,
+        tagKeys: ['project', 'count'],
+      },
+      initialData
+    );
+
+    it('selects tag expressions that overlap fields', function() {
+      const funcRow = wrapper.find('ColumnEditRow').first();
+      expect(
+        funcRow.find('SelectControl[name="field"] span[data-test-id="label"]').text()
+      ).toBe('project');
+      expect(funcRow.find('SelectControl[name="field"] Badge')).toHaveLength(1);
+    });
+
+    it('selects tag expressions that overlap functions', function() {
+      const funcRow = wrapper.find('ColumnEditRow').last();
+      expect(
+        funcRow.find('SelectControl[name="field"] span[data-test-id="label"]').text()
+      ).toBe('count');
+      expect(funcRow.find('SelectControl[name="field"] Badge')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
When custom tags overlap our standard fields or functions the current experience is not great. The selected state doesn't reflect that the value is a tag, and the selected column is also incorrect. This set of changes fixes both those problems, and widens the modal so that there is room to display the tag badges.

![Screen Shot 2020-04-07 at 3 50 21 PM](https://user-images.githubusercontent.com/24086/78718713-c9b83c00-78f0-11ea-8046-81732f712fa9.png)
