### PR TITLE
ci: dedupe python linting and consolidate scanning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ script:
   # certain commands require sentry init to be run, but this is only true for
   # running things within Travis
   - make travis-test-$TEST_SUITE
-  - make travis-scan-$TEST_SUITE
   # installing dependencies for after_* steps here ensures they get cached
   # since those steps execute after travis runs `store build cache`
 
@@ -165,11 +164,25 @@ matrix:
 
     # Proactive linting on 3.7 during the porting process
     - python: 3.7
-      name: 'Linter (Python 3.7)'
-      # XXX: this must be synced with requirements-dev.txt
-      install: pip install 'sentry-flake8==0.3.0'
+      name: 'Linter (Python) and dependency scanning'
+      install:
+        # XXX: this must be synced with requirements-dev.txt
+        - pip install 'sentry-flake8==0.3.0'
       # configuration for flake8 can be found in setup.cfg
-      script: flake8
+      script:
+        - flake8
+        # If linting was good, then we scan dependencies.
+        # Note that this isn't moved to an after_script since that would override what we already have.
+        # XXX: ideally we don't have to install sentry in its entirety just to scan dependencies...
+        # see the note in bin/scan on why this needs to be done for now.
+        - SENTRY_LIGHT_BUILD=1 SENTRY_PYTHON3=1 pip install -e .
+        - pip install safety
+        # XXX: fun fact, as of April 2020 travis preinstalls numpy 1.15.4 in their 3.7 environments
+        # and the safety scanner won't like that (safety id 36810)
+        # Previously we had 36810 ignored in bin/scan until it was removed because it was fixed in
+        # travis 2.7. So this is isolated to at least travis 3.7.
+        - pip uninstall -y numpy
+        - bin/scan
 
     - <<: *postgres_default
       name: 'Backend with migrations [Postgres] (1/2)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -173,6 +173,9 @@ matrix:
         - flake8
         # If linting was good, then we scan dependencies.
         # Note that this isn't moved to an after_script since that would override what we already have.
+        # XXX: force six to what sentry needs from what is installed by travis 3.7's virtualenv to avoid version conflict
+        # This is fixed with make setup-git in https://github.com/getsentry/sentry/pull/18176
+        - pip install "six>=1.10.0,<1.11.0"
         # XXX: ideally we don't have to install sentry in its entirety just to scan dependencies...
         # see the note in bin/scan on why this needs to be done for now.
         - SENTRY_LIGHT_BUILD=1 SENTRY_PYTHON3=1 pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,13 +152,13 @@ base_acceptance: &acceptance_default
 matrix:
   fast_finish: true
   include:
-    # Lint python and javascript together
-    - python: 2.7
-      name: 'Linter'
-      env: TEST_SUITE=lint
+    - language: generic
+      name: 'Linter (Javascript)'
+      env: TEST_SUITE=lint-js
       install:
-        - python setup.py install_egg_info
-        - SENTRY_LIGHT_BUILD=1 pip install -U -e ".[dev]"
+        # XXX: Under a "generic" language environment, travis pyenv is still present.
+        # .python-version will make it error because there is no pyenv python installed.
+        - rm .python-version
         - find "$NODE_DIR" -type d -empty -delete
         - nvm install
         - ./bin/yarn install --frozen-lockfile

--- a/Makefile
+++ b/Makefile
@@ -239,22 +239,3 @@ travis-test-js-build: test-js-build
 travis-test-cli: test-cli
 travis-test-plugins: test-plugins
 travis-test-relay-integration: test-relay-integration
-
-.PHONY: scan-python travis-scan-postgres travis-scan-acceptance travis-scan-snuba travis-scan-symbolicator
-.PHONY: travis-scan-js travis-scan-cli travis-scan-lint travis-scan-relay-integration
-scan-python:
-	@echo "--> Running Python vulnerability scanner"
-	$(PIP) install safety
-	bin/scan
-	@echo ""
-
-travis-scan-postgres: travis-noop
-travis-scan-acceptance: travis-noop
-travis-scan-snuba: travis-noop
-travis-scan-symbolicator: travis-noop
-travis-scan-js: travis-noop
-travis-scan-js-build: travis-noop
-travis-scan-cli: travis-noop
-travis-scan-lint: scan-python
-travis-scan-plugins: travis-noop
-travis-scan-relay-integration: travis-noop

--- a/Makefile
+++ b/Makefile
@@ -196,14 +196,6 @@ test-relay-integration:
 	pytest tests/relay_integration -vv
 	@echo ""
 
-lint: lint-python lint-js
-
-# configuration for flake8 can be found in setup.cfg
-lint-python:
-	@echo "--> Linting python"
-	bash -eo pipefail -c "flake8 | tee .artifacts/flake8.pycodestyle.log"
-	@echo ""
-
 review-python-snapshots:
 	@cargo insta --version &> /dev/null || cargo install cargo-insta
 	@cargo insta review --workspace-root `pwd` -e pysnap
@@ -222,7 +214,7 @@ lint-js:
 	@echo ""
 
 
-.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js
+.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint-js
 
 
 ############################
@@ -233,8 +225,8 @@ lint-js:
 travis-noop:
 	@echo "nothing to do here."
 
-.PHONY: travis-test-lint
-travis-test-lint: lint-python lint-js
+.PHONY: travis-test-lint-js
+travis-test-lint-js: lint-js
 
 .PHONY: travis-test-postgres travis-test-acceptance travis-test-snuba travis-test-symbolicator travis-test-js travis-test-js-build
 .PHONY: travis-test-cli travis-test-relay-integration

--- a/bin/scan
+++ b/bin/scan
@@ -32,4 +32,9 @@ for i in ${ignored[@]}; do
   args="$args --ignore=${i}"
 done
 
+# TODO(joshuarli): massage how getsentry bin/scan calls out to this so that this can work
+# without actually installing sentry in CI
+# HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# exec safety check -r "${HERE}/../requirements-base.txt" ${args}
+
 exec safety check ${args}


### PR DESCRIPTION
Changes are decoupled from https://github.com/getsentry/sentry/pull/18176 to reduce complexity.

This:

- dedupes python linting by removing it from the lint job which previously linted both js + py
  - saner, leaner configuration for the js linter
  - From what I've historically seen, sentry-flake8 on 3.7 catches a superset of lint errors compared to 2.7, so linting on 2.7 is basically useless.
- moves python scanning to be done lazily after python linting
  - this means safety is now installed under the 3.7 job and this future proofs us should they ever drop 2.7 support
  - verbose travis-scan stubs removed
  - unfortunate caveat with numpy; see diff