### PR TITLE
feat(Integrations): Sort categories list alphabetically & capitalize

### DIFF
--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -276,3 +276,10 @@ export function isDocumentIntegration(
 ): integration is DocumentIntegration {
   return integration.hasOwnProperty('docUrl');
 }
+
+export const capitalizeString = (string: string) => {
+  return string
+    .split(' ')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -276,10 +276,3 @@ export function isDocumentIntegration(
 ): integration is DocumentIntegration {
   return integration.hasOwnProperty('docUrl');
 }
-
-export const capitalizeString = (string: string) => {
-  return string
-    .split(' ')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import {RouteComponentProps} from 'react-router/lib/Router';
+import startCase from 'lodash/startCase';
 
 import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -284,7 +285,7 @@ class AbstractIntegrationDetailedView<
           </Flex>
           <Flex>
             {tags.map(feature => (
-              <StyledTag key={feature}>{feature}</StyledTag>
+              <StyledTag key={feature}>{startCase(feature)}</StyledTag>
             ))}
           </Flex>
         </NameContainer>
@@ -378,6 +379,7 @@ const CapitalizedLink = styled('a')`
 `;
 
 const StyledTag = styled(Tag)`
+  text-transform: none;
   &:not(:first-child) {
     margin-left: ${space(0.5)};
   }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -25,6 +25,7 @@ import {
   isPlugin,
   isDocumentIntegration,
   getCategoriesForIntegration,
+  capitalizeString,
 } from 'app/utils/integrationUtil';
 import {t, tct} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -411,7 +412,7 @@ export class IntegrationListDirectory extends AsyncComponent<
     const {displayedList, selectedCategory, list} = this.state;
 
     const title = t('Integrations');
-    const categoryList = uniq(flatten(list.map(getCategoriesForIntegration)));
+    const categoryList = uniq(flatten(list.map(getCategoriesForIntegration))).sort();
 
     return (
       <React.Fragment>
@@ -428,8 +429,11 @@ export class IntegrationListDirectory extends AsyncComponent<
                     onChange={this.onCategorySelect}
                     value={selectedCategory}
                     choices={[
-                      ['', t('All categories')],
-                      ...categoryList.map(category => [category, category]),
+                      ['', t('All Categories')],
+                      ...categoryList.map(category => [
+                        category,
+                        capitalizeString(category),
+                      ]),
                     ]}
                   />
                 ) : (

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {RouteComponentProps} from 'react-router/lib/Router';
 import flatten from 'lodash/flatten';
 import uniq from 'lodash/uniq';
+import startCase from 'lodash/startCase';
 
 import {
   Organization,
@@ -25,7 +26,6 @@ import {
   isPlugin,
   isDocumentIntegration,
   getCategoriesForIntegration,
-  capitalizeString,
 } from 'app/utils/integrationUtil';
 import {t, tct} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -430,10 +430,7 @@ export class IntegrationListDirectory extends AsyncComponent<
                     value={selectedCategory}
                     choices={[
                       ['', t('All Categories')],
-                      ...categoryList.map(category => [
-                        category,
-                        capitalizeString(category),
-                      ]),
+                      ...categoryList.map(category => [category, startCase(category)]),
                     ]}
                   />
                 ) : (

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -7,6 +7,7 @@ import PluginIcon from 'app/plugins/components/pluginIcon';
 import space from 'app/styles/space';
 import {Organization, SentryApp, IntegrationInstallationStatus} from 'app/types';
 import {t} from 'app/locale';
+import {capitalizeString} from 'app/utils/integrationUtil';
 
 import IntegrationStatus from './integrationStatus';
 
@@ -80,7 +81,7 @@ const IntegrationRow = (props: Props) => {
           {categories?.map(category => (
             <CategoryTag
               key={category}
-              category={category}
+              category={capitalizeString(category)}
               priority={category === publishStatus}
             />
           ))}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import startCase from 'lodash/startCase';
 
 import Link from 'app/components/links/link';
 import {PanelItem} from 'app/components/panels';
@@ -7,7 +8,6 @@ import PluginIcon from 'app/plugins/components/pluginIcon';
 import space from 'app/styles/space';
 import {Organization, SentryApp, IntegrationInstallationStatus} from 'app/types';
 import {t} from 'app/locale';
-import {capitalizeString} from 'app/utils/integrationUtil';
 
 import IntegrationStatus from './integrationStatus';
 
@@ -81,7 +81,7 @@ const IntegrationRow = (props: Props) => {
           {categories?.map(category => (
             <CategoryTag
               key={category}
-              category={capitalizeString(category)}
+              category={startCase(category)}
               priority={category === publishStatus}
             />
           ))}


### PR DESCRIPTION
## Objective
We want to sort categories listed in the category selector alphabetically. 

We also want to capitalize categories in the selector and tags because in the current version, `All categories` is capitalized and the other categories are in lowercase, which looks inconsistent.
And if the dropdown categories are capitalized, we want the tags in the rows to be capitalized as well to stay consistent.

## UI
_Before_
<img width="1440" alt="Screen Shot 2020-04-08 at 5 28 58 PM" src="https://user-images.githubusercontent.com/10491193/78845782-744a6080-79be-11ea-8ad6-a340a43c8299.png">

_After_
<img width="1440" alt="Screen Shot 2020-04-08 at 5 17 32 PM" src="https://user-images.githubusercontent.com/10491193/78845373-2d0fa000-79bd-11ea-9505-ec7bf0510de0.png">
<img width="1440" alt="Screen Shot 2020-04-08 at 5 17 41 PM" src="https://user-images.githubusercontent.com/10491193/78845387-33058100-79bd-11ea-8dcd-5f85dcac69a2.png">
