### PR TITLE
feat: Add new cocoa SDK name to exclude from in_app

### DIFF
--- a/src/sentry/grouping/enhancement-configs/common@2019-03-23.txt
+++ b/src/sentry/grouping/enhancement-configs/common@2019-03-23.txt
@@ -60,3 +60,4 @@ family:native function:"?[[]KSCrash *"                              -app -group
 family:native function:"?[[]SentryCrash *"                          -app -group
 family:native function:"?[[]SentryClient *"                         -app -group
 family:native function:"?[[]RNSentry *"                             -app -group
+family:native function:"?[[]SentrySDK *"                             -app -group

--- a/src/sentry/grouping/enhancement-configs/legacy@2019-03-12.txt
+++ b/src/sentry/grouping/enhancement-configs/legacy@2019-03-12.txt
@@ -29,3 +29,4 @@ family:native function:kscrash_*                                     -app -group
 family:native function:"?[[]KSCrash *"                              -app -group
 family:native function:"?[[]SentryClient *"                         -app -group
 family:native function:"?[[]RNSentry *"                             -app -group
+family:native function:"?[[]SentrySDK *"                             -app -group


### PR DESCRIPTION
cc @jan-auer @bruno-garcia @philipphofmann for visibility

Our new Cocoa SDK uses `SentrySDK` as our entry point so we should mark all frames `in_app` false.