### PR TITLE
fix(dates): Improve statsPeriod coercion on parsePeriodToHours() and getParams()

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/getParams.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/getParams.tsx
@@ -5,7 +5,7 @@ import {defined} from 'app/utils';
 
 const STATS_PERIOD_PATTERN = '^(\\d+)([hdmsw])?$';
 
-function parseStatsPeriod(input: string) {
+export function parseStatsPeriod(input: string) {
   const result = input.match(STATS_PERIOD_PATTERN);
 
   if (!result) {
@@ -21,6 +21,21 @@ function parseStatsPeriod(input: string) {
     periodLength = 's';
   }
 
+  return {
+    period,
+    periodLength,
+  };
+}
+
+function coerceStatsPeriod(input: string) {
+  const result = parseStatsPeriod(input);
+
+  if (!result) {
+    return undefined;
+  }
+
+  const {period, periodLength} = result;
+
   return `${period}${periodLength}`;
 }
 
@@ -32,15 +47,15 @@ function getStatsPeriodValue(
       return undefined;
     }
 
-    const result = maybe.find(parseStatsPeriod);
+    const result = maybe.find(coerceStatsPeriod);
     if (!result) {
       return undefined;
     }
-    return parseStatsPeriod(result);
+    return coerceStatsPeriod(result);
   }
 
   if (typeof maybe === 'string') {
-    return parseStatsPeriod(maybe);
+    return coerceStatsPeriod(maybe);
   }
 
   return undefined;

--- a/src/sentry/static/sentry/app/utils/dates.tsx
+++ b/src/sentry/static/sentry/app/utils/dates.tsx
@@ -186,7 +186,15 @@ export function intervalToMilliseconds(interval: string): number {
  * and converts it into hours
  */
 export function parsePeriodToHours(str: string): number {
-  const [, period, periodLength] = str.match(/([0-9]+)([smhdw])/);
+  const result = str.match(/([0-9]+)([smhdw])/);
+
+  if (!result) {
+    return -1;
+  }
+
+  const period = result[1];
+  const periodLength = result[2];
+
   const periodNumber = parseInt(period, 10);
 
   switch (periodLength) {

--- a/src/sentry/static/sentry/app/utils/dates.tsx
+++ b/src/sentry/static/sentry/app/utils/dates.tsx
@@ -1,6 +1,7 @@
 import moment from 'moment';
 
 import ConfigStore from 'app/stores/configStore';
+import {parseStatsPeriod} from 'app/components/organizations/globalSelectionHeader/getParams';
 
 // TODO(billy): Move to TimeRangeSelector specific utils
 export const DEFAULT_DAY_START_TIME = '00:00:00';
@@ -186,14 +187,13 @@ export function intervalToMilliseconds(interval: string): number {
  * and converts it into hours
  */
 export function parsePeriodToHours(str: string): number {
-  const result = str.match(/([0-9]+)([smhdw])/);
+  const result = parseStatsPeriod(str);
 
   if (!result) {
     return -1;
   }
 
-  const period = result[1];
-  const periodLength = result[2];
+  const {period, periodLength} = result;
 
   const periodNumber = parseInt(period, 10);
 

--- a/tests/js/spec/components/organizations/getParams.spec.jsx
+++ b/tests/js/spec/components/organizations/getParams.spec.jsx
@@ -1,4 +1,7 @@
-import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import {
+  getParams,
+  parseStatsPeriod,
+} from 'app/components/organizations/globalSelectionHeader/getParams';
 
 describe('getParams', function() {
   it('should return default statsPeriod if it is not provided or is invalid', function() {
@@ -110,5 +113,22 @@ describe('getParams', function() {
 
     expect(getParams({utc: null})).toEqual({statsPeriod: '14d'});
     expect(getParams({utc: undefined})).toEqual({statsPeriod: '14d'});
+  });
+});
+
+describe('parseStatsPeriod', function() {
+  it('should parse statsPeriod', function() {
+    expect(parseStatsPeriod('5s')).toEqual({period: '5', periodLength: 's'});
+    expect(parseStatsPeriod('11h')).toEqual({period: '11', periodLength: 'h'});
+    expect(parseStatsPeriod('14d')).toEqual({period: '14', periodLength: 'd'});
+    expect(parseStatsPeriod('24w')).toEqual({period: '24', periodLength: 'w'});
+    expect(parseStatsPeriod('42m')).toEqual({period: '42', periodLength: 'm'});
+  });
+
+  it('should return default statsPeriod if it is not provided or is invalid', function() {
+    expect(parseStatsPeriod('invalid')).toEqual(undefined);
+    expect(parseStatsPeriod('24f')).toEqual(undefined);
+    expect(parseStatsPeriod('')).toEqual(undefined);
+    expect(parseStatsPeriod('24')).toEqual({period: '24', periodLength: 's'});
   });
 });

--- a/tests/js/spec/components/organizations/getParams.spec.jsx
+++ b/tests/js/spec/components/organizations/getParams.spec.jsx
@@ -7,6 +7,7 @@ describe('getParams', function() {
     expect(getParams({statsPeriod: null})).toEqual({statsPeriod: '14d'});
     expect(getParams({statsPeriod: undefined})).toEqual({statsPeriod: '14d'});
     expect(getParams({statsPeriod: '24f'})).toEqual({statsPeriod: '14d'});
+    expect(getParams({statsPeriod: '24'})).toEqual({statsPeriod: '24s'});
   });
 
   it('should parse statsPeriod', function() {

--- a/tests/js/spec/utils/dates.spec.jsx
+++ b/tests/js/spec/utils/dates.spec.jsx
@@ -47,7 +47,7 @@ describe('utils.dates', function() {
     });
 
     it('handle invalid statsPeriod', function() {
-      expect(parsePeriodToHours('24')).toBe(-1);
+      expect(parsePeriodToHours('24')).toBe(24 / 3600);
       expect(parsePeriodToHours('')).toBe(-1);
       expect(parsePeriodToHours('24x')).toBe(-1);
     });

--- a/tests/js/spec/utils/dates.spec.jsx
+++ b/tests/js/spec/utils/dates.spec.jsx
@@ -45,5 +45,11 @@ describe('utils.dates', function() {
       expect(parsePeriodToHours('1d')).toBe(24);
       expect(parsePeriodToHours('2w')).toBe(336);
     });
+
+    it('handle invalid statsPeriod', function() {
+      expect(parsePeriodToHours('24')).toBe(-1);
+      expect(parsePeriodToHours('')).toBe(-1);
+      expect(parsePeriodToHours('24x')).toBe(-1);
+    });
   });
 });


### PR DESCRIPTION
 `parsePeriodToHours()` crashes on invalid `statsPeriod` query strings which can crash certain parts of the app. 

I added `parseStatsPeriod()` which can coerce `statsPeriod` similarly to how they're coerced on the django side here https://github.com/getsentry/sentry/blob/93f8f4febbd16a6dac47ec551dd1068811f12c44/src/sentry/utils/dates.py#L100-L101

If the units is omitted, it's assumed to be `seconds`. 

Both `parsePeriodToHours()` and `getParams()` now have this coercion behaviour for a given `statsPeriod`.

------

Fixes JAVASCRIPT-221B