### PR TITLE
ref(css): Remove CSS class `event-issue-header`

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {withRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {css} from '@emotion/core';
-import classNames from 'classnames';
 import capitalize from 'lodash/capitalize';
 
 import SentryTypes from 'app/sentryTypes';
@@ -88,12 +87,11 @@ class EventOrGroupHeader extends React.Component {
 
   render() {
     const {className, size, data} = this.props;
-    const cx = classNames('event-issue-header', className);
     const location = getLocation(data);
     const message = getMessage(data);
 
     return (
-      <div className={cx}>
+      <div className={className} data-test-id="event-issue-header">
         <Title size={size}>{this.getTitle()}</Title>
         {location && <Location size={size}>{location}</Location>}
         {message && <Message size={size}>{message}</Message>}

--- a/src/sentry/static/sentry/less/stream.less
+++ b/src/sentry/static/sentry/less/stream.less
@@ -936,27 +936,3 @@
     }
   }
 }
-
-.event-issue-header {
-  h3 {
-    font-size: 16px;
-    line-height: 1.1;
-    margin: 0 0 5px;
-    font-weight: 600;
-
-    em {
-      font-style: normal;
-      font-size: 14px;
-      color: @60;
-      font-weight: normal;
-    }
-
-    a {
-      color: @gray-darker;
-
-      &:hover {
-        color: @gray-darkest;
-      }
-    }
-  }
-}

--- a/tests/acceptance/page_objects/issue_list.py
+++ b/tests/acceptance/page_objects/issue_list.py
@@ -14,7 +14,7 @@ class IssueListPage(BasePage):
         self.wait_until_loaded()
 
     def wait_for_stream(self):
-        self.browser.wait_until(".event-issue-header", timeout=20)
+        self.browser.wait_until('[data-test-id="event-issue-header"]', timeout=20)
 
     def select_issue(self, position):
         self.browser.click(u'[data-test-id="group"]:nth-child({})'.format(position))

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -70,7 +70,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
         self.page.wait_for_stream()
         self.browser.snapshot("organization issues with issues")
 
-        groups = self.browser.find_elements_by_class_name("event-issue-header")
+        groups = self.browser.find_elements_by_css_selector('[data-test-id="event-issue-header"]')
         assert len(groups) == 2
         assert "oh snap" in groups[0].text
         assert "oh no" in groups[1].text

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupMergedView.spec.jsx.snap
@@ -987,7 +987,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                   size="normal"
                                 >
                                   <div
-                                    className="event-issue-header"
+                                    data-test-id="event-issue-header"
                                   >
                                     <Title
                                       size="normal"
@@ -1736,7 +1736,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
                                   size="normal"
                                 >
                                   <div
-                                    className="event-issue-header"
+                                    data-test-id="event-issue-header"
                                   >
                                     <Title
                                       size="normal"

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -835,7 +835,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                               size="normal"
                             >
                               <div
-                                className="event-issue-header"
+                                data-test-id="event-issue-header"
                               >
                                 <Title
                                   size="normal"


### PR DESCRIPTION
This is unused (there are no h3s nested under `<EventOrGroupHeader>` component. Change class name to `data-test-id` for acceptance tests.