### PR TITLE
feat(discover) add tracing spans to the discover backend code

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import sentry_sdk
 import six
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ParseError
@@ -88,19 +89,20 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
 class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
     def handle_results_with_meta(self, request, organization, project_ids, results):
-        data = self.handle_data(request, organization, project_ids, results.get("data"))
-        if not data:
-            return {"data": [], "meta": {}}
+        with sentry_sdk.start_span(op="discover.endpoint", description="base.handle_results"):
+            data = self.handle_data(request, organization, project_ids, results.get("data"))
+            if not data:
+                return {"data": [], "meta": {}}
 
-        meta = {
-            value["name"]: get_json_meta_type(value["name"], value["type"])
-            for value in results["meta"]
-        }
-        # Ensure all columns in the result have types.
-        for key in data[0]:
-            if key not in meta:
-                meta[key] = "string"
-        return {"meta": meta, "data": data}
+            meta = {
+                value["name"]: get_json_meta_type(value["name"], value["type"])
+                for value in results["meta"]
+            }
+            # Ensure all columns in the result have types.
+            for key in data[0]:
+                if key not in meta:
+                    meta[key] = "string"
+            return {"meta": meta, "data": data}
 
     def handle_data(self, request, organization, project_ids, results):
         if not results:
@@ -135,55 +137,60 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
 
     def get_event_stats_data(self, request, organization, get_event_stats, top_events=False):
         try:
-            columns = request.GET.getlist("yAxis", ["count()"])
-            query = request.GET.get("query")
-            params = self.get_filter_params(request, organization)
-            rollup = get_rollup_from_request(
-                request,
-                params,
-                "1h",
-                InvalidSearchQuery(
-                    "Your interval and date range would create too many results. "
-                    "Use a larger interval, or a smaller date range."
-                ),
-            )
-            # Backwards compatibility for incidents which uses the old
-            # column aliases as it straddles both versions of events/discover.
-            # We will need these aliases until discover2 flags are enabled for all
-            # users.
-            column_map = {
-                "user_count": "count_unique(user)",
-                "event_count": "count()",
-                "rpm()": "rpm(%d)" % rollup,
-                "rps()": "rps(%d)" % rollup,
-            }
-            query_columns = [column_map.get(column, column) for column in columns]
-            reference_event = self.reference_event(
-                request, organization, params.get("start"), params.get("end")
-            )
+            with sentry_sdk.start_span(
+                op="discover.endpoint", description="base.stats_query_creation"
+            ):
+                columns = request.GET.getlist("yAxis", ["count()"])
+                query = request.GET.get("query")
+                params = self.get_filter_params(request, organization)
+                rollup = get_rollup_from_request(
+                    request,
+                    params,
+                    "1h",
+                    InvalidSearchQuery(
+                        "Your interval and date range would create too many results. "
+                        "Use a larger interval, or a smaller date range."
+                    ),
+                )
+                # Backwards compatibility for incidents which uses the old
+                # column aliases as it straddles both versions of events/discover.
+                # We will need these aliases until discover2 flags are enabled for all
+                # users.
+                column_map = {
+                    "user_count": "count_unique(user)",
+                    "event_count": "count()",
+                    "rpm()": "rpm(%d)" % rollup,
+                    "rps()": "rps(%d)" % rollup,
+                }
+                query_columns = [column_map.get(column, column) for column in columns]
+                reference_event = self.reference_event(
+                    request, organization, params.get("start"), params.get("end")
+                )
 
-            result = get_event_stats(query_columns, query, params, rollup, reference_event)
+            with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_query"):
+                result = get_event_stats(query_columns, query, params, rollup, reference_event)
         except (discover.InvalidSearchQuery, snuba.QueryOutsideRetentionError) as error:
             raise ParseError(detail=six.text_type(error))
         serializer = SnubaTSResultSerializer(organization, None, request.user)
 
-        if top_events:
-            results = {}
-            for key, event_result in six.iteritems(result):
-                if len(query_columns) > 1:
-                    results[key] = self.serialize_multiple_axis(
-                        serializer, event_result, columns, query_columns
-                    )
-                else:
-                    # Need to get function alias if count is a field, but not the axis
-                    results[key] = serializer.serialize(
-                        event_result, get_function_alias(query_columns[0])
-                    )
-            return results
-        elif len(query_columns) > 1:
-            return self.serialize_multiple_axis(serializer, result, columns, query_columns)
-        else:
-            return serializer.serialize(result)
+        with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_serialization"):
+            if top_events:
+                results = {}
+                for key, event_result in six.iteritems(result):
+                    if len(query_columns) > 1:
+                        results[key] = self.serialize_multiple_axis(
+                            serializer, event_result, columns, query_columns
+                        )
+                    else:
+                        # Need to get function alias if count is a field, but not the axis
+                        results[key] = serializer.serialize(
+                            event_result, get_function_alias(query_columns[0])
+                        )
+                return results
+            elif len(query_columns) > 1:
+                return self.serialize_multiple_axis(serializer, result, columns, query_columns)
+            else:
+                return serializer.serialize(result)
 
     def serialize_multiple_axis(self, serializer, event_result, columns, query_columns):
         # Return with requested yAxis as the key

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -119,18 +119,20 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
         if not features.has("organizations:discover-basic", organization, actor=request.user):
             return Response(status=404)
 
-        try:
-            params = self.get_filter_params(request, organization)
-        except NoProjects:
-            return Response([])
+        with sentry_sdk.start_span(op="discover.endpoint", description="filter_params") as span:
+            span.set_tag("organization", organization)
+            try:
+                params = self.get_filter_params(request, organization)
+            except NoProjects:
+                return Response([])
 
-        params["organization_id"] = organization.id
+            params["organization_id"] = organization.id
 
-        has_global_views = features.has(
-            "organizations:global-views", organization, actor=request.user
-        )
-        if not has_global_views and len(params.get("project_id", [])) > 1:
-            raise ParseError(detail="You cannot view events from multiple projects.")
+            has_global_views = features.has(
+                "organizations:global-views", organization, actor=request.user
+            )
+            if not has_global_views and len(params.get("project_id", [])) > 1:
+                raise ParseError(detail="You cannot view events from multiple projects.")
 
         def data_fn(offset, limit):
             return discover.query(

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import re
+import sentry_sdk
 import six
 
 from rest_framework.response import Response
@@ -19,10 +20,12 @@ from sentry.utils import snuba
 
 class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
-        try:
-            params = self.get_filter_params(request, organization)
-        except NoProjects:
-            return Response({"count": 0})
+        with sentry_sdk.start_span(op="discover.endpoint", description="filter_params") as span:
+            span.set_data("organization", organization)
+            try:
+                params = self.get_filter_params(request, organization)
+            except NoProjects:
+                return Response({"count": 0})
 
         try:
             result = discover.query(
@@ -42,50 +45,59 @@ UNESCAPED_QUOTE_RE = re.compile('(?<!\\\\)"')
 
 class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, EnvironmentMixin):
     def get(self, request, organization):
-        try:
-            params = self.get_filter_params(request, organization)
-        except NoProjects:
-            return Response([])
-
-        possible_keys = ["transaction"]
-        lookup_keys = {key: request.query_params.get(key) for key in possible_keys}
-
-        if not any(lookup_keys.values()):
-            return Response(
-                {
-                    "detail": "Must provide one of {} in order to find related events".format(
-                        possible_keys
-                    )
-                },
-                status=400,
-            )
-
-        try:
-            projects = self.get_projects(request, organization)
-            query_kwargs = build_query_params_from_request(
-                request, organization, projects, params.get("environment")
-            )
-            query_kwargs["limit"] = 5
+        with sentry_sdk.start_span(op="discover.endpoint", description="filter_params") as span:
+            span.set_data("organization", organization)
             try:
-                # Need to escape quotes in case some "joker" has a transaction with quotes
-                transaction_name = UNESCAPED_QUOTE_RE.sub('\\"', lookup_keys["transaction"])
-                parsed_terms = parse_search_query('transaction:"{}"'.format(transaction_name))
-            except ParseError:
-                return Response({"detail": "Invalid transaction search"}, status=400)
+                params = self.get_filter_params(request, organization)
+            except NoProjects:
+                return Response([])
 
-            if query_kwargs.get("search_filters"):
-                query_kwargs["search_filters"].extend(parsed_terms)
-            else:
-                query_kwargs["search_filters"] = parsed_terms
+            possible_keys = ["transaction"]
+            lookup_keys = {key: request.query_params.get(key) for key in possible_keys}
 
-            results = search.query(**query_kwargs)
+            if not any(lookup_keys.values()):
+                return Response(
+                    {
+                        "detail": "Must provide one of {} in order to find related events".format(
+                            possible_keys
+                        )
+                    },
+                    status=400,
+                )
+
+        try:
+            with sentry_sdk.start_span(op="discover.endpoint", description="filter_creation"):
+                projects = self.get_projects(request, organization)
+                query_kwargs = build_query_params_from_request(
+                    request, organization, projects, params.get("environment")
+                )
+                query_kwargs["limit"] = 5
+                try:
+                    # Need to escape quotes in case some "joker" has a transaction with quotes
+                    transaction_name = UNESCAPED_QUOTE_RE.sub('\\"', lookup_keys["transaction"])
+                    parsed_terms = parse_search_query('transaction:"{}"'.format(transaction_name))
+                except ParseError:
+                    return Response({"detail": "Invalid transaction search"}, status=400)
+
+                if query_kwargs.get("search_filters"):
+                    query_kwargs["search_filters"].extend(parsed_terms)
+                else:
+                    query_kwargs["search_filters"] = parsed_terms
+
+            with sentry_sdk.start_span(op="discover.endpoint", description="issue_search"):
+                results = search.query(**query_kwargs)
         except discover.InvalidSearchQuery as err:
             raise ParseError(detail=six.text_type(err))
 
-        context = serialize(
-            list(results),
-            request.user,
-            GroupSerializer(environment_func=self._get_environment_func(request, organization.id)),
-        )
+        with sentry_sdk.start_span(op="discover.endpoint", description="serialize_results") as span:
+            results = list(results)
+            span.set_data("result_length", len(results))
+            context = serialize(
+                results,
+                request.user,
+                GroupSerializer(
+                    environment_func=self._get_environment_func(request, organization.id)
+                ),
+            )
 
         return Response(context)


### PR DESCRIPTION
Add some more spans to the backend code to breakup the traces into digestible
chunks.
![Screen Shot 2020-04-30 at 4 27 55 PM](https://user-images.githubusercontent.com/2727124/80756629-e535f180-8b00-11ea-897e-e3a44133a456.png)
![Screen Shot 2020-04-30 at 4 28 34 PM](https://user-images.githubusercontent.com/2727124/80756644-ea933c00-8b00-11ea-90da-2b276bee9a59.png)
![Screen Shot 2020-04-30 at 4 28 39 PM](https://user-images.githubusercontent.com/2727124/80756651-ecf59600-8b00-11ea-89a6-1b4da0867bb5.png)
![Screen Shot 2020-04-30 at 4 29 12 PM](https://user-images.githubusercontent.com/2727124/80756659-eff08680-8b00-11ea-90b7-73ae0ecb4eab.png)



