### PR TITLE
fix(async-csv): Reset the export button when the payload changes

### DIFF
--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import isEqual from 'lodash/isEqual';
 import React from 'react';
 
 import {Client} from 'app/api';
@@ -35,8 +36,22 @@ type State = {
 };
 
 class DataExport extends React.Component<Props, State> {
-  state: State = {
-    inProgress: false,
+  state = this.initialState;
+
+  componentDidUpdate({payload: prevPayload}) {
+    const {payload} = this.props;
+    if (!isEqual(prevPayload, payload)) this.resetState();
+  }
+
+  get initialState() {
+    return {
+      inProgress: false,
+      dataExportId: undefined,
+    };
+  }
+
+  resetState = () => {
+    this.setState(this.initialState);
   };
 
   startDataExport = async () => {

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -97,4 +97,25 @@ describe('DataExport', function() {
       dataExportId: 721,
     });
   });
+
+  it('should reset the state when receiving a new payload', async function() {
+    const url = `/organizations/${mockAuthorizedOrg.slug}/data-export/`;
+    MockApiClient.addMockResponse({
+      url,
+      method: 'POST',
+      body: {id: 721},
+    });
+    const wrapper = mountWithTheme(
+      <WrappedDataExport payload={mockPayload} />,
+      mockRouterContext(mockAuthorizedOrg)
+    );
+    wrapper.find('button').simulate('click');
+    await tick();
+    wrapper.update();
+    expect(wrapper.find(DataExport).state('inProgress')).toEqual(true);
+    expect(wrapper.find(DataExport).state('dataExportId')).toEqual(721);
+    wrapper.setProps({payload: {...mockPayload, queryType: 'Discover'}});
+    expect(wrapper.find(DataExport).state('inProgress')).toEqual(false);
+    expect(wrapper.find(DataExport).state('dataExportId')).toBeUndefined();
+  });
 });


### PR DESCRIPTION
When looking at datasets, if the payload which gets the data changes, the user should be allowed to start a new export (i.e. not see this:)
![image](https://user-images.githubusercontent.com/35509934/79491272-32d43980-7fec-11ea-8aa2-1af8172b4a58.png)

So this PR will reset the component if the data changes meaning that if the user:
 - changes date range,
 - changes the project filter (from the global header),
 - or changes columns in discover (see https://github.com/getsentry/sentry/pull/17603)

the button will reset back to the default:
![image](https://user-images.githubusercontent.com/35509934/79492488-11744d00-7fee-11ea-9964-d920ddc37247.png)

Also there's a new test for this behavior!