### PR TITLE
ref(discover2): Update metrics

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
@@ -11,6 +11,7 @@ import {OrganizationSummary} from 'app/types';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import {Column} from 'app/utils/discover/fields';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 
 import ColumnEditCollection from './columnEditCollection';
 
@@ -30,6 +31,16 @@ class ColumnEditModal extends React.Component<Props, State> {
   state = {
     columns: this.props.columns,
   };
+
+  componentDidMount() {
+    const {organization} = this.props;
+
+    trackAnalyticsEvent({
+      eventKey: 'discover_v2.column_editor.open',
+      eventName: 'Discoverv2: Open column editor',
+      organization_id: parseInt(organization.id, 10),
+    });
+  }
 
   handleChange = (columns: Column[]) => {
     this.setState({columns});

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -63,16 +63,6 @@ class TableView extends React.Component<TableViewProps> {
     const newWidth = nextColumn.width ? Number(nextColumn.width) : COL_WIDTH_UNDEFINED;
     const nextEventView = eventView.withResizedColumn(columnIndex, newWidth);
 
-    if (nextEventView !== eventView) {
-      const changed: string[] = [];
-
-      const prevField = eventView.fields[columnIndex];
-      const nextField = nextEventView.fields[columnIndex];
-      if (prevField.width !== nextField.width) {
-        changed.push('width');
-      }
-    }
-
     pushEventViewToLocation({
       location,
       nextEventView,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -58,7 +58,7 @@ class TableView extends React.Component<TableViewProps> {
    * Updates a column on resizing
    */
   _resizeColumn = (columnIndex: number, nextColumn: TableColumn<keyof TableDataRow>) => {
-    const {location, eventView, organization} = this.props;
+    const {location, eventView} = this.props;
 
     const newWidth = nextColumn.width ? Number(nextColumn.width) : COL_WIDTH_UNDEFINED;
     const nextEventView = eventView.withResizedColumn(columnIndex, newWidth);
@@ -71,14 +71,6 @@ class TableView extends React.Component<TableViewProps> {
       if (prevField.width !== nextField.width) {
         changed.push('width');
       }
-
-      trackAnalyticsEvent({
-        eventKey: 'discover_v2.update_column',
-        eventName: 'Discoverv2: A column was updated',
-        updated_at_index: columnIndex,
-        changed,
-        organization_id: parseInt(organization.id, 10),
-      });
     }
 
     pushEventViewToLocation({
@@ -201,7 +193,6 @@ class TableView extends React.Component<TableViewProps> {
 
   handleEditColumns = () => {
     const {organization, eventView, tagKeys} = this.props;
-    this.trackEditAnalytics(organization, true);
 
     openModal(
       modalProps => (
@@ -219,29 +210,17 @@ class TableView extends React.Component<TableViewProps> {
 
   handleUpdateColumns = (columns: Column[]): void => {
     const {organization, eventView} = this.props;
-    this.trackEditAnalytics(organization, false);
+
+    // metrics
+    trackAnalyticsEvent({
+      eventKey: 'discover_v2.update_columns',
+      eventName: 'Discoverv2: Update columns',
+      organization_id: parseInt(organization.id, 10),
+    });
 
     const nextView = eventView.withColumns(columns);
     browserHistory.push(nextView.getResultsViewUrlTarget(organization.slug));
   };
-
-  trackEditAnalytics(organization: Organization, isEditing: boolean) {
-    if (isEditing) {
-      // metrics
-      trackAnalyticsEvent({
-        eventKey: 'discover_v2.table.column_header.edit_mode.enter',
-        eventName: 'Discoverv2: Enter column header edit mode',
-        organization_id: parseInt(organization.id, 10),
-      });
-    } else {
-      // metrics
-      trackAnalyticsEvent({
-        eventKey: 'discover_v2.table.column_header.edit_mode.exit',
-        eventName: 'Discoverv2: Exit column header edit mode',
-        organization_id: parseInt(organization.id, 10),
-      });
-    }
-  }
 
   render() {
     const {isLoading, error, tableData, eventView, title, organization} = this.props;


### PR DESCRIPTION
Continuation of analytics clean up from https://github.com/getsentry/sentry/pull/18090

Associated reload PR: https://github.com/getsentry/reload/pull/159

- add `discover_v2.column_editor.open`
- add `discover_v2.update_columns`
- `discover_v2.update_column` was being tracked during resize. But this was removed in https://github.com/getsentry/reload/pull/154
- remove `discover_v2.table.column_header.edit_mode.enter`
- remove `discover_v2.table.column_header.edit_mode.exit`