### PR TITLE
meta: add CODEOWNERS coverage for build + dev files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,20 @@
 /src/sentry/scripts/tsdb/          @getsentry/owners-ingest
 
 # Security
-/src/sentry/net/  @getsentry/security
+/src/sentry/net/    @getsentry/security
 
 # Build & Releases
-/docker @getsentry/releases
+/docker             @getsentry/releases
+setup.py            @getsentry/releases
+setup.cfg           @getsentry/releases
+requirements*.txt   @joshuarli
+.travis.yml         @joshuarli
+
+# Dev
+/config/                    @joshuarli
+/scripts/                   @joshuarli
+Makefile                    @joshuarli
+.envrc                      @joshuarli
+.pre-commit-config.yaml     @joshuarli
+.git-blame-ignore-revs      @joshuarli
+pyproject.toml              @joshuarli


### PR DESCRIPTION
I was going to add a comment to https://github.com/getsentry/sentry/issues/18206 talking about how to add that dependency properly, but then I realized it'd be much nicer if my review was automatically requested on various build + dev files.

It's tricky to navigate these and hard to not break them, and I've touched these files a lot so I figure my reviews will be useful.

@billyvg there's a lot of javascript-related build + dev files that I don't know about - you interested?

Also open to just making a new "team" like getsentry/dev. I wasn't sure if getsentry/releases wanted to know about .travis.yml and requirements files though, so just added myself for now.