### PR TITLE
fix(ui): Fix broken completion of tag keys in SmartSearchBar

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -969,8 +969,12 @@ class SmartSearchBar extends React.Component<Props, State> {
     const lastChar = replaceText.charAt(replaceText.length - 1);
     replaceText += lastChar === ':' || lastChar === '.' ? '' : ' ';
 
+    const isNewTerm = query.charAt(query.length - 1) === ' ';
+
     if (!terms) {
       newQuery = replaceText;
+    } else if (isNewTerm) {
+      newQuery = `${query}${replaceText}`;
     } else {
       const last = terms.pop() ?? '';
 

--- a/src/sentry/static/sentry/app/components/smartSearchBar/searchDropdown.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/searchDropdown.jsx
@@ -127,8 +127,7 @@ const LoadingWrapper = styled('div')`
 
 const Info = styled('div')`
   display: flex;
-  justify-content: center;
-  padding: ${space(1)};
+  padding: ${space(1)} ${space(2)};
   font-size: ${p => p.theme.fontSizeLarge};
   color: ${p => p.theme.gray2};
 `;

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -552,7 +552,20 @@ describe('SmartSearchBar', function() {
     });
   });
 
-  describe('onTogglePinnedSearch', function() {
+  describe('onAutoComplete()', function() {
+    it('completes terms from the list', function() {
+      const props = {
+        query: 'event.type:error ',
+        organization,
+        supportedTags,
+      };
+      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
+      searchBar.onAutoComplete('myTag:', {type: 'tag'});
+      expect(searchBar.state.query).toEqual('event.type:error myTag:');
+    });
+  });
+
+  describe('onTogglePinnedSearch()', function() {
     let pinRequest, unpinRequest;
     beforeEach(function() {
       pinRequest = MockApiClient.addMockResponse({


### PR DESCRIPTION
Before this it wasn't possible to complete tag keys after compeleting
your first tag