### PR TITLE
ref(dev): Disable the shutdown timeout for dev Relay

### DIFF
--- a/config/relay/config.yml
+++ b/config/relay/config.yml
@@ -1,13 +1,15 @@
 ---
 relay:
-  upstream: "http://host.docker.internal:8888/"
+  upstream: 'http://host.docker.internal:8888/'
   host: 0.0.0.0
   port: 3000
 logging:
   level: INFO
   enable_backtraces: false
+limits:
+  shutdown_timeout: 0
 processing:
   enabled: true
   kafka_config:
-    - {name: "bootstrap.servers", value: "sentry_kafka:9093"}
+    - {name: 'bootstrap.servers', value: 'sentry_kafka:9093'}
   redis: redis://sentry_redis:6379


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/18426 it came up that Relay has a long shutdown time. This is due to a hardcoded shutdown delay. This sets this shutdown delay to `0`, triggering instant shutdown.

Ref https://github.com/getsentry/relay/pull/561