### PR TITLE
feat: Add {Email,Char}Field types backed by text column

### DIFF
--- a/src/sentry/db/models/fields/__init__.py
+++ b/src/sentry/db/models/fields/__init__.py
@@ -5,8 +5,9 @@ from .bounded import *  # NOQA
 from .citext import *  # NOQA
 from .encrypted import *  # NOQA
 from .foreignkey import *  # NOQA
-from .jsonfield import *  # NOQA
 from .gzippeddict import *  # NOQA
+from .jsonfield import *  # NOQA
 from .node import *  # NOQA
-from .uuid import *  # NOQA
 from .onetoone import *  # NOQA
+from .text import *  # NOQA
+from .uuid import *  # NOQA

--- a/src/sentry/db/models/fields/text.py
+++ b/src/sentry/db/models/fields/text.py
@@ -1,0 +1,33 @@
+"""
+Traditional Django model fields, except their type is
+explicitly `text` as opposed to `varchar`. All other
+validations and behaviors are identical.
+
+The reason this exists is because in Postgres, `text`
+and `varchar` are nearly identical. The issue is when
+picking a CharField and needing to size up the length
+needing a database migration. Typically the database
+validation isn't strictly required, so we can use
+`text` type instead to only enforce the length in
+python to allow us to size up the lengths without any
+migrations.
+"""
+
+from __future__ import absolute_import
+
+from django.db import models
+
+__all__ = ("CharField", "EmailField")
+
+
+class TextType(object):
+    def db_type(self, connection):
+        return "text"
+
+
+class CharField(TextType, models.CharField):
+    pass
+
+
+class EmailField(TextType, models.EmailField):
+    pass


### PR DESCRIPTION
For context: very often we pick CharField and an arbitrary `max_length` value. Then later regret the decision or lack of decision and need to widen the column. If we use these fields, it eliminates the problem entirely.

I don't know how we can enforce this, but ideally we'd always use these in place of Django's {Email,Char}Field unless someone has a strong reason not to.