### PR TITLE
fix(Plugins): Success & failure toast stays around long enough

### DIFF
--- a/src/sentry/static/sentry/app/components/bases/pluginComponentBase.jsx
+++ b/src/sentry/static/sentry/app/components/bases/pluginComponentBase.jsx
@@ -99,13 +99,16 @@ class PluginComponentBase extends React.Component {
   }
 
   onSaveSuccess(callback, ...args) {
+    callback = callbackWithArgs(callback, ...args);
     this.setState(
       {
         state: FormState.READY,
       },
-      callbackWithArgs(callback, ...args)
+      () => callback && callback()
     );
-    addSuccessMessage(t('Success!'));
+    setTimeout(() => {
+      addSuccessMessage(t('Success!'));
+    }, 0);
   }
 
   onSaveError(callback, ...args) {
@@ -114,11 +117,11 @@ class PluginComponentBase extends React.Component {
       {
         state: FormState.ERROR,
       },
-      () => {
-        addErrorMessage(t('Unable to save changes. Please try again.'));
-        callback && callback();
-      }
+      () => callback && callback()
     );
+    setTimeout(() => {
+      addErrorMessage(t('Unable to save changes. Please try again.'));
+    }, 0);
   }
 
   onSaveComplete(callback, ...args) {


### PR DESCRIPTION
## Objective
If you got a backend validation error on saving a plugin (e.g. bad phone number for Twilio), the toast message goes away so quickly you can't figure out what's going on. We want to make the toast stay long enough for a user to read in both success and failure.

## UI
![animation](https://user-images.githubusercontent.com/10491193/81006142-dce0fd80-8e03-11ea-9a0c-2ff41bc429c0.gif)

## Test Plan
Tested locally.