### PR TITLE
fix(settings): Fix organization invite members - team selector

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -14,9 +14,8 @@ import QuestionTooltip from 'app/components/questionTooltip';
 import {IconAdd, IconMail} from 'app/icons';
 import space from 'app/styles/space';
 import AsyncComponent from 'app/components/asyncComponent';
-import {Organization, Team} from 'app/types';
+import {Organization} from 'app/types';
 import withLatestContext from 'app/utils/withLatestContext';
-import withTeams from 'app/utils/withTeams';
 import LoadingIndicator from 'app/components/loadingIndicator';
 
 import {InviteRow, InviteStatus, NormalizedInvite} from './types';
@@ -25,7 +24,6 @@ import InviteRowControl from './inviteRowControl';
 type Props = AsyncComponent['props'] &
   ModalRenderProps & {
     organization: Organization;
-    teams: Team[];
     source?: string;
     initialData?: Partial<InviteRow>[];
   };
@@ -299,7 +297,7 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
   }
 
   render() {
-    const {Footer, closeModal, organization, teams: allTeams} = this.props;
+    const {Footer, closeModal, organization} = this.props;
     const {pendingInvites, sendingInvites, complete, inviteStatus, member} = this.state;
 
     const disableInputs = sendingInvites || complete;
@@ -349,8 +347,8 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
             teams={[...teams]}
             roleOptions={member ? member.roles : MEMBER_ROLES}
             roleDisabledUnallowed={this.willInvite}
-            teamOptions={allTeams}
             inviteStatus={inviteStatus}
+            organizationSlug={this.props.organization.slug}
             onRemove={() => this.removeInviteRow(i)}
             onChangeEmails={opts =>
               this.setEmails(
@@ -359,12 +357,7 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
               )
             }
             onChangeRole={({value}) => this.setRole(value, i)}
-            onChangeTeams={opts =>
-              this.setTeams(
-                opts.map(v => v.value),
-                i
-              )
-            }
+            onChangeTeams={opts => this.setTeams(opts ? opts.map(v => v.value) : [], i)}
             disableRemove={disableInputs || pendingInvites.length === 1}
           />
         ))}
@@ -513,4 +506,4 @@ export const modalCss = css`
   }
 `;
 
-export default withLatestContext(withTeams(InviteMembersModal));
+export default withLatestContext(InviteMembersModal);

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {MemberRole} from 'app/types';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import RoleSelectControl from 'app/components/roleSelectControl';
 import SelectControl from 'app/components/forms/selectControl';
-import withApi from 'app/utils/withApi';
+import loadTeamsForSelectOptions from 'app/utils/loadTeamsForSelectOptions';
 
 import {InviteStatus} from './types';
 import renderEmailValue from './renderEmailValue';
 
 type Props = {
-  api: Client;
   className?: string;
   disabled: boolean;
   disableRemove: boolean;
@@ -32,7 +30,6 @@ type Props = {
 };
 
 const InviteRowControl = ({
-  api,
   className,
   disabled,
   emails,
@@ -47,82 +44,70 @@ const InviteRowControl = ({
   onChangeRole,
   onChangeTeams,
   disableRemove,
-}: Props) => {
-  const loadTeams = async (inputValue: string) => {
-    const resp = await api.requestPromise(`/organizations/${organizationSlug}/teams/`, {
-      query: {query: inputValue, per_page: 25},
-    });
-
-    return {options: resp?.map(({slug}) => ({value: slug, label: `#${slug}`}))};
-  };
-
-  return (
-    <div className={className}>
-      <div>
-        <SelectControl
-          deprecatedSelectControl
-          data-test-id="select-emails"
-          disabled={disabled}
-          placeholder={t('Enter one or more email')}
-          value={emails}
-          options={emails.map(value => ({
-            value,
-            label: value,
-          }))}
-          valueComponent={props =>
-            renderEmailValue(inviteStatus[props.value.value], props)
-          }
-          onBlur={e =>
-            e.target.value &&
-            onChangeEmails([...emails.map(value => ({value})), {value: e.target.value}])
-          }
-          shouldKeyDownEventCreateNewOption={({keyCode}) =>
-            // Keycodes are ENTER, SPACE, TAB, COMMA
-            [13, 32, 9, 188].includes(keyCode)
-          }
-          onBlurResetsInput={false}
-          onCloseResetsInput={false}
-          onChange={onChangeEmails}
-          multiple
-          creatable
-          clearable
-          noMenu
-        />
-      </div>
-      <div>
-        <RoleSelectControl
-          deprecatedSelectControl
-          data-test-id="select-role"
-          disabled={disabled}
-          value={role}
-          roles={roleOptions}
-          disableUnallowed={roleDisabledUnallowed}
-          onChange={onChangeRole}
-        />
-      </div>
-      <div>
-        <SelectControl
-          deprecatedSelectControl
-          data-test-id="select-teams"
-          disabled={disabled}
-          placeholder={t('Add to teams...')}
-          value={teams}
-          loadOptions={loadTeams}
-          onChange={onChangeTeams}
-          async
-          multiple
-          clearable
-        />
-      </div>
-      <Button
-        borderless
-        icon="icon-close"
-        size="micro"
-        onClick={onRemove}
-        disabled={disableRemove}
+}: Props) => (
+  <div className={className}>
+    <div>
+      <SelectControl
+        deprecatedSelectControl
+        data-test-id="select-emails"
+        disabled={disabled}
+        placeholder={t('Enter one or more email')}
+        value={emails}
+        options={emails.map(value => ({
+          value,
+          label: value,
+        }))}
+        valueComponent={props => renderEmailValue(inviteStatus[props.value.value], props)}
+        onBlur={e =>
+          e.target.value &&
+          onChangeEmails([...emails.map(value => ({value})), {value: e.target.value}])
+        }
+        shouldKeyDownEventCreateNewOption={({keyCode}) =>
+          // Keycodes are ENTER, SPACE, TAB, COMMA
+          [13, 32, 9, 188].includes(keyCode)
+        }
+        onBlurResetsInput={false}
+        onCloseResetsInput={false}
+        onChange={onChangeEmails}
+        multiple
+        creatable
+        clearable
+        noMenu
       />
     </div>
-  );
-};
+    <div>
+      <RoleSelectControl
+        deprecatedSelectControl
+        data-test-id="select-role"
+        disabled={disabled}
+        value={role}
+        roles={roleOptions}
+        disableUnallowed={roleDisabledUnallowed}
+        onChange={onChangeRole}
+      />
+    </div>
+    <div>
+      <SelectControl
+        deprecatedSelectControl
+        data-test-id="select-teams"
+        disabled={disabled}
+        placeholder={t('Add to teams...')}
+        value={teams}
+        loadOptions={loadTeamsForSelectOptions(organizationSlug)}
+        onChange={onChangeTeams}
+        async
+        multiple
+        clearable
+      />
+    </div>
+    <Button
+      borderless
+      icon="icon-close"
+      size="micro"
+      onClick={onRemove}
+      disabled={disableRemove}
+    />
+  </div>
+);
 
-export default withApi(InviteRowControl);
+export default InviteRowControl;

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 
+import {Client} from 'app/api';
+import {MemberRole} from 'app/types';
 import {t} from 'app/locale';
-import {Team, MemberRole} from 'app/types';
 import Button from 'app/components/button';
-import SelectControl from 'app/components/forms/selectControl';
 import RoleSelectControl from 'app/components/roleSelectControl';
+import SelectControl from 'app/components/forms/selectControl';
+import withApi from 'app/utils/withApi';
 
-import renderEmailValue from './renderEmailValue';
 import {InviteStatus} from './types';
+import renderEmailValue from './renderEmailValue';
 
 type Props = {
+  api: Client;
   className?: string;
   disabled: boolean;
   disableRemove: boolean;
@@ -18,8 +21,8 @@ type Props = {
   teams: string[];
   roleOptions: MemberRole[];
   roleDisabledUnallowed: boolean;
-  teamOptions: Team[];
   inviteStatus: InviteStatus;
+  organizationSlug: string;
   onRemove: () => void;
 
   // TODO(ts): Update when we have react-select typings
@@ -29,6 +32,7 @@ type Props = {
 };
 
 const InviteRowControl = ({
+  api,
   className,
   disabled,
   emails,
@@ -36,79 +40,89 @@ const InviteRowControl = ({
   teams,
   roleOptions,
   roleDisabledUnallowed,
-  teamOptions,
   inviteStatus,
+  organizationSlug,
   onRemove,
   onChangeEmails,
   onChangeRole,
   onChangeTeams,
   disableRemove,
-}: Props) => (
-  <div className={className}>
-    <div>
-      <SelectControl
-        deprecatedSelectControl
-        data-test-id="select-emails"
-        disabled={disabled}
-        placeholder={t('Enter one or more email')}
-        value={emails}
-        options={emails.map(value => ({
-          value,
-          label: value,
-        }))}
-        valueComponent={props => renderEmailValue(inviteStatus[props.value.value], props)}
-        onBlur={e =>
-          e.target.value &&
-          onChangeEmails([...emails.map(value => ({value})), {value: e.target.value}])
-        }
-        shouldKeyDownEventCreateNewOption={({keyCode}) =>
-          // Keycodes are ENTER, SPACE, TAB, COMMA
-          [13, 32, 9, 188].includes(keyCode)
-        }
-        onBlurResetsInput={false}
-        onCloseResetsInput={false}
-        onChange={onChangeEmails}
-        multiple
-        creatable
-        clearable
-        noMenu
-      />
-    </div>
-    <div>
-      <RoleSelectControl
-        deprecatedSelectControl
-        data-test-id="select-role"
-        disabled={disabled}
-        value={role}
-        roles={roleOptions}
-        disableUnallowed={roleDisabledUnallowed}
-        onChange={onChangeRole}
-      />
-    </div>
-    <div>
-      <SelectControl
-        deprecatedSelectControl
-        data-test-id="select-teams"
-        disabled={disabled}
-        placeholder={t('Add to teams...')}
-        value={teams}
-        options={teamOptions.map(({slug}) => ({
-          value: slug,
-          label: `#${slug}`,
-        }))}
-        onChange={onChangeTeams}
-        multiple
-        clearable
-      />
-    </div>
-    <Button
-      borderless
-      icon="icon-close"
-      size="zero"
-      onClick={onRemove}
-      disabled={disableRemove}
-    />
-  </div>
-);
+}: Props) => {
+  const loadTeams = async (inputValue: string) => {
+    const resp = await api.requestPromise(`/organizations/${organizationSlug}/teams/`, {
+      query: {query: inputValue, per_page: 25},
+    });
 
-export default InviteRowControl;
+    return {options: resp?.map(({slug}) => ({value: slug, label: `#${slug}`}))};
+  };
+
+  return (
+    <div className={className}>
+      <div>
+        <SelectControl
+          deprecatedSelectControl
+          data-test-id="select-emails"
+          disabled={disabled}
+          placeholder={t('Enter one or more email')}
+          value={emails}
+          options={emails.map(value => ({
+            value,
+            label: value,
+          }))}
+          valueComponent={props =>
+            renderEmailValue(inviteStatus[props.value.value], props)
+          }
+          onBlur={e =>
+            e.target.value &&
+            onChangeEmails([...emails.map(value => ({value})), {value: e.target.value}])
+          }
+          shouldKeyDownEventCreateNewOption={({keyCode}) =>
+            // Keycodes are ENTER, SPACE, TAB, COMMA
+            [13, 32, 9, 188].includes(keyCode)
+          }
+          onBlurResetsInput={false}
+          onCloseResetsInput={false}
+          onChange={onChangeEmails}
+          multiple
+          creatable
+          clearable
+          noMenu
+        />
+      </div>
+      <div>
+        <RoleSelectControl
+          deprecatedSelectControl
+          data-test-id="select-role"
+          disabled={disabled}
+          value={role}
+          roles={roleOptions}
+          disableUnallowed={roleDisabledUnallowed}
+          onChange={onChangeRole}
+        />
+      </div>
+      <div>
+        <SelectControl
+          deprecatedSelectControl
+          data-test-id="select-teams"
+          disabled={disabled}
+          placeholder={t('Add to teams...')}
+          value={teams}
+          loadOptions={loadTeams}
+          onChange={onChangeTeams}
+          async
+          multiple
+          clearable
+        />
+      </div>
+      <Button
+        borderless
+        icon="icon-close"
+        size="micro"
+        onClick={onRemove}
+        disabled={disableRemove}
+      />
+    </div>
+  );
+};
+
+export default withApi(InviteRowControl);

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -103,7 +103,7 @@ const InviteRowControl = ({
     <Button
       borderless
       icon="icon-close"
-      size="micro"
+      size="zero"
       onClick={onRemove}
       disabled={disableRemove}
     />

--- a/src/sentry/static/sentry/app/utils/loadTeamsForSelectOptions.tsx
+++ b/src/sentry/static/sentry/app/utils/loadTeamsForSelectOptions.tsx
@@ -1,0 +1,18 @@
+import {Client} from 'app/api';
+
+/**
+ * Used for async `react-select` component to choose and filter teams
+ */
+function loadTeamsForSelectOptions(orgSlug: string) {
+  const api = new Client();
+
+  return async (inputValue: string) => {
+    const resp = await api.requestPromise(`/organizations/${orgSlug}/teams/`, {
+      query: {query: inputValue, per_page: 25},
+    });
+
+    return {options: resp?.map(({slug}) => ({value: slug, label: `#${slug}`}))};
+  };
+}
+
+export default loadTeamsForSelectOptions;

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {Client} from 'app/api';
 import {Member, Organization, MemberRole} from 'app/types';
 import {PanelItem} from 'app/components/panels';
 import {t, tct} from 'app/locale';
@@ -13,10 +12,10 @@ import RoleSelectControl from 'app/components/roleSelectControl';
 import SelectControl from 'app/components/forms/selectControl';
 import Tag from 'app/views/settings/components/tag';
 import Tooltip from 'app/components/tooltip';
+import loadTeamsForSelectOptions from 'app/utils/loadTeamsForSelectOptions';
 import space from 'app/styles/space';
 
 type Props = {
-  api: Client;
   inviteRequest: Member;
   inviteRequestBusy: {[key: string]: boolean};
   organization: Organization;
@@ -35,7 +34,6 @@ const InviteModalHook = HookOrDefault({
 type InviteModalRenderFunc = React.ComponentProps<typeof InviteModalHook>['children'];
 
 const InviteRequestRow = ({
-  api,
   inviteRequest,
   inviteRequestBusy,
   organization,
@@ -46,14 +44,7 @@ const InviteRequestRow = ({
 }: Props) => {
   const role = allRoles.find(r => r.id === inviteRequest.role);
   const roleDisallowed = !(role && role.allowed);
-
-  const loadTeams = async (inputValue: string) => {
-    const resp = await api.requestPromise(`/organizations/${organization.slug}/teams/`, {
-      query: {query: inputValue, per_page: 25},
-    });
-
-    return {options: resp?.map(({slug}) => ({value: slug, label: `#${slug}`}))};
-  };
+  const orgSlug = organization.slug;
 
   // eslint-disable-next-line react/prop-types
   const hookRenderer: InviteModalRenderFunc = ({sendInvites, canSend, headerInfo}) => (
@@ -97,7 +88,7 @@ const InviteRequestRow = ({
         placeholder={t('Add to teams...')}
         onChange={teams => onUpdate({teams: teams.map(team => team.value)})}
         value={inviteRequest.teams}
-        loadOptions={loadTeams}
+        loadOptions={loadTeamsForSelectOptions(orgSlug)}
         async
         multiple
         clearable

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationRequestsView.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationRequestsView.tsx
@@ -175,7 +175,6 @@ class OrganizationRequestsView extends AsyncView<Props, State> {
             <PanelBody>
               {inviteRequests.map(inviteRequest => (
                 <InviteRequestRow
-                  api={this.api}
                   key={inviteRequest.id}
                   organization={organization}
                   inviteRequest={inviteRequest}

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationRequestsView.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationRequestsView.tsx
@@ -3,14 +3,13 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {MEMBER_ROLES} from 'app/constants';
-import {AccessRequest, Member, Organization, Team} from 'app/types';
+import {AccessRequest, Member, Organization} from 'app/types';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t, tct} from 'app/locale';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import withOrganization from 'app/utils/withOrganization';
-import withTeams from 'app/utils/withTeams';
 import AsyncView from 'app/views/asyncView';
 
 import InviteRequestRow from './inviteRequestRow';
@@ -23,7 +22,6 @@ type DefaultProps = {
 type Props = {
   organization: Organization;
   requestList: AccessRequest[];
-  teams: Team[];
   onUpdateInviteRequest: (id: string, data: Partial<Member>) => void;
   onRemoveInviteRequest: (id: string) => void;
   onRemoveAccessRequest: (id: string) => void;
@@ -166,7 +164,6 @@ class OrganizationRequestsView extends AsyncView<Props, State> {
       onRemoveAccessRequest,
       onUpdateInviteRequest,
       organization,
-      teams,
     } = this.props;
     const {inviteRequestBusy, member} = this.state;
 
@@ -178,11 +175,11 @@ class OrganizationRequestsView extends AsyncView<Props, State> {
             <PanelBody>
               {inviteRequests.map(inviteRequest => (
                 <InviteRequestRow
+                  api={this.api}
                   key={inviteRequest.id}
                   organization={organization}
                   inviteRequest={inviteRequest}
                   inviteRequestBusy={inviteRequestBusy}
-                  allTeams={teams}
                   allRoles={member ? member.roles : MEMBER_ROLES}
                   onApprove={this.handleApprove}
                   onDeny={this.handleDeny}
@@ -206,4 +203,4 @@ class OrganizationRequestsView extends AsyncView<Props, State> {
   }
 }
 
-export default withTeams(withOrganization(OrganizationRequestsView));
+export default withOrganization(OrganizationRequestsView);

--- a/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
+++ b/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
@@ -4,12 +4,10 @@ import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 
 import InviteMembersModal from 'app/components/modals/inviteMembersModal';
-import TeamStore from 'app/stores/teamStore';
 
 describe('InviteMembersModal', function() {
   const team = TestStubs.Team();
-  const org = TestStubs.Organization({access: ['member:write'], teams: [team]});
-  TeamStore.loadInitialData([team]);
+  const org = TestStubs.Organization({access: ['member:write']});
 
   const noWriteOrg = TestStubs.Organization({
     access: [],
@@ -29,6 +27,12 @@ describe('InviteMembersModal', function() {
       allowed: true,
     },
   ];
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${org.slug}/teams/`,
+    method: 'GET',
+    body: [team],
+  });
 
   MockApiClient.addMockResponse({
     url: `/organizations/${org.slug}/members/me/`,
@@ -347,6 +351,9 @@ describe('InviteMembersModal', function() {
       />,
       TestStubs.routerContext()
     );
+
+    await tick();
+    wrapper.update();
 
     expect(
       wrapper

--- a/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
@@ -27,7 +27,7 @@ const roles = [
 ];
 
 describe('InviteRequestRow', function() {
-  const orgId = 'org-slug';
+  const organization = TestStubs.Organization();
   const inviteRequestBusy = new Map();
 
   const inviteRequest = TestStubs.Member({
@@ -42,11 +42,17 @@ describe('InviteRequestRow', function() {
     inviteStatus: 'requested_to_join',
     role: 'member',
   });
+  beforeAll(function() {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/teams/',
+      body: [TestStubs.Team({slug: 'one'}), TestStubs.Team({slug: 'two'})],
+    });
+  });
 
   it('renders request to be invited', function() {
     const wrapper = mountWithTheme(
       <InviteRequestRow
-        orgId={orgId}
+        organization={organization}
         inviteRequest={inviteRequest}
         inviteRequestBusy={inviteRequestBusy}
         allTeams={[]}
@@ -66,7 +72,7 @@ describe('InviteRequestRow', function() {
   it('renders request to join', function() {
     const wrapper = mountWithTheme(
       <InviteRequestRow
-        orgId={orgId}
+        organization={organization}
         inviteRequest={joinRequest}
         inviteRequestBusy={inviteRequestBusy}
         allTeams={[]}
@@ -84,7 +90,7 @@ describe('InviteRequestRow', function() {
 
     const wrapper = mountWithTheme(
       <InviteRequestRow
-        orgId={orgId}
+        organization={organization}
         inviteRequest={inviteRequest}
         inviteRequestBusy={inviteRequestBusy}
         onApprove={mockApprove}
@@ -106,7 +112,7 @@ describe('InviteRequestRow', function() {
     const mockDeny = jest.fn();
     const wrapper = mountWithTheme(
       <InviteRequestRow
-        orgId={orgId}
+        organization={organization}
         inviteRequest={inviteRequest}
         inviteRequestBusy={inviteRequestBusy}
         onApprove={mockApprove}
@@ -121,7 +127,7 @@ describe('InviteRequestRow', function() {
     expect(mockApprove).not.toHaveBeenCalled();
   });
 
-  it('can change role and teams', function() {
+  it('can change role and teams', async function() {
     const adminInviteRequest = TestStubs.Member({
       user: null,
       inviterName: TestStubs.User().name,
@@ -133,14 +139,16 @@ describe('InviteRequestRow', function() {
 
     const wrapper = mountWithTheme(
       <InviteRequestRow
-        orgId={orgId}
+        organization={organization}
         inviteRequest={adminInviteRequest}
         inviteRequestBusy={inviteRequestBusy}
-        allTeams={[{slug: 'one'}, {slug: 'two'}]}
         allRoles={roles}
         onUpdate={mockUpdate}
       />
     );
+
+    await tick();
+    wrapper.update();
 
     selectByValue(wrapper, 'member', {name: 'role', control: true});
     expect(mockUpdate).toHaveBeenCalledWith({role: 'member'});
@@ -149,7 +157,7 @@ describe('InviteRequestRow', function() {
     expect(mockUpdate).toHaveBeenCalledWith({teams: ['one']});
   });
 
-  it('cannot be approved when invitee role is not allowed', function() {
+  it('cannot be approved when invitee role is not allowed', async function() {
     const ownerInviteRequest = TestStubs.Member({
       user: null,
       inviterName: TestStubs.User().name,
@@ -161,14 +169,16 @@ describe('InviteRequestRow', function() {
 
     const wrapper = mountWithTheme(
       <InviteRequestRow
-        orgId={orgId}
+        organization={organization}
         inviteRequest={ownerInviteRequest}
         inviteRequestBusy={inviteRequestBusy}
-        allTeams={[{slug: 'one'}, {slug: 'two'}]}
         allRoles={roles}
         onUpdate={mockUpdate}
       />
     );
+
+    await tick();
+    wrapper.update();
 
     expect(wrapper.find('button[aria-label="Approve"]').props()['aria-disabled']).toBe(
       true

--- a/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
@@ -68,6 +68,10 @@ describe('OrganizationRequestsView', function() {
     trackAnalyticsEvent.mockClear();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/teams/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/invite-requests/',
       method: 'GET',
       body: [],


### PR DESCRIPTION
This changes the team selectors to not use teams from TeamsStore via `withTeams`, instead load teams via API and require users to filter down teams. Limit teams to 25 for speed.

See https://github.com/getsentry/sentry/pull/18177 for more information.

Fixes JAVASCRIPT-2206