### PR TITLE
fix(discover) Only fetch saved query data when it changes

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -41,7 +41,11 @@ class ResultsHeader extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (prevProps.eventView !== this.props.eventView) {
+    if (
+      prevProps.eventView &&
+      this.props.eventView &&
+      prevProps.eventView.id !== this.props.eventView.id
+    ) {
       this.fetchData();
     }
   }


### PR DESCRIPTION
Don't fetch saved queries each time the view changes. Instead only do it when the saved query id is updated.