### PR TITLE
fix(ts): Update GlobalSelection types in "Performance"

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -77,11 +77,9 @@ class PerformanceLanding extends React.Component<Props, State> {
     const globalSelection = eventView.getGlobalSelection();
     const start = globalSelection.start
       ? getUtcToLocalDateObject(globalSelection.start)
-      : undefined;
+      : null;
 
-    const end = globalSelection.end
-      ? getUtcToLocalDateObject(globalSelection.end)
-      : undefined;
+    const end = globalSelection.end ? getUtcToLocalDateObject(globalSelection.end) : null;
 
     const {utc} = getParams(location.query);
 
@@ -91,7 +89,7 @@ class PerformanceLanding extends React.Component<Props, State> {
       datetime: {
         start,
         end,
-        period: globalSelection.statsPeriod,
+        period: globalSelection.statsPeriod || DEFAULT_STATS_PERIOD,
         utc: utc === 'true',
       },
     };


### PR DESCRIPTION
These types were slightly wrong, see https://github.com/getsentry/sentry/blob/1fdb73cf2511d8c0ba0796f19ff22b9bbe1a683d/src/sentry/static/sentry/app/types/index.tsx#L443-L448