### PR TITLE
feat(ui) Add a short formatter for event id in discover results

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -16,6 +16,7 @@ import Projects from 'app/utils/projects';
 
 import {
   Container,
+  EventId,
   NumberContainer,
   OverflowLink,
   StyledDateTime,
@@ -147,6 +148,7 @@ type SpecialField = {
 };
 
 type SpecialFields = {
+  id: SpecialField;
   project: SpecialField;
   user: SpecialField;
   'issue.id': SpecialField;
@@ -155,11 +157,20 @@ type SpecialFields = {
 };
 
 /**
- * "Special fields" do not map 1:1 to an single column in the event database,
- * they are a UI concept that combines the results of multiple fields and
- * displays with a custom render function.
+ * "Special fields" either do not map 1:1 to an single column in the event database,
+ * or they require custom UI formatting that can't be handled by the datatype formatters.
  */
 const SPECIAL_FIELDS: SpecialFields = {
+  id: {
+    sortField: 'id',
+    renderFunc: data => {
+      return (
+        <Container>
+          <EventId value={data.id} />
+        </Container>
+      );
+    },
+  },
   'issue.id': {
     sortField: 'issue.id',
     renderFunc: (data, {organization}) => {

--- a/src/sentry/static/sentry/app/utils/discover/styles.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/styles.tsx
@@ -1,8 +1,11 @@
+import React from 'react';
 import styled from '@emotion/styled';
 
+import Clipboard from 'app/components/clipboard';
 import DateTime from 'app/components/dateTime';
 import Link from 'app/components/links/link';
 import ShortId from 'app/components/shortId';
+import {IconCopy} from 'app/icons';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 
@@ -71,3 +74,22 @@ export const HeaderControls = styled('div')`
 export const StyledShortId = styled(ShortId)`
   justify-content: flex-start;
 `;
+
+const StyledIconCopy = styled(IconCopy)`
+  cursor: pointer;
+  margin-right: ${space(0.5)};
+`;
+
+export const EventId = ({value}: {value: string}) => {
+  const shortId = value.substring(0, 8);
+  return (
+    <React.Fragment>
+      <Clipboard value={value}>
+        <span>
+          <StyledIconCopy size="xs" />
+        </span>
+      </Clipboard>
+      {shortId}
+    </React.Fragment>
+  );
+};


### PR DESCRIPTION
Format the eventid as a short sha and include a copy control to get the full value.

![Screen Shot 2020-04-23 at 11 27 10 AM](https://user-images.githubusercontent.com/24086/80117643-6ca9c080-8555-11ea-8075-7d7095eb9480.png)
