### PR TITLE
fix(source maps): Improve handling of `node_modules` files

### DIFF
--- a/src/sentry/lang/javascript/cache.py
+++ b/src/sentry/lang/javascript/cache.py
@@ -62,6 +62,14 @@ class SourceCache(object):
 
 
 class SourceMapCache(object):
+    """
+    Stores mappings between
+
+        - the url of a file to be demangled and the url of its associated
+          source map, and
+        - a source map's url and the map's contents.
+    """
+
     def __init__(self):
         self._cache = {}
         self._mapping = {}

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -27,7 +27,12 @@ except ImportError:
 from sentry import http
 from sentry.interfaces.stacktrace import Stacktrace
 from sentry.models import EventError, ReleaseFile, Organization
+
+# separate from either the source cache or the source maps cache, this is for
+# holding the results of attempting to fetch both kinds of files, either from the
+# database or from the internet
 from sentry.utils.cache import cache
+
 from sentry.utils.files import compress_file
 from sentry.utils.hashlib import md5_text
 from sentry.utils.http import is_valid_origin
@@ -141,7 +146,7 @@ def get_source_context(source, lineno, colno, context=LINES_OF_CONTEXT):
 
 def discover_sourcemap(result):
     """
-    Given a UrlResult object, attempt to discover a sourcemap.
+    Given a UrlResult object, attempt to discover a sourcemap URL.
     """
     # When coercing the headers returned by urllib to a dict
     # all keys become lowercase so they're normalized
@@ -202,12 +207,19 @@ def discover_sourcemap(result):
 
 
 def fetch_release_file(filename, release, dist=None):
+    """
+    Attempt to retrieve a release artifact from the database.
+
+    Caches the result of that attempt (whether successful or not).
+    """
+
     dist_name = dist and dist.name or None
     cache_key = "releasefile:v1:%s:%s" % (release.id, ReleaseFile.get_ident(filename, dist_name))
 
     logger.debug("Checking cache for release artifact %r (release_id=%s)", filename, release.id)
     result = cache.get(cache_key)
 
+    # not in the cache (meaning we haven't checked the database recently), so check the database
     if result is None:
         filename_choices = ReleaseFile.normalize(filename)
         filename_idents = [ReleaseFile.get_ident(f, dist_name) for f in filename_choices]
@@ -228,8 +240,10 @@ def fetch_release_file(filename, release, dist=None):
             )
             cache.set(cache_key, -1, 60)
             return None
+
         elif len(possible_files) == 1:
             releasefile = possible_files[0]
+
         else:
             # Pick first one that matches in priority order.
             # This is O(N*M) but there are only ever at most 4 things here
@@ -256,10 +270,11 @@ def fetch_release_file(filename, release, dist=None):
             # on the file system by `ReleaseFile.cache`, instead.
             cache.set(cache_key, (headers, z_body, 200, encoding), 3600)
 
+    # in the cache as an unsucessful attempt
     elif result == -1:
-        # We cached an error, so normalize
-        # it down to None
         result = None
+
+    # in the cache as a successful attempt, including the zipped contents of the file
     else:
         # Previous caches would be a 3-tuple instead of a 4-tuple,
         # so this is being maintained for backwards compatibility
@@ -278,17 +293,25 @@ def fetch_file(url, project=None, release=None, dist=None, allow_scraping=True):
     """
     Pull down a URL, returning a UrlResult object.
 
-    Attempts to fetch from the cache.
+    Attempts to fetch from the database first (assuming there's a release on the
+    event), then the internet. Caches the result of each of those two attempts
+    sperately, whether or not those attempts are successful. Used for both
+    source files and source maps.
     """
+
     # If our url has been truncated, it'd be impossible to fetch
     # so we check for this early and bail
     if url[-3:] == "...":
         raise http.CannotFetch({"type": EventError.JS_MISSING_SOURCE, "url": http.expose_url(url)})
+
+    # if we've got a release to look on, try that first (incl associated cache)
     if release:
         with metrics.timer("sourcemaps.release_file"):
             result = fetch_release_file(url, release, dist)
     else:
         result = None
+
+    # otherwise, try the web-scraping cache and then the web itself
 
     cache_key = "source:cache:v4:%s" % (md5_text(url).hexdigest(),)
 
@@ -399,6 +422,7 @@ def fetch_sourcemap(url, project=None, release=None, dist=None, allow_scraping=T
         except TypeError as e:
             raise UnparseableSourcemap({"url": "<base64>", "reason": six.text_type(e)})
     else:
+        # look in the database and, if not found, optionally try to scrape the web
         result = fetch_file(
             url, project=project, release=release, dist=dist, allow_scraping=allow_scraping
         )
@@ -476,8 +500,14 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         ) is not False and self.project.get_option("sentry:scrape_javascript", True)
         self.fetch_count = 0
         self.sourcemaps_touched = set()
+
+        # cache holding mangled code, original code, and errors associated with
+        # each abs_path in the stacktrace
         self.cache = SourceCache()
+
+        # cache holding source URLs, corresponding source map URLs, and source map contents
         self.sourcemaps = SourceMapCache()
+
         self.release = None
         self.dist = None
 
@@ -523,6 +553,10 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         processable_frame.data = {"token": None}
 
     def process_frame(self, processable_frame, processing_task):
+        """
+        Attempt to demangle the given frame.
+        """
+
         frame = processable_frame.frame
         token = None
 
@@ -531,11 +565,11 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         all_errors = []
         sourcemap_applied = False
 
-        # can't fetch source if there's no filename present or no line
+        # can't demangle if there's no filename or line number present
         if not frame.get("abs_path") or not frame.get("lineno"):
             return
 
-        # can't fetch if this is internal node module as well
+        # also can't demangle node's internal modules
         # therefore we only process user-land frames (starting with /)
         # or those created by bundle/webpack internals
         if self.data.get("platform") == "node" and not frame.get("abs_path").startswith(
@@ -718,6 +752,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             )
 
         changed_raw = sourcemap_applied and self.expand_frame(raw_frame)
+
         if sourcemap_applied or all_errors or changed_frame or changed_raw:
             if in_app is not None:
                 new_frame["in_app"] = in_app
@@ -728,6 +763,10 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             return new_frames, raw_frames, all_errors
 
     def expand_frame(self, frame, source=None):
+        """
+        Mutate the given frame to include pre- and post-context lines.
+        """
+
         if frame.get("lineno") is not None:
             if source is None:
                 source = self.get_sourceview(frame["abs_path"])
@@ -747,6 +786,11 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         return self.cache.get(filename)
 
     def cache_source(self, filename):
+        """
+        Look for and (if found) cache a source file and its associated source
+        map (if any).
+        """
+
         sourcemaps = self.sourcemaps
         cache = self.cache
 
@@ -757,8 +801,9 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             return
 
         # TODO: respect cache-control/max-age headers to some extent
-        logger.debug("Fetching remote source %r", filename)
+        logger.debug("Attempting to cache source %r", filename)
         try:
+            # this both looks in the database and tries to scrape the internet
             result = fetch_file(
                 filename,
                 project=self.project,
@@ -784,7 +829,9 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         if not sourcemap_url:
             return
 
-        logger.debug("Found sourcemap %r for minified script %r", sourcemap_url[:256], result.url)
+        logger.debug(
+            "Found sourcemap URL %r for minified script %r", sourcemap_url[:256], result.url
+        )
         sourcemaps.link(filename, sourcemap_url)
         if sourcemap_url in sourcemaps:
             return

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -538,9 +538,8 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         # can't fetch if this is internal node module as well
         # therefore we only process user-land frames (starting with /)
         # or those created by bundle/webpack internals
-        if self.data.get("platform") == "node" and (
-            "node_modules" in frame.get("abs_path")
-            or not frame.get("abs_path").startswith(("/", "app:", "webpack:"))
+        if self.data.get("platform") == "node" and not frame.get("abs_path").startswith(
+            ("/", "app:", "webpack:")
         ):
             return
 

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -813,7 +813,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             )
         except http.BadSource as exc:
             # most people don't upload release artifacts for their third-party libraries,
-            # so ignore missing node_modules files for node events
+            # so ignore missing node_modules files
             if exc.data["type"] == EventError.JS_MISSING_SOURCE and "node_modules" in filename:
                 pass
             else:

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -723,7 +723,10 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             if in_app is not None:
                 new_frame["in_app"] = in_app
                 raw_frame["in_app"] = in_app
-            return [new_frame], [raw_frame] if changed_raw else None, all_errors
+
+            new_frames = [new_frame]
+            raw_frames = [raw_frame] if changed_raw else None
+            return new_frames, raw_frames, all_errors
 
     def expand_frame(self, frame, source=None):
         if frame.get("lineno") is not None:

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -474,6 +474,8 @@ class DiscoverSourcemapTest(unittest.TestCase):
             discover_sourcemap(result)
 
 
+# NB: despite the very close name, this class (singular Module) is in fact
+# different from the GenerateModulesTest (plural Modules) class below
 class GenerateModuleTest(unittest.TestCase):
     def test_simple(self):
         assert generate_module(None) == "<unknown module>"

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -845,7 +845,7 @@ class CacheSourceTest(TestCase):
         assert len(processor.cache.get_errors(abs_path)) == 1
         assert processor.cache.get_errors(abs_path)[0] == {"url": abs_path, "type": "js_no_source"}
 
-    def test_node_modules_file_no_source_okay(self):
+    def test_node_modules_file_no_source_no_error(self):
         """
         If someone hasn't uploaded node_modules (which most people don't), it
         shouldn't complain about a source file being missing.
@@ -887,11 +887,12 @@ class CacheSourceTest(TestCase):
 
         processor.cache_source(abs_path)
 
+        # file is cached, no errors are generated
         assert processor.cache.get(abs_path)
         assert len(processor.cache.get_errors(abs_path)) == 0
 
     @patch("sentry.lang.javascript.processor.discover_sourcemap")
-    def test_node_modules_file_with_source_no_map(self, mock_discover_sourcemap):
+    def test_node_modules_file_with_source_but_no_map_records_error(self, mock_discover_sourcemap):
         """
         If someone has uploaded node_modules, but is missing maps, it should complain
         so that they either a) upload the maps, or b) don't upload the source files.

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -815,3 +815,108 @@ class ErrorMappingTest(unittest.TestCase):
         assert not rewrite_exception(actual)
 
         assert actual == expected
+
+
+class CacheSourceTest(TestCase):
+    def test_file_no_source_records_error(self):
+        """
+        If we can't find a given file, either on the release or by scraping, an
+        error should be recorded.
+        """
+
+        project = self.create_project()
+
+        processor = JavaScriptStacktraceProcessor(data={}, stacktrace_infos=None, project=project)
+
+        # no release on the event, so won't find file in database
+        assert processor.release is None
+
+        # not a real url, so won't find file on the internet
+        abs_path = "app:///i/dont/exist.js"
+
+        # before caching, no errors
+        assert len(processor.cache.get_errors(abs_path)) == 0
+
+        processor.cache_source(abs_path)
+
+        # now we have an error
+        assert len(processor.cache.get_errors(abs_path)) == 1
+        assert processor.cache.get_errors(abs_path)[0] == {"url": abs_path, "type": "js_no_source"}
+
+    def test_node_modules_file_no_source_okay(self):
+        """
+        If someone hasn't uploaded node_modules (which most people don't), it
+        shouldn't complain about a source file being missing.
+        """
+
+        project = self.create_project()
+        processor = JavaScriptStacktraceProcessor(data={}, stacktrace_infos=None, project=project)
+
+        # no release on the event, so won't find file in database
+        assert processor.release is None
+
+        # not a real url, so won't find file on the internet
+        abs_path = "app:///../node_modules/i/dont/exist.js"
+
+        processor.cache_source(abs_path)
+
+        # no errors, even though the file can't have been found
+        assert len(processor.cache.get_errors(abs_path)) == 0
+
+    def test_node_modules_file_with_source_is_used(self):
+        """
+        If someone has uploaded node_modules, files in there should be treated like
+        any other files (in other words, they should land in the cache with no errors).
+        """
+
+        project = self.create_project()
+        release = self.create_release(project=project, version="12.31.12")
+
+        abs_path = "app:///../node_modules/some-package/index.js"
+        self.create_release_file(release=release, name=abs_path)
+
+        processor = JavaScriptStacktraceProcessor(
+            data={"release": release.version}, stacktrace_infos=None, project=project
+        )
+        # in real life the preprocess step will pull release out of the data
+        # dictionary passed to the JavaScriptStacktraceProcessor constructor,
+        # but since this is just a unit test, we have to set it manually
+        processor.release = release
+
+        processor.cache_source(abs_path)
+
+        assert processor.cache.get(abs_path)
+        assert len(processor.cache.get_errors(abs_path)) == 0
+
+    @patch("sentry.lang.javascript.processor.discover_sourcemap")
+    def test_node_modules_file_with_source_no_map(self, mock_discover_sourcemap):
+        """
+        If someone has uploaded node_modules, but is missing maps, it should complain
+        so that they either a) upload the maps, or b) don't upload the source files.
+        """
+
+        map_url = "app:///../node_modules/some-package/index.js.map"
+        mock_discover_sourcemap.return_value = map_url
+
+        project = self.create_project()
+        release = self.create_release(project=project, version="12.31.12")
+
+        abs_path = "app:///../node_modules/some-package/index.js"
+        self.create_release_file(release=release, name=abs_path)
+
+        processor = JavaScriptStacktraceProcessor(
+            data={"release": release.version}, stacktrace_infos=None, project=project
+        )
+        # in real life the preprocess step will pull release out of the data
+        # dictionary passed to the JavaScriptStacktraceProcessor constructor,
+        # but since this is just a unit test, we have to set it manually
+        processor.release = release
+
+        # before caching, no errors
+        assert len(processor.cache.get_errors(abs_path)) == 0
+
+        processor.cache_source(abs_path)
+
+        # now we have an error
+        assert len(processor.cache.get_errors(abs_path)) == 1
+        assert processor.cache.get_errors(abs_path)[0] == {"url": map_url, "type": "js_no_source"}


### PR DESCRIPTION
As of https://github.com/getsentry/sentry/pull/17538, we're bailing early if the file we're looking for  comes from `node_modules`, in order to prevent a lot of false-positive error messages (see https://github.com/getsentry/sentry/issues/14700, for example).

The assumption behind this is that the code you care about - and therefore the code that needs to be source mapped, and the code for which you're going to bother to upload maps - is your own code, not code from third-party libraries, many of which don't come with maps anyway. Upon further reflection, though, it becomes clear that though that's true most of the time, it's not true all the time (for example, someone's app might depend on a separate package, living in `node_modules`, which they themselves wrote).

This PR aims to handle the issue more gracefully. Rather than giving up as soon as we realize we're looking for a file which lives in `node_modules`, we persist (just as we did before the previous PR), but once we're done searching, we just ignore the error if the missing file is from `node_modules`. That way, if someone _does_ purposefully upload maps for such a file, everything will work as expected, but people who don't need that information won't have to upload their entire `node_modules` folder just to get the UI to stop complaining.

(Oh, and it changes a return statement where unclear precedence order could lead to confusion to a slightly more verbose one that leaves no room for interpretation, as well as adds a bunch of docstrings and comments.)