### PR TITLE
chore: Remove josh as codeowner for .travis.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,6 @@
 setup.py            @getsentry/releases
 setup.cfg           @getsentry/releases
 requirements*.txt   @joshuarli
-.travis.yml         @joshuarli
 
 # Dev
 /config/                    @joshuarli


### PR DESCRIPTION
We don't want this file blocked on only @joshuarli's approval, so removing the codeowners for now. We'll
likely add in teams for this later.