### PR TITLE
fix(mail): Fix incorrect workflow status in migration

### DIFF
--- a/src/sentry/mail/utils.py
+++ b/src/sentry/mail/utils.py
@@ -43,7 +43,7 @@ def migrate_project_to_issue_alert_targeting(project):
                 sentry_orgmember_set__teams__in=project.teams.all(), is_active=True
             ):
                 set_user_option(UserOption, user, "mail:alert", 0, project)
-                set_user_option(UserOption, user, "workflow:notifications", "0", project=project)
+                set_user_option(UserOption, user, "workflow:notifications", "2", project=project)
 
         # This marks the migration finished and shows the new UI
         project.flags.has_issue_alerts_targeting = True

--- a/src/sentry/migrations/0067_migrate_rules_alert_targeting.py
+++ b/src/sentry/migrations/0067_migrate_rules_alert_targeting.py
@@ -44,7 +44,7 @@ def migrate_project_to_issue_alert_targeting(project, ProjectOption, Rule, User,
                 sentry_orgmember_set__teams__in=project.teams.all(), is_active=True
             ):
                 set_user_option(UserOption, user, "mail:alert", 0, project)
-                set_user_option(UserOption, user, "workflow:notifications", "0", project=project)
+                set_user_option(UserOption, user, "workflow:notifications", "2", project=project)
 
         # This marks the migration finished and shows the new UI
         project.flags.has_issue_alerts_targeting = True

--- a/tests/sentry/mail/test_utils.py
+++ b/tests/sentry/mail/test_utils.py
@@ -89,7 +89,7 @@ class MigrateProjectToIssueAlertTargetingTest(TestCase):
             assert UserOption.objects.get_value(user, "mail:alert", project=self.project) == 0
             assert (
                 UserOption.objects.get_value(user, "workflow:notifications", project=self.project)
-                == "0"
+                == "2"
             )
         assert self.project.flags.has_issue_alerts_targeting
 
@@ -124,6 +124,6 @@ class MigrateProjectToIssueAlertTargetingTest(TestCase):
             assert UserOption.objects.get_value(user, "mail:alert", project=self.project) == 0
             assert (
                 UserOption.objects.get_value(user, "workflow:notifications", project=self.project)
-                == "0"
+                == "2"
             )
         assert self.project.flags.has_issue_alerts_targeting


### PR DESCRIPTION
This fixes a bug in this migration that caused workflow notifications to be enabled for users on
projects that had mail disabled.