### PR TITLE
fix(discover): Catching retention errors

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -161,10 +161,8 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
                     request, organization, params["project_id"], results
                 ),
             )
-        except discover.InvalidSearchQuery as error:
+        except (discover.InvalidSearchQuery, snuba.QueryOutsideRetentionError) as error:
             raise ParseError(detail=six.text_type(error))
-        except snuba.QueryOutsideRetentionError:
-            raise ParseError(detail="Invalid date range. Please try a more recent date range.")
         except snuba.QueryIllegalTypeOfArgument:
             raise ParseError(detail="Invalid query. Argument to function is wrong type.")
         except snuba.SnubaError as error:

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ParseError
 
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
 from sentry.snuba import discover
+from sentry.utils import snuba
 from sentry import features, tagstore
 
 
@@ -32,7 +33,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsEndpointBase):
                 params=params,
                 referrer="api.organization-events-facets.top-tags",
             )
-        except discover.InvalidSearchQuery as error:
+        except (discover.InvalidSearchQuery, snuba.QueryOutsideRetentionError) as error:
             raise ParseError(detail=six.text_type(error))
 
         resp = defaultdict(lambda: {"key": "", "topValues": []})

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
+from sentry.utils import snuba
 from sentry.snuba import discover
 
 
@@ -25,7 +26,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
                 query=request.query_params.get("query"),
                 referrer="api.organization-events-meta",
             )
-        except discover.InvalidSearchQuery as err:
-            raise ParseError(detail=six.text_type(err))
+        except (discover.InvalidSearchQuery, snuba.QueryOutsideRetentionError) as error:
+            raise ParseError(detail=six.text_type(error))
 
         return Response({"count": result["data"][0]["count"]})

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -411,7 +411,9 @@ def _prepare_query_params(query_params):
     if retention:
         start = max(start, datetime.utcnow() - timedelta(days=retention))
         if start > end:
-            raise QueryOutsideRetentionError
+            raise QueryOutsideRetentionError(
+                "Invalid date range. Please try a more recent date range."
+            )
 
     # if `shrink_time_window` pushed `start` after `end` it means the user queried
     # a Group for T1 to T2 when the group was only active for T3 to T4, so the query

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -458,3 +458,16 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         assert actual is not None, "Could not find {} facet in {}".format(key, response.data)
         assert "topValues" in actual
         assert sorted(expected) == sorted(actual["topValues"])
+
+    def test_out_of_retention(self):
+        with self.options({"system.event-retention-days": 10}):
+            with self.feature(self.feature_list):
+                response = self.client.get(
+                    self.url,
+                    format="json",
+                    data={
+                        "start": iso_format(before_now(days=20)),
+                        "end": iso_format(before_now(days=15)),
+                    },
+                )
+        assert response.status_code == 400

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -99,3 +99,15 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert response.data["count"] == 1
+
+    def test_out_of_retention(self):
+        with self.options({"system.event-retention-days": 10}):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "start": iso_format(before_now(days=20)),
+                    "end": iso_format(before_now(days=15)),
+                },
+            )
+        assert response.status_code == 400

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -10,65 +10,50 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
     def setUp(self):
         super(OrganizationEventsMetaEndpoint, self).setUp()
         self.min_ago = before_now(minutes=1)
+        self.login_as(user=self.user)
+        self.project = self.create_project()
+        self.url = reverse(
+            "sentry-api-0-organization-events-meta",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
 
     def test_simple(self):
-        self.login_as(user=self.user)
-
-        project = self.create_project()
         project2 = self.create_project()
 
-        self.store_event(data={"timestamp": iso_format(self.min_ago)}, project_id=project.id)
+        self.store_event(data={"timestamp": iso_format(self.min_ago)}, project_id=self.project.id)
         self.store_event(data={"timestamp": iso_format(self.min_ago)}, project_id=project2.id)
 
-        url = reverse(
-            "sentry-api-0-organization-events-meta",
-            kwargs={"organization_slug": project.organization.slug},
-        )
-        response = self.client.get(url, format="json")
+        response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
         assert response.data["count"] == 2
 
     def test_search(self):
-        self.login_as(user=self.user)
-
-        project = self.create_project()
         self.store_event(
             data={"timestamp": iso_format(self.min_ago), "message": "how to make fast"},
-            project_id=project.id,
+            project_id=self.project.id,
         )
         self.store_event(
             data={"timestamp": iso_format(self.min_ago), "message": "Delet the Data"},
-            project_id=project.id,
+            project_id=self.project.id,
         )
 
-        url = reverse(
-            "sentry-api-0-organization-events-meta",
-            kwargs={"organization_slug": project.organization.slug},
-        )
-        response = self.client.get(url, {"query": "delet"}, format="json")
+        response = self.client.get(self.url, {"query": "delet"}, format="json")
 
         assert response.status_code == 200, response.content
         assert response.data["count"] == 1
 
     def test_invalid_query(self):
-        self.login_as(user=self.user)
-        project = self.create_project()
-
-        url = reverse(
-            "sentry-api-0-organization-events-meta",
-            kwargs={"organization_slug": project.organization.slug},
-        )
-        response = self.client.get(url, {"query": "is:unresolved"}, format="json")
+        response = self.client.get(self.url, {"query": "is:unresolved"}, format="json")
 
         assert response.status_code == 400, response.content
 
     def test_no_projects(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
+        no_project_org = self.create_organization(owner=self.user)
 
         url = reverse(
-            "sentry-api-0-organization-events-meta", kwargs={"organization_slug": org.slug}
+            "sentry-api-0-organization-events-meta",
+            kwargs={"organization_slug": no_project_org.slug},
         )
         response = self.client.get(url, format="json")
 
@@ -76,9 +61,6 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
         assert response.data["count"] == 0
 
     def test_transaction_event(self):
-        self.login_as(user=self.user)
-
-        project = self.create_project()
         data = {
             "event_id": "a" * 32,
             "type": "transaction",
@@ -89,10 +71,10 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
             "timestamp": iso_format(before_now(minutes=1)),
             "start_timestamp": iso_format(before_now(minutes=1, seconds=3)),
         }
-        self.store_event(data=data, project_id=project.id)
+        self.store_event(data=data, project_id=self.project.id)
         url = reverse(
             "sentry-api-0-organization-events-meta",
-            kwargs={"organization_slug": project.organization.slug},
+            kwargs={"organization_slug": self.project.organization.slug},
         )
         response = self.client.get(url, {"query": "transaction.duration:>1"}, format="json")
 
@@ -100,9 +82,6 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
         assert response.data["count"] == 1
 
     def test_transaction_event_with_last_seen(self):
-        self.login_as(user=self.user)
-
-        project = self.create_project()
         data = {
             "event_id": "a" * 32,
             "type": "transaction",
@@ -113,13 +92,9 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
             "timestamp": iso_format(before_now(minutes=1)),
             "start_timestamp": iso_format(before_now(minutes=1, seconds=3)),
         }
-        self.store_event(data=data, project_id=project.id)
-        url = reverse(
-            "sentry-api-0-organization-events-meta",
-            kwargs={"organization_slug": project.organization.slug},
-        )
+        self.store_event(data=data, project_id=self.project.id)
         response = self.client.get(
-            url, {"query": "event.type:transaction last_seen:>2012-12-31"}, format="json"
+            self.url, {"query": "event.type:transaction last_seen:>2012-12-31"}, format="json"
         )
 
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -574,6 +574,22 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             )
         assert response.status_code == 400
 
+    def test_out_of_retention(self):
+        with self.options({"system.event-retention-days": 10}):
+            with self.feature("organizations:discover-basic"):
+                response = self.client.get(
+                    self.url,
+                    format="json",
+                    data={
+                        "start": iso_format(before_now(days=20)),
+                        "end": iso_format(before_now(days=15)),
+                        "query": "",
+                        "interval": "30m",
+                        "yAxis": "count()",
+                    },
+                )
+        assert response.status_code == 400
+
 
 class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
     def setUp(self):

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -16,7 +16,6 @@ from sentry.utils.samples import load_data
 from sentry.utils.compat.mock import patch
 from sentry.utils.snuba import (
     RateLimitExceeded,
-    QueryOutsideRetentionError,
     QueryIllegalTypeOfArgument,
     QueryExecutionError,
 )
@@ -130,13 +129,21 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400, response.content
         assert response.data["detail"] == "Invalid query. Argument to function is wrong type."
 
-        mock_query.side_effect = QueryOutsideRetentionError("test")
-        with self.feature("organizations:discover-basic"):
-            response = self.client.get(
-                self.url,
-                data={"field": ["id", "timestamp"], "orderby": ["-timestamp", "-id"]},
-                format="json",
-            )
+    def test_out_of_retention(self):
+        self.login_as(user=self.user)
+        self.create_project()
+        with self.options({"system.event-retention-days": 10}):
+            with self.feature("organizations:discover-basic"):
+                response = self.client.get(
+                    self.url,
+                    data={
+                        "field": ["id", "timestamp"],
+                        "orderby": ["-timestamp", "-id"],
+                        "start": iso_format(before_now(days=20)),
+                        "end": iso_format(before_now(days=15)),
+                    },
+                    format="json",
+                )
 
         assert response.status_code == 400, response.content
         assert response.data["detail"] == "Invalid date range. Please try a more recent date range."


### PR DESCRIPTION
- This means that when saved queries are out of retention we no longer
  500, and respond with a helpful message and 400
- This parsing happens before hitting snuba
- Moved where error message was being created for these into utils.snuba