### PR TITLE
revert(ui): Revert moving Settings into lightweight

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1344,67 +1344,6 @@ function routes() {
           />
         </Route>
 
-        {/* Settings routes */}
-        <Route path="/settings/" name="Settings" component={SettingsWrapper}>
-          <IndexRoute
-            getComponent={(_loc, cb) =>
-              import(
-                /* webpackChunkName: "SettingsIndex" */ 'app/views/settings/settingsIndex'
-              ).then(lazyLoad(cb))
-            }
-          />
-
-          <Route
-            path="account/"
-            name="Account"
-            getComponent={(_loc, cb) =>
-              import(
-                /* webpackChunkName: "AccountSettingsLayout" */ 'app/views/settings/account/accountSettingsLayout'
-              ).then(lazyLoad(cb))
-            }
-          >
-            {accountSettingsRoutes}
-          </Route>
-
-          <Route name="Organization" path=":orgId/">
-            <Route
-              getComponent={(_loc, cb) =>
-                import(
-                  /* webpackChunkName: "OrganizationSettingsLayout" */ 'app/views/settings/organization/organizationSettingsLayout'
-                ).then(lazyLoad(cb))
-              }
-            >
-              {hook('routes:organization')}
-              {orgSettingsRoutes}
-            </Route>
-
-            <Route
-              name="Project"
-              path="projects/:projectId/"
-              getComponent={(_loc, cb) =>
-                import(
-                  /* webpackChunkName: "ProjectSettingsLayout" */ 'app/views/settings/project/projectSettingsLayout'
-                ).then(lazyLoad(cb))
-              }
-            >
-              <Route component={errorHandler(SettingsProjectProvider)}>
-                {projectSettingsRoutes}
-              </Route>
-            </Route>
-
-            <Redirect from=":projectId/" to="projects/:projectId/" />
-            <Redirect from=":projectId/alerts/" to="projects/:projectId/alerts/" />
-            <Redirect
-              from=":projectId/alerts/rules/"
-              to="projects/:projectId/alerts/rules/"
-            />
-            <Redirect
-              from=":projectId/alerts/rules/:ruleId/"
-              to="projects/:projectId/alerts/rules/:ruleId/"
-            />
-          </Route>
-        </Route>
-
         <Route
           path="/organizations/:orgId/monitors/"
           componentPromise={() =>
@@ -1740,6 +1679,68 @@ function routes() {
             }
             component={errorHandler(LazyLoad)}
           />
+
+          {/* Settings routes */}
+          <Route path="/settings/" name="Settings" component={SettingsWrapper}>
+            <IndexRoute
+              getComponent={(_loc, cb) =>
+                import(
+                  /* webpackChunkName: "SettingsIndex" */ 'app/views/settings/settingsIndex'
+                ).then(lazyLoad(cb))
+              }
+            />
+
+            <Route
+              path="account/"
+              name="Account"
+              getComponent={(_loc, cb) =>
+                import(
+                  /* webpackChunkName: "AccountSettingsLayout" */ 'app/views/settings/account/accountSettingsLayout'
+                ).then(lazyLoad(cb))
+              }
+            >
+              {accountSettingsRoutes}
+            </Route>
+
+            <Route name="Organization" path=":orgId/">
+              <Route
+                getComponent={(_loc, cb) =>
+                  import(
+                    /* webpackChunkName: "OrganizationSettingsLayout" */ 'app/views/settings/organization/organizationSettingsLayout'
+                  ).then(lazyLoad(cb))
+                }
+              >
+                {hook('routes:organization')}
+                {orgSettingsRoutes}
+              </Route>
+
+              <Route
+                name="Project"
+                path="projects/:projectId/"
+                getComponent={(_loc, cb) =>
+                  import(
+                    /* webpackChunkName: "ProjectSettingsLayout" */ 'app/views/settings/project/projectSettingsLayout'
+                  ).then(lazyLoad(cb))
+                }
+              >
+                <Route component={errorHandler(SettingsProjectProvider)}>
+                  {projectSettingsRoutes}
+                </Route>
+              </Route>
+
+              <Redirect from=":projectId/" to="projects/:projectId/" />
+              <Redirect from=":projectId/alerts/" to="projects/:projectId/alerts/" />
+              <Redirect
+                from=":projectId/alerts/rules/"
+                to="projects/:projectId/alerts/rules/"
+              />
+              <Redirect
+                from=":projectId/alerts/rules/:ruleId/"
+                to="projects/:projectId/alerts/rules/:ruleId/"
+              />
+            </Route>
+          </Route>
+
           <Route path="/organizations/:orgId/">
             {hook('routes:organization')}
             <Redirect path="/organizations/:orgId/teams/" to="/settings/:orgId/teams/" />

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1040,6 +1040,69 @@ function routes() {
         />
       </Route>
 
+      {/* Settings routes */}
+      <Route component={errorHandler(OrganizationDetails)}>
+        <Route path="/settings/" name="Settings" component={SettingsWrapper}>
+          <IndexRoute
+            getComponent={(_loc, cb) =>
+              import(
+                /* webpackChunkName: "SettingsIndex" */ 'app/views/settings/settingsIndex'
+              ).then(lazyLoad(cb))
+            }
+          />
+
+          <Route
+            path="account/"
+            name="Account"
+            getComponent={(_loc, cb) =>
+              import(
+                /* webpackChunkName: "AccountSettingsLayout" */ 'app/views/settings/account/accountSettingsLayout'
+              ).then(lazyLoad(cb))
+            }
+          >
+            {accountSettingsRoutes}
+          </Route>
+
+          <Route name="Organization" path=":orgId/">
+            <Route
+              getComponent={(_loc, cb) =>
+                import(
+                  /* webpackChunkName: "OrganizationSettingsLayout" */ 'app/views/settings/organization/organizationSettingsLayout'
+                ).then(lazyLoad(cb))
+              }
+            >
+              {hook('routes:organization')}
+              {orgSettingsRoutes}
+            </Route>
+
+            <Route
+              name="Project"
+              path="projects/:projectId/"
+              getComponent={(_loc, cb) =>
+                import(
+                  /* webpackChunkName: "ProjectSettingsLayout" */ 'app/views/settings/project/projectSettingsLayout'
+                ).then(lazyLoad(cb))
+              }
+            >
+              <Route component={errorHandler(SettingsProjectProvider)}>
+                {projectSettingsRoutes}
+              </Route>
+            </Route>
+
+            <Redirect from=":projectId/" to="projects/:projectId/" />
+            <Redirect from=":projectId/alerts/" to="projects/:projectId/alerts/" />
+            <Redirect
+              from=":projectId/alerts/rules/"
+              to="projects/:projectId/alerts/rules/"
+            />
+            <Redirect
+              from=":projectId/alerts/rules/:ruleId/"
+              to="projects/:projectId/alerts/rules/:ruleId/"
+            />
+          </Route>
+        </Route>
+      </Route>
+
       {/* A route tree for lightweight organizational detail views. We place
       this above the heavyweight organization detail views because there
       exist some redirects from deprecated routes which should not take
@@ -1679,67 +1742,6 @@ function routes() {
             }
             component={errorHandler(LazyLoad)}
           />
-
-          {/* Settings routes */}
-          <Route path="/settings/" name="Settings" component={SettingsWrapper}>
-            <IndexRoute
-              getComponent={(_loc, cb) =>
-                import(
-                  /* webpackChunkName: "SettingsIndex" */ 'app/views/settings/settingsIndex'
-                ).then(lazyLoad(cb))
-              }
-            />
-
-            <Route
-              path="account/"
-              name="Account"
-              getComponent={(_loc, cb) =>
-                import(
-                  /* webpackChunkName: "AccountSettingsLayout" */ 'app/views/settings/account/accountSettingsLayout'
-                ).then(lazyLoad(cb))
-              }
-            >
-              {accountSettingsRoutes}
-            </Route>
-
-            <Route name="Organization" path=":orgId/">
-              <Route
-                getComponent={(_loc, cb) =>
-                  import(
-                    /* webpackChunkName: "OrganizationSettingsLayout" */ 'app/views/settings/organization/organizationSettingsLayout'
-                  ).then(lazyLoad(cb))
-                }
-              >
-                {hook('routes:organization')}
-                {orgSettingsRoutes}
-              </Route>
-
-              <Route
-                name="Project"
-                path="projects/:projectId/"
-                getComponent={(_loc, cb) =>
-                  import(
-                    /* webpackChunkName: "ProjectSettingsLayout" */ 'app/views/settings/project/projectSettingsLayout'
-                  ).then(lazyLoad(cb))
-                }
-              >
-                <Route component={errorHandler(SettingsProjectProvider)}>
-                  {projectSettingsRoutes}
-                </Route>
-              </Route>
-
-              <Redirect from=":projectId/" to="projects/:projectId/" />
-              <Redirect from=":projectId/alerts/" to="projects/:projectId/alerts/" />
-              <Redirect
-                from=":projectId/alerts/rules/"
-                to="projects/:projectId/alerts/rules/"
-              />
-              <Redirect
-                from=":projectId/alerts/rules/:ruleId/"
-                to="projects/:projectId/alerts/rules/:ruleId/"
-              />
-            </Route>
-          </Route>
 
           <Route path="/organizations/:orgId/">
             {hook('routes:organization')}


### PR DESCRIPTION
There are some still some issues in settings that do not throw exceptions but are prohibiting people from using settings (e.g. Teams). Going to revert this change for now until this is assessed a bit more thoroughly.

Reverts #18067