### PR TITLE
ref(ui): Moved Event ID Status inline

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/formField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/formField.tsx
@@ -199,14 +199,14 @@ export default class FormField<
           {this.getField()}
           {this.renderDisabledReason()}
           {defined(help) && <p className="help-block">{help}</p>}
-          {shouldShowErrorMessage && <Error>{error}</Error>}
+          {shouldShowErrorMessage && <ErrorMessage>{error}</ErrorMessage>}
         </div>
       </div>
     );
   }
 }
 
-const Error = styled('p')`
+const ErrorMessage = styled('p')`
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => p.theme.red};
 `;

--- a/src/sentry/static/sentry/app/components/forms/formField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/formField.tsx
@@ -199,9 +199,14 @@ export default class FormField<
           {this.getField()}
           {this.renderDisabledReason()}
           {defined(help) && <p className="help-block">{help}</p>}
-          {shouldShowErrorMessage && <p className="error">{error}</p>}
+          {shouldShowErrorMessage && <Error>{error}</Error>}
         </div>
       </div>
     );
   }
 }
+
+const Error = styled('p')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.red};
+`;

--- a/src/sentry/static/sentry/app/icons/iconCheckmark.tsx
+++ b/src/sentry/static/sentry/app/icons/iconCheckmark.tsx
@@ -12,7 +12,7 @@ export const IconCheckmark = React.forwardRef(function IconCheckmark(
   }: IconProps,
   ref: React.Ref<SVGSVGElement>
 ) {
-  const color = providedColor;
+  const color = theme[providedColor] ?? providedColor;
   const size = theme.iconSizes[providedSize] ?? providedSize;
 
   return (

--- a/src/sentry/static/sentry/app/icons/iconClose.tsx
+++ b/src/sentry/static/sentry/app/icons/iconClose.tsx
@@ -12,7 +12,7 @@ export const IconClose = React.forwardRef(function IconClose(
   }: IconProps,
   ref: React.Ref<SVGSVGElement>
 ) {
-  const color = providedColor;
+  const color = theme[providedColor] ?? providedColor;
   const size = theme.iconSizes[providedSize] ?? providedSize;
 
   return (

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormEventIdStatusIcon.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormEventIdStatusIcon.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import ControlState from 'app/views/settings/components/forms/field/controlState';
+import {t} from 'app/locale';
+import Tooltip from 'app/components/tooltip';
+import {IconClose, IconCheckmark} from 'app/icons';
+
+import {EventIdStatus} from './types';
+
+type Props = {
+  onClickIconClose: () => void;
+  status?: EventIdStatus;
+};
+
+const DataPrivacyRulesFormEventIdStatusIcon = ({status, onClickIconClose}: Props) => {
+  switch (status) {
+    case EventIdStatus.ERROR:
+    case EventIdStatus.INVALID:
+    case EventIdStatus.NOT_FOUND:
+      return (
+        <CloseIcon onClick={onClickIconClose}>
+          <Tooltip title={t('Clear Event ID')}>
+            <IconClose color="red" />
+          </Tooltip>
+        </CloseIcon>
+      );
+    case EventIdStatus.LOADING:
+      return <ControlState isSaving />;
+    case EventIdStatus.LOADED:
+      return <IconCheckmark color="green" />;
+    default:
+      return null;
+  }
+};
+
+export default DataPrivacyRulesFormEventIdStatusIcon;
+
+const CloseIcon = styled('div')`
+  cursor: pointer;
+  :first-child {
+    line-height: 0;
+  }
+`;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
@@ -403,9 +403,8 @@ const Wrapper = styled('div')`
   width: 100%;
 `;
 
-const StyledTextField = styled(TextField)<{error?: string}>`
+const StyledTextField = styled(TextField)`
   width: 100%;
-  font-size: ${p => p.theme.fontSizeSmall};
   height: 40px;
   input {
     height: 40px;

--- a/src/sentry/static/sentry/less/forms.less
+++ b/src/sentry/static/sentry/less/forms.less
@@ -154,7 +154,14 @@ label {
 }
 
 .has-error .form-control {
-  border-color: @red-dark;
+  border-color: #c9c0d1;
+  box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.04);
+}
+
+.has-error .form-control:focus {
+  border-color: #a598b2;
+  box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.04), 0 0 6px rgba(177, 171, 225, 0.3);
+  outline: none;
 }
 
 .error,
@@ -168,7 +175,7 @@ label {
 .has-error.checkbox label,
 .has-error.radio-inline label,
 .has-error.checkbox-inline label {
-  color: @red-dark;
+  color: @red;
 }
 
 input.form-control[disabled],

--- a/tests/js/spec/views/settings/components/dataPrivacyRulesPanel/__snapshots__/dataPrivacyRulesFormSource.spec.tsx.snap
+++ b/tests/js/spec/views/settings/components/dataPrivacyRulesPanel/__snapshots__/dataPrivacyRulesFormSource.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DataPrivacyRulesPanelSelectorField default render 1`] = `
+exports[`DataPrivacyRulesFormSource default render 1`] = `
 <DataPrivacyRulesFormSource
   onChange={[MockFunction]}
   suggestions={
@@ -82,7 +82,7 @@ exports[`DataPrivacyRulesPanelSelectorField default render 1`] = `
       >
         <TextField
           autoComplete="off"
-          className="css-a4jb6d-StyledTextField e5vbseb1"
+          className="css-jvghga-StyledTextField e5vbseb1"
           disabled={false}
           hideErrorMessage={false}
           name="from"
@@ -94,7 +94,7 @@ exports[`DataPrivacyRulesPanelSelectorField default render 1`] = `
           value="$string"
         >
           <div
-            className="css-a4jb6d-StyledTextField e5vbseb1 control-group"
+            className="css-jvghga-StyledTextField e5vbseb1 control-group"
           >
             <div
               className="controls"

--- a/tests/js/spec/views/settings/components/dataPrivacyRulesPanel/dataPrivacyRulesFormSource.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataPrivacyRulesPanel/dataPrivacyRulesFormSource.spec.tsx
@@ -23,7 +23,7 @@ function renderComponent({
   );
 }
 
-describe('DataPrivacyRulesPanelSelectorField', () => {
+describe('DataPrivacyRulesFormSource', () => {
   it('default render', () => {
     const wrapper = renderComponent({});
     expect(wrapper.find('input').prop('value')).toBe('$string');


### PR DESCRIPTION
**Description:**

Before the event ID status was being displayed using `addSuccessMessage/addErrorMessage`. They are now aligned below the textField.

![image](https://user-images.githubusercontent.com/29228205/80707129-c710c700-8ae9-11ea-9ffc-02633617adc8.png)

