### PR TITLE
perf(access): Optimize Access.projects

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -187,7 +187,7 @@ class Access(BaseAccess):
     ):
         self.organization_id = organization_id
         self.teams = teams
-        self.projects = projects
+        self.projects = frozenset(projects)
         self.has_global_access = has_global_access
         self.scopes = scopes
         if permissions is not None:


### PR DESCRIPTION
This fixes quadratic time costs when `Access.has_project_membership` is
called once for each project.