### PR TITLE
fix(ui) Don't forward invalid props and fix getsentry master

### DIFF
--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -212,7 +212,9 @@ const MenuTarget = styled('span')<MenuListItemProps>`
   ${getListItemStyles}
 `;
 
-const MenuLink = styled(Link)<MenuListItemProps>`
+const MenuLink = styled(Link, {
+  shouldForwardProp: p => ['isActive', 'disabled'].includes(p) === false,
+})<MenuListItemProps>`
   display: block;
   padding: ${space(0.5)} ${space(2)};
 


### PR DESCRIPTION
Fixes the getsentry build which is failing due to a console warning