### PR TITLE
fix(perf-views) Fix reflow wobble on performance table

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -225,7 +225,7 @@ class Table extends React.Component<Props> {
               placeholder={t('Filter Transactions')}
               onSearch={this.handleTransactionSearchQuery}
             />
-            <PanelTable
+            <StyledPanelTable
               headers={this.renderHeader(tableData)}
               isLoading={isLoading}
               isEmpty={!tableData || tableData.data.length === 0}
@@ -233,7 +233,7 @@ class Table extends React.Component<Props> {
               disablePadding
             >
               {this.renderResults(isLoading, tableData)}
-            </PanelTable>
+            </StyledPanelTable>
             <Pagination pageLinks={pageLinks} />
           </div>
         )}
@@ -246,6 +246,10 @@ const StyledSearchBar = styled(SearchBar)`
   flex-grow: 1;
 
   margin-bottom: ${space(1)};
+`;
+
+const StyledPanelTable = styled(PanelTable)`
+  grid-template-columns: minmax(300px, auto) repeat(7, minmax(80px, 150px));
 `;
 
 export default withProjects(Table);


### PR DESCRIPTION
Set a grid-template-column layout that better matches the desired layout. This reduces layout wobbling when the table is resorted. There is still a small amount of wobble because of scrollbars being added/removed.