### PR TITLE
fix(discover): Allow a user to load an empty discover view

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -8,7 +8,7 @@ from rest_framework.exceptions import ParseError
 
 from sentry import features
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
-from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases import OrganizationEndpoint, NoProjects
 from sentry.api.event_search import (
     get_filter,
     InvalidSearchQuery,
@@ -142,7 +142,10 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             ):
                 columns = request.GET.getlist("yAxis", ["count()"])
                 query = request.GET.get("query")
-                params = self.get_filter_params(request, organization)
+                try:
+                    params = self.get_filter_params(request, organization)
+                except NoProjects:
+                    return {"data": []}
                 rollup = get_rollup_from_request(
                     request,
                     params,

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -22,7 +22,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsEndpointBase):
             try:
                 params = self.get_filter_params(request, organization)
             except NoProjects:
-                raise ParseError(detail="A valid project must be included.")
+                return Response([])
             self._validate_project_ids(request, organization, params)
 
         with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -321,7 +321,7 @@ class GridEditable<
 
   renderDownloadButton(canEdit: boolean) {
     const {data} = this.props;
-    if (data.length < 50) {
+    if (data && data.length < 50) {
       return this.renderBrowserExportButton(canEdit);
     } else {
       return (

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -243,8 +243,8 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         )
         with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json")
-        assert response.status_code == 400, response.content
-        assert response.data == {"detail": "A valid project must be included."}
+        assert response.status_code == 200, response.content
+        assert response.data == []
 
     def test_multiple_projects_without_global_view(self):
         self.store_event(data={"event_id": uuid4().hex}, project_id=self.project.id)


### PR DESCRIPTION
- This returns the empty result for endopints instead of erroring out
  when a user has no projects and no projects are selected
- This way they can at least navigate into a discover query to select a
  project
- Fixes SENTRY-G7N