### PR TITLE
ci: WIP port to devservices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ base_postgres: &postgres_default
     # TODO: possible to enable memcached without rewriting on-disk config files?
     # TODO: zookeeper, kafka?
     # XXX: have not yet confirmed devservices config match the old travis configs
-    - sentry devservices up postgres redis clickhouse snuba
+    - sentry devservices up relay postgres redis clickhouse snuba
   install:
     - true
 
@@ -143,6 +143,9 @@ matrix:
     - <<: *postgres_default
       name: 'Backend with migrations [Postgres] (1/2)'
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0 MIGRATIONS_TEST_MIGRATE=1
+      # TODO: it seems the only tests that require relay here are tests/relay...
+      # could they be moved into relay_integration? if so, then we can remove relay from the devservices
+      # for postgres_default. 2/2 does not need relay.
 
     - <<: *postgres_default
       name: 'Backend with migrations [Postgres] (2/2)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,7 +139,7 @@ matrix:
         - *base_install
         # TODO: it seems the only tests that require relay here are tests/relay...
         # If they were moved into relay_integration then we don't need relay here.
-        - sentry devservices up relay kafka zookeeper postgres redis clickhouse snuba
+        - sentry devservices up relay postgres redis clickhouse snuba kafka zookeeper
 
     - name: 'Backend with migrations [Postgres] (2/2)'
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
@@ -193,7 +193,7 @@ matrix:
       env: TEST_SUITE=relay-integration DB=postgres
       before_install:
         - *base_install
-        - sentry devservices up relay postgres redis clickhouse snuba
+        - sentry devservices up relay postgres redis clickhouse snuba kafka zookeeper
         # TODO: this is probably unnecessary, confirm pull = True
         # - docker pull us.gcr.io/sentryio/relay:latest  # pull relay we'll run and kill it for each test
         - docker ps -a
@@ -202,7 +202,7 @@ matrix:
       env: TEST_SUITE=snuba USE_SNUBA=1 MIGRATIONS_TEST_MIGRATE=1
       before-install:
         - *base_install
-        - sentry devservices up postgres redis clickhouse snuba
+        - sentry devservices up postgres redis clickhouse snuba kafka zookeeper
 
     # XXX: this needs to be the same as postgres_default (other than python, name, env, and the rb package override)
     # NOTE: Migrations need to also be ported to py3.6, but the errors just clog up everything.

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
     - PYTEST_SENTRY_DSN=https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
     - SENTRY_KAFKA_HOSTS=localhost:9092
     - SENTRY_ZOOKEEPER_HOSTS=localhost:2181
-    - PYTEST_ADDOPTS="--reruns 5"
+    - PYTEST_ADDOPTS="--reruns 1"
 
 base_install: &base_install |-
   pip install --no-cache-dir "pip>=20.0.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ branches:
 cache:
   yarn: true
   directories:
-    - '${HOME}/.cache/pip'
+    # We don't cache ~/.cache/pip since we cache the entire virtualenv. It's faster.
+    # When installing sentry for testing, -U/--upgrade must be passed to pip.
     - "${HOME}/virtualenv/python$(python -c 'import platform; print(platform.python_version())')"
     - '$NODE_DIR'
     - node_modules
@@ -30,7 +31,7 @@ env:
   global:
     - NODE_ENV=development
     - PIP_DISABLE_PIP_VERSION_CHECK=on
-#    - PIP_QUIET=1
+    - PIP_QUIET=1
     - SENTRY_LIGHT_BUILD=1
     - SENTRY_SKIP_BACKEND_VALIDATION=1
     - MIGRATIONS_TEST_MIGRATE=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,15 +76,9 @@ after_script:
   - $(./bin/yarn global bin)/zeus upload -t "text/xml+checkstyle" .artifacts/*checkstyle.xml
   - $(./bin/yarn global bin)/zeus upload -t "application/webpack-stats+json" .artifacts/*webpack-stats.json
 
-base_postgres: &postgres_default
-  before_install:
-    - *base_install
-    # TODO: possible to enable memcached without rewriting on-disk config files?
-    # TODO: zookeeper, kafka?
-    # XXX: have not yet confirmed devservices config match the old travis configs
-    - sentry devservices up relay postgres redis clickhouse snuba
-  install:
-    - true
+# TODO: zookeeper, kafka?
+# TODO: possible to enable memcached without rewriting on-disk config files?
+# XXX: have not yet confirmed devservices config match the old travis configs
 
 base_acceptance: &acceptance_default
   before_install:
@@ -140,16 +134,19 @@ matrix:
         - pip uninstall -y numpy
         - bin/scan
 
-    - <<: *postgres_default
-      name: 'Backend with migrations [Postgres] (1/2)'
+    - name: 'Backend with migrations [Postgres] (1/2)'
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0 MIGRATIONS_TEST_MIGRATE=1
-      # TODO: it seems the only tests that require relay here are tests/relay...
-      # could they be moved into relay_integration? if so, then we can remove relay from the devservices
-      # for postgres_default. 2/2 does not need relay.
+      before-install:
+        - *base_install
+        # TODO: it seems the only tests that require relay here are tests/relay...
+        # If they were moved into relay_integration then we don't need relay here.
+        - sentry devservices up relay postgres redis clickhouse snuba
 
-    - <<: *postgres_default
-      name: 'Backend with migrations [Postgres] (2/2)'
+    - name: 'Backend with migrations [Postgres] (2/2)'
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
+      before-install:
+        - *base_install
+        - sentry devservices up postgres redis clickhouse snuba
 
     - <<: *acceptance_default
       name: 'Acceptance'
@@ -183,30 +180,30 @@ matrix:
       install:
         - true
 
-    - <<: *postgres_default
-      name: 'Symbolicator Integration'
+    - name: 'Symbolicator Integration'
       env: TEST_SUITE=symbolicator
       before_install:
         - *base_install
         # TODO: enable symbolicator
         - sentry devservices up symbolicator postgres redis clickhouse snuba
         # TODO: this is probably unnecessary, confirm pull = True
-        - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run
+        # - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run
         - docker ps -a
 
-    - <<: *postgres_default
-      name: 'Sentry-Relay integration tests'
+    - name: 'Sentry-Relay integration tests'
       env: TEST_SUITE=relay-integration DB=postgres
       before_install:
         - *base_install
         - sentry devservices up relay postgres redis clickhouse snuba
         # TODO: this is probably unnecessary, confirm pull = True
-        - docker pull us.gcr.io/sentryio/relay:latest  # pull relay we'll run and kill it for each test
+        # - docker pull us.gcr.io/sentryio/relay:latest  # pull relay we'll run and kill it for each test
         - docker ps -a
 
-    - <<: *postgres_default
-      name: 'Snuba Integration with migrations'
+    - name: 'Snuba Integration with migrations'
       env: TEST_SUITE=snuba USE_SNUBA=1 MIGRATIONS_TEST_MIGRATE=1
+      before-install:
+        - *base_install
+        - sentry devservices up postgres redis clickhouse snuba
 
     # XXX: this needs to be the same as postgres_default (other than python, name, env, and the rb package override)
     # NOTE: Migrations need to also be ported to py3.6, but the errors just clog up everything.

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ matrix:
       env: TEST_SUITE=symbolicator
       before_install:
         - *base_install
-        - echo 'symbolicator.enabled: true' >> ~/.sentry/config.yml
+        - bash -c 'echo "symbolicator.enabled: true" >> ~/.sentry/config.yml'
         - sentry devservices up symbolicator postgres redis clickhouse snuba
         # TODO: this is probably unnecessary, confirm pull = True
         # - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,11 +90,6 @@ base_postgres: &postgres_default
     - *base_install
   install:
     - true
-  before_script:
-    # psql on travis machines expect a unix domain socket, but we're not using travis postgres service.
-    # So need to pass explicit -h 127.0.0.1.
-    # TODO: this could be probably replaced with make setup-db or similar?
-    - psql -h 127.0.0.1 -c 'create database sentry;' -U postgres
 
 base_acceptance: &acceptance_default
   python: 2.7
@@ -110,8 +105,6 @@ base_acceptance: &acceptance_default
     - unzip ~/chromedriver_linux64.zip -d ~/
     - rm ~/chromedriver_linux64.zip
     - sudo install -m755 ~/chromedriver /usr/local/bin/
-  before_script:
-    - psql -h 127.0.0.1 -c 'create database sentry;' -U postgres
 
 # each job in the matrix inherits `env/global` and uses everything above,
 # but custom `services`, `before_install`, `install`, and `before_script` directives
@@ -195,8 +188,6 @@ matrix:
         - redis-server
       install:
         - true
-      before_script:
-        - psql -h 127.0.0.1 -c 'create database sentry;' -U postgres
 
     - <<: *postgres_default
       name: 'Symbolicator Integration'
@@ -231,8 +222,6 @@ matrix:
         - *base_install
       install:
         - true
-      before_script:
-        - psql -h 127.0.0.1 -c 'create database sentry;' -U postgres
 
     # XXX: this needs to be the same as postgres_default (other than python, name, env, and the rb package override)
     # NOTE: Migrations need to also be ported to py3.6, but the errors just clog up everything.
@@ -251,8 +240,6 @@ matrix:
     #     - true
     #     - pip uninstall -y rb
     #     - pip install -e git+https://github.com/joshuarli/rb.git@505ad7665baba66c7c492b01b0e83d433ed2eb8e#egg=rb
-    #   before_script:
-    #     - psql -h 127.0.0.1 -c 'create database sentry;' -U postgres
 
     # Deploy 'storybook' (component & style guide)
     - name: 'Storybook Deploy'

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ env:
 base_install: &base_install |-
   pip install --no-cache-dir "pip>=20.0.2"
   python setup.py install_egg_info
+  # XXX: travis doesn't seem to be caching stuff anymore?
   pip install -U -e ".[dev]"
   # TODO: init --dev?
   sentry init
@@ -116,17 +117,12 @@ matrix:
       env: TEST_SUITE=lint-js
       install:
         - find "$NODE_DIR" -type d -empty -delete
-        # Under a "generic" language environment, this will make travis pyenv error because there
-        # is no pyenv python installed.
-        - rm .python-version
         - nvm install
         - ./bin/yarn install --frozen-lockfile
 
     - python: 3.7
       name: 'pre-commit hooks (includes python linting + format check) and dependency scanning'
       install:
-        # XXX: this must be synced with requirements-dev.txt
-        - pip install 'sentry-flake8==0.3.0'
         - SENTRY_NO_VIRTUALENV_CREATION=1 make setup-git
       script:
         # black is going to rewrite the files in-place.
@@ -150,6 +146,7 @@ matrix:
     - <<: *postgres_default
       name: 'Backend with migrations [Postgres] (1/2)'
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0 MIGRATIONS_TEST_MIGRATE=1
+
     - <<: *postgres_default
       name: 'Backend with migrations [Postgres] (2/2)'
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
@@ -162,8 +159,7 @@ matrix:
       name: 'Plugins'
       env: TEST_SUITE=plugins DB=postgres PERCY_TOKEN=${PLUGIN_PERCY_TOKEN}
 
-    - python: 2.7
-      name: 'Frontend [test]'
+    - name: 'Frontend [test]'
       env: TEST_SUITE=js
       before_install:
         - find "$NODE_DIR" -type d -empty -delete
@@ -171,8 +167,7 @@ matrix:
       install:
         - ./bin/yarn install --frozen-lockfile
 
-    - python: 2.7
-      name: 'Frontend [build]'
+    - name: 'Frontend [build]'
       env: TEST_SUITE=js-build
       before_install:
         - find "$NODE_DIR" -type d -empty -delete
@@ -180,8 +175,7 @@ matrix:
       install:
         - ./bin/yarn install --frozen-lockfile
 
-    - python: 2.7
-      name: 'Command Line'
+    - name: 'Command Line'
       env: TEST_SUITE=cli
       services:
         - postgresql
@@ -210,8 +204,7 @@ matrix:
         - docker pull us.gcr.io/sentryio/relay:latest # pull relay we'll run and kill it for each test
         - docker ps -a
 
-    - python: 2.7
-      name: 'Snuba Integration with migrations'
+    - name: 'Snuba Integration with migrations'
       env: TEST_SUITE=snuba USE_SNUBA=1 MIGRATIONS_TEST_MIGRATE=1
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ env:
     - NODE_DIR="${HOME}/.nvm/versions/node/v$(< .nvmrc)"
     - NODE_OPTIONS=--max-old-space-size=4096
     - PYTEST_SENTRY_DSN=https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
-    - SENTRY_KAFKA_HOSTS=localhost:9092
-    - SENTRY_ZOOKEEPER_HOSTS=localhost:2181
+    - SENTRY_KAFKA_HOSTS=127.0.0.1:9092
+    - SENTRY_ZOOKEEPER_HOSTS=127.0.0.1:2181
     - PYTEST_ADDOPTS="--reruns 1"
 
 base_install: &base_install |-

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ matrix:
       env: TEST_SUITE=symbolicator
       before_install:
         - *base_install
-        # TODO: enable symbolicator
+        - echo "symbolicator.enabled: true" >> "${HOME}/.sentry/config.yml"
         - sentry devservices up symbolicator postgres redis clickhouse snuba
         # TODO: this is probably unnecessary, confirm pull = True
         # - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,10 @@ matrix:
       env: TEST_SUITE=symbolicator
       before_install:
         - *base_install
-        - bash -c 'echo "symbolicator.enabled: true" >> ~/.sentry/config.yml'
+        # NOTE: colons are special in YAML; travis won't have a good time parsing the following line.
+        # Prepending a pipe is the workaround here.
+        - |
+          echo "symbolicator.enabled: true" >> ~/.sentry/config.yml
         - sentry devservices up symbolicator postgres redis clickhouse snuba
         # TODO: this is probably unnecessary, confirm pull = True
         # - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ matrix:
       env: TEST_SUITE=symbolicator
       before_install:
         - *base_install
-        - echo "symbolicator.enabled: true" >> "${HOME}/.sentry/config.yml"
+        - echo 'symbolicator.enabled: true' >> ~/.sentry/config.yml
         - sentry devservices up symbolicator postgres redis clickhouse snuba
         # TODO: this is probably unnecessary, confirm pull = True
         # - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,6 @@ after_script:
   - $(./bin/yarn global bin)/zeus upload -t "text/xml+checkstyle" .artifacts/*checkstyle.xml
   - $(./bin/yarn global bin)/zeus upload -t "application/webpack-stats+json" .artifacts/*webpack-stats.json
 
-# TODO: zookeeper, kafka?
 # TODO: possible to enable memcached without rewriting on-disk config files?
 # XXX: have not yet confirmed devservices config match the old travis configs
 
@@ -140,7 +139,7 @@ matrix:
         - *base_install
         # TODO: it seems the only tests that require relay here are tests/relay...
         # If they were moved into relay_integration then we don't need relay here.
-        - sentry devservices up relay postgres redis clickhouse snuba
+        - sentry devservices up relay kafka zookeeper postgres redis clickhouse snuba
 
     - name: 'Backend with migrations [Postgres] (2/2)'
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,19 +45,12 @@ env:
     - SENTRY_ZOOKEEPER_HOSTS=localhost:2181
     - PYTEST_ADDOPTS="--reruns 5"
 
-# TODO: possible to enable memcached without rewriting on-disk config files?
-# XXX: have not yet confirmed devservices config match the old travis configs
 base_install: &base_install |-
   pip install --no-cache-dir "pip>=20.0.2"
   python setup.py install_egg_info
   pip install -U -e ".[dev]"
   # TODO: init --dev?
   sentry init
-  # TODO: devservices up should be moved to before_install and tweaked for each job
-  # TODO: possible to enable memcached without rewriting on-disk config files?
-  # XXX: have not yet confirmed devservices config match the old travis configs
-  sentry devservices up
-  docker ps -a
   [ "$TRAVIS_PULL_REQUEST" != "false" ] || export PYTEST_SENTRY_ALWAYS_REPORT=1
 
 script:
@@ -86,12 +79,19 @@ after_script:
 base_postgres: &postgres_default
   before_install:
     - *base_install
+    # TODO: possible to enable memcached without rewriting on-disk config files?
+    # TODO: zookeeper, kafka?
+    # XXX: have not yet confirmed devservices config match the old travis configs
+    - sentry devservices up postgres redis clickhouse snuba
   install:
     - true
 
 base_acceptance: &acceptance_default
   before_install:
     - *base_install
+    # NOTE: relay, reverse_proxy are not needed for acceptance testing
+    #       because event ingestion is not tested
+    - sentry devservices up postgres redis clickhouse snuba
     - find "$NODE_DIR" -type d -empty -delete
     - nvm install
   install:
@@ -184,6 +184,7 @@ matrix:
       env: TEST_SUITE=symbolicator
       before_install:
         - *base_install
+        - sentry devservices up symbolicator postgres redis clickhouse snuba
         # TODO: this is probably unnecessary, confirm pull = True
         - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run
         - docker ps -a
@@ -193,16 +194,14 @@ matrix:
       env: TEST_SUITE=relay-integration DB=postgres
       before_install:
         - *base_install
+        - sentry devservices up relay postgres redis clickhouse snuba
         # TODO: this is probably unnecessary, confirm pull = True
         - docker pull us.gcr.io/sentryio/relay:latest  # pull relay we'll run and kill it for each test
         - docker ps -a
 
-    - name: 'Snuba Integration with migrations'
+    - <<: *postgres_default
+      name: 'Snuba Integration with migrations'
       env: TEST_SUITE=snuba USE_SNUBA=1 MIGRATIONS_TEST_MIGRATE=1
-      before_install:
-        - *base_install
-      install:
-        - true
 
     # XXX: this needs to be the same as postgres_default (other than python, name, env, and the rb package override)
     # NOTE: Migrations need to also be ported to py3.6, but the errors just clog up everything.

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,14 +83,12 @@ after_script:
   - $(./bin/yarn global bin)/zeus upload -t "application/webpack-stats+json" .artifacts/*webpack-stats.json
 
 base_postgres: &postgres_default
-  python: 2.7
   before_install:
     - *base_install
   install:
     - true
 
 base_acceptance: &acceptance_default
-  python: 2.7
   before_install:
     - *base_install
     - find "$NODE_DIR" -type d -empty -delete
@@ -112,9 +110,10 @@ matrix:
   include:
     - name: 'Linter (Javascript)'
       env: TEST_SUITE=lint-js
-      install:
+      before-install:
         - find "$NODE_DIR" -type d -empty -delete
         - nvm install
+      install:
         - ./bin/yarn install --frozen-lockfile
 
     - python: 3.7
@@ -174,9 +173,8 @@ matrix:
 
     - name: 'Command Line'
       env: TEST_SUITE=cli
-      services:
-        - postgresql
-        - redis-server
+      before_install:
+        - *base_install
       install:
         - true
 
@@ -185,29 +183,21 @@ matrix:
       env: TEST_SUITE=symbolicator
       before_install:
         - *base_install
+        # TODO: this is probably unnecessary, confirm pull = True
         - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run
         - docker ps -a
 
     - <<: *postgres_default
       name: 'Sentry-Relay integration tests'
       env: TEST_SUITE=relay-integration DB=postgres
-      services:
-        - docker
-        - memcached
-        - redis-server
-        - postgresql
       before_install:
         - *base_install
-        - docker pull us.gcr.io/sentryio/relay:latest # pull relay we'll run and kill it for each test
+        # TODO: this is probably unnecessary, confirm pull = True
+        - docker pull us.gcr.io/sentryio/relay:latest  # pull relay we'll run and kill it for each test
         - docker ps -a
 
     - name: 'Snuba Integration with migrations'
       env: TEST_SUITE=snuba USE_SNUBA=1 MIGRATIONS_TEST_MIGRATE=1
-      services:
-        - docker
-        - memcached
-        - redis-server
-        - postgresql
       before_install:
         - *base_install
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
 cache:
   yarn: true
   directories:
+    - '${HOME}/.cache/pip'
     - "${HOME}/virtualenv/python$(python -c 'import platform; print(platform.python_version())')"
     - '$NODE_DIR'
     - node_modules
@@ -48,7 +49,6 @@ env:
 base_install: &base_install |-
   pip install --no-cache-dir "pip>=20.0.2"
   python setup.py install_egg_info
-  # XXX: travis doesn't seem to be caching stuff anymore?
   pip install -U -e ".[dev]"
   # TODO: init --dev?
   sentry init

--- a/.travis.yml
+++ b/.travis.yml
@@ -176,6 +176,7 @@ matrix:
       env: TEST_SUITE=cli
       before_install:
         - *base_install
+        - sentry devservices up postgres redis
       install:
         - true
 
@@ -184,6 +185,7 @@ matrix:
       env: TEST_SUITE=symbolicator
       before_install:
         - *base_install
+        # TODO: enable symbolicator
         - sentry devservices up symbolicator postgres redis clickhouse snuba
         # TODO: this is probably unnecessary, confirm pull = True
         - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   global:
     - NODE_ENV=development
     - PIP_DISABLE_PIP_VERSION_CHECK=on
-    - PIP_QUIET=1
+#    - PIP_QUIET=1
     - SENTRY_LIGHT_BUILD=1
     - SENTRY_SKIP_BACKEND_VALIDATION=1
     - MIGRATIONS_TEST_MIGRATE=0
@@ -43,16 +43,19 @@ env:
     - SENTRY_ZOOKEEPER_HOSTS=localhost:2181
     - PYTEST_ADDOPTS="--reruns 5"
 
+# TODO: possible to enable memcached without rewriting on-disk config files?
+# XXX: have not yet confirmed devservices config match the old travis configs
 base_install: &base_install |-
   pip install --no-cache-dir "pip>=20.0.2"
   python setup.py install_egg_info
   pip install -U -e ".[dev]"
-
+  # TODO: init --dev?
+  sentry init
+  # TODO: devservices up should be moved to before_install and tweaked for each job
   # TODO: possible to enable memcached without rewriting on-disk config files?
   # XXX: have not yet confirmed devservices config match the old travis configs
   sentry devservices up
   docker ps -a
-
   [ "$TRAVIS_PULL_REQUEST" != "false" ] || export PYTEST_SENTRY_ALWAYS_REPORT=1
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,6 @@ script:
   # installing dependencies for after_* steps here ensures they get cached
   # since those steps execute after travis runs `store build cache`
 
-after_failure:
-  - dmesg | tail -n 100
-
 after_script:
   - |
     coverage_files=$(ls .artifacts/*coverage.xml || true)
@@ -245,7 +242,6 @@ matrix:
       install: ./bin/yarn install --frozen-lockfile
       script: ./bin/yarn run storybook-build
       after_success: .travis/deploy-storybook.sh
-      after_failure: skip
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ cache:
     - node_modules
     - '${HOME}/google-cloud-sdk'
 
+services:
+  - docker
+
 addons:
   apt:
     update: true
@@ -42,40 +45,15 @@ env:
 
 base_install: &base_install |-
   pip install --no-cache-dir "pip>=20.0.2"
+  python setup.py install_egg_info
+  pip install -U -e ".[dev]"
 
-  docker run \
-    --name sentry_zookeeper \
-    -d --network host \
-    -e ZOOKEEPER_CLIENT_PORT=2181 \
-    confluentinc/cp-zookeeper:4.1.0
-
-  docker run \
-    --name sentry_kafka \
-    -d --network host \
-    -e KAFKA_ZOOKEEPER_CONNECT=127.0.0.1:2181 \
-    -e KAFKA_LISTENERS=INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092 \
-    -e KAFKA_ADVERTISED_LISTENERS=INTERNAL://127.0.0.1:9093,EXTERNAL://127.0.0.1:9092 \
-    -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \
-    -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
-    -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
-    confluentinc/cp-kafka:5.1.2
+  # TODO: possible to enable memcached without rewriting on-disk config files?
+  # XXX: have not yet confirmed devservices config match the old travis configs
+  sentry devservices up
+  docker ps -a
 
   [ "$TRAVIS_PULL_REQUEST" != "false" ] || export PYTEST_SENTRY_ALWAYS_REPORT=1
-
-start_snuba: &start_snuba |-
-  docker run \
-    --name sentry_clickhouse \
-    -d --network host \
-    --ulimit nofile=262144:262144 \
-    yandex/clickhouse-server:19.11 \
-
-  docker run \
-    --name sentry_snuba \
-    -d --network host \
-    -e SNUBA_SETTINGS=test \
-    -e CLICKHOUSE_HOST=127.0.0.1 \
-    -e CLICKHOUSE_PORT=9000 \
-    getsentry/snuba
 
 script:
   # certain commands require sentry init to be run, but this is only true for
@@ -105,37 +83,21 @@ after_script:
 
 base_postgres: &postgres_default
   python: 2.7
-  services:
-    - memcached
-    - redis-server
-    - postgresql
   before_install:
     - *base_install
-    - *start_snuba
-    - docker ps -a
   install:
-    - python setup.py install_egg_info
-    - pip install -U -e ".[dev]"
+    - true
   before_script:
     - psql -c 'create database sentry;' -U postgres
 
 base_acceptance: &acceptance_default
   python: 2.7
-  services:
-    - docker
-    - memcached
-    - redis-server
-    - postgresql
   before_install:
     - *base_install
-    - *start_snuba
     - find "$NODE_DIR" -type d -empty -delete
     - nvm install
-    - docker ps -a
   install:
     - ./bin/yarn install --frozen-lockfile
-    - python setup.py install_egg_info
-    - pip install -U -e ".[dev]"
     - |
       CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
       wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})/chromedriver_linux64.zip" -P ~/
@@ -151,8 +113,7 @@ base_acceptance: &acceptance_default
 matrix:
   fast_finish: true
   include:
-    - language: generic
-      name: 'Linter (Javascript)'
+    - name: 'Linter (Javascript)'
       env: TEST_SUITE=lint-js
       install:
         - find "$NODE_DIR" -type d -empty -delete
@@ -227,8 +188,7 @@ matrix:
         - postgresql
         - redis-server
       install:
-        - python setup.py install_egg_info
-        - pip install -U -e ".[dev]"
+        - true
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -237,7 +197,6 @@ matrix:
       env: TEST_SUITE=symbolicator
       before_install:
         - *base_install
-        - *start_snuba
         - docker run -d --network host --name symbolicator us.gcr.io/sentryio/symbolicator:latest run
         - docker ps -a
 
@@ -251,7 +210,6 @@ matrix:
         - postgresql
       before_install:
         - *base_install
-        - *start_snuba
         - docker pull us.gcr.io/sentryio/relay:latest # pull relay we'll run and kill it for each test
         - docker ps -a
 
@@ -265,11 +223,8 @@ matrix:
         - postgresql
       before_install:
         - *base_install
-        - *start_snuba
-        - docker ps -a
       install:
-        - python setup.py install_egg_info
-        - pip install -U -e ".[dev]"
+        - true
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -286,11 +241,8 @@ matrix:
     #     - postgresql
     #   before_install:
     #     - *base_install
-    #     - *start_snuba
-    #     - docker ps -a
     #   install:
-    #     - python setup.py install_egg_info
-    #     - pip install -U -e ".[dev]"
+    #     - true
     #     - pip uninstall -y rb
     #     - pip install -e git+https://github.com/joshuarli/rb.git@505ad7665baba66c7c492b01b0e83d433ed2eb8e#egg=rb
     #   before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,10 @@ base_postgres: &postgres_default
   install:
     - true
   before_script:
-    - psql -c 'create database sentry;' -U postgres
+    # psql on travis machines expect a unix domain socket, but we're not using travis postgres service.
+    # So need to pass explicit -h 127.0.0.1.
+    # TODO: this could be probably replaced with make setup-db or similar?
+    - psql -h 127.0.0.1 -c 'create database sentry;' -U postgres
 
 base_acceptance: &acceptance_default
   python: 2.7
@@ -108,7 +111,7 @@ base_acceptance: &acceptance_default
     - rm ~/chromedriver_linux64.zip
     - sudo install -m755 ~/chromedriver /usr/local/bin/
   before_script:
-    - psql -c 'create database sentry;' -U postgres
+    - psql -h 127.0.0.1 -c 'create database sentry;' -U postgres
 
 # each job in the matrix inherits `env/global` and uses everything above,
 # but custom `services`, `before_install`, `install`, and `before_script` directives
@@ -193,7 +196,7 @@ matrix:
       install:
         - true
       before_script:
-        - psql -c 'create database sentry;' -U postgres
+        - psql -h 127.0.0.1 -c 'create database sentry;' -U postgres
 
     - <<: *postgres_default
       name: 'Symbolicator Integration'
@@ -229,7 +232,7 @@ matrix:
       install:
         - true
       before_script:
-        - psql -c 'create database sentry;' -U postgres
+        - psql -h 127.0.0.1 -c 'create database sentry;' -U postgres
 
     # XXX: this needs to be the same as postgres_default (other than python, name, env, and the rb package override)
     # NOTE: Migrations need to also be ported to py3.6, but the errors just clog up everything.
@@ -249,7 +252,7 @@ matrix:
     #     - pip uninstall -y rb
     #     - pip install -e git+https://github.com/joshuarli/rb.git@505ad7665baba66c7c492b01b0e83d433ed2eb8e#egg=rb
     #   before_script:
-    #     - psql -c 'create database sentry;' -U postgres
+    #     - psql -h 127.0.0.1 -c 'create database sentry;' -U postgres
 
     # Deploy 'storybook' (component & style guide)
     - name: 'Storybook Deploy'

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,6 @@ test-python:
 	py.test tests/integration tests/sentry
 
 test-python-ci:
-	sentry init
 	make build-platform-assets
 	@echo "--> Running CI Python tests"
 ifndef TEST_GROUP
@@ -181,7 +180,6 @@ test-symbolicator:
 	@echo ""
 
 test-acceptance: node-version-check
-	sentry init
 	@echo "--> Building static assets"
 	@$(WEBPACK) --display errors-only
 	@echo "--> Running acceptance tests"

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1407,6 +1407,7 @@ SENTRY_DEVSERVICES = {
     },
     "zookeeper": {
         "image": "confluentinc/cp-zookeeper:5.1.2",
+        "ports": {"2181/tcp": 2181},
         "environment": {"ZOOKEEPER_CLIENT_PORT": "2181"},
         "volumes": {"zookeeper": {"bind": "/var/lib/zookeeper"}},
         "only_if": lambda settings, options: (

--- a/src/sentry/runner/commands/init.py
+++ b/src/sentry/runner/commands/init.py
@@ -40,6 +40,7 @@ def init(ctx, dev, directory):
             "File already exists at '%s', overwrite?" % click.format_filename(yaml), abort=True
         )
 
+    click.echo("Writing " + yaml)
     with click.open_file(yaml, "w") as fp:
         fp.write(yaml_contents)
 
@@ -48,5 +49,6 @@ def init(ctx, dev, directory):
             "File already exists at '%s', overwrite?" % click.format_filename(py), abort=True
         )
 
+    click.echo("Writing " + py)
     with click.open_file(py, "w") as fp:
         fp.write(py_contents)

--- a/tests/relay_integration/test_message_filters.py
+++ b/tests/relay_integration/test_message_filters.py
@@ -13,7 +13,7 @@ from sentry.message_filters import (
 )
 
 
-@override_settings(ALLOWED_HOSTS=["localhost", "testserver", "host.docker.internal"])
+@override_settings(ALLOWED_HOSTS=["localhost", "127.0.0.1", "testserver", "host.docker.internal"])
 class FilterTests(RelayStoreHelper, TransactionTestCase):
     def setUp(self):  # NOQA
         RelayStoreHelper.setUp(self)


### PR DESCRIPTION
This is very WIP, you probably don't want to waste your time looking at this right now.

Following discussion [here](https://github.com/getsentry/sentry/pull/18576#discussion_r418787327), I initially wanted to check that we're actually running postgres 9.6 in ci. Then, following discussion [here](https://github.com/getsentry/sentry/pull/18576#discussion_r418787721), I thought it would be a good idea to attempt to reuse devservices for ci so we don't have to worry about duplicating important configuration all over the place.

The main penalty to solve here is CI time. Since builtin travis services are replaced with devservices, it definitely takes a while to pull images every time, _every job_. Caching them may or may not result in a speedup, since they're all quite large and in my limited experience, Travis definitely takes a while to download large travis cache.

Edit: ok, it doesn't actually take much time 40-60 secs to pull images, this is fine. Main concern is just getting it working now.
