### PR TITLE
feat(ui): Remove release series in release charts

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/healthChart.tsx
@@ -14,7 +14,6 @@ import {YAxis} from './releaseChartControls';
 type Props = {
   reloading: boolean;
   utc: boolean;
-  releaseSeries: Series[];
   timeseriesData: Series[];
   zoomRenderProps: any;
   yAxis: YAxis;
@@ -26,10 +25,7 @@ class HealthChart extends React.Component<Props> {
       return false;
     }
 
-    if (
-      isEqual(this.props.timeseriesData, nextProps.timeseriesData) &&
-      isEqual(this.props.releaseSeries, nextProps.releaseSeries)
-    ) {
+    if (isEqual(this.props.timeseriesData, nextProps.timeseriesData)) {
       return false;
     }
 
@@ -88,7 +84,7 @@ class HealthChart extends React.Component<Props> {
   };
 
   render() {
-    const {utc, releaseSeries, timeseriesData, zoomRenderProps} = this.props;
+    const {utc, timeseriesData, zoomRenderProps} = this.props;
     const Chart = this.getChart();
 
     const legend = {
@@ -113,7 +109,7 @@ class HealthChart extends React.Component<Props> {
         legend={legend}
         utc={utc}
         {...zoomRenderProps}
-        series={[...timeseriesData, ...releaseSeries]}
+        series={timeseriesData}
         isGroupedByDate
         seriesOptions={{
           showSymbol: false,

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/healthChartContainer.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/healthChartContainer.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import * as ReactRouter from 'react-router';
 
 import ChartZoom from 'app/components/charts/chartZoom';
-import ReleaseSeries from 'app/components/charts/releaseSeries';
 import {IconWarning} from 'app/icons';
 import theme from 'app/utils/theme';
 import {GlobalSelection} from 'app/types';
@@ -32,41 +31,36 @@ const ReleaseChartContainer = ({
   yAxis,
   router,
 }: Props) => {
-  const {datetime, projects} = selection;
+  const {datetime} = selection;
   const {utc, period, start, end} = datetime;
 
   return (
     <React.Fragment>
       <ChartZoom router={router} period={period} utc={utc} start={start} end={end}>
-        {zoomRenderProps => (
-          <ReleaseSeries utc={utc} projects={projects}>
-            {({releaseSeries}) => {
-              if (errored) {
-                return (
-                  <ErrorPanel>
-                    <IconWarning color={theme.gray2} size="lg" />
-                  </ErrorPanel>
-                );
-              }
+        {zoomRenderProps => {
+          if (errored) {
+            return (
+              <ErrorPanel>
+                <IconWarning color={theme.gray2} size="lg" />
+              </ErrorPanel>
+            );
+          }
 
-              return (
-                <TransitionChart loading={loading} reloading={reloading}>
-                  <React.Fragment>
-                    <TransparentLoadingMask visible={reloading} />
-                    <HealthChart
-                      utc={utc}
-                      releaseSeries={releaseSeries}
-                      timeseriesData={chartData}
-                      zoomRenderProps={zoomRenderProps}
-                      reloading={reloading}
-                      yAxis={yAxis}
-                    />
-                  </React.Fragment>
-                </TransitionChart>
-              );
-            }}
-          </ReleaseSeries>
-        )}
+          return (
+            <TransitionChart loading={loading} reloading={reloading}>
+              <React.Fragment>
+                <TransparentLoadingMask visible={reloading} />
+                <HealthChart
+                  utc={utc}
+                  timeseriesData={chartData}
+                  zoomRenderProps={zoomRenderProps}
+                  reloading={reloading}
+                  yAxis={yAxis}
+                />
+              </React.Fragment>
+            </TransitionChart>
+          );
+        }}
       </ChartZoom>
     </React.Fragment>
   );

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/healthChartContainer.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/healthChartContainer.tsx
@@ -48,16 +48,14 @@ const ReleaseChartContainer = ({
 
           return (
             <TransitionChart loading={loading} reloading={reloading}>
-              <React.Fragment>
-                <TransparentLoadingMask visible={reloading} />
-                <HealthChart
-                  utc={utc}
-                  timeseriesData={chartData}
-                  zoomRenderProps={zoomRenderProps}
-                  reloading={reloading}
-                  yAxis={yAxis}
-                />
-              </React.Fragment>
+              <TransparentLoadingMask visible={reloading} />
+              <HealthChart
+                utc={utc}
+                timeseriesData={chartData}
+                zoomRenderProps={zoomRenderProps}
+                reloading={reloading}
+                yAxis={yAxis}
+              />
             </TransitionChart>
           );
         }}

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/index.tsx
@@ -64,6 +64,7 @@ const ReleaseChartContainer = ({
           period={period}
           utc={utc}
           disablePrevious
+          disableReleases
           currentSeriesName={t('Events')}
         />
       ) : (


### PR DESCRIPTION
We decided, that release series in release charts don't provide any useful context in this case, so we decided to remove them.

Before:
![image](https://user-images.githubusercontent.com/9060071/79563777-b73ac100-80ad-11ea-9c4b-9b2341ff2926.png)


After:
![image](https://user-images.githubusercontent.com/9060071/79563729-a12d0080-80ad-11ea-87ae-9911ae364efa.png)
