### PR TITLE
feat(apm): Revise operation name breakdown

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
@@ -52,19 +52,13 @@ class OpsBreakdown extends React.Component<Props> {
     const event = this.getTransactionEvent();
 
     if (!event) {
-      return {
-        topN: [],
-        other: undefined,
-      };
+      return [];
     }
 
     const traceContext: TraceContextType | undefined = event?.contexts?.trace;
 
     if (!traceContext) {
-      return {
-        topN: [],
-        other: undefined,
-      };
+      return [];
     }
 
     const spanEntry: SpanEntry | undefined = event.entries.find(

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
@@ -83,7 +83,7 @@ class OpsBreakdown extends React.Component<Props> {
           ];
 
     const operationNameIntervals = spans.reduce(
-      (intervals: OperationNameIntervals, span: RawSpanType) => {
+      (intervals: Partial<OperationNameIntervals>, span: RawSpanType) => {
         let startTimestamp = span.start_timestamp;
         let endTimestamp = span.timestamp;
 
@@ -104,9 +104,9 @@ class OpsBreakdown extends React.Component<Props> {
 
         const cover: TimeWindowSpan = [startTimestamp, endTimestamp];
 
-        const operationNameInterval = intervals[operationName] ?? [];
+        const operationNameInterval = intervals[operationName];
 
-        if (operationNameInterval.length <= 0) {
+        if (!Array.isArray(operationNameInterval)) {
           intervals[operationName] = [cover];
 
           return intervals;
@@ -119,11 +119,11 @@ class OpsBreakdown extends React.Component<Props> {
         return intervals;
       },
       {}
-    );
+    ) as OperationNameIntervals;
 
     const operationNameCoverage = Object.entries(operationNameIntervals).reduce(
       (
-        acc: OperationNameCoverage,
+        acc: Partial<OperationNameCoverage>,
         [operationName, intervals]: [OperationName, TimeWindowSpan[]]
       ) => {
         const duration = intervals.reduce((sum: number, [start, end]) => {
@@ -135,7 +135,7 @@ class OpsBreakdown extends React.Component<Props> {
         return acc;
       },
       {}
-    );
+    ) as OperationNameCoverage;
 
     const sortedOpsBreakdown = Object.entries(operationNameCoverage).sort(
       (first: [OperationName, Duration], second: [OperationName, Duration]) => {

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
@@ -12,6 +12,8 @@ import {SectionHeading} from 'app/components/charts/styles';
 import {pickSpanBarColour} from 'app/components/events/interfaces/spans/utils';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
+import Tooltip from 'app/components/tooltip';
+import {IconQuestion} from 'app/icons';
 
 type StartTimestamp = number;
 type EndTimestamp = number;
@@ -211,7 +213,18 @@ class OpsBreakdown extends React.Component<Props> {
 
     return (
       <StyledBreakdown>
-        <SectionHeading>{t('Ops Breakdown')}</SectionHeading>
+        <BreakdownHeader>
+          <SectionHeading>{t('Ops Breakdown')}</SectionHeading>
+          <Tooltip
+            position="top"
+            containerDisplayMode="block"
+            title={t(
+              'Durations are calculated by summing span durations over the course of the transaction. Percentages are then calculated by dividing the individual op duration by the sum of total op durations. Overlapping/parallel spans are only counted once.'
+            )}
+          >
+            <StyledIconQuestion />
+          </Tooltip>
+        </BreakdownHeader>
         {breakdown.map(currOp => {
           const {name, percentage, totalInterval} = currOp;
           const durLabel = Math.round(totalInterval * 1000 * 100) / 100;
@@ -284,6 +297,15 @@ const Dur = styled('div')`
 const Pct = styled('div')`
   min-width: 40px;
   text-align: right;
+`;
+
+const BreakdownHeader = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledIconQuestion = styled(IconQuestion)`
+  color: ${p => p.theme.gray1};
 `;
 
 function mergeInterval(intervals: TimeWindowSpan[]): TimeWindowSpan[] {


### PR DESCRIPTION
Calculate the coverage of an operation name with respect to the root transaction span's operation lifetime.

<img width="1659" alt="Screen Shot 2020-04-29 at 12 46 47 PM" src="https://user-images.githubusercontent.com/139499/80624168-4e423a00-8a19-11ea-8d98-8b11186b0b6e.png">


Also fix overflow issues from operation names that can be long:

<img width="359" alt="Screen Shot 2020-04-29 at 12 49 01 PM" src="https://user-images.githubusercontent.com/139499/80624231-61550a00-8a19-11ea-83f8-a5dcf71e7b36.png">

## TODO

- [x] make ops percentage relative to the breakdown group
- [x] tooltip