### PR TITLE
feat(mail): Add form and action for targetting issue alerts

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -25,7 +25,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
             node = rule_cls(project)
             context = {"id": node.id, "label": node.label, "enabled": node.is_enabled()}
             if (
-                node.id == "sentry.rules.actions.notify_email.NotifyEmailAction"
+                node.id == "sentry.mail.actions.NotifyEmailAction"
                 and not has_issue_alerts_targeting
             ):
                 continue

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -216,6 +216,7 @@ PROTECTED_TAG_KEYS = frozenset(["environment", "release", "sentry:release"])
 
 # TODO(dcramer): once this is more flushed out we want this to be extendable
 SENTRY_RULES = (
+    "sentry.mail.actions.NotifyEmailAction",
     "sentry.rules.actions.notify_event.NotifyEventAction",
     "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
     "sentry.rules.conditions.every_event.EveryEventCondition",

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -1,0 +1,103 @@
+from __future__ import absolute_import
+
+from django import forms
+
+from sentry.db.models.fields.bounded import BoundedBigIntegerField
+from sentry.mail.adapter import ActionTargetType, MailAdapter
+from sentry.models import Project, User
+from sentry.rules.actions.base import EventAction
+from sentry.utils import metrics
+
+
+CHOICES = [
+    (ActionTargetType.ISSUE_OWNERS.value, "Issue Owners"),
+    (ActionTargetType.TEAM.value, "Team"),
+    (ActionTargetType.MEMBER.value, "Member"),
+]
+
+
+class NotifyEmailForm(forms.Form):
+    targetType = forms.ChoiceField(choices=CHOICES)
+    targetIdentifier = BoundedBigIntegerField().formfield(
+        required=False, help_text="Only required if 'Member' or 'Team' is selected"
+    )
+
+    def __init__(self, project, *args, **kwargs):
+        super(NotifyEmailForm, self).__init__(*args, **kwargs)
+        self.project = project
+
+    def clean(self):
+        cleaned_data = super(NotifyEmailForm, self).clean()
+        try:
+            targetType = ActionTargetType(cleaned_data.get("targetType"))
+        except ValueError:
+            msg = forms.ValidationError("Invalid targetType specified")
+            self.add_error("targetType", msg)
+            return
+
+        targetIdentifier = cleaned_data.get("targetIdentifier")
+
+        self.cleaned_data["targetType"] = targetType.value
+        if targetType == ActionTargetType.ISSUE_OWNERS:
+            return
+
+        if targetIdentifier is None:
+            msg = forms.ValidationError("You need to specify a Team or Member to send mail to.")
+            self.add_error("targetIdentifier", msg)
+            return
+
+        if (
+            targetType == ActionTargetType.TEAM
+            and not Project.objects.filter(
+                teams__id=int(targetIdentifier), id=self.project.id
+            ).exists()
+        ):
+            msg = forms.ValidationError("This team is not part of the project.")
+            self.add_error("targetIdentifier", msg)
+            return
+
+        if (
+            targetType == ActionTargetType.MEMBER
+            and not User.objects.get_from_projects(self.project.organization.id, [self.project])
+            .filter(id=int(targetIdentifier))
+            .exists()
+        ):
+            msg = forms.ValidationError("This user is not part of the project.")
+            self.add_error("targetIdentifier", msg)
+            return
+
+        self.cleaned_data["targetIdentifier"] = targetIdentifier
+
+
+class NotifyEmailAction(EventAction):
+    form_cls = NotifyEmailForm
+    label = "Send an email to {targetType}"
+    prompt = "Send an email"
+    metrics_slug = "EmailAction"
+
+    def __init__(self, *args, **kwargs):
+        super(NotifyEmailAction, self).__init__(*args, **kwargs)
+        self.form_fields = {"targetType": {"type": "mailAction", "choices": CHOICES}}
+        self.mail_adapter = MailAdapter()
+
+    def after(self, event, state):
+        extra = {"event_id": event.event_id}
+        group = event.group
+
+        if not self.mail_adapter.should_notify(group=group):
+            extra["group_id"] = group.id
+            self.logger.info("rule.fail.should_notify", extra=extra)
+            return
+
+        metrics.incr("notifications.sent", instance=self.metrics_slug, skip_internal=False)
+        yield self.future(
+            lambda event, futures: self.mail_adapter.rule_notify(
+                event,
+                futures,
+                ActionTargetType(self.data["targetType"]),
+                self.data.get("targetIdentifier", None),
+            )
+        )
+
+    def get_form_instance(self):
+        return self.form_cls(self.project, self.data)

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -29,10 +29,10 @@ class ProjectRuleConfigurationTest(APITestCase):
     def rules(self):
         rules = RuleRegistry()
         rule = Mock()
-        rule.id = "sentry.rules.actions.notify_email.NotifyEmailAction"
+        rule.id = "sentry.mail.actions.NotifyEmailAction"
         rule.rule_type = "action/lol"
         node = rule.return_value
-        node.id = "sentry.rules.actions.notify_email.NotifyEmailAction"
+        node.id = "sentry.mail.actions.NotifyEmailAction"
         node.label = "hello"
         node.is_enabled.return_value = True
         node.form_fields = {}

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -1,0 +1,141 @@
+from __future__ import absolute_import
+
+import six
+from django.core import mail
+
+from sentry.mail.actions import ActionTargetType, NotifyEmailAction, NotifyEmailForm
+from sentry.models import GroupStatus, OrganizationMember, OrganizationMemberTeam, Rule
+from sentry.testutils import TestCase
+from sentry.testutils.cases import RuleTestCase
+from sentry.tasks.post_process import post_process_group
+from sentry.testutils.helpers.datetime import iso_format, before_now
+
+
+class NotifyEmailFormTest(TestCase):
+    TARGET_TYPE_KEY = "targetType"
+    TARGET_IDENTIFIER_KEY = "targetIdentifier"
+
+    def setUp(self):
+        super(NotifyEmailFormTest, self).setUp()
+        self.user = self.create_user(email="foo@example.com", is_active=True)
+        self.user2 = self.create_user(email="baz@example.com", is_active=True)
+        self.inactive_user = self.create_user(email="totallynotabot@149.com", is_active=False)
+
+        organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=organization)
+        self.team_not_in_project = self.create_team(organization=organization)
+
+        self.project = self.create_project(name="Test", teams=[self.team])
+        OrganizationMemberTeam.objects.create(
+            organizationmember=OrganizationMember.objects.get(
+                user=self.user, organization=organization
+            ),
+            team=self.team,
+        )
+        self.create_member(user=self.user2, organization=organization, teams=[self.team])
+        self.create_member(
+            user=self.inactive_user,
+            organization=organization,
+            teams=[self.team, self.team_not_in_project],
+        )
+
+    def form_from_json(self, json):
+        return NotifyEmailForm(self.project, json)
+
+    def form_from_values(self, target_type_value, target_id=None):
+        json = {self.TARGET_TYPE_KEY: target_type_value}
+        if target_id:
+            json[self.TARGET_IDENTIFIER_KEY] = target_id
+        return self.form_from_json(json)
+
+    def test_validate_empty_fail(self):
+        form = self.form_from_json({})
+        assert not form.is_valid()
+
+    def test_validate_none_fail(self):
+        form = self.form_from_json(None)
+        assert not form.is_valid()
+
+    def test_validate_malformed_json_fail(self):
+        form = self.form_from_json({"notTheRightK3yName": ActionTargetType.ISSUE_OWNERS.value})
+        assert not form.is_valid()
+
+    def test_validate_invalid_target_type_fail(self):
+        form = self.form_from_values("TheLegend27")
+        assert not form.is_valid()
+
+    def test_validate_issue_owners(self):
+        form = self.form_from_values(ActionTargetType.ISSUE_OWNERS.value)
+        assert form.is_valid()
+
+    def test_validate_team(self):
+        form = self.form_from_values(ActionTargetType.TEAM.value, self.team.id)
+        assert form.is_valid()
+
+    def test_validate_team_not_in_project_fail(self):
+        form = self.form_from_values(ActionTargetType.TEAM.value, self.team_not_in_project.id)
+        assert not form.is_valid()
+
+    def test_validate_user(self):
+        for u in [self.user, self.user2]:
+            form = self.form_from_values(ActionTargetType.MEMBER.value, u.id)
+            assert form.is_valid()
+
+    def test_validate_inactive_user_fail(self):
+        form = self.form_from_values(ActionTargetType.MEMBER.value, self.inactive_user)
+        assert not form.is_valid()
+
+
+class NotifyEmailTest(RuleTestCase):
+    rule_cls = NotifyEmailAction
+
+    def test_simple(self):
+        event = self.get_event()
+        rule = self.get_rule()
+
+        results = list(rule.after(event=event, state=self.get_state()))
+        assert len(results) == 1
+
+    def test_should_not_notify(self):
+        event = self.get_event()
+        group = event.group
+        group.update(status=GroupStatus.RESOLVED)
+
+        rule = self.get_rule()
+
+        results = list(rule.after(event=event, state=self.get_state()))
+        assert len(results) == 0
+
+    def test_full_integration(self):
+        one_min_ago = iso_format(before_now(minutes=1))
+        event = self.store_event(
+            data={
+                "message": "hello",
+                "exception": {"type": "Foo", "value": "uh oh"},
+                "level": "error",
+                "timestamp": one_min_ago,
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+        action_data = {
+            "id": "sentry.mail.actions.NotifyEmailAction",
+            "targetType": "Member",
+            "targetIdentifier": six.text_type(self.user.id),
+        }
+        condition_data = {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
+
+        Rule.objects.filter(project=event.project).delete()
+        Rule.objects.create(
+            project=event.project, data={"conditions": [condition_data], "actions": [action_data]}
+        )
+
+        with self.tasks():
+            post_process_group(
+                event=event, is_new=True, is_regression=False, is_new_group_environment=False
+            )
+
+        assert len(mail.outbox) == 1
+        sent = mail.outbox[0]
+        assert sent.to == [self.user.email]
+        assert "uh oh" in sent.subject


### PR DESCRIPTION
This continues the work to break up https://github.com/getsentry/sentry/pull/17571

In this pr we create the form and action to allow users to configure targetted issue alerts. This
access is gated via the `has_issue_alerts_targeting` flag on project, so no one will see this
feature until they're completely migrated.