### PR TITLE
ref(snuba): Measure a count query as an alternative to listing IDs

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -333,7 +333,9 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             span.set_data("Result Size", len(group_ids))
         metrics.timing("snuba.search.num_candidates", len(group_ids))
 
-        if features.has("organizations:enterprise-perf"):
+        project_orgs = set(project.organization for project in projects)
+        query_org = tuple(project_orgs)[0] if len(project_orgs) == 1 else None
+        if query_org and features.has("organizations:enterprise-perf", query_org):
             with sentry_sdk.start_span(op="snuba_group_candidate_query") as span:
                 candidate_count = group_queryset.count()
                 span.set_data("Result", candidate_count)


### PR DESCRIPTION
This will inform a possible performance improvement where we do a
`.count` query first, and then do `.values_list` only if it's not a "too
many candidates" case. (The "too many candidates" case means both that
the list will be thrown out and that it was likely expensive to build.)

This is a strict downgrade in performance, in exchange for the most
useful instrumentation data. (That is, we get a side-by-side comparison
of the duration of both queries against the same result set.) Therefore,
the redundant query is made only behind the
"organizations:enterprise-perf" feature flag.