### PR TITLE
ref(ui): Handle 404s from `/issues/id/events/latest/`

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import {browserHistory} from 'react-router';
 import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
@@ -120,7 +121,7 @@ class GroupEventDetails extends React.Component<Props, State> {
     api.clear();
   }
 
-  fetchData = () => {
+  fetchData = async () => {
     const {api, group, project, organization, params, environments} = this.props;
     const eventId = params.eventId || 'latest';
     const groupId = group.id;
@@ -135,32 +136,45 @@ class GroupEventDetails extends React.Component<Props, State> {
 
     const envNames = environments.map(e => e.name);
 
-    api
-      .requestPromise(`/projects/${orgSlug}/${projSlug}/releases/completion/`)
-      .then(data => {
-        this.setState({
-          releasesCompletion: data,
-        });
-      });
-
-    fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)
-      .then(data => {
-        this.setState({
-          event: data,
-          error: false,
-          loading: false,
-        });
-      })
-      .catch(() => {
-        this.setState({
-          event: null,
-          error: true,
-          loading: false,
-        });
-      });
+    /**
+     * Perform below requests in parallel
+     */
+    const releasesCompletionPromise = api.requestPromise(
+      `/projects/${orgSlug}/${projSlug}/releases/completion/`
+    );
+    const fetchGroupEventPromise = fetchGroupEventAndMarkSeen(
+      api,
+      orgSlug,
+      projSlug,
+      groupId,
+      eventId,
+      envNames
+    );
 
     fetchSentryAppInstallations(api, orgSlug);
     fetchSentryAppComponents(api, orgSlug, projectId);
+
+    const releasesCompletion = await releasesCompletionPromise;
+    this.setState({
+      releasesCompletion,
+    });
+
+    try {
+      const event = await fetchGroupEventPromise;
+      this.setState({
+        event,
+        error: false,
+        loading: false,
+      });
+    } catch (err) {
+      // This is an expected error, capture to Sentry so that it is not considered as an unhandled error
+      Sentry.captureException(err);
+      this.setState({
+        event: null,
+        error: true,
+        loading: false,
+      });
+    }
   };
 
   get showExampleCommit() {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/utils.jsx
@@ -9,7 +9,7 @@ import {Client} from 'app/api';
  * @param {String} eventId eventId or "latest" or "oldest"
  * @returns {Promise<Object>}
  */
-export function fetchGroupEventAndMarkSeen(
+export async function fetchGroupEventAndMarkSeen(
   api,
   orgId,
   projectId,
@@ -27,9 +27,8 @@ export function fetchGroupEventAndMarkSeen(
     query.environment = envNames;
   }
 
-  const promise = api.requestPromise(url, {query});
-
-  promise.then(data => {
+  try {
+    const data = await api.requestPromise(url, {query});
     api.bulkUpdate({
       orgId,
       projectId,
@@ -38,9 +37,9 @@ export function fetchGroupEventAndMarkSeen(
       data: {hasSeen: true},
     });
     return data;
-  });
-
-  return promise;
+  } catch (err) {
+    throw err;
+  }
 }
 
 export function fetchGroupUserReports(groupId, query) {


### PR DESCRIPTION
This catches 404s from `fetchGroupEventAndMarkSeen` action and records it to Sentry. This does not change anything except the error is now considered handled in Sentry. Also updates to use promises.