### PR TITLE
refs(mail): Allow MailAdapter to be overriden via a setting.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1865,3 +1865,4 @@ SENTRY_REQUEST_METRIC_ALLOWED_PATHS = (
     "sentry.discover.endpoints",
     "sentry.incidents.endpoints",
 )
+SENTRY_MAIL_ADAPTER_BACKEND = "sentry.mail.adapter.MailAdapter"

--- a/src/sentry/mail/__init__.py
+++ b/src/sentry/mail/__init__.py
@@ -1,1 +1,12 @@
 from __future__ import absolute_import
+
+from django.conf import settings
+
+from sentry.utils.imports import import_string
+
+
+def load_mail_adapter():
+    return import_string(settings.SENTRY_MAIL_ADAPTER_BACKEND)()
+
+
+mail_adapter = load_mail_adapter()

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 import logging
 
 import sentry
-from sentry.mail.adapter import MailAdapter, ActionTargetType
+from sentry.mail import mail_adapter
+from sentry.mail.adapter import ActionTargetType
 from sentry.plugins.bases.notify import NotificationPlugin
 from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
@@ -20,13 +21,10 @@ class MailPlugin(NotificationPlugin):
     author_url = "https://github.com/getsentry/sentry"
     project_default_enabled = True
     project_conf_form = None
-    mail_adapter = MailAdapter()
 
     def rule_notify(self, event, futures):
         metrics.incr("mail_plugin.rule_notify")
-        return self.mail_adapter.rule_notify(
-            event, futures, target_type=ActionTargetType.ISSUE_OWNERS
-        )
+        return mail_adapter.rule_notify(event, futures, target_type=ActionTargetType.ISSUE_OWNERS)
 
     def get_project_url(self, project):
         return absolute_uri(u"/{}/{}/".format(project.organization.slug, project.slug))
@@ -37,20 +35,19 @@ class MailPlugin(NotificationPlugin):
 
     def should_notify(self, group, event):
         metrics.incr("mail_plugin.should_notify")
-        return (
-            not group.project.flags.has_issue_alerts_targeting
-            and self.mail_adapter.should_notify(group)
+        return not group.project.flags.has_issue_alerts_targeting and mail_adapter.should_notify(
+            group
         )
 
     def notify(self, notification, **kwargs):
         metrics.incr("mail_plugin.notify")
-        return self.mail_adapter.notify(
+        return mail_adapter.notify(
             notification, target_type=ActionTargetType.ISSUE_OWNERS, **kwargs
         )
 
     def notify_digest(self, project, digest):
         metrics.incr("mail_plugin.notify_digest")
-        return self.mail_adapter.notify_digest(
+        return mail_adapter.notify_digest(
             project, digest, target_type=ActionTargetType.ISSUE_OWNERS
         )
 
@@ -59,14 +56,14 @@ class MailPlugin(NotificationPlugin):
             return
         metrics.incr("mail_plugin.notify_about_activity")
 
-        return self.mail_adapter.notify_about_activity(activity)
+        return mail_adapter.notify_about_activity(activity)
 
     def handle_signal(self, name, payload, **kwargs):
         if name == "user-reports.created":
             project = kwargs.get("project")
             if project and not project.flags.has_issue_alerts_targeting:
                 metrics.incr("mail_plugin.handle_signal")
-                self.mail_adapter.handle_signal(name, payload, **kwargs)
+                mail_adapter.handle_signal(name, payload, **kwargs)
 
     def can_configure_for_project(self, project):
         return (

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_activity_notifiers(project):
-    from sentry.mail.adapter import MailAdapter
+    from sentry.mail import mail_adapter
     from sentry.plugins.bases.notify import NotificationPlugin
     from sentry.plugins.base import plugins
 
@@ -23,7 +23,7 @@ def get_activity_notifiers(project):
             results.append(notifier)
 
     if project.flags.has_issue_alerts_targeting:
-        results.append(MailAdapter())
+        results.append(mail_adapter)
 
     return results
 

--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -37,7 +37,7 @@ def schedule_digests():
 @instrumented_task(name="sentry.tasks.digests.deliver_digest", queue="digests.delivery")
 def deliver_digest(key, schedule_timestamp=None):
     from sentry import digests
-    from sentry.mail.adapter import MailAdapter
+    from sentry.mail import mail_adapter
 
     try:
         project, target_type, target_identifier = split_key(key)
@@ -59,4 +59,4 @@ def deliver_digest(key, schedule_timestamp=None):
             return
 
         if digest:
-            MailAdapter().notify_digest(project, digest, target_type, target_identifier)
+            mail_adapter.notify_digest(project, digest, target_type, target_identifier)

--- a/src/sentry/tasks/signals.py
+++ b/src/sentry/tasks/signals.py
@@ -7,7 +7,7 @@ from sentry.utils.safe import safe_execute
 
 @instrumented_task(name="sentry.tasks.signal")
 def signal(name, payload, project_id=None, **kwargs):
-    from sentry.mail.adapter import MailAdapter
+    from sentry.mail import mail_adapter
     from sentry.models import Project
 
     if project_id is not None:
@@ -22,4 +22,4 @@ def signal(name, payload, project_id=None, **kwargs):
         safe_execute(plugin.handle_signal, name=name, payload=payload, project=project)
 
     if project and project.flags.has_issue_alerts_targeting:
-        safe_execute(MailAdapter().handle_signal, name=name, payload=payload, project=project)
+        safe_execute(mail_adapter.handle_signal, name=name, payload=payload, project=project)


### PR DESCRIPTION
We need to override `MailAdapter` in getsentry, so adding a setting to allow us to do so.