### PR TITLE
feat(mail): Only notify in `MailPlugin` if a project hasn't migrated to issue alert targeting.

### DIFF
--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -41,7 +41,10 @@ class MailPlugin(NotificationPlugin):
         return True
 
     def should_notify(self, group, event):
-        return self.mail_adapter.should_notify(group)
+        return (
+            not group.project.flags.has_issue_alerts_targeting
+            and self.mail_adapter.should_notify(group)
+        )
 
     def notify(self, notification, **kwargs):
         return self.mail_adapter.notify(


### PR DESCRIPTION
Once we've migrated we'll have split "Send to all legacy integrations" actions into "Send Mail To
Owners" and "Send to all legacy integrations". To prevent double sending here, we disable notifying
via the mail plugin once the migration is finished for a project.