### PR TITLE
feat(api): Add `is_not_member` option to org teams endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -86,7 +86,8 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
 
         :pparam string organization_slug: the slug of the organization for
                                           which the teams should be listed.
-        :param string detailed: Specify "0" to return team details that do not include projects
+        :param string detailed:      Specify "0" to return team details that do not include projects
+        :param string is_not_member: Specify "1" to return team details for teams that user is not a member of
         :auth: required
         """
         # TODO(dcramer): this should be system-wide default for organization
@@ -97,6 +98,10 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
         queryset = Team.objects.filter(
             organization=organization, status=TeamStatus.VISIBLE
         ).order_by("slug")
+
+        if request.GET.get("is_not_member", "0") == "1":
+            user_teams = Team.objects.get_for_user(organization=organization, user=request.user)
+            queryset = queryset.exclude(id__in=[ut.id for ut in user_teams])
 
         query = request.GET.get("query")
 
@@ -110,6 +115,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                     queryset = queryset.none()
 
         is_detailed = request.GET.get("detailed", "1") != "0"
+
         serializer = (
             team_serializers.TeamWithProjectsSerializer
             if is_detailed

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -87,7 +87,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
         :pparam string organization_slug: the slug of the organization for
                                           which the teams should be listed.
         :param string detailed:      Specify "0" to return team details that do not include projects
-        :param string is_not_member: Specify "1" to return team details for teams that user is not a member of
+        :param string is_not_member: Specify "1" to *only* return team details of teams that user is not a member of
         :auth: required
         """
         # TODO(dcramer): this should be system-wide default for organization

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -31,6 +31,28 @@ class OrganizationTeamsListTest(APITestCase):
         assert response.data[1]["id"] == six.text_type(team1.id)
         assert response.data[1]["isMember"]
 
+    def test_teams_without_membership(self):
+        user = self.create_user()
+        org = self.create_organization(owner=self.user)
+        team1 = self.create_team(organization=org, name="foo")
+        team2 = self.create_team(organization=org, name="bar")
+        team3 = self.create_team(organization=org, name="baz")
+
+        self.create_member(organization=org, user=user, has_global_access=False, teams=[team1])
+
+        path = u"/api/0/organizations/{}/teams/?is_not_member=1".format(org.slug)
+
+        self.login_as(user=user)
+
+        response = self.client.get(path)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        assert response.data[0]["id"] == six.text_type(team2.id)
+        assert not response.data[0]["isMember"]
+        assert response.data[1]["id"] == six.text_type(team3.id)
+        assert not response.data[1]["isMember"]
+
     def test_simple_results_no_projects(self):
         user = self.create_user()
         org = self.create_organization(owner=self.user)


### PR DESCRIPTION
This adds an option `is_not_member` to the organization teams endpoint to return a list of teams for which the user is not a member of