### PR TITLE
feat(workflow): Making snapshots use windowed logic

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -158,7 +158,7 @@ def update_incident_status(incident, status, user=None, comment=None):
         incident.update(**kwargs)
 
         if status == IncidentStatus.CLOSED:
-            create_incident_snapshot(incident)
+            create_incident_snapshot(incident, windowed_stats=True)
 
         analytics.record(
             "incident.status_change",


### PR DESCRIPTION
We have "windowed stats" as an option when getting event stats, but snapshots weren't using it (as shown here: https://sentry.io/organizations/sentry/alerts/2517/).

This fixes that.