### PR TITLE
feat(Commits): Add logging to determine where duplicate commits are coming from

### DIFF
--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -235,6 +235,7 @@ def get_event_file_committers(project, event, frame_limit=25):
         "relevant_commits",
         extra={
             "relevant_commits": relevant_commits,
+            "project": project.id,
             "commit_path_matches": commit_path_matches,
         },
     )

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -235,7 +235,9 @@ def get_event_file_committers(project, event, frame_limit=25):
         "relevant_commits",
         extra={
             "relevant_commits": relevant_commits,
-            "project": project.id,
+            "projectId": project.id,
+            "groupId": event.group_id,
+            "eventId": event.id,
             "commit_path_matches": commit_path_matches,
         },
     )

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import operator
 import six
-
+import logging
 
 from sentry.api.serializers import serialize
 from sentry.models import Release, ReleaseCommit, Commit, CommitFileChange, Group
@@ -19,6 +19,8 @@ from functools import reduce
 from sentry.utils.compat import zip
 
 PATH_SEPERATORS = frozenset(["/", "\\"])
+
+logger = logging.getLogger("sentry.utils.committers")
 
 
 def tokenize_path(path):
@@ -227,6 +229,16 @@ def get_event_file_committers(project, event, frame_limit=25):
 
     relevant_commits = list(
         {match for match in commit_path_matches for match in commit_path_matches[match]}
+    )
+
+    logger.info(
+        "relevant_commits",
+        extra={
+            "relevant_commits": relevant_commits,
+            "project": project,
+            "group": group,
+            "commit_path_matches": commit_path_matches,
+        },
     )
 
     return _get_committers(annotated_frames, relevant_commits)

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -237,7 +237,6 @@ def get_event_file_committers(project, event, frame_limit=25):
             "relevant_commits": relevant_commits,
             "project_id": project.id,
             "group_id": event.group_id,
-            "event_id": event.id,
             "commit_path_matches": commit_path_matches,
         },
     )

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -235,8 +235,6 @@ def get_event_file_committers(project, event, frame_limit=25):
         "relevant_commits",
         extra={
             "relevant_commits": relevant_commits,
-            "project": project,
-            "group": group,
             "commit_path_matches": commit_path_matches,
         },
     )

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -235,9 +235,9 @@ def get_event_file_committers(project, event, frame_limit=25):
         "relevant_commits",
         extra={
             "relevant_commits": relevant_commits,
-            "projectId": project.id,
-            "groupId": event.group_id,
-            "eventId": event.id,
+            "project_id": project.id,
+            "group_id": event.group_id,
+            "event_id": event.id,
             "commit_path_matches": commit_path_matches,
         },
     )


### PR DESCRIPTION
## Objective
A bug was reported that there are duplicate suggested commits/assignees. Both come the same endpoint. This is difficult to replicate in a local environment. This PR is add logging so we can see what is going on inside the functions in a staging environment in ElasticSearch.

## Test Plan
None.