### PR TITLE
ref(ui): Stop sending `enable_snuba` to group details endpoint

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -29,7 +29,6 @@ const GroupDetails = createReactClass({
 
     organization: SentryTypes.Organization,
     environments: PropTypes.arrayOf(PropTypes.string),
-    enableSnuba: PropTypes.bool,
     showGlobalHeader: PropTypes.bool,
 
     finishProfile: PropTypes.func,
@@ -41,12 +40,6 @@ const GroupDetails = createReactClass({
   },
 
   mixins: [Reflux.listenTo(GroupStore, 'onGroupChange')],
-
-  getDefaultProps() {
-    return {
-      enableSnuba: false,
-    };
-  },
 
   getInitialState() {
     return {
@@ -100,10 +93,6 @@ const GroupDetails = createReactClass({
 
     if (this.props.environments) {
       query.environment = this.props.environments;
-    }
-
-    if (this.props.enableSnuba) {
-      query.enable_snuba = '1';
     }
 
     this.props.api.request(this.getGroupDetailsEndpoint(), {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/index.jsx
@@ -24,12 +24,7 @@ class OrganizationGroupDetails extends React.Component {
     const {selection, ...props} = this.props;
 
     return (
-      <GroupDetails
-        environments={selection.environments}
-        enableSnuba
-        showGlobalHeader
-        {...props}
-      />
+      <GroupDetails environments={selection.environments} showGlobalHeader {...props} />
     );
   }
 }

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -122,7 +122,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
         url = u"/api/0/issues/{}/tags/".format(event2.group.id)
         response = self.client.get(
-            "%s&environment=%s&environment=%s" % (url, env.name, env2.name), format="json"
+            "%s?environment=%s&environment=%s" % (url, env.name, env2.name), format="json"
         )
         assert response.status_code == 200
         assert set([tag["key"] for tag in response.data]) >= set(["biz", "environment", "foo"])

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -120,7 +120,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        url = u"/api/0/issues/{}/tags/?enable_snuba=1".format(event2.group.id)
+        url = u"/api/0/issues/{}/tags/".format(event2.group.id)
         response = self.client.get(
             "%s&environment=%s&environment=%s" % (url, env.name, env2.name), format="json"
         )

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -14,7 +14,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         environment = Environment.get_or_create(group.project, "production")
         environment2 = Environment.get_or_create(group.project, "staging")
 
-        url = u"/api/0/issues/{}/?enable_snuba=1".format(group.id)
+        url = u"/api/0/issues/{}/".format(group.id)
 
         from sentry.api.endpoints.group_details import tsdb
 

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -22,12 +22,12 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             "sentry.api.endpoints.group_details.tsdb.get_range", side_effect=tsdb.get_range
         ) as get_range:
             response = self.client.get(
-                "%s&environment=production&environment=staging" % (url,), format="json"
+                "%s?environment=production&environment=staging" % (url,), format="json"
             )
             assert response.status_code == 200
             assert get_range.call_count == 2
             for args, kwargs in get_range.call_args_list:
                 assert kwargs["environment_ids"] == [environment.id, environment2.id]
 
-        response = self.client.get("%s&environment=invalid" % (url,), format="json")
+        response = self.client.get("%s?environment=invalid" % (url,), format="json")
         assert response.status_code == 404

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -93,9 +93,6 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
             },
         )
         response = self.client.get(
-            url, format="json", data={"enable_snuba": "1", "environment": ["production", "staging"]}
-        )
-        response = self.client.get(
             url, format="json", data={"environment": ["production", "staging"]}
         )
 


### PR DESCRIPTION
This was made default in https://github.com/getsentry/sentry/pull/14845