### PR TITLE
feat: devservices up cherry picker

### DIFF
--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -104,6 +104,12 @@ def up(project, exclude, fast):
     """
     Run/update dependent services.
     """
+    if fast:
+        click.secho(
+            "> Warning! Fast mode completely eschews any image updating, so services may be stale.",
+            err=True,
+            fg="red",
+        )
 
     os.environ["SENTRY_SKIP_BACKEND_VALIDATION"] = "1"
 
@@ -113,28 +119,15 @@ def up(project, exclude, fast):
 
     configure()
 
-    from django.conf import settings
-
     client = get_docker_client()
 
     get_or_create(client, "network", project)
 
     containers = _prepare_containers(project)
 
-    if fast:
-        click.secho(
-            "> Warning! Fast mode completely eschews any image updating, so services may be stale.",
-            err=True,
-            fg="red",
-        )
-
-    for name, options in settings.SENTRY_DEVSERVICES.items():
+    for name, container_options in containers.items():
         if name in exclude:
             continue
-
-        if name not in containers:
-            continue
-
         _start_service(client, name, containers, project, fast=fast)
 
 


### PR DESCRIPTION
@jan-auer wanted this, I also think it's nice to have.

Now you can specify a custom list of devservices to bringup. It will also list available services (respects `only_if`, so you can see that `relay` doesn't appear as I have it disabled via `SENTRY_USE_RELAY`) if you make a typo.

```
$ sentry devservices up --fast asd
Service `asd` is not known or not enabled.

Services that are available:
redis
snuba
symbolicator
postgres
clickhouse

Aborted!

$ sentry devservices up --fast redis
> Warning! Fast mode completely eschews any image updating, so services may be stale.
> Starting EXISTING container 'sentry_redis' (listening: ('127.0.0.1', 6379))

$ sentry devservices up --fast redis postgres
> Warning! Fast mode completely eschews any image updating, so services may be stale.
> Starting EXISTING container 'sentry_redis' (listening: ('127.0.0.1', 6379))
> Starting EXISTING container 'sentry_postgres' (listening: ('127.0.0.1', 5432))
```

With `SENTRY_USE_RELAY = True` (you can see all the backend stuff becomes available):

```
$ sentry devservices up --fast foo
Service `foo` is not known or not enabled.

Services that are available:
postgres
relay
reverse_proxy
zookeeper
redis
kafka
snuba
symbolicator
clickhouse

Aborted!
```