### PR TITLE
chore(ts): Correct typing on AnalyticsTrackAdhocEvent

### DIFF
--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -197,9 +197,16 @@ type AnalyticsTrackEvent = (opts: {
 /**
  * Trigger adhoc analytics tracking in the hook store.
  */
-type AnalyticsTrackAdhocEvent = (
-  opts: Omit<Parameters<AnalyticsTrackEvent>[0], 'eventName'>
-) => void;
+type AnalyticsTrackAdhocEvent = (opts: {
+  /**
+   * The key used to identify the event.
+   */
+  eventKey: string;
+  /**
+   * Arbitrary data to track
+   */
+  [key: string]: any;
+}) => void;
 
 /**
  * Trigger experiment observed logging.


### PR DESCRIPTION
There was an additional eventName prop that wasn't correctly being removed from the type alias. Easier to just declare the two properties here.