### PR TITLE
fix(discover2): An eventview's start/end has higher precedence than the statsPeriod/period in the query string

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -857,12 +857,15 @@ class EventView {
     // pick only the query strings that we care about
     const picked = pickRelevantLocationQueryStrings(location);
 
+    // an eventview's start/end has higher precedence than the statsPeriod/period in the query string
+    const hasAbsoluteDate = this.start && this.end;
+
     // normalize datetime selection
     const normalizedTimeWindowParams = getParams({
       start: this.start || picked.start,
       end: this.end || picked.end,
-      period: decodeScalar(query.period),
-      statsPeriod: this.statsPeriod || picked.statsPeriod,
+      period: !hasAbsoluteDate ? decodeScalar(query.period) : undefined,
+      statsPeriod: !hasAbsoluteDate ? this.statsPeriod || picked.statsPeriod : undefined,
       utc: decodeScalar(query.utc),
     });
 

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -857,15 +857,25 @@ class EventView {
     // pick only the query strings that we care about
     const picked = pickRelevantLocationQueryStrings(location);
 
-    // an eventview's start/end has higher precedence than the statsPeriod/period in the query string
-    const hasAbsoluteDate = this.start && this.end;
+    const hasDateSelection = this.statsPeriod || (this.start && this.end);
+
+    // an eventview's date selection has higher precedence than the date selection in the query string
+    const dateSelection = hasDateSelection
+      ? {
+          start: this.start,
+          end: this.end,
+          statsPeriod: this.statsPeriod,
+        }
+      : {
+          start: picked.start,
+          end: picked.end,
+          period: decodeScalar(query.period),
+          statsPeriod: picked.statsPeriod,
+        };
 
     // normalize datetime selection
     const normalizedTimeWindowParams = getParams({
-      start: this.start || picked.start,
-      end: this.end || picked.end,
-      period: !hasAbsoluteDate ? decodeScalar(query.period) : undefined,
-      statsPeriod: !hasAbsoluteDate ? this.statsPeriod || picked.statsPeriod : undefined,
+      ...dateSelection,
       utc: decodeScalar(query.utc),
     });
 

--- a/tests/js/spec/components/organizations/getParams.spec.jsx
+++ b/tests/js/spec/components/organizations/getParams.spec.jsx
@@ -27,6 +27,33 @@ describe('getParams', function() {
     });
   });
 
+  it('should return statsPeriod if statsPeriod, start, and end are provided', function() {
+    expect(
+      getParams({
+        start: '2019-10-01T00:00:00',
+        end: '2019-10-02T00:00:00',
+        statsPeriod: '55d',
+        period: '90d',
+      })
+    ).toEqual({statsPeriod: '55d'});
+
+    expect(
+      getParams({
+        start: '2019-10-01T00:00:00',
+        end: '2019-10-02T00:00:00',
+        statsPeriod: '55d',
+      })
+    ).toEqual({statsPeriod: '55d'});
+
+    expect(
+      getParams({
+        start: '2019-10-01T00:00:00',
+        end: '2019-10-02T00:00:00',
+        period: '55d',
+      })
+    ).toEqual({statsPeriod: '55d'});
+  });
+
   it('should parse start and end', function() {
     expect(
       getParams({start: '2019-10-01T00:00:00', end: '2019-10-02T00:00:00'})

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -855,6 +855,117 @@ describe('EventView.getEventsAPIPayload()', function() {
       environment: [],
     });
   });
+
+  it("an eventview's date selection has higher precedence than the date selection in the query string", function() {
+    const initialState = {
+      fields: generateFields(['title', 'count()']),
+      sorts: generateSorts(['count']),
+      query: 'event.type:csp',
+      environment: [],
+      project: [],
+    };
+
+    const output = {
+      field: ['title', 'count()'],
+      sort: '-count',
+      query: 'event.type:csp',
+      per_page: 50,
+      project: [],
+      environment: [],
+    };
+
+    // eventview's statsPeriod has highest precedence
+
+    let eventView = new EventView({
+      ...initialState,
+      statsPeriod: '90d',
+      start: '2019-10-01T00:00:00',
+      end: '2019-10-02T00:00:00',
+    });
+
+    let location = {
+      query: {
+        // these should not be part of the API payload
+        statsPeriod: '55d',
+        period: '30d',
+        start: '2020-10-01T00:00:00',
+        end: '2020-10-02T00:00:00',
+      },
+    };
+
+    expect(eventView.getEventsAPIPayload(location)).toEqual({
+      ...output,
+      statsPeriod: '90d',
+    });
+
+    // eventview's start/end has higher precedence than the date selection in the query string
+
+    eventView = new EventView({
+      ...initialState,
+      start: '2019-10-01T00:00:00',
+      end: '2019-10-02T00:00:00',
+    });
+
+    location = {
+      query: {
+        // these should not be part of the API payload
+        statsPeriod: '55d',
+        period: '30d',
+        start: '2020-10-01T00:00:00',
+        end: '2020-10-02T00:00:00',
+      },
+    };
+
+    expect(eventView.getEventsAPIPayload(location)).toEqual({
+      ...output,
+      start: '2019-10-01T00:00:00.000',
+      end: '2019-10-02T00:00:00.000',
+    });
+
+    // the date selection in the query string should be applied as expected
+
+    eventView = new EventView(initialState);
+
+    location = {
+      query: {
+        statsPeriod: '55d',
+        period: '30d',
+        start: '2020-10-01T00:00:00',
+        end: '2020-10-02T00:00:00',
+      },
+    };
+
+    expect(eventView.getEventsAPIPayload(location)).toEqual({
+      ...output,
+      statsPeriod: '55d',
+    });
+
+    location = {
+      query: {
+        period: '30d',
+        start: '2020-10-01T00:00:00',
+        end: '2020-10-02T00:00:00',
+      },
+    };
+
+    expect(eventView.getEventsAPIPayload(location)).toEqual({
+      ...output,
+      statsPeriod: '30d',
+    });
+
+    location = {
+      query: {
+        start: '2020-10-01T00:00:00',
+        end: '2020-10-02T00:00:00',
+      },
+    };
+
+    expect(eventView.getEventsAPIPayload(location)).toEqual({
+      ...output,
+      start: '2020-10-01T00:00:00.000',
+      end: '2020-10-02T00:00:00.000',
+    });
+  });
 });
 
 describe('EventView.getFacetsAPIPayload()', function() {
@@ -2389,9 +2500,8 @@ describe('isAPIPayloadSimilar', function() {
       const expected = {
         query: state.query,
         project: ['42'],
+        statsPeriod: state.statsPeriod,
         environment: state.environment,
-        end: '2019-10-02T00:00:00.000',
-        start: '2019-10-01T00:00:00.000',
       };
 
       expect(results).toEqual(expected);

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -837,7 +837,11 @@ describe('EventView.getEventsAPIPayload()', function() {
     });
 
     const location = {
-      query: {},
+      query: {
+        // these should not be part of the API payload
+        statsPeriod: '55d',
+        period: '55d',
+      },
     };
 
     expect(eventView.getEventsAPIPayload(location)).toEqual({
@@ -2385,8 +2389,9 @@ describe('isAPIPayloadSimilar', function() {
       const expected = {
         query: state.query,
         project: ['42'],
-        statsPeriod: state.statsPeriod,
         environment: state.environment,
+        end: '2019-10-02T00:00:00.000',
+        start: '2019-10-01T00:00:00.000',
       };
 
       expect(results).toEqual(expected);


### PR DESCRIPTION
Saved Discover queries with absolute dates weren't properly reflected in the graph of the query cards. 