### PR TITLE
ref(ui) Move discover 2 and performance views to lightweight org

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1496,6 +1496,92 @@ function routes() {
           component={errorHandler(ProjectEventRedirect)}
         />
 
+        {/*
+        TODO(mark) Long term this /queries route should go away and /discover should be the
+        canoncial route for discover2. Also the duplication in route wrapping
+        here should go away.
+        */}
+        <Route
+          path="/organizations/:orgId/discover/queries/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "DiscoverV2Landing" */ 'app/views/eventsV2/landing'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
+        <Route
+          path="/organizations/:orgId/discover/results/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "DiscoverV2Results" */ 'app/views/eventsV2/results'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
+        <Route
+          path="/organizations/:orgId/discover/:eventSlug/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "DiscoverV2Details" */ 'app/views/eventsV2/eventDetails'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
+        <Route
+          path="/organizations/:orgId/performance/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "PerformanceContainer" */ 'app/views/performance')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "PerformanceLanding" */ 'app/views/performance/landing'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
+        <Route
+          path="/organizations/:orgId/performance/summary/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "PerformanceContainer" */ 'app/views/performance')
+          }
+          component={errorHandler(LazyLoad)}
+        >
+          <IndexRoute
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "PerformanceTransactionSummary" */ 'app/views/performance/transactionSummary'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
+
         {/* Admin/manage routes */}
         <Route
           path="/manage/"
@@ -1645,96 +1731,6 @@ function routes() {
           >
             <Redirect path="saved/" to="/organizations/:orgId/discover/" />
             <Route path="saved/:savedQueryId/" />
-          </Route>
-
-          {/*
-          TODO(mark) Long term this /queries route should go away and /discover should be the
-          canoncial route for discover2. Also the duplication in route wrapping
-          here should go away.
-          */}
-          <Route
-            path="/organizations/:orgId/discover/queries/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
-            }
-            component={errorHandler(LazyLoad)}
-          >
-            <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "DiscoverV2Landing" */ 'app/views/eventsV2/landing'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-          </Route>
-          <Route
-            path="/organizations/:orgId/discover/results/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
-            }
-            component={errorHandler(LazyLoad)}
-          >
-            <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "DiscoverV2Results" */ 'app/views/eventsV2/results'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-          </Route>
-          <Route
-            path="/organizations/:orgId/discover/:eventSlug/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
-            }
-            component={errorHandler(LazyLoad)}
-          >
-            <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "DiscoverV2Details" */ 'app/views/eventsV2/eventDetails'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-          </Route>
-          <Route
-            path="/organizations/:orgId/performance/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          >
-            <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "PerformanceLanding" */ 'app/views/performance/landing'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-          </Route>
-          <Route
-            path="/organizations/:orgId/performance/summary/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          >
-            <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "PerformanceTransactionSummary" */ 'app/views/performance/transactionSummary'
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
           </Route>
 
           <Route

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/index.tsx
@@ -8,7 +8,7 @@ import {Organization} from 'app/types';
 import {PageContent} from 'app/styles/organization';
 import {t} from 'app/locale';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
-import NoProjectMessage from 'app/components/noProjectMessage';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import SentryTypes from 'app/sentryTypes';
 import withOrganization from 'app/utils/withOrganization';
@@ -60,7 +60,7 @@ class EventDetails extends React.Component<Props> {
         <React.Fragment>
           <GlobalSelectionHeader organization={organization} />
           <StyledPageContent>
-            <NoProjectMessage organization={organization}>
+            <LightWeightNoProjectMessage organization={organization}>
               <EventDetailsContent
                 organization={organization}
                 location={location}
@@ -68,7 +68,7 @@ class EventDetails extends React.Component<Props> {
                 eventView={eventView}
                 eventSlug={this.getEventSlug()}
               />
-            </NoProjectMessage>
+            </LightWeightNoProjectMessage>
           </StyledPageContent>
         </React.Fragment>
       </SentryDocumentTitle>

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -17,7 +17,7 @@ import Banner from 'app/components/banner';
 import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
 import Feature from 'app/components/acl/feature';
-import NoProjectMessage from 'app/components/noProjectMessage';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SearchBar from 'app/components/searchBar';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import SentryTypes from 'app/sentryTypes';
@@ -267,7 +267,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
   }
 
   render() {
-    let body;
+    let body: React.ReactNode;
     const {location, organization} = this.props;
     const {loading, savedQueries, savedQueriesPageLinks, error} = this.state;
     if (loading) {
@@ -308,7 +308,9 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
       >
         <SentryDocumentTitle title={t('Discover')} objSlug={organization.slug}>
           <StyledPageContent>
-            <NoProjectMessage organization={organization}>{body}</NoProjectMessage>
+            <LightWeightNoProjectMessage organization={organization}>
+              {body}
+            </LightWeightNoProjectMessage>
           </StyledPageContent>
         </SentryDocumentTitle>
       </Feature>

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -13,7 +13,7 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 import {fetchTotalCount} from 'app/actionCreators/events';
 import {loadOrganizationTags} from 'app/actionCreators/tags';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
-import NoProjectMessage from 'app/components/noProjectMessage';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import space from 'app/styles/space';
 import SearchBar from 'app/views/events/searchBar';
@@ -224,7 +224,7 @@ class Results extends React.Component<Props, State> {
         <React.Fragment>
           <GlobalSelectionHeader organization={organization} />
           <StyledPageContent>
-            <NoProjectMessage organization={organization}>
+            <LightWeightNoProjectMessage organization={organization}>
               <ResultsHeader
                 organization={organization}
                 location={location}
@@ -261,7 +261,7 @@ class Results extends React.Component<Props, State> {
                 </Main>
                 <Side eventView={eventView}>{this.renderTagsTable()}</Side>
               </ContentBox>
-            </NoProjectMessage>
+            </LightWeightNoProjectMessage>
           </StyledPageContent>
         </React.Fragment>
       </SentryDocumentTitle>

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -9,7 +9,7 @@ import withOrganization from 'app/utils/withOrganization';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import {PageContent} from 'app/styles/organization';
-import NoProjectMessage from 'app/components/noProjectMessage';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import Alert from 'app/components/alert';
 import EventView from 'app/utils/discover/eventView';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
@@ -161,7 +161,7 @@ class PerformanceLanding extends React.Component<Props, State> {
             allowClearTimeRange={this.allowClearTimeRange()}
           />
           <PageContent>
-            <NoProjectMessage organization={organization}>
+            <LightWeightNoProjectMessage organization={organization}>
               <StyledPageHeader>
                 <div>{t('Performance')}</div>
                 <div>{this.renderDropdown()}</div>
@@ -181,7 +181,7 @@ class PerformanceLanding extends React.Component<Props, State> {
                 setError={this.setError}
                 keyTransactions={this.state.currentView === 'KEY_TRANSACTIONS'}
               />
-            </NoProjectMessage>
+            </LightWeightNoProjectMessage>
           </PageContent>
         </React.Fragment>
       </SentryDocumentTitle>

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -17,7 +17,7 @@ import {PageContent} from 'app/styles/organization';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/views/eventsV2/utils';
 import {stringifyQueryObject} from 'app/utils/tokenizeSearch';
-import NoProjectMessage from 'app/components/noProjectMessage';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import withApi from 'app/utils/withApi';
 
 import SummaryContent from './content';
@@ -125,7 +125,7 @@ class TransactionSummary extends React.Component<Props, State> {
         <React.Fragment>
           <GlobalSelectionHeader organization={organization} />
           <StyledPageContent>
-            <NoProjectMessage organization={organization}>
+            <LightWeightNoProjectMessage organization={organization}>
               <SummaryContent
                 location={location}
                 organization={organization}
@@ -133,7 +133,7 @@ class TransactionSummary extends React.Component<Props, State> {
                 transactionName={transactionName}
                 totalValues={totalValues}
               />
-            </NoProjectMessage>
+            </LightWeightNoProjectMessage>
           </StyledPageContent>
         </React.Fragment>
       </SentryDocumentTitle>


### PR DESCRIPTION
Use the LightWeightOrganization context for discover 2 and performance views to help our biggest customers have snappier render times.