### PR TITLE
security: ignore safety 38165 for now

### DIFF
--- a/bin/scan
+++ b/bin/scan
@@ -8,6 +8,8 @@ ignored=(
     37508
     # 1.3.0 upgrades builtin lz4 to 1.9.2. CVE-2019-17543
     38072
+    # Confluent-kafka < 1.4.0 includes two security issues in the SASL SCRAM protocol handler.
+    38165
 
     # low priority: pyyaml
     # Arbitrary code execution in full_load/SafeLoader - doesn't apply to us.


### PR DESCRIPTION
Unblock. Yet another vuln for confluent-kafka. cc @untitaker for visibility.