### PR TITLE
feat(ui): Add Set up releases CTA

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
@@ -33,6 +33,7 @@ const Illustration = styled(({data, className}: IllustrationProps) => (
 const cards = [
   {
     title: t("You Haven't Set Up Releases!"),
+    disclaimer: t('(you made no releases in 30 days)'),
     message: t(
       'Releases provide additional context, with rich commits, so you know which errors were addressed and which were introduced in a release'
     ),

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLandingCard.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLandingCard.jsx
@@ -36,6 +36,7 @@ class ReleaseLandingCard extends React.Component {
 
         <StyledBox>
           <h3>{card.title}</h3>
+          {card.disclaimer && <Disclaimer>{card.disclaimer}</Disclaimer>}
           <p>{card.message}</p>
           {finalStep ? (
             <Button
@@ -91,6 +92,13 @@ const CardComponentContainer = styled('div')`
     width: 320px;
     max-height: 180px;
   }
+`;
+
+const Disclaimer = styled('small')`
+  display: block;
+  margin-top: -${space(3)};
+  margin-bottom: ${space(3)};
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 export default ReleaseLandingCard;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/healthChart.tsx
@@ -62,6 +62,9 @@ class HealthChart extends React.Component<Props> {
           },
         };
       case YAxis.SESSION_DURATION:
+        return {
+          scale: true,
+        };
       case YAxis.SESSIONS:
       case YAxis.USERS:
       default:

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -24,8 +24,10 @@ import ReleaseCard from 'app/views/releasesV2/list/releaseCard';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import {getRelativeSummary} from 'app/components/organizations/timeRangeSelector/utils';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
+import {defined} from 'app/utils';
 
 import ReleaseListSortOptions from './releaseListSortOptions';
+import ReleasePromo from './releasePromo';
 
 type RouteParams = {
   orgId: string;
@@ -137,7 +139,8 @@ class ReleasesList extends AsyncView<Props, State> {
   }
 
   renderEmptyMessage() {
-    const {location} = this.props;
+    const {location, organization} = this.props;
+    const {statsPeriod} = location.query;
     const searchQuery = this.getQuery();
 
     if (searchQuery && searchQuery.length) {
@@ -150,7 +153,7 @@ class ReleasesList extends AsyncView<Props, State> {
 
     if (this.getSort() !== 'date') {
       const relativePeriod = getRelativeSummary(
-        location.query.statsPeriod || DEFAULT_STATS_PERIOD
+        statsPeriod || DEFAULT_STATS_PERIOD
       ).toLowerCase();
 
       return (
@@ -160,7 +163,11 @@ class ReleasesList extends AsyncView<Props, State> {
       );
     }
 
-    return <EmptyStateWarning small>{t('There are no releases.')}</EmptyStateWarning>;
+    if (defined(statsPeriod) && statsPeriod !== '14d') {
+      return <EmptyStateWarning small>{t('There are no releases.')}</EmptyStateWarning>;
+    }
+
+    return <ReleasePromo orgSlug={organization.slug} />;
   }
 
   renderInnerBody() {

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releasePromo.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releasePromo.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import {t} from 'app/locale';
+import AsyncView from 'app/views/asyncView';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
+import {Panel} from 'app/components/panels';
+import ReleaseLanding from 'app/views/releases/list/releaseLanding';
+
+type Props = {
+  orgSlug: string;
+} & AsyncView['props'];
+
+class ReleasePromo extends AsyncView<Props> {
+  // if there are no releases in the last 30 days, we want to show releases promo
+  getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
+    const {orgSlug} = this.props;
+
+    const query = {
+      per_page: 1,
+      summaryStatsPeriod: '30d',
+    };
+
+    return [['releases', `/organizations/${orgSlug}/releases/`, {query}]];
+  }
+
+  renderBody() {
+    if (this.state.releases.length === 0) {
+      return (
+        <Panel>
+          <ReleaseLanding />
+        </Panel>
+      );
+    }
+
+    return <EmptyStateWarning small>{t('There are no releases.')}</EmptyStateWarning>;
+  }
+}
+
+export default ReleasePromo;

--- a/tests/js/spec/views/releasesV2/list/index.spec.jsx
+++ b/tests/js/spec/views/releasesV2/list/index.spec.jsx
@@ -70,6 +70,14 @@ describe('ReleasesV2List', function() {
       routerContext
     );
     expect(wrapper.find('StyledPanel')).toHaveLength(0);
+    expect(wrapper.find('ReleasePromo').text()).toContain("You Haven't Set Up Releases!");
+
+    location = {query: {statsPeriod: '30d'}};
+    wrapper = mountWithTheme(
+      <ReleaseList {...props} location={location} />,
+      routerContext
+    );
+    expect(wrapper.find('StyledPanel')).toHaveLength(0);
     expect(wrapper.find('EmptyMessage').text()).toEqual('There are no releases.');
 
     location = {query: {query: 'abc'}};


### PR DESCRIPTION
If there are no releases and no filters active, we check if there were no releases in the last 30 days and if not, then we show releases promotion call to action component.