### PR TITLE
feat(snuba) - Adding more data to the snuba span

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -560,6 +560,9 @@ def bulk_raw_query(snuba_param_list, referrer=None):
                     op="snuba", description=u"query {}".format(body)
                 ) as span:
                     span.set_tag("referrer", headers.get("referer", "<unknown>"))
+                    for extra_key in ["conditions", "groupby", "aggregations", "selected_columns"]:
+                        if extra_key in query_params:
+                            span.set_data(extra_key, query_params.get(extra_key))
                     return (
                         _snuba_pool.urlopen("POST", "/query", body=body, headers=headers),
                         forward,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -556,13 +556,13 @@ def bulk_raw_query(snuba_param_list, referrer=None):
         try:
             with timer("snuba_query"):
                 body = json.dumps(query_params)
+                referrer = headers.get("referer", "<unknown>")
                 with thread_hub.start_span(
-                    op="snuba", description=u"query {}".format(body)
+                    op="snuba", description=u"query {}".format(referrer)
                 ) as span:
-                    span.set_tag("referrer", headers.get("referer", "<unknown>"))
-                    for extra_key in ["conditions", "groupby", "aggregations", "selected_columns"]:
-                        if extra_key in query_params:
-                            span.set_data(extra_key, query_params.get(extra_key))
+                    span.set_tag("referrer", referrer)
+                    for param_key, param_data in six.iteritems(query_params):
+                        span.set_data(param_key, param_data)
                     return (
                         _snuba_pool.urlopen("POST", "/query", body=body, headers=headers),
                         forward,


### PR DESCRIPTION
- Right now the json body of the query is set as the description, but
  many of our queries gut truncated cause they're longer than the 200
  character description limit
- This adds some of the other useful query information as data on the
  span.
- Below is a good example of this, while you can see `aggregations` and `selected_columns` in the description, both `conditions` and `groupby` are completely truncated
 - (also imo these as data fields are way more readable)
<img width="1194" alt="image" src="https://user-images.githubusercontent.com/4205004/80626627-bba39a00-8a1c-11ea-80fe-ee977be3f320.png">
