### PR TITLE
ref(discover2): Constrain EventsV2 props to require org slug instead of entire organization prop

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventsv2/index.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventsv2/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {Location} from 'history';
 
-import {Organization} from 'app/types';
 import {Client} from 'app/api';
 import withApi from 'app/utils/withApi';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
@@ -18,7 +17,7 @@ type Props = {
   api: Client;
   location: Location;
   eventView: EventView;
-  organization: Organization;
+  orgSlug: string;
   extraQuery?: {[key: string]: any};
   keyTransactions?: boolean;
 
@@ -72,7 +71,7 @@ class EventsV2 extends React.Component<Props, State> {
   };
 
   fetchData = () => {
-    const {eventView, organization, location, extraQuery, keyTransactions} = this.props;
+    const {eventView, orgSlug, location, extraQuery, keyTransactions} = this.props;
 
     if (!eventView.isValid()) {
       return;
@@ -80,7 +79,7 @@ class EventsV2 extends React.Component<Props, State> {
 
     const route = keyTransactions ? 'key-transactions' : 'eventsv2';
 
-    const url = `/organizations/${organization.slug}/${route}/`;
+    const url = `/organizations/${orgSlug}/${route}/`;
     const tableFetchID = Symbol('tableFetchID');
     const apiPayload = eventView.getEventsAPIPayload(location);
 

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -247,7 +247,7 @@ class Table extends React.Component<Props> {
     return (
       <EventsV2
         eventView={eventView}
-        organization={organization}
+        orgSlug={organization.slug}
         location={location}
         keyTransactions={keyTransactions}
       >

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -60,7 +60,7 @@ class SummaryContent extends React.Component<Props> {
           <EventsV2
             location={location}
             eventView={eventView}
-            organization={organization}
+            orgSlug={organization.slug}
             extraQuery={{
               per_page: TOP_SLOWEST_TRANSACTIONS,
             }}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -44,7 +44,7 @@ class UserStats extends React.Component<Props> {
     return (
       <EventsV2
         eventView={eventView}
-        organization={organization}
+        orgSlug={organization.slug}
         location={location}
         extraQuery={{per_page: 1}}
       >


### PR DESCRIPTION


Cherry picked from https://github.com/getsentry/sentry/pull/18025