### PR TITLE
fix(ui) Fix spacing in multi-line tooltips

### DIFF
--- a/src/sentry/static/sentry/less/includes/tooltips.less
+++ b/src/sentry/static/sentry/less/includes/tooltips.less
@@ -37,7 +37,7 @@
     margin-right: 0;
     border-radius: 3px 3px 0 0;
     position: relative;
-    margin-bottom: 2px;
+    margin-bottom: 6px;
 
     &:after {
       display: block;


### PR DESCRIPTION
Add more spacing as the content was too close to the horizontal bar.

### Before

![Screen Shot 2020-04-09 at 1 11 44 PM](https://user-images.githubusercontent.com/24086/78922039-df9a3e00-7a63-11ea-9edf-491295eca591.png)

### After
![Screen Shot 2020-04-09 at 1 11 24 PM](https://user-images.githubusercontent.com/24086/78922062-e6c14c00-7a63-11ea-9753-7cd4617d517d.png)
