### PR TITLE
fix(performance-views) - 204 on duplicate key transactions

### DIFF
--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -5,7 +5,6 @@ from rest_framework.response import Response
 
 from sentry.api.bases import KeyTransactionBase
 from sentry.api.bases.organization import OrganizationPermission
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.discover.models import KeyTransaction
 from sentry.discover.endpoints.serializers import KeyTransactionSerializer
 from sentry.snuba.discover import key_transaction_query, key_transaction_timeseries_query
@@ -100,7 +99,7 @@ class KeyTransactionEndpoint(KeyTransactionBase):
                 transaction=transaction, organization=organization, project=project
             )
         except KeyTransaction.DoesNotExist:
-            raise ResourceDoesNotExist
+            return Response(status=204)
 
         model.delete()
 

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -53,6 +53,9 @@ class KeyTransactionEndpoint(KeyTransactionBase):
                 data = serializer.validated_data
                 base_filter["transaction"] = data["transaction"]
 
+                if KeyTransaction.objects.filter(**base_filter).count() > 0:
+                    return Response(status=204)
+
                 KeyTransaction.objects.create(**base_filter)
                 return Response(status=201)
             return Response(serializer.errors, status=400)

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -247,9 +247,4 @@ class KeyTransactionSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 "At most {} Key Transactions can be added".format(MAX_KEY_TRANSACTIONS)
             )
-
-        base_filter["transaction"] = data["transaction"]
-
-        if KeyTransaction.objects.filter(**base_filter).count() > 0:
-            raise serializers.ValidationError("This Key Transaction was already added")
         return data

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -51,7 +51,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
             response = self.client.post(
                 url + "?project={}".format(self.project.id), {"transaction": data["transaction"]}
             )
-            assert response.status_code == 400
+            assert response.status_code == 204
 
         key_transactions = KeyTransaction.objects.filter(owner=self.user)
         assert len(key_transactions) == 1

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -411,6 +411,18 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
             == 0
         )
 
+    def test_delete_nonexistent_transaction(self):
+        event_data = load_data("transaction")
+
+        with self.feature("organizations:performance-view"):
+            url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
+            response = self.client.delete(
+                url + "?project={}".format(self.project.id),
+                {"transaction": event_data["transaction"]},
+            )
+
+        assert response.status_code == 204
+
     def test_delete_with_multiple_projects(self):
         other_user = self.create_user()
         other_org = self.create_organization(owner=other_user)


### PR DESCRIPTION
- There are valid cases where an user could try creating duplicate key
  transactions, eg. having a transaction on multiple tabs and marking
  them key then switching tabs.
- With this, duplicates get 204, creates get 200 so there's still a
  difference between the two situations