### PR TITLE
Fix(group-details): multiple tag value calls

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -172,15 +172,9 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 version__in=versions,
             )
         }
-        tag_values = tagstore.get_release_tags(
-            [group.project_id], None, [version for version in versions if version in releases],
+        return serialize(
+            [releases.get(version, {"version": version}) for version in versions], request.user,
         )
-        return [
-            serialize(
-                releases.get(version, {"version": version}), request.user, tag_values=tag_values
-            )
-            for version in versions
-        ]
 
     @attach_scenarios([retrieve_aggregate_scenario])
     def get(self, request, group):

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -177,7 +177,7 @@ class ReleaseSerializer(Serializer):
             False,
         )
 
-    def __get_release_data_no_environment(self, project, item_list):
+    def __get_release_data_no_environment(self, project, item_list, tag_values=None):
         if project is not None:
             project_ids = [project.id]
             specialized = True
@@ -186,10 +186,11 @@ class ReleaseSerializer(Serializer):
 
         first_seen = {}
         last_seen = {}
-        tvs = tagstore.get_release_tags(
-            project_ids, environment_id=None, versions=[o.version for o in item_list]
-        )
-        for tv in tvs:
+        if tag_values is None:
+            tag_values = tagstore.get_release_tags(
+                project_ids, environment_id=None, versions=[o.version for o in item_list]
+            )
+        for tv in tag_values:
             first_val = first_seen.get(tv.value)
             last_val = last_seen.get(tv.value)
             first_seen[tv.value] = min(tv.first_seen, first_val) if first_val else tv.first_seen
@@ -231,6 +232,7 @@ class ReleaseSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
         project = kwargs.get("project")
         environment = kwargs.get("environment")
+        tag_values = kwargs.get("tag_values")
         with_health_data = kwargs.get("with_health_data", False)
         health_stat = kwargs.get("health_stat", None)
         health_stats_period = kwargs.get("health_stats_period")
@@ -238,7 +240,7 @@ class ReleaseSerializer(Serializer):
 
         if environment is None:
             first_seen, last_seen, issue_counts_by_release = self.__get_release_data_no_environment(
-                project, item_list
+                project, item_list, tag_values
             )
         else:
             (

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -177,7 +177,7 @@ class ReleaseSerializer(Serializer):
             False,
         )
 
-    def __get_release_data_no_environment(self, project, item_list, tag_values=None):
+    def __get_release_data_no_environment(self, project, item_list):
         if project is not None:
             project_ids = [project.id]
             specialized = True
@@ -186,10 +186,9 @@ class ReleaseSerializer(Serializer):
 
         first_seen = {}
         last_seen = {}
-        if tag_values is None:
-            tag_values = tagstore.get_release_tags(
-                project_ids, environment_id=None, versions=[o.version for o in item_list]
-            )
+        tag_values = tagstore.get_release_tags(
+            project_ids, environment_id=None, versions=[o.version for o in item_list]
+        )
         for tv in tag_values:
             first_val = first_seen.get(tv.value)
             last_val = last_seen.get(tv.value)
@@ -232,7 +231,6 @@ class ReleaseSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
         project = kwargs.get("project")
         environment = kwargs.get("environment")
-        tag_values = kwargs.get("tag_values")
         with_health_data = kwargs.get("with_health_data", False)
         health_stat = kwargs.get("health_stat", None)
         health_stats_period = kwargs.get("health_stats_period")
@@ -240,7 +238,7 @@ class ReleaseSerializer(Serializer):
 
         if environment is None:
             first_seen, last_seen, issue_counts_by_release = self.__get_release_data_no_environment(
-                project, item_list, tag_values
+                project, item_list
             )
         else:
             (

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -25,11 +25,11 @@ from sentry.models import (
     Release,
     Integration,
 )
-from sentry.testutils import APITestCase
+from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.plugins.base import plugins
 
 
-class GroupDetailsTest(APITestCase):
+class GroupDetailsTest(APITestCase, SnubaTestCase):
     def test_with_numerical_id(self):
         self.login_as(user=self.user)
 

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -36,24 +36,33 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
     def test_with_first_last_release(self):
         self.login_as(user=self.user)
+        first_release = {
+            "first_seen": before_now(minutes=3),
+            "last_seen": before_now(minutes=2, seconds=30),
+        }
+        last_release = {
+            "first_seen": before_now(minutes=1),
+            "last_seen": before_now(minutes=1, seconds=30),
+        }
 
-        event = self.store_event(
-            data={"release": "1.0", "timestamp": iso_format(before_now(minutes=3))},
-            project_id=self.project.id,
-        )
+        for timestamp in first_release.values():
+            self.store_event(
+                data={"release": "1.0", "timestamp": iso_format(timestamp)},
+                project_id=self.project.id,
+            )
         self.store_event(
             data={"release": "1.1", "timestamp": iso_format(before_now(minutes=2))},
             project_id=self.project.id,
         )
-        self.store_event(
-            data={"release": "1.0a", "timestamp": iso_format(before_now(minutes=1))},
-            project_id=self.project.id,
-        )
+        for timestamp in last_release.values():
+            event = self.store_event(
+                data={"release": "1.0a", "timestamp": iso_format(timestamp)},
+                project_id=self.project.id,
+            )
 
         group = event.group
 
         url = u"/api/0/issues/{}/".format(group.id)
-
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -65,15 +74,11 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         event = self.store_event(
-            data={"release": "1.0", "timestamp": iso_format(before_now(minutes=3))},
+            data={"release": "1.0", "timestamp": iso_format(before_now(days=3))},
             project_id=self.project.id,
         )
         self.store_event(
-            data={"release": "1.1", "timestamp": iso_format(before_now(minutes=2))},
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={"release": "1.0a", "timestamp": iso_format(before_now(minutes=1))},
+            data={"release": "1.1", "timestamp": iso_format(before_now(minutes=3))},
             project_id=self.project.id,
         )
 

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, print_function
 
+import six
 from sentry.utils.compat import mock
 
 from sentry.models import Environment
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
 class GroupDetailsTest(APITestCase, SnubaTestCase):
@@ -31,3 +33,57 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         response = self.client.get("%s?environment=invalid" % (url,), format="json")
         assert response.status_code == 404
+
+    def test_with_first_last_release(self):
+        self.login_as(user=self.user)
+
+        event = self.store_event(
+            data={"release": "1.0", "timestamp": iso_format(before_now(minutes=3))},
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={"release": "1.1", "timestamp": iso_format(before_now(minutes=2))},
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={"release": "1.0a", "timestamp": iso_format(before_now(minutes=1))},
+            project_id=self.project.id,
+        )
+
+        group = event.group
+
+        url = u"/api/0/issues/{}/".format(group.id)
+
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == six.text_type(group.id)
+        assert response.data["firstRelease"]["version"] == "1.0"
+        assert response.data["lastRelease"]["version"] == "1.0a"
+
+    def test_first_last_only_one_tagstore(self):
+        self.login_as(user=self.user)
+
+        event = self.store_event(
+            data={"release": "1.0", "timestamp": iso_format(before_now(minutes=3))},
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={"release": "1.1", "timestamp": iso_format(before_now(minutes=2))},
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={"release": "1.0a", "timestamp": iso_format(before_now(minutes=1))},
+            project_id=self.project.id,
+        )
+
+        group = event.group
+
+        url = u"/api/0/issues/{}/".format(group.id)
+
+        with mock.patch(
+            "sentry.api.endpoints.group_details.tagstore.get_release_tags"
+        ) as get_release_tags:
+            response = self.client.get(url, format="json")
+            assert response.status_code == 200
+            assert get_release_tags.call_count == 1


### PR DESCRIPTION
- Currently we're calling snuba once per first/last release. This can be
  done in a single snuba query which should give us a significant time
  improvement
- TODO: test coverage of first/last release is weak will do more in a
  later PR