### PR TITLE
perf(ui): Move "Dashboards" to lightweight routes tree

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1056,6 +1056,23 @@ function routes() {
         />
 
         <Route
+          path="/organizations/:orgId/dashboards/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "DashboardsContainer" */ 'app/views/dashboards')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "OverviewDashboard" */ 'app/views/dashboards/overviewDashboard'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
+
+        <Route
           path="/organizations/:orgId/user-feedback/"
           componentPromise={() =>
             import(/* webpackChunkName: "UserFeedback" */ 'app/views/userFeedback')
@@ -1406,22 +1423,6 @@ function routes() {
             }
             component={errorHandler(LazyLoad)}
           />
-          <Route
-            path="/organizations/:orgId/dashboards/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "DashboardsContainer" */ 'app/views/dashboards')
-            }
-            component={errorHandler(LazyLoad)}
-          >
-            <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "OverviewDashboard" */ 'app/views/dashboards/overviewDashboard'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-          </Route>
           <Route
             path="/organizations/:orgId/discover/"
             componentPromise={() =>

--- a/src/sentry/static/sentry/app/views/dashboards/index.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/index.jsx
@@ -4,7 +4,7 @@ import {PageContent, PageHeader} from 'app/styles/organization';
 import {t} from 'app/locale';
 import Feature from 'app/components/acl/feature';
 import PageHeading from 'app/components/pageHeading';
-import NoProjectMessage from 'app/components/noProjectMessage';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import SentryTypes from 'app/sentryTypes';
 import withOrganization from 'app/utils/withOrganization';
@@ -22,13 +22,13 @@ class Dashboards extends React.Component {
         <GlobalSelectionHeader organization={organization} />
 
         <PageContent>
-          <NoProjectMessage organization={organization}>
+          <LightWeightNoProjectMessage organization={organization}>
             <PageHeader>
               <PageHeading withMargins>{t('Dashboards')}</PageHeading>
             </PageHeader>
 
             {children}
-          </NoProjectMessage>
+          </LightWeightNoProjectMessage>
         </PageContent>
       </Feature>
     );

--- a/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
+++ b/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
@@ -56,7 +56,8 @@ export interface QueryBuilder {
  */
 export default function createQueryBuilder(
   initial = {},
-  organization: Organization
+  organization: Organization,
+  specificProjects?: Project[]
 ): QueryBuilder {
   const api = new Client();
   let query = applyDefaults(initial);
@@ -65,7 +66,10 @@ export default function createQueryBuilder(
     query.range = DEFAULT_STATS_PERIOD;
   }
 
-  const defaultProjects = organization.projects.filter(projects => projects.isMember);
+  // TODO(lightweight-org): This needs to be refactored so that queries
+  // do not depend on organization.projects
+  const projectsToUse = specificProjects ?? organization.projects;
+  const defaultProjects = projectsToUse.filter(projects => projects.isMember);
 
   const defaultProjectIds = getProjectIds(defaultProjects);
 
@@ -73,7 +77,7 @@ export default function createQueryBuilder(
     ConfigStore.get('user').isSuperuser || organization.access.includes('org:admin');
 
   const projectsToFetchTags = getProjectIds(
-    hasGlobalProjectAccess ? organization.projects : defaultProjects
+    hasGlobalProjectAccess ? projectsToUse : defaultProjects
   );
 
   const columns = COLUMNS.map(col => ({...col, isTag: false}));

--- a/tests/js/spec/views/dashboards/dashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/dashboard.spec.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import Dashboard from 'app/views/dashboards/dashboard';
 import OrganizationDashboardContainer from 'app/views/dashboards';
+import ProjectsStore from 'app/stores/projectsStore';
 
 jest.mock('app/utils/withLatestContext');
 
@@ -12,7 +13,7 @@ describe('OrganizationDashboard', function() {
   let wrapper;
   let discoverMock;
 
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, projects, router, routerContext} = initializeOrg({
     projects: [{isMember: true}, {isMember: true, slug: 'new-project', id: 3}],
     organization: {
       features: ['discover', 'global-views'],
@@ -37,7 +38,10 @@ describe('OrganizationDashboard', function() {
     mockRouterPush(wrapper, router);
   };
 
-  beforeEach(function() {
+  beforeEach(async function() {
+    ProjectsStore.loadInitialData(projects);
+    await tick();
+
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/environments/`,
       body: TestStubs.Environments(),
@@ -75,7 +79,7 @@ describe('OrganizationDashboard', function() {
       expect.objectContaining({
         data: expect.objectContaining({
           environments: [],
-          projects: [2, 3],
+          projects: expect.arrayContaining([2, 3]),
           range: '14d',
 
           fields: [],
@@ -93,7 +97,7 @@ describe('OrganizationDashboard', function() {
       expect.objectContaining({
         data: expect.objectContaining({
           environments: [],
-          projects: [2, 3],
+          projects: expect.arrayContaining([2, 3]),
           range: '14d',
 
           fields: [],
@@ -146,7 +150,7 @@ describe('OrganizationDashboard', function() {
       expect.objectContaining({
         data: expect.objectContaining({
           environments: [],
-          projects: [2, 3],
+          projects: expect.arrayContaining([2, 3]),
           range: '14d',
 
           fields: ['browser.name'],

--- a/tests/js/spec/views/dashboards/discoverQuery.spec.jsx
+++ b/tests/js/spec/views/dashboards/discoverQuery.spec.jsx
@@ -4,6 +4,7 @@ import {mount} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
 import DiscoverQuery from 'app/views/dashboards/discoverQuery';
+import ProjectsStore from 'app/stores/projectsStore';
 
 describe('DiscoverQuery', function() {
   const {organization, router, routerContext} = initializeOrg({
@@ -23,7 +24,10 @@ describe('DiscoverQuery', function() {
   let discoverMock;
   const renderMock = jest.fn(() => null);
 
-  beforeEach(function() {
+  beforeEach(async function() {
+    ProjectsStore.loadInitialData([TestStubs.Project()]);
+    await tick();
+
     renderMock.mockClear();
     router.push.mockRestore();
     MockApiClient.clearMockResponses();

--- a/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
@@ -5,6 +5,7 @@ import {mockRouterPush} from 'sentry-test/mockRouterPush';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import DashboardsContainer from 'app/views/dashboards';
 import OverviewDashboard from 'app/views/dashboards/overviewDashboard';
+import ProjectsStore from 'app/stores/projectsStore';
 
 jest.mock('app/utils/withLatestContext');
 
@@ -13,7 +14,7 @@ describe('OverviewDashboard', function() {
   let discoverMock;
   let releasesMock;
 
-  const {organization, router, routerContext} = initializeOrg({
+  const {organization, projects, router, routerContext} = initializeOrg({
     projects: [{isMember: true}, {isMember: true, slug: 'new-project', id: 3}],
     organization: {
       features: ['discover', 'global-views'],
@@ -39,6 +40,7 @@ describe('OverviewDashboard', function() {
   };
 
   beforeEach(function() {
+    ProjectsStore.loadInitialData(projects);
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
       body: [],
@@ -107,7 +109,7 @@ describe('OverviewDashboard', function() {
       expect.objectContaining({
         data: expect.objectContaining({
           environments: [],
-          projects: [2, 3],
+          projects: expect.arrayContaining([2, 3]),
           range: '14d',
 
           fields: [],
@@ -127,7 +129,7 @@ describe('OverviewDashboard', function() {
       expect.objectContaining({
         data: expect.objectContaining({
           environments: [],
-          projects: [2, 3],
+          projects: expect.arrayContaining([2, 3]),
           range: '14d',
 
           fields: [],
@@ -147,7 +149,7 @@ describe('OverviewDashboard', function() {
       expect.objectContaining({
         data: expect.objectContaining({
           environments: [],
-          projects: [2, 3],
+          projects: expect.arrayContaining([2, 3]),
           range: '14d',
 
           fields: [],
@@ -205,7 +207,7 @@ describe('OverviewDashboard', function() {
       expect.objectContaining({
         data: expect.objectContaining({
           environments: [],
-          projects: [2, 3],
+          projects: expect.arrayContaining([2, 3]),
           range: '7d',
 
           fields: [],


### PR DESCRIPTION
This moves "Dashboards" to lightweight routes tree. This required some refactoring as a discover utility function depended on `organization.projects`. 
Wrapped `DiscoverQuery` component with `withProjects` and show placeholder until projects is loaded.