### PR TITLE
fix(ui): Fix double Mac context on event detail page

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contextSummary/filterContexts.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/filterContexts.tsx
@@ -1,0 +1,15 @@
+function filterContexts(event, context) {
+  // if the operating system is macOS, we want to hide devices called "Mac" which don't have any additional info
+  if (context.keys.includes('device')) {
+    const {model, arch, data_id} = event.contexts?.device || {};
+    const {name: os} = event.contexts?.os || event.contexts?.client_os || {};
+
+    if (model === 'Mac' && !arch && !data_id && os?.toLowerCase().includes('mac')) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export default filterContexts;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9060071/80983295-b3889780-8e2c-11ea-9559-9f4cbaca92f5.png)

After:
![image](https://user-images.githubusercontent.com/9060071/80985071-019e9a80-8e2f-11ea-861e-99812c2f59d7.png)


This PR hides device context if the operating system is macOS and the device is called Mac without any additional info.

We discussed this issue on Client Infra TSC and this is the outcome.