### PR TITLE
fix(perf-views) Make duration chart the default

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
@@ -50,7 +50,7 @@ class TransactionSummaryCharts extends React.Component<Props> {
       ? Array.isArray(location.query.display)
         ? location.query.display[0]
         : location.query.display
-      : DisplayModes.LATENCY;
+      : DisplayModes.DURATION;
 
     return (
       <Panel>

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -168,8 +168,8 @@ class DurationChart extends React.Component<Props> {
                           }}
                           tooltip={tooltip}
                           grid={{
-                            left: '24px',
-                            right: '24px',
+                            left: '12px',
+                            right: '16px',
                             top: '32px',
                             bottom: '12px',
                           }}


### PR DESCRIPTION
Load the duration chart first as the latency chart isn't as useful for many folks. I've also tweaked the chart layout so it lines up with the graph controls a bit better.