### PR TITLE
fix(devserver) Improve redis startup time

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1383,7 +1383,7 @@ SENTRY_DEVSERVICES = {
             "yes",
             "--save",
             "60",
-            "100",
+            "20",
             "--auto-aof-rewrite-percentage",
             "100",
             "--auto-aof-rewrite-min-size",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1377,7 +1377,18 @@ SENTRY_DEVSERVICES = {
     "redis": {
         "image": "redis:5.0-alpine",
         "ports": {"6379/tcp": 6379},
-        "command": ["redis-server", "--appendonly", "yes"],
+        "command": [
+            "redis-server",
+            "--appendonly",
+            "yes",
+            "--save",
+            "60",
+            "100",
+            "--auto-aof-rewrite-percentage",
+            "100",
+            "--auto-aof-rewrite-min-size",
+            "64mb",
+        ],
         "volumes": {"redis": {"bind": "/data"}},
     },
     "postgres": {


### PR DESCRIPTION
Add rdb and aof file rewriting so that devserver starts up more quickly. A few people who are experiencing very long startup times as redis rebuilds the entire state from the AOF file.