### PR TITLE
fix(ui): Fix search by event id on `<Events>`

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1453,6 +1453,11 @@ function routes() {
           component={errorHandler(LazyLoad)}
         />
 
+        <Route
+          path="/organizations/:orgId/projects/:projectId/events/:eventId/"
+          component={errorHandler(ProjectEventRedirect)}
+        />
+
         {/* Admin/manage routes */}
         <Route
           path="/manage/"
@@ -1721,10 +1726,6 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
           </Route>
-          <Route
-            path="/organizations/:orgId/projects/:projectId/events/:eventId/"
-            component={errorHandler(ProjectEventRedirect)}
-          />
           <Route
             path="/organizations/:orgId/releases/"
             componentPromise={() =>

--- a/src/sentry/static/sentry/app/views/events/events.jsx
+++ b/src/sentry/static/sentry/app/views/events/events.jsx
@@ -121,22 +121,31 @@ class Events extends AsyncView {
     return `Events - ${this.props.organization.slug}`;
   }
 
-  onRequestSuccess({data, jqXHR}) {
-    const {organization} = this.props;
-
-    // TODO: This is actually not optimal because `AsyncComponent.handleRequestSuccess`
-    // still gets called and updates state when the response may not be what the component
-    // expects.
-    //
-    // Ideally when a direct hit is found, we should not update state in `handleRequestSuccess`
+  async handleRequestSuccess({stateKey, data, jqXHR}, ...args) {
+    // When a direct hit is found, do not update state in `handleRequestSuccess`
     if (jqXHR.getResponseHeader('X-Sentry-Direct-Hit') === '1') {
+      const {organization} = this.props;
       const event = data[0];
-      const project = organization.projects.find(p => p.id === event.projectID);
 
-      browserHistory.replace(
-        `/organizations/${organization.slug}/projects/${project.slug}/events/${event.eventID}/`
+      const resp = await this.api.requestPromise(
+        `/organizations/${organization.slug}/projects/`,
+        {
+          query: {
+            query: `id:${event.projectID}`,
+          },
+        }
       );
+
+      if (resp && resp.length > 0) {
+        const project = resp[0];
+        browserHistory.replace(
+          `/organizations/${organization.slug}/projects/${project.slug}/events/${event.eventID}/`
+        );
+        return;
+      }
     }
+
+    super.handleRequestSuccess({stateKey, data, jqXHR}, ...args);
   }
 
   onRequestError(resp) {

--- a/src/sentry/static/sentry/app/views/projectEventRedirect.jsx
+++ b/src/sentry/static/sentry/app/views/projectEventRedirect.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
-import DetailedError from 'app/components/errors/detailedError';
+import {PageContent} from 'app/styles/organization';
 import {t} from 'app/locale';
+import DetailedError from 'app/components/errors/detailedError';
 
 /**
  * This component performs a client-side redirect to Event Details given only
@@ -70,7 +71,7 @@ class ProjectEventRedirect extends React.Component {
         />
       );
     }
-    return null;
+    return <PageContent />;
   }
 }
 

--- a/tests/js/spec/views/events/events.spec.jsx
+++ b/tests/js/spec/views/events/events.spec.jsx
@@ -450,6 +450,8 @@ describe('EventsContainer', function() {
       routerContext
     );
 
+    await tick();
+
     expect(eventsMock).toHaveBeenCalled();
     expect(browserHistory.replace).toHaveBeenCalledWith(
       `/organizations/org-slug/projects/project-slug/events/${eventId}/`


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/getsentry/sentry/pull/18138 - when searching by event id and there is a direct hit, the component used `organization.projects` (which no longer has a list of all projects on org) to lookup project slug by project id (id is returned by search results).

* Refactor to use `handleRequestSuccess` so that we redirect before updating state when a direct hit is found. Adds an API request for project slug lookup.
* Moves `<ProjectEventRedirect>` to lightweight routes
* Design touchups for `<ProjectEventRedirect>`

Fixes JAVASCRIPT-2200