### PR TITLE
feat(async-csv): Ensure valid project permissions for data exports 

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -48,6 +48,7 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
         data = serializer.validated_data
 
         # Validate the project field, if provided
+        # A PermissionDenied error will be raised in `_get_projects_by_id` if the request is invalid
         project_query = data["query_info"].get("project")
         if project_query:
             # Coerce the query into a set

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -4,13 +4,13 @@ import six
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
 from rest_framework.response import Response
-
 from sentry import features
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationDataExportPermission
 from sentry.api.serializers import serialize
 from sentry.models import Environment
 from sentry.utils import metrics
+from sentry.utils.compat import map
 
 from ..base import ExportQueryType
 from ..models import ExportedData
@@ -34,24 +34,37 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
         if not features.has("organizations:data-export", organization):
             return Response(status=404)
 
-        limit = request.data.get("limit")
-        serializer = DataExportQuerySerializer(
-            data=request.data, context={"organization": organization, "user": request.user}
-        )
+        # Get environment_id and limit if available
         try:
             environment_id = self._get_environment_id_from_request(request, organization.id)
         except Environment.DoesNotExist as error:
             return Response(error, status=400)
+        limit = request.data.get("limit")
 
+        # Validate the data export payload
+        serializer = DataExportQuerySerializer(data=request.data)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
-
         data = serializer.validated_data
+
+        # Validate the project field, if provided
+        project_query = data["query_info"].get("project")
+        if project_query:
+            # Coerce the query into a set
+            if isinstance(project_query, list):
+                projects = self._get_projects_by_id(
+                    set(map(int, project_query)), request, organization
+                )
+            else:
+                projects = self._get_projects_by_id({int(project_query)}, request, organization)
+            data["query_info"]["project"] = [project.id for project in projects]
+
         # Ensure discover features are enabled if necessary
         if data["query_type"] == ExportQueryType.DISCOVER_STR and not features.has(
             "organizations:discover-basic", organization, actor=request.user
         ):
             return Response({"detail": "You do not have access to discover features"}, status=403)
+
         try:
             # If this user has sent a sent a request with the same payload and organization,
             # we return them the latest one that is NOT complete (i.e. don't start another)

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -33,7 +33,9 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
                 project_ids = map(int, data_export.query_info.get("project", []))
                 projects = Project.objects.filter(organization=organization, id__in=project_ids)
                 if any(p for p in projects if not request.access.has_project_access(p)):
-                    raise PermissionDenied
+                    raise PermissionDenied(
+                        detail="You don't have access to some of the data this export contains."
+                    )
             # Ignore the download parameter unless we have a file to stream
             if request.GET.get("download") is not None and data_export.file is not None:
                 return self.download(data_export)

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -28,6 +28,7 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
 
         try:
             data_export = ExportedData.objects.get(id=kwargs["data_export_id"])
+            raise PermissionDenied
             # Check data export permissions
             if data_export.query_info.get("project"):
                 project_ids = map(int, data_export.query_info.get("project", []))

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -28,7 +28,6 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
 
         try:
             data_export = ExportedData.objects.get(id=kwargs["data_export_id"])
-            raise PermissionDenied
             # Check data export permissions
             if data_export.query_info.get("project"):
                 project_ids = map(int, data_export.query_info.get("project", []))

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import
 
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from django.http import StreamingHttpResponse
 
 from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationDataExportPermission
 from sentry.api.serializers import serialize
+from sentry.models import Project
 from sentry.utils import metrics
+from sentry.utils.compat import map
 
 from ..models import ExportedData
 
@@ -25,6 +28,12 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
 
         try:
             data_export = ExportedData.objects.get(id=kwargs["data_export_id"])
+            # Check data export permissions
+            if data_export.query_info.get("project"):
+                project_ids = map(int, data_export.query_info.get("project", []))
+                projects = Project.objects.filter(organization=organization, id__in=project_ids)
+                if any(p for p in projects if not request.access.has_project_access(p)):
+                    raise PermissionDenied
             # Ignore the download parameter unless we have a file to stream
             if request.GET.get("download") is not None and data_export.file is not None:
                 return self.download(data_export)

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -88,8 +88,8 @@ def process_issues_by_tag(data_export, file, limit, environment_id):
     payload = data_export.query_info
     try:
         processor = IssuesByTagProcessor(
-            project_id=payload["project_id"],
-            group_id=payload["group_id"],
+            project_id=payload["project"],
+            group_id=payload["group"],
             key=payload["key"],
             environment_id=environment_id,
         )

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -88,7 +88,7 @@ def process_issues_by_tag(data_export, file, limit, environment_id):
     payload = data_export.query_info
     try:
         processor = IssuesByTagProcessor(
-            project_id=payload["project"],
+            project_id=payload["project"][0],
             group_id=payload["group"],
             key=payload["key"],
             environment_id=environment_id,

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -163,17 +163,19 @@ class DataDownload extends AsyncView<Props, State> {
     );
   }
   renderError(): React.ReactNode {
-    const {errors} = this.state;
+    const {
+      errors: {download: err},
+    } = this.state;
     return (
       <Layout>
         <main>
           <Header>
             <h3>
-              {errors.download.status} - {errors.download.statusText}
+              {err.status} - {err.statusText}
             </h3>
           </Header>
           <Body>
-            <p>{errors.download.responseJSON.detail}</p>
+            <p>{err.responseJSON.detail}</p>
           </Body>
         </main>
       </Layout>

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -42,6 +42,15 @@ type Props = {} & RouteComponentProps<RouteParams, {}>;
 
 type State = {
   download: Download;
+  errors: {
+    download: {
+      status: number;
+      statusText: string;
+      responseJSON: {
+        detail: string;
+      };
+    };
+  };
 } & AsyncView['state'];
 
 class DataDownload extends AsyncView<Props, State> {
@@ -125,7 +134,6 @@ class DataDownload extends AsyncView<Props, State> {
       </React.Fragment>
     );
   }
-
   renderValid(): React.ReactNode {
     const {
       download: {dateExpired},
@@ -152,6 +160,23 @@ class DataDownload extends AsyncView<Props, State> {
           </p>
         </Body>
       </React.Fragment>
+    );
+  }
+  renderError(): React.ReactNode {
+    const {errors} = this.state;
+    return (
+      <Layout>
+        <main>
+          <Header>
+            <h3>
+              {errors.download.status} - {errors.download.statusText}
+            </h3>
+          </Header>
+          <Body>
+            <p>{errors.download.responseJSON.detail}</p>
+          </Body>
+        </main>
+      </Layout>
     );
   }
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -120,8 +120,8 @@ class GroupTagValues extends AsyncComponent<
             payload={{
               queryType: ExportQueryType.IssuesByTag,
               queryInfo: {
-                project_id: group.project.id,
-                group_id: group.id,
+                project: group.project.id,
+                group: group.id,
                 key: tagKey,
               },
             }}

--- a/tests/js/spec/views/dataExport/dataDownload.spec.jsx
+++ b/tests/js/spec/views/dataExport/dataDownload.spec.jsx
@@ -12,16 +12,33 @@ describe('DataDownload', function() {
     orgId: organization.slug,
     dataExportId: 721,
   };
-  const getDataExportDetails = body =>
+  const getDataExportDetails = (body, statusCode = 200) =>
     MockApiClient.addMockResponse({
       url: `/organizations/${mockRouteParams.orgId}/data-export/${mockRouteParams.dataExportId}/`,
       body,
+      statusCode,
     });
 
   it('should send a request to the data export endpoint', function() {
     const getValid = getDataExportDetails(DownloadStatus.Valid);
     mountWithTheme(<DataDownload params={mockRouteParams} />);
     expect(getValid).toHaveBeenCalled();
+  });
+
+  it("should render the 'Error' view when appropriate", function() {
+    const errors = {
+      download: {
+        status: 403,
+        statusText: 'Forbidden',
+        responseJSON: {
+          detail: 'You are not allowed',
+        },
+      },
+    };
+    getDataExportDetails({errors}, 403);
+    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
+    expect(wrapper.state('errors')).toBeDefined();
+    expect(wrapper.state('errors').download.status).toBe(403);
   });
 
   it("should render the 'Early' view when appropriate", function() {

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -17,6 +17,21 @@ class DataExportTest(APITestCase):
         self.organization = self.create_organization(owner=self.user)
         self.login_as(user=self.user)
 
+    def test_authorization(self):
+        # Without the data-export feature, the endpoint should 404
+        self.get_valid_response(self.organization.slug, status_code=404, **self.payload)
+        # Without project permissions, the endpoint should 403
+        modified_payload = {"query_type": self.payload["query_type"], "query_info": {"project": -5}}
+        with self.feature("organizations:data-export"):
+            self.get_valid_response(self.organization.slug, status_code=403, **modified_payload)
+        # Without the discover-basic feature, the endpoint should 403
+        discover_payload = {"query_type": "Discover", "query_info": self.payload["query_info"]}
+        with self.feature("organizations:data-export"):
+            self.get_valid_response(self.organization.slug, status_code=403, **discover_payload)
+        # With both, the endpoint should 201
+        with self.feature(["organizations:data-export", "organizations:discover-basic"]):
+            self.get_valid_response(self.organization.slug, status_code=201, **discover_payload)
+
     def test_new_export(self):
         """
         Ensures that a request to this endpoint returns a 201 status code

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -31,7 +31,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             user=self.user,
             organization=self.org,
             query_type=0,
-            query_info={"project": self.project.id, "group": self.event.group_id, "key": "foo"},
+            query_info={"project": [self.project.id], "group": self.event.group_id, "key": "foo"},
         )
         with self.tasks():
             assemble_download(de.id)
@@ -55,7 +55,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             user=self.user,
             organization=self.org,
             query_type=0,
-            query_info={"project": -1, "group": self.event.group_id, "key": "user"},
+            query_info={"project": [-1], "group": self.event.group_id, "key": "user"},
         )
         with self.tasks():
             assemble_download(de1.id)
@@ -65,7 +65,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             user=self.user,
             organization=self.org,
             query_type=0,
-            query_info={"project": self.project.id, "group": -1, "key": "user"},
+            query_info={"project": [self.project.id], "group": -1, "key": "user"},
         )
         with self.tasks():
             assemble_download(de2.id)

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -31,11 +31,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             user=self.user,
             organization=self.org,
             query_type=0,
-            query_info={
-                "project_id": self.project.id,
-                "group_id": self.event.group_id,
-                "key": "foo",
-            },
+            query_info={"project": self.project.id, "group": self.event.group_id, "key": "foo"},
         )
         with self.tasks():
             assemble_download(de.id)
@@ -59,7 +55,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             user=self.user,
             organization=self.org,
             query_type=0,
-            query_info={"project_id": -1, "group_id": self.event.group_id, "key": "user"},
+            query_info={"project": -1, "group": self.event.group_id, "key": "user"},
         )
         with self.tasks():
             assemble_download(de1.id)
@@ -69,7 +65,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
             user=self.user,
             organization=self.org,
             query_type=0,
-            query_info={"project_id": self.project.id, "group_id": -1, "key": "user"},
+            query_info={"project": self.project.id, "group": -1, "key": "user"},
         )
         with self.tasks():
             assemble_download(de2.id)


### PR DESCRIPTION
This PR will make sure that the exports for projects the request user does not have access to result in a 403 at the endpoint. This will solve some of the concerns that were commented on for the discover implementation https://github.com/getsentry/sentry/pull/17603.

This should be merged before that PR
