### PR TITLE
fix(subscription): Filter out transactions from alert stats

### DIFF
--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -15,6 +15,18 @@ from sentry.utils import metrics
 from sentry.utils.snuba import _snuba_pool, SnubaError
 
 
+# TODO: If we want to support security events here we'll need a way to
+# differentiate within the dataset. For now we can just assume all subscriptions
+# created within this dataset are just for errors.
+DATASET_CONDITIONS = {QueryDatasets.EVENTS: [["type", "=", "error"]]}
+
+
+def apply_dataset_conditions(dataset, conditions):
+    if dataset in DATASET_CONDITIONS:
+        conditions = conditions + DATASET_CONDITIONS[dataset]
+    return conditions
+
+
 @instrumented_task(
     name="sentry.snuba.tasks.create_subscription_in_snuba",
     queue="subscriptions",
@@ -107,11 +119,7 @@ def _create_in_snuba(subscription):
     environments = list(subscription.environments.all())
     if environments:
         conditions.append(["environment", "IN", [env.name for env in environments]])
-    if subscription.dataset == QueryDatasets.EVENTS.value:
-        # TODO: If we want to support security events here we'll need a way to
-        # differentiate within the dataset. For now we can just assume all subscriptions
-        # created within this dataset are just for errors.
-        conditions.append(["type", "=", "error"])
+    conditions = apply_dataset_conditions(QueryDatasets(subscription.dataset), conditions)
     response = _snuba_pool.urlopen(
         "POST",
         "/%s/subscriptions" % (subscription.dataset,),


### PR DESCRIPTION
Following up from https://github.com/getsentry/sentry/pull/18175, this makes sure we filter to
`error` when we load stats from snuba.