### PR TITLE
perf(api): Add instrumentation around the Project model in API layer

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -5,6 +5,8 @@ import six
 from django.db.models import Q
 from rest_framework.response import Response
 
+import sentry_sdk
+
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -107,7 +109,11 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         if get_all_projects:
             queryset = queryset.order_by("slug").select_related("organization")
-            return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
+            projects = list(queryset)
+            with sentry_sdk.start_span(op="serialize_all_organization_projects") as span:
+                span.set_data("Project Count", len(projects))
+                serialized = serialize(projects, request.user, ProjectSummarySerializer())
+            return Response(serialized)
         else:
             return self.paginate(
                 request=request,


### PR DESCRIPTION
Fills in some gaps of "missing instrumentation" on the current Discover views of some API endpoints that come into contact with the Project model.

Here is a preview of how the new Discover graphs look on my local stack. The production data will have the same general shape/structure (but more informative time measurements of course).

![Screen Shot 2020-04-27 at 4 47 18 PM](https://user-images.githubusercontent.com/26411900/80432298-a0b01900-88a8-11ea-9bd2-91d7e5915df6.png)
![Screen Shot 2020-04-27 at 4 47 10 PM](https://user-images.githubusercontent.com/26411900/80432303-a279dc80-88a8-11ea-80ad-cd3f35de138e.png)

