### PR TITLE
fix(analytics): Add default user_id to first transaction

### DIFF
--- a/src/sentry/analytics/events/first_transaction_sent.py
+++ b/src/sentry/analytics/events/first_transaction_sent.py
@@ -10,6 +10,7 @@ class FirstTransactionSentEvent(analytics.Event):
         analytics.Attribute("organization_id"),
         analytics.Attribute("project_id"),
         analytics.Attribute("platform", required=False),
+        analytics.Attribute("default_user_id", required=False),
     )
 
 

--- a/src/sentry/receivers/transactions.py
+++ b/src/sentry/receivers/transactions.py
@@ -11,8 +11,15 @@ from sentry.signals import event_processed
 def record_first_transaction(project, event, **kwargs):
     if event.get_event_type() == "transaction" and not project.flags.has_transactions:
         project.update(flags=F("flags").bitor(Project.flags.has_transactions))
+
+        try:
+            default_user_id = project.organization.get_default_owner().id
+        except IndexError:
+            default_user_id = None
+
         analytics.record(
             "first_transaction.sent",
+            default_user_id=default_user_id,
             project_id=project.id,
             organization_id=project.organization_id,
             platform=project.platform,

--- a/tests/sentry/receivers/test_transactions.py
+++ b/tests/sentry/receivers/test_transactions.py
@@ -2,10 +2,11 @@ from __future__ import absolute_import
 
 from exam import fixture
 
-from sentry.models import Project
+from sentry.models import Project, OrganizationMember
 from sentry.signals import event_processed
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.utils.compat.mock import patch
 
 
 class RecordFirstTransactionTest(TestCase):
@@ -30,11 +31,13 @@ class RecordFirstTransactionTest(TestCase):
         assert project.flags.has_transactions
 
     def test_transaction_processed_no_platform(self):
+        self.project.update(platform=None)
+        assert not self.project.platform
         assert not self.project.flags.has_transactions
+
         event = self.store_event(
             data={
                 "type": "transaction",
-                "platform": None,
                 "timestamp": self.min_ago,
                 "start_timestamp": self.min_ago,
                 "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
@@ -55,3 +58,42 @@ class RecordFirstTransactionTest(TestCase):
         event_processed.send(project=self.project, event=event, sender=type(self.project))
         project = Project.objects.get(id=self.project.id)
         assert not project.flags.has_transactions
+
+    @patch("sentry.analytics.record")
+    def test_analytics_event(self, mock_record):
+        assert not self.project.flags.has_transactions
+        event = self.store_event(
+            data={
+                "type": "transaction",
+                "timestamp": self.min_ago,
+                "start_timestamp": self.min_ago,
+                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+            },
+            project_id=self.project.id,
+        )
+
+        event_processed.send(project=self.project, event=event, sender=type(self.project))
+        assert self.project.flags.has_transactions
+        mock_record.assert_called_with(
+            "first_transaction.sent",
+            default_user_id=self.user.id,
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            platform=self.project.platform,
+        )
+
+    def test_analytics_event_no_owner(self):
+        OrganizationMember.objects.filter(organization=self.organization, role="owner").delete()
+        assert not self.project.flags.has_transactions
+        event = self.store_event(
+            data={
+                "type": "transaction",
+                "timestamp": self.min_ago,
+                "start_timestamp": self.min_ago,
+                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+            },
+            project_id=self.project.id,
+        )
+
+        event_processed.send(project=self.project, event=event, sender=type(self.project))
+        assert self.project.flags.has_transactions


### PR DESCRIPTION
this data is being forwarded to amplitude, and amplitude requires a user_id with all events