### PR TITLE
feat(slack): make slack v2 fully functional

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -157,6 +157,9 @@ class SlackIntegrationProvider(IntegrationProvider):
             "icon": team_data["icon"]["image_132"],
             "domain_name": team_data["domain"] + ".slack.com",
         }
+        # only set installation type for bot apps
+        if not self.use_wst_app:
+            metadata["installation_type"] = "born_as_bot"
 
         return {
             "name": team_name,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -126,7 +126,7 @@ register("slack.signing-secret", flags=FLAG_PRIORITIZE_DISK)
 # Slack V2 Integration
 register("slack-v2.client-id", flags=FLAG_PRIORITIZE_DISK)
 register("slack-v2.client-secret", flags=FLAG_PRIORITIZE_DISK)
-# TODO: add signing secret
+register("slack-v2.signing-secret", flags=FLAG_PRIORITIZE_DISK)
 
 # GitHub Integration
 register("github-app.id", default=0)

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -114,6 +114,7 @@ class SlackIntegrationTest(IntegrationTestCase):
             "scopes": sorted(self.provider.bot_oauth_scopes),
             "icon": "http://example.com/ws_icon.jpg",
             "domain_name": "test-slack-workspace.slack.com",
+            "installation_type": "born_as_bot",
         }
         oi = OrganizationIntegration.objects.get(
             integration=integration, organization=self.organization

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -167,7 +167,7 @@ class SlackEventRequestTest(TestCase):
             self.set_signature(options.get("slack.signing-secret"), self.request.body)
             self.slack_request.validate()
 
-    def test_signing_secret_v1(self):
+    def test_signing_secret_v2(self):
         with override_options({"slack-v2.signing-secret": "secret-v2"}):
             self.request.data = {"challenge": "abc123", "type": "url_verification"}
 

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -167,6 +167,16 @@ class SlackEventRequestTest(TestCase):
             self.set_signature(options.get("slack.signing-secret"), self.request.body)
             self.slack_request.validate()
 
+    def test_signing_secret_v1(self):
+        with override_options({"slack-v2.signing-secret": "secret-v2"}):
+            self.request.data = {"challenge": "abc123", "type": "url_verification"}
+
+            # we get a url encoded body with Slack
+            self.request.body = urlencode(self.request.data)
+
+            self.set_signature(options.get("slack-v2.signing-secret"), self.request.body)
+            self.slack_request.validate()
+
     def test_signing_secret_bad(self):
         with override_options({"slack.signing-secret": "secret"}):
             # even though we provide the token, should still fail


### PR DESCRIPTION
This PR adds webhook verification for Slack V2. The caveat here is that when a request comes in, we don't know if it is for OG slack or Slack V2. The strategy is to see if the request can be validated for OG Slack (using signing secret or verification token) and then validate against V2 Slack (only signing secret). If neither validation succeeds, we throw a `401` error.

This PR also adds the `installation_type` field in the `metadata` which for new bot installations is set as `born_as_bot`. We will also have `migrated` for those installations which get migrated.

PR to actually set up Slack V2 in getsentry: https://github.com/getsentry/getsentry/pull/3839