### PR TITLE
ref(discover) Don't emit additional fields when the user alias is used.

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -902,7 +902,7 @@ def get_filter(query=None, params=None):
 FIELD_ALIASES = {
     "project": {"fields": ["project.id"], "column_alias": "project.id"},
     "issue": {"fields": ["issue.id"], "column_alias": "issue.id"},
-    "user": {"fields": ["user.id", "user.username", "user.email", "user.ip"]},
+    "user": {"fields": ["user.email", "user.username", "user.ip", "user.id"]},
 }
 
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -402,19 +402,34 @@ def transform_results(result, translated_columns, snuba_filter, selected_columns
     When getting timeseries results via rollup, this function will
     zerofill the output results.
     """
-    # Translate back columns that were converted to snuba format
+    # Determine user related fields to prune based on what wasn't selected.
+    user_fields = ["user.email", "user.username", "user.ip", "user.id"]
+    user_fields_to_remove = [field for field in user_fields if field not in selected_columns]
+
+    # If the user field was selected update the meta data
+    has_user = selected_columns and "user" in selected_columns
+    meta = []
     for col in result["meta"]:
+        # Translate back column names that were converted to snuba format
         col["name"] = translated_columns.get(col["name"], col["name"])
+        # Remove user fields as they will be replaced by the alias.
+        if has_user and col["name"] in user_fields_to_remove:
+            continue
+        meta.append(col)
+    if has_user:
+        meta.append({"name": "user", "type": "Nullable(String)"})
+    result["meta"] = meta
 
     def get_row(row):
         transformed = {translated_columns.get(key, key): value for key, value in row.items()}
-        if selected_columns and "user" in selected_columns:
-            transformed["user"] = (
-                transformed.get("user.email")
-                or transformed.get("user.username")
-                or transformed.get("user.ip")
-                or transformed.get("user.id")
-            )
+        if has_user:
+            for field in user_fields:
+                if field in transformed and transformed[field]:
+                    transformed["user"] = transformed[field]
+                    break
+            # Remove user component fields once the alias is resolved.
+            for field in user_fields_to_remove:
+                del transformed[field]
         return transformed
 
     if len(translated_columns):

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -402,8 +402,11 @@ def transform_results(result, translated_columns, snuba_filter, selected_columns
     When getting timeseries results via rollup, this function will
     zerofill the output results.
     """
+    if selected_columns is None:
+        selected_columns = []
+
     # Determine user related fields to prune based on what wasn't selected.
-    user_fields = ["user.email", "user.username", "user.ip", "user.id"]
+    user_fields = FIELD_ALIASES["user"]["fields"]
     user_fields_to_remove = [field for field in user_fields if field not in selected_columns]
 
     # If the user field was selected update the meta data

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -200,11 +200,11 @@ const SPECIAL_FIELDS: SpecialFields = {
     sortField: 'user.id',
     renderFunc: data => {
       const userObj = {
-        id: data['user.id'],
-        name: data['user.name'],
-        email: data['user.email'],
-        username: data['user.username'],
-        ip_address: data['user.ip'],
+        id: data.user,
+        name: data.user,
+        email: data.user,
+        username: data.user,
+        ip_address: '',
       };
 
       const badge = <UserBadge user={userObj} hideEmail avatarSize={16} />;

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1217,13 +1217,13 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_general_negative_user_field(self):
         conditions = get_filter("!user:123").conditions
         assert len(conditions) == 4
-        assert [[["isNull", ["user.id"]], "=", 1], ["user.id", "!=", "123"]] == conditions[0]
+        assert [[["isNull", ["user.email"]], "=", 1], ["user.email", "!=", "123"]] == conditions[0]
         assert [
             [["isNull", ["user.username"]], "=", 1],
             ["user.username", "!=", "123"],
         ] == conditions[1]
-        assert [[["isNull", ["user.email"]], "=", 1], ["user.email", "!=", "123"]] == conditions[2]
-        assert [[["isNull", ["user.ip"]], "=", 1], ["user.ip", "!=", "123"]] == conditions[3]
+        assert [[["isNull", ["user.ip"]], "=", 1], ["user.ip", "!=", "123"]] == conditions[2]
+        assert [[["isNull", ["user.id"]], "=", 1], ["user.id", "!=", "123"]] == conditions[3]
 
     def test_function_with_default_arguments(self):
         result = get_filter("rpm():>100", {"start": before_now(minutes=5), "end": before_now()})
@@ -1310,10 +1310,10 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["selected_columns"] == [
             "title",
             "issue.id",
-            "user.id",
-            "user.username",
             "user.email",
+            "user.username",
             "user.ip",
+            "user.id",
             "message",
             "project.id",
         ]
@@ -1325,10 +1325,10 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["groupby"] == [
             "title",
             "issue.id",
-            "user.id",
-            "user.username",
             "user.email",
+            "user.username",
             "user.ip",
+            "user.id",
             "message",
             "project.id",
         ]

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -375,7 +375,7 @@ class QueryTransformTest(TestCase):
             selected_columns=["user", "project"], query="", params={"project_id": [self.project.id]}
         )
         mock_query.assert_called_with(
-            selected_columns=["user_id", "username", "email", "ip_address", "project_id"],
+            selected_columns=["email", "username", "ip_address", "user_id", "project_id"],
             aggregations=[
                 [
                     "transform(project_id, array({}), array('{}'), '')".format(
@@ -390,7 +390,7 @@ class QueryTransformTest(TestCase):
             end=None,
             start=None,
             conditions=[],
-            groupby=["user_id", "username", "email", "ip_address", "project_id"],
+            groupby=["email", "username", "ip_address", "user_id", "project_id"],
             having=[],
             orderby=None,
             limit=50,

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -145,17 +145,32 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         assert len(data) == 1
         assert data[0]["project.id"] == self.project.id
         assert data[0]["user"] == "bruce@example.com", "alias prefers email"
-        assert data[0]["user.email"] == "bruce@example.com"
         assert data[0]["release"] == "first-release"
 
-        assert len(result["meta"]) == 6
+        assert len(result["meta"]) == 3
         assert result["meta"] == [
             {"name": "project.id", "type": "UInt64"},
-            {"name": "user.id", "type": "Nullable(String)"},
-            {"name": "user.username", "type": "Nullable(String)"},
-            {"name": "user.email", "type": "Nullable(String)"},
-            {"name": "user.ip", "type": "Nullable(String)"},
             {"name": "release", "type": "Nullable(String)"},
+            {"name": "user", "type": "Nullable(String)"},
+        ]
+
+    def test_field_alias_with_component(self):
+        result = discover.query(
+            selected_columns=["project.id", "user", "user.email"],
+            query="",
+            params={"project_id": [self.project.id]},
+        )
+        data = result["data"]
+        assert len(data) == 1
+        assert data[0]["project.id"] == self.project.id
+        assert data[0]["user"] == "bruce@example.com", "alias prefers email"
+        assert data[0]["user.email"] == "bruce@example.com"
+
+        assert len(result["meta"]) == 3
+        assert result["meta"] == [
+            {"name": "project.id", "type": "UInt64"},
+            {"name": "user.email", "type": "Nullable(String)"},
+            {"name": "user", "type": "Nullable(String)"},
         ]
 
     def test_field_aliasing_in_aggregate_functions_and_groupby(self):
@@ -339,8 +354,22 @@ class QueryTransformTest(TestCase):
     @patch("sentry.snuba.discover.raw_query")
     def test_selected_columns_field_alias_macro(self, mock_query):
         mock_query.return_value = {
-            "meta": [{"name": "user_id"}, {"name": "email"}],
-            "data": [{"user_id": "1", "email": "a@example.org"}],
+            "meta": [
+                {"name": "user_id"},
+                {"name": "username"},
+                {"name": "email"},
+                {"name": "ip_address"},
+                {"name": "project_id"},
+            ],
+            "data": [
+                {
+                    "user_id": "1",
+                    "username": "",
+                    "email": "a@example.org",
+                    "ip_address": "",
+                    "project_id": self.project.id,
+                }
+            ],
         }
         discover.query(
             selected_columns=["user", "project"], query="", params={"project_id": [self.project.id]}

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -332,10 +332,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
                 assert response.status_code == 200, response.content
                 assert len(response.data["data"]) == 1
-                assert response.data["data"][0]["user.email"] == data["user"]["email"]
-                assert response.data["data"][0]["user.id"] == data["user"]["id"]
-                assert response.data["data"][0]["user.ip"] == data["user"]["ip_address"]
-                assert response.data["data"][0]["user.username"] == data["user"]["username"]
+                assert response.data["data"][0]["project"] == project.slug
+                assert response.data["data"][0]["user"] == data["user"]["email"]
 
     def test_has_user(self):
         self.login_as(user=self.user)
@@ -359,7 +357,6 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 assert response.status_code == 200, response.content
                 assert len(response.data["data"]) == 1
                 assert response.data["data"][0]["user"] == data["user"]["ip_address"]
-                assert response.data["data"][0]["user.ip"] == data["user"]["ip_address"]
 
     def test_negative_user_search(self):
         self.login_as(user=self.user)
@@ -402,7 +399,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             assert response.status_code == 200, response.content
             assert len(response.data["data"]) == 1
             assert response.data["data"][0]["user"] == user_data["email"]
-            assert response.data["data"][0]["user.email"] == user_data["email"]
+            assert "user.email" not in response.data["data"][0]
 
     def test_not_project_in_query(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
When the user alias is requested we don't want to emit the other user related fields. Unless they were also requested.