### PR TITLE
security: update comments in bin/scan

### DIFF
--- a/bin/scan
+++ b/bin/scan
@@ -1,21 +1,24 @@
 #!/bin/bash
 
 ignored=(
-    # TODO medium priority: confluent-kafka (we should upgrade this anyways)
+    # LOW priority: confluent-kafka
     # XXX: These issues are in safety's db, but not in synk :\
+    # 1.3.0 upgrades builtin lz4 to 1.9.2 (a heap overflow was fixed) CVE-2019-17543
+    # This affects us, but we've never actually seen this in production.
+    38072
+    # We don't set security.protocol - it defaults to plaintext.
+    # The following two issues are related to ssl and sasl.
     # 1.1.0 securely clears the private key data from memory after last use.
     # Doesn't seem to have a CVE assigned to this.
     37508
-    # 1.3.0 upgrades builtin lz4 to 1.9.2. CVE-2019-17543
-    38072
-    # Confluent-kafka < 1.4.0 includes two security issues in the SASL SCRAM protocol handler.
+    # 1.4.0 addresses two security issues in the SASL SCRAM protocol handler.
     38165
 
-    # low priority: pyyaml
+    # LOW priority: pyyaml
     # Arbitrary code execution in full_load/SafeLoader - doesn't apply to us.
     38100
 
-    # low priority: djangorestframework
+    # LOW priority: djangorestframework
     # XXX: This is... unfortunately not present in safety's db right now. It is in synk though:
     # https://snyk.io/vuln/SNYK-PYTHON-DJANGORESTFRAMEWORK-450194
     # XSS in the "browsable api" drf < 3.9.1 view templates - doesn't apply to us.


### PR DESCRIPTION
Investigated further and it was deemed that upgrading confluent-kafka is purely nice to have, and thus, low priority.
