### PR TITLE
fix(discover) Handle deleted issues gracefully

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
@@ -3,8 +3,10 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
+import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import {SectionHeading} from 'app/components/charts/styles';
+import {IconWarning} from 'app/icons';
 import GroupChart from 'app/components/stream/groupChart';
 import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
@@ -42,6 +44,20 @@ class LinkedIssue extends AsyncComponent<
 
   renderLoading() {
     return <Placeholder height="120px" bottomGutter={2} />;
+  }
+
+  renderError(error?: Error, disableLog = false, disableReport = false): React.ReactNode {
+    const {errors} = this.state;
+    const hasNotFound = Object.values(errors).find(resp => resp && resp.status === 404);
+    if (hasNotFound) {
+      return (
+        <Alert type="warning" icon={<IconWarning size="md" />}>
+          {t('The linked issue cannot be found. It may have been deleted, or merged.')}
+        </Alert>
+      );
+    }
+
+    return super.renderError(error, disableLog, disableReport);
   }
 
   renderBody() {

--- a/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
@@ -141,6 +141,26 @@ describe('EventsV2 > EventDetails', function() {
     expect(graph).toHaveLength(1);
   });
 
+  it('renders an alert when linked issues are missing', function() {
+    MockApiClient.addMockResponse({
+      url: '/issues/123/',
+      statusCode: 404,
+      method: 'GET',
+      body: {},
+    });
+    const wrapper = mountWithTheme(
+      <EventDetails
+        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
+        params={{eventSlug: 'project-slug:deadbeef'}}
+        location={{query: allEventsView.generateQueryStringObject()}}
+      />,
+      TestStubs.routerContext()
+    );
+    const alert = wrapper.find('Alert');
+    expect(alert).toHaveLength(1);
+    expect(alert.text()).toContain('linked issue cannot be found');
+  });
+
   it('navigates when tag values are clicked', async function() {
     const {organization, routerContext} = initializeOrg({
       organization: TestStubs.Organization({projects: [TestStubs.Project()]}),


### PR DESCRIPTION
It is possible to pull up events in discover for issues that have been
deleted. When this happens we should not fail hard and instead show
a message indicating that the issue has been deleted or is being merged.

![Screen Shot 2020-04-27 at 4 39 49 PM](https://user-images.githubusercontent.com/24086/80420715-364ba880-88a9-11ea-8970-1066fe08afa1.png)

Refs ISSUE-778