### PR TITLE
logging(integrations): adds more vsts webhook logging for debugging

### DIFF
--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -75,6 +75,23 @@ class WorkItemWebhook(Endpoint):
         try:
             integration_secret = integration.metadata["subscription"]["secret"]
             webhook_payload_secret = request.META["HTTP_SHARED_SECRET"]
+            logger.info(
+                "vsts.simple-webhook-check",
+                extra={
+                    "equality1": integration_secret == webhook_payload_secret,
+                    "equality2": constant_time_compare(integration_secret, webhook_payload_secret),
+                },
+            )
+            # TODO(Steve): remove
+            # I don't want to put the webhook secret in logs except for my own integration I don't care about :)
+            if integration.id == 58554:
+                logger.info(
+                    "vst.special-webhook-sercret",
+                    extra={
+                        "integration_secret": six.text_type(integration_secret),
+                        "webhook_payload_secret": six.text_type(webhook_payload_secret),
+                    },
+                )
         except KeyError as e:
             logger.info(
                 "vsts.missing-webhook-secret",


### PR DESCRIPTION
This is follow up to an earlier PR (https://github.com/getsentry/sentry/pull/18466). It seems that for my VSTS integration on prod, sometimes the webhook verification succeeds and other times it fails. I have added more logging, including logging the secrets for my own integration, to help debug the problem.