### PR TITLE
fix(ui): Fix date selector on Discover

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -206,14 +206,15 @@ function getNewQueryParams(
   {resetParams}: Options = {}
 ) {
   // Reset cursor when changing parameters
-  const {cursor: _cursor, ...oldQuery} = oldQueryParams;
+  const {cursor: _cursor, statsPeriod, ...oldQuery} = oldQueryParams;
   const oldQueryWithoutResetParams = !!resetParams?.length
     ? omit(oldQuery, resetParams)
     : oldQuery;
 
   const newQuery = getParams({
     ...oldQueryWithoutResetParams,
-
+    // Some views update using `period`, and some `statsPeriod`, we should make this uniform
+    period: !obj.start && !obj.end ? obj.period || statsPeriod : null,
     ...obj,
   });
 

--- a/tests/js/spec/actionCreators/globalSelection.spec.jsx
+++ b/tests/js/spec/actionCreators/globalSelection.spec.jsx
@@ -64,6 +64,57 @@ describe('GlobalSelection ActionCreators', function() {
 
       expect(router.push).not.toHaveBeenCalled();
     });
+
+    it('updates statsPeriod when there is no existing stats period', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {},
+        },
+      });
+      updateParams({statsPeriod: '24h'}, router);
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {
+          statsPeriod: '24h',
+        },
+      });
+    });
+
+    it('updates statsPeriod when there is an existing stats period', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {statsPeriod: '14d'},
+        },
+      });
+      updateParams({statsPeriod: '24h'}, router);
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {
+          statsPeriod: '24h',
+        },
+      });
+    });
+
+    it('updates `statsPeriod` when given a new  `period`', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {},
+        },
+      });
+      updateParams({period: '24h'}, router);
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {
+          statsPeriod: '24h',
+        },
+      });
+    });
   });
 
   describe('updateParamsWithoutHistory()', function() {

--- a/tests/js/spec/actionCreators/globalSelection.spec.jsx
+++ b/tests/js/spec/actionCreators/globalSelection.spec.jsx
@@ -1,6 +1,7 @@
 import {
   updateProjects,
   updateEnvironments,
+  updateDateTime,
   updateParams,
   updateParamsWithoutHistory,
 } from 'app/actionCreators/globalSelection';
@@ -70,6 +71,77 @@ describe('GlobalSelection ActionCreators', function() {
     });
   });
 
+  describe('updateDateTime()', function() {
+    it('updates statsPeriod when there is no existing stats period', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {},
+        },
+      });
+      updateDateTime({statsPeriod: '24h'}, router);
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {
+          statsPeriod: '24h',
+        },
+      });
+    });
+
+    it('updates statsPeriod when there is an existing stats period', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {statsPeriod: '14d'},
+        },
+      });
+      updateDateTime({statsPeriod: '24h'}, router);
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {
+          statsPeriod: '24h',
+        },
+      });
+    });
+
+    it('updates `statsPeriod` when given a new  `period`', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {},
+        },
+      });
+      updateDateTime({period: '24h'}, router);
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {
+          statsPeriod: '24h',
+        },
+      });
+    });
+
+    it('changes to absolute date', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {statsPeriod: '24h'},
+        },
+      });
+      updateDateTime({start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'}, router);
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {
+          start: '2020-03-22T00:53:38',
+          end: '2020-04-21T00:53:38',
+        },
+      });
+    });
+  });
+
   describe('updateParams()', function() {
     it('updates history when queries are different', function() {
       const router = TestStubs.router({
@@ -108,57 +180,6 @@ describe('GlobalSelection ActionCreators', function() {
       );
 
       expect(router.push).not.toHaveBeenCalled();
-    });
-
-    it('updates statsPeriod when there is no existing stats period', function() {
-      const router = TestStubs.router({
-        location: {
-          pathname: '/test/',
-          query: {},
-        },
-      });
-      updateParams({statsPeriod: '24h'}, router);
-
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {
-          statsPeriod: '24h',
-        },
-      });
-    });
-
-    it('updates statsPeriod when there is an existing stats period', function() {
-      const router = TestStubs.router({
-        location: {
-          pathname: '/test/',
-          query: {statsPeriod: '14d'},
-        },
-      });
-      updateParams({statsPeriod: '24h'}, router);
-
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {
-          statsPeriod: '24h',
-        },
-      });
-    });
-
-    it('updates `statsPeriod` when given a new  `period`', function() {
-      const router = TestStubs.router({
-        location: {
-          pathname: '/test/',
-          query: {},
-        },
-      });
-      updateParams({period: '24h'}, router);
-
-      expect(router.push).toHaveBeenCalledWith({
-        pathname: '/test/',
-        query: {
-          statsPeriod: '24h',
-        },
-      });
     });
   });
 

--- a/tests/js/spec/actionCreators/globalSelection.spec.jsx
+++ b/tests/js/spec/actionCreators/globalSelection.spec.jsx
@@ -1,5 +1,6 @@
 import {
   updateProjects,
+  updateEnvironments,
   updateParams,
   updateParamsWithoutHistory,
 } from 'app/actionCreators/globalSelection';
@@ -23,7 +24,51 @@ describe('GlobalSelection ActionCreators', function() {
     });
   });
 
-  describe('updateEnvironments()', function() {});
+  describe('updateEnvironments()', function() {
+    it('updates single', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {environment: 'test'},
+        },
+      });
+      updateEnvironments(['new-env'], router);
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {environment: ['new-env']},
+      });
+    });
+
+    it('updates multiple', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {environment: 'test'},
+        },
+      });
+      updateEnvironments(['new-env', 'another-env'], router);
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {environment: ['new-env', 'another-env']},
+      });
+    });
+
+    it('removes environment', function() {
+      const router = TestStubs.router({
+        location: {
+          pathname: '/test/',
+          query: {environment: 'test'},
+        },
+      });
+      updateEnvironments(null, router);
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/test/',
+        query: {},
+      });
+    });
+  });
 
   describe('updateParams()', function() {
     it('updates history when queries are different', function() {


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/getsentry/sentry/pull/18347 -- this affects all views
that are not Discover v1 and Issues Stream.