### PR TITLE
feat(Integrations): Track when document-based integration detailed view is shown.

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -57,6 +57,14 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
     return this.integration.features;
   }
 
+  componentDidMount() {
+    this.trackIntegrationEvent({
+      eventKey: 'integrations.integration_viewed',
+      eventName: 'Integrations: Integration Viewed',
+      integration_tab: 'overview',
+    });
+  }
+
   trackClick = () => {
     this.trackIntegrationEvent({
       eventKey: 'integrations.installation_start',


### PR DESCRIPTION
## Objective
Need to use `componentDidMount` to track `integrations.integration_viewed` event because we track it in the `onLoadAllEndpointsSuccess` method in `AbstractIntegrationDetailedView`, but there are no requests made to the backend for document-based integrations.
