### PR TITLE
fix(dev): Add envelope endpoint and increase 413 limit

### DIFF
--- a/config/reverse_proxy/nginx.conf
+++ b/config/reverse_proxy/nginx.conf
@@ -20,12 +20,9 @@ http {
 
     access_log  /var/log/nginx/access.log  main;
 
-    sendfile        on;
-    #tcp_nopush     on;
-
-    keepalive_timeout  65;
-
-    #gzip  on;
+    sendfile              on;
+    keepalive_timeout     65;
+    client_max_body_size  100m;
 
     upstream relay {
         server sentry_relay.sentry:3000;
@@ -40,6 +37,9 @@ http {
         resolver 127.0.0.11 ipv6=off;
 
         location /api/store/ {
+            proxy_pass http://relay;
+        }
+        location ~ ^/api/\d+/envelope/$ {
             proxy_pass http://relay;
         }
         location ~ ^/api/\d+/store/$ {


### PR DESCRIPTION
Debug file uploads using `sentry-cli` require requests with a payload size of 32MB. The legacy endpoint requires even larger requests. Since the default nginx limit is 1MB, it needs to be configured explicitly.

Additionally, this introduces the `/envelope/` ingestion endpoint and routes it to Relay, since this endpoint is not implemented in Sentry.
