### PR TITLE
fix(ui): hide nonfunctional filter

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboards/index.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/index.jsx
@@ -19,8 +19,10 @@ class Dashboards extends React.Component {
 
     return (
       <Feature features={['discover']} renderDisabled>
-        <GlobalSelectionHeader organization={organization} />
-
+        <GlobalSelectionHeader
+          organization={organization}
+          showEnvironmentSelector={false}
+        />
         <PageContent>
           <LightWeightNoProjectMessage organization={organization}>
             <PageHeader>


### PR DESCRIPTION
Hide the nonfunctional environment filter on the Dashboards page.