### PR TITLE
fix(discover2): Remove event id from search conditions when clicking thru on a tag

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/tagsTable.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tagsTable.tsx
@@ -22,6 +22,15 @@ type Props = {
 
 const TagsTable = (props: Props) => {
   const {organization, event, eventView} = props;
+
+  // create a clone of the event object, and delete the its id.
+  // we do this so that the id will not be added to the search conditions
+  // when the tag is clicked
+  const eventReference = {...event};
+  if (eventReference.id) {
+    delete eventReference.id;
+  }
+
   const tags = event.tags;
   return (
     <StyledTagsTable>
@@ -43,7 +52,7 @@ const TagsTable = (props: Props) => {
               const nextView = getExpandedResults(
                 eventView,
                 {[tag.key]: tag.value},
-                event
+                eventReference
               );
               target = nextView.getResultsViewUrlTarget(organization.slug);
             }


### PR DESCRIPTION
On the Discover event details page, clicking on a tag will lead to a Discover Query page with the event id included in the search conditions. 

This is a useless search since it will show the only at most one event.

We improve this Discover query by excluding the event id, which is what users will expect.