### PR TITLE
feat(mail): Move `MailPlugin.notify_about_activity` into `MailAdapter`

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -421,3 +421,17 @@ class MailAdapter(object):
                 context=context,
                 send_to=[user_id],
             )
+
+    def notify_about_activity(self, activity):
+        # TODO: We should move these into the `mail` module.
+        from sentry.plugins.sentry_mail.activity import emails
+
+        email_cls = emails.get(activity.type)
+        if not email_cls:
+            logger.debug(
+                u"No email associated with activity type `{}`".format(activity.get_type_display())
+            )
+            return
+
+        email = email_cls(activity)
+        email.send()

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -12,8 +12,6 @@ from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 from sentry.utils.linksign import generate_signed_link
 
-from .activity import emails
-
 logger = logging.getLogger(__name__)
 
 
@@ -57,15 +55,10 @@ class MailPlugin(NotificationPlugin):
         )
 
     def notify_about_activity(self, activity):
-        email_cls = emails.get(activity.type)
-        if not email_cls:
-            logger.debug(
-                u"No email associated with activity type `{}`".format(activity.get_type_display())
-            )
+        if activity.project.flags.has_issue_alerts_targeting:
             return
 
-        email = email_cls(activity)
-        email.send()
+        return self.mail_adapter.notify_about_activity(activity)
 
     def handle_user_report(self, payload, project, **kwargs):
         from sentry.models import Group, GroupSubscription, GroupSubscriptionReason

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_activity_notifiers(project):
+    from sentry.mail.adapter import MailAdapter
     from sentry.plugins.bases.notify import NotificationPlugin
     from sentry.plugins.base import plugins
 
@@ -20,6 +21,9 @@ def get_activity_notifiers(project):
     for plugin in plugins.for_project(project, version=2):
         for notifier in safe_execute(plugin.get_notifiers, _with_transaction=False) or ():
             results.append(notifier)
+
+    if project.flags.has_issue_alerts_targeting:
+        results.append(MailAdapter())
 
     return results
 


### PR DESCRIPTION
We're now close to entirely moving over to `MailAdapter`. To ensure that activity mail doesn't break
once the plugin is disabled we move `notify_about_activity` to `MailAdapter` as well, so that it'll
continue working. The migration will disable these notifications for users in projects that have
disabled `MailPlugin`, so it shouldn't cause extra noise.

I'll likely move the activity mails into `mail/` in another pr as well.