### PR TITLE
fix(alerts): Fix threshold direction in metric alert email

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -96,7 +96,7 @@ class EmailActionHandler(ActionHandler):
         trigger = self.action.alert_rule_trigger
         alert_rule = trigger.alert_rule
         is_active = status == TriggerStatus.ACTIVE
-        is_threshold_type_above = trigger.threshold_type == AlertRuleThresholdType.ABOVE
+        is_threshold_type_above = trigger.threshold_type == AlertRuleThresholdType.ABOVE.value
 
         # if alert threshold and threshold type is above then show '>'
         # if resolve threshold and threshold type is *BELOW* then show '>'

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -117,7 +117,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             "environment": "All",
             "is_critical": False,
             "is_warning": False,
-            "threshold_direction_string": "<",
+            "threshold_direction_string": ">",
             "time_window": "10 minutes",
             "triggered_at": timezone.now(),
             "unsubscribe_link": None,


### PR DESCRIPTION
The comparison had a small mistake that caused it to fail, fixing it here.