### PR TITLE
fix(ui): Fix "retry" on group details error and CSS in `<LoadingError />`

### DIFF
--- a/src/sentry/static/sentry/app/components/loadingError.tsx
+++ b/src/sentry/static/sentry/app/components/loadingError.tsx
@@ -1,7 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from '@emotion/styled';
 
+import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
+import Alert from 'app/components/alert';
+import Button from 'app/components/button';
+import space from 'app/styles/space';
 
 type DefaultProps = {
   message: React.ReactNode;
@@ -10,6 +15,10 @@ type DefaultProps = {
 type Props = DefaultProps & {
   onRetry?: () => void;
 };
+
+/**
+ * Renders an Alert box of type "error". Renders a "Retry" button only if a  `onRetry` callback is defined.
+ */
 class LoadingError extends React.Component<Props> {
   static propTypes = {
     onRetry: PropTypes.func,
@@ -27,22 +36,25 @@ class LoadingError extends React.Component<Props> {
   render() {
     const {message, onRetry} = this.props;
     return (
-      <div className="alert alert-error alert-block">
-        <p>
-          {message}
+      <Alert type="error" icon={<IconInfo size="lg" />}>
+        <Content>
+          <div data-test-id="loading-error-message">{message}</div>
           {onRetry && (
-            <a
-              onClick={onRetry}
-              className="btn btn-default btn-sm"
-              style={{marginLeft: 5}}
-            >
+            <Button onClick={onRetry} priority="default" size="small">
               {t('Retry')}
-            </a>
+            </Button>
           )}
-        </p>
-      </div>
+        </Content>
+      </Alert>
     );
   }
 }
 
 export default LoadingError;
+
+const Content = styled('div')`
+  display: grid;
+  grid-gap: ${space(1)};
+  grid-template-columns: auto max-content;
+  align-items: center;
+`;

--- a/src/sentry/static/sentry/app/components/loadingError.tsx
+++ b/src/sentry/static/sentry/app/components/loadingError.tsx
@@ -17,7 +17,7 @@ type Props = DefaultProps & {
 };
 
 /**
- * Renders an Alert box of type "error". Renders a "Retry" button only if a  `onRetry` callback is defined.
+ * Renders an Alert box of type "error". Renders a "Retry" button only if a `onRetry` callback is defined.
  */
 class LoadingError extends React.Component<Props> {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -6,11 +6,9 @@ import * as Sentry from '@sentry/browser';
 
 import {Client} from 'app/api';
 import {Group, Organization, Project} from 'app/types';
-import {IconInfo} from 'app/icons';
 import {PageContent} from 'app/styles/organization';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import {t} from 'app/locale';
-import Alert from 'app/components/alert';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import GroupStore from 'app/stores/groupStore';
 import LoadingError from 'app/components/loadingError';
@@ -81,9 +79,10 @@ class GroupDetails extends React.Component<Props, State> {
     };
   }
 
-  remountComponent() {
+  remountComponent = () => {
     this.setState(this.initialState);
-  }
+    this.fetchData();
+  };
 
   get groupDetailsEndpoint() {
     return `/issues/${this.props.params.groupId}/`;
@@ -230,9 +229,7 @@ class GroupDetails extends React.Component<Props, State> {
     switch (this.state.errorType) {
       case ERROR_TYPES.GROUP_NOT_FOUND:
         return (
-          <Alert type="error" icon={<IconInfo size="lg" />}>
-            {t('The issue you were looking for was not found.')}
-          </Alert>
+          <LoadingError message={t('The issue you were looking for was not found.')} />
         );
       default:
         return <LoadingError onRetry={this.remountComponent} />;

--- a/tests/js/spec/components/asyncComponent.spec.jsx
+++ b/tests/js/spec/components/asyncComponent.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {mount, shallow} from 'sentry-test/enzyme';
+import {mountWithTheme, shallow} from 'sentry-test/enzyme';
 import {Client} from 'app/api';
 import AsyncComponent from 'app/components/asyncComponent';
 
@@ -46,14 +46,9 @@ describe('AsyncComponent', function() {
       },
       statusCode: 400,
     });
-    const wrapper = mount(<TestAsyncComponent />);
+    const wrapper = mountWithTheme(<TestAsyncComponent />);
     expect(wrapper.find('LoadingError')).toHaveLength(1);
-    expect(
-      wrapper
-        .find('LoadingError')
-        .find('p')
-        .text()
-    ).toEqual('oops there was a problem');
+    expect(wrapper.find('LoadingError').text()).toEqual('oops there was a problem');
   });
 
   describe('multi-route component', () => {

--- a/tests/js/spec/components/lazyLoad.spec.jsx
+++ b/tests/js/spec/components/lazyLoad.spec.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import LazyLoad from 'app/components/lazyLoad';
 
 describe('LazyLoad', function() {
   it('renders with a loading indicator when promise is not resolved yet', function() {
     const promise = new Promise(() => {});
     const getComponent = () => promise;
-    const wrapper = mount(<LazyLoad component={getComponent} />);
+    const wrapper = mountWithTheme(<LazyLoad component={getComponent} />);
 
     // Should be loading
     expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
@@ -19,7 +19,7 @@ describe('LazyLoad', function() {
       res = resolve;
     });
     const getComponent = () => promise;
-    const wrapper = mount(<LazyLoad component={getComponent} />);
+    const wrapper = mountWithTheme(<LazyLoad component={getComponent} />);
 
     // Should be loading
     expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
@@ -47,7 +47,7 @@ describe('LazyLoad', function() {
     let wrapper;
 
     try {
-      wrapper = mount(<LazyLoad component={getComponent} />);
+      wrapper = mountWithTheme(<LazyLoad component={getComponent} />);
     } catch (err) {
       // ignore
     }
@@ -65,7 +65,7 @@ describe('LazyLoad', function() {
 
   it('refetches when component changes', async function() {
     const getComponent = jest.fn(() => new Promise());
-    const wrapper = mount(<LazyLoad component={getComponent} />);
+    const wrapper = mountWithTheme(<LazyLoad component={getComponent} />);
 
     // Should be loading
     expect(wrapper.find('LoadingIndicator')).toHaveLength(1);

--- a/tests/js/spec/views/auth/login.spec.jsx
+++ b/tests/js/spec/views/auth/login.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import Login from 'app/views/auth/login';
 
 describe('Login', function() {
@@ -13,7 +13,7 @@ describe('Login', function() {
       url: '/auth/config/',
     });
 
-    const wrapper = mount(<Login />);
+    const wrapper = mountWithTheme(<Login />);
 
     expect(wrapper.find('LoadingIndicator').exists()).toBe(true);
   });
@@ -24,7 +24,7 @@ describe('Login', function() {
       statusCode: 500,
     });
 
-    const wrapper = mount(<Login />);
+    const wrapper = mountWithTheme(<Login />);
 
     await tick();
     wrapper.update();
@@ -39,7 +39,7 @@ describe('Login', function() {
       body: {canRegister: false},
     });
 
-    const wrapper = mount(<Login />);
+    const wrapper = mountWithTheme(<Login />);
 
     expect(
       wrapper
@@ -55,7 +55,7 @@ describe('Login', function() {
       body: {canRegister: true},
     });
 
-    const wrapper = mount(<Login />);
+    const wrapper = mountWithTheme(<Login />);
 
     await tick();
     wrapper.update();
@@ -74,7 +74,7 @@ describe('Login', function() {
       body: {canRegister: true},
     });
 
-    const wrapper = mount(<Login />);
+    const wrapper = mountWithTheme(<Login />);
 
     await tick();
     wrapper.update();

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import {openSudo} from 'app/actionCreators/modal';
 import * as OrganizationActionCreator from 'app/actionCreators/organization';
 import ConfigStore from 'app/stores/configStore';
@@ -27,7 +27,7 @@ describe('OrganizationContext', function() {
   let getOrgMock;
 
   const createWrapper = props => {
-    wrapper = mount(
+    wrapper = mountWithTheme(
       <OrganizationContext
         api={api}
         params={{orgId: 'org-slug'}}

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -124,6 +124,29 @@ describe('groupDetails', function() {
     );
   });
 
+  it('renders error message when failing to retrieve issue details and can retry request', async function() {
+    issueDetailsMock = MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/`,
+      statusCode: 403,
+    });
+    wrapper = createWrapper();
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
+    expect(issueDetailsMock).toHaveBeenCalledTimes(1);
+    expect(MockComponent).not.toHaveBeenCalled();
+    expect(wrapper.find('LoadingError').text()).toEqual(
+      'There was an error loading data.Retry'
+    );
+
+    console.log(wrapper.debug());
+    wrapper.find('button[aria-label="Retry"]').simulate('click');
+
+    expect(issueDetailsMock).toHaveBeenCalledTimes(2);
+  });
+
   it('fetches issue details for a given environment', async function() {
     const props = initializeOrg({
       project: TestStubs.Project(),

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -141,7 +141,6 @@ describe('groupDetails', function() {
       'There was an error loading data.Retry'
     );
 
-    console.log(wrapper.debug());
     wrapper.find('button[aria-label="Retry"]').simulate('click');
 
     expect(issueDetailsMock).toHaveBeenCalledTimes(2);

--- a/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import OrganizationEnvironmentsStore from 'app/stores/organizationEnvironmentsStore';
 import GroupEventDetailsContainer from 'app/views/organizationGroupDetails/groupEventDetails';
 
@@ -21,7 +21,7 @@ describe('groupEventDetailsContainer', () => {
       url: `/organizations/${org.slug}/environments/`,
       body: TestStubs.Environments(),
     });
-    const wrapper = mount(<GroupEventDetailsContainer organization={org} />);
+    const wrapper = mountWithTheme(<GroupEventDetailsContainer organization={org} />);
     // should be in loading state
     expect(wrapper.find('LoadingIndicator').exists()).toBe(true);
     await tick();
@@ -31,8 +31,8 @@ describe('groupEventDetailsContainer', () => {
     expect(wrapper.find('LoadingIndicator').exists()).toBe(false);
     expect(wrapper.text('GroupEventDetails')).toBe('GroupEventDetails');
 
-    // remounting will not rerender
-    const wrapper2 = mount(<GroupEventDetailsContainer organization={org} />);
+    // remountWithThemeing will not rerender
+    const wrapper2 = mountWithTheme(<GroupEventDetailsContainer organization={org} />);
     expect(wrapper2.find('LoadingIndicator').exists()).toBe(false);
     expect(wrapper.text('GroupEventDetails')).toBe('GroupEventDetails');
     expect(environmentsCall).toHaveBeenCalledTimes(1);
@@ -43,7 +43,7 @@ describe('groupEventDetailsContainer', () => {
       url: `/organizations/${org.slug}/environments/`,
       statusCode: 400,
     });
-    const wrapper = mount(<GroupEventDetailsContainer organization={org} />);
+    const wrapper = mountWithTheme(<GroupEventDetailsContainer organization={org} />);
     expect(wrapper.find('LoadingIndicator').exists()).toBe(true);
     await tick();
     await tick();
@@ -58,7 +58,7 @@ describe('groupEventDetailsContainer', () => {
       url: `/organizations/${org.slug}/environments/`,
       body: null,
     });
-    const wrapper = mount(<GroupEventDetailsContainer organization={org} />);
+    const wrapper = mountWithTheme(<GroupEventDetailsContainer organization={org} />);
     expect(wrapper.find('LoadingIndicator').exists()).toBe(true);
     await tick();
     await tick();
@@ -78,7 +78,7 @@ describe('groupEventDetailsContainer', () => {
       url: `/organizations/${org.slug}/environments/`,
       body: TestStubs.Environments(),
     });
-    const wrapper = mount(<GroupEventDetailsContainer organization={org} />);
+    const wrapper = mountWithTheme(<GroupEventDetailsContainer organization={org} />);
     expect(wrapper.find('LoadingIndicator').exists()).toBe(true);
     wrapper.unmount();
     expect(unsubscribeMock).toHaveBeenCalled();


### PR DESCRIPTION
* Fixes "Retry" on error message in `GroupDetails` introduced in #18368.
* Changes `<LoadingError />` to use `<Alert>` instead of old `alert alert-error` class names
  * Fixes a vertical alignment issue

Fixes JAVASCRIPT-2233

Old:
![image](https://user-images.githubusercontent.com/79684/79932464-6c4ce080-8402-11ea-90c4-6d6b1ea6bf54.png)

New:
![image](https://user-images.githubusercontent.com/79684/79932443-5c350100-8402-11ea-8341-a92e6080594c.png)

No Retry:
![image](https://user-images.githubusercontent.com/79684/79932582-afa74f00-8402-11ea-80b9-40c8a4635cd7.png)
