### PR TITLE
fix(ui) Fix wrapping lines in multi-series charts

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/areaChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/areaChart.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import AreaSeries from './series/areaSeries';
 import BaseChart from './baseChart';
-import {AREA_SINGLE_COLOR} from './utils';
 
 class AreaChart extends React.Component {
   static propTypes = {
@@ -22,9 +21,13 @@ class AreaChart extends React.Component {
             stack: stacked ? 'area' : false,
             name: seriesName,
             data: data.map(({name, value}) => [name, value]),
-            color: (colors && colors[i]) || AREA_SINGLE_COLOR,
+            color: colors && colors[i],
+            lineStyle: {
+              opacity: 1,
+              width: 0.4,
+            },
             areaStyle: {
-              color: (colors && colors[i]) || AREA_SINGLE_COLOR,
+              color: colors && colors[i],
               opacity: 1.0,
             },
             animation: false,

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -148,10 +148,6 @@ class DurationChart extends React.Component<Props> {
                           lineStyle: {
                             opacity: 0,
                           },
-                          areaStyle: {
-                            color: colors[i],
-                            opacity: 1.0,
-                          },
                         };
                       })
                       .reverse()


### PR DESCRIPTION
Reduce lines on area charts so that they don't visibly surround other series and spill onto the x-axis. I can't go all the way to 0 as it cause unpleasant aliasing artifacts between series.