### PR TITLE
fix(views): Add warning for empty alert rule name

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -460,7 +460,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
             <PanelHeader>{t('Give your rule a name')}</PanelHeader>
 
             {this.hasError('name') && (
-                <PanelAlert type="error">{t('Must enter a rule name')}
+                <PanelAlert type="error">{t('Must enter a rule name')}</PanelAlert>
             )}
 
             <PanelBody>

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -458,6 +458,15 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
           <Panel>
             <PanelHeader>{t('Give your rule a name')}</PanelHeader>
+
+            {this.hasError('name') && (
+                <PanelAlert type="error">
+                  {t(
+                      'Must enter a rule name'
+                  )}
+                </PanelAlert>
+            )}
+
             <PanelBody>
               <TextField
                 label={t('Rule name')}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -460,7 +460,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
             <PanelHeader>{t('Give your rule a name')}</PanelHeader>
 
             {this.hasError('name') && (
-                <PanelAlert type="error">{t('Must enter a rule name')}</PanelAlert>
+              <PanelAlert type="error">{t('Must enter a rule name')}</PanelAlert>
             )}
 
             <PanelBody>

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -460,11 +460,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
             <PanelHeader>{t('Give your rule a name')}</PanelHeader>
 
             {this.hasError('name') && (
-                <PanelAlert type="error">
-                  {t(
-                      'Must enter a rule name'
-                  )}
-                </PanelAlert>
+                <PanelAlert type="error">{t('Must enter a rule name')}
             )}
 
             <PanelBody>


### PR DESCRIPTION
This adds a warning above an empty alert rule name field in the add alert rule form.

@getsentry/app-frontend

When the user submits the form in which all fields all filled in except the alert rule name, then no warning popped up above the field. I found this a bit confusing as described in #18153.
Therefore, I added a PanelAlert above the field that is triggered when an error has occurred. This is also used by the other form components. I am not sure whether this is the correct solution, so feel free to leave any feedback.

![afbeelding](https://user-images.githubusercontent.com/23528405/78878472-c2a93f00-7a52-11ea-964a-7b91824ab35b.png)

Fixes #18153