### PR TITLE
refs(mail): Copy `rule_notify` code into `MailAdapter`, and remove digest specific code from original.

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -8,10 +8,13 @@ from django.utils import dateformat
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
-from sentry import options
+from sentry import digests, options
+from sentry.digests import get_option_key as get_digest_option_key
+from sentry.digests.notifications import event_to_record, unsplit_key
 from sentry.digests.utilities import get_digest_metadata, get_personalized_digests
 from sentry.models import Commit, ProjectOption, ProjectOwnership, Release, User
 from sentry.plugins.base.structs import Notification
+from sentry.tasks.digests import deliver_digest
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.committers import get_serialized_event_file_committers
@@ -29,8 +32,51 @@ class MailAdapter(object):
     and eventually deprecate `MailPlugin` entirely.
     """
 
+    # TODO: Remove this once we've fully moved over to the new action. Just for use with
+    # `unsplit_key`
+    slug = "mail"
+
     mail_option_key = "mail:subject_prefix"
     alert_option_key = "mail:alert"
+
+    def rule_notify(self, event, futures):
+        rules = []
+        extra = {"event_id": event.event_id, "group_id": event.group_id, "plugin": "mail"}
+        log_event = "dispatched"
+        for future in futures:
+            rules.append(future.rule)
+            extra["rule_id"] = future.rule.id
+            if not future.kwargs:
+                continue
+            raise NotImplementedError(
+                "The default behavior for notification de-duplication does not support args"
+            )
+
+        project = event.group.project
+        extra["project_id"] = project.id
+        if digests.enabled(project):
+
+            def get_digest_option(key):
+                return ProjectOption.objects.get_value(project, get_digest_option_key("mail", key))
+
+            digest_key = unsplit_key(self, event.group.project)
+            extra["digest_key"] = digest_key
+            immediate_delivery = digests.add(
+                digest_key,
+                event_to_record(event, rules),
+                increment_delay=get_digest_option("increment_delay"),
+                maximum_delay=get_digest_option("maximum_delay"),
+            )
+            if immediate_delivery:
+                deliver_digest.delay(digest_key)
+            else:
+                log_event = "digested"
+
+        else:
+            notification = Notification(event=event, rules=rules)
+            self.notify(notification)
+
+        logger.info("mail.notification.%s" % log_event, extra=extra)
 
     def _build_subject_prefix(self, project):
         subject_prefix = ProjectOption.objects.get_value(project, self.mail_option_key, None)

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -9,14 +9,10 @@ from django import forms
 from requests.exceptions import SSLError, HTTPError
 
 from sentry import digests, ratelimits
-from sentry.digests import get_option_key as get_digest_option_key
-from sentry.digests.notifications import event_to_record, unsplit_key
 from sentry.exceptions import PluginError
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.plugins.base import Notification, Plugin
 from sentry.plugins.base.configuration import react_plugin_config
-from sentry.models import ProjectOption
-from sentry.tasks.digests import deliver_digest
 
 
 class NotificationConfigurationForm(forms.Form):
@@ -95,30 +91,8 @@ class NotificationPlugin(Plugin):
 
         project = event.group.project
         extra["project_id"] = project.id
-        if hasattr(self, "notify_digest") and digests.enabled(project):
-
-            def get_digest_option(key):
-                return ProjectOption.objects.get_value(
-                    project, get_digest_option_key(self.get_conf_key(), key)
-                )
-
-            digest_key = unsplit_key(self, event.group.project)
-            extra["digest_key"] = digest_key
-            immediate_delivery = digests.add(
-                digest_key,
-                event_to_record(event, rules),
-                increment_delay=get_digest_option("increment_delay"),
-                maximum_delay=get_digest_option("maximum_delay"),
-            )
-            if immediate_delivery:
-                deliver_digest.delay(digest_key)
-            else:
-                log_event = "digested"
-
-        else:
-            notification = Notification(event=event, rules=rules)
-            self.notify(notification)
-
+        notification = Notification(event=event, rules=rules)
+        self.notify(notification)
         self.logger.info("notification.%s" % log_event, extra=extra)
 
     def notify_users(self, group, event, triggering_rules, fail_silently=False, **kwargs):

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -28,6 +28,9 @@ class MailPlugin(NotificationPlugin):
     project_conf_form = None
     mail_adapter = MailAdapter()
 
+    def rule_notify(self, event, futures):
+        return self.mail_adapter.rule_notify(event, futures)
+
     def _send_mail(self, *args, **kwargs):
         return self.mail_adapter._send_mail(*args, **kwargs)
 


### PR DESCRIPTION
It's difficult to refactor the `rule_notify` code well, and isn't all that necessary since we're
moving away from using the plugin soon enough. So just copying the original code.

We also remove the digest related code from the original `rule_notify`, since it is only ever used
with the `MailPlugin` and isn't needed in `NotificationPlugin` any more.