### PR TITLE
fix(search) Separate the issue and events tag HOCs

### DIFF
--- a/src/sentry/static/sentry/app/utils/withIssueTags.tsx
+++ b/src/sentry/static/sentry/app/utils/withIssueTags.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import Reflux from 'reflux';
+import createReactClass from 'create-react-class';
+import assign from 'lodash/assign';
+
+import getDisplayName from 'app/utils/getDisplayName';
+import MemberListStore from 'app/stores/memberListStore';
+import TagStore from 'app/stores/tagStore';
+import {User, Tag} from 'app/types';
+
+type TagCollection = {[key: string]: Tag};
+
+type InjectedTagsProps = {
+  tags: TagCollection;
+};
+
+type State = {
+  tags: TagCollection;
+  users: User[];
+};
+
+const uuidPattern = /[0-9a-f]{32}$/;
+const getUsername = ({isManaged, username, email}: User) => {
+  // Users created via SAML receive unique UUID usernames. Use
+  // their email in these cases, instead.
+  if (username && uuidPattern.test(username)) {
+    return email;
+  } else {
+    return !isManaged && username ? username : email;
+  }
+};
+
+/**
+ * HOC for getting tags and many useful issue attributes as 'tags' for use
+ * in autocomplete selectors or condition builders.
+ */
+const withIssueTags = <P extends InjectedTagsProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
+  createReactClass<Omit<P, keyof InjectedTagsProps>, State>({
+    displayName: `withIssueTags(${getDisplayName(WrappedComponent)})`,
+
+    mixins: [
+      Reflux.listenTo(MemberListStore, 'onMemberListStoreChange') as any,
+      Reflux.listenTo(TagStore, 'onTagsUpdate') as any,
+    ],
+
+    getInitialState() {
+      const tags = assign(
+        {},
+        TagStore.getAllTags(),
+        TagStore.getIssueAttributes(),
+        TagStore.getBuiltInTags()
+      );
+      const users = MemberListStore.getAll();
+
+      return {tags, users};
+    },
+
+    onMemberListStoreChange(users: User[]) {
+      this.setState({users});
+      this.setAssigned();
+    },
+
+    onTagsUpdate(storeTags: TagCollection) {
+      const tags = assign(
+        {},
+        storeTags,
+        TagStore.getIssueAttributes(),
+        TagStore.getBuiltInTags()
+      );
+      this.setState({tags});
+      this.setAssigned();
+    },
+
+    setAssigned() {
+      if (this.state.users && this.state.tags.assigned) {
+        const {tags, users} = this.state;
+        const usernames: string[] = users.map(getUsername);
+        usernames.unshift('me');
+
+        this.setState({
+          tags: {
+            ...tags,
+            assigned: {
+              ...tags.assigned,
+              values: usernames,
+            },
+            bookmarks: {
+              ...tags.bookmarks,
+              values: usernames,
+            },
+          },
+        });
+      }
+    },
+
+    render() {
+      return <WrappedComponent tags={this.state.tags} {...(this.props as P)} />;
+    },
+  });
+
+export default withIssueTags;

--- a/src/sentry/static/sentry/app/views/events/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.jsx
@@ -22,7 +22,7 @@ const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
 );
 
 const FIELD_TAGS = Object.fromEntries(
-Object.keys(FIELDS).map(item => [item, {key: item, name: item}])
+  Object.keys(FIELDS).map(item => [item, {key: item, name: item}])
 );
 
 class SearchBar extends React.PureComponent {
@@ -82,12 +82,13 @@ class SearchBar extends React.PureComponent {
       ? FIELD_TAGS
       : omit(FIELD_TAGS, TRACING_FIELDS);
     const combined = assign({}, tags, fields, {
-    has: {
-      key: 'has',
-      name: 'Has property',
-      values: Object.keys(combined),
-      predefined: true,
-    }});
+      has: {
+        key: 'has',
+        name: 'Has property',
+        values: Object.keys(combined),
+        predefined: true,
+      },
+    });
 
     return combined;
   }

--- a/src/sentry/static/sentry/app/views/events/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.jsx
@@ -1,30 +1,30 @@
 import {ClassNames} from '@emotion/core';
+import assign from 'lodash/assign';
 import flatten from 'lodash/flatten';
+import isEqual from 'lodash/isEqual';
 import memoize from 'lodash/memoize';
+import omit from 'lodash/omit';
 import PropTypes from 'prop-types';
 import React from 'react';
-import isEqual from 'lodash/isEqual';
 
 import {NEGATION_OPERATOR, SEARCH_TYPES, SEARCH_WILDCARD} from 'app/constants';
 import {defined} from 'app/utils';
 import {fetchTagValues} from 'app/actionCreators/tags';
 import SentryTypes from 'app/sentryTypes';
 import SmartSearchBar from 'app/components/smartSearchBar';
+import {FIELDS, TRACING_FIELDS} from 'app/utils/discover/fields';
 import withApi from 'app/utils/withApi';
 import withTags from 'app/utils/withTags';
-
-const tagToObjectReducer = (acc, name) => {
-  acc[name] = {
-    key: name,
-    name,
-  };
-  return acc;
-};
 
 const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   `^${NEGATION_OPERATOR}|\\${SEARCH_WILDCARD}`,
   'g'
 );
+
+const FIELD_TAGS = Object.keys(FIELDS).reduce((acc, item) => {
+  acc[item] = {key: item, name: item};
+  return acc;
+}, {});
 
 class SearchBar extends React.PureComponent {
   static propTypes = {
@@ -72,14 +72,29 @@ class SearchBar extends React.PureComponent {
     ({key}, query) => `${key}-${query}`
   );
 
-  getAllTags = (orgTags = []) => orgTags.sort().reduce(tagToObjectReducer, {});
-
   /**
    * Prepare query string (e.g. strip special characters like negation operator)
    */
   prepareQuery = query => query.replace(SEARCH_SPECIAL_CHARS_REGEXP, '');
 
+  getTagList() {
+    const {organization, tags} = this.props;
+    const fields = organization.features.includes('transaction-events')
+      ? FIELD_TAGS
+      : omit(FIELD_TAGS, TRACING_FIELDS);
+    const combined = assign({}, tags, fields);
+    combined.has = {
+      key: 'has',
+      name: 'Has property',
+      values: Object.keys(combined),
+      predefined: true,
+    };
+
+    return combined;
+  }
+
   render() {
+    const tags = this.getTagList();
     return (
       <ClassNames>
         {({css}) => (
@@ -88,7 +103,7 @@ class SearchBar extends React.PureComponent {
             hasRecentSearches
             savedSearchType={SEARCH_TYPES.EVENT}
             onGetTagValues={this.getEventFieldValues}
-            supportedTags={this.props.tags}
+            supportedTags={tags}
             prepareQuery={this.prepareQuery}
             excludeEnvironment
             dropdownClassName={css`

--- a/src/sentry/static/sentry/app/views/events/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.jsx
@@ -81,14 +81,13 @@ class SearchBar extends React.PureComponent {
     const fields = organization.features.includes('transaction-events')
       ? FIELD_TAGS
       : omit(FIELD_TAGS, TRACING_FIELDS);
-    const combined = assign({}, tags, fields, {
-      has: {
-        key: 'has',
-        name: 'Has property',
-        values: Object.keys(combined),
-        predefined: true,
-      },
-    });
+    const combined = assign({}, tags, fields);
+    combined.has = {
+      key: 'has',
+      name: 'Has property',
+      values: Object.keys(combined),
+      predefined: true,
+    };
 
     return combined;
   }

--- a/src/sentry/static/sentry/app/views/events/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.jsx
@@ -21,10 +21,9 @@ const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   'g'
 );
 
-const FIELD_TAGS = Object.keys(FIELDS).reduce((acc, item) => {
-  acc[item] = {key: item, name: item};
-  return acc;
-}, {});
+const FIELD_TAGS = Object.fromEntries(
+Object.keys(FIELDS).map(item => [item, {key: item, name: item}])
+);
 
 class SearchBar extends React.PureComponent {
   static propTypes = {
@@ -82,13 +81,13 @@ class SearchBar extends React.PureComponent {
     const fields = organization.features.includes('transaction-events')
       ? FIELD_TAGS
       : omit(FIELD_TAGS, TRACING_FIELDS);
-    const combined = assign({}, tags, fields);
-    combined.has = {
+    const combined = assign({}, tags, fields, {
+    has: {
       key: 'has',
       name: 'Has property',
       values: Object.keys(combined),
       predefined: true,
-    };
+    }});
 
     return combined;
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -153,9 +153,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
   }
 }
 
-export default withApi(
-  withTags(Table, {includeEventAttributes: false, includeIssueAttributes: false})
-);
+export default withApi(withTags(Table));
 
 const Container = styled('div')`
   min-width: 0;

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -38,7 +38,7 @@ import withProfiler from 'app/utils/withProfiler';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import withSavedSearches from 'app/utils/withSavedSearches';
-import withTags from 'app/utils/withTags';
+import withIssueTags from 'app/utils/withIssueTags';
 
 import IssueListActions from './actions';
 import IssueListFilters from './filters';
@@ -656,13 +656,6 @@ const IssueListOverview = createReactClass({
 });
 
 export default withGlobalSelection(
-  withSavedSearches(
-    withOrganization(
-      withTags(withProfiler(IssueListOverview), {
-        includeIssueAttributes: true,
-        includeEventAttributes: true,
-      })
-    )
-  )
+  withSavedSearches(withOrganization(withIssueTags(withProfiler(IssueListOverview))))
 );
 export {IssueListOverview};

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -43,6 +43,10 @@ describe('SmartSearchBar', function() {
     TagStore.onLoadTagsSuccess(TestStubs.Tags());
     tagValuesMock.mockClear();
     supportedTags = TagStore.getAllTags();
+    supportedTags.firstRelease = {
+      key: 'firstRelease',
+      name: 'firstRelease',
+    };
     organization = TestStubs.Organization({id: '123'});
 
     const location = {

--- a/tests/js/spec/utils/withIssueTags.spec.jsx
+++ b/tests/js/spec/utils/withIssueTags.spec.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import {mount} from 'sentry-test/enzyme';
+import TagStore from 'app/stores/tagStore';
+import MemberListStore from 'app/stores/memberListStore';
+import withIssueTags from 'app/utils/withIssueTags';
+
+describe('withIssueTags HoC', function() {
+  beforeEach(() => {
+    TagStore.reset();
+    MemberListStore.loadInitialData([]);
+  });
+
+  it('fowards loaded tags to the wrapped component', async function() {
+    const MyComponent = () => null;
+    const Container = withIssueTags(MyComponent);
+    const wrapper = mount(<Container other="value" />);
+
+    // Should forward props.
+    expect(wrapper.find('MyComponent').prop('other')).toEqual('value');
+
+    TagStore.onLoadTagsSuccess([{name: 'Mechanism', key: 'mechanism', count: 1}]);
+    await wrapper.update();
+
+    // Should forward prop
+    expect(wrapper.find('MyComponent').prop('other')).toEqual('value');
+
+    const tagsProp = wrapper.find('MyComponent').prop('tags');
+    // includes custom tags
+    expect(tagsProp.mechanism).toBeTruthy();
+
+    // should include special issue and attributes.
+    expect(tagsProp.is).toBeTruthy();
+    expect(tagsProp.bookmarks).toBeTruthy();
+    expect(tagsProp.assigned).toBeTruthy();
+    expect(tagsProp['stack.filename']).toBeTruthy();
+  });
+
+  it('updates the assigned and bookmark tags with users', async function() {
+    const MyComponent = () => null;
+    const Container = withIssueTags(MyComponent);
+    const wrapper = mount(<Container other="value" />);
+
+    // Should forward props.
+    expect(wrapper.find('MyComponent').prop('other')).toEqual('value');
+
+    TagStore.onLoadTagsSuccess([{name: 'Mechanism', key: 'mechanism', count: 1}]);
+    await wrapper.update();
+
+    let tagsProp = wrapper.find('MyComponent').prop('tags');
+    expect(tagsProp.assigned).toBeTruthy();
+    expect(tagsProp.assigned.values).toEqual(['me']);
+
+    const users = [TestStubs.User(), TestStubs.User({username: 'joe@example.com'})];
+    MemberListStore.loadInitialData(users);
+    await wrapper.update();
+
+    tagsProp = wrapper.find('MyComponent').prop('tags');
+    expect(tagsProp.assigned.values).toEqual([
+      'me',
+      'foo@example.com',
+      'joe@example.com',
+    ]);
+    expect(tagsProp.bookmarks.values).toEqual([
+      'me',
+      'foo@example.com',
+      'joe@example.com',
+    ]);
+  });
+});

--- a/tests/js/spec/utils/withTags.spec.jsx
+++ b/tests/js/spec/utils/withTags.spec.jsx
@@ -29,22 +29,4 @@ describe('withTags HoC', function() {
     // excludes issue tags by default
     expect(tagsProp.is).toBeUndefined();
   });
-
-  it('can include issue attributes', async function() {
-    const MyComponent = () => null;
-    const Container = withTags(MyComponent, {includeIssueAttributes: true});
-    const wrapper = mount(<Container other="value" />);
-
-    TagStore.onLoadTagsSuccess([{name: 'Mechanism', key: 'mechanism', count: 1}]);
-    await wrapper.update();
-
-    // Should forward props.
-    expect(wrapper.find('MyComponent').prop('other')).toEqual('value');
-
-    const tagsProp = wrapper.find('MyComponent').prop('tags');
-    // includes custom tags
-    expect(tagsProp.mechanism).toBeTruthy();
-    // includes issue tags
-    expect(tagsProp.is).toBeTruthy();
-  });
 });

--- a/tests/js/spec/views/issueList/searchBar.spec.jsx
+++ b/tests/js/spec/views/issueList/searchBar.spec.jsx
@@ -20,6 +20,13 @@ describe('IssueListSearchBar', function() {
     TagStore.reset();
     TagStore.onLoadTagsSuccess(TestStubs.Tags());
     supportedTags = TagStore.getAllTags();
+    // Add a tag that is preseeded with values.
+    supportedTags.is = {
+      key: 'is',
+      name: 'is',
+      values: ['assigned', 'unresolved', 'ignored'],
+      predefined: true,
+    };
 
     tagValuePromise = Promise.resolve([]);
 


### PR DESCRIPTION
Remove the options that let consumers choose which tag lists they want in favor of having two different HOCs that do what is needed. This allows discover2 to have transaction attributes show up in the key autocomplete, and issue search to have issue-only properties show up. This also streamlines the TagStore to only actively store tags alone.