### PR TITLE
fix(api) Remove OrganizationEventsError to fix a few 500s

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import six
 from rest_framework.exceptions import PermissionDenied, ParseError
 from django.core.cache import cache
 
@@ -25,10 +24,6 @@ from sentry.utils import auth
 from sentry.utils.hashlib import hash_values
 from sentry.utils.sdk import bind_organization_context
 from sentry.utils.compat import map
-
-
-class OrganizationEventsError(Exception):
-    pass
 
 
 class NoProjects(Exception):
@@ -271,12 +266,12 @@ class OrganizationEndpoint(Endpoint):
         try:
             start, end = get_date_range_from_params(request.GET, optional=date_filter_optional)
         except InvalidParams as e:
-            raise OrganizationEventsError(six.text_type(e))
+            raise ParseError(detail=u"Invalid date range: {}".format(e))
 
         try:
             projects = self.get_projects(request, organization)
         except ValueError:
-            raise OrganizationEventsError("Invalid project ids")
+            raise ParseError(detail="Invalid project ids")
 
         if not projects:
             raise NoProjects

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import ParseError
 
 from sentry import features
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
-from sentry.api.bases import OrganizationEndpoint, OrganizationEventsError
+from sentry.api.bases import OrganizationEndpoint
 from sentry.api.event_search import (
     get_filter,
     InvalidSearchQuery,
@@ -31,7 +31,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         try:
             return get_filter(query, params)
         except InvalidSearchQuery as e:
-            raise OrganizationEventsError(six.text_type(e))
+            raise ParseError(detail=six.text_type(e))
 
     def get_orderby(self, request):
         sort = request.GET.getlist("sort")
@@ -60,7 +60,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
             try:
                 group_ids = set(map(int, [_f for _f in group_ids if _f]))
             except ValueError:
-                raise OrganizationEventsError("Invalid group parameter. Values must be numbers")
+                raise ParseError(detail="Invalid group parameter. Values must be numbers")
 
             projects = Project.objects.filter(
                 organization=organization, group__id__in=group_ids
@@ -74,7 +74,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         try:
             _filter = get_filter(query, params)
         except InvalidSearchQuery as e:
-            raise OrganizationEventsError(six.text_type(e))
+            raise ParseError(detail=six.text_type(e))
 
         snuba_args = {
             "start": _filter.start,

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -5,7 +5,7 @@ import six
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
-from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
+from sentry.api.bases import OrganizationEventsEndpointBase, NoProjects
 from sentry import eventstore, features
 from sentry.snuba import discover
 from sentry.models.project import Project, ProjectStatus
@@ -19,8 +19,6 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
         try:
             params = self.get_filter_params(request, organization)
-        except OrganizationEventsError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -13,7 +13,6 @@ from sentry.api.base import LINK_HEADER
 from sentry.api.bases import (
     OrganizationEventsEndpointBase,
     OrganizationEventsV2EndpointBase,
-    OrganizationEventsError,
     NoProjects,
 )
 from sentry.api.helpers.events import get_direct_hit_response
@@ -40,7 +39,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 self.get_filter_params(request, organization),
                 "api.organization-events-direct-hit",
             )
-        except (OrganizationEventsError, NoProjects):
+        except NoProjects:
             pass
         else:
             if direct_hit_resp:
@@ -49,8 +48,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         full = request.GET.get("full", False)
         try:
             snuba_args = self.get_snuba_query_args_legacy(request, organization)
-        except OrganizationEventsError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             # return empty result if org doesn't have projects
             # or user doesn't have access to projects in org
@@ -124,8 +121,6 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
 
         try:
             params = self.get_filter_params(request, organization)
-        except OrganizationEventsError as exc:
-            raise ParseError(detail=six.text_type(exc))
         except NoProjects:
             return Response([])
 

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -8,7 +8,7 @@ from rest_framework.exceptions import ParseError
 
 from sentry import search
 from sentry.api.base import EnvironmentMixin
-from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
+from sentry.api.bases import OrganizationEventsEndpointBase, NoProjects
 from sentry.api.helpers.group_index import build_query_params_from_request
 from sentry.api.event_search import parse_search_query
 from sentry.api.serializers import serialize
@@ -21,8 +21,6 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
         try:
             params = self.get_filter_params(request, organization)
-        except OrganizationEventsError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             return Response({"count": 0})
 
@@ -46,8 +44,6 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, En
     def get(self, request, organization):
         try:
             params = self.get_filter_params(request, organization)
-        except OrganizationEventsError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             return Response([])
 

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import ParseError
 
 from sentry import features, eventstore
 from sentry.constants import MAX_TOP_EVENTS
-from sentry.api.bases import OrganizationEventsV2EndpointBase, OrganizationEventsError, NoProjects
+from sentry.api.bases import OrganizationEventsV2EndpointBase, NoProjects
 from sentry.api.event_search import resolve_field_list, InvalidSearchQuery
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
 from sentry.discover.utils import transform_aliases_and_query
@@ -67,7 +67,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
     def get_v1_results(self, request, organization):
         try:
             snuba_args = self.get_snuba_query_args_legacy(request, organization)
-        except (OrganizationEventsError, InvalidSearchQuery) as exc:
+        except InvalidSearchQuery as exc:
             raise ParseError(detail=six.text_type(exc))
         except NoProjects:
             return Response({"data": []})

--- a/src/sentry/api/endpoints/organization_monitors.py
+++ b/src/sentry/api/endpoints/organization_monitors.py
@@ -5,7 +5,7 @@ import six
 from django.db.models import Q
 
 from sentry import features
-from sentry.api.bases import NoProjects, OrganizationEventsError
+from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
@@ -41,8 +41,6 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
             filter_params = self.get_filter_params(request, organization, date_filter_optional=True)
         except NoProjects:
             return self.respond([])
-        except OrganizationEventsError as e:
-            return self.respond({"detail": six.text_type(e)}, status=400)
 
         queryset = Monitor.objects.filter(
             organization_id=organization.id, project_id__in=filter_params["project_id"]

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -5,7 +5,7 @@ from django.db import IntegrityError, transaction
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
-from sentry.api.bases import NoProjects, OrganizationEventsError
+from sentry.api.bases import NoProjects
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import InvalidRepository
@@ -185,8 +185,6 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
             filter_params = self.get_filter_params(request, organization, date_filter_optional=True)
         except NoProjects:
             return Response([])
-        except OrganizationEventsError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
 
         # This should get us all the projects into postgres that have received
         # health data in the last 24 hours.  If health data is not requested

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import
 
-import six
 from rest_framework.response import Response
 
-from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
+from sentry.api.bases import OrganizationEventsEndpointBase, NoProjects
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
 from sentry.tagstore.base import TAG_KEY_RE
@@ -17,8 +16,6 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
 
         try:
             filter_params = self.get_filter_params(request, organization)
-        except OrganizationEventsError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             paginator = SequencePaginator([])
         else:

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import
 
-import six
 from rest_framework.response import Response
 
 from sentry import tagstore
-from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
+from sentry.api.bases import OrganizationEventsEndpointBase, NoProjects
 from sentry.api.serializers import serialize
 
 
@@ -12,8 +11,6 @@ class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
         try:
             filter_params = self.get_filter_params(request, organization)
-        except OrganizationEventsError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
         except NoProjects:
             return Response([])
 

--- a/src/sentry/api/endpoints/organization_user_reports.py
+++ b/src/sentry/api/endpoints/organization_user_reports.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import
 
-import six
 from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationUserReportsPermission
-from sentry.api.bases import NoProjects, OrganizationEventsError
+from sentry.api.bases import NoProjects
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import UserReportWithGroupSerializer
@@ -37,8 +36,6 @@ class OrganizationUserReportsEndpoint(OrganizationEndpoint):
             filter_params = self.get_filter_params(request, organization, date_filter_optional=True)
         except NoProjects:
             return Response([])
-        except OrganizationEventsError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
 
         queryset = UserReport.objects.filter(
             project_id__in=filter_params["project_id"], group__isnull=False


### PR DESCRIPTION
We raise the OrganizationEventsError when date filters are invalid and generally catch it but there were a few endpoints that were not catching and converting it into a response. By replacing this error with one from DRF we don't have to catch and convert it anymore making endpoint code simpler and removing a few 500s

Fixes SENTRY-G36