### PR TITLE
fix(discover2): The link to switch between new and legacy Discover should be displayed as inline

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -289,12 +289,14 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
             onQueryChange={this.handleQueryChange}
           />
           <Feature features={['organizations:discover']} organization={organization}>
-            <SwitchLink
-              href={`/organizations/${organization.slug}/discover/`}
-              onClick={this.onGoLegacyDiscover}
-            >
-              {t('Go to Legacy Discover')}
-            </SwitchLink>
+            <div>
+              <SwitchLink
+                href={`/organizations/${organization.slug}/discover/`}
+                onClick={this.onGoLegacyDiscover}
+              >
+                {t('Go to Legacy Discover')}
+              </SwitchLink>
+            </div>
           </Feature>
         </PageContent>
       );


### PR DESCRIPTION
This is because the container has `display: flex` causing all children to fill the entire row. 

