### PR TITLE
fix(workflow): Fixing some logic around auto resolving incidents

### DIFF
--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -38,7 +38,7 @@ class IncidentSerializer(Serializer):
             "organizationId": six.text_type(obj.organization_id),
             "projects": attrs["projects"],
             "status": obj.status,
-            "status_method": obj.status_method,
+            "statusMethod": obj.status_method,
             "type": obj.type,
             "title": obj.title,
             "query": obj.query,

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -606,7 +606,7 @@ def snapshot_alert_rule(alert_rule):
 
     # Change the incident status asynchronously, which could take awhile with many incidents due to snapshot creations.
     tasks.auto_resolve_snapshot_incidents.apply_async(
-        kwargs={"alert_rule_id": alert_rule_snapshot.id}
+        kwargs={"alert_rule_id": alert_rule_snapshot.id}, countdown=3
     )
 
 

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -147,7 +147,7 @@ def handle_trigger_action(action_id, incident_id, project_id, method):
 @instrumented_task(
     name="sentry.incidents.tasks.auto_resolve_snapshot_incidents",
     queue="incidents",
-    default_retry_delay=60 * 5,
+    default_retry_delay=60,
     max_retries=2,
 )
 def auto_resolve_snapshot_incidents(alert_rule_id, **kwargs):

--- a/src/sentry/static/sentry/app/views/alerts/details/activity/statusItem.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/statusItem.tsx
@@ -5,7 +5,13 @@ import {t, tct} from 'app/locale';
 import ActivityItem from 'app/components/activity/item';
 import getDynamicText from 'app/utils/getDynamicText';
 
-import {Incident, IncidentActivityType, IncidentStatus, ActivityType} from '../../types';
+import {
+  Incident,
+  IncidentActivityType,
+  IncidentStatus,
+  ActivityType,
+  IncidentStatusMethod,
+} from '../../types';
 
 type Props = {
   activity: ActivityType;
@@ -66,7 +72,7 @@ class StatusItem extends React.Component<Props> {
                 currentTrigger: <StatusValue>{currentTrigger}</StatusValue>,
               })}
             {isClosed &&
-              !activity.user &&
+              incident?.statusMethod === IncidentStatusMethod.RULE_UPDATED &&
               t(
                 'This alert has been auto-resolved because the rule that triggered it has been modified or deleted.'
               )}

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -27,7 +27,7 @@ class IncidentSerializerTest(TestCase):
         assert result["organizationId"] == six.text_type(incident.organization_id)
         assert result["projects"] == [p.slug for p in incident.projects.all()]
         assert result["status"] == incident.status
-        assert result["status_method"] == incident.status_method
+        assert result["statusMethod"] == incident.status_method
         assert result["type"] == incident.type
         assert result["title"] == incident.title
         assert result["query"] == incident.query


### PR DESCRIPTION
This PR has a few small fixes in it. I just rolled them all into one since they're small (and I did them all on the same branch, so I'd have to explicitly separate them into different branches which doesn't feel like it's worth the time).

The first, is that the incident serializer is now sending a proper camel case statusMethod. 

The second is that I added a countdown to the async task that resolves incidents. It seems to have been firing before the transaction completed, and was reporting no rule existing with the ID it was sent. Adding the countdown reasonably ensures that it will run after this. I also lowered the default_retry_delay but this is a negligible change that has no effect. 

And the third is fixing the logic behind the incident activity item. This is the same logic that we're using for the banner now.