### PR TITLE
fix(perf-views): Fixing max key transactions

### DIFF
--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -53,13 +53,14 @@ class KeyTransactionEndpoint(KeyTransactionBase):
 
         project = self.get_project(request, organization)
 
-        base_filter = {"organization": organization, "project": project, "owner": request.user}
+        base_filter = {"organization": organization, "owner": request.user}
 
         with transaction.atomic():
             serializer = KeyTransactionSerializer(data=request.data, context=base_filter)
             if serializer.is_valid():
                 data = serializer.validated_data
                 base_filter["transaction"] = data["transaction"]
+                base_filter["project"] = project
 
                 if KeyTransaction.objects.filter(**base_filter).count() > 0:
                     return Response(status=204)

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -140,12 +140,17 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
 
     def test_max_key_transaction(self):
         data = load_data("transaction")
+        other_project = self.create_project(organization=self.org)
         for i in range(MAX_KEY_TRANSACTIONS):
+            if i % 2 == 0:
+                project = self.project
+            else:
+                project = other_project
             KeyTransaction.objects.create(
                 owner=self.user,
                 organization=self.org,
                 transaction=data["transaction"] + six.text_type(i),
-                project=self.project,
+                project=project,
             )
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])


### PR DESCRIPTION
- This makes the max count per organization rather than per project
- GET is per org, so a user should still not be able to create a snuba query with >10 key transactions in it
- There doesn't currently exist any user >10 key transacitons/org so no need for a data fix