### PR TITLE
fix(alerts): Fix edge case around threshold validation

### DIFF
--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -195,11 +195,13 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             resp = self.get_valid_response(
                 self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
             )
-            assert resp.data == {
-                "nonFieldErrors": [
-                    'First trigger must be labeled "critical", second trigger must be labeled "warning"'
-                ]
-            }
+            assert resp.data == {"nonFieldErrors": ['Trigger 1 must be labeled "critical"']}
+            serialized_alert_rule["triggers"][0]["label"] = "critical"
+            serialized_alert_rule["triggers"][1]["label"] = "goodbye"
+            resp = self.get_valid_response(
+                self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
+            )
+            assert resp.data == {"nonFieldErrors": ['Trigger 2 must be labeled "warning"']}
 
     def test_update_trigger_alert_threshold(self):
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -223,7 +223,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
             resp = self.get_valid_response(
                 self.organization.slug, status_code=400, **rule_one_trigger_only_warning
             )
-            assert resp.data == {"nonFieldErrors": [u'First trigger must be labeled "critical"']}
+            assert resp.data == {"nonFieldErrors": [u'Trigger 1 must be labeled "critical"']}
 
     def test_critical_trigger_no_action(self):
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -217,6 +217,49 @@ class TestAlertRuleSerializer(TestCase):
 
         assert serializer.is_valid(), serializer.errors
 
+    def test_boundary(self):
+        payload = {
+            "name": "hello_im_a_test",
+            "time_window": 10,
+            "query": "level:error",
+            "threshold_type": 0,
+            "aggregation": 0,
+            "threshold_period": 1,
+            "projects": [self.project.slug],
+            "triggers": [
+                {
+                    "label": "critical",
+                    "alertThreshold": 1,
+                    "resolveThreshold": 2,
+                    "thresholdType": AlertRuleThresholdType.ABOVE.value,
+                    "actions": [
+                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id}
+                    ],
+                }
+            ],
+        }
+        serializer = AlertRuleSerializer(context=self.context, data=payload, partial=True)
+
+        assert serializer.is_valid(), serializer.errors
+
+        # Now do a two trigger test:
+        payload["triggers"].append(
+            {
+                "label": "warning",
+                "alertThreshold": 0,
+                "resolveThreshold": 1,
+                "thresholdType": AlertRuleThresholdType.ABOVE.value,
+                "actions": [
+                    {"type": "email", "targetType": "team", "targetIdentifier": self.team.id},
+                    {"type": "email", "targetType": "user", "targetIdentifier": self.user.id},
+                ],
+            }
+        )
+
+        serializer = AlertRuleSerializer(context=self.context, data=payload, partial=True)
+
+        assert serializer.is_valid(), serializer.errors
+
     def test_invalid_slack_channel(self):
         # We had an error where an invalid slack channel was spitting out unclear
         # error for the user, and CREATING THE RULE. So the next save (after fixing slack action)


### PR DESCRIPTION
This fixes an edge case where we don't allow a valid alert to be created. The main example is an
alert where we want to set the alert threshold > 0, and the resolve threshold to < 1. This is a
valid threshold, but because 0 < 1 it will fail.

What we're actually saying with this threshold is to alert on values >= 1, and resolve on values <=
0. This pr allows this to work. We also refactor the validation method to remove some duplication.