### PR TITLE
feat(ui): Refactor `<GlobalSelectionHeader>`

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -143,9 +143,10 @@ export function initializeUrlState({
           ...JSON.parse(storedValue),
         };
       }
-    } catch (ex) {
+    } catch (err) {
       // use default if invalid
-      console.error(ex); // eslint-disable-line no-console
+      Sentry.captureException(err);
+      console.error(err); // eslint-disable-line no-console
     }
   }
 

--- a/src/sentry/static/sentry/app/actions/globalSelectionActions.tsx
+++ b/src/sentry/static/sentry/app/actions/globalSelectionActions.tsx
@@ -2,6 +2,8 @@ import Reflux from 'reflux';
 
 export default Reflux.createActions([
   'reset',
+  'setOrganization',
+  'initializeUrlState',
   'updateProjects',
   'updateDateTime',
   'updateEnvironments',

--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import moment from 'moment';
 
 import {callIfFunction} from 'app/utils/callIfFunction';
-import {updateParams} from 'app/actionCreators/globalSelection';
+import {getUtcToLocalDateObject} from 'app/utils/dates';
+import {updateDateTime} from 'app/actionCreators/globalSelection';
 import DataZoom from 'app/components/charts/components/dataZoom';
 import SentryTypes from 'app/sentryTypes';
 import ToolBox from 'app/components/charts/components/toolBox';
@@ -89,6 +90,7 @@ class ChartZoom extends React.Component {
    * Saves a callback function to be called after chart animation is completed
    */
   setPeriod = ({period, start, end}, saveHistory) => {
+    const {router, onZoom} = this.props;
     const startFormatted = getDate(start);
     const endFormatted = getDate(end);
 
@@ -103,20 +105,22 @@ class ChartZoom extends React.Component {
     //
     // Parent container can use this to change into a loading state before
     // URL parameters are changed
-    callIfFunction(this.props.onZoom, {
+    callIfFunction(onZoom, {
       period,
       start: startFormatted,
       end: endFormatted,
     });
 
     this.zooming = () => {
-      updateParams(
+      updateDateTime(
         {
           period,
-          start: startFormatted,
-          end: endFormatted,
+          start: startFormatted
+            ? getUtcToLocalDateObject(startFormatted)
+            : startFormatted,
+          end: endFormatted ? getUtcToLocalDateObject(endFormatted) : endFormatted,
         },
-        this.props.router
+        router
       );
 
       this.saveCurrentPeriod({period, start, end});
@@ -202,11 +206,11 @@ class ChartZoom extends React.Component {
       children,
       xAxisIndex,
 
-      onZoom, // eslint-disable-line no-unused-vars
-      onRestore, // eslint-disable-line no-unused-vars
-      onChartReady, // eslint-disable-line no-unused-vars
-      onDataZoom, // eslint-disable-line no-unused-vars
-      onFinished, // eslint-disable-line no-unused-vars
+      onZoom: _onZoom,
+      onRestore: _onRestore,
+      onChartReady: _onChartReady,
+      onDataZoom: _onDataZoom,
+      onFinished: _onFinished,
       ...props
     } = this.props;
 

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -360,8 +360,6 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
       ? [parseInt(forceProject.id, 10)]
       : this.props.selection.projects;
 
-    const isReady = !loadingProjects && !isGlobalSelectionReady;
-
     return (
       <React.Fragment>
         <Header className={className}>
@@ -399,7 +397,8 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
                     shouldForceProject={shouldForceProject}
                     forceProject={forceProject}
                     projects={loadingProjects ? projects : memberProjects}
-                    loadingProjects={!initiallyLoaded && !isReady}
+                    isGlobalSelectionReady={isGlobalSelectionReady}
+                    isLoadingProjects={!initiallyLoaded}
                     nonMemberProjects={nonMemberProjects}
                     value={this.state.projects || this.props.selection.projects}
                     onChange={this.handleChangeProjects}

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.tsx
@@ -1,29 +1,96 @@
 import * as ReactRouter from 'react-router';
 import React from 'react';
+import partition from 'lodash/partition';
 
-import {GlobalSelection, Organization, Project} from 'app/types';
+import {Organization, Project} from 'app/types';
+import ConfigStore from 'app/stores/configStore';
 import withOrganization from 'app/utils/withOrganization';
-import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withProjectsSpecified from 'app/utils/withProjectsSpecified';
 
 import GlobalSelectionHeader from './globalSelectionHeader';
+import InitializeGlobalSelectionHeader from './initializeGlobalSelectionHeader';
+
+type GlobalSelectionHeaderProps = Omit<
+  React.ComponentPropsWithoutRef<typeof GlobalSelectionHeader>,
+  'router' | 'nonMemberProjects' | 'memberProjects' | 'selection'
+>;
 
 type Props = {
   organization: Organization;
-  selection: GlobalSelection;
   projects: Project[];
-  loadingProjects: boolean;
+  hasCustomRouting?: boolean;
 } & ReactRouter.WithRouterProps &
-  React.ComponentProps<typeof GlobalSelectionHeader>;
+  GlobalSelectionHeaderProps;
 
 class GlobalSelectionHeaderContainer extends React.Component<Props> {
+  getProjects = () => {
+    const {organization, projects} = this.props;
+    const {isSuperuser} = ConfigStore.get('user');
+    const isOrgAdmin = organization.access.includes('org:admin');
+
+    const [memberProjects, nonMemberProjects] = partition(
+      projects,
+      project => project.isMember
+    );
+
+    if (isSuperuser || isOrgAdmin) {
+      return [memberProjects, nonMemberProjects];
+    }
+
+    return [memberProjects, []];
+  };
+
   render() {
-    return <GlobalSelectionHeader {...this.props} />;
+    const {
+      loadingProjects,
+      location,
+      organization,
+      router,
+      routes,
+
+      defaultSelection,
+      forceProject,
+      shouldForceProject,
+      hasCustomRouting,
+      ...props
+    } = this.props;
+    const enforceSingleProject = !organization.features.includes('global-views');
+    const [memberProjects, nonMemberProjects] = this.getProjects();
+
+    return (
+      <React.Fragment>
+        {!loadingProjects && (
+          <InitializeGlobalSelectionHeader
+            location={location}
+            router={router}
+            routes={routes}
+            organization={organization}
+            defaultSelection={defaultSelection}
+            forceProject={forceProject}
+            isDisabled={!!hasCustomRouting}
+            shouldForceProject={!!shouldForceProject}
+            shouldEnforceSingleProject={!hasCustomRouting && enforceSingleProject}
+            memberProjects={memberProjects}
+          />
+        )}
+        <GlobalSelectionHeader
+          {...props}
+          loadingProjects={loadingProjects}
+          location={location}
+          organization={organization}
+          router={!hasCustomRouting ? router : null}
+          routes={routes}
+          shouldForceProject={!!shouldForceProject}
+          defaultSelection={defaultSelection}
+          forceProject={forceProject}
+          memberProjects={memberProjects}
+          nonMemberProjects={nonMemberProjects}
+        />
+      </React.Fragment>
+    );
   }
 }
 
 export default withOrganization(
-  withProjectsSpecified(
-    ReactRouter.withRouter(withGlobalSelection(GlobalSelectionHeaderContainer))
-  )
+  withProjectsSpecified(ReactRouter.withRouter(GlobalSelectionHeaderContainer))
 );

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.tsx
@@ -57,9 +57,10 @@ class GlobalSelectionHeaderContainer extends React.Component<Props> {
     const enforceSingleProject = !organization.features.includes('global-views');
     const [memberProjects, nonMemberProjects] = this.getProjects();
 
+    // We can initialize before ProjectsStore is fully loaded if we don't need to enforce single project.
     return (
       <React.Fragment>
-        {!loadingProjects && (
+        {(!loadingProjects || (!shouldForceProject && !enforceSingleProject)) && (
           <InitializeGlobalSelectionHeader
             location={location}
             router={router}

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/initializeGlobalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/initializeGlobalSelectionHeader.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import * as ReactRouter from 'react-router';
+
+import {initializeUrlState} from 'app/actionCreators/globalSelection';
+
+import GlobalSelectionHeader from './globalSelectionHeader';
+
+type Props = {
+  isDisabled: boolean;
+  shouldEnforceSingleProject: boolean;
+} & Pick<ReactRouter.WithRouterProps, 'location' | 'router' | 'routes'> &
+  Pick<
+    React.ComponentPropsWithoutRef<typeof GlobalSelectionHeader>,
+    | 'defaultSelection'
+    | 'forceProject'
+    | 'shouldForceProject'
+    | 'memberProjects'
+    | 'organization'
+  >;
+
+/**
+ * Initializes GlobalSelectionHeader
+ *
+ * Calls an actionCreator to load project/environment from local storage if possible,
+ * otherwise populate with defaults.
+ *
+ * This should only happen when the header is mounted
+ * e.g. when changing views or organizations.
+ */
+class InitializeGlobalSelectionHeader extends React.Component<Props> {
+  componentDidMount() {
+    const {
+      location,
+      router,
+      routes,
+      organization,
+      defaultSelection,
+      forceProject,
+      memberProjects,
+      shouldForceProject,
+      shouldEnforceSingleProject,
+    } = this.props;
+
+    // Make an exception for issue details in the case where it is accessed directly (e.g. from email)
+    // We do not want to load the user's last used env/project in this case, otherwise will
+    // lead to very confusing behavior.
+    //
+    // `routes` is only ever undefined in tests
+    const skipLastUsed = !!routes?.find(
+      ({path}) => path && path.includes('/organizations/:orgId/issues/:groupId/')
+    );
+    initializeUrlState({
+      organization,
+      queryParams: location.query,
+      router,
+      skipLastUsed,
+      memberProjects,
+      defaultSelection,
+      forceProject,
+      shouldForceProject,
+      shouldEnforceSingleProject,
+    });
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default InitializeGlobalSelectionHeader;

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/initializeGlobalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/initializeGlobalSelectionHeader.tsx
@@ -8,7 +8,7 @@ import GlobalSelectionHeader from './globalSelectionHeader';
 type Props = {
   isDisabled: boolean;
   shouldEnforceSingleProject: boolean;
-} & Pick<ReactRouter.WithRouterProps, 'location' | 'router' | 'routes'> &
+} & Pick<ReactRouter.WithRouterProps, 'location' | 'router'> &
   Pick<
     React.ComponentPropsWithoutRef<typeof GlobalSelectionHeader>,
     | 'defaultSelection'
@@ -16,7 +16,13 @@ type Props = {
     | 'shouldForceProject'
     | 'memberProjects'
     | 'organization'
-  >;
+  > & {
+    routes: Array<
+      ReactRouter.PlainRoute<any> & {
+        globalSelectionSkipLastUsed?: boolean;
+      }
+    >;
+  };
 
 /**
  * Initializes GlobalSelectionHeader
@@ -41,13 +47,13 @@ class InitializeGlobalSelectionHeader extends React.Component<Props> {
       shouldEnforceSingleProject,
     } = this.props;
 
-    // Make an exception for issue details in the case where it is accessed directly (e.g. from email)
+    // Make an exception for routes (e.g. issue details, in the case where it is accessed directly (e.g. from email))
     // We do not want to load the user's last used env/project in this case, otherwise will
     // lead to very confusing behavior.
     //
     // `routes` is only ever undefined in tests
     const skipLastUsed = !!routes?.find(
-      ({path}) => path && path.includes('/organizations/:orgId/issues/:groupId/')
+      ({globalSelectionSkipLastUsed}) => globalSelectionSkipLastUsed
     );
     initializeUrlState({
       organization,

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.tsx
@@ -1,13 +1,15 @@
 import {Location} from 'history';
+import identity from 'lodash/identity';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
-import identity from 'lodash/identity';
 
+import {DATE_TIME, DATE_TIME_KEYS, URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {defined} from 'app/utils';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
-import {URL_PARAM, DATE_TIME_KEYS} from 'app/constants/globalSelectionHeader';
 
 import {getParams} from './getParams';
+
+const DEFAULT_PARAMS = getParams({});
 
 // Parses URL query parameters for values relevant to global selection header
 export function getStateFromQuery(
@@ -67,4 +69,16 @@ export function extractSelectionParameters(query) {
  */
 export function extractDatetimeSelectionParameters(query) {
   return pickBy(pick(query, Object.values(DATE_TIME_KEYS)), identity);
+}
+export function getDefaultSelection() {
+  return {
+    projects: [],
+    environments: [],
+    datetime: {
+      [DATE_TIME.START]: DEFAULT_PARAMS.start || null,
+      [DATE_TIME.END]: DEFAULT_PARAMS.end || null,
+      [DATE_TIME.PERIOD]: DEFAULT_PARAMS.statsPeriod || null,
+      [DATE_TIME.UTC]: DEFAULT_PARAMS.utc || null,
+    },
+  };
 }

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -24,7 +24,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     value: PropTypes.array,
     projects: PropTypes.array.isRequired,
     nonMemberProjects: PropTypes.array.isRequired,
-    loadingProjects: PropTypes.bool,
+    isGlobalSelectionReady: PropTypes.bool,
     onChange: PropTypes.func,
     onUpdate: PropTypes.func,
     multi: PropTypes.bool,
@@ -45,12 +45,9 @@ export default class MultipleProjectSelector extends React.PureComponent {
     lockedMessageSubject: t('page'),
   };
 
-  constructor() {
-    super();
-    this.state = {
-      hasChanges: false,
-    };
-  }
+  state = {
+    hasChanges: false,
+  };
 
   // Reset "hasChanges" state and call `onUpdate` callback
   doUpdate = () => {
@@ -183,7 +180,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     const {
       value,
       projects,
-      loadingProjects,
+      isGlobalSelectionReady,
       nonMemberProjects,
       multi,
       organization,
@@ -216,11 +213,11 @@ export default class MultipleProjectSelector extends React.PureComponent {
       >
         {this.renderProjectName()}
       </StyledHeaderItem>
-    ) : loadingProjects ? (
+    ) : !isGlobalSelectionReady ? (
       <StyledHeaderItem
         data-test-id="global-header-project-selector"
         icon={<StyledInlineSvg src="icon-project" />}
-        loading={loadingProjects}
+        loading
       >
         {t('Loading\u2026')}
       </StyledHeaderItem>

--- a/src/sentry/static/sentry/app/components/organizations/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/projectSelector.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import sortBy from 'lodash/sortBy';
 import styled from '@emotion/styled';
 import {Link} from 'react-router';
 

--- a/src/sentry/static/sentry/app/components/organizations/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/projectSelector.jsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {Link} from 'react-router';
 
 import {analytics} from 'app/utils/analytics';
-import {sortArray} from 'app/utils';
 import {t} from 'app/locale';
 import {alertHighlight, pulse} from 'app/styles/animations';
 import Button from 'app/components/button';
@@ -102,7 +101,7 @@ class ProjectSelector extends React.Component {
     const {multiProjects, nonMemberProjects} = this.props;
 
     return [
-      sortArray(multiProjects, project => [!project.isBookmarked, project.name]),
+      sortBy(multiProjects, project => [!project.isBookmarked, project.name]),
       nonMemberProjects || [],
     ];
   }

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -63,6 +63,12 @@ const SelectorItemsHook = HookOrDefault({
 class TimeRangeSelector extends React.PureComponent {
   static propTypes = {
     /**
+     * When the default period is selected, it is visually dimmed and
+     * makes the selector unclearable.
+     */
+    defaultPeriod: PropTypes.string,
+
+    /**
      * Show absolute date selectors
      */
     showAbsolute: PropTypes.bool,
@@ -111,11 +117,6 @@ class TimeRangeSelector extends React.PureComponent {
      * Just used for metrics
      */
     organization: SentryTypes.Organization,
-
-    /**
-     * Allow user to clear the time range selection
-     */
-    allowClearTimeRange: PropTypes.bool,
 
     /**
      * Small info icon with tooltip hint text
@@ -305,13 +306,7 @@ class TimeRangeSelector extends React.PureComponent {
   };
 
   render() {
-    const {
-      showAbsolute,
-      showRelative,
-      organization,
-      allowClearTimeRange,
-      hint,
-    } = this.props;
+    const {defaultPeriod, showAbsolute, showRelative, organization, hint} = this.props;
     const {start, end, relative} = this.state;
 
     const shouldShowAbsolute = showAbsolute;
@@ -321,13 +316,10 @@ class TimeRangeSelector extends React.PureComponent {
     const summary = isAbsoluteSelected ? (
       <DateSummary utc={this.state.utc} start={start} end={end} />
     ) : (
-      getRelativeSummary(relative || DEFAULT_STATS_PERIOD)
+      getRelativeSummary(relative || defaultPeriod)
     );
 
-    const relativeSelected = isAbsoluteSelected ? null : relative || DEFAULT_STATS_PERIOD;
-
-    const allowClear =
-      typeof allowClearTimeRange === 'boolean' ? allowClearTimeRange : true;
+    const relativeSelected = isAbsoluteSelected ? null : relative || defaultPeriod;
 
     return (
       <DropdownMenu
@@ -343,12 +335,12 @@ class TimeRangeSelector extends React.PureComponent {
               icon={<IconCalendar />}
               isOpen={isOpen}
               hasSelected={
-                (!!this.props.relative && this.props.relative !== DEFAULT_STATS_PERIOD) ||
+                (!!this.props.relative && this.props.relative !== defaultPeriod) ||
                 isAbsoluteSelected
               }
               hasChanges={this.state.hasChanges}
               onClear={this.handleClear}
-              allowClear={allowClear}
+              allowClear
               hint={hint}
               {...getActorProps()}
             >

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1158,6 +1158,7 @@ function routes() {
           /organizations/:orgId/issues */}
         <Route
           path="/organizations/:orgId/issues/:groupId/"
+          globalSelectionSkipLastUsed
           componentPromise={() =>
             import(
               /* webpackChunkName: "OrganizationGroupDetails" */ 'app/views/organizationGroupDetails'
@@ -1165,8 +1166,6 @@ function routes() {
           }
           component={errorHandler(LazyLoad)}
         >
-          {/* XXX: if we change the path for group details, we *must* update `OrganizationContext`.
-            There is behavior that depends on this path and unfortunately no great way to test for this contract */}
           <IndexRoute
             componentPromise={() =>
               import(

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -155,6 +155,8 @@ export type Project = {
   processingIssues: number;
 } & AvatarProject;
 
+export type MinimalProject = Pick<Project, 'id' | 'slug'>;
+
 export type ProjectRelease = {
   version: string;
   dateCreated: string;

--- a/src/sentry/static/sentry/app/types/react-router.d.ts
+++ b/src/sentry/static/sentry/app/types/react-router.d.ts
@@ -1,4 +1,4 @@
-import {ComponentClass, StatelessComponent} from 'react';
+import {ComponentClass, ComponentType, StatelessComponent} from 'react';
 import {WithRouterProps} from 'react-router/lib/withRouter';
 import {InjectedRouter, Params} from 'react-router/lib/Router';
 import {Location} from 'history';
@@ -18,7 +18,10 @@ declare module 'react-router' {
     routes: PlainRoute[];
   }
 
-  type ComponentConstructor<P> = ComponentClass<P> | StatelessComponent<P>;
+  type ComponentConstructor<P> =
+    | ComponentClass<P>
+    | StatelessComponent<P>
+    | ComponentType<P>;
 
   declare function withRouter<P extends WithRouterProps>(
     component: ComponentConstructor<P>,

--- a/src/sentry/static/sentry/app/utils/dates.tsx
+++ b/src/sentry/static/sentry/app/utils/dates.tsx
@@ -49,8 +49,6 @@ export function getUserTimezone(): string {
   return user && user.options && user.options.timezone;
 }
 
-// TODO(billy): The below functions should be refactored to a TimeRangeSelector specific utils
-
 /**
  * Given a UTC date, return a Date object in local time
  */

--- a/src/sentry/static/sentry/app/utils/withGlobalSelection.tsx
+++ b/src/sentry/static/sentry/app/utils/withGlobalSelection.tsx
@@ -7,11 +7,13 @@ import getDisplayName from 'app/utils/getDisplayName';
 import {GlobalSelection} from 'app/types';
 
 type InjectedGlobalSelectionProps = {
-  selection: GlobalSelection;
+  selection?: GlobalSelection;
+  isGlobalSelectionReady?: boolean;
 };
 
 type State = {
   selection: GlobalSelection;
+  isReady?: boolean;
 };
 
 /**
@@ -29,32 +31,22 @@ const withGlobalSelection = <P extends InjectedGlobalSelectionProps>(
     mixins: [Reflux.listenTo(GlobalSelectionStore, 'onUpdate') as any],
 
     getInitialState() {
-      return {
-        selection: GlobalSelectionStore.get(),
-      };
+      return GlobalSelectionStore.get();
     },
 
-    componentDidMount() {
-      this.updateSelection();
-    },
-
-    onUpdate() {
-      this.updateSelection();
-    },
-
-    updateSelection() {
-      const selection = GlobalSelectionStore.get();
-
-      if (this.state.selection !== selection) {
-        this.setState({selection});
+    onUpdate(selection: State) {
+      if (this.state !== selection) {
+        this.setState(selection);
       }
     },
 
     render() {
-      const {selection} = this.state;
+      const {isReady, selection} = this.state;
+
       return (
         <WrappedComponent
           selection={selection as GlobalSelection}
+          isGlobalSelectionReady={isReady}
           {...(this.props as P)}
         />
       );

--- a/src/sentry/static/sentry/app/utils/withProjectsSpecified.tsx
+++ b/src/sentry/static/sentry/app/utils/withProjectsSpecified.tsx
@@ -1,17 +1,20 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 
 import getDisplayName from 'app/utils/getDisplayName';
 import ProjectsStore from 'app/stores/projectsStore';
-import SentryTypes from 'app/sentryTypes';
 import {Project} from 'app/types';
 
-type InjectedProjectsProps = {
-  projects: Project[];
-  loadingProjects?: boolean;
+type Props = {
+  projects?: Project[];
+  specificProjectSlugs?: string[];
 };
+
+type InjectedProjectsProps = {
+  loadingProjects: boolean;
+} & Props;
 
 type State = {
   projects: Project[];
@@ -24,16 +27,8 @@ type State = {
 const withProjectsSpecified = <P extends InjectedProjectsProps>(
   WrappedComponent: React.ComponentType<P>
 ) =>
-  createReactClass<
-    Omit<P, keyof InjectedProjectsProps> & Partial<InjectedProjectsProps>,
-    State
-  >({
+  createReactClass<Props & Omit<P, keyof InjectedProjectsProps>, State>({
     displayName: `withProjectsSpecified(${getDisplayName(WrappedComponent)})`,
-    propTypes: {
-      organization: SentryTypes.Organization,
-      project: SentryTypes.Project,
-      specificProjectSlugs: PropTypes.arrayOf(PropTypes.string),
-    },
     mixins: [Reflux.listenTo(ProjectsStore, 'onProjectUpdate') as any],
     getInitialState() {
       return ProjectsStore.getState(this.props.specificProjectSlugs);
@@ -45,8 +40,8 @@ const withProjectsSpecified = <P extends InjectedProjectsProps>(
     render() {
       return (
         <WrappedComponent
-          {...this.props}
-          projects={this.state.projects}
+          {...(this.props as P)}
+          projects={this.state.projects as Project[]}
           loadingProjects={this.state.loading}
         />
       );

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -255,9 +255,8 @@ class IncidentsListContainer extends React.Component<Props> {
     const status = getQueryStatus(query.status);
 
     return (
-      <React.Fragment>
-        <GlobalSelectionHeader organization={organization} showDateSelector={false} />
-        <DocumentTitle title={`Alerts- ${orgId} - Sentry`}>
+      <DocumentTitle title={`Alerts- ${orgId} - Sentry`}>
+        <GlobalSelectionHeader organization={organization} showDateSelector={false}>
           <PageContent>
             <PageHeader>
               <StyledPageHeading>
@@ -341,8 +340,8 @@ class IncidentsListContainer extends React.Component<Props> {
             </Alert>
             <IncidentsList {...this.props} />
           </PageContent>
-        </DocumentTitle>
-      </React.Fragment>
+        </GlobalSelectionHeader>
+      </DocumentTitle>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/dashboards/index.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/index.jsx
@@ -19,19 +19,17 @@ class Dashboards extends React.Component {
 
     return (
       <Feature features={['discover']} renderDisabled>
-        <GlobalSelectionHeader
-          organization={organization}
-          showEnvironmentSelector={false}
-        />
-        <PageContent>
-          <LightWeightNoProjectMessage organization={organization}>
-            <PageHeader>
-              <PageHeading withMargins>{t('Dashboards')}</PageHeading>
-            </PageHeader>
+        <GlobalSelectionHeader showEnvironmentSelector={false}>
+          <PageContent>
+            <LightWeightNoProjectMessage organization={organization}>
+              <PageHeader>
+                <PageHeading withMargins>{t('Dashboards')}</PageHeading>
+              </PageHeader>
 
-            {children}
-          </LightWeightNoProjectMessage>
-        </PageContent>
+              {children}
+            </LightWeightNoProjectMessage>
+          </PageContent>
+        </GlobalSelectionHeader>
       </Feature>
     );
   }

--- a/src/sentry/static/sentry/app/views/discover/discover.tsx
+++ b/src/sentry/static/sentry/app/views/discover/discover.tsx
@@ -463,7 +463,6 @@ export default class Discover extends React.Component<Props, State> {
           onChangeTime={this.changeTime}
           onUpdateTime={this.updateDateTimeAndRun}
         />
-
         <Body>
           <BodyContent>
             {shouldDisplayResult && (

--- a/src/sentry/static/sentry/app/views/events/index.jsx
+++ b/src/sentry/static/sentry/app/views/events/index.jsx
@@ -62,29 +62,29 @@ class EventsContainer extends React.Component {
         hookName="feature-disabled:events-page"
         renderDisabled
       >
-        <GlobalSelectionHeader
-          organization={organization}
-          resetParamsOnChange={['cursor']}
-        />
-        <PageContent>
-          <LightWeightNoProjectMessage organization={organization}>
-            <Body>
-              <PageHeader>
-                <HeaderTitle>
-                  {t('Events')} <BetaTag />
-                </HeaderTitle>
-                <StyledSearchBar
-                  organization={organization}
-                  projectIds={selection.projects}
-                  query={(location.query && location.query.query) || ''}
-                  placeholder={t('Search for events, users, tags, and everything else.')}
-                  onSearch={this.handleSearch}
-                />
-              </PageHeader>
-              {children}
-            </Body>
-          </LightWeightNoProjectMessage>
-        </PageContent>
+        <GlobalSelectionHeader resetParamsOnChange={['cursor']}>
+          <PageContent>
+            <LightWeightNoProjectMessage organization={organization}>
+              <Body>
+                <PageHeader>
+                  <HeaderTitle>
+                    {t('Events')} <BetaTag />
+                  </HeaderTitle>
+                  <StyledSearchBar
+                    organization={organization}
+                    projectIds={selection.projects}
+                    query={(location.query && location.query.query) || ''}
+                    placeholder={t(
+                      'Search for events, users, tags, and everything else.'
+                    )}
+                    onSearch={this.handleSearch}
+                  />
+                </PageHeader>
+                {children}
+              </Body>
+            </LightWeightNoProjectMessage>
+          </PageContent>
+        </GlobalSelectionHeader>
       </Feature>
     );
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -222,47 +222,48 @@ class Results extends React.Component<Props, State> {
     return (
       <SentryDocumentTitle title={title} objSlug={organization.slug}>
         <React.Fragment>
-          <GlobalSelectionHeader organization={organization} />
-          <StyledPageContent>
-            <LightWeightNoProjectMessage organization={organization}>
-              <ResultsHeader
-                organization={organization}
-                location={location}
-                eventView={eventView}
-              />
-              <ContentBox>
-                <Top>
-                  {this.renderError(error)}
-                  <StyledSearchBar
-                    organization={organization}
-                    projectIds={eventView.project}
-                    query={query}
-                    onSearch={this.handleSearch}
-                  />
-                  <ResultsChart
-                    api={api}
-                    router={router}
-                    organization={organization}
-                    eventView={eventView}
-                    location={location}
-                    onAxisChange={this.handleYAxisChange}
-                    onDisplayChange={this.handleDisplayChange}
-                    total={totalValues}
-                  />
-                </Top>
-                <Main>
-                  <Table
-                    organization={organization}
-                    eventView={eventView}
-                    location={location}
-                    title={title}
-                    setError={this.setError}
-                  />
-                </Main>
-                <Side>{this.renderTagsTable()}</Side>
-              </ContentBox>
-            </LightWeightNoProjectMessage>
-          </StyledPageContent>
+          <GlobalSelectionHeader>
+            <StyledPageContent>
+              <LightWeightNoProjectMessage organization={organization}>
+                <ResultsHeader
+                  organization={organization}
+                  location={location}
+                  eventView={eventView}
+                />
+                <ContentBox>
+                  <Top>
+                    {this.renderError(error)}
+                    <StyledSearchBar
+                      organization={organization}
+                      projectIds={eventView.project}
+                      query={query}
+                      onSearch={this.handleSearch}
+                    />
+                    <ResultsChart
+                      api={api}
+                      router={router}
+                      organization={organization}
+                      eventView={eventView}
+                      location={location}
+                      onAxisChange={this.handleYAxisChange}
+                      onDisplayChange={this.handleDisplayChange}
+                      total={totalValues}
+                    />
+                  </Top>
+                  <Main>
+                    <Table
+                      organization={organization}
+                      eventView={eventView}
+                      location={location}
+                      title={title}
+                      setError={this.setError}
+                    />
+                  </Main>
+                  <Side>{this.renderTagsTable()}</Side>
+                </ContentBox>
+              </LightWeightNoProjectMessage>
+            </StyledPageContent>
+          </GlobalSelectionHeader>
         </React.Fragment>
       </SentryDocumentTitle>
     );

--- a/src/sentry/static/sentry/app/views/issueList/container.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/container.jsx
@@ -21,15 +21,13 @@ class IssueListContainer extends React.Component {
 
     return (
       <DocumentTitle title={this.getTitle()}>
-        <React.Fragment>
-          <GlobalSelectionHeader organization={organization} />
-
+        <GlobalSelectionHeader>
           <PageContent>
             <LightWeightNoProjectMessage organization={organization}>
               {children}
             </LightWeightNoProjectMessage>
           </PageContent>
-        </React.Fragment>
+        </GlobalSelectionHeader>
       </DocumentTitle>
     );
   }

--- a/src/sentry/static/sentry/app/views/monitors/index.jsx
+++ b/src/sentry/static/sentry/app/views/monitors/index.jsx
@@ -5,8 +5,6 @@ import Feature from 'app/components/acl/feature';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import {PageContent} from 'app/styles/organization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
-import withOrganization from 'app/utils/withOrganization';
-import SentryTypes from 'app/sentryTypes';
 
 const Body = styled('div')`
   background-color: ${p => p.theme.whiteDark};
@@ -15,28 +13,24 @@ const Body = styled('div')`
 `;
 
 class MonitorsContainer extends React.Component {
-  static propTypes = {
-    organization: SentryTypes.Organization,
-  };
-
   render() {
-    const {organization, children} = this.props;
+    const {children} = this.props;
 
     return (
       <Feature features={['monitors']} renderDisabled>
         <GlobalSelectionHeader
-          organization={organization}
           showEnvironmentSelector={false}
           showDateSelector={false}
           resetParamsOnChange={['cursor']}
-        />
-        <PageContent>
-          <Body>{children}</Body>
-        </PageContent>
+        >
+          <PageContent>
+            <Body>{children}</Body>
+          </PageContent>
+        </GlobalSelectionHeader>
       </Feature>
     );
   }
 }
 
-export default withOrganization(withGlobalSelection(MonitorsContainer));
+export default withGlobalSelection(MonitorsContainer);
 export {MonitorsContainer};

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -13,7 +13,6 @@ import {openSudo} from 'app/actionCreators/modal';
 import {t} from 'app/locale';
 import Alert from 'app/components/alert';
 import ConfigStore from 'app/stores/configStore';
-import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import HookStore from 'app/stores/hookStore';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -22,10 +21,10 @@ import ProjectActions from 'app/actions/projectActions';
 import SentryTypes from 'app/sentryTypes';
 import Sidebar from 'app/components/sidebar';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
-import withProfiler from 'app/utils/withProfiler';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 import withOrganizations from 'app/utils/withOrganizations';
+import withProfiler from 'app/utils/withProfiler';
 
 const OrganizationContext = createReactClass({
   displayName: 'OrganizationContext',
@@ -201,16 +200,6 @@ const OrganizationContext = createReactClass({
         scope.setTag('organization', organization.id);
         scope.setTag('organization.slug', organization.slug);
         scope.setContext('organization', {id: organization.id, slug: organization.slug});
-      });
-      // Make an exception for issue details in the case where it is accessed directly (e.g. from email)
-      // We do not want to load the user's last used env/project in this case, otherwise will
-      // lead to very confusing behavior.
-      const skipLastUsed = !!this.props.routes.find(
-        ({path}) => path && path.includes('/organizations/:orgId/issues/:groupId/')
-      );
-      GlobalSelectionStore.loadInitialData(organization, this.props.location.query, {
-        skipLastUsed,
-        api: this.props.api,
       });
     } else if (error) {
       // If user is superuser, open sudo window

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/index.tsx
@@ -10,6 +10,7 @@ import GroupDetails from './groupDetails';
 
 type Props = {
   selection: GlobalSelection;
+  isGlobalSelectionReady: boolean;
   organization: Organization;
   children: React.ReactNode;
 } & ReactRouter.RouteComponentProps<{orgId: string; groupId: string}, {}>;

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -12,8 +12,6 @@ import {PageContent} from 'app/styles/organization';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import Alert from 'app/components/alert';
 import EventView from 'app/utils/discover/eventView';
-import {getUtcToLocalDateObject} from 'app/utils/dates';
-import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import space from 'app/styles/space';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -70,46 +68,6 @@ class PerformanceLanding extends React.Component<Props, State> {
     this.setState({error});
   };
 
-  generateGlobalSelection = () => {
-    const {location} = this.props;
-    const {eventView} = this.state;
-
-    const globalSelection = eventView.getGlobalSelection();
-    const start = globalSelection.start
-      ? getUtcToLocalDateObject(globalSelection.start)
-      : null;
-
-    const end = globalSelection.end ? getUtcToLocalDateObject(globalSelection.end) : null;
-
-    const {utc} = getParams(location.query);
-
-    return {
-      projects: globalSelection.project,
-      environments: globalSelection.environment,
-      datetime: {
-        start,
-        end,
-        period: globalSelection.statsPeriod || DEFAULT_STATS_PERIOD,
-        utc: utc === 'true',
-      },
-    };
-  };
-
-  allowClearTimeRange = (): boolean => {
-    const {datetime} = this.generateGlobalSelection();
-    const {start, end, period} = datetime;
-
-    if (period === DEFAULT_STATS_PERIOD) {
-      return false;
-    }
-
-    if ((start && end) || typeof period === 'string') {
-      return true;
-    }
-
-    return false;
-  };
-
   getViewLabel(currentView: FilterViews): string {
     switch (currentView) {
       case FilterViews.ALL_TRANSACTIONS:
@@ -154,12 +112,16 @@ class PerformanceLanding extends React.Component<Props, State> {
 
     return (
       <SentryDocumentTitle title={t('Performance')} objSlug={organization.slug}>
-        <React.Fragment>
-          <GlobalSelectionHeader
-            organization={organization}
-            selection={this.generateGlobalSelection()}
-            allowClearTimeRange={this.allowClearTimeRange()}
-          />
+        <GlobalSelectionHeader
+          defaultSelection={{
+            datetime: {
+              start: null,
+              end: null,
+              utc: false,
+              period: DEFAULT_STATS_PERIOD,
+            },
+          }}
+        >
           <PageContent>
             <LightWeightNoProjectMessage organization={organization}>
               <StyledPageHeader>
@@ -183,7 +145,7 @@ class PerformanceLanding extends React.Component<Props, State> {
               />
             </LightWeightNoProjectMessage>
           </PageContent>
-        </React.Fragment>
+        </GlobalSelectionHeader>
       </SentryDocumentTitle>
     );
   }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -122,8 +122,7 @@ class TransactionSummary extends React.Component<Props, State> {
 
     return (
       <SentryDocumentTitle title={this.getDocumentTitle()} objSlug={organization.slug}>
-        <React.Fragment>
-          <GlobalSelectionHeader organization={organization} />
+        <GlobalSelectionHeader>
           <StyledPageContent>
             <LightWeightNoProjectMessage organization={organization}>
               <SummaryContent
@@ -135,7 +134,7 @@ class TransactionSummary extends React.Component<Props, State> {
               />
             </LightWeightNoProjectMessage>
           </StyledPageContent>
-        </React.Fragment>
+        </GlobalSelectionHeader>
       </SentryDocumentTitle>
     );
   }

--- a/src/sentry/static/sentry/app/views/releases/detail/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.jsx
@@ -22,13 +22,11 @@ import ReleaseHeader from './releaseHeader';
 
 const ReleaseDetailsContainer = props => (
   <React.Fragment>
-    <GlobalSelectionHeader organization={props.organization} />
-    <OrganizationReleaseDetails {...props} />
+    <GlobalSelectionHeader>
+      <OrganizationReleaseDetails {...props} />
+    </GlobalSelectionHeader>
   </React.Fragment>
 );
-ReleaseDetailsContainer.propTypes = {
-  organization: SentryTypes.Organization,
-};
 
 class OrganizationReleaseDetails extends AsyncView {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/releases/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/index.jsx
@@ -27,11 +27,11 @@ import ReleaseListHeader from './releaseListHeader';
 import ReleaseProgress from './releaseProgress';
 
 const ReleasesContainer = props => {
-  const {organization} = props;
   return (
     <React.Fragment>
-      <GlobalSelectionHeader organization={organization} />
-      <OrganizationReleases {...props} />
+      <GlobalSelectionHeader>
+        <OrganizationReleases {...props} />
+      </GlobalSelectionHeader>
     </React.Fragment>
   );
 };

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
@@ -196,20 +196,17 @@ class ReleasesV2DetailContainer extends AsyncComponent<Omit<Props, 'releaseProje
     }
 
     return (
-      <React.Fragment>
-        <GlobalSelectionHeader
-          organization={organization}
-          lockedMessageSubject={t('release')}
-          shouldForceProject={projects.length === 1}
-          forceProject={projects.length === 1 ? projects[0] : undefined}
-          specificProjectSlugs={projects.map(p => p.slug)}
-          disableMultipleProjectSelection
-          showProjectSettingsLink
-          projectsFooterMessage={this.renderProjectsFooterMessage()}
-        />
-
+      <GlobalSelectionHeader
+        lockedMessageSubject={t('release')}
+        shouldForceProject={projects.length === 1}
+        forceProject={projects.length === 1 ? projects[0] : undefined}
+        specificProjectSlugs={projects.map(p => p.slug)}
+        disableMultipleProjectSelection
+        showProjectSettingsLink
+        projectsFooterMessage={this.renderProjectsFooterMessage()}
+      >
         <ReleasesV2Detail {...this.props} releaseProjects={projects} />
-      </React.Fragment>
+      </GlobalSelectionHeader>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -206,15 +206,12 @@ class ReleasesList extends AsyncView<Props, State> {
     const {organization} = this.props;
 
     return (
-      <React.Fragment>
-        <GlobalSelectionHeader
-          organization={organization}
-          showAbsolute={false}
-          timeRangeHint={t(
-            'Changing this date range will recalculate the release metrics.'
-          )}
-        />
-
+      <GlobalSelectionHeader
+        showAbsolute={false}
+        timeRangeHint={t(
+          'Changing this date range will recalculate the release metrics.'
+        )}
+      >
         <PageContent>
           <LightWeightNoProjectMessage organization={organization}>
             <StyledPageHeader>
@@ -245,7 +242,7 @@ class ReleasesList extends AsyncView<Props, State> {
             )}
           </LightWeightNoProjectMessage>
         </PageContent>
-      </React.Fragment>
+      </GlobalSelectionHeader>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/userFeedback/index.tsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/index.tsx
@@ -114,8 +114,7 @@ class OrganizationUserFeedback extends AsyncView<Props, State> {
     const allIssuesQuery = {...query, status: ''};
 
     return (
-      <React.Fragment>
-        <GlobalSelectionHeader organization={organization} />
+      <GlobalSelectionHeader>
         <PageContent>
           <LightWeightNoProjectMessage organization={organization}>
             <div data-test-id="user-feedback">
@@ -148,7 +147,7 @@ class OrganizationUserFeedback extends AsyncView<Props, State> {
             </div>
           </LightWeightNoProjectMessage>
         </PageContent>
-      </React.Fragment>
+      </GlobalSelectionHeader>
     );
   }
 }

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -119,12 +119,9 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         # selecting an explicit project should load previously selected project
         # from local storage
         # TODO check environment as well
-        # FIXME below is currently broken
-        # self.issues_list.visit_issue_list(
-        #     self.org.slug
-        # )
-        # self.issues_list.wait_until_loaded()
-        # assert u"project={}".format(self.project_3.id) in self.browser.current_url
+        self.issues_list.visit_issue_list(self.org.slug)
+        self.issues_list.wait_until_loaded()
+        assert u"project={}".format(self.project_3.id) in self.browser.current_url
 
     def test_global_selection_header_loads_with_correct_project_with_multi_project(self):
         """
@@ -163,8 +160,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             # there has been no explicit project selection via UI
             self.issues_list.visit_issue_list(self.org.slug)
             assert u"project=" not in self.browser.current_url
-            # FIXME
-            # assert self.issues_list.global_selection.get_selected_project_slug() == "My Projects"
+            assert self.issues_list.global_selection.get_selected_project_slug() == "My Projects"
 
             # can select a different project
             self.issues_list.global_selection.select_project_by_slug(self.project_3.slug)
@@ -186,8 +182,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             self.issues_list.visit_issue_list(self.org.slug)
             self.issues_list.wait_until_loaded()
             # TODO check environment as well
-            # FIXME: This is current broken and is a bug
-            # assert u"project={}".format(self.project_3.id) in self.browser.current_url
+            assert u"project={}".format(self.project_3.id) in self.browser.current_url
             assert (
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
             )

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -62,7 +62,15 @@ describe('GlobalSelectionHeader', function() {
       projects: organization.projects,
       loading: false,
     }));
-    GlobalSelectionStore.reset();
+
+    getItem.mockImplementation(() => null);
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+  });
+
+  afterEach(function() {
     [
       globalActions.updateDateTime,
       globalActions.updateProjects,
@@ -73,12 +81,7 @@ describe('GlobalSelectionHeader', function() {
       router.replace,
       getItem,
     ].forEach(mock => mock.mockClear());
-
-    getItem.mockImplementation(() => null);
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/projects/',
-      body: [],
-    });
+    GlobalSelectionStore.reset();
   });
 
   it('does not update router if there is custom routing', function() {
@@ -144,6 +147,9 @@ describe('GlobalSelectionHeader', function() {
       />,
       routerContext
     );
+
+    await tick();
+    wrapper.update();
 
     mockRouterPush(wrapper, router);
 
@@ -981,7 +987,7 @@ describe('GlobalSelectionHeader', function() {
       ]);
     });
 
-    it('shows "My Projects" button', function() {
+    it('shows "My Projects" button', async function() {
       initialData.organization.features.push('global-views');
       wrapper = mountWithTheme(
         <GlobalSelectionHeader
@@ -990,6 +996,9 @@ describe('GlobalSelectionHeader', function() {
         />,
         initialData.routerContext
       );
+
+      await tick();
+      wrapper.update();
 
       // open the project menu.
       wrapper.find('MultipleProjectSelector HeaderItem').simulate('click');
@@ -1006,7 +1015,7 @@ describe('GlobalSelectionHeader', function() {
       ).toEqual('View My Projects');
     });
 
-    it('shows "All Projects" button based on features', function() {
+    it('shows "All Projects" button based on features', async function() {
       initialData.organization.features.push('global-views');
       initialData.organization.features.push('open-membership');
       wrapper = mountWithTheme(
@@ -1016,6 +1025,8 @@ describe('GlobalSelectionHeader', function() {
         />,
         initialData.routerContext
       );
+      await tick();
+      wrapper.update();
 
       // open the project menu.
       wrapper.find('MultipleProjectSelector HeaderItem').simulate('click');
@@ -1032,7 +1043,7 @@ describe('GlobalSelectionHeader', function() {
       ).toEqual('View All Projects');
     });
 
-    it('shows "All Projects" button based on role', function() {
+    it('shows "All Projects" button based on role', async function() {
       initialData.organization.features.push('global-views');
       initialData.organization.role = 'owner';
       wrapper = mountWithTheme(
@@ -1043,6 +1054,8 @@ describe('GlobalSelectionHeader', function() {
         initialData.routerContext
       );
 
+      await tick();
+      wrapper.update();
       // open the project menu.
       wrapper.find('MultipleProjectSelector HeaderItem').simulate('click');
       const projectSelector = wrapper.find('MultipleProjectSelector');

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -9,6 +9,7 @@ import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import OrganizationActions from 'app/actions/organizationActions';
 import ProjectsStore from 'app/stores/projectsStore';
 import * as globalActions from 'app/actionCreators/globalSelection';
+import {getItem} from 'app/utils/localStorage';
 
 const changeQuery = (routerContext, query) => ({
   ...routerContext,
@@ -24,7 +25,7 @@ const changeQuery = (routerContext, query) => ({
 });
 
 jest.mock('app/utils/localStorage', () => ({
-  getItem: () => JSON.stringify({projects: [3], environments: ['staging']}),
+  getItem: jest.fn(),
   setItem: jest.fn(),
 }));
 
@@ -51,6 +52,8 @@ describe('GlobalSelectionHeader', function() {
     jest.spyOn(globalActions, 'updateDateTime');
     jest.spyOn(globalActions, 'updateEnvironments');
     jest.spyOn(globalActions, 'updateProjects');
+    jest.spyOn(globalActions, 'updateParams');
+    jest.spyOn(globalActions, 'updateParamsWithoutHistory');
   });
 
   beforeEach(function() {
@@ -64,10 +67,14 @@ describe('GlobalSelectionHeader', function() {
       globalActions.updateDateTime,
       globalActions.updateProjects,
       globalActions.updateEnvironments,
+      globalActions.updateParams,
+      globalActions.updateParamsWithoutHistory,
       router.push,
       router.replace,
+      getItem,
     ].forEach(mock => mock.mockClear());
 
+    getItem.mockImplementation(() => null);
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
       body: [],
@@ -114,63 +121,12 @@ describe('GlobalSelectionHeader', function() {
     );
 
     expect(router.push).not.toHaveBeenCalled();
-    expect(globalActions.updateDateTime).toHaveBeenCalledWith({
-      period: '7d',
-      utc: null,
-      start: null,
-      end: null,
-    });
-    expect(globalActions.updateProjects).toHaveBeenCalledWith([]);
-    expect(globalActions.updateEnvironments).toHaveBeenCalledWith([]);
 
     await tick();
 
-    expect(GlobalSelectionStore.get()).toEqual({
+    expect(GlobalSelectionStore.get().selection).toEqual({
       datetime: {
         period: '7d',
-        utc: null,
-        start: null,
-        end: null,
-      },
-      environments: [],
-      projects: [],
-    });
-  });
-
-  it('updates GlobalSelection store when re-rendered with different query params', async function() {
-    const wrapper = mountWithTheme(
-      <GlobalSelectionHeader organization={organization} />,
-      changeQuery(routerContext, {
-        statsPeriod: '7d',
-      })
-    );
-
-    wrapper.setContext(
-      changeQuery(routerContext, {
-        statsPeriod: '21d',
-      }).context
-    );
-
-    await tick();
-    wrapper.update();
-
-    expect(globalActions.updateDateTime).toHaveBeenCalledWith({
-      period: '21d',
-      utc: null,
-      start: null,
-      end: null,
-    });
-    // These should not be called because they have not changed, only date has changed
-    expect(globalActions.updateProjects).toHaveBeenCalledWith([]);
-    expect(globalActions.updateEnvironments).toHaveBeenCalledWith([]);
-
-    globalActions.updateDateTime.mockClear();
-    globalActions.updateProjects.mockClear();
-    globalActions.updateEnvironments.mockClear();
-
-    expect(GlobalSelectionStore.get()).toEqual({
-      datetime: {
-        period: '21d',
         utc: null,
         start: null,
         end: null,
@@ -220,7 +176,7 @@ describe('GlobalSelectionHeader', function() {
 
     expect(wrapper.find('MultipleEnvironmentSelector Content').text()).toBe('staging');
 
-    expect(GlobalSelectionStore.get()).toEqual({
+    expect(GlobalSelectionStore.get().selection).toEqual({
       datetime: {
         period: '14d',
         utc: null,
@@ -249,7 +205,7 @@ describe('GlobalSelectionHeader', function() {
     wrapper.update();
 
     // Store should not have any environments selected
-    expect(GlobalSelectionStore.get()).toEqual({
+    expect(GlobalSelectionStore.get().selection).toEqual({
       datetime: {
         period: '14d',
         utc: null,
@@ -259,7 +215,6 @@ describe('GlobalSelectionHeader', function() {
       environments: [],
       projects: [2],
     });
-    expect(wrapper.prop('location').query).toEqual({project: '2'});
     expect(wrapper.find('MultipleEnvironmentSelector Content').text()).toBe(
       'All Environments'
     );
@@ -309,67 +264,53 @@ describe('GlobalSelectionHeader', function() {
       })
     );
 
-    expect(router.push).not.toHaveBeenCalled();
-    expect(globalActions.updateDateTime).toHaveBeenCalledWith({
-      period: '14d',
-      utc: null,
-      start: null,
-      end: null,
-    });
-    expect(globalActions.updateProjects).toHaveBeenCalledWith([]);
-    expect(globalActions.updateEnvironments).toHaveBeenCalledWith(['prod']);
-
     await tick();
 
     expect(GlobalSelectionStore.get()).toEqual({
-      datetime: {
-        period: '14d',
-        utc: null,
-        start: null,
-        end: null,
+      isReady: true,
+      selection: {
+        datetime: {
+          period: '14d',
+          utc: null,
+          start: null,
+          end: null,
+        },
+        environments: ['prod'],
+        projects: [],
       },
-      environments: ['prod'],
-      projects: [],
     });
+    // Not called because of the default date
+    expect(router.replace).not.toHaveBeenCalled();
   });
 
-  it('updates GlobalSelection store with empty date selections', async function() {
-    const wrapper = mountWithTheme(
+  it('updates GlobalSelection store with empty dates in URL', async function() {
+    mountWithTheme(
       <GlobalSelectionHeader organization={organization} />,
       changeQuery(routerContext, {
-        statsPeriod: '7d',
+        statsPeriod: null,
       })
     );
 
-    wrapper.setContext(
-      changeQuery(routerContext, {
-        statsPeriod: null,
-      }).context
-    );
     await tick();
-    wrapper.update();
-
-    expect(globalActions.updateDateTime).toHaveBeenCalledWith({
-      period: '7d',
-      utc: null,
-      start: null,
-      end: null,
-    });
-    expect(globalActions.updateProjects).toHaveBeenCalledWith([]);
-    expect(globalActions.updateEnvironments).toHaveBeenCalledWith([]);
 
     expect(GlobalSelectionStore.get()).toEqual({
-      datetime: {
-        period: '14d',
-        utc: null,
-        start: null,
-        end: null,
+      isReady: true,
+      selection: {
+        datetime: {
+          period: '14d',
+          utc: null,
+          start: null,
+          end: null,
+        },
+        environments: [],
+        projects: [],
       },
-      environments: [],
-      projects: [],
     });
   });
 
+  /**
+   * I don't think this test is really applicable anymore
+   */
   it('does not update store if url params have not changed', async function() {
     const wrapper = mountWithTheme(
       <GlobalSelectionHeader organization={organization} />,
@@ -398,18 +339,58 @@ describe('GlobalSelectionHeader', function() {
     expect(globalActions.updateEnvironments).not.toHaveBeenCalled();
 
     expect(GlobalSelectionStore.get()).toEqual({
-      datetime: {
-        period: '7d',
-        utc: null,
-        start: null,
-        end: null,
+      isReady: true,
+      selection: {
+        datetime: {
+          period: '7d',
+          utc: null,
+          start: null,
+          end: null,
+        },
+        environments: [],
+        projects: [],
       },
-      environments: [],
-      projects: [],
     });
   });
 
-  it('updates store when there are query params in URL', function() {
+  it('loads from local storage when no URL parameters', async function() {
+    getItem.mockImplementation(() =>
+      JSON.stringify({projects: [3], environments: ['staging']})
+    );
+    const initializationObj = initializeOrg({
+      organization: {
+        features: ['global-views'],
+      },
+      router: {
+        params: {orgId: 'org-slug'}, // we need this to be set to make sure org in context is same as current org in URL
+      },
+    });
+
+    mountWithTheme(
+      <GlobalSelectionHeader organization={initializationObj.organization} />,
+      initializationObj.routerContext
+    );
+
+    await tick(); // reflux tick
+
+    expect(GlobalSelectionStore.get().selection.projects).toEqual([3]);
+    // Since these are coming from URL, there should be no changes and
+    // router does not need to be called
+    expect(initializationObj.router.replace).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: {
+          environment: ['staging'],
+          project: [3],
+        },
+      })
+    );
+  });
+
+  it('does not load from local storage when there are URL params', async function() {
+    getItem.mockImplementation(() =>
+      JSON.stringify({projects: [3], environments: ['staging']})
+    );
+
     const initializationObj = initializeOrg({
       organization: {
         features: ['global-views'],
@@ -425,12 +406,39 @@ describe('GlobalSelectionHeader', function() {
       initializationObj.routerContext
     );
 
-    expect(globalActions.updateProjects).toHaveBeenCalledWith([1, 2]);
-    expect(globalActions.updateEnvironments).toHaveBeenCalledWith([]);
-    expect(globalActions.updateDateTime).toHaveBeenCalled();
+    await tick(); // reflux tick
+
+    expect(GlobalSelectionStore.get().selection.projects).toEqual([1, 2]);
+    // Since these are coming from URL, there should be no changes and
+    // router does not need to be called
+    expect(initializationObj.router.replace).not.toHaveBeenCalled();
   });
 
-  it('updates store with default values when there are no query params in URL', function() {
+  it('updates store when there are query params in URL', async function() {
+    const initializationObj = initializeOrg({
+      organization: {
+        features: ['global-views'],
+      },
+      router: {
+        params: {orgId: 'org-slug'}, // we need this to be set to make sure org in context is same as current org in URL
+        location: {query: {project: [1, 2]}},
+      },
+    });
+
+    mountWithTheme(
+      <GlobalSelectionHeader organization={initializationObj.organization} />,
+      initializationObj.routerContext
+    );
+
+    await tick(); // reflux tick
+
+    expect(GlobalSelectionStore.get().selection.projects).toEqual([1, 2]);
+    // Since these are coming from URL, there should be no changes and
+    // router does not need to be called
+    expect(initializationObj.router.replace).not.toHaveBeenCalled();
+  });
+
+  it('updates store with default values when there are no query params in URL', async function() {
     const initializationObj = initializeOrg({
       organization: {
         features: ['global-views'],
@@ -446,14 +454,8 @@ describe('GlobalSelectionHeader', function() {
       initializationObj.routerContext
     );
 
-    expect(globalActions.updateProjects).toHaveBeenCalledWith([]);
-    expect(globalActions.updateEnvironments).toHaveBeenCalledWith([]);
-    expect(globalActions.updateDateTime).toHaveBeenCalledWith({
-      end: null,
-      period: '14d',
-      start: null,
-      utc: null,
-    });
+    // Router does not update because params have not changed
+    expect(initializationObj.router.replace).not.toHaveBeenCalled();
   });
 
   /**
@@ -528,7 +530,11 @@ describe('GlobalSelectionHeader', function() {
 
       ProjectsStore.loadInitialData(updatedOrganization.projects);
 
-      expect(globalActions.updateProjects).toHaveBeenLastCalledWith([123]);
+      expect(initialData.router.replace).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          query: {environment: [], project: [123]},
+        })
+      );
     });
 
     it('selects first project if more than one is requested', function() {
@@ -544,10 +550,14 @@ describe('GlobalSelectionHeader', function() {
         initializationObj.routerContext
       );
 
-      expect(globalActions.updateProjects).toHaveBeenCalledWith([1]);
+      expect(initializationObj.router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {environment: [], project: [1]},
+        })
+      );
     });
 
-    it('selects first project if none (i.e. all) is requested', function() {
+    it('selects first project if none (i.e. all) is requested', async function() {
       const project = TestStubs.Project({id: '3'});
       const org = TestStubs.Organization({projects: [project]});
       jest
@@ -567,13 +577,17 @@ describe('GlobalSelectionHeader', function() {
         initializationObj.routerContext
       );
 
-      expect(globalActions.updateProjects).toHaveBeenCalledWith([3]);
+      expect(initializationObj.router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {environment: [], project: [3]},
+        })
+      );
     });
   });
 
   describe('forceProject selection mode', function() {
     let wrapper;
-    beforeAll(function() {
+    beforeEach(function() {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',
         body: [],
@@ -663,7 +677,7 @@ describe('GlobalSelectionHeader', function() {
 
         expect(initialData.router.replace).toHaveBeenLastCalledWith({
           pathname: undefined,
-          query: {project: [0]},
+          query: {environment: [], project: [0]},
         });
       });
 
@@ -692,7 +706,7 @@ describe('GlobalSelectionHeader', function() {
 
         expect(initialData.router.replace).toHaveBeenLastCalledWith({
           pathname: undefined,
-          query: {project: [1]},
+          query: {environment: [], project: [1]},
         });
 
         expect(initialData.router.replace).toHaveBeenCalledTimes(1);
@@ -733,7 +747,7 @@ describe('GlobalSelectionHeader', function() {
 
         expect(initialData.router.replace).toHaveBeenLastCalledWith({
           pathname: undefined,
-          query: {project: [1]},
+          query: {environment: [], project: [1]},
         });
       });
     });
@@ -783,7 +797,7 @@ describe('GlobalSelectionHeader', function() {
 
         expect(initialData.router.replace).toHaveBeenLastCalledWith({
           pathname: undefined,
-          query: {project: [1], statsPeriod: '90d'},
+          query: {environment: [], project: [1], statsPeriod: '90d'},
         });
       });
     });
@@ -805,14 +819,17 @@ describe('GlobalSelectionHeader', function() {
         },
       });
 
-      const createWrapper = props => {
+      const createWrapper = (props, ctx) => {
         wrapper = mountWithTheme(
           <GlobalSelectionHeader
             params={{orgId: initialData.organization.slug}}
             organization={initialData.organization}
             {...props}
           />,
-          initialData.routerContext
+          {
+            ...initialData.routerContext,
+            ...ctx,
+          }
         );
         return wrapper;
       };
@@ -826,7 +843,7 @@ describe('GlobalSelectionHeader', function() {
         initialData.router.replace.mockClear();
       });
 
-      it('does not use first project in org projects when mounting', async function() {
+      it('does not use first project in org projects when mounting (and without localStorage data)', async function() {
         createWrapper();
 
         await tick();
@@ -869,6 +886,8 @@ describe('GlobalSelectionHeader', function() {
         // forceProject generally starts undefined
         createWrapper({shouldForceProject: true});
 
+        await tick();
+
         // load the projects
         mockProjectsStoreState.projects = initialData.organization.projects;
         mockProjectsStoreState.loading = false;
@@ -881,7 +900,7 @@ describe('GlobalSelectionHeader', function() {
 
         expect(initialData.router.replace).toHaveBeenLastCalledWith({
           pathname: undefined,
-          query: {project: [1]},
+          query: {environment: [], project: [1]},
         });
 
         expect(initialData.router.replace).toHaveBeenCalledTimes(1);
@@ -889,19 +908,13 @@ describe('GlobalSelectionHeader', function() {
 
       it('does not append projectId to URL when `forceProject` becomes available but project id already exists in URL', async function() {
         // forceProject generally starts undefined
-        createWrapper({shouldForceProject: true});
+        createWrapper(
+          {shouldForceProject: true},
+          changeQuery(initialData.routerContext, {project: 321})
+        );
 
-        wrapper.setContext({
-          router: {
-            ...initialData.router,
-            location: {
-              ...initialData.router.location,
-              query: {
-                project: 321,
-              },
-            },
-          },
-        });
+        await tick();
+
         wrapper.setProps({
           forceProject: initialData.organization.projects[1],
         });
@@ -1056,7 +1069,9 @@ describe('GlobalSelectionHeader', function() {
         />,
         changeQuery(initialData.routerContext, {project: -1})
       );
+
       await tick();
+      wrapper.update();
 
       // open the project menu.
       wrapper.find('MultipleProjectSelector HeaderItem').simulate('click');

--- a/tests/js/spec/stores/globalSelectionStore.spec.jsx
+++ b/tests/js/spec/stores/globalSelectionStore.spec.jsx
@@ -11,32 +11,30 @@ jest.mock('app/utils/localStorage', () => ({
 }));
 
 describe('GlobalSelectionStore', function() {
-  const organization = TestStubs.Organization({
-    features: ['global-views'],
-    projects: [TestStubs.Project({id: '5'})],
-  });
-
   afterEach(function() {
     GlobalSelectionStore.reset();
   });
 
   it('get()', function() {
     expect(GlobalSelectionStore.get()).toEqual({
-      projects: [],
-      environments: [],
-      datetime: {period: '14d', start: null, end: null, utc: null},
+      isReady: false,
+      selection: {
+        projects: [],
+        environments: [],
+        datetime: {period: '14d', start: null, end: null, utc: null},
+      },
     });
   });
 
   it('updateProjects()', async function() {
-    expect(GlobalSelectionStore.get().projects).toEqual([]);
+    expect(GlobalSelectionStore.get().selection.projects).toEqual([]);
     updateProjects([1]);
     await tick();
-    expect(GlobalSelectionStore.get().projects).toEqual([1]);
+    expect(GlobalSelectionStore.get().selection.projects).toEqual([1]);
   });
 
   it('updateDateTime()', async function() {
-    expect(GlobalSelectionStore.get().datetime).toEqual({
+    expect(GlobalSelectionStore.get().selection.datetime).toEqual({
       period: '14d',
       start: null,
       end: null,
@@ -44,7 +42,7 @@ describe('GlobalSelectionStore', function() {
     });
     updateDateTime({period: '2h', start: null, end: null});
     await tick();
-    expect(GlobalSelectionStore.get().datetime).toEqual({
+    expect(GlobalSelectionStore.get().selection.datetime).toEqual({
       period: '2h',
       start: null,
       end: null,
@@ -57,7 +55,7 @@ describe('GlobalSelectionStore', function() {
       utc: true,
     });
     await tick();
-    expect(GlobalSelectionStore.get().datetime).toEqual({
+    expect(GlobalSelectionStore.get().selection.datetime).toEqual({
       period: null,
       start: '2018-08-08T00:00:00',
       end: '2018-09-08T00:00:00',
@@ -71,7 +69,7 @@ describe('GlobalSelectionStore', function() {
       utc: null,
     });
     await tick();
-    expect(GlobalSelectionStore.get().datetime).toEqual({
+    expect(GlobalSelectionStore.get().selection.datetime).toEqual({
       period: null,
       start: null,
       end: null,
@@ -80,37 +78,9 @@ describe('GlobalSelectionStore', function() {
   });
 
   it('updateEnvironments()', async function() {
-    expect(GlobalSelectionStore.get().environments).toEqual([]);
+    expect(GlobalSelectionStore.get().selection.environments).toEqual([]);
     updateEnvironments(['alpha']);
     await tick();
-    expect(GlobalSelectionStore.get().environments).toEqual(['alpha']);
-  });
-
-  it('loadInitialData() - queryParams', async function() {
-    GlobalSelectionStore.loadInitialData(organization, {
-      project: '5',
-      environment: ['staging'],
-    });
-
-    await tick();
-
-    expect(GlobalSelectionStore.get().projects).toEqual([5]);
-    expect(GlobalSelectionStore.get().environments).toEqual(['staging']);
-  });
-
-  it('loadInitialData() - localStorage', async function() {
-    GlobalSelectionStore.loadInitialData(organization, {});
-    await tick();
-
-    expect(GlobalSelectionStore.get().projects).toEqual([5]);
-    expect(GlobalSelectionStore.get().environments).toEqual(['staging']);
-  });
-
-  it('loadInitialData() - defaults used if invalid', async function() {
-    GlobalSelectionStore.loadInitialData(organization, {project: [2]});
-    await tick();
-
-    expect(GlobalSelectionStore.get().projects).toEqual([]);
-    expect(GlobalSelectionStore.get().environments).toEqual([]);
+    expect(GlobalSelectionStore.get().selection.environments).toEqual(['alpha']);
   });
 });

--- a/tests/js/spec/views/dashboards/dashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/dashboard.spec.jsx
@@ -72,6 +72,8 @@ describe('OrganizationDashboard', function() {
 
   it('queries and renders discover-based widgets grouped by time', async function() {
     createWrapper(TestStubs.Dashboard());
+    await tick();
+    wrapper.update();
 
     expect(discoverMock).toHaveBeenCalledTimes(2);
     expect(discoverMock).toHaveBeenCalledWith(

--- a/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
@@ -29,13 +29,16 @@ describe('OverviewDashboard', function() {
 
   const org = organization;
 
-  const createWrapper = props => {
+  const createWrapper = async props => {
+    ProjectsStore.loadInitialData(organization.projects);
     wrapper = mountWithTheme(
       <DashboardsContainer>
         <OverviewDashboard params={{orgId: organization.slug}} {...props} />
       </DashboardsContainer>,
       routerContext
     );
+    await tick();
+    wrapper.update();
     mockRouterPush(wrapper, router);
   };
 
@@ -96,7 +99,7 @@ describe('OverviewDashboard', function() {
       eventsByReleaseWidget,
     ]);
 
-    createWrapper(dashboardData);
+    await createWrapper(dashboardData);
 
     // TODO(billy): Figure out why releases gets called twice
     expect(discoverMock).toHaveBeenCalledTimes(4);

--- a/tests/js/spec/views/discover/index.spec.jsx
+++ b/tests/js/spec/views/discover/index.spec.jsx
@@ -63,26 +63,6 @@ describe('DiscoverContainer', function() {
       expect(queryBuilder.getColumns().some(column => column.name === 'tag1')).toBe(true);
       expect(queryBuilder.getColumns().some(column => column.name === 'tag2')).toBe(true);
     });
-
-    it('sets active projects from global selection', async function() {
-      ProjectsStore.loadInitialData(organization.projects);
-
-      GlobalSelectionStore.reset({
-        projects: [1],
-        environments: [],
-        datetime: {start: null, end: null, period: '14d'},
-      });
-
-      wrapper = mountWithTheme(
-        <DiscoverContainerWithStore
-          location={{query: {}, search: ''}}
-          params={{}}
-          organization={organization}
-        />,
-        TestStubs.routerContext()
-      );
-      expect(wrapper.find('MultipleProjectSelector').text()).toBe('test-project');
-    });
   });
 
   describe('saved query', function() {

--- a/tests/js/spec/views/discover/index.spec.jsx
+++ b/tests/js/spec/views/discover/index.spec.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
-import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import DiscoverContainerWithStore, {DiscoverContainer} from 'app/views/discover';
-import ProjectsStore from 'app/stores/projectsStore';
 
 describe('DiscoverContainer', function() {
   beforeEach(function() {

--- a/tests/js/spec/views/events/events.spec.jsx
+++ b/tests/js/spec/views/events/events.spec.jsx
@@ -372,6 +372,11 @@ describe('EventsContainer', function() {
     mockRouterPush(wrapper, router);
   });
 
+  afterEach(async function() {
+    ProjectsStore.reset();
+    await tick();
+  });
+
   it('performs the correct queries when there is a search query', async function() {
     wrapper.find('SmartSearchBar input').simulate('change', {target: {value: 'http'}});
     wrapper.find('SmartSearchBar input').simulate('submit');

--- a/tests/js/spec/views/events/eventsChart.spec.jsx
+++ b/tests/js/spec/views/events/eventsChart.spec.jsx
@@ -5,13 +5,10 @@ import {chart, doZoom, mockZoomRange} from 'sentry-test/charts';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mount} from 'sentry-test/enzyme';
-import {updateParams} from 'app/actionCreators/globalSelection';
+import * as globalSelection from 'app/actionCreators/globalSelection';
 
 jest.mock('app/views/events/utils/eventsRequest', () => jest.fn(() => null));
-
-jest.mock('app/actionCreators/globalSelection', () => ({
-  updateParams: jest.fn(),
-}));
+jest.spyOn(globalSelection, 'updateDateTime');
 
 describe('EventsChart', function() {
   const {router, routerContext, org} = initializeOrg();
@@ -19,6 +16,7 @@ describe('EventsChart', function() {
   let wrapper;
 
   beforeEach(function() {
+    globalSelection.updateDateTime.mockClear();
     mockZoomRange(1543449600000, 1543708800000);
     wrapper = mount(
       <EventsChart
@@ -100,14 +98,14 @@ describe('EventsChart', function() {
     expect(chartZoomInstance.currentPeriod.end).toEqual('2018-12-02T00:00:00');
     const newParams = {
       period: null,
-      start: '2018-11-29T00:00:00',
-      end: '2018-12-02T00:00:00',
+      start: getUtcToLocalDateObject('2018-11-29T00:00:00'),
+      end: getUtcToLocalDateObject('2018-12-02T00:00:00'),
     };
-    expect(updateParams).toHaveBeenCalledWith(newParams, router);
+    expect(globalSelection.updateDateTime).toHaveBeenCalledWith(newParams, router);
     wrapper.setProps({
       period: newParams.period,
-      start: getUtcToLocalDateObject(newParams.start),
-      end: getUtcToLocalDateObject(newParams.end),
+      start: newParams.start,
+      end: newParams.end,
     });
     wrapper.update();
   });
@@ -136,7 +134,7 @@ describe('EventsChart', function() {
       start: null,
       end: null,
     };
-    expect(updateParams).toHaveBeenCalledWith(newParams, router);
+    expect(globalSelection.updateDateTime).toHaveBeenLastCalledWith(newParams, router);
     wrapper.setProps({
       period: '14d',
       start: null,

--- a/tests/js/spec/views/events/index.spec.jsx
+++ b/tests/js/spec/views/events/index.spec.jsx
@@ -50,7 +50,7 @@ describe('EventsContainer', function() {
   });
 
   describe('Header', function() {
-    beforeEach(function() {
+    beforeEach(async function() {
       GlobalSelectionStore.reset();
       ProjectsStore.loadInitialData(organization.projects);
 
@@ -68,6 +68,9 @@ describe('EventsContainer', function() {
         </EventsContainer>,
         routerContext
       );
+
+      await tick();
+      wrapper.update();
 
       mockRouterPush(wrapper, router);
     });
@@ -112,18 +115,19 @@ describe('EventsContainer', function() {
         .find('CheckboxHitbox')
         .simulate('click');
 
-      expect(wrapper.find('MultipleEnvironmentSelector').prop('value')).toEqual([
-        'production',
-        'staging',
-      ]);
-
-      // close dropdown
+      // Value only updates if "Apply" is clicked or menu is closed
       wrapper
         .find('MultipleEnvironmentSelector StyledInput')
         .simulate('keyDown', {key: 'Escape'});
 
       await tick();
       wrapper.update();
+
+      expect(wrapper.find('MultipleEnvironmentSelector').prop('value')).toEqual([
+        'production',
+        'staging',
+      ]);
+
       expect(router.push).toHaveBeenLastCalledWith({
         pathname: '/organizations/org-slug/events/',
         query: {
@@ -331,54 +335,6 @@ describe('EventsContainer', function() {
           relative: '7d',
         })
       );
-    });
-
-    it('updates TimeRangeSelector when changing routes', async function() {
-      let newRouter = {
-        router: {
-          ...router,
-          location: {
-            pathname: '/organizations/org-slug/events2/',
-            query: {
-              end: '2017-10-17T02:41:20',
-              start: '2017-10-03T02:41:20',
-              utc: 'true',
-            },
-          },
-        },
-      };
-      wrapper.setProps(newRouter);
-      wrapper.setContext(newRouter);
-
-      await tick();
-      wrapper.update();
-
-      expect(wrapper.find('TimeRangeSelector').text()).toEqual(
-        'Oct 3, 201702:41toOct 17, 201702:41'
-      );
-
-      newRouter = {
-        router: {
-          ...router,
-          location: {
-            pathname: '/organizations/org-slug/events/',
-            query: {
-              statsPeriod: '7d',
-              end: null,
-              start: null,
-              utc: 'true',
-            },
-          },
-        },
-      };
-
-      wrapper.setProps(newRouter);
-      wrapper.setContext(newRouter);
-
-      await tick();
-      wrapper.update();
-
-      expect(wrapper.find('TimeRangeSelector').text()).toEqual('Last 7 days');
     });
   });
 });

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import {browserHistory} from 'react-router';
+import React from 'react';
 
-import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountWithTheme} from 'sentry-test/enzyme';
+import ProjectsStore from 'app/stores/projectsStore';
 import Results from 'app/views/eventsV2/results';
 
 const FIELDS = [
@@ -119,9 +120,10 @@ describe('EventsV2 > Results', function() {
 
   afterEach(function() {
     MockApiClient.clearMockResponses();
+    ProjectsStore.reset();
   });
 
-  it('loads data when moving from an invalid to valid EventView', function() {
+  it('loads data when moving from an invalid to valid EventView', async function() {
     const organization = TestStubs.Organization({
       features,
       projects: [TestStubs.Project()],
@@ -143,6 +145,10 @@ describe('EventsV2 > Results', function() {
       />,
       initialData.routerContext
     );
+
+    ProjectsStore.loadInitialData(initialData.organization.projects);
+    await tick();
+    wrapper.update();
     // No request as eventview was invalid.
     expect(eventResultsMock).not.toHaveBeenCalled();
 
@@ -157,7 +163,7 @@ describe('EventsV2 > Results', function() {
     expect(eventResultsMock).toHaveBeenCalled();
   });
 
-  it('pagination cursor should be cleared when making a search', function() {
+  it('pagination cursor should be cleared when making a search', async function() {
     const organization = TestStubs.Organization({
       features,
       projects: [TestStubs.Project()],
@@ -170,6 +176,8 @@ describe('EventsV2 > Results', function() {
       },
     });
 
+    ProjectsStore.loadInitialData(initialData.organization.projects);
+
     const wrapper = mountWithTheme(
       <Results
         organization={organization}
@@ -178,6 +186,9 @@ describe('EventsV2 > Results', function() {
       />,
       initialData.routerContext
     );
+
+    await tick();
+    wrapper.update();
 
     // ensure cursor query string is initially present in the location
     expect(initialData.router.location).toEqual({

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -7,7 +7,6 @@ import ConfigStore from 'app/stores/configStore';
 import {OrganizationContext} from 'app/views/organizationContext';
 import ProjectsStore from 'app/stores/projectsStore';
 import TeamStore from 'app/stores/teamStore';
-import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import OrganizationStore from 'app/stores/organizationStore';
 
 jest.mock('app/stores/configStore', () => ({
@@ -49,7 +48,6 @@ describe('OrganizationContext', function() {
     });
     jest.spyOn(TeamStore, 'loadInitialData');
     jest.spyOn(ProjectsStore, 'loadInitialData');
-    jest.spyOn(GlobalSelectionStore, 'loadInitialData');
     jest.spyOn(OrganizationActionCreator, 'fetchOrganizationDetails');
   });
 
@@ -62,7 +60,6 @@ describe('OrganizationContext', function() {
     TeamStore.loadInitialData.mockRestore();
     ProjectsStore.loadInitialData.mockRestore();
     ConfigStore.get.mockRestore();
-    GlobalSelectionStore.loadInitialData.mockRestore();
     OrganizationActionCreator.fetchOrganizationDetails.mockRestore();
   });
 
@@ -88,11 +85,6 @@ describe('OrganizationContext', function() {
       'org-slug',
       true,
       true
-    );
-    expect(GlobalSelectionStore.loadInitialData).toHaveBeenCalledWith(
-      org,
-      {},
-      {api, skipLastUsed: false}
     );
   });
 
@@ -261,26 +253,5 @@ describe('OrganizationContext', function() {
     });
 
     expect(getOrgMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls `GlobalSelectionStore.loadInitialData` with `skipLastUsed` option when loadigno group details route', async function() {
-    expect(GlobalSelectionStore.loadInitialData).not.toHaveBeenCalled();
-    wrapper = createWrapper({
-      routes: [{path: '/organizations/:orgId/issues/:groupId/'}],
-    });
-    // await dispatching action
-    await tick();
-    // await resolving api, and updating component
-    await tick();
-    wrapper.update();
-
-    expect(wrapper.state('loading')).toBe(false);
-    expect(wrapper.state('error')).toBe(null);
-
-    expect(GlobalSelectionStore.loadInitialData).toHaveBeenCalledWith(
-      org,
-      {},
-      {api, skipLastUsed: true}
-    );
   });
 });

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -5,6 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import GroupDetails from 'app/views/organizationGroupDetails';
+import ProjectsStore from 'app/stores/projectsStore';
 import GroupStore from 'app/stores/groupStore';
 
 jest.mock('app/views/organizationGroupDetails/header', () => jest.fn(() => null));
@@ -58,6 +59,7 @@ describe('groupDetails', function() {
 
   let issueDetailsMock;
   beforeEach(function() {
+    ProjectsStore.loadInitialData(organization.projects);
     MockComponent = jest.fn(() => null);
     issueDetailsMock = MockApiClient.addMockResponse({
       url: `/issues/${group.id}/`,
@@ -76,6 +78,7 @@ describe('groupDetails', function() {
     if (wrapper) {
       wrapper.unmount();
     }
+    ProjectsStore.reset();
     GroupStore.reset();
     GlobalSelectionStore.reset();
     MockApiClient.clearMockResponses();
@@ -85,12 +88,19 @@ describe('groupDetails', function() {
   });
 
   it('renders', async function() {
+    ProjectsStore.reset();
+    await tick();
+
     wrapper = createWrapper();
 
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
+    expect(MockComponent).not.toHaveBeenCalled();
+
+    ProjectsStore.loadInitialData(organization.projects);
+    await tick();
+
     expect(MockComponent).toHaveBeenLastCalledWith(
       {
         environments: [],
@@ -162,6 +172,8 @@ describe('groupDetails', function() {
 
     wrapper = createWrapper(props);
 
+    ProjectsStore.loadInitialData(props.organization.projects);
+
     await tick();
     // Reflux and stuff
     await tick();
@@ -169,8 +181,7 @@ describe('groupDetails', function() {
 
     expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
 
-    // TODO(billy): This should be 1 time, but GSH syncs the environment to store and causes re-render and thus a second request
-    expect(issueDetailsMock).toHaveBeenCalledTimes(2);
+    expect(issueDetailsMock).toHaveBeenCalledTimes(1);
     expect(issueDetailsMock).toHaveBeenLastCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/tests/js/spec/views/releases/detail/releaseDetails.spec.jsx
+++ b/tests/js/spec/views/releases/detail/releaseDetails.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import ReleaseDetails from 'app/views/releases/detail/';
+import ProjectsStore from 'app/stores/projectsStore';
 
 describe('ReleaseDetails', function() {
   let deleteMock;
@@ -33,7 +34,8 @@ describe('ReleaseDetails', function() {
     });
   });
 
-  it('shows release details', function() {
+  it('shows release details', async function() {
+    const organization = TestStubs.Organization();
     const params = {
       orgId: 'acme',
       projectId: 'anvils',
@@ -53,6 +55,11 @@ describe('ReleaseDetails', function() {
       </ReleaseDetails>,
       TestStubs.routerContext()
     );
+
+    ProjectsStore.loadInitialData(organization.projects);
+
+    await tick();
+    wrapper.update();
 
     // Click delete button
     wrapper

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import ProjectsStore from 'app/stores/projectsStore';
 import ReleaseList from 'app/views/releases/list/';
 
 describe('ReleaseList', function() {
@@ -8,7 +9,7 @@ describe('ReleaseList', function() {
   let props;
   let wrapper;
 
-  beforeEach(function() {
+  beforeEach(async function() {
     organization = TestStubs.Organization({
       projects: [TestStubs.Project()],
       features: ['global-views'],
@@ -44,10 +45,13 @@ describe('ReleaseList', function() {
       location: {query: {per_page: 0, query: 'derp'}},
     };
 
+    ProjectsStore.loadInitialData(organization.projects);
     wrapper = mountWithTheme(
       <ReleaseList {...props} />,
       TestStubs.routerContext([{organization}])
     );
+    await tick();
+    wrapper.update();
   });
 
   afterEach(function() {

--- a/tests/js/spec/views/releasesV2/list/index.spec.jsx
+++ b/tests/js/spec/views/releasesV2/list/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import ProjectsStore from 'app/stores/projectsStore';
 import ReleaseList from 'app/views/releasesV2/list/';
 
 describe('ReleasesV2List', function() {
@@ -25,7 +26,8 @@ describe('ReleasesV2List', function() {
   };
   let wrapper, endpointMock;
 
-  beforeEach(function() {
+  beforeEach(async function() {
+    ProjectsStore.loadInitialData(organization.projects);
     endpointMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/releases/',
       body: [
@@ -41,9 +43,12 @@ describe('ReleasesV2List', function() {
     });
 
     wrapper = mountWithTheme(<ReleaseList {...props} />, routerContext);
+    await tick();
+    wrapper.update();
   });
 
   afterEach(function() {
+    ProjectsStore.reset();
     MockApiClient.clearMockResponses();
   });
 


### PR DESCRIPTION
This fixes a number of bugs with Global Selection Header including:

* Loading and saving of last used projects/envs with local storage. 
* race conditions with enforcement of a single project and the child view being mounted (and thus firing api requests before enforcing a single project)
* lost project context in certain situations eg after deleting a release. 