### PR TITLE
feat(workflow): Using discoverQuery instead of query

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -59,7 +59,7 @@ export default class DetailsBody extends React.Component<Props> {
         incident.aggregation === AlertRuleAggregations.UNIQUE_USERS
           ? '-count_unique_user_id'
           : '-count_id',
-      query: (incident && incident.discoverQuery) || '',
+      query: incident?.discoverQuery ?? '',
       projects: projects
         .filter(({slug}) => incident.projects.includes(slug))
         .map(({id}) => Number(id)),

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -59,7 +59,7 @@ export default class DetailsBody extends React.Component<Props> {
         incident.aggregation === AlertRuleAggregations.UNIQUE_USERS
           ? '-count_unique_user_id'
           : '-count_id',
-      query: (incident && incident.query) || '',
+      query: (incident && incident.discoverQuery) || '',
       projects: projects
         .filter(({slug}) => incident.projects.includes(slug))
         .map(({id}) => Number(id)),

--- a/src/sentry/static/sentry/app/views/alerts/types.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/types.tsx
@@ -16,6 +16,7 @@ export type Incident = {
   isSubscribed: boolean;
   groups: string[]; // Array of group ids
   query: string;
+  discoverQuery: string;
   organizationId: string;
   projects: string[]; // Array of slugs
   seenBy: User[];


### PR DESCRIPTION
There is a new field passed from the backend that includes the added event.type filter (as an alternative to doing this on the frontend). Just making a switch to that field.