### PR TITLE
fix(discover): Supporting user field for top events

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1361,7 +1361,8 @@ def resolve_field_list(fields, snuba_filter, auto_fields=True):
     to build a more complete snuba query based on event search conventions.
     """
     aggregations = []
-    columns = []
+    # Avoid duplicates since this becomes groupby
+    columns = set()
     groupby = []
     project_key = ""
     # Which column to map to project names
@@ -1384,10 +1385,12 @@ def resolve_field_list(fields, snuba_filter, auto_fields=True):
             continue
         column_additions, agg_additions = resolve_field(field, snuba_filter.date_params)
         if column_additions:
-            columns.extend(column_additions)
+            columns.update(column_additions)
 
         if agg_additions:
             aggregations.extend(agg_additions)
+
+    columns = list(columns)
 
     rollup = snuba_filter.rollup
     if not rollup and auto_fields:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1361,8 +1361,7 @@ def resolve_field_list(fields, snuba_filter, auto_fields=True):
     to build a more complete snuba query based on event search conventions.
     """
     aggregations = []
-    # Avoid duplicates since this becomes groupby
-    columns = set()
+    columns = []
     groupby = []
     project_key = ""
     # Which column to map to project names
@@ -1385,12 +1384,10 @@ def resolve_field_list(fields, snuba_filter, auto_fields=True):
             continue
         column_additions, agg_additions = resolve_field(field, snuba_filter.date_params)
         if column_additions:
-            columns.update(column_additions)
+            columns.extend([column for column in column_additions if column not in columns])
 
         if agg_additions:
             aggregations.extend(agg_additions)
-
-    columns = list(columns)
 
     rollup = snuba_filter.rollup
     if not rollup and auto_fields:

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -840,6 +840,14 @@ def top_events_timeseries(
             # timestamp needs special handling, creating a big OR instead
             if field == "timestamp":
                 snuba_filter.conditions.append([["timestamp", "=", value] for value in values])
+            # A user field can be any of its field aliases, do an OR across all the user fields
+            elif field == "user":
+                snuba_filter.conditions.append(
+                    [
+                        [resolve_column(user_field), "IN", values]
+                        for user_field in FIELD_ALIASES["user"]["fields"]
+                    ]
+                )
             else:
                 snuba_filter.conditions.append([resolve_column(field), "IN", values])
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1045,11 +1045,40 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(data) == 5
 
-        for key, result in six.iteritems(data):
-            # Because user represents all the possible user fields eg. user.id
-            # or user.email, the key is email followed by None several times
-            if key.startswith("bar@example.com"):
-                assert [attrs for time, attrs in result["data"]] == [
-                    [{"count": 6}],
-                    [{"count": 0}],
-                ]
+        assert [attrs for time, attrs in data["bar@example.com"]["data"]] == [
+            [{"count": 6}],
+            [{"count": 0}],
+        ]
+        assert [attrs for time, attrs in data["127.0.0.1"]["data"]] == [
+            [{"count": 3}],
+            [{"count": 0}],
+        ]
+
+    def test_top_events_with_user_and_email(self):
+        with self.feature("organizations:discover-basic"):
+            response = self.client.get(
+                self.url,
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
+                    "interval": "1h",
+                    "yAxis": "count()",
+                    "orderby": ["-count()"],
+                    "field": ["user", "user.email", "count()"],
+                    "topEvents": 5,
+                },
+                format="json",
+            )
+
+        data = response.data
+        assert response.status_code == 200, response.content
+        assert len(data) == 5
+
+        assert [attrs for time, attrs in data["bar@example.com,bar@example.com"]["data"]] == [
+            [{"count": 6}],
+            [{"count": 0}],
+        ]
+        assert [attrs for time, attrs in data["127.0.0.1,None"]["data"]] == [
+            [{"count": 3}],
+            [{"count": 0}],
+        ]


### PR DESCRIPTION
- Fixes a bug when the user field is supplied for top events
- This widens the net quite a bit, as it does an IN for each user field
  and ORs them together.
- An alternative solution here is to skip user as a field to add to
  conditions, but I think that's worse since we'll get incorrect results
  in the final timeseries