### PR TITLE
feat(ui) Expand proptypes to enable multi-axis graphs

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -49,10 +49,17 @@ class BaseChart extends React.Component {
     yAxis: SentryTypes.EChartsYAxis,
 
     // Pass `true` to have 2 y-axes with default properties
-    // Can pass an array of 2 objects to customize yAxis properties
+    // Can pass an array of objects to customize yAxis properties
     yAxes: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.arrayOf(SentryTypes.EChartsYAxis),
+    ]),
+
+    // Pass `true` to have 2 x-axes with default properties
+    // Can pass an array of multiple objects to customize xAxis properties
+    xAxes: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.arrayOf(SentryTypes.EChartsXAxis),
     ]),
 
     // Tooltip options
@@ -61,12 +68,19 @@ class BaseChart extends React.Component {
     // DataZoom (allows for zooming of chart)
     dataZoom: SentryTypes.EChartsDataZoom,
 
+    // Axis pointer options
+    axisPointer: SentryTypes.EChartsAxisPointer,
+
     toolBox: SentryTypes.EChartsToolBox,
 
     graphic: SentryTypes.EchartsGraphic,
 
     // ECharts Grid options
-    grid: SentryTypes.EChartsGrid,
+    // multiple grids allow multiple sub-graphs.
+    grid: PropTypes.oneOfType([
+      SentryTypes.EChartsGrid,
+      PropTypes.arrayOf(SentryTypes.EChartsGrid),
+    ]),
 
     // Chart legend
     legend: SentryTypes.EChartsLegend,
@@ -208,6 +222,7 @@ class BaseChart extends React.Component {
       dataZoom,
       toolBox,
       graphic,
+      axisPointer,
 
       isGroupedByDate,
       showTimeInTooltip,
@@ -218,6 +233,7 @@ class BaseChart extends React.Component {
       period,
       utc,
       yAxes,
+      xAxes,
 
       devicePixelRatio,
       height,
@@ -235,8 +251,23 @@ class BaseChart extends React.Component {
         ? YAxis(yAxis)
         : null
       : Array.isArray(yAxes)
-      ? yAxes.slice(0, 2).map(YAxis)
+      ? yAxes.map(YAxis)
       : [YAxis(), YAxis()];
+    const xAxisOrCustom = !xAxes
+      ? xAxis !== null
+        ? XAxis({
+            ...xAxis,
+            useShortDate,
+            start,
+            end,
+            period,
+            isGroupedByDate,
+            utc,
+          })
+        : null
+      : Array.isArray(xAxes)
+      ? xAxes.map(XAxis)
+      : [XAxis(), XAxis()];
 
     return (
       <ChartContainer>
@@ -264,25 +295,14 @@ class BaseChart extends React.Component {
             ...options,
             useUTC: utc,
             color: colors || this.getColorPalette(),
-            grid: Grid(grid),
+            grid: Array.isArray(grid) ? grid.map(Grid) : Grid(grid),
             tooltip:
               tooltip !== null
                 ? Tooltip({showTimeInTooltip, isGroupedByDate, utc, ...tooltip})
                 : null,
             legend: legend ? Legend({...legend}) : null,
             yAxis: yAxisOrCustom,
-            xAxis:
-              xAxis !== null
-                ? XAxis({
-                    ...xAxis,
-                    useShortDate,
-                    start,
-                    end,
-                    period,
-                    isGroupedByDate,
-                    utc,
-                  })
-                : null,
+            xAxis: xAxisOrCustom,
             series: !previousPeriod
               ? series
               : [
@@ -301,6 +321,7 @@ class BaseChart extends React.Component {
                     })
                   ),
                 ],
+            axisPointer,
             dataZoom,
             toolbox: toolBox,
             graphic,

--- a/src/sentry/static/sentry/app/components/charts/components/axisPointer.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/axisPointer.jsx
@@ -1,0 +1,5 @@
+export default function AxisPointer({...props} = {}) {
+  return {
+    ...props,
+  };
+}

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -1065,6 +1065,26 @@ export const EChartsGrid = PropTypes.shape({
   tooltip: EChartsTooltip,
 });
 
+export const EChartsAxisPointer = PropTypes.shape({
+  // A list of link groups
+  link: PropTypes.arrayOf(
+    PropTypes.shape({
+      // Link by x-axis index.
+      xAxisIndex: PropTypes.arrayOf(PropTypes.number),
+      // Link by y-axis index.
+      yAxisIndex: PropTypes.arrayOf(PropTypes.number),
+      // Link by x-axis id.
+      xAxisId: PropTypes.arrayOf(PropTypes.string),
+      // Link by y-axis id.
+      yAxisId: PropTypes.arrayOf(PropTypes.string),
+      // Link by x-axis name.
+      xAxisName: PropTypes.arrayOf(PropTypes.string),
+      // Link by y-axis name.
+      yAxisName: PropTypes.arrayOf(PropTypes.string),
+    })
+  ),
+});
+
 export const EChartsLegend = PropTypes.shape({
   // Show legend on chart
   show: PropTypes.bool,
@@ -1280,6 +1300,7 @@ const SentryTypes = {
   EChartsYAxis: EChartsAxis,
   EChartsTooltip,
   EChartsGrid,
+  EChartsAxisPointer,
   EChartsLegend,
   EChartsDataZoom,
   EChartsToolBox,


### PR DESCRIPTION
For performance views we need to show multiple subcharts in the same chart instance. Having multiple grid definitions in the same chart will enable us to have shared hover states between multiple graphs which make for easier to digest data that overlaying different kinds of data together does.