### PR TITLE
ref(ui) Remove 'new' from discover sidebar item

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -400,7 +400,6 @@ class Sidebar extends React.Component<Props, State> {
                           label={t('Discover')}
                           to={getDiscoverLandingUrl(organization)}
                           id="discover-v2"
-                          isNew
                         />
                       </GuideAnchor>
                     </Feature>


### PR DESCRIPTION
Releases v2 is coming soon and having two things be new/beta is distracting. Related to #18158