### PR TITLE
fix(discover) Update chart palette

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/utils.tsx
+++ b/src/sentry/static/sentry/app/components/charts/utils.tsx
@@ -11,10 +11,6 @@ const DEFAULT_TRUNCATE_LENGTH = 80;
 const TWENTY_FOUR_HOURS = 1440;
 const ONE_HOUR = 60;
 
-export const AREA_COLORS = ['#FFE3FD', '#E8B0F2', '#BD81E6', '#5246A3', '#422C6F'];
-
-export const AREA_SINGLE_COLOR = AREA_COLORS[3];
-
 export type DateTimeObject = Partial<GlobalSelection['datetime']>;
 
 export function truncationFormatter(value: string, truncate: number): string {

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -82,7 +82,7 @@ class EventsAreaChart extends React.Component {
       data: [currentSeriesName ?? t('Current'), previousSeriesName ?? t('Previous'), ''],
     };
 
-    const colors = theme.charts.getColorPalette(timeseriesData.length);
+    const colors = theme.charts.getColorPalette(timeseriesData.length - 2);
 
     return (
       <AreaChart

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import isEqual from 'lodash/isEqual';
 
 import {t} from 'app/locale';
-import {getInterval, AREA_SINGLE_COLOR, AREA_COLORS} from 'app/components/charts/utils';
+import {getInterval} from 'app/components/charts/utils';
 import ChartZoom from 'app/components/charts/chartZoom';
 import AreaChart from 'app/components/charts/areaChart';
 import TransitionChart from 'app/components/charts/transitionChart';
@@ -82,10 +82,7 @@ class EventsAreaChart extends React.Component {
       data: [currentSeriesName ?? t('Current'), previousSeriesName ?? t('Previous'), ''],
     };
 
-    const colors =
-      timeseriesData.length === 1
-        ? [AREA_SINGLE_COLOR]
-        : AREA_COLORS.slice(0, timeseriesData.length);
+    const colors = theme.charts.getColorPalette(timeseriesData.length);
 
     return (
       <AreaChart

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -8,7 +8,7 @@ import {Client} from 'app/api';
 import {Organization} from 'app/types';
 import EventsRequest from 'app/views/events/utils/eventsRequest';
 import AreaChart from 'app/components/charts/areaChart';
-import {AREA_SINGLE_COLOR, getInterval} from 'app/components/charts/utils';
+import {getInterval} from 'app/components/charts/utils';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingContainer from 'app/components/loading/loadingContainer';
@@ -69,6 +69,7 @@ class MiniGraph extends React.Component<Props> {
       environment,
       yAxis,
     } = this.getRefreshProps(this.props);
+    const colors = theme.charts.getColorPalette(1);
 
     return (
       <EventsRequest
@@ -103,7 +104,7 @@ class MiniGraph extends React.Component<Props> {
           const data = (timeseriesData || []).map(series => ({
             ...series,
             areaStyle: {
-              color: AREA_SINGLE_COLOR,
+              color: colors[0],
               opacity: 0.5,
             },
             lineStyle: {

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -3,8 +3,8 @@ import * as ReactRouter from 'react-router';
 
 import {Series} from 'app/types/echarts';
 import AreaChart from 'app/components/charts/areaChart';
-import {AREA_SINGLE_COLOR} from 'app/components/charts/utils';
 import ChartZoom from 'app/components/charts/chartZoom';
+import theme from 'app/utils/theme';
 
 type Props = {
   data: Series[];
@@ -23,6 +23,7 @@ class Chart extends React.Component<Props> {
     if (!data || data.length <= 0) {
       return null;
     }
+    const colors = theme.charts.getColorPalette(1);
 
     const areaChartProps = {
       seriesOptions: {
@@ -60,7 +61,7 @@ class Chart extends React.Component<Props> {
       utc,
       isGroupedByDate: true,
       showTimeInTooltip: true,
-      colors: [AREA_SINGLE_COLOR, AREA_SINGLE_COLOR],
+      colors: [colors[0], colors[0]],
     };
 
     if (loading) {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -135,7 +135,7 @@ class DurationChart extends React.Component<Props> {
                   );
                 }
                 const colors =
-                  (results && theme.charts.getColorPalette(results.length)) || [];
+                  (results && theme.charts.getColorPalette(results.length - 2)) || [];
 
                 // Create a list of series based on the order of the fields,
                 // We need to flip it at the end to ensure the series stack right.

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -11,7 +11,7 @@ import ErrorPanel from 'app/components/charts/components/errorPanel';
 import TransparentLoadingMask from 'app/components/charts/components/transparentLoadingMask';
 import TransitionChart from 'app/components/charts/transitionChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
-import {AREA_COLORS, getInterval} from 'app/components/charts/utils';
+import {getInterval} from 'app/components/charts/utils';
 import {IconWarning} from 'app/icons';
 import EventsRequest from 'app/views/events/utils/eventsRequest';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
@@ -134,6 +134,9 @@ class DurationChart extends React.Component<Props> {
                     </ErrorPanel>
                   );
                 }
+                const colors =
+                  (results && theme.charts.getColorPalette(results.length)) || [];
+
                 // Create a list of series based on the order of the fields,
                 // We need to flip it at the end to ensure the series stack right.
                 const series = results
@@ -141,12 +144,12 @@ class DurationChart extends React.Component<Props> {
                       .map((values, i: number) => {
                         return {
                           ...values,
-                          color: AREA_COLORS[i],
+                          color: colors[i],
                           lineStyle: {
                             opacity: 0,
                           },
                           areaStyle: {
-                            color: AREA_COLORS[i],
+                            color: colors[i],
                             opacity: 1.0,
                           },
                         };

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -8,7 +8,6 @@ import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import BarChart from 'app/components/charts/barChart';
 import ErrorPanel from 'app/components/charts/components/errorPanel';
-import {AREA_COLORS} from 'app/components/charts/utils';
 import AsyncComponent from 'app/components/asyncComponent';
 import Tooltip from 'app/components/tooltip';
 import {OrganizationSummary} from 'app/types';
@@ -188,6 +187,7 @@ class LatencyChart extends AsyncComponent<Props, State> {
         alignWithLabel: true,
       },
     };
+    const colors = theme.charts.getColorPalette(1);
 
     // Use a custom tooltip formatter as we need to replace
     // the tooltip content entirely when zooming is no longer available.
@@ -227,7 +227,7 @@ class LatencyChart extends AsyncComponent<Props, State> {
         yAxis={{type: 'value'}}
         series={transformData(chartData.data, this.bucketWidth)}
         tooltip={tooltip}
-        colors={[AREA_COLORS[2]]}
+        colors={colors}
         onClick={this.handleClick}
         onMouseOver={this.handleMouseOver}
       />


### PR DESCRIPTION
Use the same palette for discover + performance as we're using on releases v2.

## discover top5
![Screen Shot 2020-04-30 at 3 12 58 PM](https://user-images.githubusercontent.com/24086/80750199-a9e1f580-8af5-11ea-8622-e833823f6b13.png)

## discover results
![Screen Shot 2020-04-30 at 3 12 39 PM](https://user-images.githubusercontent.com/24086/80750219-b0706d00-8af5-11ea-9f2a-8d0687e2bab6.png)

## performance duration charts
![Screen Shot 2020-04-30 at 3 12 09 PM](https://user-images.githubusercontent.com/24086/80750234-b5cdb780-8af5-11ea-937c-29ce0e49bd06.png)

## performance latency distribution
![Screen Shot 2020-04-30 at 3 16 44 PM](https://user-images.githubusercontent.com/24086/80750245-bb2b0200-8af5-11ea-92c1-d0e1fcab9a23.png)

## discover query cards
![Screen Shot 2020-04-30 at 3 12 31 PM](https://user-images.githubusercontent.com/24086/80750269-c4b46a00-8af5-11ea-904b-3de998823d1e.png)

