### PR TITLE
feat(ecosystem): adds doc integrations and sentry apps as global search results

### DIFF
--- a/src/sentry/static/sentry/app/components/search/searchResult.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResult.jsx
@@ -138,7 +138,7 @@ class SearchResult extends React.Component {
     }
 
     if (isIntegration) {
-      return <StyledPluginIcon pluginId={model.key || model.id} />;
+      return <StyledPluginIcon pluginId={model.slug} />;
     }
 
     return null;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
@@ -64,10 +64,8 @@ export const POPULARITY_WEIGHT: {
   rocketchat: 8,
 } as const;
 
-export const documentIntegrations: {
-  [key: string]: DocumentIntegration;
-} = {
-  fullstory: {
+export const documentIntegrationList: DocumentIntegration[] = [
+  {
     slug: 'fullstory',
     name: 'FullStory',
     author: 'Sentry',
@@ -93,7 +91,7 @@ export const documentIntegrations: {
       },
     ],
   },
-  datadog: {
+  {
     slug: 'datadog',
     name: 'Datadog',
     author: 'Datadog',
@@ -116,7 +114,7 @@ export const documentIntegrations: {
       {title: 'Documentation', url: 'https://docs.datadoghq.com/integrations/sentry/'},
     ],
   },
-  msteams: {
+  {
     slug: 'msteams',
     name: 'Microsoft Teams',
     author: 'Microsoft',
@@ -143,7 +141,7 @@ export const documentIntegrations: {
       },
     ],
   },
-  asayer: {
+  {
     slug: 'asayer',
     name: 'Asayer',
     author: 'Sentry',
@@ -161,7 +159,7 @@ export const documentIntegrations: {
       {title: 'Documentation', url: 'https://docs.asayer.io/integrations/sentry'},
     ],
   },
-  rocketchat: {
+  {
     slug: 'rocketchat',
     name: 'Rocket.Chat',
     author: 'Rocket.Chat',
@@ -186,4 +184,11 @@ export const documentIntegrations: {
       },
     ],
   },
-};
+];
+
+export const documentIntegrations: {
+  [key: string]: DocumentIntegration;
+} = documentIntegrationList.reduce((accum, integration) => {
+  accum[integration.slug] = integration;
+  return accum;
+}, {});

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
@@ -188,7 +188,6 @@ export const documentIntegrationList: DocumentIntegration[] = [
 
 export const documentIntegrations: {
   [key: string]: DocumentIntegration;
-} = documentIntegrationList.reduce((accum, integration) => {
-  accum[integration.slug] = integration;
-  return accum;
-}, {});
+} = Object.fromEntries(
+  documentIntegrationList.map(integration => [integration.slug, integration])
+);

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -50,6 +50,10 @@ describe('Command Palette Modal', function() {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/sentry-apps/?status=published',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/internal/health/',
       body: {
         problems: [],

--- a/tests/js/spec/components/search/sources/apiSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/apiSource.spec.jsx
@@ -66,6 +66,10 @@ describe('ApiSource', function() {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/sentry-apps/?status=published',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/shortids/foo-t/',
       body: [],
     });

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -56,6 +56,10 @@ describe('SettingsSearch', function() {
       query: 'foo',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: '/sentry-apps/?status=published',
+      body: [],
+    });
   });
 
   it('renders', async function() {


### PR DESCRIPTION
This PR adds published sentry apps and document integrations to the global search results. Example with Datadaog:

![Screen Shot 2020-05-01 at 4 23 17 PM](https://user-images.githubusercontent.com/8533851/80848520-65735a00-8bc8-11ea-8be2-e0c39a498195.png)
