### PR TITLE
refs(mail): Cleanup digests task key migration code.

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -11,7 +11,6 @@ from six.moves import reduce
 from sentry.app import tsdb
 from sentry.digests import Record
 from sentry.models import Project, Group, GroupStatus, Rule
-from sentry.utils import metrics
 from sentry.utils.dates import to_timestamp
 
 logger = logging.getLogger("sentry.digests")
@@ -24,15 +23,8 @@ def split_key(key):
 
     key_parts = key.split(":", 4)
     project_id = key_parts[2]
-    if len(key_parts) == 5:
-        target_type = ActionTargetType(key_parts[3])
-        target_identifier = key_parts[4] if key_parts[4] else None
-        metrics.incr("digests.new_key_seen")
-    else:
-        metrics.incr("digests.old_key_seen")
-
-        target_type = ActionTargetType.ISSUE_OWNERS
-        target_identifier = None
+    target_type = ActionTargetType(key_parts[3])
+    target_identifier = key_parts[4] if key_parts[4] else None
     return Project.objects.get(pk=project_id), target_type, target_identifier
 
 

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -118,13 +118,6 @@ class SortRecordsTestCase(TestCase):
 
 
 class SplitKeyTestCase(TestCase):
-    def test_old_style_key(self):
-        assert split_key("mail:p:{}".format(self.project.id)) == (
-            self.project,
-            ActionTargetType.ISSUE_OWNERS,
-            None,
-        )
-
     def test_new_style_key_no_identifier(self):
         assert split_key(
             "mail:p:{}:{}:".format(self.project.id, ActionTargetType.ISSUE_OWNERS.value)

--- a/tests/sentry/tasks/test_digests.py
+++ b/tests/sentry/tasks/test_digests.py
@@ -28,17 +28,12 @@ class DeliverDigestTest(TestCase):
             data={"timestamp": iso_format(before_now(days=1)), "fingerprint": ["group-2"]},
             project_id=self.project.id,
         )
-        key = "mail:p:{}".format(self.project.id)
         backend.add(key, event_to_record(event, [rule]), increment_delay=0, maximum_delay=0)
         backend.add(key, event_to_record(event_2, [rule]), increment_delay=0, maximum_delay=0)
         digests.digest = backend.digest
         with self.tasks():
             deliver_digest(key)
         assert "2 new alerts since" in mail.outbox[0].subject
-
-    @patch.object(sentry, "digests")
-    def test_old_key(self, digests):
-        self.run_test("mail:p:{}".format(self.project.id), digests)
 
     @patch.object(sentry, "digests")
     def test_new_key(self, digests):


### PR DESCRIPTION
We had transition code in place so that we could handle old-style and new-style digest keys. The
metrics show that we're only using new-style keys now, so it's safe to remove this extra code.