### PR TITLE
fix(integrations): handle case where Content-Type header is missing

### DIFF
--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -62,14 +62,14 @@ class BaseApiResponse(object):
 
         # Some APIs will return JSON with an invalid content-type, so we try
         # to decode it anyways
-        if "application/json" not in response.headers["Content-Type"]:
+        if "application/json" not in response.headers.get("Content-Type", {}):
             try:
                 data = json.loads(response.text, object_pairs_hook=OrderedDict)
             except (TypeError, ValueError):
                 if allow_text:
                     return TextApiResponse(response.text, response.headers, response.status_code)
                 raise UnsupportedResponseType(
-                    response.headers["Content-Type"], response.status_code
+                    response.headers.get("Content-Type", "No Content-Type"), response.status_code
                 )
         else:
             data = json.loads(response.text, object_pairs_hook=OrderedDict)

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -69,7 +69,7 @@ class BaseApiResponse(object):
                 if allow_text:
                     return TextApiResponse(response.text, response.headers, response.status_code)
                 raise UnsupportedResponseType(
-                    response.headers.get("Content-Type", "No Content-Type"), response.status_code
+                    response.headers.get("Content-Type", ""), response.status_code
                 )
         else:
             data = json.loads(response.text, object_pairs_hook=OrderedDict)

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -62,7 +62,7 @@ class BaseApiResponse(object):
 
         # Some APIs will return JSON with an invalid content-type, so we try
         # to decode it anyways
-        if "application/json" not in response.headers.get("Content-Type", {}):
+        if "application/json" not in response.headers.get("Content-Type", ""):
             try:
                 data = json.loads(response.text, object_pairs_hook=OrderedDict)
             except (TypeError, ValueError):


### PR DESCRIPTION
We sometimes see this error: `KeyError: 'content-type'` if the header is not defined in the response.

Fixes: SENTRY-FXP and SENTRY-FMC