### PR TITLE
ref(alerts): Do not set default critical trigger threshold

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -8,7 +8,7 @@ import {
 export function createDefaultTrigger(): Trigger {
   return {
     label: 'critical',
-    alertThreshold: 0,
+    alertThreshold: '',
     resolveThreshold: '',
     thresholdType: AlertRuleThresholdType.ABOVE,
     actions: [],

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -241,10 +241,13 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       const criticalTrigger = triggers[criticalTriggerIndex];
       const warningTrigger = triggers[warningTriggerIndex];
 
+      const warningThreshold = warningTrigger.alertThreshold ?? 0;
+      const criticalThreshold = criticalTrigger.alertThreshold ?? 0;
+
       const hasError =
         criticalTrigger.thresholdType === AlertRuleThresholdType.ABOVE
-          ? warningTrigger.alertThreshold > criticalTrigger.alertThreshold
-          : warningTrigger.alertThreshold < criticalTrigger.alertThreshold;
+          ? warningThreshold > criticalThreshold
+          : warningThreshold < criticalThreshold;
 
       if (hasError) {
         [criticalTriggerIndex, warningTriggerIndex].forEach(index => {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -220,7 +220,9 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
   };
 
   getChartPixelForThreshold = (threshold: number | '' | null) =>
-    this.chartRef && this.chartRef.convertToPixel({yAxisIndex: 0}, `${threshold}`);
+    threshold !== '' &&
+    this.chartRef &&
+    this.chartRef.convertToPixel({yAxisIndex: 0}, `${threshold}`);
 
   render() {
     const {data, triggers, period} = this.props;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -14,11 +14,12 @@ export enum AlertRuleAggregations {
 }
 
 export type UnsavedTrigger = {
-  // UnsavedTrigger can be apart of an Unsaved Alert Rule that does not have an id yet
+  // UnsavedTrigger can be apart of an Unsaved Alert Rule that does not have an
+  // id yet
   alertRuleId?: string;
   label: string;
   thresholdType: AlertRuleThresholdType;
-  alertThreshold: number;
+  alertThreshold: number | '' | null;
   resolveThreshold: number | '' | null;
   actions: Action[];
 };


### PR DESCRIPTION
This avoids the chart from defaulting to a big red box, which upon first
glance before understanding thresholds, is a bit distracting.