### PR TITLE
ref(slack): Add APM to Slack and use use ApiClient 

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -9,11 +9,13 @@ from sentry.api.serializers.rest_framework.rule import RuleSerializer
 from sentry.integrations.slack import tasks
 from sentry.mediators import project_rules
 from sentry.models import AuditLogEntryEvent, Rule, RuleStatus
+from sentry.web.decorators import transaction_start
 
 
 class ProjectRuleDetailsEndpoint(ProjectEndpoint):
     permission_classes = [ProjectSettingPermission]
 
+    @transaction_start("ProjectRuleDetailsEndpoint")
     def get(self, request, project, rule_id):
         """
         Retrieve a rule
@@ -28,6 +30,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
         )
         return Response(serialize(rule, request.user))
 
+    @transaction_start("ProjectRuleDetailsEndpoint")
     def put(self, request, project, rule_id):
         """
         Update a rule
@@ -81,6 +84,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+    @transaction_start("ProjectRuleDetailsEndpoint")
     def delete(self, request, project, rule_id):
         """
         Delete a rule

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -11,9 +11,11 @@ from sentry.integrations.slack import tasks
 from sentry.mediators import project_rules
 from sentry.models import AuditLogEntryEvent, Rule, RuleStatus
 from sentry.signals import alert_rule_created
+from sentry.web.decorators import transaction_start
 
 
 class ProjectRulesEndpoint(ProjectEndpoint):
+    @transaction_start("ProjectRulesEndpoint")
     def get(self, request, project):
         """
         List a project's rules
@@ -34,6 +36,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
+    @transaction_start("ProjectRulesEndpoint")
     def post(self, request, project):
         """
         Create a rule

--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.integrations.client import ApiClient
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils import metrics
+
+SLACK_DATADOG_METRIC = "integrations.slack.http_response"
+
+
+class SlackClient(ApiClient):
+    allow_redirects = False
+    integration_name = "slack"
+    base_url = "https://slack.com/api"
+    datadog_prefix = "integrations.slack"
+
+    def __init__(self):
+        super(SlackClient, self).__init__()
+
+    def track_response_data(self, code, span, error=None, resp=None):
+        span.set_http_status(code)
+        span.set_tag("integration", "slack")
+
+        # If Slack gives us back a 200 we still want to check the 'ok' param
+        if resp:
+            response = resp.json()
+            is_ok = response.get("ok")
+            span.set_tag("ok", is_ok)
+
+            # when 'ok' is False, we can add the error we get back as a tag
+            if not is_ok:
+                span.set_tag("slack_error", response.get("error"))
+
+        metrics.incr(
+            SLACK_DATADOG_METRIC,
+            sample_rate=1.0,
+            tags={"ok": False if is_ok is False else True, "status": code},
+        )
+
+        extra = {
+            self.integration_type: self.name,
+            "status_string": six.text_type(code),
+            "error": six.text_type(error)[:256] if error else None,
+        }
+        extra.update(getattr(self, "logging_context", None) or {})
+        self.logger.info(u"%s.http_response" % (self.integration_type), extra=extra)
+
+    def request(self, method, path, headers=None, data=None, params=None, timeout=None):
+        # TODO(meredith): Slack actually supports json now for the chat.postMessage so we
+        # can update that so we don't have to pass json=False here
+        response = self._request(
+            method, path, headers=headers, data=data, params=params, json=False
+        )
+        if not response.json.get("ok"):
+            raise ApiError(response.get("error", ""))
+        return response

--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -22,6 +22,7 @@ class SlackClient(ApiClient):
         span.set_http_status(code)
         span.set_tag("integration", "slack")
 
+        is_ok = False
         # If Slack gives us back a 200 we still want to check the 'ok' param
         if resp:
             response = resp.json()
@@ -46,12 +47,10 @@ class SlackClient(ApiClient):
         extra.update(getattr(self, "logging_context", None) or {})
         self.logger.info(u"%s.http_response" % (self.integration_type), extra=extra)
 
-    def request(self, method, path, headers=None, data=None, params=None, timeout=None):
+    def request(self, method, path, headers=None, data=None, params=None, json=False, timeout=None):
         # TODO(meredith): Slack actually supports json now for the chat.postMessage so we
         # can update that so we don't have to pass json=False here
-        response = self._request(
-            method, path, headers=headers, data=data, params=params, json=False
-        )
+        response = self._request(method, path, headers=headers, data=data, params=params, json=json)
         if not response.json.get("ok"):
             raise ApiError(response.get("error", ""))
         return response

--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -15,9 +15,6 @@ class SlackClient(ApiClient):
     base_url = "https://slack.com/api"
     datadog_prefix = "integrations.slack"
 
-    def __init__(self):
-        super(SlackClient, self).__init__()
-
     def track_response_data(self, code, span, error=None, resp=None):
         span.set_http_status(code)
         span.set_tag("integration", "slack")
@@ -31,12 +28,11 @@ class SlackClient(ApiClient):
 
             # when 'ok' is False, we can add the error we get back as a tag
             if not is_ok:
-                span.set_tag("slack_error", response.get("error"))
+                error = response.get("error")
+                span.set_tag("slack_error", error)
 
         metrics.incr(
-            SLACK_DATADOG_METRIC,
-            sample_rate=1.0,
-            tags={"ok": False if is_ok is False else True, "status": code},
+            SLACK_DATADOG_METRIC, sample_rate=1.0, tags={"ok": is_ok, "status": code},
         )
 
         extra = {

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -14,7 +14,7 @@ from sentry.integrations import (
 )
 from sentry.pipeline import NestedPipelineView
 from sentry.utils.http import absolute_uri
-from sentry.shared_integrations.exceptions import ApiError
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 from .client import SlackClient
 from .utils import logger, use_slack_v2
@@ -129,6 +129,7 @@ class SlackIntegrationProvider(IntegrationProvider):
             resp = client.get("/team.info", params=payload)
         except ApiError as e:
             logger.error("slack.team-info.response-error", extra={"error": six.text_type(e)})
+            raise IntegrationError("Could not retrieve Slack team information.")
 
         return resp["team"]
 

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -1,19 +1,23 @@
 from __future__ import absolute_import, print_function
 
+import six
+
 from django.core.urlresolvers import reverse
 from django.db import IntegrityError
 from django.http import Http404
 from django.utils import timezone
 from django.views.decorators.cache import never_cache
 
-from sentry import http
 from sentry.models import Integration, Identity, IdentityProvider, IdentityStatus, Organization
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
+from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
+from sentry.shared_integrations.exceptions import ApiError
 
-from .utils import logger, track_response_code
+from .client import SlackClient
+from .utils import logger
 
 
 def build_linking_url(integration, organization, slack_id, channel_id, response_url):
@@ -31,6 +35,7 @@ def build_linking_url(integration, organization, slack_id, channel_id, response_
 
 
 class SlackLinkIdentityView(BaseView):
+    @transaction_start("SlackLinkIdentityView")
     @never_cache
     def handle(self, request, signed_params):
         params = unsign(signed_params.encode("ascii", errors="ignore"))
@@ -82,19 +87,18 @@ class SlackLinkIdentityView(BaseView):
             "text": "Your Slack identity has been linked to your Sentry account. You're good to go!",
         }
 
-        session = http.build_session()
-        req = session.post(params["response_url"], json=payload)
-        status_code = req.status_code
-        resp = req.json()
-
-        # If the user took their time to link their slack account, we may no
-        # longer be able to respond, and we're not guaranteed able to post into
-        # the channel. Ignore Expired url errors.
-        #
-        # XXX(epurkhiser): Yes the error string has a space in it.
-        if not resp.get("ok") and resp.get("error") != "Expired url":
-            logger.error("slack.link-notify.response-error", extra={"response": resp})
-        track_response_code(status_code, resp.get("ok"))
+        client = SlackClient()
+        try:
+            client.post(params["response_url"], data=payload, json=True)
+        except ApiError as e:
+            message = six.text_type(e)
+            # If the user took their time to link their slack account, we may no
+            # longer be able to respond, and we're not guaranteed able to post into
+            # the channel. Ignore Expired url errors.
+            #
+            # XXX(epurkhiser): Yes the error string has a space in it.
+            if message != "Expired url":
+                logger.error("slack.link-notify.response-error", extra={"error": message})
 
         return render_to_response(
             "sentry/slack-linked.html",

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -125,6 +125,7 @@ class SlackNotifyServiceAction(EventAction):
                         "error": six.text_type(e),
                         "project_id": event.project_id,
                         "event_id": event.event_id,
+                        "channel_name": self.get_option("channel"),
                     },
                 )
 

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -405,7 +405,6 @@ def get_channel_id_with_timeout(integration, name, timeout):
     time_to_quit = time.time() + timeout
 
     client = SlackClient()
-    # session = http.build_session()
     for list_type, result_name, prefix in LIST_TYPES:
         cursor = ""
         while True:
@@ -450,7 +449,6 @@ def send_incident_alert_notification(action, incident):
         logger.info(
             "rule.fail.slack_post", extra={"error": six.text_type(e)},
         )
-
 
 
 def use_slack_v2(pipeline):

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -148,7 +148,7 @@ class BaseApiClient(object):
     def get_cache_prefix(self):
         return u"%s.%s.client:" % (self.integration_type, self.name)
 
-    def track_response_data(self, code, span, error=None):
+    def track_response_data(self, code, span, error=None, resp=None):
         metrics.incr(
             u"%s.http_response" % (self.datadog_prefix),
             sample_rate=1.0,
@@ -242,7 +242,7 @@ class BaseApiClient(object):
                 self.track_response_data(resp.status_code, span, e)
                 raise ApiError.from_response(resp)
 
-            self.track_response_data(resp.status_code, span)
+            self.track_response_data(resp.status_code, span, None, resp)
 
             if resp.status_code == 204:
                 return {}

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -7,6 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.web.frontend.base import BaseView
+from sentry.web.decorators import transaction_start
 
 
 # The request doesn't contain the pipeline type (pipeline information is stored
@@ -28,6 +29,7 @@ class PipelineAdvancerView(BaseView):
 
     csrf_protect = False
 
+    @transaction_start("PipelineAdvancerView")
     def handle(self, request, provider_id):
         pipeline = None
 


### PR DESCRIPTION
**Context:**

Slack works differently than other integrations in terms of letting us know when something went wrong. In many cases, we still get a `200` level status code back, but it's on us to check the response param `ok` to see whether that is `True` or `False`. Because of this we haven't use a shared ApiClient. Because of _that_, APM for sentry was not added to the Slack integration in this PR https://github.com/getsentry/sentry/pull/17792. The current PR covers:
* Using the `ApiClient` for the Slack integration
* Modifies `track_response_data` to make sure we can record when `ok: False` happens and the error along with it

<hr/>

**ApiClient for Slack:**

Normally in the `_request` method for the shared integrations client, we [raise an ApiError](https://github.com/getsentry/sentry/blob/master/src/sentry/shared_integrations/client.py#L243). That won't happen in the shared client when we get 200s, so instead I've raised in within the Slack client's `request` method if the response includes `ok: False`. 

We've been [sending the response as extra data](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/slack/action_endpoint.py#L128) when capture the errors in sentry but I've changed this to just report the error message since it's not much different:

**before**
><img width="824" alt="Screen Shot 2020-04-23 at 10 00 03 AM" src="https://user-images.githubusercontent.com/15368179/80127499-441bc980-8549-11ea-900d-431006b48e07.png">
**after**
>![Screen Shot 2020-04-23 at 10 28 07 AM](https://user-images.githubusercontent.com/15368179/80130261-27819080-854d-11ea-91ee-815300fcd4fb.png)

<hr/>

**APM for Slack:**
I've added some extra tags along with the other data:
* `ok`: either True or False
* `slack_error`: if `ok` is False, then we can see what the error was. 

<img width="891" alt="Screen Shot 2020-04-23 at 9 51 28 AM" src="https://user-images.githubusercontent.com/15368179/80127482-3e25e880-8549-11ea-85db-6c42d58bca25.png">



todos:
- [x] update link identity to use slack client
- [x] update event_action to use slack client 
- [x] update getting team.info to use slack client