### PR TITLE
refs(mail): Move `should_notify` to `MailAdapter`.

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -133,6 +133,13 @@ class MailAdapter(object):
         """
         return project.get_notification_recipients(self.alert_option_key)
 
+    def should_notify(self, group):
+        send_to = self.get_sendable_users(group.project)
+        if not send_to:
+            return False
+
+        return group.is_unresolved()
+
     def get_send_to(self, project, event=None):
         """
         Returns a list of user IDs for the users that should receive

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -42,11 +42,7 @@ class MailPlugin(NotificationPlugin):
         return True
 
     def should_notify(self, group, event):
-        send_to = self.get_sendable_users(group.project)
-        if not send_to:
-            return False
-
-        return super(MailPlugin, self).should_notify(group, event)
+        return self.mail_adapter.should_notify(group)
 
     def get_send_to(self, project, event=None):
         """

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -47,12 +47,7 @@ class MailPluginTest(TestCase):
     def plugin(self):
         return MailPlugin()
 
-    @mock.patch(
-        "sentry.models.ProjectOption.objects.get_value", Mock(side_effect=lambda p, k, d, **kw: d)
-    )
-    @mock.patch(
-        "sentry.plugins.sentry_mail.models.MailPlugin.get_sendable_users", Mock(return_value=[])
-    )
+    @mock.patch("sentry.mail.adapter.MailAdapter.get_sendable_users", Mock(return_value=[]))
     def test_should_notify_no_sendable_users(self):
         assert not self.plugin.should_notify(group=Mock(), event=Mock())
 


### PR DESCRIPTION
This copies the logic for `should_notify` to the `MailAdapter` class, and has
`MailPlugin.should_notify` use it instead.

Note that we removed the code to handle digests being disabled - This is hardcoded to `True` in the
`digests.RedisBackend`, and so we don't need to handle the separate logic here, since we'll always
have digests available.