### PR TITLE
ref: Rename some batching consumer metrics

### DIFF
--- a/src/sentry/utils/batching_kafka_consumer.py
+++ b/src/sentry/utils/batching_kafka_consumer.py
@@ -326,15 +326,17 @@ class BatchingKafkaConsumer(object):
         )
 
         batch_results_length = len(self.__batch_results)
-        self.__record_timing("batch.size", batch_results_length)
+        self.__record_timing("batching_consumer.batch.size", batch_results_length)
         if batch_results_length > 0:
             logger.debug("Flushing batch via worker")
             flush_start = time.time()
             self.worker.flush_batch(self.__batch_results)
             flush_duration = (time.time() - flush_start) * 1000
             logger.info("Worker flush took %dms", flush_duration)
-            self.__record_timing("batch.flush", flush_duration)
-            self.__record_timing("batch.flush.normalized", flush_duration / batch_results_length)
+            self.__record_timing("batching_consumer.batch.flush", flush_duration)
+            self.__record_timing(
+                "batching_consumer.batch.flush.normalized", flush_duration / batch_results_length
+            )
 
         logger.debug("Committing Kafka offsets")
         commit_start = time.time()


### PR DESCRIPTION
Those metric names look pretty generic and might cause confusion.