### PR TITLE
fix(jira): update all.js path for Jira

### DIFF
--- a/src/sentry/integrations/jira/configure.py
+++ b/src/sentry/integrations/jira/configure.py
@@ -35,10 +35,7 @@ class JiraConfigForm(forms.Form):
 
 class JiraConfigureView(View):
     def get_response(self, context):
-        context["ac_js_src"] = "%(base_url)s%(context_path)s/atlassian-connect/all.js" % {
-            "base_url": self.request.GET["xdm_e"],
-            "context_path": self.request.GET.get("cp", ""),
-        }
+        context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         res = render_to_response("sentry/integrations/jira-config.html", context, self.request)
         res["X-Frame-Options"] = "ALLOW-FROM %s" % self.request.GET["xdm_e"]
         return res

--- a/src/sentry_plugins/jira_ac/views.py
+++ b/src/sentry_plugins/jira_ac/views.py
@@ -33,12 +33,7 @@ class BaseJiraWidgetView(View):
 
     def get_context(self):
         return {
-            "ac_js_src": "%s%s%s"
-            % (
-                self.request.GET["xdm_e"],
-                self.request.GET.get("cp", ""),
-                "/atlassian-connect/all.js",
-            ),
+            "ac_js_src": "https://connect-cdn.atl-paas.net/all.js",
             "login_url": absolute_uri(reverse("sentry-login")),
             "body_class": "",
         }


### PR DESCRIPTION
Jira changed the path for the `all.js` file (https://community.developer.atlassian.com/t/deprecation-of-xdm-e-usage/32768) which caused the configure UI to look funny and things get cropped out. This happened in Feb. I have updated it to the right path of `https://connect-cdn.atl-paas.net/all.js`

Before fix:

![Screen Shot 2020-04-27 at 11 50 54 AM](https://user-images.githubusercontent.com/8533851/80409674-2074be00-887e-11ea-8a98-5beca5bebae2.png)

After:

![Screen Shot 2020-04-27 at 11 51 25 AM](https://user-images.githubusercontent.com/8533851/80409687-25397200-887e-11ea-84ba-e5c964535d87.png)


