### PR TITLE
feat(ingest) Tracing for ingest consumers

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -963,6 +963,9 @@ SENTRY_PROCESS_EVENT_APM_SAMPLING = 0
 # sample rate for the relay projectconfig endpoint
 SENTRY_RELAY_ENDPOINT_APM_SAMPLING = 0
 
+# sample rate for ingest consumer processing functions
+SENTRY_INGEST_CONSUMER_APM_SAMPLING = 0
+
 # ----
 # end APM config
 # ----

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import random
+import functools
 import atexit
 import logging
 import msgpack
@@ -8,7 +10,10 @@ from six import BytesIO
 import multiprocessing.dummy
 import multiprocessing as _multiprocessing
 
+from django.conf import settings
 from django.core.cache import cache
+
+import sentry_sdk
 
 from sentry import eventstore, features, options
 from sentry.cache import default_cache
@@ -16,6 +21,7 @@ from sentry.models import Project, File, EventAttachment
 from sentry.signals import event_accepted
 from sentry.tasks.store import preprocess_event
 from sentry.utils import json, metrics
+from sentry.utils.sdk import mark_scope_as_unsafe
 from sentry.utils.dates import to_datetime
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.kafka import create_batching_kafka_consumer
@@ -41,6 +47,11 @@ class IngestConsumerWorker(AbstractBatchWorker):
         return message
 
     def flush_batch(self, batch):
+        mark_scope_as_unsafe()
+        with metrics.timer("ingest_consumer.flush_batch"):
+            return self._flush_batch(batch)
+
+    def _flush_batch(self, batch):
         attachment_chunks = []
         other_messages = []
         transactions = []
@@ -84,17 +95,34 @@ class IngestConsumerWorker(AbstractBatchWorker):
         if other_messages:
             with metrics.timer("ingest_consumer.process_other_messages_batch"):
                 for _ in self.pool.imap_unordered(
-                    lambda args: args[0](args[1], projects=projects), other_messages, chunksize=100
+                    lambda args: args[0](args[1], projects=projects), other_messages, chunksize=100,
                 ):
                     pass
 
         if transactions:
-            process_transactions_batch(transactions, projects)
+            with metrics.timer("ingest_consumer.process_transactions"):
+                process_transactions_batch(transactions, projects)
 
     def shutdown(self):
         pass
 
 
+def trace_func(**span_kwargs):
+    def wrapper(f):
+        @functools.wraps(f)
+        def inner(*args, **kwargs):
+            span_kwargs["sampled"] = random.random() < getattr(
+                settings, "SENTRY_INGEST_CONSUMER_APM_SAMPLING", 0
+            )
+            with sentry_sdk.start_span(**span_kwargs):
+                return f(*args, **kwargs)
+
+        return inner
+
+    return wrapper
+
+
+@trace_func(transaction="ingest_consumer.process_transactions_batch")
 @metrics.wraps("ingest_consumer.process_transactions_batch")
 def process_transactions_batch(messages, projects):
     if options.get("store.transactions-celery") is True:
@@ -118,6 +146,7 @@ def process_transactions_batch(messages, projects):
     save_transaction_events(jobs, projects)
 
 
+@trace_func(transaction="ingest_consumer.process_event")
 @metrics.wraps("ingest_consumer.process_event")
 def process_event(message, projects):
     payload = message["payload"]
@@ -177,9 +206,14 @@ def process_event(message, projects):
     # Preprocess this event, which spawns either process_event or
     # save_event. Pass data explicitly to avoid fetching it again from the
     # cache.
-    preprocess_event(
-        cache_key=cache_key, data=data, start_time=start_time, event_id=event_id, project=project
-    )
+    with sentry_sdk.start_span(op="ingest_consumer.process_event.preprocess_event"):
+        preprocess_event(
+            cache_key=cache_key,
+            data=data,
+            start_time=start_time,
+            event_id=event_id,
+            project=project,
+        )
 
     # remember for an 1 hour that we saved this event (deduplication protection)
     cache.set(deduplication_key, "", CACHE_TIMEOUT)
@@ -188,6 +222,7 @@ def process_event(message, projects):
     event_accepted.send_robust(ip=remote_addr, data=data, project=project, sender=process_event)
 
 
+@trace_func(transaction="ingest_consumer.process_attachment_chunk")
 @metrics.wraps("ingest_consumer.process_attachment_chunk")
 def process_attachment_chunk(message, projects):
     payload = message["payload"]
@@ -201,6 +236,7 @@ def process_attachment_chunk(message, projects):
     )
 
 
+@trace_func(transaction="ingest_consumer.process_individual_attachment")
 @metrics.wraps("ingest_consumer.process_individual_attachment")
 def process_individual_attachment(message, projects):
     event_id = message["event_id"]
@@ -256,6 +292,7 @@ def process_individual_attachment(message, projects):
     attachment.delete()
 
 
+@trace_func(transaction="ingest_consumer.process_userreport")
 @metrics.wraps("ingest_consumer.process_userreport")
 def process_userreport(message, projects):
     project_id = int(message["project_id"])

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -172,7 +172,8 @@ def configure_sdk():
                 relay_transport.capture_event(event)
             else:
                 metrics.incr("internal.uncaptured.events.relay", skip_internal=False)
-                sdk_logger.warn("internal-error.unsafe-stacktrace.relay")
+                if event.get("type") != "transaction":
+                    sdk_logger.warn("internal-error.unsafe-stacktrace.relay")
 
     sentry_sdk.init(
         transport=capture_event,

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, print_function
+import uuid
 
 import pytest
 
-from sentry_sdk import Hub, last_event_id
+import sentry_sdk
+from sentry_sdk import Hub, push_scope
 
 from django.conf import settings
 from sentry.utils.sdk import configure_sdk, bind_organization_context
 from sentry.utils.compat import mock
-from sentry.app import raven
 
 from sentry import eventstore
 from sentry.testutils import assert_mock_called_once_with_partial
@@ -24,37 +25,39 @@ def post_event_with_sdk(settings, relay_server, wait_for_ingest_consumer):
     wait_for_ingest_consumer = wait_for_ingest_consumer(settings)
 
     def inner(*args, **kwargs):
-        event_id = raven.captureMessage(*args, **kwargs)
+        event_id = sentry_sdk.capture_event(*args, **kwargs)
         Hub.current.client.flush()
 
-        return wait_for_ingest_consumer(
-            lambda: eventstore.get_event_by_id(settings.SENTRY_PROJECT, event_id)
-        )
+        with push_scope():
+            return wait_for_ingest_consumer(
+                lambda: eventstore.get_event_by_id(settings.SENTRY_PROJECT, event_id)
+            )
 
     return inner
 
 
 @pytest.mark.django_db
 def test_simple(post_event_with_sdk):
-    event = post_event_with_sdk("internal client test")
+    event = post_event_with_sdk({"message": "internal client test"})
 
     assert event
     assert event.data["project"] == settings.SENTRY_PROJECT
-    assert event.data["event_id"] == last_event_id()
     assert event.data["logentry"]["formatted"] == "internal client test"
 
 
 @pytest.mark.django_db
-def test_recursion_breaker(post_event_with_sdk):
+def test_recursion_breaker(settings, post_event_with_sdk):
     # If this test terminates at all then we avoided recursion.
+    settings.SENTRY_INGEST_CONSUMER_APM_SAMPLING = 1.0
+    event_id = uuid.uuid4().hex
     with mock.patch(
         "sentry.event_manager.EventManager.save", side_effect=ValueError("oh no!")
     ) as save:
         with pytest.raises(ValueError):
-            post_event_with_sdk("internal client test")
+            post_event_with_sdk({"message": "internal client test", "event_id": event_id})
 
     assert_mock_called_once_with_partial(
-        save, settings.SENTRY_PROJECT, cache_key=u"e:{}:1".format(last_event_id())
+        save, settings.SENTRY_PROJECT, cache_key=u"e:{}:1".format(event_id)
     )
 
 
@@ -63,7 +66,9 @@ def test_encoding(post_event_with_sdk):
     class NotJSONSerializable:
         pass
 
-    event = post_event_with_sdk("check the req", extra={"request": NotJSONSerializable()})
+    with push_scope() as scope:
+        scope.set_extra("request", NotJSONSerializable())
+        event = post_event_with_sdk({"message": "check the req"})
 
     assert event.data["project"] == settings.SENTRY_PROJECT
     assert event.data["logentry"]["formatted"] == "check the req"


### PR DESCRIPTION
Introduces tracing to the ingest consumer.

- adds function to mark whole scope of transaction as `unsafe` for breaking the recursion without walking the stack for each transaction
- wrap each processing function in transaction and have at least timing metric for the whole batch processing

