### PR TITLE
fix(ui): Fixed calling of onClose in PickProjectToContinue

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/pickProjectToContinue.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/pickProjectToContinue.tsx
@@ -14,6 +14,8 @@ type Props = {
 };
 
 const PickProjectToContinue = ({orgSlug, version, router, projects}: Props) => {
+  let navigating = false;
+
   const path = `/organizations/${orgSlug}/releases-v2/${encodeURIComponent(
     version
   )}/?project=`;
@@ -32,6 +34,7 @@ const PickProjectToContinue = ({orgSlug, version, router, projects}: Props) => {
         needProject
         nextPath={`${path}:project`}
         onFinish={pathname => {
+          navigating = true;
           router.replace(pathname);
         }}
         projectSlugs={projects.map(p => p.slug)}
@@ -39,8 +42,11 @@ const PickProjectToContinue = ({orgSlug, version, router, projects}: Props) => {
     ),
     {
       onClose() {
-        // if a user closes the modal (either via button, Esc, clicking outside)
-        router.push(`/organizations/${orgSlug}/releases-v2/`);
+        // we want this to be executed only if the user didn't select any project
+        // (closed modal either via button, Esc, clicking outside, ...)
+        if (!navigating) {
+          router.push(`/organizations/${orgSlug}/releases-v2/`);
+        }
       },
     }
   );


### PR DESCRIPTION
We want the onClose callback to be called only when the modal has been closed without picking a project. This could be because of clicking on the close button, pressing Esc, clicking outside of modal, etc..

The behavior of when onClose is called was recently changed in https://github.com/getsentry/sentry/pull/18245, so this PR adds a piece of logic to decide what the callback should be.