### PR TITLE
perf(project): Omit feature flags from "all projects" API view

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -5,6 +5,7 @@ import six
 from django.db.models import Q
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -107,7 +108,10 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         if get_all_projects:
             queryset = queryset.order_by("slug").select_related("organization")
-            return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
+            serializer = ProjectSummarySerializer(
+                include_features=not features.has("organizations:enterprise-perf", organization)
+            )
+            return Response(serialize(list(queryset), request.user, serializer))
         else:
 
             def serialize_on_result(result):

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -58,12 +58,13 @@ class ProjectSerializer(Serializer):
     such as "show all projects for this organization", and its attributes be kept to a minimum.
     """
 
-    def __init__(self, environment_id=None, stats_period=None):
+    def __init__(self, environment_id=None, stats_period=None, include_features=True):
         if stats_period is not None:
             assert stats_period in STATS_PERIOD_CHOICES
 
         self.environment_id = environment_id
         self.stats_period = stats_period
+        self.include_features = include_features
 
     def get_access_by_project(self, item_list, user):
         request = env.request
@@ -164,6 +165,9 @@ class ProjectSerializer(Serializer):
     def get_feature_list(self, obj, user):
         from sentry import features
         from sentry.features.base import ProjectFeature
+
+        if not self.include_features:
+            return None
 
         with sentry_sdk.start_span(
             op="project_feature_list", description=getattr(obj, "name")

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from django.db.models import Count
 
 
-from sentry import roles
+from sentry import roles, features
 from sentry.app import env
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.auth.superuser import is_active_superuser
@@ -132,6 +132,8 @@ class TeamSerializer(Serializer):
 
 class TeamWithProjectsSerializer(TeamSerializer):
     def get_attrs(self, item_list, user):
+        from sentry.api.serializers.models.project import ProjectSerializer
+
         project_teams = list(
             ProjectTeam.objects.filter(team__in=item_list, project__status=ProjectStatus.VISIBLE)
             .order_by("project__name", "project__slug")
@@ -145,9 +147,13 @@ class TeamWithProjectsSerializer(TeamSerializer):
             project_team.project._organization_cache = orgs[project_team.project.organization_id]
 
         projects = [pt.project for pt in project_teams]
-        projects_by_id = {
-            project.id: data for project, data in zip(projects, serialize(projects, user))
-        }
+        project_serializer = ProjectSerializer(
+            include_features=not all(
+                features.has("organizations:enterprise-perf", org) for org in orgs
+            )
+        )
+        serialized_projects = serialize(projects, user, project_serializer)
+        projects_by_id = {project.id: data for project, data in zip(projects, serialized_projects)}
 
         project_map = defaultdict(list)
         for project_team in project_teams:

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -12,6 +12,7 @@ from exam import fixture
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import (
     bulk_fetch_project_latest_releases,
+    ProjectSerializer,
     ProjectWithOrganizationSerializer,
     ProjectWithTeamSerializer,
     ProjectSummarySerializer,
@@ -39,6 +40,17 @@ class ProjectSerializerTest(TestCase):
         assert result["slug"] == project.slug
         assert result["name"] == project.name
         assert result["id"] == six.text_type(project.id)
+        assert "features" in result
+
+    def test_suppress_features(self):
+        user = self.create_user(username="foo")
+        organization = self.create_organization(owner=user)
+        team = self.create_team(organization=organization)
+        project = self.create_project(teams=[team], organization=organization, name="foo")
+
+        result = serialize(project, user, ProjectSerializer(include_features=False))
+
+        assert result["features"] is None
 
     def test_member_access(self):
         user = self.create_user(username="foo")
@@ -211,6 +223,12 @@ class ProjectSummarySerializerTest(TestCase):
         }
         assert result["latestRelease"] == {"version": self.release.version}
         assert result["environments"] == ["production", "staging"]
+
+    def test_suppress_features(self):
+        result = serialize(
+            self.project, self.user, ProjectSummarySerializer(include_features=False)
+        )
+        assert result["features"] is None
 
     def test_user_reports(self):
         result = serialize(self.project, self.user, ProjectSummarySerializer())


### PR DESCRIPTION
This is an experimental change meant to test (1) that it improves performance when there are many projects and (2) that it is a non-breaking change in practice.

**(Opening PR to check Travis run for failures of existing unit tests. Not ready for review yet.)**