### PR TITLE
logging(vsts): update logging for secret verification for vsts

### DIFF
--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -75,23 +75,15 @@ class WorkItemWebhook(Endpoint):
         try:
             integration_secret = integration.metadata["subscription"]["secret"]
             webhook_payload_secret = request.META["HTTP_SHARED_SECRET"]
+            # TODO(Steve): remove
             logger.info(
-                "vsts.simple-webhook-check",
+                "vst.special-webhook-sercret",
                 extra={
-                    "equality1": integration_secret == webhook_payload_secret,
-                    "equality2": constant_time_compare(integration_secret, webhook_payload_secret),
+                    "integration_id": integration.id,
+                    "integration_secret": six.text_type(integration_secret)[:6],
+                    "webhook_payload_secret": six.text_type(webhook_payload_secret)[:6],
                 },
             )
-            # TODO(Steve): remove
-            # I don't want to put the webhook secret in logs except for my own integration I don't care about :)
-            if integration.id == 58554:
-                logger.info(
-                    "vst.special-webhook-sercret",
-                    extra={
-                        "integration_secret": six.text_type(integration_secret),
-                        "webhook_payload_secret": six.text_type(webhook_payload_secret),
-                    },
-                )
         except KeyError as e:
             logger.info(
                 "vsts.missing-webhook-secret",

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -77,7 +77,7 @@ class WorkItemWebhook(Endpoint):
             webhook_payload_secret = request.META["HTTP_SHARED_SECRET"]
             # TODO(Steve): remove
             logger.info(
-                "vst.special-webhook-sercret",
+                "vsts.special-webhook-sercret",
                 extra={
                     "integration_id": integration.id,
                     "integration_secret": six.text_type(integration_secret)[:6],

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -77,7 +77,7 @@ class WorkItemWebhook(Endpoint):
             webhook_payload_secret = request.META["HTTP_SHARED_SECRET"]
             # TODO(Steve): remove
             logger.info(
-                "vsts.special-webhook-sercret",
+                "vsts.special-webhook-secret",
                 extra={
                     "integration_id": integration.id,
                     "integration_secret": six.text_type(integration_secret)[:6],


### PR DESCRIPTION
This PR modifies some of the logging I put in last week. I have been unable to replicate the webhook signature mismatch bug for my own integration, so I modified the logs to spit out the first 6 digits of the secret for all requests. Also removed another log message about the different types of equality that turned out to be useless since either both equality checks succeed or both fail.