### PR TITLE
feat(Integrations): Update Bitbucket scopes

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -70,7 +70,7 @@ metadata = IntegrationMetadata(
     aspects={},
 )
 # see https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication#scopes-bbc
-scopes = ("issue:write", "pullrequest", "webhook")
+scopes = ("issue:write", "pullrequest", "webhook", "repository")
 
 
 class BitbucketIntegration(IntegrationInstallation, BitbucketIssueBasicMixin, RepositoryMixin):


### PR DESCRIPTION
## Objective
We received the following notice from Bitbucket about changing scopes: [here](https://developer.atlassian.com/cloud/bitbucket/2019-12-15-webhook-scope/?utm_source=alert-email&utm_medium=email&utm_campaign=bb-app-change_EML-6520&jobid=104571697&subid=1386892344)

We re-confirmed with the Bitbucket dev team that "Existing installations will continue to work as is, new installations will be affected."

Add the `repository` scope to the Bitbucket integration so that we can continue making webhooks.

## Test Plan
Tested locally with ngrok and successfully added a new Bitbucket configuration with the new scopes.