### PR TITLE
feat(ts): Fix `withRouter` types

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/react-bootstrap": "^0.32.19",
     "@types/react-document-title": "^2.0.3",
     "@types/react-dom": "~16.9.5",
-    "@types/react-router": "^3.0.20",
+    "@types/react-router": "3.0.22",
     "@types/react-select": "3.0.8",
     "@types/react-sparklines": "^1.7.0",
     "@types/react-virtualized": "^9.20.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/react-bootstrap": "^0.32.19",
     "@types/react-document-title": "^2.0.3",
     "@types/react-dom": "~16.9.5",
-    "@types/react-router": "3.0.22",
+    "@types/react-router": "^3.0.22",
     "@types/react-select": "3.0.8",
     "@types/react-sparklines": "^1.7.0",
     "@types/react-virtualized": "^9.20.1",

--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import * as Sentry from '@sentry/browser';
 import {RouteComponentProps} from 'react-router/lib/Router';
+import {WithRouterProps} from 'react-router/lib/withRouter';
 
 import {Client} from 'app/api';
 import {metric} from 'app/utils/analytics';
@@ -37,7 +38,7 @@ type SearchInputProps = React.ComponentProps<typeof AsyncComponentSearchInput>;
 
 type RenderSearchInputArgs = Omit<
   SearchInputProps,
-  'api' | 'onSuccess' | 'onError' | 'url'
+  'api' | 'onSuccess' | 'onError' | 'url' | keyof WithRouterProps
 > & {
   stateKey?: string;
   url?: SearchInputProps['url'];

--- a/src/sentry/static/sentry/app/components/asyncComponentSearchInput.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponentSearchInput.tsx
@@ -158,11 +158,4 @@ const Form = styled('form')`
   position: relative;
 `;
 
-// XXX(epurkhiser): The withRouter HoC has incorrect typings. It does not
-// correctly remove the WithRouterProps from the return type of the HoC, thus
-// we manually have to do this.
-type PropsWithoutRouter = Omit<Props, keyof ReactRouter.WithRouterProps>;
-
-export default ReactRouter.withRouter(AsyncComponentSearchInput) as React.ComponentClass<
-  PropsWithoutRouter
->;
+export default ReactRouter.withRouter(AsyncComponentSearchInput);

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -267,14 +267,7 @@ const TaskBlankAvatar = styled(posed(LetterAvatar)(completedItemPoses))`
   position: unset;
 `;
 
-// XXX(epurkhiser): The withRouter HoC has incorrect typings. It does not
-// correctly remove the WithRouterProps from the return type of the HoC, thus
-// we manually have to do this.
-type PropsWithoutRouter = Omit<Props, keyof ReactRouter.WithRouterProps>;
-
-const WrappedTask = withOrganization(
-  ReactRouter.withRouter(Task) as React.ComponentClass<PropsWithoutRouter>
-);
+const WrappedTask = withOrganization(ReactRouter.withRouter(Task));
 
 export default React.forwardRef<
   HTMLDivElement,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,7 +2615,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-router@3.0.22":
+"@types/react-router@^3.0.22":
   version "3.0.22"
   resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-3.0.22.tgz#047e971f2a5ff69aef981b4ffb69fa1150674e80"
   integrity sha512-MUjQtRC4vS+rTqQKag3r0Pf6wSy0Y2h/hfk4OE03STgNmtRWGfyjckHLHgESbdqz2VnL12xS6pdncsCDiudC2g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,10 +2615,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-router@^3.0.20":
-  version "3.0.20"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-3.0.20.tgz#a711682475ccef70ad9ad9e459859380221e6ee6"
-  integrity sha512-0sx2ThGYgblXPf8we/c+umFzP3RCbBp1bbFmd3pO1UaOYnTDno82iql3MQTVqB09rhopKORNfakDU/9xZ4QR6g==
+"@types/react-router@3.0.22":
+  version "3.0.22"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-3.0.22.tgz#047e971f2a5ff69aef981b4ffb69fa1150674e80"
+  integrity sha512-MUjQtRC4vS+rTqQKag3r0Pf6wSy0Y2h/hfk4OE03STgNmtRWGfyjckHLHgESbdqz2VnL12xS6pdncsCDiudC2g==
   dependencies:
     "@types/history" "^3"
     "@types/react" "*"


### PR DESCRIPTION
Upgrades `@types/react-router` to fix `withRouter` typing. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43566