### PR TITLE
ref(dev): Forward all store-like endpoints to Relay

### DIFF
--- a/config/reverse_proxy/nginx.conf
+++ b/config/reverse_proxy/nginx.conf
@@ -39,6 +39,7 @@ http {
         location /api/store/ {
             proxy_pass http://relay;
         }
+        # All supported ingest endpoints
         location ~ ^/api/[1-9]\d*/ {
             proxy_pass http://relay;
         }

--- a/config/reverse_proxy/nginx.conf
+++ b/config/reverse_proxy/nginx.conf
@@ -39,25 +39,7 @@ http {
         location /api/store/ {
             proxy_pass http://relay;
         }
-        location ~ ^/api/\d+/envelope/$ {
-            proxy_pass http://relay;
-        }
-        location ~ ^/api/\d+/store/$ {
-            proxy_pass http://relay;
-        }
-        location ~ ^/api/\d+/minidump/?$ {
-            proxy_pass http://relay;
-        }
-        location ~ ^/api/\d+/unreal/\w+/$ {
-            proxy_pass http://relay;
-        }
-        location ~ ^/api/\d+/security/$ {
-            proxy_pass http://relay;
-        }
-        location ~ ^/api/\d+/csp-report/$ {
-            proxy_pass http://relay;
-        }
-        location ~ ^/api/\d+/events/[\w-]+/attachments/$ {
+        location ~ ^/api/[1-9]\d*/ {
             proxy_pass http://relay;
         }
         location / {


### PR DESCRIPTION
In order to not have to maintain this list manually, we can forward all store-like endpoints (everything outside of `/api/0/`) to Relay.

cc @RaduW @BYK 