### PR TITLE
feat(deps): Upgrade to typescript@3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "svg-sprite-loader": "^3.9.0",
     "svgo": "^1.0.3",
     "svgo-loader": "^2.1.0",
-    "typescript": "3.7",
+    "typescript": "^3.8",
     "u2f-api": "1.0.10",
     "webpack": "4.42.1",
     "webpack-cli": "3.3.11",

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -230,7 +230,7 @@ type LegacyAnalyticsEvent = (
   /**
    * Arbitrary data to track
    */
-  data: {[key: string]: number | string | boolean | number[]}
+  data: {[key: string]: number | string | boolean | number[] | string[]}
 ) => void;
 
 /**

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -230,7 +230,7 @@ type LegacyAnalyticsEvent = (
   /**
    * Arbitrary data to track
    */
-  data: {[key: string]: number | string | boolean}
+  data: {[key: string]: number | string | boolean | number[]}
 ) => void;
 
 /**

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -230,7 +230,7 @@ type LegacyAnalyticsEvent = (
   /**
    * Arbitrary data to track
    */
-  data: {[key: string]: number | string | boolean | number[] | string[]}
+  data: {[key: string]: any}
 ) => void;
 
 /**

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
@@ -127,7 +127,7 @@ export default function getConfiguration({
         ...plugins.map(plugin => ({
           path: `${pathPrefix}/plugins/${plugin.id}/`,
           title: plugin.name,
-          show: ({access}) => access.has('project:write'),
+          show: opts => opts?.access?.has('project:write'),
           id: 'plugin_details',
           recordAnalytics: true,
         })),

--- a/yarn.lock
+++ b/yarn.lock
@@ -14977,10 +14977,15 @@ typescript-template-language-service-decorator@^2.2.0:
   resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz#4ee6d580f307fb9239978e69626f2775b8a59b2a"
   integrity sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w==
 
-typescript@3.7, typescript@^3.7.2:
+typescript@^3.7.2:
   version "3.7.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+
+typescript@^3.8:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 u2f-api@1.0.10:
   version "1.0.10"


### PR DESCRIPTION
See changelog here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html


```
* Type-Only Imports and Exports
* ECMAScript Private Fields
* export * as ns Syntax
* Top-Level await
* JSDoc Property Modifiers
* Better Directory Watching on Linux and watchOptions
* “Fast and Loose” Incremental Checking
* Type-Only Imports and Export
```