### PR TITLE
ref(organization_projects): Extract callback for readability

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -109,19 +109,18 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
             queryset = queryset.order_by("slug").select_related("organization")
             return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
         else:
+
+            def serialize_on_result(result):
+                environment_id = self._get_environment_id_from_request(request, organization.id)
+                serializer = ProjectSummarySerializer(
+                    environment_id=environment_id, stats_period=stats_period,
+                )
+                return serialize(result, request.user, serializer)
+
             return self.paginate(
                 request=request,
                 queryset=queryset,
                 order_by=order_by,
-                on_results=lambda x: serialize(
-                    x,
-                    request.user,
-                    ProjectSummarySerializer(
-                        environment_id=self._get_environment_id_from_request(
-                            request, organization.id
-                        ),
-                        stats_period=stats_period,
-                    ),
-                ),
+                on_results=serialize_on_result,
                 paginator_cls=OffsetPaginator,
             )


### PR DESCRIPTION
Just something I noticed could be cleaned up while working on #18494.

I know that a lot of similar classes use the `on_results=lambda x: serialize(x, ...)` pattern (I'm fine with lambdas generally) but this is one of the only multiline ones with a big compound expression.