### PR TITLE
fix(perf-views) Format apdex() as a number

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1083,7 +1083,7 @@ FUNCTIONS = {
         "name": "apdex",
         "args": [NumberRange("satisfaction", 0, None)],
         "transform": u"apdex(duration, {satisfaction:g})",
-        "result_type": "percentage",
+        "result_type": "number",
     },
     "impact": {
         "name": "impact",

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -113,7 +113,7 @@ const FIELD_FORMATTERS: FieldFormatters = {
     sortField: true,
     renderFunc: (field, data) => (
       <NumberContainer>
-        {typeof data[field] === 'number' ? formatFloat(data[field], 5) : emptyValue}
+        {typeof data[field] === 'number' ? formatFloat(data[field], 4) : emptyValue}
       </NumberContainer>
     ),
   },

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -20,7 +20,7 @@ import {getDuration, formatPercentage} from 'app/utils/formatters';
 import EventsRequest from './utils/eventsRequest';
 
 const DURATION_AGGREGATE_PATTERN = /^(p75|p95|p99|percentile)|transaction\.duration/;
-const PERCENTAGE_AGGREGATE_PATTERN = /^(apdex|error_rate)/;
+const PERCENTAGE_AGGREGATE_PATTERN = /^(error_rate)/;
 
 class EventsAreaChart extends React.Component {
   static propTypes = {

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -46,7 +46,7 @@ def test_get_json_meta_type():
     assert get_json_meta_type("p75", "number") == "duration"
     assert get_json_meta_type("p95", "number") == "duration"
     assert get_json_meta_type("p99", "number") == "duration"
-    assert get_json_meta_type("apdex_transaction_duration_300", "number") == "percentage"
+    assert get_json_meta_type("apdex_transaction_duration_300", "number") == "number"
     assert get_json_meta_type("error_rate", "number") == "percentage"
     assert get_json_meta_type("impact_300", "number") == "number"
     assert get_json_meta_type("percentile_transaction_duration_0_95", "number") == "duration"

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1693,7 +1693,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             assert meta["p75"] == "duration"
             assert meta["p95"] == "duration"
             assert meta["percentile_transaction_duration_0_99"] == "duration"
-            assert meta["apdex_300"] == "percentage"
+            assert meta["apdex_300"] == "number"
             assert meta["error_rate"] == "percentage"
             assert meta["impact"] == "number"
 


### PR DESCRIPTION
Formatting as a %age was a mistake.