### PR TITLE
ref(Integrations): Use existing components for empty view

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -163,8 +163,10 @@ class AbstractIntegrationDetailedView<
     return (
       <Panel>
         <EmptyMessage
-          title={"You haven't set anything up yet"}
-          description="But that doesn’t have to be the case for long! Add an installation to get started."
+          title={t("You haven't set anything up yet")}
+          description={t(
+            'But that doesn’t have to be the case for long! Add an installation to get started.'
+          )}
           action={this.renderAddInstallButton(true)}
         />
       </Panel>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -25,6 +25,8 @@ import {
   SingleIntegrationEvent,
   getCategories,
 } from 'app/utils/integrationUtil';
+import {Panel} from 'app/components/panels';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
 import IntegrationStatus from './integrationStatus';
 
@@ -159,14 +161,13 @@ class AbstractIntegrationDetailedView<
 
   renderEmptyConfigurations() {
     return (
-      <EmptyConfigurationContainer>
-        <EmptyConfigurationTitle>You haven't set anything up yet</EmptyConfigurationTitle>
-        <EmptyConfigurationBody>
-          But that doesn’t have to be the case for long! Add an installation to get
-          started.
-        </EmptyConfigurationBody>
-        <div>{this.renderAddInstallButton(true)}</div>
-      </EmptyConfigurationContainer>
+      <Panel>
+        <EmptyMessage
+          title={"You haven't set anything up yet"}
+          description="But that doesn’t have to be the case for long! Add an installation to get started."
+          action={this.renderAddInstallButton(true)}
+        />
+      </Panel>
     );
   }
 
@@ -470,32 +471,6 @@ const CreatedContainer = styled('div')`
   color: ${p => p.theme.gray2};
   font-weight: 600;
   font-size: 12px;
-`;
-
-const EmptyConfigurationContainer = styled('div')`
-  height: 200px;
-  background: #ffffff;
-  border: 1px solid #c6becf;
-  box-sizing: border-box;
-  box-shadow: 0px 2px 1px rgba(0, 0, 0, 0.08);
-  border-radius: 4px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-`;
-
-const EmptyConfigurationTitle = styled('div')`
-  font-size: 22px;
-  line-height: 31px;
-  padding-bottom: ${space(2)};
-`;
-
-const EmptyConfigurationBody = styled('div')`
-  font-size: 16px;
-  line-height: 28px;
-  color: ${p => p.theme.gray2};
-  padding-bottom: ${space(2)};
 `;
 
 export default AbstractIntegrationDetailedView;


### PR DESCRIPTION
## Objective
Refactor styled-components with standard components to reduce the number of styles. This only affects the empty configuration view for all integrations.

Related comment: https://github.com/getsentry/sentry/commit/928b3e3d562fd1a06b8e09be2733571a9ee8de2c#r38037439

## UI
_Before_
<img width="1440" alt="Screen Shot 2020-04-07 at 5 29 02 PM" src="https://user-images.githubusercontent.com/10491193/78731723-55cc6280-78f5-11ea-94f9-8aee4895aa0b.png">
_After_
<img width="1440" alt="Screen Shot 2020-04-07 at 5 24 53 PM" src="https://user-images.githubusercontent.com/10491193/78731584-fb330680-78f4-11ea-912c-f6cf2e079681.png">

## Test Plan
Visually checked. We lose some padding between elements, but if that is the standard, I think we should leave it.