### PR TITLE
feat(discover2): Delete Global Selection Header from Discover event details page

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -29,6 +29,7 @@ import {DataSection} from 'app/components/events/styles';
 import Projects from 'app/utils/projects';
 import EventView from 'app/utils/discover/eventView';
 import {ContentBox, HeaderBox} from 'app/utils/discover/styles';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
 
 import {generateTitle} from '../utils';
 import Pagination from './pagination';
@@ -309,6 +310,17 @@ const EventMetadata = (props: {
           })}
         />
       </MetadataContainer>
+      <Projects orgId={organization.slug} slugs={[projectId]}>
+        {({projects}) => {
+          const project = projects.find(p => p.slug === projectId);
+          return (
+            <StyledProjectBadge
+              project={project ? project : {slug: projectId}}
+              avatarSize={16}
+            />
+          );
+        }}
+      </Projects>
       <MetadataJSON href={eventJsonUrl} className="json-link">
         {t('Preview JSON')} (<FileSize bytes={event.size} />)
       </MetadataJSON>
@@ -368,6 +380,10 @@ const StyledEventEntries = styled(EventEntries)`
     padding-top: 0;
     border-top: none;
   }
+`;
+
+const StyledProjectBadge = styled(ProjectBadge)`
+  margin-bottom: ${space(2)};
 `;
 
 export default withApi(EventDetailsContent);

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/index.tsx
@@ -7,7 +7,6 @@ import {Location} from 'history';
 import {Organization} from 'app/types';
 import {PageContent} from 'app/styles/organization';
 import {t} from 'app/locale';
-import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import SentryTypes from 'app/sentryTypes';
@@ -57,20 +56,17 @@ class EventDetails extends React.Component<Props> {
 
     return (
       <SentryDocumentTitle title={documentTitle} objSlug={organization.slug}>
-        <React.Fragment>
-          <GlobalSelectionHeader organization={organization} />
-          <StyledPageContent>
-            <LightWeightNoProjectMessage organization={organization}>
-              <EventDetailsContent
-                organization={organization}
-                location={location}
-                params={params}
-                eventView={eventView}
-                eventSlug={this.getEventSlug()}
-              />
-            </LightWeightNoProjectMessage>
-          </StyledPageContent>
-        </React.Fragment>
+        <StyledPageContent>
+          <LightWeightNoProjectMessage organization={organization}>
+            <EventDetailsContent
+              organization={organization}
+              location={location}
+              params={params}
+              eventView={eventView}
+              eventSlug={this.getEventSlug()}
+            />
+          </LightWeightNoProjectMessage>
+        </StyledPageContent>
       </SentryDocumentTitle>
     );
   }


### PR DESCRIPTION

![Screen Shot 2020-04-20 at 8 39 47 PM](https://user-images.githubusercontent.com/139499/79812835-03a12d80-8348-11ea-94e9-3916116d3ca8.png)

@doralchan  will be designing and adding something to communicate the event's project somewhere on the sidebar on the right-hand side.