### PR TITLE
fix(ui) Restore MenuLink href prop

### DIFF
--- a/docs-ui/components/dropdownControl.stories.js
+++ b/docs-ui/components/dropdownControl.stories.js
@@ -22,11 +22,9 @@ storiesOf('UI|Dropdowns/DropdownControl', module)
             menuOffset={menuOffset}
             alwaysRenderMenu={alwaysRenderMenu}
           >
-            <DropdownItem href="">Item</DropdownItem>
-            <DropdownItem href="">Item</DropdownItem>
-            <DropdownItem disabled href="">
-              Disabled Item
-            </DropdownItem>
+            <DropdownItem href="">Href Item</DropdownItem>
+            <DropdownItem to="">Router Item</DropdownItem>
+            <DropdownItem disabled>Disabled Item</DropdownItem>
             <DropdownItem divider />
             <DropdownItem isActive href="">
               Active Item

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -41,8 +41,16 @@ type MenuItemProps = {
    * Enable to provide custom button/contents via children
    */
   noAnchor?: boolean;
+  /**
+   * A router target destination
+   */
+  to?: Pick<Link['props'], 'to'>;
+  /**
+   * A server rendered URL.
+   */
+  href?: Pick<React.HTMLProps<HTMLAnchorElement>, 'href'>;
   className?: string;
-} & Partial<Pick<Link['props'], 'to'>>;
+};
 
 type Props = MenuItemProps & Omit<React.HTMLProps<HTMLLIElement>, keyof MenuItemProps>;
 
@@ -57,6 +65,7 @@ class MenuItem extends React.Component<Props> {
     isActive: PropTypes.bool,
     noAnchor: PropTypes.bool,
     to: PropTypes.string,
+    href: PropTypes.string,
     query: PropTypes.object,
     className: PropTypes.string,
   };
@@ -73,7 +82,7 @@ class MenuItem extends React.Component<Props> {
   };
 
   renderAnchor = (): React.ReactNode => {
-    const {to, title, disabled, isActive, children} = this.props;
+    const {to, href, title, disabled, isActive, children} = this.props;
     if (to) {
       return (
         <MenuLink
@@ -86,6 +95,20 @@ class MenuItem extends React.Component<Props> {
         >
           {children}
         </MenuLink>
+      );
+    }
+
+    if (href) {
+      return (
+        <MenuAnchor
+          href={href}
+          onClick={this.handleClick}
+          tabIndex={-1}
+          isActive={isActive}
+          disabled={disabled}
+        >
+          {children}
+        </MenuAnchor>
       );
     }
 
@@ -131,7 +154,7 @@ class MenuItem extends React.Component<Props> {
         divider={divider}
         noAnchor={noAnchor}
         header={header}
-        {...omit(props, ['title', 'onSelect', 'eventKey', 'to'])}
+        {...omit(props, ['href', 'title', 'onSelect', 'eventKey', 'to'])}
       >
         {renderChildren}
       </MenuListItem>
@@ -148,20 +171,33 @@ type MenuListItemProps = {
 } & React.HTMLProps<HTMLLIElement>;
 
 function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
+  const common = `
+    display: block;
+    padding: ${space(0.5)} ${space(2)};
+    &:focus {
+      outline: 'none';
+    }
+  `;
+
   if (props.disabled) {
     return `
-    color: ${props.theme.disabled};
-    background: transparent;
-    cursor: not-allowed;
+      ${common}
+      color: ${props.theme.disabled};
+      background: transparent;
+      cursor: not-allowed;
     `;
   }
+
   if (props.isActive) {
     return `
+      ${common}
       color: ${props.theme.white};
       background: ${props.theme.purple};
     `;
   }
+
   return `
+    ${common}
     color: ${props.theme.foreground};
 
     &:hover {
@@ -181,6 +217,12 @@ function getChildStyles(props: MenuListItemProps & {theme: Theme}) {
     }
   `;
 }
+
+const MenuAnchor = styled('a', {
+  shouldForwardProp: p => ['isActive', 'disabled'].includes(p) === false,
+})<MenuListItemProps>`
+  ${getListItemStyles}
+`;
 
 const MenuListItem = styled('li')<MenuListItemProps>`
   display: block;
@@ -206,23 +248,13 @@ background-color: ${p.theme.borderLight};
 `;
 
 const MenuTarget = styled('span')<MenuListItemProps>`
-  display: block;
-  padding: ${space(0.5)} ${space(2)};
-
   ${getListItemStyles}
 `;
 
 const MenuLink = styled(Link, {
   shouldForwardProp: p => ['isActive', 'disabled'].includes(p) === false,
 })<MenuListItemProps>`
-  display: block;
-  padding: ${space(0.5)} ${space(2)};
-
   ${getListItemStyles}
-
-  &:focus {
-    outline: none;
-  }
 `;
 
 export default MenuItem;

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -44,11 +44,12 @@ type MenuItemProps = {
   /**
    * A router target destination
    */
-  to?: Pick<Link['props'], 'to'>;
+  to?: Link['props']['to'];
   /**
    * A server rendered URL.
    */
-  href?: Pick<React.HTMLProps<HTMLAnchorElement>, 'href'>;
+  href?: string;
+
   className?: string;
 };
 

--- a/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
@@ -229,7 +229,7 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                     role="presentation"
                   >
                     <li
-                      className="css-1bgc7al-MenuListItem e80rkhl0"
+                      className="css-1bgc7al-MenuListItem e80rkhl1"
                       role="presentation"
                     >
                       Resolved In
@@ -244,7 +244,7 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                     role="presentation"
                   >
                     <li
-                      className="css-1wwymep-MenuListItem e80rkhl0"
+                      className="css-43835y-MenuListItem e80rkhl1"
                       role="presentation"
                     >
                       <Tooltip
@@ -712,7 +712,7 @@ exports[`ResolveActions without confirmation renders 1`] = `
                     role="presentation"
                   >
                     <li
-                      className="css-1bgc7al-MenuListItem e80rkhl0"
+                      className="css-1bgc7al-MenuListItem e80rkhl1"
                       role="presentation"
                     >
                       Resolved In
@@ -727,7 +727,7 @@ exports[`ResolveActions without confirmation renders 1`] = `
                     role="presentation"
                   >
                     <li
-                      className="css-1wwymep-MenuListItem e80rkhl0"
+                      className="css-43835y-MenuListItem e80rkhl1"
                       role="presentation"
                     >
                       <Tooltip


### PR DESCRIPTION
I had removed this prop as it was seemingly unused in sentry as the only use cases of it were trivially converted to `to` values. I missed important scenarios in getsentry though.

I've also done some cleanup on the CSS to reduce duplication more.