### PR TITLE
feat(ui): Project Debug Files improvements

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/scrollToTop.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/scrollToTop.jsx
@@ -5,10 +5,16 @@ import React from 'react';
 class ScrollToTop extends React.Component {
   static propTypes = {
     location: PropTypes.object,
+    disable: PropTypes.func,
   };
 
   componentDidUpdate(prevProps) {
-    if (this.props.location !== prevProps.location) {
+    const {disable, location} = this.props;
+
+    const shouldDisable =
+      typeof disable === 'function' && disable(location, prevProps.location);
+
+    if (!shouldDisable && this.props.location !== prevProps.location) {
       window.scrollTo(0, 0);
     }
   }

--- a/src/sentry/static/sentry/app/views/settings/components/scrollToTop.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/scrollToTop.jsx
@@ -2,6 +2,8 @@ import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {callIfFunction} from 'app/utils/callIfFunction';
+
 class ScrollToTop extends React.Component {
   static propTypes = {
     location: PropTypes.object,
@@ -11,8 +13,7 @@ class ScrollToTop extends React.Component {
   componentDidUpdate(prevProps) {
     const {disable, location} = this.props;
 
-    const shouldDisable =
-      typeof disable === 'function' && disable(location, prevProps.location);
+    const shouldDisable = callIfFunction(disable, location, prevProps.location);
 
     if (!shouldDisable && this.props.location !== prevProps.location) {
       window.scrollTo(0, 0);

--- a/src/sentry/static/sentry/app/views/settings/components/settingsWrapper.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsWrapper.jsx
@@ -33,10 +33,20 @@ class SettingsWrapper extends React.Component {
     };
   }
 
+  shouldDisableScrollToTop(location, prevLocation) {
+    // we do not want to scroll to top when user just perform a search
+    return (
+      location.pathname === prevLocation.pathname &&
+      location.query?.query !== prevLocation.query?.query
+    );
+  }
+
   render() {
     return (
       <StyledSettingsWrapper>
-        <ScrollToTop>{this.props.children}</ScrollToTop>
+        <ScrollToTop disable={this.shouldDisableScrollToTop}>
+          {this.props.children}
+        </ScrollToTop>
       </StyledSettingsWrapper>
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -12,17 +12,19 @@ import Confirm from 'app/components/confirm';
 import {IconDelete, IconClock, IconDownload} from 'app/icons';
 import Access from 'app/components/acl/access';
 import ButtonBar from 'app/components/buttonBar';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 import {getFileType, getFeatureTooltip} from './utils';
 import {DebugFile} from './types';
 
 type Props = {
   debugFile: DebugFile;
+  showDetails: boolean;
   downloadUrl: string;
   onDelete: (id: string) => void;
 };
 
-const DebugFileRow = ({debugFile, downloadUrl, onDelete}: Props) => {
+const DebugFileRow = ({debugFile, showDetails, downloadUrl, onDelete}: Props) => {
   const {
     id,
     data,
@@ -33,6 +35,7 @@ const DebugFileRow = ({debugFile, downloadUrl, onDelete}: Props) => {
     objectName,
     cpuName,
     symbolType,
+    codeId,
   } = debugFile;
   const fileType = getFileType(debugFile);
   const {features} = data || {};
@@ -40,7 +43,9 @@ const DebugFileRow = ({debugFile, downloadUrl, onDelete}: Props) => {
   return (
     <React.Fragment>
       <Column>
-        <DebugId>{debugId || uuid}</DebugId>
+        <div>
+          <DebugId>{debugId || uuid}</DebugId>
+        </div>
         <TimeAndSizeWrapper>
           <StyledFileSize bytes={size} />
           <TimeWrapper>
@@ -55,7 +60,7 @@ const DebugFileRow = ({debugFile, downloadUrl, onDelete}: Props) => {
             ? '\u2015'
             : objectName}
         </Name>
-        <Details>
+        <Description>
           {symbolType === 'proguard' && cpuName === 'any'
             ? t('proguard mapping')
             : `${cpuName} (${symbolType}${fileType && ` ${fileType}`})`}
@@ -66,7 +71,17 @@ const DebugFileRow = ({debugFile, downloadUrl, onDelete}: Props) => {
                 <Tag inline>{feature}</Tag>
               </Tooltip>
             ))}
-        </Details>
+          {showDetails && (
+            <Details>
+              {/* there will be more stuff here in the future */}
+              {codeId && (
+                <Overflow>
+                  {t('Code ID')}: {codeId}
+                </Overflow>
+              )}
+            </Details>
+          )}
+        </Description>
       </Column>
       <RightColumn>
         <ButtonBar gap={0.5}>
@@ -114,26 +129,26 @@ const Column = styled('div')`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  justify-content: center;
 `;
 
 const RightColumn = styled('div')`
   display: flex;
   justify-content: flex-end;
-  align-items: center;
+  align-items: flex-start;
+  margin-top: ${space(1)};
 `;
 
 const DebugId = styled('code')`
-  display: inline-block;
   font-size: ${p => p.theme.fontSizeSmall};
-  margin-bottom: ${space(1.5)};
 `;
 
 const TimeAndSizeWrapper = styled('div')`
   width: 100%;
   display: flex;
   font-size: ${p => p.theme.fontSizeSmall};
+  margin-top: ${space(1)};
   color: ${p => p.theme.gray3};
+  align-items: center;
 `;
 
 const StyledFileSize = styled(FileSize)`
@@ -152,12 +167,27 @@ const TimeWrapper = styled('div')`
 
 const Name = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
-  margin-bottom: ${space(1.5)};
+  margin-bottom: ${space(1)};
+`;
+
+const Description = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.gray3};
+  @media (max-width: ${p => p.theme.breakpoints[2]}) {
+    line-height: 1.7;
+  }
 `;
 
 const Details = styled('div')`
-  font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray3};
+  display: grid;
+  grid-gap: ${space(0.75)};
+  &:not(:empty) {
+    margin-top: ${space(2)};
+  }
+`;
+
+const Overflow = styled('div')`
+  ${overflowEllipsis}
 `;
 
 export default DebugFileRow;

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -114,6 +114,7 @@ const DebugFileRow = ({debugFile, showDetails, downloadUrl, onDelete}: Props) =>
                     icon={<IconDelete size="xs" />}
                     size="xsmall"
                     disabled={!hasAccess}
+                    data-test-id="delete-dif"
                   />
                 </Confirm>
               </Tooltip>

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/index.tsx
@@ -183,7 +183,7 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
                   this.setState({showDetails: (e.target as HTMLInputElement).checked});
                 }}
               />
-              {t('details')}
+              {t('show details')}
             </Label>
 
             <SearchBar
@@ -247,6 +247,7 @@ const Label = styled('label')`
   font-weight: normal;
   display: flex;
   margin-bottom: 0;
+  white-space: nowrap;
   input {
     margin-top: 0;
     margin-right: ${space(1)};

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import space from 'app/styles/space';
-import {PanelTable, PanelTableHeader} from 'app/components/panels';
+import {PanelTable} from 'app/components/panels';
 import {fields} from 'app/data/forms/projectDebugFiles';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
@@ -15,6 +15,8 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import {Organization, Project} from 'app/types';
 import routeTitleGen from 'app/utils/routeTitle';
+import Checkbox from 'app/components/checkbox';
+import SearchBar from 'app/components/searchBar';
 
 import {DebugFile, BuiltinSymbolSource} from './types';
 import DebugFileRow from './debugFileRow';
@@ -27,6 +29,7 @@ type Props = RouteComponentProps<{orgId: string; projectId: string}, {}> & {
 type State = AsyncView['state'] & {
   debugFiles: DebugFile[];
   builtinSymbolSources?: BuiltinSymbolSource[];
+  showDetails: boolean;
 };
 
 class ProjectDebugSymbols extends AsyncView<Props, State> {
@@ -36,8 +39,16 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
     return routeTitleGen(t('Debug Files'), projectId, false);
   }
 
+  getDefaultState() {
+    return {
+      ...super.getDefaultState(),
+      showDetails: false,
+    };
+  }
+
   getEndpoints() {
     const {organization, params, location} = this.props;
+    const {builtinSymbolSources} = this.state || {};
     const {orgId, projectId} = params;
 
     const endpoints: ReturnType<AsyncView['getEndpoints']> = [
@@ -48,14 +59,14 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
       ],
     ];
 
-    if (organization.features.includes('symbol-sources')) {
-      endpoints.push(['builtinSymbolSources', '/builtin-symbol-sources/']);
+    if (!builtinSymbolSources && organization.features.includes('symbol-sources')) {
+      endpoints.push(['builtinSymbolSources', '/builtin-symbol-sources/', {}]);
     }
 
     return endpoints;
   }
 
-  onDelete(id: string) {
+  handleDelete(id: string) {
     const {orgId, projectId} = this.props.params;
 
     this.setState({
@@ -68,9 +79,32 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
     });
   }
 
+  handleSearch = (query: string) => {
+    const {location, router} = this.props;
+
+    router.push({
+      ...location,
+      query: {...location.query, cursor: undefined, query},
+    });
+  };
+
+  getQuery() {
+    const {query} = this.props.location.query;
+
+    return typeof query === 'string' ? query : undefined;
+  }
+
+  renderLoading() {
+    return this.renderBody();
+  }
+
   renderDebugFiles() {
-    const {debugFiles} = this.state;
+    const {debugFiles, showDetails} = this.state;
     const {orgId, projectId} = this.props.params;
+
+    if (!debugFiles?.length) {
+      return null;
+    }
 
     return debugFiles.map(debugFile => {
       const downloadUrl = `${this.api.baseUrl}/projects/${orgId}/${projectId}/files/dsyms/?id=${debugFile.id}`;
@@ -78,8 +112,9 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
       return (
         <DebugFileRow
           debugFile={debugFile}
+          showDetails={showDetails}
           downloadUrl={downloadUrl}
-          onDelete={this.onDelete}
+          onDelete={this.handleDelete}
           key={debugFile.id}
         />
       );
@@ -88,13 +123,19 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
 
   renderBody() {
     const {organization, project, params} = this.props;
-    const {builtinSymbolSources, debugFiles, debugFilesPageLinks} = this.state;
+    const {
+      loading,
+      showDetails,
+      builtinSymbolSources,
+      debugFiles,
+      debugFilesPageLinks,
+    } = this.state;
     const {orgId, projectId} = params;
     const {features, access} = organization;
 
     const fieldProps = {
       organization,
-      builtinSymbolSources,
+      builtinSymbolSources: builtinSymbolSources || [],
     };
 
     return (
@@ -131,25 +172,40 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
           </React.Fragment>
         )}
 
-        <TextBlock>
-          {t('This list contains all uploaded debug information files:')}
-        </TextBlock>
+        <Wrapper>
+          <TextBlock noMargin>{t('Uploaded debug information files')}:</TextBlock>
+
+          <Filters>
+            <Label>
+              <Checkbox
+                checked={showDetails}
+                onChange={e => {
+                  this.setState({showDetails: (e.target as HTMLInputElement).checked});
+                }}
+              />
+              {t('details')}
+            </Label>
+
+            <SearchBar
+              placeholder={t('Search DIFs')}
+              onSearch={this.handleSearch}
+              query={this.getQuery()}
+            />
+          </Filters>
+        </Wrapper>
 
         <StyledPanelTable
           headers={[
             t('Debug ID'),
             t('Name'),
-            this.renderSearchInput({
-              updateRoute: true,
-              placeholder: t('Search DIFs'),
-            }),
+            <TextRight key="actions">{t('Actions')}</TextRight>,
           ]}
           emptyMessage={t('There are no debug symbols for this project.')}
-          isEmpty={debugFiles.length === 0}
+          isEmpty={debugFiles?.length === 0}
+          isLoading={loading}
         >
           {this.renderDebugFiles()}
         </StyledPanelTable>
-
         <Pagination pageLinks={debugFilesPageLinks} />
       </React.Fragment>
     );
@@ -157,11 +213,43 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
 }
 
 const StyledPanelTable = styled(PanelTable)`
-  grid-template-columns: 1fr 1.3fr auto;
-  ${PanelTableHeader} {
-    padding: ${space(1)} ${space(2)};
-    display: flex;
-    align-items: center;
+  grid-template-columns: 37% 1fr auto;
+`;
+
+const TextRight = styled('div')`
+  text-align: right;
+`;
+
+const Wrapper = styled('div')`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-gap: ${space(4)};
+  align-items: center;
+  margin-top: ${space(4)};
+  margin-bottom: ${space(1)};
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    display: block;
+  }
+`;
+
+const Filters = styled('div')`
+  display: grid;
+  grid-template-columns: min-content minmax(200px, 400px);
+  align-items: center;
+  justify-content: flex-end;
+  grid-gap: ${space(2)};
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: min-content 1fr;
+  }
+`;
+
+const Label = styled('label')`
+  font-weight: normal;
+  display: flex;
+  margin-bottom: 0;
+  input {
+    margin-top: 0;
+    margin-right: ${space(1)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/index.tsx
@@ -66,7 +66,7 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
     return endpoints;
   }
 
-  handleDelete(id: string) {
+  handleDelete = (id: string) => {
     const {orgId, projectId} = this.props.params;
 
     this.setState({
@@ -77,7 +77,7 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
       method: 'DELETE',
       complete: () => this.fetchData(),
     });
-  }
+  };
 
   handleSearch = (query: string) => {
     const {location, router} = this.props;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -694,7 +694,7 @@ table.table.key-value {
   .search-input {
     // Match the height of buttons adjacent to the search input.
     height: 40px;
-    padding: 8px 24px 8px 37px;
+    padding: 8px 34px 8px 37px;
     font-size: 14px;
     background: #fff;
     .transition(none);
@@ -732,7 +732,7 @@ table.table.key-value {
 
 .search-clear-form {
   position: absolute;
-  top: 8px;
+  top: 11px;
   right: 10px;
   color: lighten(@gray, 30);
 

--- a/tests/js/spec/views/settings/projectDebugFiles.spec.jsx
+++ b/tests/js/spec/views/settings/projectDebugFiles.spec.jsx
@@ -19,7 +19,7 @@ describe('ProjectDebugFiles', function() {
 
   const endpoint = `/projects/${organization.slug}/${project.slug}/files/dsyms/`;
 
-  it('renders', async function() {
+  it('renders', function() {
     MockApiClient.addMockResponse({
       url: endpoint,
       body: [TestStubs.DebugFile()],
@@ -38,7 +38,7 @@ describe('ProjectDebugFiles', function() {
     ).toBe('libS.so');
   });
 
-  it('renders empty', async function() {
+  it('renders empty', function() {
     MockApiClient.addMockResponse({
       url: endpoint,
       body: [],
@@ -49,5 +49,28 @@ describe('ProjectDebugFiles', function() {
     expect(wrapper.find('EmptyStateWarning').text()).toBe(
       'There are no debug symbols for this project.'
     );
+  });
+
+  it('deletes the file', function() {
+    MockApiClient.addMockResponse({
+      url: endpoint,
+      body: [TestStubs.DebugFile()],
+    });
+
+    const deleteMock = MockApiClient.addMockResponse({
+      method: 'DELETE',
+      url: `/projects/${organization.slug}/${project.slug}/files/dsyms/?id=${
+        TestStubs.DebugFile().id
+      }`,
+    });
+
+    const wrapper = mountWithTheme(<ProjectDebugFiles {...props} />, routerContext);
+
+    wrapper.find('Button[data-test-id="delete-dif"]').simulate('click');
+
+    // Confirm Modal
+    wrapper.find('Modal Button[data-test-id="confirm-button"]').simulate('click');
+
+    expect(deleteMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This PR improves multiple things on project debug files page (pasted from asana):

Searchbar:
It never shows the search query. While typing, it shows a loading indicator, but it doesn't search. When searching by hitting [ENTER], it reloads the entire page. Also, the bar is too narrow for the expected kind of queries (debug IDs).

Pagination:
Every pagination reloads the entire page. Instead, this could just reload the file list.

Show more information:
For most debug files, we also have the code identifier (as shown in the Images Loaded section in issue details). In the future, we might collect more information, so we need a place to show it. This may need to be a toggle, similar to issue details.