### PR TITLE
feat(ui): Improve UX for dropdown to add teams

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -496,6 +496,11 @@ const InputLoadingWrapper = styled('div')`
   align-items: center;
   flex-shrink: 0;
   width: 30px;
+
+  .loading.mini {
+    height: 16px;
+    margin: 0;
+  }
 `;
 
 const StyledInputWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -217,6 +217,7 @@ export const MAX_AUTOCOMPLETE_RECENT_SEARCHES = 3;
 export const MAX_AUTOCOMPLETE_RELEASES = 5;
 
 export const DEFAULT_PER_PAGE = 50;
+export const TEAMS_PER_PAGE = 25;
 
 // Webpack configures DEPLOY_PREVIEW_CONFIG for deploy preview builds.
 // eslint-disable-next-line no-undef

--- a/src/sentry/static/sentry/app/views/settings/components/teamSelect.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/teamSelect.jsx
@@ -1,17 +1,18 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
+import styled from '@emotion/styled';
 
+import {DEFAULT_DEBOUNCE_DURATION, TEAMS_PER_PAGE} from 'app/constants';
+import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
-import SentryTypes from 'app/sentryTypes';
-import Link from 'app/components/links/link';
-import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownButton from 'app/components/dropdownButton';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import Link from 'app/components/links/link';
+import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 
@@ -19,23 +20,39 @@ class TeamSelect extends React.Component {
   static propTypes = {
     api: PropTypes.object.isRequired,
     organization: SentryTypes.Organization.isRequired,
+
+    /**
+     * Should button be disabled
+     */
     disabled: PropTypes.bool,
-    // Teams that are already selected.
+
+    /**
+     * Teams that are already selected.
+     */
     selectedTeams: PropTypes.array.isRequired,
-    // callback when teams are added
+    /**
+     * callback when teams are added
+     */
     onAddTeam: PropTypes.func.isRequired,
-    // Callback when teams are removed
+    /**
+     * Callback when teams are removed
+     */
     onRemoveTeam: PropTypes.func.isRequired,
 
-    // Optional menu header.
+    /**
+     * Optional menu header.
+     */
     menuHeader: PropTypes.element,
 
-    // Message to display when the last team is removed
-    // if empty no confirm will be displayed.
+    /**
+     * Message to display when the last team is removed
+     * if empty no confirm will be displayed.
+     */
     confirmLastTeamRemoveMessage: PropTypes.string,
   };
 
   state = {
+    loading: true,
     teams: null,
   };
 
@@ -43,16 +60,16 @@ class TeamSelect extends React.Component {
     this.fetchTeams();
   }
 
-  fetchTeams = debounce(query => {
-    const {organization} = this.props;
-    this.props.api
-      .requestPromise(`/organizations/${organization.slug}/teams/`, {
-        query: {query},
-      })
-      .then(teams => this.setState({teams}));
-  }, 100);
+  fetchTeams = debounce(async query => {
+    const {api, organization} = this.props;
+    const teams = await api.requestPromise(`/organizations/${organization.slug}/teams/`, {
+      query: {query, per_page: TEAMS_PER_PAGE},
+    });
+    this.setState({teams, loading: false});
+  }, DEFAULT_DEBOUNCE_DURATION);
 
   handleQueryUpdate = event => {
+    this.setState({loading: true});
     this.fetchTeams(event.target.value);
   };
 
@@ -69,7 +86,7 @@ class TeamSelect extends React.Component {
     const {disabled, selectedTeams, menuHeader} = this.props;
     const {teams} = this.state;
     const noTeams = teams === null || teams.length === 0;
-    const isDisabled = noTeams || disabled;
+    const isDisabled = disabled;
 
     let options;
     if (noTeams) {
@@ -87,6 +104,7 @@ class TeamSelect extends React.Component {
     return (
       <DropdownAutoComplete
         items={options}
+        busyItemsStillVisible={this.state.loading}
         onChange={this.handleQueryUpdate}
         onSelect={this.handleAddTeam}
         emptyMessage={t('No teams')}

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -167,7 +167,7 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
                       </StyledInput>
                       <InputLoadingWrapper>
                         <div
-                          className="css-8mpytx-InputLoadingWrapper ejumqxq1"
+                          className="css-1bkeadj-InputLoadingWrapper ejumqxq1"
                         />
                       </InputLoadingWrapper>
                     </div>
@@ -406,7 +406,7 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
                       </StyledInput>
                       <InputLoadingWrapper>
                         <div
-                          className="css-8mpytx-InputLoadingWrapper ejumqxq1"
+                          className="css-1bkeadj-InputLoadingWrapper ejumqxq1"
                         />
                       </InputLoadingWrapper>
                     </div>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -527,7 +527,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                     Team
                     <DropdownAutoComplete
                       alignMenu="right"
-                      disabled={true}
+                      busyItemsStillVisible={true}
                       emptyMessage="No teams"
                       items={Array []}
                       onChange={[Function]}
@@ -536,7 +536,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                       <DropdownAutoCompleteMenu
                         alignMenu="right"
                         blendCorner={true}
-                        disabled={true}
+                        busyItemsStillVisible={true}
                         emptyMessage="No teams"
                         items={Array []}
                         maxHeight={300}
@@ -546,7 +546,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                       >
                         <AutoComplete
                           closeOnSelect={true}
-                          disabled={true}
+                          disabled={false}
                           inputIsActor={false}
                           itemToString={[Function]}
                           onSelect={[Function]}
@@ -597,13 +597,11 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                     >
                                       <ForwardRef
                                         aria-label="Add Team"
-                                        disabled={true}
                                         isOpen={false}
                                         size="xsmall"
                                       >
                                         <DropdownButton
                                           aria-label="Add Team"
-                                          disabled={true}
                                           forwardedRef={null}
                                           isOpen={false}
                                           showChevron={true}
@@ -611,15 +609,13 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                         >
                                           <StyledButton
                                             aria-label="Add Team"
-                                            disabled={true}
                                             isOpen={false}
                                             size="xsmall"
                                             type="button"
                                           >
                                             <forwardRef<Button>
                                               aria-label="Add Team"
-                                              className="css-k164fp-StyledButton eenpoef1"
-                                              disabled={true}
+                                              className="css-1k1xa0j-StyledButton eenpoef1"
                                               isOpen={false}
                                               size="xsmall"
                                               type="button"
@@ -627,18 +623,18 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                               <Button
                                                 align="center"
                                                 aria-label="Add Team"
-                                                className="css-k164fp-StyledButton eenpoef1"
-                                                disabled={true}
+                                                className="css-1k1xa0j-StyledButton eenpoef1"
+                                                disabled={false}
                                                 forwardRef={null}
                                                 isOpen={false}
                                                 size="xsmall"
                                                 type="button"
                                               >
                                                 <StyledButton
-                                                  aria-disabled={true}
+                                                  aria-disabled={false}
                                                   aria-label="Add Team"
-                                                  className="css-k164fp-StyledButton eenpoef1"
-                                                  disabled={true}
+                                                  className="css-1k1xa0j-StyledButton eenpoef1"
+                                                  disabled={false}
                                                   forwardRef={null}
                                                   isOpen={false}
                                                   onClick={[Function]}
@@ -647,9 +643,9 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                                   type="button"
                                                 >
                                                   <Component
-                                                    aria-disabled={true}
+                                                    aria-disabled={false}
                                                     aria-label="Add Team"
-                                                    className="eenpoef1 css-jk8rcx-StyledButton-StyledButton edwq9my0"
+                                                    className="eenpoef1 css-ssbzqs-StyledButton-StyledButton edwq9my0"
                                                     forwardRef={null}
                                                     onClick={[Function]}
                                                     role="button"
@@ -657,9 +653,9 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                                     type="button"
                                                   >
                                                     <button
-                                                      aria-disabled={true}
+                                                      aria-disabled={false}
                                                       aria-label="Add Team"
-                                                      className="eenpoef1 css-jk8rcx-StyledButton-StyledButton edwq9my0"
+                                                      className="eenpoef1 css-ssbzqs-StyledButton-StyledButton edwq9my0"
                                                       onClick={[Function]}
                                                       role="button"
                                                       size="xsmall"


### PR DESCRIPTION
This improves the UX for the dropdown to add teams e.g. on project teams page and invite members.

* Previously button was disabled when there were no teams, however the dropdown can have an option to create a team. This enables the button even when there are no teams.
* Decreased the number of teams to fetch so that this loads faster
* Adds loading state to dropdown when filtering

Empty
![image](https://user-images.githubusercontent.com/79684/78925141-c8515580-7a4f-11ea-9b7c-d3015455580c.png)

Gif of dropdown: https://share.getcloudapp.com/o0ugo7A8