### PR TITLE
fix(ui) Handle cancelled errors and 500s better

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -3,6 +3,7 @@ import {Location} from 'history';
 import styled from '@emotion/styled';
 
 import {Client} from 'app/api';
+import {t} from 'app/locale';
 import {Organization, Tag} from 'app/types';
 import {metric} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
@@ -121,14 +122,15 @@ class Table extends React.PureComponent<TableProps, TableState> {
             status: err.status,
           },
         });
+        const message = err?.responseJSON?.detail || t('An unknown error occurred.');
         this.setState({
           isLoading: false,
           tableFetchID: undefined,
-          error: err.responseJSON.detail,
+          error: message,
           pageLinks: null,
           tableData: null,
         });
-        setError(err.responseJSON.detail);
+        setError(message);
       });
   };
 


### PR DESCRIPTION
Don't fail to generate an error message when handling a cancelled request or a 500 from the server.

Fixes JAVASCRIPT-20W9