### PR TITLE
ref(apm): Update eventviews used for span child/children traversal

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -100,13 +100,11 @@ class SpanDetail extends React.Component<Props, State> {
       return null;
     }
 
-    const {span, orgId, trace} = this.props;
+    const {span, orgId, trace, eventView} = this.props;
 
     assert(!isGapSpan(span));
 
     if (this.state.transactionResults.length === 1) {
-      const {eventView} = this.props;
-
       const parentTransactionLink = eventDetailsRoute({
         eventSlug: generateSlug(this.state.transactionResults[0]),
         orgSlug: this.props.orgId,
@@ -129,7 +127,7 @@ class SpanDetail extends React.Component<Props, State> {
       end: trace.traceEndTimestamp,
     });
 
-    const eventView = EventView.fromSavedQuery({
+    const childrenEventView = EventView.fromSavedQuery({
       id: undefined,
       name: `Children from Span ID ${span.span_id}`,
       fields: [
@@ -141,8 +139,7 @@ class SpanDetail extends React.Component<Props, State> {
       ],
       orderby: '-timestamp',
       query: `event.type:transaction trace:${span.trace_id} trace.parent_span:${span.span_id}`,
-      tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
-      projects: [],
+      projects: eventView.project,
       version: 2,
       start,
       end,
@@ -152,7 +149,7 @@ class SpanDetail extends React.Component<Props, State> {
       <StyledButton
         data-test-id="view-child-transactions"
         size="xsmall"
-        to={eventView.getResultsViewUrlTarget(orgId)}
+        to={childrenEventView.getResultsViewUrlTarget(orgId)}
       >
         {t('View Children')}
       </StyledButton>
@@ -160,7 +157,7 @@ class SpanDetail extends React.Component<Props, State> {
   }
 
   renderTraceButton() {
-    const {span, orgId, trace} = this.props;
+    const {span, orgId, trace, eventView} = this.props;
 
     const {start, end} = getTraceDateTimeRange({
       start: trace.traceStartTimestamp,
@@ -171,7 +168,7 @@ class SpanDetail extends React.Component<Props, State> {
       return null;
     }
 
-    const eventView = EventView.fromSavedQuery({
+    const traceEventView = EventView.fromSavedQuery({
       id: undefined,
       name: `Transactions with Trace ID ${span.trace_id}`,
       fields: [
@@ -183,15 +180,14 @@ class SpanDetail extends React.Component<Props, State> {
       ],
       orderby: '-timestamp',
       query: `event.type:transaction trace:${span.trace_id}`,
-      tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
-      projects: [],
+      projects: eventView.project,
       version: 2,
       start,
       end,
     });
 
     return (
-      <StyledButton size="xsmall" to={eventView.getResultsViewUrlTarget(orgId)}>
+      <StyledButton size="xsmall" to={traceEventView.getResultsViewUrlTarget(orgId)}>
         {t('Search by Trace')}
       </StyledButton>
     );


### PR DESCRIPTION
Update `EventView` objects used for span child/children traversal links:

- dropping `tags` as they're no longer used
- forward any projects to the constructed eventviews

------

Cherry picked from https://github.com/getsentry/sentry/pull/18025