### PR TITLE
perf(ui): Move "Release Details" into lightweight routes

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1177,6 +1177,59 @@ function routes() {
         </Route>
 
         <Route
+          path="/organizations/:orgId/releases/:version/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "ReleaseDetail" */ 'app/views/releases/detail')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "ReleaseOverview" */ 'app/views/releases/detail/releaseOverview'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="new-events/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "ReleaseNewEvents" */ 'app/views/releases/detail/releaseNewEvents'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="all-events/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "ReleaseAllEvents" */ 'app/views/releases/detail/releaseAllEvents'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="artifacts/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "ReleaseArtifacts" */ 'app/views/releases/detail/releaseArtifacts'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
+            path="commits/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "ReleaseCommits" */ 'app/views/releases/detail/releaseCommits'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
+
+        <Route
           path="/organizations/:orgId/alerts/"
           componentPromise={() =>
             import(/* webpackChunkName: "AlertsContainer" */ 'app/views/alerts')
@@ -1673,58 +1726,6 @@ function routes() {
             }
             component={errorHandler(LazyLoad)}
           />
-          <Route
-            path="/organizations/:orgId/releases/:version/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "ReleaseDetail" */ 'app/views/releases/detail')
-            }
-            component={errorHandler(LazyLoad)}
-          >
-            <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "ReleaseOverview" */ 'app/views/releases/detail/releaseOverview'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-            <Route
-              path="new-events/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "ReleaseNewEvents" */ 'app/views/releases/detail/releaseNewEvents'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-            <Route
-              path="all-events/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "ReleaseAllEvents" */ 'app/views/releases/detail/releaseAllEvents'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-            <Route
-              path="artifacts/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "ReleaseArtifacts" */ 'app/views/releases/detail/releaseArtifacts'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-            <Route
-              path="commits/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "ReleaseCommits" */ 'app/views/releases/detail/releaseCommits'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-          </Route>
           <Route
             path="/organizations/:orgId/teams/new/"
             componentPromise={() =>

--- a/src/sentry/static/sentry/app/views/releases/detail/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.jsx
@@ -4,16 +4,16 @@ import pick from 'lodash/pick';
 
 import {PageContent} from 'app/styles/organization';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
-import {t} from 'app/locale';
+import {tn} from 'app/locale';
 import Alert from 'app/components/alert';
 import AsyncView from 'app/views/asyncView';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import SentryTypes from 'app/sentryTypes';
-import withProfiler from 'app/utils/withProfiler';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
+import withProfiler from 'app/utils/withProfiler';
 import withProjects from 'app/utils/withProjects';
 
 import ReleaseHeader from './releaseHeader';
@@ -76,6 +76,40 @@ class OrganizationReleaseDetails extends AsyncView {
     ];
   }
 
+  renderError(error, disableLog = false, disableReport = false) {
+    const has404Errors = Object.values(this.state.errors).find(
+      resp => resp && resp.status === 404
+    );
+    if (has404Errors) {
+      // This catches a 404 coming from the release endpoint and displays a custom error message.
+      const {projects: allProjects} = this.props;
+      const {projects: projectsFromSelection} = this.props.selection;
+
+      // It's possible that `allProjects` is not fully loaded yet
+      const selectedProjects = projectsFromSelection
+        .map(selectedProjectId =>
+          allProjects.find(({id}) => parseInt(id, 10) === selectedProjectId)
+        )
+        .filter(Boolean);
+
+      return (
+        <PageContent>
+          <Alert type="error" icon="icon-circle-exclamation">
+            {tn(
+              'This release may not be in your selected project',
+              'This release may not be in your selected projects',
+              projectsFromSelection.length
+            )}
+            {selectedProjects.length
+              ? `: ${selectedProjects.map(({slug}) => slug).join(', ')}`
+              : ''}
+          </Alert>
+        </PageContent>
+      );
+    }
+    return super.renderError(error, disableLog, disableReport);
+  }
+
   renderBody() {
     const {
       location,
@@ -101,33 +135,6 @@ class OrganizationReleaseDetails extends AsyncView {
         })}
       </PageContent>
     );
-  }
-
-  renderError(error, disableLog = false, disableReport = false) {
-    const has404Errors = Object.values(this.state.errors).find(
-      resp => resp && resp.status === 404
-    );
-    if (has404Errors) {
-      // This catches a 404 coming from the release endpoint and displays a custom error message.
-      const {projects: all_projects} = this.props;
-      const {projects: selected_projects} = this.props.selection;
-
-      return (
-        <PageContent>
-          <Alert type="error" icon="icon-circle-exclamation">
-            {t(
-              'This release may not be in your selected project' +
-                (selected_projects.length > 1 ? 's' : '')
-            )}
-            :{' '}
-            {selected_projects
-              .map(p => all_projects.find(pp => parseInt(pp.id, 10) === p).name)
-              .join(', ')}
-          </Alert>
-        </PageContent>
-      );
-    }
-    return super.renderError(error, disableLog, disableReport);
   }
 }
 


### PR DESCRIPTION
This moves "Release Details" into lightweight routes. AFAICT only the renderError method uses `projects`, otherwise `ReleaseOverview` uses projects from the release.