### PR TITLE
fix(apm): Fix locale for inline errors on the span view

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -73,7 +73,7 @@ class SpansInterface extends React.Component<Props, State> {
 
     const label = tn(
       'There is an error event associated with this transaction event.',
-      `There are %d error events associated with this transaction event.`,
+      `There are %s error events associated with this transaction event.`,
       numOfErrors
     );
 


### PR DESCRIPTION
Address this error:

![Screen Shot 2020-04-22 at 7 10 33 PM](https://user-images.githubusercontent.com/139499/80042488-1e50df00-84cd-11ea-852a-1d49589c6291.png)
