### PR TITLE
fix(discover) Fix apdex() getting the incorrect number of parameters

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -52,7 +52,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
     draggingTargetIndex: void 0,
     left: void 0,
     top: void 0,
-    fieldOptions: {},
+    fieldOptions: this.generateFieldOptions(),
   };
 
   componentDidMount() {
@@ -68,7 +68,6 @@ class ColumnEditCollection extends React.Component<Props, State> {
 
       document.body.appendChild(this.portal);
     }
-    this.syncFields();
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -88,7 +87,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
   portal: HTMLElement | null = null;
   dragGhostRef = React.createRef<HTMLDivElement>();
 
-  syncFields() {
+  generateFieldOptions() {
     const {organization, tagKeys} = this.props;
 
     let fields = Object.keys(FIELDS);
@@ -148,7 +147,11 @@ class ColumnEditCollection extends React.Component<Props, State> {
       });
     }
 
-    this.setState({fieldOptions});
+    return fieldOptions;
+  }
+
+  syncFields() {
+    this.setState({fieldOptions: this.generateFieldOptions()});
   }
 
   keyForColumn(column: Column, isGhost: boolean): string {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -114,6 +114,14 @@ class ColumnEditRow extends React.Component<Props> {
     this.triggerChange(newColumn);
   };
 
+  handleScalarParameterChange = (value: string) => {
+    const newColumn = cloneDeep(this.props.column);
+    if (newColumn.kind === 'function') {
+      newColumn.function[1] = value;
+    }
+    this.triggerChange(newColumn);
+  };
+
   handleRefinementChange = (value: string) => {
     const newColumn = cloneDeep(this.props.column);
     if (newColumn.kind === 'function') {
@@ -241,7 +249,7 @@ class ColumnEditRow extends React.Component<Props> {
 
   renderParameterInputs(parameters: ParameterDescription[]): React.ReactNode[] {
     const {gridColumns} = this.props;
-    const inputs = parameters.map((descriptor: ParameterDescription) => {
+    const inputs = parameters.map((descriptor: ParameterDescription, index: number) => {
       if (descriptor.kind === 'column' && descriptor.options.length > 0) {
         return (
           <SelectControl
@@ -256,10 +264,13 @@ class ColumnEditRow extends React.Component<Props> {
         );
       }
       if (descriptor.kind === 'value') {
+        const handler =
+          index === 0 ? this.handleScalarParameterChange : this.handleRefinementChange;
+
         const inputProps = {
           required: descriptor.required,
           value: descriptor.value,
-          onUpdate: this.handleRefinementChange,
+          onUpdate: handler,
         };
         switch (descriptor.dataType) {
           case 'number':

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -237,6 +237,30 @@ describe('EventsV2 -> ColumnEditModal', function() {
         {kind: 'function', function: ['apdex', '300', undefined]},
       ]);
     });
+
+    it('clears unused parameters', function() {
+      // Choose percentile, then apdex which has fewer parameters and different types.
+      selectByLabel(wrapper, 'percentile(\u2026)', {name: 'field', at: 0, control: true});
+      selectByLabel(wrapper, 'apdex(\u2026)', {name: 'field', at: 0, control: true});
+
+      // Apply the changes so we can see the new columns.
+      wrapper.find('Button[priority="primary"]').simulate('click');
+      expect(onApply).toHaveBeenCalledWith([
+        {kind: 'function', function: ['apdex', '300', undefined]},
+      ]);
+    });
+
+    it('clears all unused parameters', function() {
+      // Choose percentile, then error_rate which has no parameters.
+      selectByLabel(wrapper, 'percentile(\u2026)', {name: 'field', at: 0, control: true});
+      selectByLabel(wrapper, 'error_rate()', {name: 'field', at: 0, control: true});
+
+      // Apply the changes so we can see the new columns.
+      wrapper.find('Button[priority="primary"]').simulate('click');
+      expect(onApply).toHaveBeenCalledWith([
+        {kind: 'function', function: ['error_rate', '', undefined]},
+      ]);
+    });
   });
 
   describe('removing rows', function() {

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -177,14 +177,18 @@ describe('EventsV2 -> ColumnEditModal', function() {
   });
 
   describe('function & column selection', function() {
-    const wrapper = mountModal(
-      {
-        columns: [columns[0]],
-        onApply: () => void 0,
-        tagKeys,
-      },
-      initialData
-    );
+    let onApply, wrapper;
+    beforeEach(function() {
+      onApply = jest.fn();
+      wrapper = mountModal(
+        {
+          columns: [columns[0]],
+          onApply,
+          tagKeys,
+        },
+        initialData
+      );
+    });
 
     it('restricts column choices', function() {
       selectByLabel(wrapper, 'avg(\u2026)', {name: 'field', at: 0, control: true});
@@ -215,6 +219,23 @@ describe('EventsV2 -> ColumnEditModal', function() {
       // Input should show and have default value.
       const refinement = wrapper.find('ColumnEditRow input[inputMode="numeric"]');
       expect(refinement.props().value).toBe('0.5');
+    });
+
+    it('handles scalar field parameters', function() {
+      selectByLabel(wrapper, 'apdex(\u2026)', {name: 'field', at: 0, control: true});
+
+      // Parameter select should display and use the default value.
+      const field = wrapper.find('ColumnEditRow input[name="refinement"]');
+      expect(field.props().value).toBe('300');
+
+      // Trigger a blur and make sure the column is not wrong.
+      field.simulate('blur');
+
+      // Apply the changes so we can see the new columns.
+      wrapper.find('Button[priority="primary"]').simulate('click');
+      expect(onApply).toHaveBeenCalledWith([
+        {kind: 'function', function: ['apdex', '300', undefined]},
+      ]);
     });
   });
 


### PR DESCRIPTION
Functions with only a single scalar parameter should not update the 'refinement' slot as that would make it a 3 parameter function.