### PR TITLE
feat(ui): Add additional states for SpanDetail

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -5,6 +5,7 @@ import map from 'lodash/map';
 import {t} from 'app/locale';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import DateTime from 'app/components/dateTime';
+import LoadingIndicator from 'app/components/loadingIndicator';
 import Pills from 'app/components/pills';
 import Pill from 'app/components/pill';
 import space from 'app/styles/space';
@@ -96,8 +97,18 @@ class SpanDetail extends React.Component<Props, State> {
   }
 
   renderTraversalButton(): React.ReactNode {
-    if (!this.state.transactionResults || this.state.transactionResults.length <= 0) {
-      return null;
+    if (!this.state.transactionResults) {
+      // TODO: Amend size to use theme when we evetually refactor LoadingIndicator
+      // 12px is consistent with theme.iconSizes['xs'] but theme returns a string.
+      return <LoadingIndicator size={12} />;
+    }
+
+    if (this.state.transactionResults.length <= 0) {
+      return (
+        <StyledButton size="xsmall" disabled>
+          {t('No Child')}
+        </StyledButton>
+      );
     }
 
     const {span, orgId, trace, eventView} = this.props;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -53,11 +53,7 @@ class SpanDetail extends React.Component<Props, State> {
 
     this.fetchSpanDescendents(span.span_id, span.trace_id)
       .then(response => {
-        if (
-          !response.data ||
-          !Array.isArray(response.data) ||
-          response.data.length <= 0
-        ) {
+        if (!response.data || !Array.isArray(response.data)) {
           return;
         }
 
@@ -100,13 +96,17 @@ class SpanDetail extends React.Component<Props, State> {
     if (!this.state.transactionResults) {
       // TODO: Amend size to use theme when we evetually refactor LoadingIndicator
       // 12px is consistent with theme.iconSizes['xs'] but theme returns a string.
-      return <LoadingIndicator size={12} />;
+      return (
+        <StyledButton size="xsmall" disabled>
+          <StyledLoadingIndicator size={12} />
+        </StyledButton>
+      );
     }
 
     if (this.state.transactionResults.length <= 0) {
       return (
         <StyledButton size="xsmall" disabled>
-          {t('No Child')}
+          {t('No Children')}
         </StyledButton>
       );
     }
@@ -289,6 +289,13 @@ const SpanDetailContainer = styled('div')`
 
 const ValueTd = styled('td')`
   position: relative;
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  display: flex;
+  align-items: center;
+  height: ${space(2)};
+  margin: 0;
 `;
 
 const Row = ({


### PR DESCRIPTION
It wasn't immediately obvious that we need to wait for some request to be completed before we know if a span has children.

This PR adds:
* a spinner while loading <img width="836" alt="Screen Shot 2020-04-17 at 12 53 08 PM" src="https://user-images.githubusercontent.com/1748388/79609802-3929ea80-80ac-11ea-95ba-1231d930c110.png">
* a disabled button for "no children" <img width="835" alt="Screen Shot 2020-04-17 at 12 52 28 PM" src="https://user-images.githubusercontent.com/1748388/79609798-36c79080-80ac-11ea-96e8-9db0d0ee219f.png">




