### PR TITLE
feat(Integrations): Use withExperiment HOC for CategoryExperiment

### DIFF
--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -35,14 +35,12 @@ export const getAnalyticsSessionId = () =>
 
 export const getCategorySelectActive = (organization?: Organization) => {
   const variant = organization?.experiments?.IntegrationDirectoryCategoryExperiment;
-  switch (localStorage.getItem(SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT)) {
-    case '1':
-      return true;
-    case '0':
-      return false;
-    default:
-      return variant && variant === '1';
+  const localStore = localStorage.getItem(SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT);
+
+  if (localStore !== undefined) {
+    return localStore === '1';
   }
+  return variant === '1';
 };
 
 export type SingleIntegrationEvent = {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -36,7 +36,8 @@ import SearchInput from 'app/components/forms/searchInput';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import space from 'app/styles/space';
 import SelectControl from 'app/components/forms/selectControl';
-import {logExperiment} from 'app/utils/analytics';
+import withExperiment from 'app/utils/withExperiment';
+import {ExperimentAssignment} from 'app/types/experiments';
 
 import {POPULARITY_WEIGHT, documentIntegrations} from './constants';
 import IntegrationRow from './integrationRow';
@@ -44,6 +45,7 @@ import IntegrationRow from './integrationRow';
 type Props = RouteComponentProps<{orgId: string}, {}> & {
   organization: Organization;
   hideHeader: boolean;
+  experimentAssignment: ExperimentAssignment['IntegrationDirectoryCategoryExperiment'];
 };
 
 type State = {
@@ -80,13 +82,6 @@ export class IntegrationListDirectory extends AsyncComponent<
       displayedList: [],
       selectedCategory: '',
     };
-  }
-
-  componentDidMount() {
-    logExperiment({
-      organization: this.props.organization,
-      key: 'IntegrationDirectoryCategoryExperiment',
-    });
   }
 
   onLoadAllEndpointsSuccess() {
@@ -493,4 +488,8 @@ const EmptyResultsBody = styled('div')`
   padding-bottom: ${space(2)};
 `;
 
-export default withOrganization(IntegrationListDirectory);
+export default withOrganization(
+  withExperiment(IntegrationListDirectory, {
+    experiment: 'IntegrationDirectoryCategoryExperiment',
+  })
+);


### PR DESCRIPTION
## Objective

This PR fixes the issues raised here: https://github.com/getsentry/sentry/pull/18119#discussion_r405316572

We want to use the `withExperiment` HOC, so that we don't need to call `logExperiment`.