### PR TITLE
fix(discover2): New event id field render crashes when given data isn't a string.

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -164,9 +164,13 @@ const SPECIAL_FIELDS: SpecialFields = {
   id: {
     sortField: 'id',
     renderFunc: data => {
+      const id = data?.id;
+      if (typeof id !== 'string') {
+        return null;
+      }
       return (
         <Container>
-          <EventId value={data.id} />
+          <EventId value={id} />
         </Container>
       );
     },

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -164,7 +164,7 @@ const SPECIAL_FIELDS: SpecialFields = {
   id: {
     sortField: 'id',
     renderFunc: data => {
-      const id = data?.id;
+      const id: string | unknown = data?.id;
       if (typeof id !== 'string') {
         return null;
       }


### PR DESCRIPTION
Drilling down on an event aggregate in Discover will crash the app:

![Screen Shot 2020-04-23 at 7 31 28 PM](https://user-images.githubusercontent.com/139499/80159575-65a4a180-8599-11ea-9b7a-4f73c724be9f.png)
![Screen Shot 2020-04-23 at 7 33 00 PM](https://user-images.githubusercontent.com/139499/80159626-866cf700-8599-11ea-8341-1ff619fe1242.png)

-----


Regression from https://github.com/getsentry/sentry/pull/18435

Fixes JAVASCRIPT-223J
