### PR TITLE
ref(ui): Clean up old `showGlobalHeader` prop in `<GroupDetails>`

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -29,7 +29,6 @@ const GroupDetails = createReactClass({
 
     organization: SentryTypes.Organization,
     environments: PropTypes.arrayOf(PropTypes.string),
-    showGlobalHeader: PropTypes.bool,
 
     finishProfile: PropTypes.func,
   },
@@ -211,34 +210,28 @@ const GroupDetails = createReactClass({
     }
   },
 
-  renderContent(shouldShowGlobalHeader, project) {
-    const {environments} = this.props;
+  renderContent(project) {
+    const {children, environments} = this.props;
     const {group} = this.state;
 
-    const Content = (
-      <DocumentTitle title={this.getTitle()}>
-        <div className={this.props.className}>
-          <GroupHeader project={project} group={group} />
-          {React.cloneElement(this.props.children, {
-            environments,
-            group,
-            project,
-          })}
-        </div>
-      </DocumentTitle>
+    return (
+      <PageContent>
+        <DocumentTitle title={this.getTitle()}>
+          <div>
+            <GroupHeader project={project} group={group} />
+            {React.cloneElement(children, {
+              environments,
+              group,
+              project,
+            })}
+          </div>
+        </DocumentTitle>
+      </PageContent>
     );
-
-    // If we are showing global header (e.g. on Organization group details)
-    // We need `<PageContent>` for padding, otherwise render content as normal
-    if (shouldShowGlobalHeader) {
-      return <PageContent>{Content}</PageContent>;
-    }
-
-    return Content;
   },
 
   render() {
-    const {organization, showGlobalHeader} = this.props;
+    const {organization} = this.props;
     const {group, project, loading} = this.state;
 
     if (this.state.error) {
@@ -258,17 +251,15 @@ const GroupDetails = createReactClass({
 
     return (
       <React.Fragment>
-        {showGlobalHeader && (
-          <GlobalSelectionHeader
-            organization={organization}
-            forceProject={project}
-            showDateSelector={false}
-            shouldForceProject
-            lockedMessageSubject={t('issue')}
-            showIssueStreamLink
-            showProjectSettingsLink
-          />
-        )}
+        <GlobalSelectionHeader
+          organization={organization}
+          forceProject={project}
+          showDateSelector={false}
+          shouldForceProject
+          lockedMessageSubject={t('issue')}
+          showIssueStreamLink
+          showProjectSettingsLink
+        />
         {isLoading ? (
           <PageContent>
             <LoadingIndicator />
@@ -280,7 +271,7 @@ const GroupDetails = createReactClass({
                 fetchError ? (
                   <LoadingError message={t('Error loading the specified project')} />
                 ) : (
-                  this.renderContent(showGlobalHeader, projects[0])
+                  this.renderContent(projects[0])
                 )
               ) : (
                 <LoadingIndicator />

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/index.jsx
@@ -23,9 +23,7 @@ class OrganizationGroupDetails extends React.Component {
   render() {
     const {selection, ...props} = this.props;
 
-    return (
-      <GroupDetails environments={selection.environments} showGlobalHeader {...props} />
-    );
+    return <GroupDetails environments={selection.environments} {...props} />;
   }
 }
 


### PR DESCRIPTION
This is now always true so there is no reason to keep this prop and logic
around.