### PR TITLE
Fix(discover): Top events with array fields

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import six
+import logging
 
 from collections import namedtuple
 from copy import deepcopy
@@ -47,6 +48,8 @@ __all__ = (
     "zerofill",
 )
 
+
+logger = logging.getLogger(__name__)
 
 ReferenceEvent = namedtuple("ReferenceEvent", ["organization", "slug", "fields", "start", "end"])
 ReferenceEvent.__new__.__defaults__ = (None, None)
@@ -930,6 +933,11 @@ def top_events_timeseries(
         result_key = create_result_key(row, translated_groupby, issues)
         if result_key in results:
             results[result_key]["data"].append(row)
+        else:
+            logger.warning(
+                "Timeseries top events key mismatch",
+                extra={"result_key": result_key, "top_event_keys": results.keys()},
+            )
     for key, item in six.iteritems(results):
         results[key] = SnubaTSResult(
             {

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -858,7 +858,7 @@ def top_events_timeseries(
             continue
         if field == "issue":
             field = FIELD_ALIASES["issue"]["column_alias"]
-        # Note that cause orderby shouldn't be an array field its not included in the values
+        # Note that because orderby shouldn't be an array field its not included in the values
         values = list(
             {
                 event.get(field)
@@ -935,7 +935,7 @@ def top_events_timeseries(
             results[result_key]["data"].append(row)
         else:
             logger.warning(
-                "Timeseries top events key mismatch",
+                "discover.top-events.timeseries.key-mismatch",
                 extra={"result_key": result_key, "top_event_keys": results.keys()},
             )
     for key, item in six.iteritems(results):


### PR DESCRIPTION
- This basically ignored array fields in top events except in the
  groupby, this is cause they can't be used in the orderby already
- When generating the result_keys these array fields become their last item,
  this is to match what the frontend does when getting an array
- This also restricts results to the 5 result_keys from top_events.