### PR TITLE
fix(ui): Allow beta tag in panel header

### DIFF
--- a/src/sentry/static/sentry/app/components/betaTag.tsx
+++ b/src/sentry/static/sentry/app/components/betaTag.tsx
@@ -7,13 +7,13 @@ import space from 'app/styles/space';
 import {t} from 'app/locale';
 
 type Props = {
-  title?: string;
+  title?: string | null;
 };
 
 const BetaTag = ({
   title = t('This feature is in beta and may change in the future.'),
 }: Props) => (
-  <Tooltip title={title} position="right">
+  <Tooltip title={title} disabled={!title} position="right">
     <StyledTag priority="beta" size="small">
       {t('beta')}
     </StyledTag>

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formPanel.tsx
@@ -11,7 +11,7 @@ type Props = {
   /**
    * Panel title
    */
-  title?: string;
+  title?: React.ReactNode;
 
   /**
    * List of fields to render
@@ -59,7 +59,7 @@ export default class FormPanel extends React.Component<Props> {
     } = this.props;
 
     return (
-      <Panel key={title} id={sanitizeQuerySelector(title ?? '')}>
+      <Panel id={typeof title === 'string' ? sanitizeQuerySelector(title) : undefined}>
         {title && <PanelHeader>{title}</PanelHeader>}
         <PanelBody>
           {typeof renderHeader === 'function' && renderHeader({title, fields})}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.tsx
@@ -157,9 +157,9 @@ class JsonForm extends React.Component<Props, State> {
     return (
       <Box {...otherProps}>
         {typeof forms !== 'undefined' &&
-          forms.map(formGroup => (
+          forms.map((formGroup, i) => (
             <FormPanel
-              key={formGroup.title}
+              key={i}
               title={formGroup.title}
               fields={formGroup.fields}
               {...formPanelProps}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -140,6 +140,6 @@ export type Field = (
 export type FieldObject = Field | Function;
 
 export type JsonFormObject = {
-  title?: string;
+  title?: React.ReactNode;
   fields: FieldObject[];
 };


### PR DESCRIPTION
Changes to allow adding a beta tag in a panel header in settings. This already exists in some places, and the `title` proptype in jsonForm allows a node in addition to a string, but this was missing from the typing. Also, allows the beta tag tooltip to be optional.