### PR TITLE
fix(discover) Fix event attributes showing up as tags

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/tags.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/tags.tsx
@@ -10,50 +10,6 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 
 const MAX_TAGS = 1000;
 
-const BUILTIN_TAGS = [
-  'event.type',
-  'platform',
-  'message',
-  'title',
-  'location',
-  'timestamp',
-  'release',
-  'user.id',
-  'user.username',
-  'user.email',
-  'user.ip',
-  'sdk.name',
-  'sdk.version',
-  'contexts.key',
-  'contexts.value',
-  'http.method',
-  'http.url',
-  'os.build',
-  'os.kernel_version',
-  'device.brand',
-  'device.locale',
-  'device.uuid',
-  'device.model_id',
-  'device.arch',
-  'device.orientation',
-  'geo.country_code',
-  'geo.region',
-  'geo.city',
-  'error.type',
-  'error.value',
-  'error.mechanism',
-  'error.handled',
-  'stack.abs_path',
-  'stack.filename',
-  'stack.package',
-  'stack.module',
-  'stack.function',
-  'stack.stack_level',
-].map(tag => ({
-  key: tag,
-  name: tag,
-}));
-
 function tagFetchSuccess(tags: Tag[]) {
   const trimmedTags = tags.slice(0, MAX_TAGS);
 
@@ -83,21 +39,12 @@ export function loadOrganizationTags(
   if (selection.projects) {
     query.project = selection.projects.map(String);
   }
-  const promise = api
-    .requestPromise(url, {
-      method: 'GET',
-      query,
-    })
-    .then((tags: Tag[]) => [...BUILTIN_TAGS, ...tags]);
+  const promise = api.requestPromise(url, {
+    method: 'GET',
+    query,
+  });
 
-  promise.then(
-    results => {
-      tagFetchSuccess(results);
-    },
-    reason => {
-      TagActions.loadTagsError(reason);
-    }
-  );
+  promise.then(tagFetchSuccess, TagActions.loadTagsError);
 
   return promise;
 }
@@ -118,12 +65,10 @@ export function fetchOrganizationTags(
     query.project = projectIds;
   }
 
-  const promise = api
-    .requestPromise(url, {
-      method: 'GET',
-      query,
-    })
-    .then(tags => [...BUILTIN_TAGS, ...tags]);
+  const promise = api.requestPromise(url, {
+    method: 'GET',
+    query,
+  });
   promise.then(tagFetchSuccess, TagActions.loadTagsError);
 
   return promise;

--- a/src/sentry/static/sentry/app/actionCreators/tags.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/tags.tsx
@@ -111,7 +111,6 @@ export function fetchOrganizationTags(
   projectIds: string[] | null = null
 ) {
   TagStore.reset();
-  TagActions.loadTags();
 
   const url = `/organizations/${orgId}/tags/`;
   const query: Query = {use_cache: '1'};

--- a/src/sentry/static/sentry/app/actions/tagActions.tsx
+++ b/src/sentry/static/sentry/app/actions/tagActions.tsx
@@ -1,3 +1,3 @@
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['loadTags', 'loadTagsError', 'loadTagsSuccess']);
+export default Reflux.createActions(['loadTagsError', 'loadTagsSuccess']);

--- a/src/sentry/static/sentry/app/stores/tagStore.jsx
+++ b/src/sentry/static/sentry/app/stores/tagStore.jsx
@@ -18,12 +18,63 @@ const getUsername = ({isManaged, username, email}) => {
 
 const getMemberListStoreUsernames = () => MemberListStore.getAll().map(getUsername);
 
+// This list is not the same as the list of
+// fields in app/utils/discover/fields.tsx@FIELDS
+// The differences are because discover1 and issue
+// search expose a subset of all event attributes.
+const BUILTIN_TAGS = [
+  'event.type',
+  'platform',
+  'message',
+  'title',
+  'location',
+  'timestamp',
+  'release',
+  'user.id',
+  'user.username',
+  'user.email',
+  'user.ip',
+  'sdk.name',
+  'sdk.version',
+  'contexts.key',
+  'contexts.value',
+  'http.method',
+  'http.url',
+  'os.build',
+  'os.kernel_version',
+  'device.brand',
+  'device.locale',
+  'device.uuid',
+  'device.model_id',
+  'device.arch',
+  'device.orientation',
+  'geo.country_code',
+  'geo.region',
+  'geo.city',
+  'error.type',
+  'error.value',
+  'error.mechanism',
+  'error.handled',
+  'stack.abs_path',
+  'stack.filename',
+  'stack.package',
+  'stack.module',
+  'stack.function',
+  'stack.stack_level',
+].map(tag => ({
+  key: tag,
+}));
+
 const TagStore = Reflux.createStore({
   listenables: TagActions,
 
   init() {
     this.listenTo(MemberListStore, this.onMemberListStoreChange);
     this.reset();
+  },
+
+  getBuiltInTags() {
+    return [...BUILTIN_TAGS];
   },
 
   getIssueAttributes() {
@@ -102,20 +153,8 @@ const TagStore = Reflux.createStore({
     this.trigger(this.tags);
   },
 
-  getTag(tagName) {
-    return this.tags[tagName];
-  },
-
   getAllTags() {
     return this.tags;
-  },
-
-  getTagKeys() {
-    return Object.keys(this.tags);
-  },
-
-  getTagValues(tagKey) {
-    return this.tags[tagKey].values || [];
   },
 
   onLoadTagsSuccess(data) {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -153,7 +153,9 @@ class Table extends React.PureComponent<TableProps, TableState> {
   }
 }
 
-export default withApi(withTags(Table));
+export default withApi(
+  withTags(Table, {includeEventAttributes: false, includeIssueAttributes: false})
+);
 
 const Container = styled('div')`
   min-width: 0;

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -6,7 +6,6 @@ import Reflux from 'reflux';
 import classNames from 'classnames';
 import createReactClass from 'create-react-class';
 import isEqual from 'lodash/isEqual';
-import omit from 'lodash/omit';
 import pickBy from 'lodash/pickBy';
 import qs from 'query-string';
 
@@ -33,13 +32,13 @@ import ProcessingIssueList from 'app/components/stream/processingIssueList';
 import SentryTypes from 'app/sentryTypes';
 import StreamGroup from 'app/components/stream/group';
 import StreamManager from 'app/utils/streamManager';
-import TagStore from 'app/stores/tagStore';
 import parseApiError from 'app/utils/parseApiError';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
 import withProfiler from 'app/utils/withProfiler';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import withSavedSearches from 'app/utils/withSavedSearches';
+import withTags from 'app/utils/withTags';
 
 import IssueListActions from './actions';
 import IssueListFilters from './filters';
@@ -62,15 +61,13 @@ const IssueListOverview = createReactClass({
     savedSearch: SentryTypes.SavedSearch,
     savedSearches: PropTypes.arrayOf(SentryTypes.SavedSearch),
     savedSearchLoading: PropTypes.bool.isRequired,
+    tags: PropTypes.object,
 
     // TODO(apm): manual profiling
     finishProfile: PropTypes.func,
   },
 
-  mixins: [
-    Reflux.listenTo(GroupStore, 'onGroupChange'),
-    Reflux.listenTo(TagStore, 'onTagsChange'),
-  ],
+  mixins: [Reflux.listenTo(GroupStore, 'onGroupChange')],
 
   getInitialState() {
     const realtimeActiveCookie = Cookies.get('realtimeActive');
@@ -90,7 +87,6 @@ const IssueListOverview = createReactClass({
       issuesLoading: true,
       tagsLoading: true,
       memberList: {},
-      tags: TagStore.getAllTags(),
       // the project for the selected issues
       // Will only be set if selected issues all belong
       // to one project.
@@ -266,7 +262,10 @@ const IssueListOverview = createReactClass({
 
   fetchTags() {
     const {organization, selection} = this.props;
-    loadOrganizationTags(this.api, organization.slug, selection);
+    this.setState({tagsLoading: true});
+    loadOrganizationTags(this.api, organization.slug, selection).then(() =>
+      this.setState({tagsLoading: false})
+    );
   },
 
   fetchData() {
@@ -438,15 +437,6 @@ const IssueListOverview = createReactClass({
     this.transitionTo({cursor, page: nextPage});
   },
 
-  onTagsChange(tags) {
-    // Exclude the environment tag as it lives in global search.
-    // Exclude the timestamp tag since we use event.timestamp instead here
-    this.setState({
-      tags: omit(tags, ['environment', 'timestamp']),
-      tagsLoading: false,
-    });
-  },
-
   onSidebarToggle() {
     const {organization} = this.props;
     this.setState({
@@ -601,7 +591,7 @@ const IssueListOverview = createReactClass({
       classes.push('show-sidebar');
     }
 
-    const {params, organization, savedSearch, savedSearches} = this.props;
+    const {params, organization, savedSearch, savedSearches, tags} = this.props;
     const query = this.getQuery();
 
     return (
@@ -624,7 +614,7 @@ const IssueListOverview = createReactClass({
             isSearchDisabled={this.state.isSidebarVisible}
             savedSearchList={savedSearches}
             tagValueLoader={this.tagValueLoader}
-            tags={this.state.tags}
+            tags={tags}
           />
 
           <Panel>
@@ -654,7 +644,7 @@ const IssueListOverview = createReactClass({
         </div>
         <IssueListSidebar
           loading={this.state.tagsLoading}
-          tags={this.state.tags}
+          tags={tags}
           query={query}
           onQueryChange={this.onIssueListSidebarSearch}
           orgId={organization.slug}
@@ -665,7 +655,14 @@ const IssueListOverview = createReactClass({
   },
 });
 
-export default withSavedSearches(
-  withGlobalSelection(withOrganization(withProfiler(IssueListOverview)))
+export default withGlobalSelection(
+  withSavedSearches(
+    withOrganization(
+      withTags(withProfiler(IssueListOverview), {
+        includeIssueAttributes: true,
+        includeEventAttributes: true,
+      })
+    )
+  )
 );
 export {IssueListOverview};

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -22,7 +22,7 @@ const DEFAULT_LINKS_HEADER =
   '<http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=1443575731:0:1>; rel="previous"; results="false"; cursor="1443575731:0:1", ' +
   '<http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=1443575000:0:0>; rel="next"; results="true"; cursor="1443575000:0:0"';
 
-describe('IssueList,', function() {
+describe('IssueList', function() {
   let wrapper;
   let props;
 
@@ -90,10 +90,11 @@ describe('IssueList,', function() {
         },
       ],
     });
+    const tags = TestStubs.Tags();
     fetchTagsRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/tags/',
       method: 'GET',
-      body: TestStubs.Tags(),
+      body: tags,
     });
     fetchMembersRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/users/',
@@ -123,6 +124,11 @@ describe('IssueList,', function() {
       location: {query: {query: 'is:unresolved'}, search: 'query=is:unresolved'},
       params: {orgId: organization.slug},
       organization,
+      tags: tags.reduce((acc, tag) => {
+        acc[tag.key] = tag;
+
+        return acc;
+      }),
     };
   });
 
@@ -1202,7 +1208,6 @@ describe('IssueList,', function() {
       await instance.componentDidMount();
 
       expect(fetchTagsRequest).toHaveBeenCalled();
-      expect(instance.state.tags.assigned).toBeTruthy();
       expect(instance.state.tagsLoading).toBeFalsy();
     });
 


### PR DESCRIPTION
Event attributes should not be showing up as tags in discover2. This problem was caused the the tags action creators adding the event attributes in as tags. I've had to expand the withTags() HOC to allow opting out of this flow as a short term solution.

I'd like to revisit this and have separate HOCs for 'issue tags' and 'event tags', and make TagStore only contain actual 'tags'. The issue and events usages are different enough and we shouldn't conflate them.

I've removed a few unused methods from TagStore so that we don't try and use them in the future.