### PR TITLE
fix(issue_details): Coerce missing image_vmaddr to 0

### DIFF
--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -154,8 +154,8 @@ class AppleCrashReport(object):
     def _get_slide_value(self, image_addr):
         if self.debug_images:
             for debug_image in self.debug_images:
-                if parse_addr(debug_image["image_addr"]) == parse_addr(image_addr):
-                    return parse_addr(debug_image["image_vmaddr"])
+                if parse_addr(debug_image.get("image_addr")) == parse_addr(image_addr):
+                    return parse_addr(debug_image.get("image_vmaddr", 0))
         return 0
 
     def get_binary_images_apple_string(self):
@@ -169,7 +169,7 @@ class AppleCrashReport(object):
         return "Binary Images:\n" + "\n".join(binary_images)
 
     def _convert_debug_meta_to_binary_image_row(self, debug_image):
-        slide_value = parse_addr(debug_image["image_vmaddr"])
+        slide_value = parse_addr(debug_image.get("image_vmaddr", 0))
         image_addr = parse_addr(debug_image["image_addr"]) + slide_value
         return "%s - %s %s %s  <%s> %s" % (
             hex(image_addr),

--- a/tests/sentry/lang/native/test_applecrashreport.py
+++ b/tests/sentry/lang/native/test_applecrashreport.py
@@ -393,7 +393,7 @@ def test_get_binary_images_apple_string():
             {
                 "image_addr": "0x1406f000",
                 "image_size": 913408,
-                "image_vmaddr": "0x0",
+                # image_vmaddr defaults to 0x0
                 "code_file": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/PrivateFrameworks/CorePDF.framework/CorePDF",
                 "type": "native",
                 "debug_id": "BE602DC1-D3A0-3389-B8F4-922C37DEA3DC",
@@ -452,7 +452,7 @@ def test_binary_images_without_code_file():
             {
                 "image_addr": "0x1406f000",
                 "image_size": 913408,
-                "image_vmaddr": "0x0",
+                # image_vmaddr defaults to 0x0
                 "type": "native",
                 "debug_id": "BE602DC1-D3A0-3389-B8F4-922C37DEA3DC",
             },


### PR DESCRIPTION
`image_vmaddr` was deprecated and made optional. This fixes the apple crash report endpoint to coerce the missing value to `0`.

Fixes SENTRY-FG8
Fixes SENTRY-FPM
Fixes ISSUE-822