### PR TITLE
fix(ui): Fix `<ProjectInstallOverview>` when keys are empty

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
@@ -53,7 +53,7 @@ class ProjectInstallOverview extends AsyncComponent {
 
     const issueStreamLink = `/organizations/${orgId}/issues/#welcome`;
 
-    const dsn = keyList ? keyList[0].dsn : {};
+    const dsn = !!keyList?.length ? keyList[0].dsn : {};
 
     return (
       <div>


### PR DESCRIPTION
Not sure how this can even happen, but there was an error where a project had no keys?

Fixes JAVASCRIPT-21NN