### PR TITLE
perf(serializer): Add instrumentation to serializers

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -5,8 +5,6 @@ import six
 from django.db.models import Q
 from rest_framework.response import Response
 
-import sentry_sdk
-
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -109,11 +107,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         if get_all_projects:
             queryset = queryset.order_by("slug").select_related("organization")
-            projects = list(queryset)
-            with sentry_sdk.start_span(op="serialize_all_organization_projects") as span:
-                span.set_data("Project Count", len(projects))
-                serialized = serialize(projects, request.user, ProjectSummarySerializer())
-            return Response(serialized)
+            return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
         else:
             return self.paginate(
                 request=request,

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -9,6 +9,8 @@ from django.db.models import Q
 from django.db.models.aggregates import Count
 from django.utils import timezone
 
+import sentry_sdk
+
 from sentry import options, roles, tsdb, projectoptions
 from sentry.api.serializers import register, serialize, Serializer
 from sentry.api.serializers.models.plugin import PluginSerializer
@@ -163,20 +165,24 @@ class ProjectSerializer(Serializer):
         from sentry import features
         from sentry.features.base import ProjectFeature
 
-        # Retrieve all registered organization features
-        project_features = features.all(feature_type=ProjectFeature).keys()
-        feature_list = set()
+        with sentry_sdk.start_span(op="project_feature_list") as span:
+            # Retrieve all registered organization features
+            project_features = features.all(feature_type=ProjectFeature).keys()
+            feature_list = set()
 
-        for feature_name in project_features:
-            if not feature_name.startswith("projects:"):
-                continue
-            if features.has(feature_name, obj, actor=user):
-                # Remove the project scope prefix
-                feature_list.add(feature_name[len("projects:") :])
+            for feature_name in project_features:
+                if not feature_name.startswith("projects:"):
+                    continue
+                if features.has(feature_name, obj, actor=user):
+                    # Remove the project scope prefix
+                    feature_list.add(feature_name[len("projects:") :])
 
-        if obj.flags.has_releases:
-            feature_list.add("releases")
-        return feature_list
+            if obj.flags.has_releases:
+                feature_list.add("releases")
+
+            span.set_data("Feature Count", len(feature_list))
+
+            return feature_list
 
     def serialize(self, obj, attrs, user):
         feature_list = self.get_feature_list(obj, user)


### PR DESCRIPTION
### Add instrumentation to base serializer function

This will add time cost coverage across all API endpoints and will show
when serializers are dispatching to other serializers (in which case the
spans will be nested recursively) and which.

It also allows us to distinguish the time cost of `get_attrs` (which is
done with a constant number of DB queries) from the cost of iterating
linearly over all objects to be serialized. Because these are done in
the base `serialize` function, it's not possible to measure on a
per-model basis (and arguably we want to do it for all models anyway).

Because this supplants the `serialize_all_organization_projects` span,
revert it.

### Instrument ProjectSerializer's get_feature_list

The targeted span should represent the bulk of the cost of each
iteration over a list of projects being serialized. By capturing them
all, we can sum the span lengths to find its percentage of the total
cost of running the serializer.

The output will be a little different from other spans in that the
number of span instances scales linearly with the number of projects
being iterated over.