### PR TITLE
fix(search): Dont create an empty "query" param

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -331,7 +331,8 @@ def tokenize_query(query):
                 break
         query_params[state].append(token)
 
-    result["query"] = map(format_query, query_params["query"])
+    if "query" in query_params:
+        result["query"] = map(format_query, query_params["query"])
     for tag in query_params["tags"]:
         key, value = format_tag(tag)
         result[key].append(value)

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -21,6 +21,7 @@ from sentry.search.utils import (
     get_latest_release,
     get_numeric_field_value,
     convert_user_tag_to_query,
+    tokenize_query,
     InvalidQuery,
 )
 
@@ -45,6 +46,10 @@ def test_get_numeric_field_value():
         "foo_upper": -3.5,
         "foo_upper_inclusive": True,
     }
+
+
+def test_tokenize_query_only_keyed_fields():
+    assert tokenize_query("foo:bar") == {"foo": ["bar"]}
 
 
 def test_get_numeric_field_value_invalid():


### PR DESCRIPTION
This ensures we're not passing an invalid 'query=[]' token to upstream users, which would commonly treat this as 'find something with a blank string' and exclude searches that might have been operating on NULL columns.