### PR TITLE
fix(group-details): Removing batch serialize

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -172,9 +172,15 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 version__in=versions,
             )
         }
-        return serialize(
-            [releases.get(version, {"version": version}) for version in versions], request.user,
+        tag_values = tagstore.get_release_tags(
+            [group.project_id], None, [version for version in versions if version in releases],
         )
+        return [
+            serialize(
+                releases.get(version, {"version": version}), request.user, tag_values=tag_values
+            )
+            for version in versions
+        ]
 
     @attach_scenarios([retrieve_aggregate_scenario])
     def get(self, request, group):

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -177,7 +177,7 @@ class ReleaseSerializer(Serializer):
             False,
         )
 
-    def __get_release_data_no_environment(self, project, item_list):
+    def __get_release_data_no_environment(self, project, item_list, tag_values=None):
         if project is not None:
             project_ids = [project.id]
             specialized = True
@@ -186,9 +186,10 @@ class ReleaseSerializer(Serializer):
 
         first_seen = {}
         last_seen = {}
-        tag_values = tagstore.get_release_tags(
-            project_ids, environment_id=None, versions=[o.version for o in item_list]
-        )
+        if tag_values is None:
+            tag_values = tagstore.get_release_tags(
+                project_ids, environment_id=None, versions=[o.version for o in item_list]
+            )
         for tv in tag_values:
             first_val = first_seen.get(tv.value)
             last_val = last_seen.get(tv.value)
@@ -231,6 +232,7 @@ class ReleaseSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
         project = kwargs.get("project")
         environment = kwargs.get("environment")
+        tag_values = kwargs.get("tag_values")
         with_health_data = kwargs.get("with_health_data", False)
         health_stat = kwargs.get("health_stat", None)
         health_stats_period = kwargs.get("health_stats_period")
@@ -238,7 +240,7 @@ class ReleaseSerializer(Serializer):
 
         if environment is None:
             first_seen, last_seen, issue_counts_by_release = self.__get_release_data_no_environment(
-                project, item_list
+                project, item_list, tag_values
             )
         else:
             (


### PR DESCRIPTION
- This reverts commit 2e4b7e0e8650d21e07c6838c0f0059a916455d1d.
- Undoing the batch serialize since the serializer shouldn't handle the dictionary 
- Fixes Sentry-G22