### PR TITLE
fix(subscriptions): Add `discoverQuery` to `DetailedIncidentSerializer`

### DIFF
--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -12,6 +12,7 @@ from sentry.incidents.models import (
     IncidentSeen,
     IncidentSubscription,
 )
+from sentry.snuba.models import QueryDatasets
 from sentry.utils.db import attach_foreignkey
 
 
@@ -97,5 +98,19 @@ class DetailedIncidentSerializer(IncidentSerializer):
         context["hasSeen"] = seen_list["has_seen"]
         context["groups"] = attrs["groups"]
         context["alertRule"] = serialize(obj.alert_rule, user)
+        # The query we should use to get accurate results in Discover.
+        context["discoverQuery"] = self._build_discover_query(obj)
 
         return context
+
+    def _build_discover_query(self, incident):
+        query = incident.query
+        if (
+            incident.alert_rule
+            and QueryDatasets(incident.alert_rule.dataset) == QueryDatasets.EVENTS
+        ):
+            query = incident.alert_rule.query
+            condition = "event.type:error"
+            query = "{} {}".format(condition, query) if query else condition
+
+        return query

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -61,9 +61,11 @@ class DetailedIncidentSerializerTest(TestCase):
         serializer = DetailedIncidentSerializer()
         result = serialize(incident, serializer=serializer)
         assert result["alertRule"] is None
+        assert result["discoverQuery"] == incident.query
 
     def test_alert_rule(self):
         incident = self.create_incident()
+        query = "test query"
         alert_rule = create_alert_rule(
             self.organization, [self.project], "hi", "test query", QueryAggregations.TOTAL, 10, 1
         )
@@ -72,3 +74,4 @@ class DetailedIncidentSerializerTest(TestCase):
         serializer = DetailedIncidentSerializer()
         result = serialize(incident, serializer=serializer)
         assert result["alertRule"] == serialize(alert_rule)
+        assert result["discoverQuery"] == "event.type:error {}".format(query)


### PR DESCRIPTION
Frontend should use this query to build the link to Discover from the alert screen so that we show
correct data.