### PR TITLE
fix(discover) Populate the user alias field in responses

### DIFF
--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -137,20 +137,26 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
     def test_field_aliasing_in_selected_columns(self):
         result = discover.query(
-            selected_columns=["project.id", "user.email", "release"],
+            selected_columns=["project.id", "user", "release"],
             query="",
             params={"project_id": [self.project.id]},
         )
         data = result["data"]
         assert len(data) == 1
         assert data[0]["project.id"] == self.project.id
+        assert data[0]["user"] == "bruce@example.com", "alias prefers email"
         assert data[0]["user.email"] == "bruce@example.com"
         assert data[0]["release"] == "first-release"
 
-        assert len(result["meta"]) == 3
-        assert result["meta"][0] == {"name": "project.id", "type": "UInt64"}
-        assert result["meta"][1] == {"name": "user.email", "type": "Nullable(String)"}
-        assert result["meta"][2] == {"name": "release", "type": "Nullable(String)"}
+        assert len(result["meta"]) == 6
+        assert result["meta"] == [
+            {"name": "project.id", "type": "UInt64"},
+            {"name": "user.id", "type": "Nullable(String)"},
+            {"name": "user.username", "type": "Nullable(String)"},
+            {"name": "user.email", "type": "Nullable(String)"},
+            {"name": "user.ip", "type": "Nullable(String)"},
+            {"name": "release", "type": "Nullable(String)"},
+        ]
 
     def test_field_aliasing_in_aggregate_functions_and_groupby(self):
         result = discover.query(

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -358,6 +358,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
                 assert response.status_code == 200, response.content
                 assert len(response.data["data"]) == 1
+                assert response.data["data"][0]["user"] == data["user"]["ip_address"]
                 assert response.data["data"][0]["user.ip"] == data["user"]["ip_address"]
 
     def test_negative_user_search(self):
@@ -400,6 +401,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
             assert response.status_code == 200, response.content
             assert len(response.data["data"]) == 1
+            assert response.data["data"][0]["user"] == user_data["email"]
             assert response.data["data"][0]["user.email"] == user_data["email"]
 
     def test_not_project_in_query(self):
@@ -603,7 +605,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "field": ["issue.id", "issue_title", "count(id)", "count_unique(user)"],
+                    "field": ["issue.id", "count(id)", "count_unique(user)"],
                     "orderby": "issue.id",
                 },
             )


### PR DESCRIPTION
When the `user` alias field is requested it is helpful to have the `user` field present in the output columns as well. This will help cell-actions and CSV export have access to the same coalesced data that the UI has.

I'm also considering removing the user component fields from the response as we can 'fake' a user in the UI code. Doing so would allow us to transfer fewer bytes to clients.

cc @leeandher 