### PR TITLE
feat(mail): Start sending new digest key format to digests

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -36,8 +36,10 @@ def split_key(key):
     return Project.objects.get(pk=project_id), target_type, target_identifier
 
 
-def unsplit_key(plugin, project):
-    return u"{plugin.slug}:p:{project.id}".format(plugin=plugin, project=project)
+def unsplit_key(project, target_type, target_identifier):
+    return u"mail:p:{}:{}:{}".format(
+        project.id, target_type.value, target_identifier if target_identifier is not None else ""
+    )
 
 
 def event_to_record(event, rules):

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -70,7 +70,7 @@ class MailAdapter(object):
             def get_digest_option(key):
                 return ProjectOption.objects.get_value(project, get_digest_option_key("mail", key))
 
-            digest_key = unsplit_key(self, event.group.project)
+            digest_key = unsplit_key(event.group.project, target_type, target_identifier)
             extra["digest_key"] = digest_key
             immediate_delivery = digests.add(
                 digest_key,

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -13,6 +13,7 @@ from sentry.digests.notifications import (
     sort_group_contents,
     sort_rule_groups,
     split_key,
+    unsplit_key,
 )
 from sentry.mail.adapter import ActionTargetType
 from sentry.models import Rule
@@ -136,3 +137,18 @@ class SplitKeyTestCase(TestCase):
                 self.project.id, ActionTargetType.ISSUE_OWNERS.value, identifier
             )
         ) == (self.project, ActionTargetType.ISSUE_OWNERS, identifier)
+
+
+class UnsplitKeyTestCase(TestCase):
+    def test_no_identifier(self):
+        assert unsplit_key(
+            self.project, ActionTargetType.ISSUE_OWNERS, None
+        ) == "mail:p:{}:{}:".format(self.project.id, ActionTargetType.ISSUE_OWNERS.value)
+
+    def test_identifier(self):
+        identifier = "123"
+        assert unsplit_key(
+            self.project, ActionTargetType.ISSUE_OWNERS, identifier
+        ) == "mail:p:{}:{}:{}".format(
+            self.project.id, ActionTargetType.ISSUE_OWNERS.value, identifier
+        )


### PR DESCRIPTION
Continuing to split out logic from https://github.com/getsentry/sentry/pull/17571. This starts
sending the new digest key format to digests. It's important that we don't merge this until #18258
is deployed so that we know digests can handle this new format.

Depends on https://github.com/getsentry/sentry/pull/18258