### PR TITLE
refs(alerts): Change internal metric alerts code to handle only a single environment.

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_incident_index.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_index.py
@@ -51,7 +51,7 @@ class IncidentListEndpointTest(APITestCase):
     def test_filter_env(self):
         self.create_team(organization=self.organization, members=[self.user])
         env = self.create_environment(self.project)
-        rule = self.create_alert_rule(projects=[self.project], environment=[env])
+        rule = self.create_alert_rule(projects=[self.project], environment=env)
 
         incident = self.create_incident(alert_rule=rule)
         self.create_incident()
@@ -59,9 +59,7 @@ class IncidentListEndpointTest(APITestCase):
         self.login_as(self.user)
 
         with self.feature("organizations:incidents"):
-            resp_filter_env = self.get_valid_response(
-                self.organization.slug, environment=[env.name]
-            )
+            resp_filter_env = self.get_valid_response(self.organization.slug, environment=env.name)
             resp_no_env_filter = self.get_valid_response(self.organization.slug)
 
         # The alert without an environment assigned should not be selected

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -88,6 +88,10 @@ class AlertRuleDetailsBase(object):
             resp = self.get_valid_response(self.organization.slug)
             assert len(resp.data) >= 1
             serialized_alert_rule = resp.data[0]
+            if serialized_alert_rule["environment"]:
+                serialized_alert_rule["environment"] = serialized_alert_rule["environment"][0]
+            else:
+                serialized_alert_rule.pop("environment", None)
         self.endpoint = original_endpoint
         self.method = original_method
         return serialized_alert_rule

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -94,67 +94,9 @@ class TestAlertRuleSerializer(TestCase):
             "triggers": field_is_required,
         }
 
-    def test_environment(self):
-        base_params = self.valid_params.copy()
-        env_1 = Environment.objects.create(organization_id=self.organization.id, name="test_env_1")
-        env_2 = Environment.objects.create(organization_id=self.organization.id, name="test_env_2")
-
-        base_params.update({"environment": [env_1.name]})
-        serializer = AlertRuleSerializer(context=self.context, data=base_params)
-        assert serializer.is_valid(), serializer.errors
-        alert_rule = serializer.save()
-
-        # Make sure AlertRuleEnvironment entry was made:
-        alert_rule_env = AlertRuleEnvironment.objects.get(
-            environment=env_1.id, alert_rule=alert_rule
-        )
-        assert alert_rule_env
-
-        base_params.update({"id": alert_rule.id})
-        base_params.update({"environment": [env_1.name, env_2.name]})
-        serializer = AlertRuleSerializer(
-            context=self.context, instance=alert_rule, data=base_params
-        )
-        assert serializer.is_valid()
-        alert_rule = serializer.save()
-
-        assert len(AlertRuleEnvironment.objects.filter(alert_rule=alert_rule)) == 2
-        assert len(list(alert_rule.environment.all())) == 2
-
-        base_params.update({"environment": [env_2.name]})
-        serializer = AlertRuleSerializer(
-            context=self.context, instance=alert_rule, data=base_params
-        )
-        assert serializer.is_valid()
-        serializer.save()
-
-        # Make sure env_1 AlertRuleEnvironment was deleted:
-        try:
-            alert_rule_env = AlertRuleEnvironment.objects.get(
-                environment=env_1.id, alert_rule=alert_rule
-            )
-            assert False
-        except AlertRuleEnvironment.DoesNotExist:
-            assert True
-        # And that env_2 is still present:
-        assert len(AlertRuleEnvironment.objects.filter(alert_rule=alert_rule)) == 1
-        assert (
-            len(AlertRuleEnvironment.objects.filter(environment=env_2.id, alert_rule=alert_rule))
-            == 1
-        )
-
-        base_params.update({"environment": []})
-        serializer = AlertRuleSerializer(
-            context=self.context, instance=alert_rule, data=base_params
-        )
-        assert serializer.is_valid()
-        serializer.save()
-        assert len(AlertRuleEnvironment.objects.filter(alert_rule=alert_rule)) == 0
-
     def test_environment_non_list(self):
         base_params = self.valid_params.copy()
         env_1 = Environment.objects.create(organization_id=self.organization.id, name="test_env_1")
-        Environment.objects.create(organization_id=self.organization.id, name="test_env_2")
 
         base_params.update({"environment": env_1.name})
         serializer = AlertRuleSerializer(context=self.context, data=base_params)

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -130,12 +130,12 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             self.create_environment(project=self.project, name="prod"),
             self.create_environment(project=self.project, name="dev"),
         ]
-        alert_rule = self.create_alert_rule(environment=environments)
+        alert_rule = self.create_alert_rule(environment=environments[0])
         alert_rule_trigger = self.create_alert_rule_trigger(alert_rule=alert_rule)
         action = self.create_alert_rule_trigger_action(alert_rule_trigger=alert_rule_trigger)
         incident = self.create_incident()
         handler = EmailActionHandler(action, incident, self.project)
-        assert "dev, prod" == handler.generate_email_context(status).get("environment")
+        assert "prod" == handler.generate_email_context(status).get("environment")
 
 
 @freeze_time()

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -21,7 +21,7 @@ class CreateSnubaSubscriptionTest(TestCase):
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
         subscription = create_snuba_subscription(
-            self.project, type, dataset, query, aggregation, time_window, resolution, []
+            self.project, type, dataset, query, aggregation, time_window, resolution, None
         )
         assert subscription.status == QuerySubscription.Status.CREATING.value
         assert subscription.project == self.project
@@ -42,7 +42,7 @@ class CreateSnubaSubscriptionTest(TestCase):
             time_window = timedelta(minutes=10)
             resolution = timedelta(minutes=1)
             subscription = create_snuba_subscription(
-                self.project, type, dataset, query, aggregation, time_window, resolution, []
+                self.project, type, dataset, query, aggregation, time_window, resolution, None
             )
             subscription = QuerySubscription.objects.get(id=subscription.id)
             assert subscription.status == QuerySubscription.Status.ACTIVE.value
@@ -63,7 +63,7 @@ class CreateSnubaSubscriptionTest(TestCase):
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
         subscription = create_snuba_subscription(
-            self.project, type, dataset, query, aggregation, time_window, resolution, []
+            self.project, type, dataset, query, aggregation, time_window, resolution, None
         )
         assert subscription.status == QuerySubscription.Status.CREATING.value
         assert subscription.project == self.project
@@ -87,7 +87,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
                 QueryAggregations.TOTAL,
                 timedelta(minutes=10),
                 timedelta(minutes=1),
-                [],
+                None,
             )
 
         query = "level:warning"
@@ -97,7 +97,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
         subscription = QuerySubscription.objects.get(id=subscription.id)
         subscription_id = subscription.subscription_id
         assert subscription_id is not None
-        update_snuba_subscription(subscription, query, aggregation, time_window, resolution, [])
+        update_snuba_subscription(subscription, query, aggregation, time_window, resolution, None)
         assert subscription.status == QuerySubscription.Status.UPDATING.value
         assert subscription.subscription_id == subscription_id
         assert subscription.query == query
@@ -115,7 +115,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
                 QueryAggregations.TOTAL,
                 timedelta(minutes=10),
                 timedelta(minutes=1),
-                [],
+                None,
             )
 
             query = "level:warning"
@@ -125,7 +125,9 @@ class UpdateSnubaSubscriptionTest(TestCase):
             subscription = QuerySubscription.objects.get(id=subscription.id)
             subscription_id = subscription.subscription_id
             assert subscription_id is not None
-            update_snuba_subscription(subscription, query, aggregation, time_window, resolution, [])
+            update_snuba_subscription(
+                subscription, query, aggregation, time_window, resolution, None
+            )
             subscription = QuerySubscription.objects.get(id=subscription.id)
             assert subscription.status == QuerySubscription.Status.ACTIVE.value
             assert subscription.subscription_id is not None
@@ -147,7 +149,7 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
                 QueryAggregations.TOTAL,
                 timedelta(minutes=10),
                 timedelta(minutes=1),
-                [],
+                None,
             )
             other_subscription = create_snuba_subscription(
                 self.create_project(organization=self.organization),
@@ -157,7 +159,7 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
                 QueryAggregations.TOTAL,
                 timedelta(minutes=10),
                 timedelta(minutes=1),
-                [],
+                None,
             )
         subscription_ids = [subscription.id, other_subscription.id]
         bulk_delete_snuba_subscriptions([subscription, other_subscription])
@@ -182,7 +184,7 @@ class DeleteSnubaSubscriptionTest(TestCase):
                 QueryAggregations.TOTAL,
                 timedelta(minutes=10),
                 timedelta(minutes=1),
-                [],
+                None,
             )
         # Refetch since snuba creation happens in a task
         subscription = QuerySubscription.objects.get(id=subscription.id)
@@ -202,7 +204,7 @@ class DeleteSnubaSubscriptionTest(TestCase):
                 QueryAggregations.TOTAL,
                 timedelta(minutes=10),
                 timedelta(minutes=1),
-                [],
+                None,
             )
             subscription_id = subscription.id
             delete_snuba_subscription(subscription)


### PR DESCRIPTION
This restricts us to selecting only a single environment for an alert rule. We should not merge this pr 
until we change the frontend UI to accept just a single environment.

Depends on https://github.com/getsentry/sentry/pull/18555