### PR TITLE
fix(async-csv): Finishing touches on some async-csv bugs

### DIFF
--- a/src/sentry/data_export/base.py
+++ b/src/sentry/data_export/base.py
@@ -4,7 +4,7 @@ import six
 from datetime import timedelta
 from enum import Enum
 
-SNUBA_MAX_RESULTS = 50000
+SNUBA_MAX_RESULTS = 10000
 DEFAULT_EXPIRATION = timedelta(weeks=4)
 
 

--- a/src/sentry/data_export/base.py
+++ b/src/sentry/data_export/base.py
@@ -4,7 +4,7 @@ import six
 from datetime import timedelta
 from enum import Enum
 
-SNUBA_MAX_RESULTS = 1000
+SNUBA_MAX_RESULTS = 50000
 DEFAULT_EXPIRATION = timedelta(weeks=4)
 
 

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @instrumented_task(name="sentry.data_export.tasks.assemble_download", queue="data_export")
-def assemble_download(data_export_id, limit=None, environment_id=None):
+def assemble_download(data_export_id, limit=1000000, environment_id=None):
     # Get the ExportedData object
     try:
         logger.info("dataexport.start", extra={"data_export_id": data_export_id})

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -46,9 +46,10 @@ class DataExport extends React.Component<Props, State> {
       payload: {queryType, queryInfo},
     } = this.props;
     try {
-      const {id: dataExportId} = await api.requestPromise(
+      const [data, _, response] = await api.requestPromise(
         `/organizations/${slug}/data-export/`,
         {
+          includeAllArgs: true,
           method: 'POST',
           data: {
             query_type: queryType,
@@ -56,8 +57,11 @@ class DataExport extends React.Component<Props, State> {
           },
         }
       );
+      const {id: dataExportId} = data;
       addSuccessMessage(
-        t("Sit tight. We'll shoot you an email when your data is ready for download.")
+        response?.status === 201
+          ? t("Sit tight. We'll shoot you an email when your data is ready for download.")
+          : t("It looks like we're already working on it. Sit tight, we'll email you.")
       );
       this.setState({inProgress: true, dataExportId});
     } catch (_err) {

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -39,36 +39,38 @@ class DataExport extends React.Component<Props, State> {
     inProgress: false,
   };
 
-  startDataExport = async () => {
+  startDataExport = () => {
     const {
       api,
       organization: {slug},
       payload: {queryType, queryInfo},
     } = this.props;
-    try {
-      const [data, _, response] = await api.requestPromise(
-        `/organizations/${slug}/data-export/`,
-        {
-          includeAllArgs: true,
-          method: 'POST',
-          data: {
-            query_type: queryType,
-            query_info: queryInfo,
-          },
-        }
-      );
-      const {id: dataExportId} = data;
-      addSuccessMessage(
-        response?.status === 201
-          ? t("Sit tight. We'll shoot you an email when your data is ready for download.")
-          : t("It looks like we're already working on it. Sit tight, we'll email you.")
-      );
-      this.setState({inProgress: true, dataExportId});
-    } catch (_err) {
-      addErrorMessage(
-        t("We tried our hardest, but we couldn't export your data. Give it another go.")
-      );
-    }
+
+    api
+      .requestPromise(`/organizations/${slug}/data-export/`, {
+        includeAllArgs: true,
+        method: 'POST',
+        data: {
+          query_type: queryType,
+          query_info: queryInfo,
+        },
+      })
+      .then(([data, _, response]) => {
+        const {id: dataExportId} = data;
+        addSuccessMessage(
+          response?.status === 201
+            ? t(
+                "Sit tight. We'll shoot you an email when your data is ready for download."
+              )
+            : t("It looks like we're already working on it. Sit tight, we'll email you.")
+        );
+        this.setState({inProgress: true, dataExportId});
+      })
+      .catch(_err => {
+        addErrorMessage(
+          t("We tried our hardest, but we couldn't export your data. Give it another go.")
+        );
+      });
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -166,6 +166,7 @@ class DataDownload extends AsyncView<Props, State> {
     const {
       errors: {download: err},
     } = this.state;
+    const errDetail = err?.responseJSON?.detail;
     return (
       <Layout>
         <main>
@@ -174,9 +175,11 @@ class DataDownload extends AsyncView<Props, State> {
               {err.status} - {err.statusText}
             </h3>
           </Header>
-          <Body>
-            <p>{err.responseJSON.detail}</p>
-          </Body>
+          {errDetail && (
+            <Body>
+              <p>{errDetail}</p>
+            </Body>
+          )}
         </main>
       </Layout>
     );


### PR DESCRIPTION
This PR is aimed at fixing up 4 smaller tasks.

1. When the user refreshes the page and clicks 'Export' again, we return a 200 (not a 201) because we didn't queue up another export. We just found their previous. Instead of swallowing this, the user now receives a different toast notification

2. As this will feature will likely go to GA soon, we're going to temporarily enforce a hard limit on file sizes at 1M rows.

3. The 404 response from the server doesn't have a `responseJSON` field. This change should still render an alright UI in case this happens (resolves JAVASCRIPT-222B)

4. Increase the number of entries written to the CSV every iteration from 1000 to something higher. I just set it to <s>50000</s> 10000 as a safety net.