### PR TITLE
feat(workflow): Removing view rule link for snapshotted rules

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -194,7 +194,7 @@ export default class DetailsBody extends React.Component<Props> {
                     {incident?.alertRule?.status !== AlertRuleStatus.SNAPSHOT && (
                         <SideHeaderLink
                           to={{
-                            pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule.id}/`,
+                            pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule?.id}/`,
                           }}
                         >
                           <IconEdit />

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -25,7 +25,7 @@ import Projects from 'app/utils/projects';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 
-import {Incident, IncidentStats} from '../types';
+import {Incident, IncidentStats, AlertRuleStatus} from '../types';
 import Activity from './activity';
 import Chart from './chart';
 import SideHeader from './sideHeader';
@@ -191,15 +191,17 @@ export default class DetailsBody extends React.Component<Props> {
                 <React.Fragment>
                   <SideHeader>
                     <span>{t('Alert Rule')}</span>
-
-                    <SideHeaderLink
-                      to={{
-                        pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule.id}/`,
-                      }}
-                    >
-                      <IconEdit />
-                      {t('View Rule')}
-                    </SideHeaderLink>
+                    {incident?.alertRule &&
+                      incident?.alertRule?.status !== AlertRuleStatus.SNAPSHOT && (
+                        <SideHeaderLink
+                          to={{
+                            pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule.id}/`,
+                          }}
+                        >
+                          <IconEdit />
+                          {t('View Rule')}
+                        </SideHeaderLink>
+                      )}
                   </SideHeader>
 
                   {this.renderRuleDetails()}

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -191,8 +191,7 @@ export default class DetailsBody extends React.Component<Props> {
                 <React.Fragment>
                   <SideHeader>
                     <span>{t('Alert Rule')}</span>
-                    {incident?.alertRule &&
-                      incident?.alertRule?.status !== AlertRuleStatus.SNAPSHOT && (
+                    {incident?.alertRule?.status !== AlertRuleStatus.SNAPSHOT && (
                         <SideHeaderLink
                           to={{
                             pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule.id}/`,

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -194,7 +194,7 @@ export default class DetailsBody extends React.Component<Props> {
                     {incident?.alertRule?.status !== AlertRuleStatus.SNAPSHOT && (
                       <SideHeaderLink
                         to={{
-                          pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule.id}/`,
+                          pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule?.id}/`,
                         }}
                       >
                         <IconEdit />

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -192,15 +192,15 @@ export default class DetailsBody extends React.Component<Props> {
                   <SideHeader>
                     <span>{t('Alert Rule')}</span>
                     {incident?.alertRule?.status !== AlertRuleStatus.SNAPSHOT && (
-                        <SideHeaderLink
-                          to={{
-                            pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule?.id}/`,
-                          }}
-                        >
-                          <IconEdit />
-                          {t('View Rule')}
-                        </SideHeaderLink>
-                      )}
+                      <SideHeaderLink
+                        to={{
+                          pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule.id}/`,
+                        }}
+                      >
+                        <IconEdit />
+                        {t('View Rule')}
+                      </SideHeaderLink>
+                    )}
                   </SideHeader>
 
                   {this.renderRuleDetails()}

--- a/src/sentry/static/sentry/app/views/alerts/types.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/types.tsx
@@ -82,3 +82,8 @@ export enum IncidentStatus {
   WARNING = 10,
   CRITICAL = 20,
 }
+
+export enum AlertRuleStatus {
+  PENDING = 0,
+  SNAPSHOT = 4,
+}


### PR DESCRIPTION
This removes the "View Rule" link if a rule is a snapshot (as there is nothing to view/edit)