### PR TITLE
ref(alert): Add hideCloseButton prop to <AlertMessage />

### DIFF
--- a/src/sentry/static/sentry/app/components/alertMessage.tsx
+++ b/src/sentry/static/sentry/app/components/alertMessage.tsx
@@ -19,9 +19,10 @@ type AlertType = {
 type Props = {
   alert: AlertType;
   system: boolean;
+  hideCloseButton?: boolean;
 };
 
-const AlertMessage = ({alert, system}: Props) => {
+const AlertMessage = ({alert, system, hideCloseButton}: Props) => {
   const handleCloseAlert = () => {
     AlertActions.closeAlert(alert);
   };
@@ -30,18 +31,22 @@ const AlertMessage = ({alert, system}: Props) => {
   const icon =
     type === 'success' ? <IconCheckmark size="md" circle /> : <IconWarning size="md" />;
 
+  const closeButton = hideCloseButton ? null : (
+    <StyledCloseButton
+      icon={<IconClose size="md" circle />}
+      aria-label={t('Close')}
+      onClick={handleCloseAlert}
+      size="zero"
+      borderless
+    />
+  );
+
   return (
     <StyledAlert type={type} icon={icon} system={system}>
       <StyledMessage>
         {url ? <ExternalLink href={url}>{message}</ExternalLink> : message}
       </StyledMessage>
-      <StyledCloseButton
-        icon={<IconClose size="md" circle />}
-        aria-label={t('Close')}
-        onClick={handleCloseAlert}
-        size="zero"
-        borderless
-      />
+      {closeButton}
     </StyledAlert>
   );
 };


### PR DESCRIPTION
Without `hideCloseButton` prop:

![Screen Shot 2020-04-08 at 8 29 40 PM](https://user-images.githubusercontent.com/139499/78845815-b338e000-79d7-11ea-9d0b-1f14f2a7d259.png)

With `hideCloseButton` prop:

![Screen Shot 2020-04-08 at 8 27 19 PM](https://user-images.githubusercontent.com/139499/78845816-b3d17680-79d7-11ea-950c-858e600bf7ed.png)

------

For in-line event errors of the span view on the transactions event details page. https://github.com/getsentry/sentry/pull/18025
