### PR TITLE
fix: Do not trigger relay cache update when fetching options

### DIFF
--- a/src/sentry/models/organizationoption.py
+++ b/src/sentry/models/organizationoption.py
@@ -50,9 +50,10 @@ class OrganizationOptionManager(OptionManager):
         return self._option_cache.get(cache_key, {})
 
     def reload_cache(self, organization_id, update_reason):
-        schedule_update_config_cache(
-            organization_id=organization_id, generate=False, update_reason=update_reason
-        )
+        if update_reason != "organizationoption.get_all_values":
+            schedule_update_config_cache(
+                organization_id=organization_id, generate=False, update_reason=update_reason
+            )
 
         cache_key = self._make_key(organization_id)
         result = dict((i.key, i.value) for i in self.filter(organization=organization_id))

--- a/src/sentry/models/projectoption.py
+++ b/src/sentry/models/projectoption.py
@@ -55,9 +55,10 @@ class ProjectOptionManager(OptionManager):
         return self._option_cache.get(cache_key, {})
 
     def reload_cache(self, project_id, update_reason):
-        schedule_update_config_cache(
-            project_id=project_id, generate=True, update_reason=update_reason
-        )
+        if update_reason != "projectoption.get_all_values":
+            schedule_update_config_cache(
+                project_id=project_id, generate=True, update_reason=update_reason
+            )
         cache_key = self._make_key(project_id)
         result = dict((i.key, i.value) for i in self.filter(project=project_id))
         cache.set(cache_key, result)


### PR DESCRIPTION
We generically hook into all the places where the redis cache for project and org options gets refreshed. However, that cache gets also "refreshed" when it is empty and needs to be populated. For those cases we do not need to refresh the relay cache