### PR TITLE
feat(tooltip-def): latency distribution tooltip

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -260,12 +260,10 @@ function LatencyChart({totalValues, ...props}: WrapperProps) {
           <Tooltip
             position="top"
             title={t(
-              `This graph shows the volume of transactions that completed within each duration bucket.
-                X-axis values represent the median value of each bucket.
-                `
+              `Latency Distribution reflects the volume of transactions per median duration.`
             )}
           >
-            <StyledIconQuestion size="sm" />
+            <StyledIconQuestion />
           </Tooltip>
         </HeaderTitle>
         <LatencyHistogram {...props} />


### PR DESCRIPTION
**Before:**
<img width="323" alt="Screen Shot 2020-04-15 at 11 48 27 AM" src="https://user-images.githubusercontent.com/4830259/79376484-17dfc780-7f0f-11ea-80c0-2d820250df01.png">

**After:**
<img width="335" alt="Screen Shot 2020-04-15 at 11 48 10 AM" src="https://user-images.githubusercontent.com/4830259/79376492-1c0be500-7f0f-11ea-89e5-13c20af312f8.png">