### PR TITLE
fix(ecosystem): adds data-forwarding feature as organization feature

### DIFF
--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -64,7 +64,9 @@ class PluginSerializer(Serializer):
         if obj.description:
             d["description"] = six.text_type(obj.description)
 
-        d["features"] = list(set(f.featureGate.value for f in obj.feature_descriptions))
+        d["features"] = list(
+            set(obj.feature_flag_name(f.featureGate.value) for f in obj.feature_descriptions)
+        )
 
         d["featureDescriptions"] = [
             {

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -64,9 +64,7 @@ class PluginSerializer(Serializer):
         if obj.description:
             d["description"] = six.text_type(obj.description)
 
-        d["features"] = list(
-            set(obj.feature_flag_name(f.featureGate.value) for f in obj.feature_descriptions)
-        )
+        d["features"] = list(set(f.featureGate.value for f in obj.feature_descriptions))
 
         d["featureDescriptions"] = [
             {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -844,7 +844,7 @@ SENTRY_FEATURES = {
     # Enable interface functionality to receive event hooks.
     "organizations:integrations-event-hooks": False,
     # Enable data forwarding functionality for organizations.
-    "organizations:integrations-data-forwarding": True,
+    "organizations:data-forwarding": True,
     # Special feature flag primarily used on the sentry.io SAAS product for
     # easily enabling features while in early development.
     "organizations:internal-catchall": False,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -843,6 +843,8 @@ SENTRY_FEATURES = {
     "organizations:integrations-issue-sync": True,
     # Enable interface functionality to receive event hooks.
     "organizations:integrations-event-hooks": False,
+    # Enable data forwarding functionality for organizations.
+    "organizations:integrations-data-forwarding": True,
     # Special feature flag primarily used on the sentry.io SAAS product for
     # easily enabling features while in early development.
     "organizations:internal-catchall": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -73,6 +73,7 @@ default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-issue-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-issue-sync", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-event-hooks", OrganizationFeature)  # NOQA
+default_manager.add("organizations:integrations-data-forwarding", OrganizationFeature)  # NOQA
 default_manager.add("organizations:internal-catchall", OrganizationFeature)  # NOQA
 default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -73,7 +73,7 @@ default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-issue-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-issue-sync", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-event-hooks", OrganizationFeature)  # NOQA
-default_manager.add("organizations:integrations-data-forwarding", OrganizationFeature)  # NOQA
+default_manager.add("organizations:data-forwarding", OrganizationFeature)  # NOQA
 default_manager.add("organizations:internal-catchall", OrganizationFeature)  # NOQA
 default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -10,6 +10,7 @@ from rest_framework import serializers
 
 from sentry.exceptions import PluginError
 from sentry.utils.forms import form_to_config
+from sentry.integrations import IntegrationFeatures
 
 from .providers import ProviderMixin
 from .validators import DEFAULT_VALIDATORS
@@ -174,4 +175,6 @@ class PluginConfigMixin(ProviderMixin):
         users can install the Trello and Asana plugins but not Jira even though both utilize issue-commits.
         By not prefixing, we can avoid making new feature flags for data-forwarding which are restricted.
         """
+        if f == IntegrationFeatures.DATA_FORWARDING:
+            return u"integrations-{}".format(f)
         return f

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -175,6 +175,6 @@ class PluginConfigMixin(ProviderMixin):
         users can install the Trello and Asana plugins but not Jira even though both utilize issue-commits.
         By not prefixing, we can avoid making new feature flags for data-forwarding which are restricted.
         """
-        if f == IntegrationFeatures.DATA_FORWARDING:
+        if f == IntegrationFeatures.DATA_FORWARDING.value:
             return u"integrations-{}".format(f)
         return f

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -170,10 +170,13 @@ class PluginConfigMixin(ProviderMixin):
     @staticmethod
     def feature_flag_name(f):
         """
-        For the time being, we want the features for plugins to be treated separately than integrations
-        (integration features prefix with integrations-). This is because in Saas Sentry,
-        users can install the Trello and Asana plugins but not Jira even though both utilize issue-commits.
-        By not prefixing, we can avoid making new feature flags for data-forwarding which are restricted.
+        In order to ensure that plugins in the integration directory have the same feature restrictions
+        as they do in the legacy integrations page, we need to prefix data forwarding plugin with "integrations-"
+        but not any other type of plugin. Data forwarding plugins were the only ones that should be restricted
+        which is why they get the prefix. On the other hand, while issue-basic first-party integrations are
+        restricted (ex: Jira), issue-basic plugins like Asana and Trello are not restricted. By not prefixing
+        those other types of plugins, they won't have the same restrictions as the first-party integrations with
+        the same feature set.
         """
         if f == IntegrationFeatures.DATA_FORWARDING.value:
             return u"integrations-{}".format(f)

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -10,7 +10,6 @@ from rest_framework import serializers
 
 from sentry.exceptions import PluginError
 from sentry.utils.forms import form_to_config
-from sentry.integrations import IntegrationFeatures
 
 from .providers import ProviderMixin
 from .validators import DEFAULT_VALIDATORS
@@ -97,7 +96,6 @@ class PluginConfigMixin(ProviderMixin):
     def get_metadata(self):
         """
         Return extra metadata which is used to represent this plugin.
-
         This is available via the API, and commonly used for runtime
         configuration that changes per-install, but not per-project.
         """
@@ -170,12 +168,9 @@ class PluginConfigMixin(ProviderMixin):
     @staticmethod
     def feature_flag_name(f):
         """
-        In order to ensure that plugins in the integration directory have the same feature restrictions
-        as they do in the legacy integrations page, we need to prefix data forwarding plugin with "integrations-"
-        but not any other type of plugin. Data forwarding plugins were the only ones that should be restricted
-        which is why they get the prefix. On the other hand, while issue-basic first-party integrations are
-        restricted (ex: Jira), issue-basic plugins like Asana and Trello are not restricted. By not prefixing
-        those other types of plugins, they won't have the same restrictions as the first-party integrations with
-        the same feature set.
+        For the time being, we want the features for plugins to be treated separately than integrations
+        (integration features prefix with integrations-). This is because in Saas Sentry,
+        users can install the Trello and Asana plugins but not Jira even though both utilize issue-commits.
+        By not prefixing, we can avoid making new feature flags for data-forwarding which are restricted.
         """
         return f

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -178,6 +178,4 @@ class PluginConfigMixin(ProviderMixin):
         those other types of plugins, they won't have the same restrictions as the first-party integrations with
         the same feature set.
         """
-        if f == IntegrationFeatures.DATA_FORWARDING.value:
-            return u"integrations-{}".format(f)
         return f

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -11,30 +11,30 @@ from sentry.api.serializers import serialize, DetailedOrganizationSerializer
 from sentry.testutils import TestCase
 
 
-class OrganizationSerializerTest(TestCase):
-    def test_simple(self):
-        user = self.create_user()
-        organization = self.create_organization(owner=user)
+# class OrganizationSerializerTest(TestCase):
+#     def test_simple(self):
+#         user = self.create_user()
+#         organization = self.create_organization(owner=user)
 
-        result = serialize(organization, user)
+#         result = serialize(organization, user)
 
-        assert result["id"] == six.text_type(organization.id)
-        assert result["features"] == set(
-            [
-                "advanced-search",
-                "shared-issues",
-                "open-membership",
-                "integrations-issue-basic",
-                "integrations-issue-sync",
-                "invite-members",
-                "sso-saml2",
-                "sso-basic",
-                "symbol-sources",
-                "custom-symbol-sources",
-                "tweak-grouping-config",
-                "grouping-info",
-            ]
-        )
+#         assert result["id"] == six.text_type(organization.id)
+#         assert result["features"] == set(
+#             [
+#                 "advanced-search",
+#                 "shared-issues",
+#                 "open-membership",
+#                 "integrations-issue-basic",
+#                 "integrations-issue-sync",
+#                 "invite-members",
+#                 "sso-saml2",
+#                 "sso-basic",
+#                 "symbol-sources",
+#                 "custom-symbol-sources",
+#                 "tweak-grouping-config",
+#                 "grouping-info",
+#             ]
+#         )
 
 
 class DetailedOrganizationSerializerTest(TestCase):

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -26,7 +26,7 @@ class OrganizationSerializerTest(TestCase):
                 "open-membership",
                 "integrations-issue-basic",
                 "integrations-issue-sync",
-                "integrations-data-forwarding",
+                "data-forwarding",
                 "invite-members",
                 "sso-saml2",
                 "sso-basic",

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -11,30 +11,31 @@ from sentry.api.serializers import serialize, DetailedOrganizationSerializer
 from sentry.testutils import TestCase
 
 
-# class OrganizationSerializerTest(TestCase):
-#     def test_simple(self):
-#         user = self.create_user()
-#         organization = self.create_organization(owner=user)
+class OrganizationSerializerTest(TestCase):
+    def test_simple(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
 
-#         result = serialize(organization, user)
+        result = serialize(organization, user)
 
-#         assert result["id"] == six.text_type(organization.id)
-#         assert result["features"] == set(
-#             [
-#                 "advanced-search",
-#                 "shared-issues",
-#                 "open-membership",
-#                 "integrations-issue-basic",
-#                 "integrations-issue-sync",
-#                 "invite-members",
-#                 "sso-saml2",
-#                 "sso-basic",
-#                 "symbol-sources",
-#                 "custom-symbol-sources",
-#                 "tweak-grouping-config",
-#                 "grouping-info",
-#             ]
-#         )
+        assert result["id"] == six.text_type(organization.id)
+        assert result["features"] == set(
+            [
+                "advanced-search",
+                "shared-issues",
+                "open-membership",
+                "integrations-issue-basic",
+                "integrations-issue-sync",
+                "integrations-data-forwarding",
+                "invite-members",
+                "sso-saml2",
+                "sso-basic",
+                "symbol-sources",
+                "custom-symbol-sources",
+                "tweak-grouping-config",
+                "grouping-info",
+            ]
+        )
 
 
 class DetailedOrganizationSerializerTest(TestCase):


### PR DESCRIPTION
This PR adds data-forwarding as an organization feature so we can check that value in the integration directory. This way, we can know if an org should be able to install a data-forwarding plugin like Amazon SQS or Splunk without loading the available features for a project.

This PR must be merged with: https://github.com/getsentry/getsentry/pull/3758