### PR TITLE
fix(charts) Encode entities in series names

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/utils.tsx
+++ b/src/sentry/static/sentry/app/components/charts/utils.tsx
@@ -2,6 +2,7 @@ import moment from 'moment';
 
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {parsePeriodToHours} from 'app/utils/dates';
+import {escape} from 'app/utils';
 
 const DEFAULT_TRUNCATE_LENGTH = 80;
 
@@ -27,13 +28,13 @@ export type DateTimeObject = {
 
 export function truncationFormatter(value: string, truncate: number): string {
   if (!truncate) {
-    return value;
+    return escape(value);
   }
   const truncationLength =
     truncate && typeof truncate === 'number' ? truncate : DEFAULT_TRUNCATE_LENGTH;
-  return value.length > truncationLength
-    ? value.substring(0, truncationLength) + '…'
-    : value;
+  const truncated =
+    value.length > truncationLength ? value.substring(0, truncationLength) + '…' : value;
+  return escape(truncated);
 }
 
 /**

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -155,6 +155,7 @@ class EventsChart extends React.Component {
     const currentSeriesName = currentName ?? yAxis;
 
     const tooltip = {
+      truncate: 80,
       valueFormatter(value) {
         if (DURATION_AGGREGATE_PATTERN.test(yAxis)) {
           return getDuration(value / 1000, 2);

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -8,7 +8,6 @@ import {Series, SeriesDataUnit} from 'app/types/echarts';
 import {Client} from 'app/api';
 import {doEventsRequest} from 'app/actionCreators/events';
 import {addErrorMessage} from 'app/actionCreators/indicator';
-import {truncationFormatter} from 'app/components/charts/utils';
 import {canIncludePreviousPeriod} from 'app/views/events/utils/canIncludePreviousPeriod';
 import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
@@ -401,8 +400,10 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
       const results: MultiSeriesResults = Object.fromEntries(
         Object.keys(timeseriesData).map((seriesName: string): [string, Series] => {
           const seriesData: EventsStats = timeseriesData[seriesName];
-          const name = truncationFormatter(seriesName, 80);
-          return [name, this.transformTimeseriesData(seriesData.data, name)[0]];
+          return [
+            seriesName,
+            this.transformTimeseriesData(seriesData.data, seriesName)[0],
+          ];
         })
       );
 


### PR DESCRIPTION
series names in charts can contain user content in top5 mode.