### PR TITLE
fix(releases): adds repo name in email when cannot fetch commits and better error message

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -130,7 +130,7 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
             message = API_ERRORS.get(exc.code)
             if exc.code == 404 and re.search(r"/repos/.*/(compare|commits)", exc.url):
                 message += (
-                    "\nPlease also confirm that the commits associated with the following URL have been pushed to GitHub: %s"
+                    " Please also confirm that the commits associated with the following URL have been pushed to GitHub: %s"
                     % exc.url
                 )
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -130,7 +130,7 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
             message = API_ERRORS.get(exc.code)
             if exc.code == 404 and re.search(r"/repos/.*/(compare|commits)", exc.url):
                 message += (
-                    "\nPlease also confirm that the commits associated with the following URL have been pushed to Github: %s"
+                    "\nPlease also confirm that the commits associated with the following URL have been pushed to GitHub: %s"
                     % exc.url
                 )
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import re
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 
@@ -127,6 +128,12 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
     def message_from_error(self, exc):
         if isinstance(exc, ApiError):
             message = API_ERRORS.get(exc.code)
+            if exc.code == 404 and re.search(r"/repos/.*/(compare|commits)", exc.url):
+                message += (
+                    "\nPlease also confirm that the commits associated with the following URL have been pushed to Github: %s"
+                    % exc.url
+                )
+
             if message is None:
                 message = exc.json.get("message", "unknown error") if exc.json else "unknown error"
             return "Error Communicating with GitHub (HTTP %s): %s" % (exc.code, message)

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -238,9 +238,9 @@ class BaseApiClient(object):
                     self.logger.exception(
                         "request.error", extra={self.integration_type: self.name, "url": full_url}
                     )
-                    raise ApiError("Internal Error")
+                    raise ApiError("Internal Error", url=full_url)
                 self.track_response_data(resp.status_code, span, e)
-                raise ApiError.from_response(resp)
+                raise ApiError.from_response(resp, url=full_url)
 
             self.track_response_data(resp.status_code, span, None, resp)
 

--- a/src/sentry/shared_integrations/exceptions.py
+++ b/src/sentry/shared_integrations/exceptions.py
@@ -12,10 +12,11 @@ class ApiError(Exception):
     json = None
     xml = None
 
-    def __init__(self, text, code=None):
+    def __init__(self, text, code=None, url=None):
         if code is not None:
             self.code = code
         self.text = text
+        self.url = url
         self.xml = None
         # TODO(dcramer): pull in XML support from Jira
         if text:
@@ -32,10 +33,10 @@ class ApiError(Exception):
         super(ApiError, self).__init__(text[:1024])
 
     @classmethod
-    def from_response(cls, response):
+    def from_response(cls, response, url=None):
         if response.status_code == 401:
             return ApiUnauthorized(response.text)
-        return cls(response.text, response.status_code)
+        return cls(response.text, response.status_code, url=url)
 
 
 class ApiHostError(ApiError):

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -39,8 +39,8 @@ def generate_invalid_identity_email(identity, commit_failure=False):
     )
 
 
-def generate_fetch_commits_error_email(release, error_message):
-    new_context = {"release": release, "error_message": error_message}
+def generate_fetch_commits_error_email(release, repo, error_message):
+    new_context = {"release": release, "error_message": error_message, "repo": repo}
 
     return MessageBuilder(
         subject="Unable to Fetch Commits",
@@ -149,12 +149,12 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
             if isinstance(e, InvalidIdentity) and getattr(e, "identity", None):
                 handle_invalid_identity(identity=e.identity, commit_failure=True)
             elif isinstance(e, (PluginError, InvalidIdentity, IntegrationError)):
-                msg = generate_fetch_commits_error_email(release, six.text_type(e))
+                msg = generate_fetch_commits_error_email(release, repo, six.text_type(e))
                 emails = get_emails_for_user_or_org(user, release.organization_id)
                 msg.send_async(to=emails)
             else:
                 msg = generate_fetch_commits_error_email(
-                    release, "An internal system error occurred."
+                    release, repo, "An internal system error occurred."
                 )
                 emails = get_emails_for_user_or_org(user, release.organization_id)
                 msg.send_async(to=emails)

--- a/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
+++ b/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
@@ -2,7 +2,7 @@
 
 {% block main %}
   <h3>Unable to Fetch Commits</h3>
-  <p>We were unable to fetch the commit log for your release (<em>{{ release.version }}</em>) for repo <em>{{ repo.name }}</em> due to the following error:</p>
+  <p>We were unable to fetch the commit log for your release (<em>{{ release.version }}</em>) for repository <em>{{ repo.name }}</em> due to the following error:</p>
   <p>{{ error_message }}</p>
   <p><strong>Troubleshooting &amp; References</strong></p>
   <ul>

--- a/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
+++ b/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
@@ -2,7 +2,7 @@
 
 {% block main %}
   <h3>Unable to Fetch Commits</h3>
-  <p>We were unable to fetch the commit log for your release (<em>{{ release.version }}</em>) due to the following error:</p>
+  <p>We were unable to fetch the commit log for your release (<em>{{ release.version }}</em>) for repo <em>{{ repo.name }}</em> due to the following error:</p>
   <p>{{ error_message }}</p>
   <p><strong>Troubleshooting &amp; References</strong></p>
   <ul>

--- a/src/sentry/web/frontend/debug/debug_unable_to_fetch_commits_email.py
+++ b/src/sentry/web/frontend/debug/debug_unable_to_fetch_commits_email.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function
 
 from django.views.generic import View
 
-from sentry.models import Release
+from sentry.models import Release, Repository
 from sentry.tasks.commits import generate_fetch_commits_error_email
 
 from .mail import MailPreview
@@ -11,8 +11,11 @@ from .mail import MailPreview
 class DebugUnableToFetchCommitsEmailView(View):
     def get(self, request):
         release = Release(version="abcdef")
+        repo = Repository(name="repo_name")
 
-        email = generate_fetch_commits_error_email(release, "An internal server error occurred")
+        email = generate_fetch_commits_error_email(
+            release, repo, "An internal server error occurred"
+        )
         return MailPreview(
             html_template=email.html_template, text_template=email.template, context=email.context
         ).render(request)


### PR DESCRIPTION
We've had [some complaints](https://forum.sentry.io/t/unable-to-fetch-commits/5391/4?u=scefali) that the email for fetching commits failing isn't helpful because it doesn't say which repository had the problem.

I have also learned from Neil that a common reason why users get this error is that the commit they are trying to associate has not been pushed yet to Github. I have also added content to the error message saying to verify the commit exists in Github along with the actual URL we are using. Here's an example of what it looks like now:

![Screen Shot 2020-04-29 at 4 34 09 PM](https://user-images.githubusercontent.com/8533851/80657055-7fc9fe00-8a37-11ea-9c00-c3a6c39ead06.png)

Once I get the OK with this approach, I will add some unit tests for the logic I added in the error handler.
