### PR TITLE
feat(slack): sets up UI for slack migration

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -76,6 +76,7 @@ default_manager.add("organizations:integrations-issue-sync", OrganizationFeature
 default_manager.add("organizations:integrations-event-hooks", OrganizationFeature)  # NOQA
 default_manager.add("organizations:data-forwarding", OrganizationFeature)  # NOQA
 default_manager.add("organizations:slack-v2", OrganizationFeature)  # NOQA
+default_manager.add("organizations:slack-migration", OrganizationFeature)  # NOQA
 default_manager.add("organizations:internal-catchall", OrganizationFeature)  # NOQA
 default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -45,6 +45,10 @@ setup_alert = {
     "text": "The Slack integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to Slack you must create a rule using the slack workspace action in your project settings.",
 }
 
+reauthentication_alert = {
+    "alertText": _("Slack must be re-authorized to avoid a disruption of Slack notifications"),
+}
+
 metadata = IntegrationMetadata(
     description=_(DESCRIPTION.strip()),
     features=FEATURES,
@@ -52,7 +56,7 @@ metadata = IntegrationMetadata(
     noun=_("Workspace"),
     issue_url="https://github.com/getsentry/sentry/issues/new?title=Slack%20Integration:%20&labels=Component%3A%20Integrations",
     source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/slack",
-    aspects={"alerts": [setup_alert]},
+    aspects={"alerts": [setup_alert], "reauthentication_alert": reauthentication_alert},
 )
 
 

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -10,6 +10,7 @@ from sentry.integrations import (
     IntegrationMetadata,
     IntegrationProvider,
     FeatureDescription,
+    IntegrationInstallation,
 )
 from sentry.pipeline import NestedPipelineView
 from sentry.utils.http import absolute_uri
@@ -55,11 +56,20 @@ metadata = IntegrationMetadata(
 )
 
 
+class SlackIntegration(IntegrationInstallation):
+    def get_config_data(self):
+        metadata = self.model.metadata
+        # classic bots had a user_access_token in the metadata
+        default_installation = "classic_bot" if "user_access_token" in metadata else "workspace_app"
+        return {"installationType": metadata.get("installation_type", default_installation)}
+
+
 class SlackIntegrationProvider(IntegrationProvider):
     key = "slack"
     name = "Slack"
     metadata = metadata
     features = frozenset([IntegrationFeatures.CHAT_UNFURL, IntegrationFeatures.ALERT_RULE])
+    integration_cls = SlackIntegration
 
     # Scopes differ depending on if it's a workspace app
     wst_oauth_scopes = frozenset(

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -46,7 +46,7 @@ setup_alert = {
 }
 
 reauthentication_alert = {
-    "alertText": _("Slack must be re-authorized to avoid a disruption of Slack notifications"),
+    "alertText": "Slack must be re-authorized to avoid a disruption of Slack notifications",
 }
 
 metadata = IntegrationMetadata(

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -8,6 +8,7 @@ import {
   NOT_INSTALLED,
   PENDING,
 } from 'app/views/organizationIntegrations/constants';
+import {Props as AlertProps} from 'app/components/alert';
 
 declare global {
   interface Window {
@@ -663,7 +664,7 @@ type IntegrationDialog = {
 };
 
 type IntegrationAspects = {
-  alerts?: Array<{type: 'info' | 'warning'; text: string; icon?: string}>;
+  alerts?: Array<AlertProps & {text: string}>;
   reauthentication_alert?: {alertText: string};
   disable_dialog?: IntegrationDialog;
   removal_dialog?: IntegrationDialog;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -749,7 +749,14 @@ export type Integration = {
   provider: BaseIntegrationProvider & {aspects: any};
   configOrganization: Field[];
   //TODO(ts): This includes the initial data that is passed into the integration's configuration form
-  configData: object;
+  configData: object & {
+    //installationType is only for Slack migration and can be removed after migrations are done
+    installationType?:
+      | 'workspace_app'
+      | 'classic_bot'
+      | 'born_as_bot'
+      | 'migrated_to_bot';
+  };
 };
 
 export type IntegrationExternalIssue = {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -657,6 +657,23 @@ export type PullRequest = {
   externalUrl: string;
 };
 
+type IntegrationDialog = {
+  actionText: string;
+  body: string;
+};
+
+type IntegrationAspects = {
+  alerts?: Array<{type: 'info' | 'warning'; text: string; icon?: string}>;
+  reauthentication_alert?: {alertText: string};
+  disable_dialog?: IntegrationDialog;
+  removal_dialog?: IntegrationDialog;
+  externalInstall?: {
+    url: string;
+    buttonText: string;
+    noticeText: string;
+  };
+};
+
 type BaseIntegrationProvider = {
   key: string;
   slug: string;
@@ -675,7 +692,7 @@ export type IntegrationProvider = BaseIntegrationProvider & {
     noun: string;
     issue_url: string;
     source_url: string;
-    aspects: any; //TODO(ts)
+    aspects: IntegrationAspects;
   };
 };
 
@@ -746,7 +763,7 @@ export type Integration = {
   domainName: string;
   accountType: string;
   status: ObjectStatus;
-  provider: BaseIntegrationProvider & {aspects: any}; //TODO: Type properly
+  provider: BaseIntegrationProvider & {aspects: IntegrationAspects};
   configOrganization: Field[];
   //TODO(ts): This includes the initial data that is passed into the integration's configuration form
   configData: object & {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -746,7 +746,7 @@ export type Integration = {
   domainName: string;
   accountType: string;
   status: ObjectStatus;
-  provider: BaseIntegrationProvider & {aspects: any};
+  provider: BaseIntegrationProvider & {aspects: any}; //TODO: Type properly
   configOrganization: Field[];
   //TODO(ts): This includes the initial data that is passed into the integration's configuration form
   configData: object & {

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -13,6 +13,7 @@ import {
   SentryApp,
   PluginWithProjectList,
   DocumentIntegration,
+  Integration,
 } from 'app/types';
 import {Hooks} from 'app/types/hooks';
 import HookStore from 'app/stores/hookStore';
@@ -274,4 +275,8 @@ export function isDocumentIntegration(
   integration: AppOrProviderOrPlugin
 ): integration is DocumentIntegration {
   return integration.hasOwnProperty('docUrl');
+}
+
+export function isSlackWorkspaceApp(integration: Integration) {
+  return integration.configData.installationType === 'workspace_app';
 }

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -14,6 +14,7 @@ import {
   PluginWithProjectList,
   DocumentIntegration,
   Integration,
+  IntegrationProvider,
 } from 'app/types';
 import {Hooks} from 'app/types/hooks';
 import HookStore from 'app/stores/hookStore';
@@ -279,4 +280,9 @@ export function isDocumentIntegration(
 
 export function isSlackWorkspaceApp(integration: Integration) {
   return integration.configData.installationType === 'workspace_app';
+}
+
+//returns the text in the alert asking the user to re-authenticate a first-party integration
+export function getReauthAlertText(provider: IntegrationProvider) {
+  return provider.metadata.aspects?.reauthentication_alert?.alertText;
 }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
@@ -27,6 +27,7 @@ export type Props = {
   className?: string;
 };
 
+//TODO: Replace with InstalledIntegrationInDirectory
 export default class InstalledIntegration extends React.Component<Props> {
   static propTypes = {
     organization: SentryTypes.Organization.isRequired,
@@ -122,7 +123,7 @@ export default class InstalledIntegration extends React.Component<Props> {
 
   get disableConfirmProps() {
     const {integration} = this.props;
-    const {body, actionText} = integration.provider.aspects.disable_dialog;
+    const {body, actionText} = integration.provider.aspects.disable_dialog || {};
     const message = (
       <React.Fragment>
         <Alert type="error" icon="icon-circle-exclamation">

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
@@ -16,7 +16,7 @@ import theme from 'app/utils/theme';
 import space from 'app/styles/space';
 import {IconWarning} from 'app/icons';
 
-const CONFIGURABLE_FEATURES = [];
+const CONFIGURABLE_FEATURES = ['commits', 'alert-rule'];
 
 export type Props = {
   organization: Organization;
@@ -65,7 +65,7 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
   };
 
   //TODO(TS): add typing on aspects
-  getRemovalBodyAndText(aspects) {
+  getRemovalBodyAndText(aspects: Integration['provider']['aspects']) {
     if (aspects && aspects.removal_dialog) {
       return {
         body: aspects.removal_dialog.body,
@@ -110,7 +110,7 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
 
   get disableConfirmProps() {
     const {integration} = this.props;
-    const {body, actionText} = integration.provider.aspects.disable_dialog;
+    const {body, actionText} = integration.provider.aspects.disable_dialog || {};
     const message = (
       <React.Fragment>
         <Alert type="error" icon="icon-circle-exclamation">

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
@@ -14,6 +14,7 @@ import {SingleIntegrationEvent} from 'app/utils/integrationUtil';
 import CircleIndicator from 'app/components/circleIndicator';
 import theme from 'app/utils/theme';
 import space from 'app/styles/space';
+import {IconWarning} from 'app/icons';
 
 const CONFIGURABLE_FEATURES = ['commits', 'alert-rule'];
 
@@ -28,6 +29,7 @@ export type Props = {
     options: Pick<SingleIntegrationEvent, 'eventKey' | 'eventName'>
   ) => void; //analytics callback
   className?: string;
+  showSlackAlert?: boolean;
 };
 
 //TODO: Rename to InstalledIntegration when we can remove the old one
@@ -125,7 +127,7 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
   }
 
   render() {
-    const {className, integration, provider, organization} = this.props;
+    const {className, integration, provider, organization, showSlackAlert} = this.props;
 
     const removeConfirmProps =
       integration.status === 'active' && integration.provider.canDisable
@@ -140,11 +142,33 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
               <IntegrationItem integration={integration} />
             </IntegrationItemBox>
             <div>
-              {
+              {showSlackAlert && (
                 <Tooltip
-                  disabled={this.hasConfiguration()}
-                  position="left"
-                  title="Integration not configurable"
+                  disabled={hasAccess}
+                  title={t(
+                    'You must be an organization owner, manager or admin to re-authenticate'
+                  )}
+                >
+                  <Button
+                    disabled={!hasAccess}
+                    priority="primary"
+                    size="small"
+                    icon={<IconWarning size="sm" />}
+                  >
+                    {t('Re-authenticate Now')}
+                  </Button>
+                </Tooltip>
+              )}
+              <Tooltip
+                disabled={this.hasConfiguration()}
+                position="left"
+                title="Integration not configurable"
+              >
+                <Tooltip
+                  disabled={hasAccess || !this.hasConfiguration()}
+                  title={t(
+                    'You must be an organization owner, manager or admin to configure'
+                  )}
                 >
                   <StyledButton
                     borderless
@@ -157,27 +181,34 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
                     to={`/settings/${organization.slug}/integrations/${provider.key}/${integration.id}/`}
                     data-test-id="integration-configure-button"
                   >
-                    Configure
+                    {t('Configure')}
                   </StyledButton>
                 </Tooltip>
-              }
+              </Tooltip>
             </div>
             <div>
-              <Confirm
-                priority="danger"
-                onConfirming={this.handleUninstallClick}
-                disabled={!hasAccess}
-                {...removeConfirmProps}
+              <Tooltip
+                disabled={hasAccess}
+                title={t(
+                  'You must be an organization owner, manager or admin to uninstall'
+                )}
               >
-                <StyledButton
+                <Confirm
+                  priority="danger"
+                  onConfirming={this.handleUninstallClick}
                   disabled={!hasAccess}
-                  borderless
-                  icon={<IconDelete />}
-                  data-test-id="integration-remove-button"
+                  {...removeConfirmProps}
                 >
-                  Uninstall
-                </StyledButton>
-              </Confirm>
+                  <StyledButton
+                    disabled={!hasAccess}
+                    borderless
+                    icon={<IconDelete />}
+                    data-test-id="integration-remove-button"
+                  >
+                    {t('Uninstall')}
+                  </StyledButton>
+                </Confirm>
+              </Tooltip>
             </div>
 
             <IntegrationStatus status={integration.status} />

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegrationInDirectory.tsx
@@ -64,7 +64,6 @@ export default class InstalledIntegrationInDirectory extends React.Component<Pro
     });
   };
 
-  //TODO(TS): add typing on aspects
   getRemovalBodyAndText(aspects: Integration['provider']['aspects']) {
     if (aspects && aspects.removal_dialog) {
       return {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -15,7 +15,7 @@ import Button from 'app/components/button';
 import InstalledIntegration from 'app/views/organizationIntegrations/installedIntegrationInDirectory';
 import withOrganization from 'app/utils/withOrganization';
 import {sortArray} from 'app/utils';
-import {isSlackWorkspaceApp} from 'app/utils/integrationUtil';
+import {isSlackWorkspaceApp, getReauthAlertText} from 'app/utils/integrationUtil';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 
@@ -215,9 +215,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
             <div>
               {hasFeature && hasWorkspaceApp && (
                 <Alert type="warning" icon={<IconWarning size="sm" />}>
-                  {t(
-                    'Slack must be re-authorized to avoid a disruption of Slack notifications'
-                  )}
+                  {getReauthAlertText(provider)}
                 </Alert>
               )}
               <div>
@@ -232,7 +230,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
                       onReinstallIntegration={this.onInstall}
                       data-test-id={integration.id}
                       trackIntegrationEvent={this.trackIntegrationEvent}
-                      showSlackAlert={hasFeature && isSlackWorkspaceApp(integration)}
+                      showReauthMessage={hasFeature && isSlackWorkspaceApp(integration)}
                     />
                   </InstallWrapper>
                 ))}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -218,23 +218,21 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
                   {getReauthAlertText(provider)}
                 </Alert>
               )}
-              <div>
-                {configurations.map(integration => (
-                  <InstallWrapper key={integration.id}>
-                    <InstalledIntegration
-                      organization={organization}
-                      provider={provider}
-                      integration={integration}
-                      onRemove={this.onRemove}
-                      onDisable={this.onDisable}
-                      onReinstallIntegration={this.onInstall}
-                      data-test-id={integration.id}
-                      trackIntegrationEvent={this.trackIntegrationEvent}
-                      showReauthMessage={hasFeature && isSlackWorkspaceApp(integration)}
-                    />
-                  </InstallWrapper>
-                ))}
-              </div>
+              {configurations.map(integration => (
+                <InstallWrapper key={integration.id}>
+                  <InstalledIntegration
+                    organization={organization}
+                    provider={provider}
+                    integration={integration}
+                    onRemove={this.onRemove}
+                    onDisable={this.onDisable}
+                    onReinstallIntegration={this.onInstall}
+                    data-test-id={integration.id}
+                    trackIntegrationEvent={this.trackIntegrationEvent}
+                    showReauthMessage={hasFeature && isSlackWorkspaceApp(integration)}
+                  />
+                </InstallWrapper>
+              ))}
             </div>
           )}
         </Feature>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -27,6 +27,7 @@ import {
   isDocumentIntegration,
   getCategoriesForIntegration,
   isSlackWorkspaceApp,
+  getReauthAlertText,
 } from 'app/utils/integrationUtil';
 import {t, tct} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -337,7 +338,7 @@ export class IntegrationListDirectory extends AsyncComponent<
             publishStatus="published"
             configurations={integrations.length}
             categories={getCategoriesForIntegration(provider)}
-            showSlackAlert={hasFeature && hasWorkspaceApp}
+            alertText={hasFeature && hasWorkspaceApp && getReauthAlertText(provider)}
           />
         )}
       </Feature>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -26,6 +26,7 @@ import {
   isPlugin,
   isDocumentIntegration,
   getCategoriesForIntegration,
+  isSlackWorkspaceApp,
 } from 'app/utils/integrationUtil';
 import {t, tct} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -39,6 +40,7 @@ import space from 'app/styles/space';
 import SelectControl from 'app/components/forms/selectControl';
 import withExperiment from 'app/utils/withExperiment';
 import {ExperimentAssignment} from 'app/types/experiments';
+import Feature from 'app/components/acl/feature';
 
 import {POPULARITY_WEIGHT, documentIntegrations} from './constants';
 import IntegrationRow from './integrationRow';
@@ -315,19 +317,30 @@ export class IntegrationListDirectory extends AsyncComponent<
       i => i.provider.key === provider.key
     );
 
+    const hasWorkspaceApp = integrations.some(isSlackWorkspaceApp);
+
     return (
-      <IntegrationRow
+      <Feature
         key={`row-${provider.key}`}
-        data-test-id="integration-row"
         organization={organization}
-        type="firstParty"
-        slug={provider.slug}
-        displayName={provider.name}
-        status={integrations.length ? 'Installed' : 'Not Installed'}
-        publishStatus="published"
-        configurations={integrations.length}
-        categories={getCategoriesForIntegration(provider)}
-      />
+        features={['slack-migration']}
+      >
+        {({hasFeature}) => (
+          <IntegrationRow
+            key={`row-${provider.key}`}
+            data-test-id="integration-row"
+            organization={organization}
+            type="firstParty"
+            slug={provider.slug}
+            displayName={provider.name}
+            status={integrations.length ? 'Installed' : 'Not Installed'}
+            publishStatus="published"
+            configurations={integrations.length}
+            categories={getCategoriesForIntegration(provider)}
+            showSlackAlert={hasFeature && hasWorkspaceApp}
+          />
+        )}
+      </Feature>
     );
   };
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -338,7 +338,9 @@ export class IntegrationListDirectory extends AsyncComponent<
             publishStatus="published"
             configurations={integrations.length}
             categories={getCategoriesForIntegration(provider)}
-            alertText={hasFeature && hasWorkspaceApp && getReauthAlertText(provider)}
+            alertText={
+              hasFeature && hasWorkspaceApp ? getReauthAlertText(provider) : undefined
+            }
           />
         )}
       </Feature>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -23,7 +23,7 @@ type Props = {
   publishStatus: 'unpublished' | 'published' | 'internal';
   configurations: number;
   categories: string[];
-  showSlackAlert?: boolean;
+  alertText?: string;
 };
 
 const urlMap = {
@@ -43,7 +43,7 @@ const IntegrationRow = (props: Props) => {
     publishStatus,
     configurations,
     categories,
-    showSlackAlert,
+    alertText,
   } = props;
 
   const baseUrl =
@@ -92,12 +92,10 @@ const IntegrationRow = (props: Props) => {
           ))}
         </InternalContainer>
       </FlexContainer>
-      {showSlackAlert && (
+      {alertText && (
         <AlertContainer>
           <Alert type="warning" icon={<IconWarning size="sm" />}>
-            {t(
-              'Slack must be re-authorized to avoid a disruption of Slack notifications'
-            )}
+            {alertText}
             <ResolveNowButton href={`${baseUrl}?tab=configurations`} size="xsmall">
               {t('Resolve Now')}
             </ResolveNowButton>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import styled from '@emotion/styled';
 import startCase from 'lodash/startCase';
 
+import {IconWarning} from 'app/icons';
+import Button from 'app/components/button';
+import Alert from 'app/components/alert';
 import Link from 'app/components/links/link';
 import {PanelItem} from 'app/components/panels';
 import PluginIcon from 'app/plugins/components/pluginIcon';
@@ -20,6 +23,7 @@ type Props = {
   publishStatus: 'unpublished' | 'published' | 'internal';
   configurations: number;
   categories: string[];
+  showSlackAlert?: boolean;
 };
 
 const urlMap = {
@@ -39,6 +43,7 @@ const IntegrationRow = (props: Props) => {
     publishStatus,
     configurations,
     categories,
+    showSlackAlert,
   } = props;
 
   const baseUrl =
@@ -87,6 +92,18 @@ const IntegrationRow = (props: Props) => {
           ))}
         </InternalContainer>
       </FlexContainer>
+      {showSlackAlert && (
+        <AlertContainer>
+          <Alert type="warning" icon={<IconWarning size="sm" />}>
+            {t(
+              'Slack must be re-authorized to avoid a disruption of Slack notifications'
+            )}
+            <ResolveNowButton href={`${baseUrl}?tab=configurations`} size="xsmall">
+              {t('Resolve Now')}
+            </ResolveNowButton>
+          </Alert>
+        </AlertContainer>
+      )}
     </PanelItem>
   );
 };
@@ -171,6 +188,21 @@ const CategoryTag = styled(
   line-height: ${space(3)};
   text-align: center;
   color: ${p => (p.priority ? p.theme.white : p.theme.gray4)};
+`;
+
+const ResolveNowButton = styled(Button)`
+  color: ${p => p.theme.gray2};
+  background: #ffffff;
+
+  border: ${p => `1px solid ${p.theme.gray2}`};
+  box-sizing: border-box;
+  box-shadow: 0px 2px 1px rgba(0, 0, 0, 0.08);
+  border-radius: 4px;
+  float: right;
+`;
+
+const AlertContainer = styled('div')`
+  padding: 0px 20px 0px 68px;
 `;
 
 export default IntegrationRow;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -95,7 +95,7 @@ const IntegrationRow = (props: Props) => {
       {alertText && (
         <AlertContainer>
           <Alert type="warning" icon={<IconWarning size="sm" />}>
-            {alertText}
+            <span>{alertText}</span>
             <ResolveNowButton href={`${baseUrl}?tab=configurations`} size="xsmall">
               {t('Resolve Now')}
             </ResolveNowButton>
@@ -191,16 +191,11 @@ const CategoryTag = styled(
 const ResolveNowButton = styled(Button)`
   color: ${p => p.theme.gray2};
   background: #ffffff;
-
-  border: ${p => `1px solid ${p.theme.gray2}`};
-  box-sizing: border-box;
-  box-shadow: 0px 2px 1px rgba(0, 0, 0, 0.08);
-  border-radius: 4px;
   float: right;
 `;
 
 const AlertContainer = styled('div')`
-  padding: 0px 20px 0px 68px;
+  padding: 0px ${space(3)} 0px 68px;
 `;
 
 export default IntegrationRow;

--- a/src/sentry/static/sentry/app/views/settings/organization/permissionAlert.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/permissionAlert.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {t} from 'app/locale';
 import Access from 'app/components/acl/access';
 import Alert from 'app/components/alert';
+import {IconWarning} from 'app/icons';
 
 type Props = React.ComponentPropsWithoutRef<typeof Alert> &
   Pick<React.ComponentProps<typeof Access>, 'access'>;
@@ -12,7 +13,7 @@ const PermissionAlert = ({access = ['org:write'], ...props}: Props) => (
   <Access access={access}>
     {({hasAccess}) =>
       !hasAccess && (
-        <Alert type="warning" icon="icon-warning-sm" {...props}>
+        <Alert type="warning" icon={<IconWarning size="sm" />} {...props}>
           {t(
             'These settings can only be edited by users with the organization owner or manager role.'
           )}

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -6,7 +6,7 @@ import six
 from django.test.utils import override_settings
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 
-from sentry.integrations.slack import SlackIntegrationProvider
+from sentry.integrations.slack import SlackIntegrationProvider, SlackIntegration
 from sentry.models import (
     Identity,
     IdentityProvider,
@@ -14,7 +14,7 @@ from sentry.models import (
     Integration,
     OrganizationIntegration,
 )
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils import IntegrationTestCase, TestCase
 from sentry.testutils.helpers import override_options, with_feature
 
 
@@ -204,3 +204,20 @@ class SlackIntegrationTest(IntegrationTestCase):
                 expected_client_id="other-id",
                 expected_client_secret="other-secret",
             )
+
+
+class SlackIntegrationConfigTest(TestCase):
+    def setUp(self):
+        self.integration = Integration.objects.create(provider="slack", name="Slack", metadata={})
+        self.installation = SlackIntegration(self.integration, self.organization.id)
+
+    def test_config_data_workspace_app(self):
+        self.installation.get_config_data()["installationType"] = "workspace_app"
+
+    def test_config_data_user_token(self):
+        self.integration.metadata["user_access_token"] = "token"
+        self.installation.get_config_data()["installationType"] = "classic_bot"
+
+    def test_config_data_born_as_bot(self):
+        self.integration.metadata["installation_type"] = "born_as_bot"
+        self.installation.get_config_data()["installationType"] = "born_as_bot"


### PR DESCRIPTION
This PR adds the UI for alerting the user that they need to re-authenticate their slack app if their installation is from a workspace app. This logic is driven by the new `installationType` field in the `configData` of the `Integration` serializer. If we don't have `installation_type` in the `metadata`, we determine the value based on whether or not there is `user_access_token` in the metadata. If there is, the type is `classic_bot`, otherwise it's `workspace_app` which means we would show the re-auth alerts. The feature is hidden behind a new feature flag called `organizations:slack-migration` so only orgs we flag in will see it for now.

I also made a few other changes:

- Added tooltips for disabled actions of the installed integrations if the user doesn't have permissions
- Reduced the size of the icon in `PermissionAlert` so it matches the new alert for the slack migration

![Screen Shot 2020-04-22 at 3 48 10 PM](https://user-images.githubusercontent.com/8533851/80043478-aaa3d780-84b6-11ea-8178-234a708f25dd.png)
![Screen Shot 2020-04-22 at 3 59 35 PM](https://user-images.githubusercontent.com/8533851/80043523-cdce8700-84b6-11ea-86e2-6edd957c6180.png)
