### PR TITLE
fix(ui) Fix additional border in PanelTable

### DIFF
--- a/src/sentry/static/sentry/app/components/panels/panelTable.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelTable.tsx
@@ -76,6 +76,7 @@ const PanelTable = ({
       columns={headers.length}
       disablePadding={disablePadding}
       className={className}
+      hasRows={shouldShowContent}
     >
       {headers.map((header, i) => (
         <PanelTableHeader key={i}>{header}</PanelTableHeader>
@@ -111,6 +112,7 @@ type WrapperProps = {
    * The number of columns the table will have, this is derived from the headers list
    */
   columns: number;
+  hasRows: boolean;
   disablePadding: Props['disablePadding'];
 };
 
@@ -126,10 +128,9 @@ const Wrapper = styled(Panel, {
 
   > * {
     padding: ${p => (p.disablePadding ? 0 : space(2))};
-    border-bottom: 1px solid ${p => p.theme.borderDark};
 
-    &:nth-child(-${p => p.columns}) {
-      border-bottom: none;
+    &:nth-last-child(n + ${p => (p.hasRows ? p.columns + 1 : 0)}) {
+      border-bottom: 1px solid ${p => p.theme.borderDark};
     }
   }
 


### PR DESCRIPTION
The `:nth-child(-x)` selector is invalid, and doesn't work. We can use
an `nth-last-child` to select all elements except the last
n + 1 children and give them a border though. This fixes the double
border showing on PanelTable children.

### Before

![Screen Shot 2020-04-23 at 2 33 51 PM](https://user-images.githubusercontent.com/24086/80136302-85bf6b00-856f-11ea-858e-f646cce65142.png)

### After
![Screen Shot 2020-04-23 at 2 32 43 PM](https://user-images.githubusercontent.com/24086/80136348-8fe16980-856f-11ea-8c02-c3d065149fca.png)
