### PR TITLE
fix(perf-views) Link apdex and rpm graphs

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -66,7 +66,10 @@ class BaseChart extends React.Component {
     tooltip: SentryTypes.EChartsTooltip,
 
     // DataZoom (allows for zooming of chart)
-    dataZoom: SentryTypes.EChartsDataZoom,
+    dataZoom: PropTypes.oneOfType([
+      SentryTypes.EChartsDataZoom,
+      PropTypes.arrayOf(SentryTypes.EChartsDataZoom),
+    ]),
 
     // Axis pointer options
     axisPointer: SentryTypes.EChartsAxisPointer,
@@ -266,7 +269,9 @@ class BaseChart extends React.Component {
           })
         : null
       : Array.isArray(xAxes)
-      ? xAxes.map(XAxis)
+      ? xAxes.map(axis =>
+          XAxis({...axis, useShortDate, start, end, period, isGroupedByDate, utc})
+        )
       : [XAxis(), XAxis()];
 
     return (

--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -32,6 +32,11 @@ class ChartZoom extends React.Component {
     disabled: PropTypes.bool,
 
     xAxis: SentryTypes.EChartsXAxis,
+    /**
+     * If you need the dataZoom control to control more than one chart.
+     * you can provide a list of the axis indexes.
+     */
+    xAxisIndex: PropTypes.arrayOf(PropTypes.number),
 
     // Callback for when chart has been zoomed
     onZoom: PropTypes.func,
@@ -195,6 +200,7 @@ class ChartZoom extends React.Component {
       utc,
       disabled,
       children,
+      xAxisIndex,
 
       onZoom, // eslint-disable-line no-unused-vars
       onRestore, // eslint-disable-line no-unused-vars
@@ -213,7 +219,7 @@ class ChartZoom extends React.Component {
       isGroupedByDate: true,
       onChartReady: this.handleChartReady,
       utc,
-      dataZoom: DataZoom(),
+      dataZoom: DataZoom({xAxisIndex}),
       showTimeInTooltip: true,
       toolBox: ToolBox(
         {},

--- a/src/sentry/static/sentry/app/components/charts/components/dataZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/dataZoom.jsx
@@ -9,7 +9,7 @@ const DEFAULT = {
 export default function DataZoom(props) {
   // `props` can be boolean, if so return default
   if (!props || !Array.isArray(props)) {
-    return [DEFAULT];
+    return [{...DEFAULT, ...props}];
   }
 
   return props;

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -3,38 +3,24 @@ import * as ReactRouter from 'react-router';
 
 import {Series} from 'app/types/echarts';
 import AreaChart from 'app/components/charts/areaChart';
+import {AREA_COLORS} from 'app/components/charts/utils';
 import ChartZoom from 'app/components/charts/chartZoom';
-import Tooltip from 'app/components/tooltip';
-
-import {HeaderTitle, ChartContainer, StyledIconQuestion} from '../styles';
 
 type Props = {
-  yAxis: string;
-  data: Series;
+  data: Series[];
   router: ReactRouter.InjectedRouter;
   statsPeriod: string | undefined;
   utc: boolean;
   projects: number[];
   environments: string[];
   loading: boolean;
-  tooltipCopy: string;
 };
 
 class Chart extends React.Component<Props> {
   render() {
-    const {
-      data,
-      yAxis,
-      router,
-      statsPeriod,
-      utc,
-      projects,
-      environments,
-      loading,
-      tooltipCopy,
-    } = this.props;
+    const {data, router, statsPeriod, utc, projects, environments, loading} = this.props;
 
-    if (!data || data.data.length <= 0) {
+    if (!data || data.length <= 0) {
       return null;
     }
 
@@ -42,46 +28,67 @@ class Chart extends React.Component<Props> {
       seriesOptions: {
         showSymbol: false,
       },
-      grid: {
-        left: '10px',
-        right: '10px',
-        top: '16px',
-        bottom: '0px',
+      grid: [
+        {
+          top: '8px',
+          left: '24px',
+          right: '52%',
+          bottom: '16px',
+        },
+        {
+          top: '8px',
+          left: '52%',
+          right: '24px',
+          bottom: '16px',
+        },
+      ],
+      axisPointer: {
+        // Link the two series x-axis together.
+        link: [{xAxisIndex: [0, 1]}],
       },
+      xAxes: [
+        {
+          gridIndex: 0,
+          type: 'time',
+        },
+        {
+          gridIndex: 1,
+          type: 'time',
+        },
+      ],
+      yAxes: [{gridIndex: 0}, {gridIndex: 1}],
       utc,
       isGroupedByDate: true,
       showTimeInTooltip: true,
     };
 
     if (loading) {
-      return (
-        <ChartContainer key="loading">
-          <HeaderTitle>{yAxis}</HeaderTitle>
-          <AreaChart series={[]} {...areaChartProps} />
-        </ChartContainer>
-      );
+      return <AreaChart series={[]} {...areaChartProps} />;
     }
+    const series = data.map((values, i: number) => ({
+      ...values,
+      yAxisIndex: i,
+      xAxisIndex: i,
+      color: AREA_COLORS[0].line,
+      areaStyle: {
+        color: AREA_COLORS[0].area,
+        opacity: 1.0,
+      },
+    }));
 
     return (
-      <ChartContainer key="loaded">
-        <HeaderTitle>
-          {yAxis}
-          <Tooltip position="top" title={tooltipCopy}>
-            <StyledIconQuestion size="sm" />
-          </Tooltip>
-        </HeaderTitle>
-        <ChartZoom
-          router={router}
-          period={statsPeriod}
-          utc={utc}
-          projects={projects}
-          environments={environments}
-        >
-          {zoomRenderProps => (
-            <AreaChart {...zoomRenderProps} series={[data]} {...areaChartProps} />
-          )}
-        </ChartZoom>
-      </ChartContainer>
+      <ChartZoom
+        router={router}
+        period={statsPeriod}
+        utc={utc}
+        projects={projects}
+        environments={environments}
+        xAxisIndex={[0, 1]}
+      >
+        {zoomRenderProps => (
+          <AreaChart {...zoomRenderProps} series={series} {...areaChartProps} />
+        )}
+      </ChartZoom>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -8,6 +8,7 @@ import {Client} from 'app/api';
 import withApi from 'app/utils/withApi';
 import {getInterval} from 'app/components/charts/utils';
 import LoadingPanel from 'app/views/events/loadingPanel';
+import Tooltip from 'app/components/tooltip';
 import getDynamicText from 'app/utils/getDynamicText';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel} from 'app/components/panels';
@@ -16,8 +17,9 @@ import EventsRequest from 'app/views/events/utils/eventsRequest';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import {IconWarning} from 'app/icons';
 import theme from 'app/utils/theme';
+import space from 'app/styles/space';
 
-import {ChartsContainer, ChartsGrid} from '../styles';
+import {HeaderTitle, StyledIconQuestion} from '../styles';
 import Chart from './chart';
 import Footer from './footer';
 
@@ -63,72 +65,71 @@ class Container extends React.Component<Props> {
 
     return (
       <Panel>
-        <ChartsContainer>
-          <EventsRequest
-            organization={organization}
-            api={api}
-            period={globalSelection.statsPeriod}
-            project={globalSelection.project}
-            environment={globalSelection.environment}
-            start={start}
-            end={end}
-            interval={getInterval(
-              {
-                start: start || null,
-                end: end || null,
-                period: globalSelection.statsPeriod,
-              },
-              true
-            )}
-            showLoading={false}
-            query={eventView.getEventsAPIPayload(location).query}
-            includePrevious={false}
-            yAxis={YAXIS_OPTIONS.map(option => option.value)}
-            keyTransactions={keyTransactions}
-          >
-            {({loading, reloading, errored, results}) => {
-              if (errored) {
-                return (
-                  <ErrorPanel>
-                    <IconWarning color={theme.gray2} size="lg" />
-                  </ErrorPanel>
-                );
-              }
-
-              if (!results) {
-                return <LoadingPanel data-test-id="events-request-loading" />;
-              }
-              const resultMap = Object.fromEntries(
-                results.map(item => [item.seriesName, item])
-              );
-
+        <EventsRequest
+          organization={organization}
+          api={api}
+          period={globalSelection.statsPeriod}
+          project={globalSelection.project}
+          environment={globalSelection.environment}
+          start={start}
+          end={end}
+          interval={getInterval(
+            {
+              start: start || null,
+              end: end || null,
+              period: globalSelection.statsPeriod,
+            },
+            true
+          )}
+          showLoading={false}
+          query={eventView.getEventsAPIPayload(location).query}
+          includePrevious={false}
+          yAxis={YAXIS_OPTIONS.map(option => option.value)}
+          keyTransactions={keyTransactions}
+        >
+          {({loading, reloading, errored, results}) => {
+            if (errored) {
               return (
-                <ChartsGrid>
-                  {YAXIS_OPTIONS.map(yAxis => (
-                    <React.Fragment key={yAxis.label}>
-                      {getDynamicText({
-                        value: (
-                          <Chart
-                            loading={loading || reloading}
-                            yAxis={yAxis.label}
-                            data={resultMap[yAxis.value]}
-                            router={router}
-                            statsPeriod={globalSelection.statsPeriod}
-                            utc={utc === 'true'}
-                            projects={globalSelection.project}
-                            environments={globalSelection.environment}
-                            tooltipCopy={yAxis.tooltip}
-                          />
-                        ),
-                        fixed: 'events chart',
-                      })}
-                    </React.Fragment>
-                  ))}
-                </ChartsGrid>
+                <ErrorPanel>
+                  <IconWarning color={theme.gray2} size="lg" />
+                </ErrorPanel>
               );
-            }}
-          </EventsRequest>
-        </ChartsContainer>
+            }
+
+            if (!results) {
+              return <LoadingPanel data-test-id="events-request-loading" />;
+            }
+
+            return (
+              <React.Fragment>
+                <HeaderContainer>
+                  {YAXIS_OPTIONS.map(option => (
+                    <HeaderTitle key={option.label}>
+                      {option.label}
+                      <Tooltip position="top" title={option.tooltip}>
+                        <StyledIconQuestion size="sm" />
+                      </Tooltip>
+                    </HeaderTitle>
+                  ))}
+                </HeaderContainer>
+                {getDynamicText({
+                  value: (
+                    <Chart
+                      data={results}
+                      loading={loading || reloading}
+                      router={router}
+                      statsPeriod={globalSelection.statsPeriod}
+                      utc={utc === 'true'}
+                      projects={globalSelection.project}
+                      environments={globalSelection.environment}
+                    />
+                  ),
+                  fixed: 'performance charts',
+                })}
+              </React.Fragment>
+            );
+          }}
+        </EventsRequest>
         <Footer
           api={api}
           organization={organization}
@@ -152,6 +153,13 @@ const ErrorPanel = styled('div')`
   position: relative;
   border-color: transparent;
   margin-bottom: 0;
+`;
+
+const HeaderContainer = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: ${space(2)};
+  padding: ${space(2)} ${space(1.5)} ${space(1)} ${space(1.5)};
 `;
 
 export default withApi(Container);


### PR DESCRIPTION
Use sub-grids on the performance overview charts. This lets us link the hover and zoom states for these graphs.

![linked chart zoom](https://user-images.githubusercontent.com/24086/80258736-f17a0480-8651-11ea-9967-86dae1e814e0.gif)
