### PR TITLE
fix(issues): Ignore modal for custom num of occurrences opens wrong modal

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/ignore.tsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.tsx
@@ -229,7 +229,7 @@ export default class IgnoreActions extends React.Component<Props, State> {
                 ))}
                 <MenuItem divider />
                 <MenuItem noAnchor>
-                  <a onClick={() => this.setState({modal: ModalStates.USERS})}>
+                  <a onClick={() => this.setState({modal: ModalStates.COUNT})}>
                     {t('Custom')}
                   </a>
                 </MenuItem>


### PR DESCRIPTION


When attempting to ignore an issue until it has occurred a custom number of times, the modal for ignoring an issue when it's affected a custom number of users opens instead.

-----

Regression from #18348

------

Fixes ISSUE-816