### PR TITLE
feat(mail): Move `MailPlugin.handle_signal` and `handle_user_report` to `MailAdapter`.

### DIFF
--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -4,13 +4,9 @@ import logging
 
 import sentry
 
-from django.utils.encoding import force_text
-
 from sentry.mail.adapter import MailAdapter, ActionTargetType
 from sentry.plugins.bases.notify import NotificationPlugin
-from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
-from sentry.utils.linksign import generate_signed_link
 
 logger = logging.getLogger(__name__)
 
@@ -60,81 +56,11 @@ class MailPlugin(NotificationPlugin):
 
         return self.mail_adapter.notify_about_activity(activity)
 
-    def handle_user_report(self, payload, project, **kwargs):
-        from sentry.models import Group, GroupSubscription, GroupSubscriptionReason
-
-        group = Group.objects.get(id=payload["report"]["issue"]["id"])
-
-        participants = GroupSubscription.objects.get_participants(group=group)
-
-        if not participants:
-            return
-
-        org = group.organization
-        enhanced_privacy = org.flags.enhanced_privacy
-
-        context = {
-            "project": project,
-            "project_link": absolute_uri(
-                u"/{}/{}/".format(project.organization.slug, project.slug)
-            ),
-            "issue_link": absolute_uri(
-                u"/{}/{}/issues/{}/".format(
-                    project.organization.slug, project.slug, payload["report"]["issue"]["id"]
-                )
-            ),
-            # TODO(dcramer): we dont have permalinks to feedback yet
-            "link": absolute_uri(
-                u"/{}/{}/issues/{}/feedback/".format(
-                    project.organization.slug, project.slug, payload["report"]["issue"]["id"]
-                )
-            ),
-            "group": group,
-            "report": payload["report"],
-            "enhanced_privacy": enhanced_privacy,
-        }
-
-        subject_prefix = self.mail_adapter._build_subject_prefix(project)
-        subject = force_text(
-            u"{}{} - New Feedback from {}".format(
-                subject_prefix, group.qualified_short_id, payload["report"]["name"]
-            )
-        )
-
-        headers = {"X-Sentry-Project": project.slug}
-
-        # TODO(dcramer): this is copypasta'd from activity notifications
-        # and while it'd be nice to re-use all of that, they are currently
-        # coupled to <Activity> instances which makes this tough
-        for user, reason in participants.items():
-            context.update(
-                {
-                    "reason": GroupSubscriptionReason.descriptions.get(
-                        reason, "are subscribed to this issue"
-                    ),
-                    "unsubscribe_link": generate_signed_link(
-                        user.id,
-                        "sentry-account-email-unsubscribe-issue",
-                        kwargs={"issue_id": group.id},
-                    ),
-                }
-            )
-
-            msg = MessageBuilder(
-                subject=subject,
-                template="sentry/emails/activity/new-user-feedback.txt",
-                html_template="sentry/emails/activity/new-user-feedback.html",
-                headers=headers,
-                type="notify.user-report",
-                context=context,
-                reference=group,
-            )
-            msg.add_users([user.id], project=project)
-            msg.send_async()
-
     def handle_signal(self, name, payload, **kwargs):
         if name == "user-reports.created":
-            self.handle_user_report(payload, **kwargs)
+            project = kwargs.get("project")
+            if project and not project.flags.has_issue_alerts_targeting:
+                self.mail_adapter.handle_signal(name, payload, **kwargs)
 
     def can_configure_for_project(self, project):
         return (

--- a/src/sentry/tasks/signals.py
+++ b/src/sentry/tasks/signals.py
@@ -7,6 +7,7 @@ from sentry.utils.safe import safe_execute
 
 @instrumented_task(name="sentry.tasks.signal")
 def signal(name, payload, project_id=None, **kwargs):
+    from sentry.mail.adapter import MailAdapter
     from sentry.models import Project
 
     if project_id is not None:
@@ -19,3 +20,6 @@ def signal(name, payload, project_id=None, **kwargs):
 
     for plugin in plugins.for_project(project, version=2):
         safe_execute(plugin.handle_signal, name=name, payload=payload, project=project)
+
+    if project and project.flags.has_issue_alerts_targeting:
+        safe_execute(MailAdapter().handle_signal, name=name, payload=payload, project=project)


### PR DESCRIPTION
We're now close to entirely moving over to MailAdapter. To ensure that user report mail doesn't
break once the plugin is disabled we move `handle_signal` and `handle_user_report` to `MailAdapter`
as well, so that it'll continue working. The migration will disable these notifications for users
in projects that have disabled MailPlugin, so it shouldn't cause extra noise.