### PR TITLE
ref(ui): Align alert rule settings center in grid

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/list.tsx
@@ -144,6 +144,11 @@ const ScrollWrapper = styled('div')`
 const StyledPanelTable = styled(PanelTable)`
   width: fit-content;
   min-width: 100%;
+
+  > * {
+    display: flex;
+    align-items: center;
+  }
 `;
 
 const HeaderActions = styled('div')`


### PR DESCRIPTION
@billyvg maybe there's a more appropriate way to do this (I know some people think `> *` has less good performance)

Looks like this
![image](https://user-images.githubusercontent.com/1421724/80433814-dbb44b80-88ac-11ea-88f0-45e5de95d9fa.png)

Old
![image](https://user-images.githubusercontent.com/1421724/80433829-e969d100-88ac-11ea-800d-903687ea1ca6.png)
