### PR TITLE
feat(alerts): Temporarily allow environments passed to alert rule creation/update endpoint to be either a list or a string.

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -10,7 +10,6 @@ from django.db import transaction
 
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.serializers.rest_framework.project import ProjectField
-from sentry.api.serializers.rest_framework.environment import EnvironmentField
 from sentry.incidents.logic import (
     AlertRuleNameAlreadyUsedError,
     AlertRuleTriggerLabelAlreadyUsedError,
@@ -30,6 +29,7 @@ from sentry.incidents.models import (
     AlertRuleTrigger,
     AlertRuleTriggerAction,
 )
+from sentry.models.environment import Environment
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.models.user import User
@@ -256,6 +256,11 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
                     raise serializers.ValidationError(action_serializer.errors)
 
 
+class ObjectField(serializers.Field):
+    def to_internal_value(self, data):
+        return data
+
+
 class AlertRuleSerializer(CamelSnakeModelSerializer):
     """
     Serializer for creating/updating an alert rule. Required context:
@@ -263,7 +268,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
      - `access`: An access object (from `request.access`)
     """
 
-    environment = serializers.ListField(child=EnvironmentField(), required=False)
+    environment = ObjectField(required=False)
     # TODO: These might be slow for many projects, since it will query for each
     # individually. If we find this to be a problem then we can look into batching.
     projects = serializers.ListField(child=ProjectField(), required=False)
@@ -305,6 +310,21 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 "Invalid aggregation, valid values are %s"
                 % [item.value for item in QueryAggregations]
             )
+
+    def validate_environment(self, environment):
+        def convert_to_environment(env_name):
+            try:
+                return Environment.objects.get(
+                    organization_id=self.context["organization"].id, name=env_name
+                )
+            except Environment.DoesNotExist:
+                raise serializers.ValidationError("Environment is not part of this organization")
+
+        if isinstance(environment, list):
+            environments = map(convert_to_environment, environment)
+        else:
+            environments = [convert_to_environment(environment)]
+        return environments
 
     def validate(self, data):
         """Performs validation on an alert rule's data

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -101,7 +101,7 @@ class TestAlertRuleSerializer(TestCase):
 
         base_params.update({"environment": [env_1.name]})
         serializer = AlertRuleSerializer(context=self.context, data=base_params)
-        assert serializer.is_valid()
+        assert serializer.is_valid(), serializer.errors
         alert_rule = serializer.save()
 
         # Make sure AlertRuleEnvironment entry was made:
@@ -150,6 +150,22 @@ class TestAlertRuleSerializer(TestCase):
         assert serializer.is_valid()
         serializer.save()
         assert len(AlertRuleEnvironment.objects.filter(alert_rule=alert_rule)) == 0
+
+    def test_environment_non_list(self):
+        base_params = self.valid_params.copy()
+        env_1 = Environment.objects.create(organization_id=self.organization.id, name="test_env_1")
+        Environment.objects.create(organization_id=self.organization.id, name="test_env_2")
+
+        base_params.update({"environment": env_1.name})
+        serializer = AlertRuleSerializer(context=self.context, data=base_params)
+        assert serializer.is_valid(), serializer.errors
+        alert_rule = serializer.save()
+
+        # Make sure AlertRuleEnvironment entry was made:
+        alert_rule_env = AlertRuleEnvironment.objects.get(
+            environment=env_1.id, alert_rule=alert_rule
+        )
+        assert alert_rule_env
 
     def test_time_window(self):
         self.run_fail_validation_test(


### PR DESCRIPTION
This is to allow frontend to transition to no longer passing a list when editing environments. The
code is pretty gross, once we've transitioned I'll remove it and just switch to using an
`EnvironmentField`instead.