### PR TITLE
test(discover) Add an acceptance test for drilldowns

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -492,7 +492,7 @@ class GridEditable<
         </Header>
 
         <Body>
-          <Grid ref={this.refGrid}>
+          <Grid data-test-id="grid-editable" ref={this.refGrid}>
             <GridHead>{this.renderGridHead()}</GridHead>
             <GridBody>{this.renderGridBody()}</GridBody>
           </Grid>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -290,7 +290,7 @@ function ExpandAggregateRow(props: {
     };
 
     return (
-      <Link to={target} onClick={handleClick}>
+      <Link data-test-id="expand-count" to={target} onClick={handleClick}>
         {children}
       </Link>
     );
@@ -310,7 +310,7 @@ function ExpandAggregateRow(props: {
     };
 
     return (
-      <Link to={target} onClick={handleClick}>
+      <Link data-test-id="expand-count-unique" to={target} onClick={handleClick}>
         {children}
       </Link>
     );


### PR DESCRIPTION
Drilldowns broke yesterday in a way that could not be captured in Jest. Having an acceptance test for this should help prevent regressions in the future.