### PR TITLE
logging(integrrations): adds logger event for valid webhook for VSTS

### DIFF
--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -58,6 +58,10 @@ class WorkItemWebhook(Endpoint):
 
             try:
                 self.check_webhook_secret(request, integration)
+                logger.info(
+                    "vsts.valid-webhook-secret",
+                    extra={"event_type": event_type, "integration_id": integration.id},
+                )
             except AssertionError:
                 logger.info(
                     "vsts.invalid-webhook-secret",


### PR DESCRIPTION
It seems that webhooks are failing in production but they work on my machine. I want to figure out if all orgs are impacted or just some.