### PR TITLE
fix(discover2): Update eventview query for "Open in Discover" button on the issue details page

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
@@ -144,14 +144,12 @@ const GroupDetailsActions = createReactClass({
     const discoverQuery = {
       id: undefined,
       name: group.title || group.type,
-      fields: ['title', 'url', 'count(id)', 'project', 'last_seen'],
-      widths: [400, 200, -1, 200, -1],
-      orderby: '-count_id',
+      fields: ['title', 'release', 'environment', 'user', 'timestamp'],
+      orderby: '-timestamp',
       query: `issue.id:${group.id}`,
-      tags: ['environment', 'release', 'event.type', 'user.email'],
       projects: [project.id],
       version: 2,
-      range: '24h',
+      range: '90d',
     };
 
     const discoverView = EventView.fromSavedQuery(discoverQuery);


### PR DESCRIPTION
**Before:**

![Screen Shot 2020-04-14 at 8 59 45 PM](https://user-images.githubusercontent.com/139499/79287912-3c965980-7e93-11ea-9afd-b7a341792fad.png)

**After:**

![Screen Shot 2020-04-14 at 8 58 39 PM](https://user-images.githubusercontent.com/139499/79287916-3ef8b380-7e93-11ea-972e-be0f88769c1b.png)

--------

User should be able to click on an Issue, click 'Open in Discover', and view the 'All Events' query, with the same columns, and the corresponding issue.id that they were viewing in their filter conditions
