### PR TITLE
feat(Commits): Remove APM logging and deduplicate results

### DIFF
--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -248,7 +248,7 @@ def get_serialized_event_file_committers(project, event, frame_limit=25):
         commit_ids = [commit.id for (commit, _) in committer["commits"]]
         commits_result = [serialized_commits_by_id[commit_id] for commit_id in commit_ids]
         # Deduplicate commits
-        committer["commits"] = dedupeCommits(commits_result)
+        committer["commits"] = dedupe_commits(commits_result)
 
     metrics.incr(
         "feature.owners.has-committers",
@@ -258,7 +258,7 @@ def get_serialized_event_file_committers(project, event, frame_limit=25):
     return committers
 
 
-def dedupeCommits(commits):
+def dedupe_commits(commits):
     result = {}
     for obj in commits:
         if obj["id"] not in result:

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -248,9 +248,12 @@ def get_serialized_event_file_committers(project, event, frame_limit=25):
         commit_ids = [commit.id for (commit, _) in committer["commits"]]
         commits_result = [serialized_commits_by_id[commit_id] for commit_id in commit_ids]
         # Deduplicate commits
-        committer["commits"] = [
-            i for n, i in enumerate(commits_result) if i not in commits_result[n + 1 :]
-        ]
+        seen = set()
+        committer["commits"] = []
+        for obj in commits_result:
+            if obj["id"] not in seen:
+                committer["commits"].append(obj)
+                seen.add(obj["id"])
 
     metrics.incr(
         "feature.owners.has-committers",

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -259,11 +259,9 @@ def get_serialized_event_file_committers(project, event, frame_limit=25):
 
 
 def dedupeCommits(commits):
-    seen = set()
-    result = []
+    result = {}
     for obj in commits:
-        if obj["id"] not in seen:
-            result.append(obj)
-            seen.add(obj["id"])
+        if obj["id"] not in result:
+            result[obj["id"]] = obj
 
-    return result
+    return result.values()

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import
 import operator
 import six
 
-import sentry_sdk
-
 from sentry.api.serializers import serialize
 from sentry.models import Release, ReleaseCommit, Commit, CommitFileChange, Group
 from sentry.api.serializers.models.commit import CommitSerializer, get_users_for_commits
@@ -230,12 +228,6 @@ def get_event_file_committers(project, event, frame_limit=25):
         {match for match in commit_path_matches for match in commit_path_matches[match]}
     )
 
-    with sentry_sdk.start_span(op="get_event_file_committers") as span:
-        span.set_data("project_id", project.id)
-        span.set_data("group_id", event.group_id)
-        span.set_data("commit_path_matches", commit_path_matches)
-        span.set_data("relevant_commits", relevant_commits)
-
     return _get_committers(annotated_frames, relevant_commits)
 
 
@@ -254,7 +246,11 @@ def get_serialized_event_file_committers(project, event, frame_limit=25):
 
     for committer in committers:
         commit_ids = [commit.id for (commit, _) in committer["commits"]]
-        committer["commits"] = [serialized_commits_by_id[commit_id] for commit_id in commit_ids]
+        commits_result = [serialized_commits_by_id[commit_id] for commit_id in commit_ids]
+        # Deduplicate commits
+        committer["commits"] = [
+            i for n, i in enumerate(commits_result) if i not in commits_result[n + 1 :]
+        ]
 
     metrics.incr(
         "feature.owners.has-committers",

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -248,12 +248,7 @@ def get_serialized_event_file_committers(project, event, frame_limit=25):
         commit_ids = [commit.id for (commit, _) in committer["commits"]]
         commits_result = [serialized_commits_by_id[commit_id] for commit_id in commit_ids]
         # Deduplicate commits
-        seen = set()
-        committer["commits"] = []
-        for obj in commits_result:
-            if obj["id"] not in seen:
-                committer["commits"].append(obj)
-                seen.add(obj["id"])
+        committer["commits"] = dedupeCommits(commits_result)
 
     metrics.incr(
         "feature.owners.has-committers",
@@ -261,3 +256,14 @@ def get_serialized_event_file_committers(project, event, frame_limit=25):
         skip_internal=False,
     )
     return committers
+
+
+def dedupeCommits(commits):
+    seen = set()
+    result = []
+    for obj in commits:
+        if obj["id"] not in seen:
+            result.append(obj)
+            seen.add(obj["id"])
+
+    return result

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -18,6 +18,7 @@ from sentry.utils.committers import (
     get_previous_releases,
     score_path_match_length,
     tokenize_path,
+    dedupeCommits,
 )
 
 # TODO(lb): Tests are still needed for _get_committers and _get_event_file_commiters
@@ -445,3 +446,21 @@ class GetEventFileCommitters(CommitTestCase):
 
         with self.assertRaises(Commit.DoesNotExist):
             get_serialized_event_file_committers(self.project, event)
+
+
+class DedupeCommits(CommitTestCase):
+    def setUp(self):
+        super(DedupeCommits, self).setUp()
+
+    def test_dedupe_with_same_commit(self):
+        commit = self.create_commit().__dict__
+        commits = [commit, commit, commit]
+        result = dedupeCommits(commits)
+        assert len(result) == 1
+
+    def test_dedupe_with_different_commit(self):
+        same_commit = self.create_commit().__dict__
+        diff_commit = self.create_commit().__dict__
+        commits = [same_commit, diff_commit, same_commit]
+        result = dedupeCommits(commits)
+        assert len(result) == 2

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -18,7 +18,7 @@ from sentry.utils.committers import (
     get_previous_releases,
     score_path_match_length,
     tokenize_path,
-    dedupeCommits,
+    dedupe_commits,
 )
 
 # TODO(lb): Tests are still needed for _get_committers and _get_event_file_commiters
@@ -455,12 +455,12 @@ class DedupeCommits(CommitTestCase):
     def test_dedupe_with_same_commit(self):
         commit = self.create_commit().__dict__
         commits = [commit, commit, commit]
-        result = dedupeCommits(commits)
+        result = dedupe_commits(commits)
         assert len(result) == 1
 
     def test_dedupe_with_different_commit(self):
         same_commit = self.create_commit().__dict__
         diff_commit = self.create_commit().__dict__
         commits = [same_commit, diff_commit, same_commit]
-        result = dedupeCommits(commits)
+        result = dedupe_commits(commits)
         assert len(result) == 2


### PR DESCRIPTION
## Objective
A bug was reported that there are duplicate suggested commits/assignees. This is difficult to replicate in a local environment. Attempted to use logging in https://github.com/getsentry/sentry/pull/18526 but got reverted in https://github.com/getsentry/sentry/pull/18533 because the data structures were too large for our internal logging infrastructure.

Then tried logging through Sentry tracing instead in https://github.com/getsentry/sentry/pull/18548, but this is not the intended use case of Sentry APM because it samples requests.

So in this PR we are going to remove the Sentry APM logging and just deduplicate the results at the end of the request.

## Test Plan
Tested deduplication function in repl with the mock data from production issue. And wrote unit tests.