### PR TITLE
ref(ts) Convert actionCreator/tags to typescript

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/utils.tsx
+++ b/src/sentry/static/sentry/app/components/charts/utils.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 
+import {GlobalSelection} from 'app/types';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {parsePeriodToHours} from 'app/utils/dates';
 import {escape} from 'app/utils';
@@ -20,11 +21,7 @@ export const AREA_COLORS = [
   {line: '#422C6F', area: '#422C6F'},
 ];
 
-export type DateTimeObject = {
-  start: Date | null;
-  end: Date | null;
-  period?: string;
-};
+export type DateTimeObject = Partial<GlobalSelection['datetime']>;
 
 export function truncationFormatter(value: string, truncate: number): string {
   if (!truncate) {

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/getParams.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/getParams.tsx
@@ -66,7 +66,7 @@ function getStatsPeriodValue(
 // This format was transformed to the form that moment.js understands using
 // https://gist.github.com/asafge/0b13c5066d06ae9a4446
 const normalizeDateTimeString = (
-  input: string | undefined | null
+  input: Date | string | undefined | null
 ): string | undefined => {
   if (!input) {
     return undefined;
@@ -82,7 +82,7 @@ const normalizeDateTimeString = (
 };
 
 const getDateTimeString = (
-  maybe: string | string[] | undefined | null
+  maybe: Date | string | string[] | undefined | null
 ): string | undefined => {
   if (Array.isArray(maybe)) {
     if (maybe.length <= 0) {
@@ -104,7 +104,9 @@ const parseUtcValue = (utc: any) => {
   return undefined;
 };
 
-const getUtcValue = (maybe: string | string[] | undefined | null): string | undefined => {
+const getUtcValue = (
+  maybe: string | string[] | boolean | undefined | null
+): string | undefined => {
   if (Array.isArray(maybe)) {
     if (maybe.length <= 0) {
       return undefined;
@@ -113,32 +115,32 @@ const getUtcValue = (maybe: string | string[] | undefined | null): string | unde
     return maybe.find(needle => !!parseUtcValue(needle));
   }
 
-  maybe = parseUtcValue(maybe);
-
-  if (typeof maybe === 'string') {
-    return maybe;
-  }
-
-  return undefined;
+  return parseUtcValue(maybe);
 };
 
 type ParamValue = string | string[] | undefined | null;
-type Params = {
-  start?: ParamValue;
-  end?: ParamValue;
+
+type ParsedParams = {
+  start?: string;
+  end?: string;
+  period?: string;
+  utc?: string;
+  [others: string]: string | null | undefined;
+};
+
+type InputParams = {
+  start?: Date | ParamValue;
+  end?: Date | ParamValue;
   period?: ParamValue;
   statsPeriod?: ParamValue;
-  utc?: ParamValue;
+  utc?: boolean | ParamValue;
+  [others: string]: any;
 };
-type RestParams = {[others: string]: ParamValue};
 
 export function getParams(
-  params: Params & RestParams,
+  params: InputParams,
   {allowEmptyPeriod = false}: {allowEmptyPeriod?: boolean} = {}
-): {
-  [K in keyof Params]: Exclude<NonNullable<Params[K]>, string[]>;
-} &
-  RestParams {
+): ParsedParams {
   const {start, end, period, statsPeriod, utc, ...otherParams} = params;
 
   // `statsPeriod` takes precendence for now

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -449,8 +449,8 @@ export type GlobalSelection = {
   projects: number[];
   environments: string[];
   datetime: {
-    start: Date | null;
-    end: Date | null;
+    start: Date | string | null;
+    end: Date | string | null;
     period: string;
     utc: boolean;
   };


### PR DESCRIPTION
I had to rejig a few types in globalSelectionHeader because the getParams() function was unable to accept a GlobalSelection header value which is used in a few places.