### PR TITLE
fix(ui): Only save on explicit user actions

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -20,6 +20,7 @@ type Options = {
    * List of parameters to remove when changing URL params
    */
   resetParams?: string[];
+  save?: boolean;
 };
 
 /**
@@ -147,6 +148,10 @@ export function updateParams(obj: UrlParams, router?: Router, options?: Options)
   // Only push new location if query params has changed because this will cause a heavy re-render
   if (qs.stringify(newQuery) === qs.stringify(router.location.query)) {
     return;
+  }
+
+  if (options?.save) {
+    GlobalSelectionActions.save(newQuery);
   }
 
   router.push({

--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -107,7 +107,7 @@ export function updateDateTime(
   if (!router) {
     GlobalSelectionActions.updateDateTime(datetime);
   }
-  updateParams(datetime, router, options);
+  updateParams(datetime, router, {...options, save: false});
 }
 
 /**

--- a/src/sentry/static/sentry/app/actions/globalSelectionActions.tsx
+++ b/src/sentry/static/sentry/app/actions/globalSelectionActions.tsx
@@ -5,4 +5,5 @@ export default Reflux.createActions([
   'updateProjects',
   'updateDateTime',
   'updateEnvironments',
+  'save',
 ]);

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -478,6 +478,7 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
     !this.props.hasCustomRouting
       ? {
           resetParams: this.props.resetParamsOnChange,
+          save: true,
         }
       : {};
 

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -195,12 +195,15 @@ const GlobalSelectionStore = Reflux.createStore({
     }
 
     const {project, environment} = updateObj;
+    const validatedProject = typeof project === 'string' ? [Number(project)] : project;
+    const validatedEnvironment =
+      typeof environment === 'string' ? [environment] : environment;
 
     try {
       const localStorageKey = `${LOCAL_STORAGE_KEY}:${this.organization.slug}`;
       const dataToSave = {
-        projects: project || this.selection.projects,
-        environments: environment || this.selection.environments,
+        projects: validatedProject || this.selection.projects,
+        environments: validatedEnvironment || this.selection.environments,
       };
       localStorage.setItem(localStorageKey, JSON.stringify(dataToSave));
     } catch (ex) {

--- a/tests/acceptance/page_objects/global_selection.py
+++ b/tests/acceptance/page_objects/global_selection.py
@@ -14,6 +14,9 @@ class GlobalSelectionPage(BasePage):
     def get_selected_environment(self):
         return self.browser.element('[data-test-id="global-header-environment-selector"]').text
 
+    def get_selected_date(self):
+        return self.browser.element('[data-test-id="global-header-timerange-selector"]').text
+
     def go_back_to_issues(self):
         self.browser.click('[data-test-id="back-to-issues"]')
 
@@ -45,6 +48,6 @@ class GlobalSelectionPage(BasePage):
     def select_date(self, date):
         date_path = u'//*[text()="{}"]'.format(date)
 
-        self.open_project_selector()
+        self.open_date_selector()
         self.browser.wait_until(xpath=date_path)
         self.browser.click(xpath=date_path)

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -177,7 +177,8 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             self.issues_list.global_selection.select_date("Last 24 hours")
             self.issues_list.wait_until_loaded()
             assert u"statsPeriod=24h" in self.browser.current_url
-            assert self.issues_list.global_selection.get_selected_date() == "Last 24 hours"
+            # This doesn't work because we treat as dynamic data in CI
+            # assert self.issues_list.global_selection.get_selected_date() == "Last 24 hours"
 
             # reloading page with no project id in URL after previously
             # selecting an explicit project should load previously selected project

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -174,6 +174,11 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
             )
 
+            self.issues_list.global_selection.select_date("Last 24 hours")
+            self.issues_list.wait_until_loaded()
+            assert u"statsPeriod=24h" in self.browser.current_url
+            assert self.issues_list.global_selection.get_selected_date() == "Last 24 hours"
+
             # reloading page with no project id in URL after previously
             # selecting an explicit project should load previously selected project
             # from local storage

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -153,9 +153,11 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_2.slug
             )
 
-            # FIXME(billy): This is a bug, should not be in local storage
             # should not be in local storage
-            # assert self.browser.get_local_storage_item(u"global-selection:{}".format(self.org.slug)) is None
+            assert (
+                self.browser.get_local_storage_item(u"global-selection:{}".format(self.org.slug))
+                is None
+            )
 
             # reloads page with no project id in URL, remains "My Projects" because
             # there has been no explicit project selection via UI


### PR DESCRIPTION
This only saves last selected projects/environments on explicit user actions on global selection header