### PR TITLE
refs(mail): Remove unused methods in `MailPlugin`

### DIFF
--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -31,9 +31,6 @@ class MailPlugin(NotificationPlugin):
     def rule_notify(self, event, futures):
         return self.mail_adapter.rule_notify(event, futures)
 
-    def _send_mail(self, *args, **kwargs):
-        return self.mail_adapter._send_mail(*args, **kwargs)
-
     def get_project_url(self, project):
         return absolute_uri(u"/{}/{}/".format(project.organization.slug, project.slug))
 
@@ -43,15 +40,6 @@ class MailPlugin(NotificationPlugin):
 
     def should_notify(self, group, event):
         return self.mail_adapter.should_notify(group)
-
-    def get_send_to(self, project, event=None):
-        """
-        Returns a list of user IDs for the users that should receive
-        notifications for the provided project.
-
-        This result may come from cached data.
-        """
-        return self.mail_adapter.get_send_to(project, event)
 
     def notify(self, notification, **kwargs):
         return self.mail_adapter.notify(notification, **kwargs)

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -229,10 +229,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest, TestCase):
 
     @mock.patch("sentry.interfaces.stacktrace.Stacktrace.get_title")
     @mock.patch("sentry.interfaces.stacktrace.Stacktrace.to_email_html")
-    @mock.patch("sentry.plugins.sentry_mail.models.MailPlugin._send_mail")
-    def test_notify_users_renders_interfaces_with_utf8(
-        self, _send_mail, _to_email_html, _get_title
-    ):
+    def test_notify_users_renders_interfaces_with_utf8(self, _to_email_html, _get_title):
         _to_email_html.return_value = u"רונית מגן"
         _get_title.return_value = "Stacktrace"
 

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -69,10 +69,7 @@ class MailPluginTest(TestCase):
 
     @mock.patch("sentry.interfaces.stacktrace.Stacktrace.get_title")
     @mock.patch("sentry.interfaces.stacktrace.Stacktrace.to_email_html")
-    @mock.patch("sentry.plugins.sentry_mail.models.MailPlugin._send_mail")
-    def test_notify_users_renders_interfaces_with_utf8(
-        self, _send_mail, _to_email_html, _get_title
-    ):
+    def test_notify_users_renders_interfaces_with_utf8(self, _to_email_html, _get_title):
         _to_email_html.return_value = u"רונית מגן"
         _get_title.return_value = "Stacktrace"
 
@@ -596,43 +593,6 @@ class MailPluginOwnersTest(TestCase):
             self.plugin.notify(Notification(event=event))
         assert len(mail.outbox) == len(emails_sent_to)
         assert sorted(email.to[0] for email in mail.outbox) == sorted(emails_sent_to)
-
-    def test_get_send_to_with_team_owners(self):
-        event = self.store_event(data=self.make_event_data("foo.py"), project_id=self.project.id)
-        assert sorted(set([self.user.pk, self.user2.pk])) == sorted(
-            self.plugin.get_send_to(self.project, event.data)
-        )
-
-        # Make sure that disabling mail alerts works as expected
-        UserOption.objects.set_value(
-            user=self.user2, key="mail:alert", value=0, project=self.project
-        )
-        assert set([self.user.pk]) == self.plugin.get_send_to(self.project, event.data)
-
-    def test_get_send_to_with_user_owners(self):
-        event = self.store_event(data=self.make_event_data("foo.cbl"), project_id=self.project.id)
-        assert sorted(set([self.user.pk, self.user2.pk])) == sorted(
-            self.plugin.get_send_to(self.project, event.data)
-        )
-
-        # Make sure that disabling mail alerts works as expected
-        UserOption.objects.set_value(
-            user=self.user2, key="mail:alert", value=0, project=self.project
-        )
-        assert set([self.user.pk]) == self.plugin.get_send_to(self.project, event.data)
-
-    def test_get_send_to_with_user_owner(self):
-        event = self.store_event(data=self.make_event_data("foo.jx"), project_id=self.project.id)
-        assert set([self.user2.pk]) == self.plugin.get_send_to(self.project, event.data)
-
-    def test_get_send_to_with_fallthrough(self):
-        event = self.store_event(data=self.make_event_data("foo.jx"), project_id=self.project.id)
-        assert set([self.user2.pk]) == self.plugin.get_send_to(self.project, event.data)
-
-    def test_get_send_to_without_fallthrough(self):
-        ProjectOwnership.objects.get(project_id=self.project.id).update(fallthrough=False)
-        event = self.store_event(data=self.make_event_data("foo.cpp"), project_id=self.project.id)
-        assert [] == self.plugin.get_send_to(self.project, event.data)
 
     def test_notify_users_with_owners(self):
         event_all_users = self.store_event(


### PR DESCRIPTION
These have become unused as we've pushed logic into `MailAdapter`, so removing.