### PR TITLE
feat(workflow): Adding support for auto resolved activity item

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/activity/statusItem.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/statusItem.tsx
@@ -66,6 +66,12 @@ class StatusItem extends React.Component<Props> {
                 currentTrigger: <StatusValue>{currentTrigger}</StatusValue>,
               })}
             {isClosed &&
+              !activity.user &&
+              t(
+                'This alert has been auto-resolved because the rule that triggered it has been modified or deleted.'
+              )}
+            {isClosed &&
+              activity.user &&
               tct('[user] resolved the alert', {
                 user: <StatusValue>{authorName}</StatusValue>,
               })}


### PR DESCRIPTION
Adding support for a new activity item, which is a STATUS_CHANGE to CLOSED without a defined user. This means that the alert has been resolved automatically due to an alert rule being modified or deleted.