### PR TITLE
ref(discover) Rename discover query wrapper component

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/discoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/discoverQuery.tsx
@@ -28,7 +28,7 @@ type State = {
   tableFetchID: symbol | undefined;
 } & ChildrenProps;
 
-class EventsV2 extends React.Component<Props, State> {
+class DiscoverQuery extends React.Component<Props, State> {
   static defaultProps = {
     keyTransactions: false,
   };
@@ -133,4 +133,4 @@ class EventsV2 extends React.Component<Props, State> {
   }
 }
 
-export default withApi(EventsV2);
+export default withApi(DiscoverQuery);

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -20,7 +20,7 @@ import HeaderCell from 'app/views/eventsV2/table/headerCell';
 import {decodeScalar} from 'app/views/eventsV2/utils';
 import withProjects from 'app/utils/withProjects';
 import SearchBar from 'app/components/searchBar';
-import EventsV2 from 'app/utils/discover/eventsv2';
+import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {getAggregateAlias} from 'app/utils/discover/fields';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
@@ -245,7 +245,7 @@ class Table extends React.Component<Props> {
     const columnOrder = eventView.getColumns();
 
     return (
-      <EventsV2
+      <DiscoverQuery
         eventView={eventView}
         orgSlug={organization.slug}
         location={location}
@@ -271,7 +271,7 @@ class Table extends React.Component<Props> {
             <Pagination pageLinks={pageLinks} />
           </div>
         )}
-      </EventsV2>
+      </DiscoverQuery>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -7,7 +7,7 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 import EventView from 'app/utils/discover/eventView';
 import {ContentBox, HeaderBox} from 'app/views/eventsV2/styles';
 import Tags from 'app/views/eventsV2/tags';
-import EventsV2 from 'app/utils/discover/eventsv2';
+import DiscoverQuery from 'app/utils/discover/discoverQuery';
 
 import SummaryContentTable from './table';
 import Breadcrumb from './breadcrumb';
@@ -57,7 +57,7 @@ class SummaryContent extends React.Component<Props> {
           <StyledTitleHeader>{transactionName}</StyledTitleHeader>
         </HeaderBox>
         <ContentBox>
-          <EventsV2
+          <DiscoverQuery
             location={location}
             eventView={eventView}
             orgSlug={organization.slug}
@@ -75,7 +75,7 @@ class SummaryContent extends React.Component<Props> {
                 totalValues={totalValues}
               />
             )}
-          </EventsV2>
+          </DiscoverQuery>
           <Side>
             <UserStats
               organization={organization}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -8,7 +8,7 @@ import EventView from 'app/utils/discover/eventView';
 import {t} from 'app/locale';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 import {assert} from 'app/types/utils';
-import EventsV2 from 'app/utils/discover/eventsv2';
+import DiscoverQuery from 'app/utils/discover/discoverQuery';
 
 type Props = {
   location: Location;
@@ -42,7 +42,7 @@ class UserStats extends React.Component<Props> {
     const eventView = this.generateUserStatsEventView(this.props.eventView);
 
     return (
-      <EventsV2
+      <DiscoverQuery
         eventView={eventView}
         orgSlug={organization.slug}
         location={location}
@@ -88,7 +88,7 @@ class UserStats extends React.Component<Props> {
             </Container>
           );
         }}
-      </EventsV2>
+      </DiscoverQuery>
     );
   }
 }


### PR DESCRIPTION
Use a name that will better matches how we refer to the feature elsewhere in the product. EventsV2 is an unfortunate name that we'll be removing soonish, but this was an easy win now.