### PR TITLE
feat(integrations): adds signing secret verification for slack webhooks

### DIFF
--- a/src/sentry/integrations/slack/requests.py
+++ b/src/sentry/integrations/slack/requests.py
@@ -96,6 +96,7 @@ class SlackRequest(object):
             raise SlackRequestError(status=400)
 
     def _authorize(self):
+        # TODO(steve): update check when we add the v2 slack app
         signing_secret = options.get("slack.signing-secret")
         # use the signing_secret if it's available
         if signing_secret:

--- a/src/sentry/integrations/slack/requests.py
+++ b/src/sentry/integrations/slack/requests.py
@@ -100,6 +100,7 @@ class SlackRequest(object):
         # use the signing_secret if it's available
         if signing_secret:
             # Taken from: https://github.com/slackapi/python-slack-events-api/blob/master/slackeventsapi/server.py#L47
+            # Slack docs on this here: https://api.slack.com/authentication/verifying-requests-from-slack#about
             signature = self.request.META["HTTP_X_SLACK_SIGNATURE"]
             timestamp = self.request.META["HTTP_X_SLACK_REQUEST_TIMESTAMP"]
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -121,6 +121,7 @@ register("cloudflare.secret-key", default="")
 register("slack.client-id", flags=FLAG_PRIORITIZE_DISK)
 register("slack.client-secret", flags=FLAG_PRIORITIZE_DISK)
 register("slack.verification-token", flags=FLAG_PRIORITIZE_DISK)
+register("slack.signing-secret", flags=FLAG_PRIORITIZE_DISK)
 
 # GitHub Integration
 register("github-app.id", default=0)

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -115,7 +115,6 @@ def pytest_configure(config):
             "slack.client-id": "slack-client-id",
             "slack.client-secret": "slack-client-secret",
             "slack.verification-token": "slack-verification-token",
-            "slack.signing-secret": "slack.signing-secret",
             "github-app.name": "sentry-test-app",
             "github-app.client-id": "github-client-id",
             "github-app.client-secret": "github-client-secret",

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -115,6 +115,7 @@ def pytest_configure(config):
             "slack.client-id": "slack-client-id",
             "slack.client-secret": "slack-client-secret",
             "slack.verification-token": "slack-verification-token",
+            "slack.signing-secret": "slack.signing-secret",
             "github-app.name": "sentry-test-app",
             "github-app.client-id": "github-client-id",
             "github-app.client-secret": "github-client-secret",

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -1,11 +1,19 @@
 from __future__ import absolute_import
 
 import json
+import hmac
+import time
+import six
+from datetime import datetime
+from hashlib import sha256
+from six.moves.urllib.parse import urlencode
+
 from sentry.utils.compat import mock
 
 from sentry import options
 from sentry.utils.cache import memoize
 from sentry.testutils import TestCase
+from sentry.testutils.helpers import override_options
 from sentry.integrations.slack.requests import (
     SlackRequest,
     SlackEventRequest,
@@ -100,6 +108,15 @@ class SlackEventRequestTest(TestCase):
             "user": {"id": "2"},
             "api_app_id": "S1",
         }
+        self.request.META = {}
+
+    def set_signature(self, secret, data):
+        timestamp = six.text_type(int(time.mktime(datetime.utcnow().timetuple())))
+        req = six.binary_type("v0:%s:%s" % (timestamp, six.binary_type(data)))
+
+        signature = "v0=" + hmac.new(six.binary_type(secret), req, sha256).hexdigest()
+        self.request.META["HTTP_X_SLACK_REQUEST_TIMESTAMP"] = timestamp
+        self.request.META["HTTP_X_SLACK_SIGNATURE"] = signature
 
     @memoize
     def slack_request(self):
@@ -139,6 +156,40 @@ class SlackEventRequestTest(TestCase):
 
     def test_type(self):
         assert self.slack_request.type == "bar"
+
+    def test_signing_secret(self):
+        self.request.data = {"challenge": "abc123", "type": "url_verification"}
+
+        # we get a url encoded body with Slack
+        self.request.body = urlencode(self.request.data)
+
+        self.set_signature(options.get("slack.signing-secret"), self.request.body)
+        self.slack_request.validate()
+
+    def test_signing_secret_bad(self):
+        # even though we provide the token, should still fail
+        self.request.data = {
+            "token": options.get("slack.verification-token"),
+            "challenge": "abc123",
+            "type": "url_verification",
+        }
+        self.request.body = urlencode(self.request.data)
+
+        self.set_signature("bad_key", self.request.body)
+        with self.assertRaises(SlackRequestError) as e:
+            self.slack_request.validate()
+            assert e.status == 401
+
+    def test_signing_secret_use_verification_token(self):
+        with override_options({"slack.signing-secret": ""}):
+            self.request.data = {
+                "token": options.get("slack.verification-token"),
+                "challenge": "abc123",
+                "type": "url_verification",
+            }
+            self.request.body = json.dumps(self.request.data)
+
+            self.slack_request.validate()
 
 
 class SlackActionRequestTest(TestCase):


### PR DESCRIPTION
The verification token is a “deprecated” way of verifying requests, and the signing secret is what is now preferred. This PR adds signing secret request verification for the Slack integration. If `slack.signing-secret` is set, we use the new secret request verification. Otherwise, we default to the old verification token verification. Slack docs on it here: https://api.slack.com/authentication/verifying-requests-from-slack#about