### PR TITLE
fix: Fixing manager selection

### DIFF
--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -48,7 +48,7 @@ def attach_foreignkey(objects, field, related=(), database=None):
     # values specified in select_related
     values = set([_f for _f in (getattr(o, column) for o in objects) if _f])
     if values:
-        qs = model.objects
+        qs = model._default_manager
         if database:
             qs = qs.using(database)
         if related:


### PR DESCRIPTION
The attach_foreignkey function was always using .objects as the manager, but some models (i.e. AlertRule) don't use .objects as the default manager, and this was running into issues fetching related fields.

This fixes that. The default manager will be .objects if it's not reassigned, so the behaviour stays the same for most use cases. 