### PR TITLE
fix(workflow): Only include users to an alert's viewing history if member of org + project

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -177,11 +177,13 @@ def set_incident_seen(incident, user=None):
     """
     Updates the incident to be seen
     """
-    incident_seen, created = IncidentSeen.objects.create_or_update(
-        incident=incident, user=user, values={"last_seen": timezone.now()}
-    )
+    if incident.organization.has_access(user):
+        incident_seen, created = IncidentSeen.objects.create_or_update(
+            incident=incident, user=user, values={"last_seen": timezone.now()}
+        )
+        return incident_seen
 
-    return incident_seen
+    return False
 
 
 @transaction.atomic

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -177,11 +177,23 @@ def set_incident_seen(incident, user=None):
     """
     Updates the incident to be seen
     """
-    if incident.organization.has_access(user):
-        incident_seen, created = IncidentSeen.objects.create_or_update(
-            incident=incident, user=user, values={"last_seen": timezone.now()}
-        )
-        return incident_seen
+
+    is_org_member = incident.organization.has_access(user)
+
+    if is_org_member:
+        is_project_member = False
+        for incident_project in IncidentProject.objects.filter(incident=incident).select_related(
+            "project"
+        ):
+            if incident_project.project.member_set.filter(user=user).exists():
+                is_project_member = True
+                break
+
+        if is_project_member:
+            incident_seen, created = IncidentSeen.objects.create_or_update(
+                incident=incident, user=user, values={"last_seen": timezone.now()}
+            )
+            return incident_seen
 
     return False
 


### PR DESCRIPTION
When users were viewing an alert, we were tracking that no matter what. This was not good if we, as superusers, were viewing alerts of another org. We now check to see if the user is a part of the org, and a part of the alert's project(s) before tracking their view.