### PR TITLE
ref(ui) Don't use grey purple in charts

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/areaChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/areaChart.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import AreaSeries from './series/areaSeries';
 import BaseChart from './baseChart';
-import {AREA_COLORS} from './utils';
+import {AREA_SINGLE_COLOR} from './utils';
 
 class AreaChart extends React.Component {
   static propTypes = {
@@ -12,7 +12,7 @@ class AreaChart extends React.Component {
   };
 
   render() {
-    const {series, stacked, ...props} = this.props;
+    const {series, stacked, colors, ...props} = this.props;
 
     return (
       <BaseChart
@@ -22,9 +22,9 @@ class AreaChart extends React.Component {
             stack: stacked ? 'area' : false,
             name: seriesName,
             data: data.map(({name, value}) => [name, value]),
-            color: AREA_COLORS[i].line,
+            color: (colors && colors[i]) || AREA_SINGLE_COLOR,
             areaStyle: {
-              color: AREA_COLORS[i].area,
+              color: (colors && colors[i]) || AREA_SINGLE_COLOR,
               opacity: 1.0,
             },
             animation: false,

--- a/src/sentry/static/sentry/app/components/charts/utils.tsx
+++ b/src/sentry/static/sentry/app/components/charts/utils.tsx
@@ -10,15 +10,9 @@ const DEFAULT_TRUNCATE_LENGTH = 80;
 const TWENTY_FOUR_HOURS = 1440;
 const ONE_HOUR = 60;
 
-export const AREA_COLORS = [
-  // This first color is used when only a single series is plotted.
-  {line: '#948BCF', area: '#C4BFE9'},
-  {line: '#FFE3FD', area: '#FFE3FD'},
-  {line: '#E8B0F2', area: '#E8B0F2'},
-  {line: '#BD81E6', area: '#BD81E6'},
-  {line: '#5246A3', area: '#5246A3'},
-  {line: '#422C6F', area: '#422C6F'},
-];
+export const AREA_COLORS = ['#FFE3FD', '#E8B0F2', '#BD81E6', '#5246A3', '#422C6F'];
+
+export const AREA_SINGLE_COLOR = AREA_COLORS[3];
 
 export type DateTimeObject = {
   start: Date | null;

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import isEqual from 'lodash/isEqual';
 
 import {t} from 'app/locale';
-import {getInterval} from 'app/components/charts/utils';
+import {getInterval, AREA_SINGLE_COLOR, AREA_COLORS} from 'app/components/charts/utils';
 import ChartZoom from 'app/components/charts/chartZoom';
 import AreaChart from 'app/components/charts/areaChart';
 import TransitionChart from 'app/components/charts/transitionChart';
@@ -82,6 +82,11 @@ class EventsAreaChart extends React.Component {
       data: [currentSeriesName ?? t('Current'), previousSeriesName ?? t('Previous'), ''],
     };
 
+    const colors =
+      timeseriesData.length === 1
+        ? [AREA_SINGLE_COLOR]
+        : AREA_COLORS.slice(0, timeseriesData.length);
+
     return (
       <AreaChart
         {...props}
@@ -92,6 +97,7 @@ class EventsAreaChart extends React.Component {
           showSymbol: false,
         }}
         previousPeriod={previousTimeseriesData ? [previousTimeseriesData] : null}
+        colors={colors}
         grid={{
           left: '24px',
           right: '24px',

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -8,7 +8,7 @@ import {Client} from 'app/api';
 import {Organization} from 'app/types';
 import EventsRequest from 'app/views/events/utils/eventsRequest';
 import AreaChart from 'app/components/charts/areaChart';
-import {getInterval} from 'app/components/charts/utils';
+import {AREA_SINGLE_COLOR, getInterval} from 'app/components/charts/utils';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingContainer from 'app/components/loading/loadingContainer';
@@ -103,7 +103,8 @@ class MiniGraph extends React.Component<Props> {
           const data = (timeseriesData || []).map(series => ({
             ...series,
             areaStyle: {
-              opacity: 0.4,
+              color: AREA_SINGLE_COLOR,
+              opacity: 0.5,
             },
             lineStyle: {
               opacity: 0,
@@ -137,7 +138,6 @@ class MiniGraph extends React.Component<Props> {
                 bottom: 0,
                 containLabel: false,
               }}
-              colors={['#6d5fc7']}
               options={{
                 hoverAnimation: false,
               }}

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -3,7 +3,7 @@ import * as ReactRouter from 'react-router';
 
 import {Series} from 'app/types/echarts';
 import AreaChart from 'app/components/charts/areaChart';
-import {AREA_COLORS} from 'app/components/charts/utils';
+import {AREA_SINGLE_COLOR} from 'app/components/charts/utils';
 import ChartZoom from 'app/components/charts/chartZoom';
 
 type Props = {
@@ -60,6 +60,7 @@ class Chart extends React.Component<Props> {
       utc,
       isGroupedByDate: true,
       showTimeInTooltip: true,
+      colors: [AREA_SINGLE_COLOR, AREA_SINGLE_COLOR],
     };
 
     if (loading) {
@@ -69,11 +70,6 @@ class Chart extends React.Component<Props> {
       ...values,
       yAxisIndex: i,
       xAxisIndex: i,
-      color: AREA_COLORS[0].line,
-      areaStyle: {
-        color: AREA_COLORS[0].area,
-        opacity: 1.0,
-      },
     }));
 
     return (

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -138,12 +138,12 @@ class DurationChart extends React.Component<Props> {
                       .map((values, i: number) => {
                         return {
                           ...values,
-                          color: AREA_COLORS[i].line,
+                          color: AREA_COLORS[i],
                           lineStyle: {
                             opacity: 0,
                           },
                           areaStyle: {
-                            color: AREA_COLORS[i].area,
+                            color: AREA_COLORS[i],
                             opacity: 1.0,
                           },
                         };

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -8,6 +8,7 @@ import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import BarChart from 'app/components/charts/barChart';
 import ErrorPanel from 'app/components/charts/components/errorPanel';
+import {AREA_COLORS} from 'app/components/charts/utils';
 import AsyncComponent from 'app/components/asyncComponent';
 import Tooltip from 'app/components/tooltip';
 import {OrganizationSummary} from 'app/types';
@@ -226,7 +227,7 @@ class LatencyChart extends AsyncComponent<Props, State> {
         yAxis={{type: 'value'}}
         series={transformData(chartData.data, this.bucketWidth)}
         tooltip={tooltip}
-        colors={['rgba(140, 79, 189, 0.3)']}
+        colors={[AREA_COLORS[2]]}
         onClick={this.handleClick}
         onMouseOver={this.handleMouseOver}
       />


### PR DESCRIPTION
With the addition of the top5 colour palette, the classic grey purple was out of place. This replaces the grey purple with the mid colour in the top5 palette making single and multi-series graphs visually similar.

## Discover query cards
![Screen Shot 2020-04-27 at 3 39 54 PM](https://user-images.githubusercontent.com/24086/80415371-74909a00-88a0-11ea-863c-10c11fd39333.png)

## Discover overview graph & events v1
![Screen Shot 2020-04-27 at 3 40 30 PM](https://user-images.githubusercontent.com/24086/80415408-81ad8900-88a0-11ea-9d0c-e325f0cf768c.png)

## Performance overview
![Screen Shot 2020-04-27 at 3 40 04 PM](https://user-images.githubusercontent.com/24086/80415434-8bcf8780-88a0-11ea-9796-34a7173f01fe.png)

## Latency histogram
![Screen Shot 2020-04-27 at 3 55 35 PM](https://user-images.githubusercontent.com/24086/80415462-968a1c80-88a0-11ea-9403-bf2fd9348dd3.png)


Discover1 and dashboards are unaffected by this change as they set their own palette ranges up.