### PR TITLE
fix(ui): Issue list page and Issue detail page UI fixes

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.jsx
@@ -104,14 +104,15 @@ class EventOrGroupExtraDetails extends React.Component {
 }
 
 const GroupExtra = styled('div')`
-  display: grid;
-  grid-auto-flow: column;
+  display: inline-grid;
+  grid-auto-flow: column dense;
   grid-gap: ${space(2)};
   justify-content: start;
   align-items: center;
   color: ${p => p.theme.gray3};
   font-size: 12px;
   position: relative;
+  min-width: 500px;
 
   a {
     color: inherit;

--- a/src/sentry/static/sentry/app/components/group/times.tsx
+++ b/src/sentry/static/sentry/app/components/group/times.tsx
@@ -24,6 +24,8 @@ const Times = ({lastSeen, firstSeen}: Props) => (
     <div
       css={css`
         ${overflowEllipsis}
+        display: flex;
+        align-items: center;
       `}
     >
       {lastSeen && (

--- a/src/sentry/static/sentry/app/components/group/times.tsx
+++ b/src/sentry/static/sentry/app/components/group/times.tsx
@@ -1,4 +1,3 @@
-import {css} from '@emotion/core';
 import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
@@ -21,13 +20,7 @@ type Props = {
 
 const Times = ({lastSeen, firstSeen}: Props) => (
   <Container>
-    <div
-      css={css`
-        ${overflowEllipsis}
-        display: flex;
-        align-items: center;
-      `}
-    >
+    <FlexWrapper>
       {lastSeen && (
         <React.Fragment>
           <GroupTimeIcon src="icon-clock-sm" />
@@ -40,7 +33,7 @@ const Times = ({lastSeen, firstSeen}: Props) => (
       {firstSeen && (
         <TimeSince date={firstSeen} suffix={t('old')} className="hidden-xs hidden-sm" />
       )}
-    </div>
+    </FlexWrapper>
   </Container>
 );
 Times.propTypes = {
@@ -51,6 +44,14 @@ Times.propTypes = {
 const Container = styled('div')`
   flex-shrink: 1;
   min-width: 0; /* flex-hack for overflow-ellipsised children */
+`;
+
+const FlexWrapper = styled('div')`
+  ${overflowEllipsis}
+
+  /* The following aligns the icon with the text, fixes bug in Firefox */
+  display: flex;
+  align-items: center;
 `;
 
 const GroupTimeIcon = styled(InlineSvg)`

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
@@ -135,6 +135,7 @@ const GroupEventToolbar = createReactClass({
     const eventNavNodes = [
       this.renderRelatedTransactionButton(),
       <Button
+        size="small"
         key="oldest"
         to={{pathname: `${baseEventsPath}oldest/`, query: location.query}}
         disabled={!evt.previousEventID}
@@ -143,6 +144,7 @@ const GroupEventToolbar = createReactClass({
         <span className="icon-skip-back" />
       </Button>,
       <Button
+        size="small"
         key="prev"
         to={{
           pathname: `${baseEventsPath}${evt.previousEventID}/`,
@@ -153,6 +155,7 @@ const GroupEventToolbar = createReactClass({
         {t('Older')}
       </Button>,
       <Button
+        size="small"
         key="next"
         to={{pathname: `${baseEventsPath}${evt.nextEventID}/`, query: location.query}}
         disabled={!evt.nextEventID}
@@ -160,6 +163,7 @@ const GroupEventToolbar = createReactClass({
         {t('Newer')}
       </Button>,
       <Button
+        size="small"
         key="latest"
         to={{pathname: `${baseEventsPath}latest/`, query: location.query}}
         disabled={!evt.nextEventID}

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -1272,7 +1272,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                             >
                               <GroupExtra>
                                 <div
-                                  className="css-1s7tq6o-GroupExtra eec9orn0"
+                                  className="css-29ed03-GroupExtra eec9orn0"
                                 >
                                   <GroupShortId
                                     avatar={
@@ -1565,27 +1565,9 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                         <div
                                           className="css-1lz86t0-Container e1fmxtba0"
                                         >
-                                          <EmotionCssPropInternal
-                                            __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Times"
-                                            __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                            css={
-                                              Object {
-                                                "map": undefined,
-                                                "name": "1ggv3lw-Times",
-                                                "next": undefined,
-                                                "styles": "
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  width: 100%;
-;label:Times;",
-                                                "toString": [Function],
-                                              }
-                                            }
-                                          >
+                                          <FlexWrapper>
                                             <div
-                                              className="css-1ggv3lw-Times"
+                                              className="css-13zgepw-FlexWrapper e1fmxtba1"
                                             >
                                               <TimeSince
                                                 className="hidden-xs hidden-sm"
@@ -1601,7 +1583,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                                 </time>
                                               </TimeSince>
                                             </div>
-                                          </EmotionCssPropInternal>
+                                          </FlexWrapper>
                                         </div>
                                       </Container>
                                     </Times>


### PR DESCRIPTION
### Issue list page
- Fixed the alignment of clock icon + text in Firefox 
- Fixed compressed logo/project name in the bottom left of each issue

---

#### Before

<img width="852" alt="Screen Shot 2020-05-01 at 2 38 32 PM" src="https://user-images.githubusercontent.com/1900676/80983837-e8233180-8de1-11ea-88d3-56697f139559.png">

---

#### After

![Screen Shot 2020-05-04 at 9 03 13 AM](https://user-images.githubusercontent.com/1900676/80986938-23276400-8de6-11ea-86e5-8cbdc4068d55.png)

---

### Issue detail page
- Made next error/previous error buttons smaller so text is less scrunched up here:

---

#### Before

<img width="712" alt="Screen Shot 2020-05-01 at 2 40 28 PM" src="https://user-images.githubusercontent.com/1900676/80983853-ee191280-8de1-11ea-94b5-e8b1d49fffdd.png">

---

#### After
![Screen Shot 2020-05-04 at 9 04 06 AM](https://user-images.githubusercontent.com/1900676/80986999-3afee800-8de6-11ea-95ed-ac1d999ed146.png)
