### PR TITLE
ref(ui) Add a disabled state to MenuItem and convert to a styled component

### DIFF
--- a/docs-ui/components/dropdownControl.stories.js
+++ b/docs-ui/components/dropdownControl.stories.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 import {text, boolean} from '@storybook/addon-knobs';
 
-import DropdownControl from 'app/components/dropdownControl';
+import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import MenuItem from 'app/components/menuItem';
 
 storiesOf('UI|Dropdowns/DropdownControl', module)
@@ -22,12 +22,30 @@ storiesOf('UI|Dropdowns/DropdownControl', module)
             menuOffset={menuOffset}
             alwaysRenderMenu={alwaysRenderMenu}
           >
-            <MenuItem href="">Item</MenuItem>
-            <MenuItem href="">Item</MenuItem>
+            <DropdownItem href="">Item</DropdownItem>
+            <DropdownItem href="">Item</DropdownItem>
+            <DropdownItem disabled href="">
+              Disabled Item
+            </DropdownItem>
+            <DropdownItem divider />
+            <DropdownItem isActive href="">
+              Active Item
+            </DropdownItem>
           </DropdownControl>
         </div>
       );
     })
+  )
+  .add(
+    'basic menu item',
+    withInfo('Element labels replace the button contents')(() => (
+      <div className="clearfix">
+        <DropdownControl label={<em>Slanty</em>}>
+          <MenuItem href="">Item</MenuItem>
+          <MenuItem href="">Item</MenuItem>
+        </DropdownControl>
+      </div>
+    ))
   )
   .add(
     'element label',
@@ -45,9 +63,7 @@ storiesOf('UI|Dropdowns/DropdownControl', module)
     withInfo('button prop lets you replace the entire button.')(() => (
       <div className="clearfix">
         <DropdownControl
-          button={({isOpen, getActorProps}) => (
-            <button {...getActorProps()}>click me</button>
-          )}
+          button={({getActorProps}) => <button {...getActorProps()}>click me</button>}
         >
           <MenuItem href="">Item</MenuItem>
           <MenuItem href="">Item</MenuItem>

--- a/src/sentry/static/sentry/app/components/dropdownControl.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownControl.jsx
@@ -6,7 +6,6 @@ import DropdownBubble from 'app/components/dropdownBubble';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownMenu from 'app/components/dropdownMenu';
 import MenuItem from 'app/components/menuItem';
-import space from 'app/styles/space';
 
 /*
  * A higher level dropdown component that helps with building complete dropdowns
@@ -109,29 +108,6 @@ const MenuContainer = styled(DropdownBubble.withComponent('ul'))`
 const DropdownItem = styled(MenuItem)`
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => p.theme.gray2};
-
-  & a,
-  & .menu-target {
-    color: ${p => p.theme.foreground};
-    display: block;
-    padding: ${space(0.5)} ${space(2)};
-  }
-  & a:hover,
-  & .menu-target:hover {
-    background: ${p => p.theme.offWhite};
-  }
-  & a:focus,
-  & .menu-target:focus {
-    outline: none;
-  }
-
-  &.active a,
-  &.active a:hover,
-  &.active .menu-target,
-  &.active .menu-target:hover {
-    color: ${p => p.theme.white};
-    background: ${p => p.theme.purple};
-  }
 `;
 
 export default DropdownControl;

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -1,21 +1,47 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
 import omit from 'lodash/omit';
+import styled from '@emotion/styled';
 
 import Link from 'app/components/links/link';
+import {callIfFunction} from 'app/utils/callIfFunction';
+import space from 'app/styles/space';
+import {Theme} from 'app/utils/theme';
 
 type MenuItemProps = {
+  /**
+   * Should this item act as a header
+   */
   header?: boolean;
+  /**
+   * Should this item act as a divider
+   */
   divider?: boolean;
+  /**
+   * The title/tooltipe of the item
+   */
   title?: string;
+  /**
+   * Is the item disabled?
+   */
+  disabled?: boolean;
+  /**
+   * Triggered when the item is clicked
+   */
   onSelect?: (eventKey: any) => void;
+  /**
+   * Provided to the onSelect callback when this item is selected.
+   */
   eventKey?: any;
+  /**
+   * Is the item actively seleted?
+   */
   isActive?: boolean;
+  /**
+   * Enable to provide custom button/contents via children
+   */
   noAnchor?: boolean;
-  href?: string;
   className?: string;
-  onClick?: (evt: React.MouseEvent) => void;
 } & Partial<Pick<Link['props'], 'to'>>;
 
 type Props = MenuItemProps & Omit<React.HTMLProps<HTMLLIElement>, keyof MenuItemProps>;
@@ -25,62 +51,55 @@ class MenuItem extends React.Component<Props> {
     header: PropTypes.bool,
     divider: PropTypes.bool,
     title: PropTypes.string,
+    disabled: PropTypes.bool,
     onSelect: PropTypes.func,
     eventKey: PropTypes.any,
     isActive: PropTypes.bool,
     noAnchor: PropTypes.bool,
-    // basic link
-    href: PropTypes.string,
-    // router link
     to: PropTypes.string,
     query: PropTypes.object,
     className: PropTypes.string,
-    onClick: PropTypes.func,
   };
 
   handleClick = (e: React.MouseEvent): void => {
-    if (this.props.onSelect) {
+    const {onSelect, disabled, eventKey} = this.props;
+    if (disabled) {
+      return;
+    }
+    if (onSelect) {
       e.preventDefault();
-      this.props.onSelect(this.props.eventKey);
+      callIfFunction(onSelect, eventKey);
     }
   };
 
   renderAnchor = (): React.ReactNode => {
-    if (this.props.to) {
+    const {to, title, disabled, isActive, children} = this.props;
+    if (to) {
       return (
-        <Link
-          to={this.props.to}
-          title={this.props.title}
+        <MenuLink
+          to={to}
+          title={title}
           onClick={this.handleClick}
           tabIndex={-1}
+          isActive={isActive}
+          disabled={disabled}
         >
-          {this.props.children}
-        </Link>
-      );
-    }
-    if (this.props.href) {
-      return (
-        <a
-          title={this.props.title}
-          onClick={this.handleClick}
-          href={this.props.href}
-          tabIndex={-1}
-        >
-          {this.props.children}
-        </a>
+          {children}
+        </MenuLink>
       );
     }
 
     return (
-      <span
-        className="menu-target"
+      <MenuTarget
         role="button"
-        title={this.props.title}
+        title={title}
         onClick={this.handleClick}
         tabIndex={-1}
+        isActive={isActive}
+        disabled={disabled}
       >
         {this.props.children}
-      </span>
+      </MenuTarget>
     );
   };
 
@@ -91,16 +110,9 @@ class MenuItem extends React.Component<Props> {
       isActive,
       noAnchor,
       className,
-      onClick,
       children,
       ...props
     } = this.props;
-
-    const classes = {
-      'dropdown-header': header,
-      active: isActive,
-      divider,
-    };
 
     let renderChildren: React.ReactNode | null = null;
     if (noAnchor) {
@@ -112,16 +124,103 @@ class MenuItem extends React.Component<Props> {
     }
 
     return (
-      <li
+      <MenuListItem
+        className={className}
         role="presentation"
-        className={classNames(className, classes)}
-        onClick={onClick}
+        isActive={isActive}
+        divider={divider}
+        noAnchor={noAnchor}
+        header={header}
         {...omit(props, ['title', 'onSelect', 'eventKey', 'to'])}
       >
         {renderChildren}
-      </li>
+      </MenuListItem>
     );
   }
 }
+
+type MenuListItemProps = {
+  header?: boolean;
+  noAnchor?: boolean;
+  isActive?: boolean;
+  disabled?: boolean;
+  divider?: boolean;
+} & React.HTMLProps<HTMLLIElement>;
+
+function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
+  if (props.disabled) {
+    return `
+    color: ${props.theme.disabled};
+    background: transparent;
+    cursor: not-allowed;
+    `;
+  }
+  if (props.isActive) {
+    return `
+      color: ${props.theme.white};
+      background: ${props.theme.purple};
+    `;
+  }
+  return `
+    color: ${props.theme.foreground};
+
+    &:hover {
+      background: ${props.theme.offWhite};
+    }
+  `;
+}
+
+function getChildStyles(props: MenuListItemProps & {theme: Theme}) {
+  if (!props.noAnchor) {
+    return '';
+  }
+
+  return `
+    & a {
+      ${getListItemStyles(props)}
+    }
+  `;
+}
+
+const MenuListItem = styled('li')<MenuListItemProps>`
+  display: block;
+
+  ${p =>
+    p.divider &&
+    `
+height: 1px;
+margin: ${space(0.5)} 0;
+overflow: hidden;
+background-color: ${p.theme.borderLight};
+    `}
+  ${p =>
+    p.header &&
+    `
+    padding: ${space(0.25)} ${space(1)};
+    font-size: ${p.theme.fontSizeSmall};
+    line-height: 1.4;
+    color: ${p.theme.gray2};
+  `}
+
+  ${getChildStyles}
+`;
+
+const MenuTarget = styled('span')<MenuListItemProps>`
+  display: block;
+  padding: ${space(0.5)} ${space(2)};
+
+  ${getListItemStyles}
+`;
+
+const MenuLink = styled(Link)<MenuListItemProps>`
+  display: block;
+  padding: ${space(0.5)} ${space(2)};
+
+  ${getListItemStyles}
+
+  &:focus {
+    outline: none;
+  }
+`;
 
 export default MenuItem;

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -30,7 +30,7 @@ type MenuItemProps = {
    */
   onSelect?: (eventKey: any) => void;
   /**
-   * Provided to the onSelect callback when this item is selected.
+   * Provided to the onSelect callback when this item is selected
    */
   eventKey?: any;
   /**

--- a/src/sentry/static/sentry/less/dropdowns.less
+++ b/src/sentry/static/sentry/less/dropdowns.less
@@ -1,9 +1,7 @@
 .dropdown-menu {
   z-index: 1001;
-  .dropdown-header,
   .dropdown-toggle,
-  > li a,
-  > li span.menu-target {
+  > li a {
     display: block;
     padding: 3px 10px;
   }
@@ -40,6 +38,7 @@
   }
 
   &:hover > span {
+    background: @white-darker;
     > a:after {
       border-left-color: #fff;
     }

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1319,27 +1319,10 @@ header + .alert {
     }
   }
 
-  li a,
-  li span.menu-target {
-    .transition(none);
-    color: @gray-dark;
-    cursor: pointer;
-
-    &:hover,
-    &.hover {
-      background: #f7f8f9;
-      color: darken(@gray-dark, 10);
-    }
-  }
-
   li.active a,
   li.active a:hover {
     background: @purple;
     color: #fff !important;
-  }
-
-  .divider {
-    margin: 4px 0;
   }
 
   .disabled {

--- a/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
@@ -224,301 +224,311 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                 <MenuItem
                   header={true}
                 >
-                  <li
-                    className="dropdown-header"
+                  <MenuListItem
+                    header={true}
                     role="presentation"
                   >
-                    Resolved In
-                  </li>
+                    <li
+                      className="css-1bgc7al-MenuListItem e80rkhl0"
+                      role="presentation"
+                    >
+                      Resolved In
+                    </li>
+                  </MenuListItem>
                 </MenuItem>
                 <MenuItem
                   noAnchor={true}
                 >
-                  <li
-                    className=""
+                  <MenuListItem
+                    noAnchor={true}
                     role="presentation"
                   >
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
+                    <li
+                      className="css-1wwymep-MenuListItem e80rkhl0"
+                      role="presentation"
                     >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
                             >
-                              <span
+                              <Container
                                 aria-describedby="tooltip-123456"
-                                className="css-1513qml-Container eowlwvy0"
+                                containerDisplayMode="block"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  message="Are you sure???"
-                                  onAction={[Function]}
-                                  shouldConfirm={true}
-                                  title="The next release"
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1513qml-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
                                 >
-                                  <Confirm
-                                    cancelText="Cancel"
-                                    confirmText="Resolve"
-                                    disableConfirmButton={false}
-                                    message="Are you sure???"
-                                    onConfirm={[Function]}
-                                    priority="primary"
-                                    stopPropagation={false}
-                                  >
-                                    <a
-                                      aria-label="The next release"
-                                      onClick={[Function]}
-                                      title="The next release"
-                                    >
-                                       
-                                      The next release
-                                    </a>
-                                    <Modal
-                                      animation={false}
-                                      autoFocus={true}
-                                      backdrop={true}
-                                      bsClass="modal"
-                                      dialogComponentClass={[Function]}
-                                      enforceFocus={true}
-                                      keyboard={true}
-                                      manager={
-                                        ModalManager {
-                                          "add": [Function],
-                                          "containers": Array [],
-                                          "data": Array [],
-                                          "handleContainerOverflow": true,
-                                          "hideSiblingNodes": true,
-                                          "isTopModal": [Function],
-                                          "modals": Array [],
-                                          "remove": [Function],
-                                        }
-                                      }
-                                      onHide={[Function]}
-                                      renderBackdrop={[Function]}
-                                      restoreFocus={true}
-                                      show={false}
-                                    >
-                                      <Modal
-                                        autoFocus={true}
-                                        backdrop={true}
-                                        backdropClassName="modal-backdrop"
-                                        containerClassName="modal-open"
-                                        enforceFocus={true}
-                                        keyboard={true}
-                                        manager={
-                                          ModalManager {
-                                            "add": [Function],
-                                            "containers": Array [],
-                                            "data": Array [],
-                                            "handleContainerOverflow": true,
-                                            "hideSiblingNodes": true,
-                                            "isTopModal": [Function],
-                                            "modals": Array [],
-                                            "remove": [Function],
-                                          }
-                                        }
-                                        onEntering={[Function]}
-                                        onExited={[Function]}
-                                        onHide={[Function]}
-                                        renderBackdrop={[Function]}
-                                        restoreFocus={true}
-                                        show={false}
-                                      />
-                                    </Modal>
-                                  </Confirm>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
-                    >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                            >
-                              <span
-                                aria-describedby="tooltip-123456"
-                                className="css-1513qml-Container eowlwvy0"
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                onMouseEnter={[Function]}
-                                onMouseLeave={[Function]}
-                              >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  message="Are you sure???"
-                                  onAction={[Function]}
-                                  shouldConfirm={true}
-                                  title="The current release"
-                                >
-                                  <Confirm
-                                    cancelText="Cancel"
-                                    confirmText="Resolve"
-                                    disableConfirmButton={false}
-                                    message="Are you sure???"
-                                    onConfirm={[Function]}
-                                    priority="primary"
-                                    stopPropagation={false}
-                                  >
-                                    <a
-                                      aria-label="The current release"
-                                      onClick={[Function]}
-                                      title="The current release"
-                                    >
-                                       
-                                      The current release
-                                    </a>
-                                    <Modal
-                                      animation={false}
-                                      autoFocus={true}
-                                      backdrop={true}
-                                      bsClass="modal"
-                                      dialogComponentClass={[Function]}
-                                      enforceFocus={true}
-                                      keyboard={true}
-                                      manager={
-                                        ModalManager {
-                                          "add": [Function],
-                                          "containers": Array [],
-                                          "data": Array [],
-                                          "handleContainerOverflow": true,
-                                          "hideSiblingNodes": true,
-                                          "isTopModal": [Function],
-                                          "modals": Array [],
-                                          "remove": [Function],
-                                        }
-                                      }
-                                      onHide={[Function]}
-                                      renderBackdrop={[Function]}
-                                      restoreFocus={true}
-                                      show={false}
-                                    >
-                                      <Modal
-                                        autoFocus={true}
-                                        backdrop={true}
-                                        backdropClassName="modal-backdrop"
-                                        containerClassName="modal-open"
-                                        enforceFocus={true}
-                                        keyboard={true}
-                                        manager={
-                                          ModalManager {
-                                            "add": [Function],
-                                            "containers": Array [],
-                                            "data": Array [],
-                                            "handleContainerOverflow": true,
-                                            "hideSiblingNodes": true,
-                                            "isTopModal": [Function],
-                                            "modals": Array [],
-                                            "remove": [Function],
-                                          }
-                                        }
-                                        onEntering={[Function]}
-                                        onExited={[Function]}
-                                        onHide={[Function]}
-                                        renderBackdrop={[Function]}
-                                        restoreFocus={true}
-                                        show={false}
-                                      />
-                                    </Modal>
-                                  </Confirm>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
-                    >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                            >
-                              <span
-                                aria-describedby="tooltip-123456"
-                                className="css-1513qml-Container eowlwvy0"
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                onMouseEnter={[Function]}
-                                onMouseLeave={[Function]}
-                              >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  message="Are you sure???"
-                                  onAction={[Function]}
-                                  shouldConfirm={false}
-                                  title="Another version"
-                                >
-                                  <ActionLinkAnchor
-                                    aria-label="Another version"
-                                    className=""
-                                    data-test-id="action-link-another-version"
+                                  <ActionLink
+                                    confirmLabel="Resolve"
                                     disabled={false}
-                                    onClick={[Function]}
+                                    message="Are you sure???"
+                                    onAction={[Function]}
+                                    shouldConfirm={true}
+                                    title="The next release"
                                   >
-                                    <a
+                                    <Confirm
+                                      cancelText="Cancel"
+                                      confirmText="Resolve"
+                                      disableConfirmButton={false}
+                                      message="Are you sure???"
+                                      onConfirm={[Function]}
+                                      priority="primary"
+                                      stopPropagation={false}
+                                    >
+                                      <a
+                                        aria-label="The next release"
+                                        onClick={[Function]}
+                                        title="The next release"
+                                      >
+                                         
+                                        The next release
+                                      </a>
+                                      <Modal
+                                        animation={false}
+                                        autoFocus={true}
+                                        backdrop={true}
+                                        bsClass="modal"
+                                        dialogComponentClass={[Function]}
+                                        enforceFocus={true}
+                                        keyboard={true}
+                                        manager={
+                                          ModalManager {
+                                            "add": [Function],
+                                            "containers": Array [],
+                                            "data": Array [],
+                                            "handleContainerOverflow": true,
+                                            "hideSiblingNodes": true,
+                                            "isTopModal": [Function],
+                                            "modals": Array [],
+                                            "remove": [Function],
+                                          }
+                                        }
+                                        onHide={[Function]}
+                                        renderBackdrop={[Function]}
+                                        restoreFocus={true}
+                                        show={false}
+                                      >
+                                        <Modal
+                                          autoFocus={true}
+                                          backdrop={true}
+                                          backdropClassName="modal-backdrop"
+                                          containerClassName="modal-open"
+                                          enforceFocus={true}
+                                          keyboard={true}
+                                          manager={
+                                            ModalManager {
+                                              "add": [Function],
+                                              "containers": Array [],
+                                              "data": Array [],
+                                              "handleContainerOverflow": true,
+                                              "hideSiblingNodes": true,
+                                              "isTopModal": [Function],
+                                              "modals": Array [],
+                                              "remove": [Function],
+                                            }
+                                          }
+                                          onEntering={[Function]}
+                                          onExited={[Function]}
+                                          onHide={[Function]}
+                                          renderBackdrop={[Function]}
+                                          restoreFocus={true}
+                                          show={false}
+                                        />
+                                      </Modal>
+                                    </Confirm>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
+                            >
+                              <Container
+                                aria-describedby="tooltip-123456"
+                                containerDisplayMode="block"
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                              >
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1513qml-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  <ActionLink
+                                    confirmLabel="Resolve"
+                                    disabled={false}
+                                    message="Are you sure???"
+                                    onAction={[Function]}
+                                    shouldConfirm={true}
+                                    title="The current release"
+                                  >
+                                    <Confirm
+                                      cancelText="Cancel"
+                                      confirmText="Resolve"
+                                      disableConfirmButton={false}
+                                      message="Are you sure???"
+                                      onConfirm={[Function]}
+                                      priority="primary"
+                                      stopPropagation={false}
+                                    >
+                                      <a
+                                        aria-label="The current release"
+                                        onClick={[Function]}
+                                        title="The current release"
+                                      >
+                                         
+                                        The current release
+                                      </a>
+                                      <Modal
+                                        animation={false}
+                                        autoFocus={true}
+                                        backdrop={true}
+                                        bsClass="modal"
+                                        dialogComponentClass={[Function]}
+                                        enforceFocus={true}
+                                        keyboard={true}
+                                        manager={
+                                          ModalManager {
+                                            "add": [Function],
+                                            "containers": Array [],
+                                            "data": Array [],
+                                            "handleContainerOverflow": true,
+                                            "hideSiblingNodes": true,
+                                            "isTopModal": [Function],
+                                            "modals": Array [],
+                                            "remove": [Function],
+                                          }
+                                        }
+                                        onHide={[Function]}
+                                        renderBackdrop={[Function]}
+                                        restoreFocus={true}
+                                        show={false}
+                                      >
+                                        <Modal
+                                          autoFocus={true}
+                                          backdrop={true}
+                                          backdropClassName="modal-backdrop"
+                                          containerClassName="modal-open"
+                                          enforceFocus={true}
+                                          keyboard={true}
+                                          manager={
+                                            ModalManager {
+                                              "add": [Function],
+                                              "containers": Array [],
+                                              "data": Array [],
+                                              "handleContainerOverflow": true,
+                                              "hideSiblingNodes": true,
+                                              "isTopModal": [Function],
+                                              "modals": Array [],
+                                              "remove": [Function],
+                                            }
+                                          }
+                                          onEntering={[Function]}
+                                          onExited={[Function]}
+                                          onHide={[Function]}
+                                          renderBackdrop={[Function]}
+                                          restoreFocus={true}
+                                          show={false}
+                                        />
+                                      </Modal>
+                                    </Confirm>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
+                            >
+                              <Container
+                                aria-describedby="tooltip-123456"
+                                containerDisplayMode="block"
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                              >
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1513qml-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  <ActionLink
+                                    confirmLabel="Resolve"
+                                    disabled={false}
+                                    message="Are you sure???"
+                                    onAction={[Function]}
+                                    shouldConfirm={false}
+                                    title="Another version"
+                                  >
+                                    <ActionLinkAnchor
                                       aria-label="Another version"
-                                      className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                      className=""
                                       data-test-id="action-link-another-version"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      Another version…
-                                    </a>
-                                  </ActionLinkAnchor>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                  </li>
+                                      <a
+                                        aria-label="Another version"
+                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                        data-test-id="action-link-another-version"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                      >
+                                        Another version…
+                                      </a>
+                                    </ActionLinkAnchor>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                    </li>
+                  </MenuListItem>
                 </MenuItem>
               </ul>
             </span>
@@ -697,192 +707,202 @@ exports[`ResolveActions without confirmation renders 1`] = `
                 <MenuItem
                   header={true}
                 >
-                  <li
-                    className="dropdown-header"
+                  <MenuListItem
+                    header={true}
                     role="presentation"
                   >
-                    Resolved In
-                  </li>
+                    <li
+                      className="css-1bgc7al-MenuListItem e80rkhl0"
+                      role="presentation"
+                    >
+                      Resolved In
+                    </li>
+                  </MenuListItem>
                 </MenuItem>
                 <MenuItem
                   noAnchor={true}
                 >
-                  <li
-                    className=""
+                  <MenuListItem
+                    noAnchor={true}
                     role="presentation"
                   >
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
+                    <li
+                      className="css-1wwymep-MenuListItem e80rkhl0"
+                      role="presentation"
                     >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
                             >
-                              <span
+                              <Container
                                 aria-describedby="tooltip-123456"
-                                className="css-1513qml-Container eowlwvy0"
+                                containerDisplayMode="block"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  onAction={[Function]}
-                                  shouldConfirm={false}
-                                  title="The next release"
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1513qml-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
                                 >
-                                  <ActionLinkAnchor
-                                    aria-label="The next release"
-                                    className=""
-                                    data-test-id="action-link-the-next-release"
+                                  <ActionLink
+                                    confirmLabel="Resolve"
                                     disabled={false}
-                                    onClick={[Function]}
+                                    onAction={[Function]}
+                                    shouldConfirm={false}
+                                    title="The next release"
                                   >
-                                    <a
+                                    <ActionLinkAnchor
                                       aria-label="The next release"
-                                      className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                      className=""
                                       data-test-id="action-link-the-next-release"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      The next release
-                                    </a>
-                                  </ActionLinkAnchor>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
-                    >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
+                                      <a
+                                        aria-label="The next release"
+                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                        data-test-id="action-link-the-next-release"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                      >
+                                        The next release
+                                      </a>
+                                    </ActionLinkAnchor>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
                             >
-                              <span
+                              <Container
                                 aria-describedby="tooltip-123456"
-                                className="css-1513qml-Container eowlwvy0"
+                                containerDisplayMode="block"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  onAction={[Function]}
-                                  shouldConfirm={false}
-                                  title="The current release"
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1513qml-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
                                 >
-                                  <ActionLinkAnchor
-                                    aria-label="The current release"
-                                    className=""
-                                    data-test-id="action-link-the-current-release"
+                                  <ActionLink
+                                    confirmLabel="Resolve"
                                     disabled={false}
-                                    onClick={[Function]}
+                                    onAction={[Function]}
+                                    shouldConfirm={false}
+                                    title="The current release"
                                   >
-                                    <a
+                                    <ActionLinkAnchor
                                       aria-label="The current release"
-                                      className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                      className=""
                                       data-test-id="action-link-the-current-release"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      The current release
-                                    </a>
-                                  </ActionLinkAnchor>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
-                    >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
+                                      <a
+                                        aria-label="The current release"
+                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                        data-test-id="action-link-the-current-release"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                      >
+                                        The current release
+                                      </a>
+                                    </ActionLinkAnchor>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
                             >
-                              <span
+                              <Container
                                 aria-describedby="tooltip-123456"
-                                className="css-1513qml-Container eowlwvy0"
+                                containerDisplayMode="block"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  onAction={[Function]}
-                                  shouldConfirm={false}
-                                  title="Another version"
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1513qml-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
                                 >
-                                  <ActionLinkAnchor
-                                    aria-label="Another version"
-                                    className=""
-                                    data-test-id="action-link-another-version"
+                                  <ActionLink
+                                    confirmLabel="Resolve"
                                     disabled={false}
-                                    onClick={[Function]}
+                                    onAction={[Function]}
+                                    shouldConfirm={false}
+                                    title="Another version"
                                   >
-                                    <a
+                                    <ActionLinkAnchor
                                       aria-label="Another version"
-                                      className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                      className=""
                                       data-test-id="action-link-another-version"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      Another version…
-                                    </a>
-                                  </ActionLinkAnchor>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                  </li>
+                                      <a
+                                        aria-label="Another version"
+                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                        data-test-id="action-link-another-version"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                      >
+                                        Another version…
+                                      </a>
+                                    </ActionLinkAnchor>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                    </li>
+                  </MenuListItem>
                 </MenuItem>
               </ul>
             </span>


### PR DESCRIPTION
I have a dropdown in discover that will need disabled options to avoid mystery meat patterns. This adds a disabled state to the MenuItem component. Because I didn't want to add to our LESS styles I've refactored MenuItem to be a styled component as well. While I wasn't able to remove a good pile of LESS styles I got a few rules.

Percy won't be very useful for this change as we don't have many open menu snapshots. I've manually checked the dropdowns in:

* Issue list actions
* Issue details actions
* Releases v2
* Context menus on discover 2

Are there other dropdowns I should check?