### PR TITLE
fix: Fix duplicate event node binding

### DIFF
--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -231,7 +231,8 @@ class EventStorage(Service):
             (i, getattr(i, node_name)) for i in object_list if getattr(i, node_name).id
         ]
 
-        node_ids = [n.id for _, n in object_node_list]
+        # Remove duplicates from the list of nodes to be fetched
+        node_ids = list(set([n.id for _, n in object_node_list]))
         if not node_ids:
             return
 

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -232,7 +232,7 @@ class EventStorage(Service):
         ]
 
         # Remove duplicates from the list of nodes to be fetched
-        node_ids = list(set([n.id for _, n in object_node_list]))
+        node_ids = list({n.id for _, n in object_node_list})
         if not node_ids:
             return
 


### PR DESCRIPTION
nodestore.get_multi() currently fails to return when duplicate node
IDs are provided. Remove any duplicates from the list before sending
to nodestore. The same node data will be bound to both events with
matching IDs.