### PR TITLE
fix(docker): Not all Sentry commands work through CMD

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -187,6 +187,7 @@ RUN set -x \
 
 COPY --from=sdist /dist/*.whl /tmp/dist/
 RUN pip install /tmp/dist/*.whl && pip check
+RUN sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
 
 COPY ./docker/sentry.conf.py ./docker/config.yml $SENTRY_CONF/
 COPY ./docker/docker-entrypoint.sh /

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- sentry "$@"
 fi
 
-if [[ $1 =~ ^[[:alnum:]]+$ ]] && [ -f "/usr/local/lib/python2.7/site-packages/sentry/runner/commands/$1.py" ]; then
+if [[ $1 =~ ^[[:alnum:]]+$ ]] && grep -Fxq "$1" /sentry-commands.txt; then
 	set -- sentry "$@";
 fi
 


### PR DESCRIPTION
Following up to #16417, which assumed all commands are listed in individual modules. This was not the case and this PR broke commands like `docker run getsentry/sentry:latest export`.

In this PR, we run `sentry help` and dump its output with some `sed` and `awk` magic to a file to check against. This approach is:

1. Simple
2. Serves as a simple smoke test for the image
3. Is independent of the underlying CLI libarary (not that we'll change it, but who knows).