### PR TITLE
feature(discover) - Adding an order key to top events response

### DIFF
--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -290,7 +290,7 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
     Serializer for time-series Snuba data.
     """
 
-    def serialize(self, result, column="count"):
+    def serialize(self, result, column="count", order=None):
         data = [
             (key, list(group))
             for key, group in itertools.groupby(result.data["data"], key=lambda r: r["time"])
@@ -314,7 +314,10 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
 
         if result.data.get("totals"):
             res["totals"] = {"count": result.data["totals"][column]}
-        if "order" in result.data:
+        # If order is passed let that overwrite whats in data since its order for multi-axis
+        if order is not None:
+            res["order"] = order
+        elif "order" in result.data:
             res["order"] = result.data["order"]
 
         return res

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -314,5 +314,7 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
 
         if result.data.get("totals"):
             res["totals"] = {"count": result.data["totals"][column]}
+        if "order" in result.data:
+            res["order"] = result.data["order"]
 
         return res

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -788,6 +788,16 @@ def timeseries_query(selected_columns, query, params, rollup, reference_event=No
     return SnubaTSResult({"data": result}, snuba_filter.start, snuba_filter.end, rollup)
 
 
+def create_result_key(result_row, fields, issues):
+    values = []
+    for field in fields:
+        if field == "issue.id":
+            values.append(issues.get(result_row["issue.id"], "unknown"))
+        else:
+            values.append(six.text_type(result_row.get(field)))
+    return ",".join(values)
+
+
 def top_events_timeseries(
     timeseries_columns,
     selected_columns,
@@ -897,17 +907,20 @@ def top_events_timeseries(
 
     results = {}
     for row in result["data"]:
-        values = []
-        for field in translated_groupby:
-            if field == "issue.id":
-                values.append(issues.get(row["issue.id"], "unknown"))
-            else:
-                values.append(six.text_type(row.get(field)))
-        result_key = ",".join(values)
-        results.setdefault(result_key, []).append(row)
+        result_key = create_result_key(row, translated_groupby, issues)
+        results.setdefault(result_key, {"data": []})["data"].append(row)
+    # Using the top events add the order to the results
+    for index, item in enumerate(top_events["data"]):
+        result_key = create_result_key(item, translated_groupby, issues)
+        results[result_key]["order"] = index
     for key, item in six.iteritems(results):
         results[key] = SnubaTSResult(
-            {"data": zerofill(item, snuba_filter.start, snuba_filter.end, rollup, "time")},
+            {
+                "data": zerofill(
+                    item["data"], snuba_filter.start, snuba_filter.end, rollup, "time"
+                ),
+                "order": item["order"],
+            },
             snuba_filter.start,
             snuba_filter.end,
             rollup,

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -534,10 +534,12 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             )
 
         assert response.status_code == 200, response.content
+        response.data["user_count"]["order"] == 0
         assert [attrs for time, attrs in response.data["user_count"]["data"]] == [
             [{"count": 1}],
             [{"count": 1}],
         ]
+        response.data["event_count"]["order"] == 1
         assert [attrs for time, attrs in response.data["event_count"]["data"]] == [
             [{"count": 1}],
             [{"count": 2}],
@@ -961,8 +963,9 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             results = data[
                 ",".join([message, self.event_data[index]["data"]["user"].get("email", "None")])
             ]
-            assert results["rpm()"]["order"] == index
-            assert results["count()"]["order"] == index
+            assert results["order"] == index
+            assert results["rpm()"]["order"] == 0
+            assert results["count()"]["order"] == 1
             assert [{"count": self.event_data[index]["count"] / (3600.0 / 60.0)}] in [
                 attrs for time, attrs in results["rpm()"]["data"]
             ]


### PR DESCRIPTION
- This will allow the frontend to order the tooltip, so that it matches
  what's in the table
- This modifies the tests so the test events have an order from count
  too