### PR TITLE
24 hr graphs

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -1,14 +1,22 @@
 import 'echarts/lib/component/tooltip';
 
+import ConfigStore from 'app/stores/configStore';
 import {getFormattedDate} from 'app/utils/dates';
 
 import {truncationFormatter} from '../utils';
+
+const use24Hours = () => {
+  const user = ConfigStore.get('user');
+  const options = user ? user.options : {};
+  return options.clock24Hours;
+};
 
 function defaultFormatAxisLabel(value, isTimestamp, utc, showTimeInTooltip) {
   if (!isTimestamp) {
     return value;
   }
-  const format = `MMM D, YYYY${showTimeInTooltip ? ' LT' : ''}`;
+  const timeFormat = use24Hours() ? ' HH:mm' : ' LT';
+  const format = `MMM D, YYYY${showTimeInTooltip ? timeFormat : ''}`;
 
   return getFormattedDate(value, format, {local: !utc});
 }

--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -1,15 +1,8 @@
 import 'echarts/lib/component/tooltip';
 
-import ConfigStore from 'app/stores/configStore';
-import {getFormattedDate} from 'app/utils/dates';
+import {getFormattedDate, use24Hours} from 'app/utils/dates';
 
 import {truncationFormatter} from '../utils';
-
-const use24Hours = () => {
-  const user = ConfigStore.get('user');
-  const options = user ? user.options : {};
-  return options.clock24Hours;
-};
 
 function defaultFormatAxisLabel(value, isTimestamp, utc, showTimeInTooltip) {
   if (!isTimestamp) {

--- a/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
@@ -1,5 +1,4 @@
-import ConfigStore from 'app/stores/configStore';
-import {getFormattedDate} from 'app/utils/dates';
+import {getFormattedDate, use24Hours} from 'app/utils/dates';
 import theme from 'app/utils/theme';
 
 import {truncationFormatter, useShortInterval} from '../utils';
@@ -17,12 +16,6 @@ export default function XAxis({
   utc,
   ...props
 } = {}) {
-  const use24Hours = () => {
-    const user = ConfigStore.get('user');
-    const options = user ? user.options : {};
-    return options.clock24Hours;
-  };
-
   const axisLabelFormatter = (value, index) => {
     if (isGroupedByDate) {
       const timeFormat = use24Hours() ? 'HH:mm' : 'LT';

--- a/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
@@ -1,3 +1,4 @@
+import ConfigStore from 'app/stores/configStore';
 import {getFormattedDate} from 'app/utils/dates';
 import theme from 'app/utils/theme';
 
@@ -16,12 +17,19 @@ export default function XAxis({
   utc,
   ...props
 } = {}) {
+  const use24Hours = () => {
+    const user = ConfigStore.get('user');
+    const options = user ? user.options : {};
+    return options.clock24Hours;
+  };
+
   const axisLabelFormatter = (value, index) => {
     if (isGroupedByDate) {
-      const dateFormat = useShortDate ? 'MMM Do' : 'MMM D LT';
+      const timeFormat = use24Hours() ? 'HH:mm' : 'LT';
+      const dateFormat = useShortDate ? 'MMM Do' : `MMM D {timeFormat}`;
       const firstItem = index === 0;
       const format =
-        useShortInterval({start, end, period}) && !firstItem ? 'LT' : dateFormat;
+        useShortInterval({start, end, period}) && !firstItem ? timeFormat : dateFormat;
       return getFormattedDate(value, format, {local: !utc});
     } else if (props.truncate) {
       return truncationFormatter(value, props.truncate);

--- a/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/xAxis.jsx
@@ -26,7 +26,7 @@ export default function XAxis({
   const axisLabelFormatter = (value, index) => {
     if (isGroupedByDate) {
       const timeFormat = use24Hours() ? 'HH:mm' : 'LT';
-      const dateFormat = useShortDate ? 'MMM Do' : `MMM D {timeFormat}`;
+      const dateFormat = useShortDate ? 'MMM Do' : `MMM D ${timeFormat}`;
       const firstItem = index === 0;
       const format =
         useShortInterval({start, end, period}) && !firstItem ? timeFormat : dateFormat;

--- a/src/sentry/static/sentry/app/components/stackedBarChart.jsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.jsx
@@ -7,7 +7,7 @@ import styled from '@emotion/styled';
 
 import Tooltip from 'app/components/tooltip';
 import Count from 'app/components/count';
-import ConfigStore from 'app/stores/configStore';
+import {use24Hours} from 'app/utils/dates';
 import theme from 'app/utils/theme';
 import {formatFloat} from 'app/utils/formatters';
 
@@ -138,16 +138,10 @@ class StackedBarChart extends React.Component {
     return points;
   };
 
-  use24Hours() {
-    const user = ConfigStore.get('user');
-    const options = user ? user.options : {};
-    return options.clock24Hours;
-  }
-
   timeLabelAsHour(point) {
     const timeMoment = moment(point.x * 1000);
     const nextMoment = timeMoment.clone().add(59, 'minute');
-    const format = this.use24Hours() ? 'HH:mm' : 'LT';
+    const format = use24Hours() ? 'HH:mm' : 'LT';
 
     return (
       <span>
@@ -169,7 +163,7 @@ class StackedBarChart extends React.Component {
   timeLabelAsRange(interval, point) {
     const timeMoment = moment(point.x * 1000);
     const nextMoment = timeMoment.clone().add(interval - 1, 'second');
-    const format = this.use24Hours() ? 'MMM Do, HH:mm' : 'MMM Do, h:mm a';
+    const format = use24Hours() ? 'MMM Do, HH:mm' : 'MMM Do, h:mm a';
 
     // e.g. Aug 23rd, 12:50 pm
     return (
@@ -183,7 +177,7 @@ class StackedBarChart extends React.Component {
 
   timeLabelAsFull(point) {
     const timeMoment = moment(point.x * 1000);
-    const format = this.use24Hours() ? 'MMM D, YYYY HH:mm' : 'lll';
+    const format = use24Hours() ? 'MMM D, YYYY HH:mm' : 'lll';
     return timeMoment.format(format);
   }
 

--- a/src/sentry/static/sentry/app/utils/dates.tsx
+++ b/src/sentry/static/sentry/app/utils/dates.tsx
@@ -212,3 +212,8 @@ export function parsePeriodToHours(str: string): number {
       return -1;
   }
 }
+
+export const use24Hours = (): boolean => {
+  const user = ConfigStore.get('user');
+  return user && user.options && user.options.clock24Hours;
+};

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -244,41 +244,43 @@ class GroupDetails extends React.Component<Props, State> {
     const isLoading = loading || (!group && !isError);
 
     return (
-      <DocumentTitle title={this.getTitle()}>
-        {!isLoading && !isError ? (
-          <GlobalSelectionHeader
-            organization={organization}
-            forceProject={project}
-            showDateSelector={false}
-            shouldForceProject
-            lockedMessageSubject={t('issue')}
-            showIssueStreamLink
-            showProjectSettingsLink
-          />
-        ) : null}
+      <React.Fragment>
+        <DocumentTitle title={this.getTitle()}>
+          {!isLoading && !isError ? (
+            <GlobalSelectionHeader
+              organization={organization}
+              forceProject={project}
+              showDateSelector={false}
+              shouldForceProject
+              lockedMessageSubject={t('issue')}
+              showIssueStreamLink
+              showProjectSettingsLink
+            />
+          ) : null}
 
-        <PageContent>
-          {isLoading ? (
-            <LoadingIndicator />
-          ) : isError ? (
-            this.renderError()
-          ) : (
-            <Projects orgId={organization.slug} slugs={[project!.slug]}>
-              {({projects, initiallyLoaded, fetchError}) =>
-                initiallyLoaded ? (
-                  fetchError ? (
-                    <LoadingError message={t('Error loading the specified project')} />
+          <PageContent>
+            {isLoading ? (
+              <LoadingIndicator />
+            ) : isError ? (
+              this.renderError()
+            ) : (
+              <Projects orgId={organization.slug} slugs={[project!.slug]}>
+                {({projects, initiallyLoaded, fetchError}) =>
+                  initiallyLoaded ? (
+                    fetchError ? (
+                      <LoadingError message={t('Error loading the specified project')} />
+                    ) : (
+                      this.renderContent(projects[0])
+                    )
                   ) : (
-                    this.renderContent(projects[0])
+                    <LoadingIndicator />
                   )
-                ) : (
-                  <LoadingIndicator />
-                )
-              }
-            </Projects>
-          )}
-        </PageContent>
-      </DocumentTitle>
+                }
+              </Projects>
+            )}
+          </PageContent>
+        </DocumentTitle>
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -244,8 +244,8 @@ class GroupDetails extends React.Component<Props, State> {
     const isLoading = loading || (!group && !isError);
 
     return (
-      <React.Fragment>
-        <DocumentTitle title={this.getTitle()}>
+      <DocumentTitle title={this.getTitle()}>
+        <React.Fragment>
           {!isLoading && !isError ? (
             <GlobalSelectionHeader
               organization={organization}
@@ -279,8 +279,8 @@ class GroupDetails extends React.Component<Props, State> {
               </Projects>
             )}
           </PageContent>
-        </DocumentTitle>
-      </React.Fragment>
+        </React.Fragment>
+      </DocumentTitle>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -245,41 +245,39 @@ class GroupDetails extends React.Component<Props, State> {
 
     return (
       <DocumentTitle title={this.getTitle()}>
-        <React.Fragment>
-          {!isLoading && !isError ? (
-            <GlobalSelectionHeader
-              organization={organization}
-              forceProject={project}
-              showDateSelector={false}
-              shouldForceProject
-              lockedMessageSubject={t('issue')}
-              showIssueStreamLink
-              showProjectSettingsLink
-            />
-          ) : null}
+        {!isLoading && !isError ? (
+          <GlobalSelectionHeader
+            organization={organization}
+            forceProject={project}
+            showDateSelector={false}
+            shouldForceProject
+            lockedMessageSubject={t('issue')}
+            showIssueStreamLink
+            showProjectSettingsLink
+          />
+        ) : null}
 
-          <PageContent>
-            {isLoading ? (
-              <LoadingIndicator />
-            ) : isError ? (
-              this.renderError()
-            ) : (
-              <Projects orgId={organization.slug} slugs={[project!.slug]}>
-                {({projects, initiallyLoaded, fetchError}) =>
-                  initiallyLoaded ? (
-                    fetchError ? (
-                      <LoadingError message={t('Error loading the specified project')} />
-                    ) : (
-                      this.renderContent(projects[0])
-                    )
+        <PageContent>
+          {isLoading ? (
+            <LoadingIndicator />
+          ) : isError ? (
+            this.renderError()
+          ) : (
+            <Projects orgId={organization.slug} slugs={[project!.slug]}>
+              {({projects, initiallyLoaded, fetchError}) =>
+                initiallyLoaded ? (
+                  fetchError ? (
+                    <LoadingError message={t('Error loading the specified project')} />
                   ) : (
-                    <LoadingIndicator />
+                    this.renderContent(projects[0])
                   )
-                }
-              </Projects>
-            )}
-          </PageContent>
-        </React.Fragment>
+                ) : (
+                  <LoadingIndicator />
+                )
+              }
+            </Projects>
+          )}
+        </PageContent>
       </DocumentTitle>
     );
   }

--- a/tests/js/spec/components/stackedBarChart.spec.jsx
+++ b/tests/js/spec/components/stackedBarChart.spec.jsx
@@ -61,22 +61,4 @@ describe('StackedBarChart', function() {
       expect(columns.at(2).text()).toEqual('last seen');
     });
   });
-  describe('functions', function() {
-    it('creates an AM/PM time label if use24Hours is disabled', function() {
-      const marker = {x: 1439776800, className: 'first-seen', label: 'first seen'};
-
-      const wrapper = shallow(<StackedBarChart />);
-      wrapper.instance().use24Hours = () => false;
-
-      expect(wrapper.instance().timeLabelAsFull(marker)).toMatch(/[A|P]M/);
-    });
-    it('creates a 24h time label if use24Hours is enabled', function() {
-      const marker = {x: 1439776800, className: 'first-seen', label: 'first seen'};
-
-      const wrapper = shallow(<StackedBarChart />);
-      wrapper.instance().use24Hours = () => true;
-
-      expect(wrapper.instance().timeLabelAsFull(marker)).not.toMatch(/[A|P]M/);
-    });
-  });
 });

--- a/tests/js/spec/utils/dates.spec.jsx
+++ b/tests/js/spec/utils/dates.spec.jsx
@@ -1,4 +1,10 @@
-import {setDateToTime, intervalToMilliseconds, parsePeriodToHours} from 'app/utils/dates';
+import {
+  setDateToTime,
+  intervalToMilliseconds,
+  parsePeriodToHours,
+  use24Hours,
+} from 'app/utils/dates';
+import ConfigStore from 'app/stores/configStore';
 
 describe('utils.dates', function() {
   describe('setDateToTime', function() {
@@ -50,6 +56,22 @@ describe('utils.dates', function() {
       expect(parsePeriodToHours('24')).toBe(24 / 3600);
       expect(parsePeriodToHours('')).toBe(-1);
       expect(parsePeriodToHours('24x')).toBe(-1);
+    });
+  });
+
+  describe('use24Hours()', function() {
+    it('returns false if user preference is 12 hour clock', function() {
+      const user = TestStubs.User();
+      user.options.clock24Hours = false;
+      ConfigStore.set('user', user);
+      expect(use24Hours()).toBe(false);
+    });
+
+    it('returns true if user preference is 24 hour clock', function() {
+      const user = TestStubs.User();
+      user.options.clock24Hours = true;
+      ConfigStore.set('user', user);
+      expect(use24Hours()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
This precommit hook test is failing from these changes: 

  ● groupDetails › redirects to new issue if params id !== id returned from API request

    React.Children.only expected to receive a single React element child.

      14 |   );
      15 |
    > 16 |   return mount(tree, {wrappingComponent: WrappingThemeProvider, ...opts});
         |          ^
      17 | };
      18 |
      19 | export {mountWithTheme, mount, shallow, render};

      at Object.onlyChild [as only] (node_modules/react/cjs/react.development.js:1385:13)
      at DocumentTitle.Object.<anonymous>.DocumentTitle.render (node_modules/react-document-title/index.js:31:27)
      at finishClassComponent (node_modules/react-dom/cjs/react-dom.development.js:18470:31)
      at updateClassComponent (node_modules/react-dom/cjs/react-dom.development.js:18423:24)
      at beginWork$1 (node_modules/react-dom/cjs/react-dom.development.js:20186:16)
      at HTMLUnknownElement.callCallback (node_modules/react-dom/cjs/react-dom.development.js:336:14)
      at invokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:193:27)
      at HTMLUnknownElementImpl._dispatch (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:119:9)
      at HTMLUnknownElementImpl.dispatchEvent (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:82:17)
      at HTMLUnknownElementImpl.dispatchEvent (node_modules/jsdom/lib/jsdom/living/nodes/HTMLElement-impl.js:30:27)
      at HTMLUnknownElement.dispatchEvent (node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:157:21)
      at Object.invokeGuardedCallbackDev (node_modules/react-dom/cjs/react-dom.development.js:385:16)
      at invokeGuardedCallback (node_modules/react-dom/cjs/react-dom.development.js:440:31)
      at beginWork$$1 (node_modules/react-dom/cjs/react-dom.development.js:25780:7)
      at performUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:24698:12)
      at workLoopSync (node_modules/react-dom/cjs/react-dom.development.js:24671:22)
      at performSyncWorkOnRoot (node_modules/react-dom/cjs/react-dom.development.js:24270:11)
      at scheduleUpdateOnFiber (node_modules/react-dom/cjs/react-dom.development.js:23698:7)
      at updateContainer (node_modules/react-dom/cjs/react-dom.development.js:27103:3)
      at node_modules/react-dom/cjs/react-dom.development.js:27528:7
      at unbatchedUpdates (node_modules/react-dom/cjs/react-dom.development.js:24433:12)
      at legacyRenderSubtreeIntoContainer (node_modules/react-dom/cjs/react-dom.development.js:27527:5)
      at Object.render (node_modules/react-dom/cjs/react-dom.development.js:27608:10)
      at fn (node_modules/enzyme-adapter-react-16/src/ReactSixteenAdapter.js:430:26)
      at node_modules/enzyme-adapter-react-16/src/ReactSixteenAdapter.js:347:37
      at batchedUpdates$1 (node_modules/react-dom/cjs/react-dom.development.js:24386:12)
      at Object.act (node_modules/react-dom/cjs/react-dom-test-utils.development.js:1092:14)
      at wrapAct (node_modules/enzyme-adapter-react-16/src/ReactSixteenAdapter.js:347:13)
      at Object.render (node_modules/enzyme-adapter-react-16/src/ReactSixteenAdapter.js:416:16)
      at new ReactWrapper (node_modules/enzyme/src/ReactWrapper.js:115:16)
      at mount (node_modules/enzyme/src/mount.js:10:10)
      at mountWithTheme (tests/js/sentry-test/enzyme.js:16:10)
      at createWrapper (tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx:86:42)
      at _callee6$ (tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx:299:23)
      at tryCatch (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:45:40)
      at Generator.invoke [as _invoke] (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:274:22)
      at Generator.prototype.(anonymous function) [as next] (node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:97:21)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
      at node_modules/@babel/runtime/helpers/asyncToGenerator.js:32:7
      at Object.<anonymous> (node_modules/@babel/runtime/helpers/asyncToGenerator.js:21:12)


Test Suites: 1 failed, 21 passed, 22 of 109 total
Tests:       5 failed, 314 passed, 319 total
Snapshots:   15 passed, 15 total
Time:        15.894s
Ran all test suites related to files matching /\/Users\/sarah\/code\/sentry\/src\/sentry\/static\/sentry\/app\/components\/charts\/components\/tooltip.jsx|\/Users\/sarah\/code\/sentry\/src\/sentry\/static\/sentry\/app\/components\/charts\/components\/xAxis.jsx|\/Users\/sarah\/code\/sentry\/src\/sentry\/static\/sentry\/app\/components\/stackedBarChart.jsx|\/Users\/sarah\/code\/sentry\/src\/sentry\/static\/sentry\/app\/utils\/dates.tsx|\/Users\/sarah\/code\/sentry\/src\/sentry\/static\/sentry\/app\/views\/organizationGroupDetails\/groupDetails.tsx/i.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
black................................................(no files to check)Skipped
flake8...............................................(no files to check)Skipped
Check for case conflicts.................................................Passed
Check that executables have shebangs.................(no files to check)Skipped
Check for merge conflicts................................................Passed
Check for broken symlinks............................(no files to check)Skipped
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
Debug Statements (Python)............................(no files to check)Skipped