### PR TITLE
feat(filters): Add an IE11 inbound data filter

### DIFF
--- a/src/sentry/message_filters.py
+++ b/src/sentry/message_filters.py
@@ -377,6 +377,7 @@ class _LegacyBrowserFilterSerializer(serializers.Serializer):
             "ie_pre_9",
             "ie9",
             "ie10",
+            "ie11",
             "opera_pre_15",
             "android_pre_4",
             "safari_pre_6",
@@ -474,6 +475,10 @@ def _filter_opera_mini_pre_8(browser):
     return False
 
 
+def _filter_ie11(browser):
+    return _filter_ie_internal(browser, lambda major_ver: major_ver == 11)
+
+
 def _filter_ie10(browser):
     return _filter_ie_internal(browser, lambda major_ver: major_ver == 10)
 
@@ -507,6 +512,7 @@ _legacy_browsers_sub_filters = {
     "opera_mini_pre_8": _filter_opera_mini_pre_8,
     "ie9": _filter_ie9,
     "ie10": _filter_ie10,
+    "ie11": _filter_ie11,
     "ie_pre_9": _filter_ie_pre_9,
 }
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
@@ -39,6 +39,11 @@ const LEGACY_BROWSER_SUBFILTERS = {
     helpText: 'Version 10',
     title: 'Internet Explorer',
   },
+  ie11: {
+    icon: 'internet-explorer',
+    helpText: 'Version 11',
+    title: 'Internet Explorer',
+  },
   safari_pre_6: {
     icon: 'safari',
     helpText: 'Version 5 and lower',

--- a/tests/js/spec/views/projectFilters.spec.jsx
+++ b/tests/js/spec/views/projectFilters.spec.jsx
@@ -132,7 +132,7 @@ describe('ProjectFilters', function() {
     expect(Array.from(mock.mock.calls[0][1].data.subfilters)).toEqual([
       'ie_pre_9',
       'ie9',
-      'opera_pre_15',
+      'safari_pre_6',
     ]);
 
     // Toggle filter off
@@ -143,8 +143,8 @@ describe('ProjectFilters', function() {
     expect(Array.from(mock.mock.calls[1][1].data.subfilters)).toEqual([
       'ie_pre_9',
       'ie9',
-      'opera_pre_15',
       'safari_pre_6',
+      'ie11',
     ]);
 
     mock.mockReset();
@@ -160,8 +160,8 @@ describe('ProjectFilters', function() {
       .simulate('click');
 
     expect(Array.from(mock.mock.calls[1][1].data.subfilters)).toEqual([
-      'opera_pre_15',
       'safari_pre_6',
+      'ie11',
     ]);
   });
 
@@ -178,6 +178,7 @@ describe('ProjectFilters', function() {
       'ie_pre_9',
       'ie9',
       'ie10',
+      'ie11',
       'safari_pre_6',
       'opera_pre_15',
       'opera_mini_pre_8',


### PR DESCRIPTION
Adds an inbound data filter setting for IE11, which is executed by Relay.

<img width="639" alt="Screen Shot 2020-04-23 at 16 22 41" src="https://user-images.githubusercontent.com/1433023/80111523-45b4b400-8580-11ea-91a2-3475b6804ec8.png">

Ref https://github.com/getsentry/relay/pull/562