### PR TITLE
fix(api): Don't log success if pagerduty notification raises an exception

### DIFF
--- a/src/sentry/integrations/pagerduty/notify_action.py
+++ b/src/sentry/integrations/pagerduty/notify_action.py
@@ -113,7 +113,7 @@ class PagerDutyNotifyServiceAction(EventAction):
                         "service_id": service.id,
                     },
                 )
-                return
+                raise e
 
             # TODO(meredith): Maybe have a generic success log statements for
             # first-party integrations similar to plugin `notification.dispatched`

--- a/src/sentry/integrations/pagerduty/notify_action.py
+++ b/src/sentry/integrations/pagerduty/notify_action.py
@@ -113,6 +113,7 @@ class PagerDutyNotifyServiceAction(EventAction):
                         "service_id": service.id,
                     },
                 )
+                return
 
             # TODO(meredith): Maybe have a generic success log statements for
             # first-party integrations similar to plugin `notification.dispatched`


### PR DESCRIPTION
We were seeing an `UnboundLocalError` in a logging call. In this PR we return early if we catch an exception so that we don't also create a success log.

Fixes API-866