### PR TITLE
fix(alerts): Make clear that superuser may edit comments

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_comment_details.py
+++ b/src/sentry/api/endpoints/organization_incident_comment_details.py
@@ -28,12 +28,15 @@ class CommentDetailsEndpoint(IncidentEndpoint):
         args, kwargs = super(CommentDetailsEndpoint, self).convert_args(request, *args, **kwargs)
 
         try:
+            # Superusers may mutate any comment
+            user_filter = {} if request.user.is_superuser else {"user": request.user}
+
             kwargs["activity"] = IncidentActivity.objects.get(
                 id=activity_id,
-                user=request.user,
                 incident=kwargs["incident"],
                 # Only allow modifying comments
                 type=IncidentActivityType.COMMENT.value,
+                **user_filter
             )
         except IncidentActivity.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/static/sentry/app/components/activity/note/header.tsx
+++ b/src/sentry/static/sentry/app/components/activity/note/header.tsx
@@ -7,6 +7,7 @@ import ConfigStore from 'app/stores/configStore';
 import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
 import {User} from 'app/types';
 import {Theme} from 'app/utils/theme';
+import Tooltip from 'app/components/tooltip';
 
 import EditorTools from './editorTools';
 
@@ -17,28 +18,38 @@ type Props = {
   onDelete: () => void;
 };
 
-function canEdit(editingUser: User) {
-  const user = ConfigStore.get('user');
-  return user && (user.isSuperuser || user.id === editingUser.id);
-}
+const NoteHeader = ({authorName, user, onEdit, onDelete}: Props) => {
+  const activeUser = ConfigStore.get('user');
+  const canEdit = activeUser && (activeUser.isSuperuser || user.id === activeUser.id);
 
-const NoteHeader = ({authorName, user, onEdit, onDelete}: Props) => (
-  <div>
-    <ActivityAuthor>{authorName}</ActivityAuthor>
-    {canEdit(user) && (
-      <EditorTools>
-        <Edit onClick={onEdit}>{t('Edit')}</Edit>
-        <LinkWithConfirmation
-          title={t('Remove')}
-          message={t('Are you sure you wish to delete this comment?')}
-          onConfirm={onDelete}
-        >
-          <Remove>{t('Remove')}</Remove>
-        </LinkWithConfirmation>
-      </EditorTools>
-    )}
-  </div>
-);
+  return (
+    <div>
+      <ActivityAuthor>{authorName}</ActivityAuthor>
+      {canEdit && (
+        <EditorTools>
+          <Tooltip
+            title={t('You can edit this comment due to your superuser status')}
+            disabled={!activeUser.isSuperuser}
+          >
+            <Edit onClick={onEdit}>{t('Edit')}</Edit>
+          </Tooltip>
+          <Tooltip
+            title={t('You can delete this comment due to your superuser status')}
+            disabled={!activeUser.isSuperuser}
+          >
+            <LinkWithConfirmation
+              title={t('Remove')}
+              message={t('Are you sure you wish to delete this comment?')}
+              onConfirm={onDelete}
+            >
+              <Remove>{t('Remove')}</Remove>
+            </LinkWithConfirmation>
+          </Tooltip>
+        </EditorTools>
+      )}
+    </div>
+  );
+};
 
 const getActionStyle = (p: {theme: Theme}) => `
   padding: 0 7px;


### PR DESCRIPTION
Fixes the backend endpoint to allow superuser mutation

![image](https://user-images.githubusercontent.com/1421724/80172304-82dd6e00-85a1-11ea-9a39-1f9cfe4fd624.png)

Adds this tooltip too.