### PR TITLE
ref(btn sizes): removing lg, xxs and micro

### DIFF
--- a/docs-ui/components/button.stories.js
+++ b/docs-ui/components/button.stories.js
@@ -72,22 +72,13 @@ storiesOf('UI|Buttons', module)
             </Button>
           </Item>
           <Item>
-            <Button size="micro">Micro</Button>
-          </Item>
-          <Item>
-            <Button size="xxsmall">XX Small</Button>
-          </Item>
-          <Item>
             <Button size="xsmall">X Small</Button>
           </Item>
           <Item>
             <Button size="small">Small</Button>
           </Item>
           <Item>
-            <Button>Normal</Button>
-          </Item>
-          <Item>
-            <Button size="large">Large</Button>
+            <Button>Default</Button>
           </Item>
         </Section>
         <Section>
@@ -97,32 +88,17 @@ storiesOf('UI|Buttons', module)
               <Button size="zero" borderless icon={<IconDelete size="xs" />} />
             </Item>
             <Item>
-              <Button size="micro" icon={<IconDelete size="xs" />}>
-                Micro
-              </Button>
-            </Item>
-            <Item>
-              <Button size="xxsmall" icon={<IconDelete size="xs" />}>
-                XX Small
-              </Button>
-            </Item>
-            <Item>
               <Button size="xsmall" icon={<IconDelete size="xs" />}>
                 X Small
               </Button>
             </Item>
             <Item>
-              <Button size="small" icon={<IconDelete />}>
+              <Button size="small" icon={<IconDelete size="xs" />}>
                 Small
               </Button>
             </Item>
             <Item>
-              <Button icon={<IconDelete />}>Normal</Button>
-            </Item>
-            <Item>
-              <Button size="large" icon={<IconDelete size="md" />}>
-                Large
-              </Button>
+              <Button icon={<IconDelete />}>Default</Button>
             </Item>
           </div>
         </Section>
@@ -155,11 +131,6 @@ storiesOf('UI|Buttons', module)
             <Item>
               <Button busy={boolean('Normal Busy', true)} priority="primary">
                 Normal
-              </Button>
-            </Item>
-            <Item>
-              <Button busy={boolean('Large Busy', true)} priority="primary" size="large">
-                Large
               </Button>
             </Item>
             <Item>

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -19,7 +19,7 @@ type ButtonElement = HTMLButtonElement & HTMLAnchorElement & any;
 
 type Props = {
   priority?: 'default' | 'primary' | 'danger' | 'link' | 'success';
-  size?: 'zero' | 'micro' | 'small' | 'xsmall' | 'xxsmall' | 'large';
+  size?: 'zero' | 'xsmall' | 'small';
   align?: 'center' | 'left' | 'right';
   disabled?: boolean;
   busy?: boolean;
@@ -47,7 +47,7 @@ type Url = ButtonProps['to'] | ButtonProps['href'];
 class Button extends React.Component<ButtonProps, {}> {
   static propTypes: any = {
     priority: PropTypes.oneOf(['default', 'primary', 'danger', 'link', 'success']),
-    size: PropTypes.oneOf(['zero', 'micro', 'small', 'xxsmall', 'xsmall', 'large']),
+    size: PropTypes.oneOf(['zero', 'xsmall', 'small']),
     disabled: PropTypes.bool,
     busy: PropTypes.bool,
     /**
@@ -173,11 +173,7 @@ class Button extends React.Component<ButtonProps, {}> {
                 <StyledInlineSvg
                   src={icon}
                   size={
-                    iconSize
-                      ? iconSize
-                      : (size && size.endsWith('small')) || size === 'micro'
-                      ? '12px'
-                      : '14px'
+                    iconSize ? iconSize : size && size.endsWith('small') ? '12px' : '14px'
                   }
                 />
               ) : (
@@ -217,13 +213,9 @@ type StyledButtonProps = ButtonProps & {theme: Theme};
 
 const getFontSize = ({size, theme}: StyledButtonProps) => {
   switch (size) {
-    case 'micro':
     case 'xsmall':
-    case 'xxsmall':
     case 'small':
       return theme.fontSizeSmall;
-    case 'large':
-      return theme.fontSizeLarge;
     default:
       return theme.fontSizeMedium;
   }
@@ -307,11 +299,10 @@ const StyledButton = styled(
   }
 )<Props>`
   display: inline-block;
-  line-height: 1;
+  line-height: 1.2;
   border-radius: ${p => p.theme.button.borderRadius};
   padding: 0;
   text-transform: none;
-
   ${getFontWeight};
   font-size: ${getFontSize};
   ${getColors};
@@ -335,27 +326,20 @@ const StyledButton = styled(
 const getLabelPadding = ({
   size,
   priority,
-  borderless,
 }: Pick<StyledButtonProps, 'size' | 'priority' | 'borderless'>) => {
   if (priority === 'link') {
     return '0';
   }
 
   switch (size) {
-    case 'micro':
     case 'zero':
       return '0';
-    case 'xxsmall':
-      return borderless ? '1px 2px' : '2px 4px';
     case 'xsmall':
-      return borderless ? '4px 6px' : '6px 10px';
+      return '4px 8px';
     case 'small':
-      return borderless ? '6px 8px' : '8px 12px';
-    case 'large':
-      return borderless ? '8px 10px' : '14px 20px';
-
+      return '8px 12px';
     default:
-      return borderless ? '6px 10px' : '12px 16px';
+      return '11px 16px';
   }
 };
 

--- a/src/sentry/static/sentry/app/components/errorRobot.tsx
+++ b/src/sentry/static/sentry/app/components/errorRobot.tsx
@@ -87,7 +87,6 @@ class ErrorRobot extends React.Component<Props, State> {
           <CreateSampleEventButton
             priority="link"
             borderless
-            size="large"
             project={project}
             source="issues_list"
             disabled={!project}
@@ -123,7 +122,6 @@ class ErrorRobot extends React.Component<Props, State> {
               <Button
                 data-test-id="install-instructions"
                 priority="primary"
-                size="large"
                 to={`/${org.slug}/${project.slug}/getting-started/${project.platform ||
                   ''}`}
               >

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -401,7 +401,7 @@ class DebugMetaInterface extends React.PureComponent {
       return tct(
         'No images are referenced in the stack trace. [toggle: Show Unreferenced]',
         {
-          toggle: <Button size="large" priority="link" onClick={this.handleShowUnused} />,
+          toggle: <Button priority="link" onClick={this.handleShowUnused} />,
         }
       );
     }

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -104,7 +104,7 @@ const InviteRowControl = ({
     <Button
       borderless
       icon="icon-close"
-      size="micro"
+      size="zero"
       onClick={onRemove}
       disabled={disableRemove}
     />

--- a/src/sentry/static/sentry/app/components/pagination.tsx
+++ b/src/sentry/static/sentry/app/components/pagination.tsx
@@ -59,7 +59,6 @@ class Pagination extends React.Component<Props> {
         <ButtonBar merged>
           <Button
             aria-label={t('Previous')}
-            size="large"
             disabled={previousDisabled}
             onClick={() => {
               callIfFunction(onCursor, links.previous.cursor, path, query, -1);
@@ -69,7 +68,6 @@ class Pagination extends React.Component<Props> {
           </Button>
           <Button
             aria-label={t('Next')}
-            size="large"
             disabled={nextDisabled}
             onClick={() => {
               callIfFunction(onCursor, links.next.cursor, path, query, 1);

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -284,7 +284,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
         onClick={this.handleDeleteQuery}
         disabled={this.props.disabled}
       >
-        <IconDelete size="xs" color={theme.gray4} />
+        <IconDelete color={theme.gray4} />
       </Button>
     );
   }

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -126,12 +126,7 @@ class ProjectInstallPlatform extends React.Component {
           )}
 
           {this.isGettingStarted && (
-            <Button
-              priority="primary"
-              size="large"
-              to={issueStreamLink}
-              style={{marginTop: 20}}
-            >
+            <Button priority="primary" to={issueStreamLink} style={{marginTop: 20}}>
               {t('Got it! Take me to the Issue Stream.')}
             </Button>
           )}

--- a/src/sentry/static/sentry/app/views/releases/list/releaseProgress.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseProgress.jsx
@@ -192,7 +192,6 @@ class ReleaseProgress extends AsyncComponent {
             <StyledButton
               className="text-light"
               onClick={() => this.handleClick('dismissed')}
-              size="large"
               data-test-id="dismissed"
             >
               {t('Dismiss')}
@@ -200,7 +199,6 @@ class ReleaseProgress extends AsyncComponent {
             <StyledButton
               className="text-light"
               onClick={() => this.handleClick('snoozed')}
-              size="large"
               data-test-id="snoozed"
             >
               {t('Remind Me Later')}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/richListField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/richListField.jsx
@@ -125,7 +125,7 @@ class RichList extends React.PureComponent {
       <ItemButton
         onClick={onClick}
         disabled={disabled}
-        size="micro"
+        size="zero"
         icon={<IconDelete size="xs" />}
         borderless
       />
@@ -153,7 +153,7 @@ class RichList extends React.PureComponent {
             onClick={() => this.onEditItem(item, index)}
             disabled={disabled}
             icon="icon-settings"
-            size="micro"
+            size="zero"
             borderless
           />
         )}

--- a/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
@@ -3,14 +3,12 @@
 exports[`Button renders 1`] = `
 <forwardRef<Button>
   priority="primary"
-  size="large"
 >
   <Button
     align="center"
     disabled={false}
     forwardRef={null}
     priority="primary"
-    size="large"
   >
     <StyledButton
       aria-disabled={false}
@@ -20,32 +18,28 @@ exports[`Button renders 1`] = `
       onClick={[Function]}
       priority="primary"
       role="button"
-      size="large"
     >
       <Component
         aria-disabled={false}
         aria-label="Button"
-        className="css-1bbx5hm-StyledButton edwq9my0"
+        className="css-1f41kyg-StyledButton edwq9my0"
         forwardRef={null}
         onClick={[Function]}
         role="button"
-        size="large"
       >
         <button
           aria-disabled={false}
           aria-label="Button"
-          className="css-1bbx5hm-StyledButton edwq9my0"
+          className="css-1f41kyg-StyledButton edwq9my0"
           onClick={[Function]}
           role="button"
-          size="large"
         >
           <ButtonLabel
             align="center"
             priority="primary"
-            size="large"
           >
             <span
-              className="css-ym5hp1-ButtonLabel edwq9my1"
+              className="css-fkumu4-ButtonLabel edwq9my1"
             >
               Button
             </span>
@@ -79,7 +73,7 @@ exports[`Button renders disabled normal link 1`] = `
       <Component
         aria-disabled={false}
         aria-label="Normal Link"
-        className="css-1c2phb1-StyledButton edwq9my0"
+        className="css-ca6sk5-StyledButton edwq9my0"
         forwardRef={null}
         href="/some/relative/url"
         onClick={[Function]}
@@ -88,7 +82,7 @@ exports[`Button renders disabled normal link 1`] = `
         <a
           aria-disabled={false}
           aria-label="Normal Link"
-          className="css-1c2phb1-StyledButton edwq9my0"
+          className="css-ca6sk5-StyledButton edwq9my0"
           href="/some/relative/url"
           onClick={[Function]}
           role="button"
@@ -97,7 +91,7 @@ exports[`Button renders disabled normal link 1`] = `
             align="center"
           >
             <span
-              className="css-zmpclt-ButtonLabel edwq9my1"
+              className="css-fkumu4-ButtonLabel edwq9my1"
             >
               Normal Link
             </span>
@@ -131,7 +125,7 @@ exports[`Button renders normal link 1`] = `
       <Component
         aria-disabled={false}
         aria-label="Normal Link"
-        className="css-1c2phb1-StyledButton edwq9my0"
+        className="css-ca6sk5-StyledButton edwq9my0"
         forwardRef={null}
         href="/some/relative/url"
         onClick={[Function]}
@@ -140,7 +134,7 @@ exports[`Button renders normal link 1`] = `
         <a
           aria-disabled={false}
           aria-label="Normal Link"
-          className="css-1c2phb1-StyledButton edwq9my0"
+          className="css-ca6sk5-StyledButton edwq9my0"
           href="/some/relative/url"
           onClick={[Function]}
           role="button"
@@ -149,7 +143,7 @@ exports[`Button renders normal link 1`] = `
             align="center"
           >
             <span
-              className="css-zmpclt-ButtonLabel edwq9my1"
+              className="css-fkumu4-ButtonLabel edwq9my1"
             >
               Normal Link
             </span>
@@ -183,7 +177,7 @@ exports[`Button renders react-router link 1`] = `
       <Component
         aria-disabled={false}
         aria-label="Router Link"
-        className="css-1c2phb1-StyledButton edwq9my0"
+        className="css-ca6sk5-StyledButton edwq9my0"
         forwardRef={null}
         onClick={[Function]}
         role="button"
@@ -192,7 +186,7 @@ exports[`Button renders react-router link 1`] = `
         <Link
           aria-disabled={false}
           aria-label="Router Link"
-          className="css-1c2phb1-StyledButton edwq9my0"
+          className="css-ca6sk5-StyledButton edwq9my0"
           onClick={[Function]}
           onlyActiveOnIndex={false}
           role="button"
@@ -202,7 +196,7 @@ exports[`Button renders react-router link 1`] = `
           <a
             aria-disabled={false}
             aria-label="Router Link"
-            className="css-1c2phb1-StyledButton edwq9my0"
+            className="css-ca6sk5-StyledButton edwq9my0"
             onClick={[Function]}
             role="button"
             style={Object {}}
@@ -211,7 +205,7 @@ exports[`Button renders react-router link 1`] = `
               align="center"
             >
               <span
-                className="css-zmpclt-ButtonLabel edwq9my1"
+                className="css-fkumu4-ButtonLabel edwq9my1"
               >
                 Router Link
               </span>

--- a/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
@@ -196,7 +196,7 @@ exports[`ConfirmDelete renders 1`] = `
                 <Component
                   aria-disabled={false}
                   aria-label="Cancel"
-                  className="css-1c2phb1-StyledButton edwq9my0"
+                  className="css-ca6sk5-StyledButton edwq9my0"
                   forwardRef={null}
                   onClick={[Function]}
                   role="button"
@@ -209,7 +209,7 @@ exports[`ConfirmDelete renders 1`] = `
                   <button
                     aria-disabled={false}
                     aria-label="Cancel"
-                    className="css-1c2phb1-StyledButton edwq9my0"
+                    className="css-ca6sk5-StyledButton edwq9my0"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -222,7 +222,7 @@ exports[`ConfirmDelete renders 1`] = `
                       align="center"
                     >
                       <span
-                        className="css-zmpclt-ButtonLabel edwq9my1"
+                        className="css-fkumu4-ButtonLabel edwq9my1"
                       >
                         Cancel
                       </span>
@@ -263,7 +263,7 @@ exports[`ConfirmDelete renders 1`] = `
                   aria-disabled={true}
                   aria-label="Confirm"
                   autoFocus={true}
-                  className="css-1e3hcbu-StyledButton edwq9my0"
+                  className="css-e2c5jg-StyledButton edwq9my0"
                   data-test-id="confirm-button"
                   forwardRef={null}
                   onClick={[Function]}
@@ -273,7 +273,7 @@ exports[`ConfirmDelete renders 1`] = `
                     aria-disabled={true}
                     aria-label="Confirm"
                     autoFocus={true}
-                    className="css-1e3hcbu-StyledButton edwq9my0"
+                    className="css-e2c5jg-StyledButton edwq9my0"
                     data-test-id="confirm-button"
                     onClick={[Function]}
                     role="button"
@@ -283,7 +283,7 @@ exports[`ConfirmDelete renders 1`] = `
                       priority="primary"
                     >
                       <span
-                        className="css-zmpclt-ButtonLabel edwq9my1"
+                        className="css-fkumu4-ButtonLabel edwq9my1"
                       >
                         Confirm
                       </span>

--- a/tests/js/spec/components/button.spec.jsx
+++ b/tests/js/spec/components/button.spec.jsx
@@ -7,11 +7,7 @@ describe('Button', function() {
   const routerContext = TestStubs.routerContext();
 
   it('renders', function() {
-    const component = mountWithTheme(
-      <Button priority="primary" size="large">
-        Button
-      </Button>
-    );
+    const component = mountWithTheme(<Button priority="primary">Button</Button>);
     expect(component).toMatchSnapshot();
   });
 

--- a/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
@@ -305,7 +305,7 @@ exports[`FormField + model renders with Form 1`] = `
                     <Component
                       aria-disabled={false}
                       aria-label="Save Changes"
-                      className="css-1e05jtd-StyledButton edwq9my0"
+                      className="css-1f41kyg-StyledButton edwq9my0"
                       data-test-id="form-submit"
                       forwardRef={null}
                       onClick={[Function]}
@@ -315,7 +315,7 @@ exports[`FormField + model renders with Form 1`] = `
                       <button
                         aria-disabled={false}
                         aria-label="Save Changes"
-                        className="css-1e05jtd-StyledButton edwq9my0"
+                        className="css-1f41kyg-StyledButton edwq9my0"
                         data-test-id="form-submit"
                         onClick={[Function]}
                         role="button"
@@ -326,7 +326,7 @@ exports[`FormField + model renders with Form 1`] = `
                           priority="primary"
                         >
                           <span
-                            className="css-zmpclt-ButtonLabel edwq9my1"
+                            className="css-fkumu4-ButtonLabel edwq9my1"
                           >
                             Save Changes
                           </span>

--- a/tests/js/spec/components/forms/__snapshots__/tableField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/tableField.spec.jsx.snap
@@ -284,7 +284,7 @@ exports[`TableField renders renders with form context 1`] = `
                                             <Component
                                               aria-disabled={false}
                                               aria-label="Add Thing"
-                                              className="css-12ogwys-StyledButton edwq9my0"
+                                              className="css-1he25ws-StyledButton edwq9my0"
                                               forwardRef={null}
                                               onClick={[Function]}
                                               role="button"
@@ -293,7 +293,7 @@ exports[`TableField renders renders with form context 1`] = `
                                               <button
                                                 aria-disabled={false}
                                                 aria-label="Add Thing"
-                                                className="css-12ogwys-StyledButton edwq9my0"
+                                                className="css-1he25ws-StyledButton edwq9my0"
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
@@ -303,7 +303,7 @@ exports[`TableField renders renders with form context 1`] = `
                                                   size="xsmall"
                                                 >
                                                   <span
-                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                    className="css-1acbab4-ButtonLabel edwq9my1"
                                                   >
                                                     <Icon
                                                       hasChildren={true}
@@ -474,7 +474,7 @@ exports[`TableField renders renders with form context 1`] = `
                     <Component
                       aria-disabled={false}
                       aria-label="Save Changes"
-                      className="css-1e05jtd-StyledButton edwq9my0"
+                      className="css-1f41kyg-StyledButton edwq9my0"
                       data-test-id="form-submit"
                       forwardRef={null}
                       onClick={[Function]}
@@ -484,7 +484,7 @@ exports[`TableField renders renders with form context 1`] = `
                       <button
                         aria-disabled={false}
                         aria-label="Save Changes"
-                        className="css-1e05jtd-StyledButton edwq9my0"
+                        className="css-1f41kyg-StyledButton edwq9my0"
                         data-test-id="form-submit"
                         onClick={[Function]}
                         role="button"
@@ -495,7 +495,7 @@ exports[`TableField renders renders with form context 1`] = `
                           priority="primary"
                         >
                           <span
-                            className="css-zmpclt-ButtonLabel edwq9my1"
+                            className="css-fkumu4-ButtonLabel edwq9my1"
                           >
                             Save Changes
                           </span>
@@ -705,7 +705,7 @@ exports[`TableField renders renders without form context 1`] = `
                                       <Component
                                         aria-disabled={false}
                                         aria-label="Add Item"
-                                        className="css-12ogwys-StyledButton edwq9my0"
+                                        className="css-1he25ws-StyledButton edwq9my0"
                                         forwardRef={null}
                                         onClick={[Function]}
                                         role="button"
@@ -714,7 +714,7 @@ exports[`TableField renders renders without form context 1`] = `
                                         <button
                                           aria-disabled={false}
                                           aria-label="Add Item"
-                                          className="css-12ogwys-StyledButton edwq9my0"
+                                          className="css-1he25ws-StyledButton edwq9my0"
                                           onClick={[Function]}
                                           role="button"
                                           size="xsmall"
@@ -724,7 +724,7 @@ exports[`TableField renders renders without form context 1`] = `
                                             size="xsmall"
                                           >
                                             <span
-                                              className="css-cmi7y3-ButtonLabel edwq9my1"
+                                              className="css-1acbab4-ButtonLabel edwq9my1"
                                             >
                                               <Icon
                                                 hasChildren={true}

--- a/tests/js/spec/components/group/__snapshots__/externalIssueForm.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueForm.spec.jsx.snap
@@ -153,7 +153,7 @@ exports[`ExternalIssueForm create renders 1`] = `
                       <Component
                         aria-disabled={false}
                         aria-label="Create Issue"
-                        className="css-1e05jtd-StyledButton edwq9my0"
+                        className="css-1f41kyg-StyledButton edwq9my0"
                         data-test-id="form-submit"
                         forwardRef={null}
                         onClick={[Function]}
@@ -163,7 +163,7 @@ exports[`ExternalIssueForm create renders 1`] = `
                         <button
                           aria-disabled={false}
                           aria-label="Create Issue"
-                          className="css-1e05jtd-StyledButton edwq9my0"
+                          className="css-1f41kyg-StyledButton edwq9my0"
                           data-test-id="form-submit"
                           onClick={[Function]}
                           role="button"
@@ -174,7 +174,7 @@ exports[`ExternalIssueForm create renders 1`] = `
                             priority="primary"
                           >
                             <span
-                              className="css-zmpclt-ButtonLabel edwq9my1"
+                              className="css-fkumu4-ButtonLabel edwq9my1"
                             >
                               Create Issue
                             </span>
@@ -2875,7 +2875,7 @@ exports[`ExternalIssueForm link renders 1`] = `
                       <Component
                         aria-disabled={false}
                         aria-label="Link Issue"
-                        className="css-1e05jtd-StyledButton edwq9my0"
+                        className="css-1f41kyg-StyledButton edwq9my0"
                         data-test-id="form-submit"
                         forwardRef={null}
                         onClick={[Function]}
@@ -2885,7 +2885,7 @@ exports[`ExternalIssueForm link renders 1`] = `
                         <button
                           aria-disabled={false}
                           aria-label="Link Issue"
-                          className="css-1e05jtd-StyledButton edwq9my0"
+                          className="css-1f41kyg-StyledButton edwq9my0"
                           data-test-id="form-submit"
                           onClick={[Function]}
                           role="button"
@@ -2896,7 +2896,7 @@ exports[`ExternalIssueForm link renders 1`] = `
                             priority="primary"
                           >
                             <span
-                              className="css-zmpclt-ButtonLabel edwq9my1"
+                              className="css-fkumu4-ButtonLabel edwq9my1"
                             >
                               Link Issue
                             </span>

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1177,7 +1177,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                 <Component
                   aria-disabled={false}
                   aria-label="Learn more"
-                  className="css-12ogwys-StyledButton edwq9my0"
+                  className="css-1he25ws-StyledButton edwq9my0"
                   external={true}
                   forwardRef={null}
                   href="https://status.sentry.io"
@@ -1188,7 +1188,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                   <ForwardRef(ExternalLink)
                     aria-disabled={false}
                     aria-label="Learn more"
-                    className="css-12ogwys-StyledButton edwq9my0"
+                    className="css-1he25ws-StyledButton edwq9my0"
                     href="https://status.sentry.io"
                     onClick={[Function]}
                     role="button"
@@ -1197,7 +1197,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                     <a
                       aria-disabled={false}
                       aria-label="Learn more"
-                      className="css-12ogwys-StyledButton edwq9my0"
+                      className="css-1he25ws-StyledButton edwq9my0"
                       href="https://status.sentry.io"
                       onClick={[Function]}
                       rel="noreferrer noopener"
@@ -1367,7 +1367,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                   <button
                     aria-disabled="false"
                     aria-label="Skip task"
-                    class="e9zebce6 css-1x12sty-StyledButton-SkipButton edwq9my0"
+                    class="e9zebce6 css-19omt2n-StyledButton-SkipButton edwq9my0"
                     role="button"
                   >
                     <span
@@ -1388,11 +1388,11 @@ exports[`Sidebar can have onboarding feature 1`] = `
                       <a
                         aria-disabled="false"
                         aria-label="Community Forum"
-                        class="css-z8at1v-StyledButton edwq9my0"
+                        class="css-1mpdtii-StyledButton edwq9my0"
                         role="button"
                       >
                         <span
-                          class="css-cmi7y3-ButtonLabel edwq9my1"
+                          class="css-1acbab4-ButtonLabel edwq9my1"
                         >
                           Community Forum
                         </span>
@@ -1400,11 +1400,11 @@ exports[`Sidebar can have onboarding feature 1`] = `
                       <button
                         aria-disabled="false"
                         aria-label="Just skip"
-                        class="css-12ogwys-StyledButton edwq9my0"
+                        class="css-1he25ws-StyledButton edwq9my0"
                         role="button"
                       >
                         <span
-                          class="css-cmi7y3-ButtonLabel edwq9my1"
+                          class="css-1acbab4-ButtonLabel edwq9my1"
                         >
                           Just skip
                         </span>
@@ -3203,7 +3203,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                   <Component
                                                     aria-disabled={false}
                                                     aria-label="Skip task"
-                                                    className="e9zebce6 css-1x12sty-StyledButton-SkipButton edwq9my0"
+                                                    className="e9zebce6 css-19omt2n-StyledButton-SkipButton edwq9my0"
                                                     forwardRef={null}
                                                     onClick={[Function]}
                                                     role="button"
@@ -3211,7 +3211,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                     <button
                                                       aria-disabled={false}
                                                       aria-label="Skip task"
-                                                      className="e9zebce6 css-1x12sty-StyledButton-SkipButton edwq9my0"
+                                                      className="e9zebce6 css-19omt2n-StyledButton-SkipButton edwq9my0"
                                                       onClick={[Function]}
                                                       role="button"
                                                     >
@@ -3291,7 +3291,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                                 <Component
                                                                   aria-disabled={false}
                                                                   aria-label="Community Forum"
-                                                                  className="css-z8at1v-StyledButton edwq9my0"
+                                                                  className="css-1mpdtii-StyledButton edwq9my0"
                                                                   external={true}
                                                                   forwardRef={null}
                                                                   onClick={[Function]}
@@ -3302,7 +3302,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                                   <Link
                                                                     aria-disabled={false}
                                                                     aria-label="Community Forum"
-                                                                    className="css-z8at1v-StyledButton edwq9my0"
+                                                                    className="css-1mpdtii-StyledButton edwq9my0"
                                                                     onClick={[Function]}
                                                                     onlyActiveOnIndex={false}
                                                                     role="button"
@@ -3313,7 +3313,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                                     <a
                                                                       aria-disabled={false}
                                                                       aria-label="Community Forum"
-                                                                      className="css-z8at1v-StyledButton edwq9my0"
+                                                                      className="css-1mpdtii-StyledButton edwq9my0"
                                                                       onClick={[Function]}
                                                                       role="button"
                                                                       size="xsmall"
@@ -3325,7 +3325,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                                         size="xsmall"
                                                                       >
                                                                         <span
-                                                                          className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                                          className="css-1acbab4-ButtonLabel edwq9my1"
                                                                         >
                                                                           Community Forum
                                                                         </span>
@@ -3361,7 +3361,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                             <Component
                                                               aria-disabled={false}
                                                               aria-label="Just skip"
-                                                              className="css-12ogwys-StyledButton edwq9my0"
+                                                              className="css-1he25ws-StyledButton edwq9my0"
                                                               forwardRef={null}
                                                               onClick={[Function]}
                                                               role="button"
@@ -3370,7 +3370,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                               <button
                                                                 aria-disabled={false}
                                                                 aria-label="Just skip"
-                                                                className="css-12ogwys-StyledButton edwq9my0"
+                                                                className="css-1he25ws-StyledButton edwq9my0"
                                                                 onClick={[Function]}
                                                                 role="button"
                                                                 size="xsmall"
@@ -3380,7 +3380,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                                   size="xsmall"
                                                                 >
                                                                   <span
-                                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                                    className="css-1acbab4-ButtonLabel edwq9my1"
                                                                   >
                                                                     Just skip
                                                                   </span>

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -220,7 +220,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                           >
                                             <Component
                                               aria-disabled={false}
-                                              className="eenpoef1 css-ssbzqs-StyledButton-StyledButton edwq9my0"
+                                              className="eenpoef1 css-14kowsm-StyledButton-StyledButton edwq9my0"
                                               forwardRef={null}
                                               onClick={[Function]}
                                               role="button"
@@ -229,7 +229,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                             >
                                               <button
                                                 aria-disabled={false}
-                                                className="eenpoef1 css-ssbzqs-StyledButton-StyledButton edwq9my0"
+                                                className="eenpoef1 css-14kowsm-StyledButton-StyledButton edwq9my0"
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
@@ -240,7 +240,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                                   size="xsmall"
                                                 >
                                                   <span
-                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                    className="css-1acbab4-ButtonLabel edwq9my1"
                                                   >
                                                     Add Project
                                                     <StyledChevronDown>
@@ -613,7 +613,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                         >
                           <Component
                             aria-disabled={false}
-                            className="css-12ogwys-StyledButton edwq9my0"
+                            className="css-1he25ws-StyledButton edwq9my0"
                             forwardRef={null}
                             onClick={[Function]}
                             role="button"
@@ -621,7 +621,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           >
                             <button
                               aria-disabled={false}
-                              className="css-12ogwys-StyledButton edwq9my0"
+                              className="css-1he25ws-StyledButton edwq9my0"
                               onClick={[Function]}
                               role="button"
                               size="small"
@@ -973,7 +973,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                         >
                           <Component
                             aria-disabled={false}
-                            className="css-12ogwys-StyledButton edwq9my0"
+                            className="css-1he25ws-StyledButton edwq9my0"
                             forwardRef={null}
                             onClick={[Function]}
                             role="button"
@@ -981,7 +981,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           >
                             <button
                               aria-disabled={false}
-                              className="css-12ogwys-StyledButton edwq9my0"
+                              className="css-1he25ws-StyledButton edwq9my0"
                               onClick={[Function]}
                               role="button"
                               size="small"

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -972,7 +972,7 @@ exports[`Project Ownership Input renders 1`] = `
               >
                 <Component
                   aria-disabled={true}
-                  className="e1hyuoc710 css-1vf07fg-StyledButton-AddButton edwq9my0"
+                  className="e1hyuoc710 css-14jegea-StyledButton-AddButton edwq9my0"
                   forwardRef={null}
                   onClick={[Function]}
                   role="button"
@@ -980,7 +980,7 @@ exports[`Project Ownership Input renders 1`] = `
                 >
                   <button
                     aria-disabled={true}
-                    className="e1hyuoc710 css-1vf07fg-StyledButton-AddButton edwq9my0"
+                    className="e1hyuoc710 css-14jegea-StyledButton-AddButton edwq9my0"
                     onClick={[Function]}
                     role="button"
                     size="small"
@@ -1124,7 +1124,7 @@ url:http://example.com/settings/* #product"
                   <Component
                     aria-disabled={false}
                     aria-label="Save Changes"
-                    className="css-z8at1v-StyledButton edwq9my0"
+                    className="css-1mpdtii-StyledButton edwq9my0"
                     forwardRef={null}
                     onClick={[Function]}
                     role="button"
@@ -1133,7 +1133,7 @@ url:http://example.com/settings/* #product"
                     <button
                       aria-disabled={false}
                       aria-label="Save Changes"
-                      className="css-z8at1v-StyledButton edwq9my0"
+                      className="css-1mpdtii-StyledButton edwq9my0"
                       onClick={[Function]}
                       role="button"
                       size="small"

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -485,7 +485,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                                         <Component
                                           aria-disabled={false}
                                           aria-label="Enable Plugin"
-                                          className="css-12ogwys-StyledButton edwq9my0"
+                                          className="css-1he25ws-StyledButton edwq9my0"
                                           forwardRef={null}
                                           onClick={[Function]}
                                           role="button"
@@ -499,7 +499,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                                           <button
                                             aria-disabled={false}
                                             aria-label="Enable Plugin"
-                                            className="css-12ogwys-StyledButton edwq9my0"
+                                            className="css-1he25ws-StyledButton edwq9my0"
                                             onClick={[Function]}
                                             role="button"
                                             size="small"
@@ -547,7 +547,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                                         <Component
                                           aria-disabled={false}
                                           aria-label="Reset Configuration"
-                                          className="css-12ogwys-StyledButton edwq9my0"
+                                          className="css-1he25ws-StyledButton edwq9my0"
                                           forwardRef={null}
                                           onClick={[Function]}
                                           role="button"
@@ -556,7 +556,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                                           <button
                                             aria-disabled={false}
                                             aria-label="Reset Configuration"
-                                            className="css-12ogwys-StyledButton edwq9my0"
+                                            className="css-1he25ws-StyledButton edwq9my0"
                                             onClick={[Function]}
                                             role="button"
                                             size="small"

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -404,7 +404,7 @@ exports[`ProjectTags renders 1`] = `
                                             >
                                               <Component
                                                 aria-disabled={false}
-                                                className="css-12ogwys-StyledButton edwq9my0"
+                                                className="css-1he25ws-StyledButton edwq9my0"
                                                 data-test-id="delete"
                                                 forwardRef={null}
                                                 onClick={[Function]}
@@ -413,7 +413,7 @@ exports[`ProjectTags renders 1`] = `
                                               >
                                                 <button
                                                   aria-disabled={false}
-                                                  className="css-12ogwys-StyledButton edwq9my0"
+                                                  className="css-1he25ws-StyledButton edwq9my0"
                                                   data-test-id="delete"
                                                   onClick={[Function]}
                                                   role="button"
@@ -424,7 +424,7 @@ exports[`ProjectTags renders 1`] = `
                                                     size="xsmall"
                                                   >
                                                     <span
-                                                      className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                      className="css-1acbab4-ButtonLabel edwq9my1"
                                                     >
                                                       <Icon
                                                         hasChildren={false}
@@ -614,7 +614,7 @@ exports[`ProjectTags renders 1`] = `
                                             >
                                               <Component
                                                 aria-disabled={false}
-                                                className="css-12ogwys-StyledButton edwq9my0"
+                                                className="css-1he25ws-StyledButton edwq9my0"
                                                 data-test-id="delete"
                                                 forwardRef={null}
                                                 onClick={[Function]}
@@ -623,7 +623,7 @@ exports[`ProjectTags renders 1`] = `
                                               >
                                                 <button
                                                   aria-disabled={false}
-                                                  className="css-12ogwys-StyledButton edwq9my0"
+                                                  className="css-1he25ws-StyledButton edwq9my0"
                                                   data-test-id="delete"
                                                   onClick={[Function]}
                                                   role="button"
@@ -634,7 +634,7 @@ exports[`ProjectTags renders 1`] = `
                                                     size="xsmall"
                                                   >
                                                     <span
-                                                      className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                      className="css-1acbab4-ButtonLabel edwq9my1"
                                                     >
                                                       <Icon
                                                         hasChildren={false}
@@ -824,7 +824,7 @@ exports[`ProjectTags renders 1`] = `
                                             >
                                               <Component
                                                 aria-disabled={false}
-                                                className="css-12ogwys-StyledButton edwq9my0"
+                                                className="css-1he25ws-StyledButton edwq9my0"
                                                 data-test-id="delete"
                                                 forwardRef={null}
                                                 onClick={[Function]}
@@ -833,7 +833,7 @@ exports[`ProjectTags renders 1`] = `
                                               >
                                                 <button
                                                   aria-disabled={false}
-                                                  className="css-12ogwys-StyledButton edwq9my0"
+                                                  className="css-1he25ws-StyledButton edwq9my0"
                                                   data-test-id="delete"
                                                   onClick={[Function]}
                                                   role="button"
@@ -844,7 +844,7 @@ exports[`ProjectTags renders 1`] = `
                                                     size="xsmall"
                                                   >
                                                     <span
-                                                      className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                      className="css-1acbab4-ButtonLabel edwq9my1"
                                                     >
                                                       <Icon
                                                         hasChildren={false}
@@ -1055,7 +1055,7 @@ exports[`ProjectTags renders 1`] = `
                                                       >
                                                         <Component
                                                           aria-disabled={true}
-                                                          className="css-1lloe1u-StyledButton edwq9my0"
+                                                          className="css-hbnwrz-StyledButton edwq9my0"
                                                           data-test-id="delete"
                                                           forwardRef={null}
                                                           onClick={[Function]}
@@ -1064,7 +1064,7 @@ exports[`ProjectTags renders 1`] = `
                                                         >
                                                           <button
                                                             aria-disabled={true}
-                                                            className="css-1lloe1u-StyledButton edwq9my0"
+                                                            className="css-hbnwrz-StyledButton edwq9my0"
                                                             data-test-id="delete"
                                                             onClick={[Function]}
                                                             role="button"
@@ -1075,7 +1075,7 @@ exports[`ProjectTags renders 1`] = `
                                                               size="xsmall"
                                                             >
                                                               <span
-                                                                className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                                className="css-1acbab4-ButtonLabel edwq9my1"
                                                               >
                                                                 <Icon
                                                                   hasChildren={false}
@@ -1290,7 +1290,7 @@ exports[`ProjectTags renders 1`] = `
                                                       >
                                                         <Component
                                                           aria-disabled={true}
-                                                          className="css-1lloe1u-StyledButton edwq9my0"
+                                                          className="css-hbnwrz-StyledButton edwq9my0"
                                                           data-test-id="delete"
                                                           forwardRef={null}
                                                           onClick={[Function]}
@@ -1299,7 +1299,7 @@ exports[`ProjectTags renders 1`] = `
                                                         >
                                                           <button
                                                             aria-disabled={true}
-                                                            className="css-1lloe1u-StyledButton edwq9my0"
+                                                            className="css-hbnwrz-StyledButton edwq9my0"
                                                             data-test-id="delete"
                                                             onClick={[Function]}
                                                             role="button"
@@ -1310,7 +1310,7 @@ exports[`ProjectTags renders 1`] = `
                                                               size="xsmall"
                                                             >
                                                               <span
-                                                                className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                                className="css-1acbab4-ButtonLabel edwq9my1"
                                                               >
                                                                 <Icon
                                                                   hasChildren={false}

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -1080,7 +1080,7 @@ exports[`RuleBuilder renders 1`] = `
             >
               <Component
                 aria-disabled={true}
-                className="e1hyuoc710 css-1vf07fg-StyledButton-AddButton edwq9my0"
+                className="e1hyuoc710 css-14jegea-StyledButton-AddButton edwq9my0"
                 forwardRef={null}
                 onClick={[Function]}
                 role="button"
@@ -1088,7 +1088,7 @@ exports[`RuleBuilder renders 1`] = `
               >
                 <button
                   aria-disabled={true}
-                  className="e1hyuoc710 css-1vf07fg-StyledButton-AddButton edwq9my0"
+                  className="e1hyuoc710 css-14jegea-StyledButton-AddButton edwq9my0"
                   onClick={[Function]}
                   role="button"
                   size="small"
@@ -3093,7 +3093,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
             >
               <Component
                 aria-disabled={false}
-                className="e1hyuoc710 css-cdfv3-StyledButton-AddButton edwq9my0"
+                className="e1hyuoc710 css-6209gq-StyledButton-AddButton edwq9my0"
                 forwardRef={null}
                 onClick={[Function]}
                 role="button"
@@ -3101,7 +3101,7 @@ exports[`RuleBuilder renders with suggestions 1`] = `
               >
                 <button
                   aria-disabled={false}
-                  className="e1hyuoc710 css-cdfv3-StyledButton-AddButton edwq9my0"
+                  className="e1hyuoc710 css-6209gq-StyledButton-AddButton edwq9my0"
                   onClick={[Function]}
                   role="button"
                   size="small"

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -645,7 +645,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                                   <Component
                                                     aria-disabled={false}
                                                     aria-label="Add Team"
-                                                    className="eenpoef1 css-ssbzqs-StyledButton-StyledButton edwq9my0"
+                                                    className="eenpoef1 css-14kowsm-StyledButton-StyledButton edwq9my0"
                                                     forwardRef={null}
                                                     onClick={[Function]}
                                                     role="button"
@@ -655,7 +655,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                                     <button
                                                       aria-disabled={false}
                                                       aria-label="Add Team"
-                                                      className="eenpoef1 css-ssbzqs-StyledButton-StyledButton edwq9my0"
+                                                      className="eenpoef1 css-14kowsm-StyledButton-StyledButton edwq9my0"
                                                       onClick={[Function]}
                                                       role="button"
                                                       size="xsmall"
@@ -666,7 +666,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                                         size="xsmall"
                                                       >
                                                         <span
-                                                          className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                          className="css-1acbab4-ButtonLabel edwq9my1"
                                                         >
                                                           Add Team
                                                           <StyledChevronDown>
@@ -784,7 +784,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
             <Component
               aria-disabled={false}
               aria-label="Add Member"
-              className="invite-member-submit css-1e05jtd-StyledButton edwq9my0"
+              className="invite-member-submit css-1f41kyg-StyledButton edwq9my0"
               forwardRef={null}
               onClick={[Function]}
               role="button"
@@ -792,7 +792,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
               <button
                 aria-disabled={false}
                 aria-label="Add Member"
-                className="invite-member-submit css-1e05jtd-StyledButton edwq9my0"
+                className="invite-member-submit css-1f41kyg-StyledButton edwq9my0"
                 onClick={[Function]}
                 role="button"
               >
@@ -801,7 +801,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                   priority="primary"
                 >
                   <span
-                    className="css-zmpclt-ButtonLabel edwq9my1"
+                    className="css-fkumu4-ButtonLabel edwq9my1"
                   >
                     Add Member
                   </span>

--- a/tests/js/spec/views/issueList/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/issueList/__snapshots__/actions.spec.jsx.snap
@@ -178,7 +178,7 @@ exports[`IssueListActions Bulk Total results < bulk limit bulk resolves 1`] = `
                 <Component
                   aria-disabled={false}
                   aria-label="Cancel"
-                  className="css-1c2phb1-StyledButton edwq9my0"
+                  className="css-ca6sk5-StyledButton edwq9my0"
                   forwardRef={null}
                   onClick={[Function]}
                   role="button"
@@ -191,7 +191,7 @@ exports[`IssueListActions Bulk Total results < bulk limit bulk resolves 1`] = `
                   <button
                     aria-disabled={false}
                     aria-label="Cancel"
-                    className="css-1c2phb1-StyledButton edwq9my0"
+                    className="css-ca6sk5-StyledButton edwq9my0"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -204,7 +204,7 @@ exports[`IssueListActions Bulk Total results < bulk limit bulk resolves 1`] = `
                       align="center"
                     >
                       <span
-                        className="css-zmpclt-ButtonLabel edwq9my1"
+                        className="css-fkumu4-ButtonLabel edwq9my1"
                       >
                         Cancel
                       </span>
@@ -245,7 +245,7 @@ exports[`IssueListActions Bulk Total results < bulk limit bulk resolves 1`] = `
                   aria-disabled={false}
                   aria-label="Bulk resolve issues"
                   autoFocus={true}
-                  className="css-1e05jtd-StyledButton edwq9my0"
+                  className="css-1f41kyg-StyledButton edwq9my0"
                   data-test-id="confirm-button"
                   forwardRef={null}
                   onClick={[Function]}
@@ -255,7 +255,7 @@ exports[`IssueListActions Bulk Total results < bulk limit bulk resolves 1`] = `
                     aria-disabled={false}
                     aria-label="Bulk resolve issues"
                     autoFocus={true}
-                    className="css-1e05jtd-StyledButton edwq9my0"
+                    className="css-1f41kyg-StyledButton edwq9my0"
                     data-test-id="confirm-button"
                     onClick={[Function]}
                     role="button"
@@ -265,7 +265,7 @@ exports[`IssueListActions Bulk Total results < bulk limit bulk resolves 1`] = `
                       priority="primary"
                     >
                       <span
-                        className="css-zmpclt-ButtonLabel edwq9my1"
+                        className="css-fkumu4-ButtonLabel edwq9my1"
                       >
                         Bulk resolve issues
                       </span>
@@ -492,7 +492,7 @@ exports[`IssueListActions Bulk Total results > bulk limit bulk resolves 1`] = `
                 <Component
                   aria-disabled={false}
                   aria-label="Cancel"
-                  className="css-1c2phb1-StyledButton edwq9my0"
+                  className="css-ca6sk5-StyledButton edwq9my0"
                   forwardRef={null}
                   onClick={[Function]}
                   role="button"
@@ -505,7 +505,7 @@ exports[`IssueListActions Bulk Total results > bulk limit bulk resolves 1`] = `
                   <button
                     aria-disabled={false}
                     aria-label="Cancel"
-                    className="css-1c2phb1-StyledButton edwq9my0"
+                    className="css-ca6sk5-StyledButton edwq9my0"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -518,7 +518,7 @@ exports[`IssueListActions Bulk Total results > bulk limit bulk resolves 1`] = `
                       align="center"
                     >
                       <span
-                        className="css-zmpclt-ButtonLabel edwq9my1"
+                        className="css-fkumu4-ButtonLabel edwq9my1"
                       >
                         Cancel
                       </span>
@@ -559,7 +559,7 @@ exports[`IssueListActions Bulk Total results > bulk limit bulk resolves 1`] = `
                   aria-disabled={false}
                   aria-label="Bulk resolve issues"
                   autoFocus={true}
-                  className="css-1e05jtd-StyledButton edwq9my0"
+                  className="css-1f41kyg-StyledButton edwq9my0"
                   data-test-id="confirm-button"
                   forwardRef={null}
                   onClick={[Function]}
@@ -569,7 +569,7 @@ exports[`IssueListActions Bulk Total results > bulk limit bulk resolves 1`] = `
                     aria-disabled={false}
                     aria-label="Bulk resolve issues"
                     autoFocus={true}
-                    className="css-1e05jtd-StyledButton edwq9my0"
+                    className="css-1f41kyg-StyledButton edwq9my0"
                     data-test-id="confirm-button"
                     onClick={[Function]}
                     role="button"
@@ -579,7 +579,7 @@ exports[`IssueListActions Bulk Total results > bulk limit bulk resolves 1`] = `
                       priority="primary"
                     >
                       <span
-                        className="css-zmpclt-ButtonLabel edwq9my1"
+                        className="css-fkumu4-ButtonLabel edwq9my1"
                       >
                         Bulk resolve issues
                       </span>

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupMergedView.spec.jsx.snap
@@ -407,7 +407,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                 <Component
                                   aria-disabled={true}
                                   aria-label="Compare"
-                                  className="e1seayw30 css-8unam4-StyledButton-CompareButton edwq9my0"
+                                  className="e1seayw30 css-1j6kd2c-StyledButton-CompareButton edwq9my0"
                                   forwardRef={null}
                                   onClick={[Function]}
                                   role="button"
@@ -416,7 +416,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                   <button
                                     aria-disabled={true}
                                     aria-label="Compare"
-                                    className="e1seayw30 css-8unam4-StyledButton-CompareButton edwq9my0"
+                                    className="e1seayw30 css-1j6kd2c-StyledButton-CompareButton edwq9my0"
                                     onClick={[Function]}
                                     role="button"
                                     size="small"
@@ -468,7 +468,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                               <Component
                                 aria-disabled={false}
                                 aria-label="Collapse All"
-                                className="css-12ogwys-StyledButton edwq9my0"
+                                className="css-1he25ws-StyledButton edwq9my0"
                                 forwardRef={null}
                                 onClick={[Function]}
                                 role="button"
@@ -477,7 +477,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                 <button
                                   aria-disabled={false}
                                   aria-label="Collapse All"
-                                  className="css-12ogwys-StyledButton edwq9my0"
+                                  className="css-1he25ws-StyledButton edwq9my0"
                                   onClick={[Function]}
                                   role="button"
                                   size="small"

--- a/tests/js/spec/views/projectInstall/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/views/projectInstall/__snapshots__/createProject.spec.jsx.snap
@@ -1555,7 +1555,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                                   >
                                     <Component
                                       aria-disabled={false}
-                                      className="css-e1k74m-StyledButton edwq9my0"
+                                      className="css-186eces-StyledButton edwq9my0"
                                       data-test-id="create-team"
                                       forwardRef={null}
                                       onClick={[Function]}
@@ -1564,7 +1564,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                                     >
                                       <button
                                         aria-disabled={false}
-                                        className="css-e1k74m-StyledButton edwq9my0"
+                                        className="css-186eces-StyledButton edwq9my0"
                                         data-test-id="create-team"
                                         onClick={[Function]}
                                         role="button"
@@ -1575,7 +1575,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                                           borderless={true}
                                         >
                                           <span
-                                            className="css-cmi7y3-ButtonLabel edwq9my1"
+                                            className="css-fkumu4-ButtonLabel edwq9my1"
                                           >
                                             <Icon
                                               hasChildren={false}
@@ -1649,7 +1649,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                     <Component
                       aria-disabled={true}
                       aria-label="Create Project"
-                      className="css-1e3hcbu-StyledButton edwq9my0"
+                      className="css-e2c5jg-StyledButton edwq9my0"
                       data-test-id="create-project"
                       forwardRef={null}
                       onClick={[Function]}
@@ -1658,7 +1658,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                       <button
                         aria-disabled={true}
                         aria-label="Create Project"
-                        className="css-1e3hcbu-StyledButton edwq9my0"
+                        className="css-e2c5jg-StyledButton edwq9my0"
                         data-test-id="create-project"
                         onClick={[Function]}
                         role="button"
@@ -1668,7 +1668,7 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                           priority="primary"
                         >
                           <span
-                            className="css-zmpclt-ButtonLabel edwq9my1"
+                            className="css-fkumu4-ButtonLabel edwq9my1"
                           >
                             Create Project
                           </span>
@@ -2168,7 +2168,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                         >
                           <Component
                             aria-disabled={false}
-                            className="exv4dm85 css-4y1t77-StyledButton-ClearButton edwq9my0"
+                            className="exv4dm85 css-1ctvepc-StyledButton-ClearButton edwq9my0"
                             forwardRef={null}
                             onClick={[Function]}
                             role="button"
@@ -2176,7 +2176,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                           >
                             <button
                               aria-disabled={false}
-                              className="exv4dm85 css-4y1t77-StyledButton-ClearButton edwq9my0"
+                              className="exv4dm85 css-1ctvepc-StyledButton-ClearButton edwq9my0"
                               onClick={[Function]}
                               role="button"
                               size="xsmall"
@@ -2187,7 +2187,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                                 size="xsmall"
                               >
                                 <span
-                                  className="css-12az27u-ButtonLabel edwq9my1"
+                                  className="css-1acbab4-ButtonLabel edwq9my1"
                                 >
                                   <Icon
                                     hasChildren={false}
@@ -2559,7 +2559,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                                   >
                                     <Component
                                       aria-disabled={false}
-                                      className="css-e1k74m-StyledButton edwq9my0"
+                                      className="css-186eces-StyledButton edwq9my0"
                                       data-test-id="create-team"
                                       forwardRef={null}
                                       onClick={[Function]}
@@ -2568,7 +2568,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                                     >
                                       <button
                                         aria-disabled={false}
-                                        className="css-e1k74m-StyledButton edwq9my0"
+                                        className="css-186eces-StyledButton edwq9my0"
                                         data-test-id="create-team"
                                         onClick={[Function]}
                                         role="button"
@@ -2579,7 +2579,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                                           borderless={true}
                                         >
                                           <span
-                                            className="css-cmi7y3-ButtonLabel edwq9my1"
+                                            className="css-fkumu4-ButtonLabel edwq9my1"
                                           >
                                             <Icon
                                               hasChildren={false}
@@ -2653,7 +2653,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                     <Component
                       aria-disabled={true}
                       aria-label="Create Project"
-                      className="css-1e3hcbu-StyledButton edwq9my0"
+                      className="css-e2c5jg-StyledButton edwq9my0"
                       data-test-id="create-project"
                       forwardRef={null}
                       onClick={[Function]}
@@ -2662,7 +2662,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                       <button
                         aria-disabled={true}
                         aria-label="Create Project"
-                        className="css-1e3hcbu-StyledButton edwq9my0"
+                        className="css-e2c5jg-StyledButton edwq9my0"
                         data-test-id="create-project"
                         onClick={[Function]}
                         role="button"
@@ -2672,7 +2672,7 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                           priority="primary"
                         >
                           <span
-                            className="css-zmpclt-ButtonLabel edwq9my1"
+                            className="css-fkumu4-ButtonLabel edwq9my1"
                           >
                             Create Project
                           </span>
@@ -3072,7 +3072,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                         >
                           <Component
                             aria-disabled={false}
-                            className="exv4dm85 css-4y1t77-StyledButton-ClearButton edwq9my0"
+                            className="exv4dm85 css-1ctvepc-StyledButton-ClearButton edwq9my0"
                             forwardRef={null}
                             onClick={[Function]}
                             role="button"
@@ -3080,7 +3080,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                           >
                             <button
                               aria-disabled={false}
-                              className="exv4dm85 css-4y1t77-StyledButton-ClearButton edwq9my0"
+                              className="exv4dm85 css-1ctvepc-StyledButton-ClearButton edwq9my0"
                               onClick={[Function]}
                               role="button"
                               size="xsmall"
@@ -3091,7 +3091,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                                 size="xsmall"
                               >
                                 <span
-                                  className="css-12az27u-ButtonLabel edwq9my1"
+                                  className="css-1acbab4-ButtonLabel edwq9my1"
                                 >
                                   <Icon
                                     hasChildren={false}
@@ -4263,7 +4263,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                                   >
                                     <Component
                                       aria-disabled={false}
-                                      className="css-e1k74m-StyledButton edwq9my0"
+                                      className="css-186eces-StyledButton edwq9my0"
                                       data-test-id="create-team"
                                       forwardRef={null}
                                       onClick={[Function]}
@@ -4272,7 +4272,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                                     >
                                       <button
                                         aria-disabled={false}
-                                        className="css-e1k74m-StyledButton edwq9my0"
+                                        className="css-186eces-StyledButton edwq9my0"
                                         data-test-id="create-team"
                                         onClick={[Function]}
                                         role="button"
@@ -4283,7 +4283,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                                           borderless={true}
                                         >
                                           <span
-                                            className="css-cmi7y3-ButtonLabel edwq9my1"
+                                            className="css-fkumu4-ButtonLabel edwq9my1"
                                           >
                                             <Icon
                                               hasChildren={false}
@@ -4357,7 +4357,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                     <Component
                       aria-disabled={true}
                       aria-label="Create Project"
-                      className="css-1e3hcbu-StyledButton edwq9my0"
+                      className="css-e2c5jg-StyledButton edwq9my0"
                       data-test-id="create-project"
                       forwardRef={null}
                       onClick={[Function]}
@@ -4366,7 +4366,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                       <button
                         aria-disabled={true}
                         aria-label="Create Project"
-                        className="css-1e3hcbu-StyledButton edwq9my0"
+                        className="css-e2c5jg-StyledButton edwq9my0"
                         data-test-id="create-project"
                         onClick={[Function]}
                         role="button"
@@ -4376,7 +4376,7 @@ exports[`CreateProject should fill in project name if its empty when platform is
                           priority="primary"
                         >
                           <span
-                            className="css-zmpclt-ButtonLabel edwq9my1"
+                            className="css-fkumu4-ButtonLabel edwq9my1"
                           >
                             Create Project
                           </span>

--- a/tests/js/spec/views/projectsDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/projectsDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -1019,7 +1019,7 @@ exports[`ProjectCard renders 1`] = `
                             <Component
                               aria-disabled={false}
                               aria-label="Track deploys"
-                              className="css-12ogwys-StyledButton edwq9my0"
+                              className="css-1he25ws-StyledButton edwq9my0"
                               external={true}
                               forwardRef={null}
                               href="https://docs.sentry.io/learn/releases/"
@@ -1030,7 +1030,7 @@ exports[`ProjectCard renders 1`] = `
                               <ForwardRef(ExternalLink)
                                 aria-disabled={false}
                                 aria-label="Track deploys"
-                                className="css-12ogwys-StyledButton edwq9my0"
+                                className="css-1he25ws-StyledButton edwq9my0"
                                 href="https://docs.sentry.io/learn/releases/"
                                 onClick={[Function]}
                                 role="button"
@@ -1039,7 +1039,7 @@ exports[`ProjectCard renders 1`] = `
                                 <a
                                   aria-disabled={false}
                                   aria-label="Track deploys"
-                                  className="css-12ogwys-StyledButton edwq9my0"
+                                  className="css-1he25ws-StyledButton edwq9my0"
                                   href="https://docs.sentry.io/learn/releases/"
                                   onClick={[Function]}
                                   rel="noreferrer noopener"
@@ -1052,7 +1052,7 @@ exports[`ProjectCard renders 1`] = `
                                     size="xsmall"
                                   >
                                     <span
-                                      className="css-cmi7y3-ButtonLabel edwq9my1"
+                                      className="css-1acbab4-ButtonLabel edwq9my1"
                                     >
                                       Track deploys
                                     </span>

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -142,7 +142,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                         <Component
                           aria-disabled={false}
                           aria-label="New API Key"
-                          className="css-z8at1v-StyledButton edwq9my0"
+                          className="css-1mpdtii-StyledButton edwq9my0"
                           forwardRef={null}
                           onClick={[Function]}
                           role="button"
@@ -151,7 +151,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                           <button
                             aria-disabled={false}
                             aria-label="New API Key"
-                            className="css-z8at1v-StyledButton edwq9my0"
+                            className="css-1mpdtii-StyledButton edwq9my0"
                             onClick={[Function]}
                             role="button"
                             size="small"

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -168,7 +168,7 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                               <Component
                                 aria-disabled={false}
                                 aria-label="Create Project"
-                                className="css-z8at1v-StyledButton edwq9my0"
+                                className="css-1mpdtii-StyledButton edwq9my0"
                                 forwardRef={null}
                                 onClick={[Function]}
                                 role="button"
@@ -178,7 +178,7 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                                 <Link
                                   aria-disabled={false}
                                   aria-label="Create Project"
-                                  className="css-z8at1v-StyledButton edwq9my0"
+                                  className="css-1mpdtii-StyledButton edwq9my0"
                                   onClick={[Function]}
                                   onlyActiveOnIndex={false}
                                   role="button"
@@ -189,7 +189,7 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                                   <a
                                     aria-disabled={false}
                                     aria-label="Create Project"
-                                    className="css-z8at1v-StyledButton edwq9my0"
+                                    className="css-1mpdtii-StyledButton edwq9my0"
                                     onClick={[Function]}
                                     role="button"
                                     size="small"

--- a/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -1202,7 +1202,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                                       <Component
                                         aria-disabled={false}
                                         aria-label="Show"
-                                        className="e1pnz46f2 css-kzdej5-StyledButton-EnvironmentButton edwq9my0"
+                                        className="e1pnz46f2 css-1r7x408-StyledButton-EnvironmentButton edwq9my0"
                                         forwardRef={null}
                                         onClick={[Function]}
                                         role="button"
@@ -1211,7 +1211,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                                         <button
                                           aria-disabled={false}
                                           aria-label="Show"
-                                          className="e1pnz46f2 css-kzdej5-StyledButton-EnvironmentButton edwq9my0"
+                                          className="e1pnz46f2 css-1r7x408-StyledButton-EnvironmentButton edwq9my0"
                                           onClick={[Function]}
                                           role="button"
                                           size="xsmall"
@@ -1221,7 +1221,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                                             size="xsmall"
                                           >
                                             <span
-                                              className="css-cmi7y3-ButtonLabel edwq9my1"
+                                              className="css-1acbab4-ButtonLabel edwq9my1"
                                             >
                                               Show
                                             </span>

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -244,7 +244,7 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                           <Component
                             aria-disabled={false}
                             aria-label="New Public Integration"
-                            className="css-z8at1v-StyledButton edwq9my0"
+                            className="css-1mpdtii-StyledButton edwq9my0"
                             forwardRef={null}
                             onClick={[Function]}
                             role="button"
@@ -254,7 +254,7 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                             <Link
                               aria-disabled={false}
                               aria-label="New Public Integration"
-                              className="css-z8at1v-StyledButton edwq9my0"
+                              className="css-1mpdtii-StyledButton edwq9my0"
                               onClick={[Function]}
                               onlyActiveOnIndex={false}
                               role="button"
@@ -265,7 +265,7 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                               <a
                                 aria-disabled={false}
                                 aria-label="New Public Integration"
-                                className="css-z8at1v-StyledButton edwq9my0"
+                                className="css-1mpdtii-StyledButton edwq9my0"
                                 onClick={[Function]}
                                 role="button"
                                 size="small"
@@ -412,7 +412,7 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                           <Component
                             aria-disabled={false}
                             aria-label="New Internal Integration"
-                            className="css-z8at1v-StyledButton edwq9my0"
+                            className="css-1mpdtii-StyledButton edwq9my0"
                             forwardRef={null}
                             onClick={[Function]}
                             role="button"
@@ -422,7 +422,7 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                             <Link
                               aria-disabled={false}
                               aria-label="New Internal Integration"
-                              className="css-z8at1v-StyledButton edwq9my0"
+                              className="css-1mpdtii-StyledButton edwq9my0"
                               onClick={[Function]}
                               onlyActiveOnIndex={false}
                               role="button"
@@ -433,7 +433,7 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                               <a
                                 aria-disabled={false}
                                 aria-label="New Internal Integration"
-                                className="css-z8at1v-StyledButton edwq9my0"
+                                className="css-1mpdtii-StyledButton edwq9my0"
                                 onClick={[Function]}
                                 role="button"
                                 size="small"


### PR DESCRIPTION
**DS Proposal:**
For context, micro was only being used 3 times without a border (which made it the same as zero) and xxsmall was never used. Large is close enough to the default size that we'll be removing it. These were primarily used in empty states. 

![Screen Shot 2020-04-11 at 3 19 20 PM](https://user-images.githubusercontent.com/4830259/79056130-eb266a00-7c07-11ea-9704-8687beb03355.png)

**Before:**
![Screen Shot 2020-04-11 at 3 31 13 PM](https://user-images.githubusercontent.com/4830259/79056289-88ce6900-7c09-11ea-8310-037165e6edfb.png)
![Screen Shot 2020-04-11 at 3 20 35 PM](https://user-images.githubusercontent.com/4830259/79056139-0a24fc00-7c08-11ea-87cd-d2a257d86ba2.png)
![Screen Shot 2020-04-11 at 3 24 05 PM](https://user-images.githubusercontent.com/4830259/79056182-80c1f980-7c08-11ea-894f-302623677124.png)

**After:** 
![Screen Shot 2020-04-11 at 3 30 12 PM](https://user-images.githubusercontent.com/4830259/79056292-8e2bb380-7c09-11ea-8ffe-a07331e42d36.png)
![Screen Shot 2020-04-11 at 3 22 09 PM](https://user-images.githubusercontent.com/4830259/79056162-45bfc600-7c08-11ea-8176-2338fcb51d2a.png)
![Screen Shot 2020-04-11 at 3 18 58 PM](https://user-images.githubusercontent.com/4830259/79056164-4a847a00-7c08-11ea-90dc-f640870adff6.png)

**Related To:**
https://github.com/getsentry/getsentry/pull/3767