### PR TITLE
feat(IntegrationDirectory): Remove Category Select experiment

### DIFF
--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -20,7 +20,6 @@ import {Hooks} from 'app/types/hooks';
 import HookStore from 'app/stores/hookStore';
 
 const INTEGRATIONS_ANALYTICS_SESSION_KEY = 'INTEGRATION_ANALYTICS_SESSION' as const;
-const SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT = 'SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT' as const;
 
 export const startAnalyticsSession = () => {
   const sessionId = uniqueId();
@@ -34,15 +33,6 @@ export const clearAnalyticsSession = () => {
 
 export const getAnalyticsSessionId = () =>
   window.sessionStorage.getItem(INTEGRATIONS_ANALYTICS_SESSION_KEY);
-
-export const getCategorySelectActive = (organization?: Organization) => {
-  const variant = organization?.experiments?.IntegrationDirectoryCategoryExperiment;
-  const localStore = localStorage.getItem(SHOW_INTEGRATION_DIRECTORY_CATEGORY_SELECT);
-  if (localStore !== null) {
-    return localStore === '1';
-  }
-  return variant === '1';
-};
 
 export type SingleIntegrationEvent = {
   eventKey:

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -21,7 +21,6 @@ import {Panel, PanelBody} from 'app/components/panels';
 import {
   trackIntegrationEvent,
   getSentryAppInstallStatus,
-  getCategorySelectActive,
   isSentryApp,
   isPlugin,
   isDocumentIntegration,
@@ -39,8 +38,6 @@ import SearchBar from 'app/components/searchBar';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import space from 'app/styles/space';
 import SelectControl from 'app/components/forms/selectControl';
-import withExperiment from 'app/utils/withExperiment';
-import {ExperimentAssignment} from 'app/types/experiments';
 import Feature from 'app/components/acl/feature';
 
 import {POPULARITY_WEIGHT, documentIntegrations} from './constants';
@@ -49,7 +46,6 @@ import IntegrationRow from './integrationRow';
 type Props = RouteComponentProps<{orgId: string}, {}> & {
   organization: Organization;
   hideHeader: boolean;
-  experimentAssignment: ExperimentAssignment['IntegrationDirectoryCategoryExperiment'];
 };
 
 type State = {
@@ -439,19 +435,15 @@ export class IntegrationListDirectory extends AsyncComponent<
             title={title}
             action={
               <ActionContainer>
-                {getCategorySelectActive(this.props.organization) ? (
-                  <SelectControl
-                    name="select-categories"
-                    onChange={this.onCategorySelect}
-                    value={selectedCategory}
-                    choices={[
-                      ['', t('All Categories')],
-                      ...categoryList.map(category => [category, startCase(category)]),
-                    ]}
-                  />
-                ) : (
-                  <div />
-                )}
+                <SelectControl
+                  name="select-categories"
+                  onChange={this.onCategorySelect}
+                  value={selectedCategory}
+                  choices={[
+                    ['', t('All Categories')],
+                    ...categoryList.map(category => [category, startCase(category)]),
+                  ]}
+                />
                 <SearchBar
                   query={this.state.searchInput || ''}
                   onChange={this.handleSearchChange}
@@ -505,8 +497,4 @@ const EmptyResultsBody = styled('div')`
   padding-bottom: ${space(2)};
 `;
 
-export default withOrganization(
-  withExperiment(IntegrationListDirectory, {
-    experiment: 'IntegrationDirectoryCategoryExperiment',
-  })
-);
+export default withOrganization(IntegrationListDirectory);


### PR DESCRIPTION
## Objective
We want remove all code relate to the Category Select A/B test and let 100% of users use the feature.

Associated PR: https://github.com/getsentry/getsentry/pull/3861

## UI
<img width="1440" alt="Screen Shot 2020-04-27 at 11 26 31 AM" src="https://user-images.githubusercontent.com/10491193/80407204-1ea8fb80-887a-11ea-8a4d-a1c2f4868daa.png">

## Test Plan
Built getsentry locally and checked that the feature works after removing all A/B test-related code.