### PR TITLE
ref(slack): Add user_scope parameter

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -89,12 +89,16 @@ class OAuth2Provider(Provider):
     def get_refresh_token_headers(self):
         return None
 
+    def get_user_scopes(self):
+        return self.config.get("user_scopes", "")
+
     def get_pipeline_views(self):
         return [
             OAuth2LoginView(
                 authorize_url=self.get_oauth_authorize_url(),
                 client_id=self.get_oauth_client_id(),
                 scope=" ".join(self.get_oauth_scopes()),
+                user_scope=" ".join(self.get_user_scopes()),
             ),
             OAuth2CallbackView(
                 access_token_url=self.get_oauth_access_token_url(),
@@ -204,8 +208,11 @@ class OAuth2LoginView(PipelineView):
     authorize_url = None
     client_id = None
     scope = ""
+    user_scope = ""
 
-    def __init__(self, authorize_url=None, client_id=None, scope=None, *args, **kwargs):
+    def __init__(
+        self, authorize_url=None, client_id=None, scope=None, user_scope=None, *args, **kwargs
+    ):
         super(OAuth2LoginView, self).__init__(*args, **kwargs)
         if authorize_url is not None:
             self.authorize_url = authorize_url
@@ -213,6 +220,8 @@ class OAuth2LoginView(PipelineView):
             self.client_id = client_id
         if scope is not None:
             self.scope = scope
+        if user_scope is not None:
+            self.user_scope = user_scope
 
     def get_scope(self):
         return self.scope
@@ -221,13 +230,17 @@ class OAuth2LoginView(PipelineView):
         return self.authorize_url
 
     def get_authorize_params(self, state, redirect_uri):
-        return {
+        data = {
             "client_id": self.client_id,
             "response_type": "code",
             "scope": self.get_scope(),
             "state": state,
             "redirect_uri": redirect_uri,
         }
+        if self.user_scope:
+            data["user_scope"] = self.user_scope
+
+        return data
 
     @csrf_exempt
     def dispatch(self, request, pipeline):

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -89,16 +89,12 @@ class OAuth2Provider(Provider):
     def get_refresh_token_headers(self):
         return None
 
-    def get_user_scopes(self):
-        return self.config.get("user_scopes", "")
-
     def get_pipeline_views(self):
         return [
             OAuth2LoginView(
                 authorize_url=self.get_oauth_authorize_url(),
                 client_id=self.get_oauth_client_id(),
                 scope=" ".join(self.get_oauth_scopes()),
-                user_scope=" ".join(self.get_user_scopes()),
             ),
             OAuth2CallbackView(
                 access_token_url=self.get_oauth_access_token_url(),
@@ -208,11 +204,8 @@ class OAuth2LoginView(PipelineView):
     authorize_url = None
     client_id = None
     scope = ""
-    user_scope = ""
 
-    def __init__(
-        self, authorize_url=None, client_id=None, scope=None, user_scope=None, *args, **kwargs
-    ):
+    def __init__(self, authorize_url=None, client_id=None, scope=None, *args, **kwargs):
         super(OAuth2LoginView, self).__init__(*args, **kwargs)
         if authorize_url is not None:
             self.authorize_url = authorize_url
@@ -220,8 +213,6 @@ class OAuth2LoginView(PipelineView):
             self.client_id = client_id
         if scope is not None:
             self.scope = scope
-        if user_scope is not None:
-            self.user_scope = user_scope
 
     def get_scope(self):
         return self.scope
@@ -230,17 +221,13 @@ class OAuth2LoginView(PipelineView):
         return self.authorize_url
 
     def get_authorize_params(self, state, redirect_uri):
-        data = {
+        return {
             "client_id": self.client_id,
             "response_type": "code",
             "scope": self.get_scope(),
             "state": state,
             "redirect_uri": redirect_uri,
         }
-        if self.user_scope:
-            data["user_scope"] = self.user_scope
-
-        return data
 
     @csrf_exempt
     def dispatch(self, request, pipeline):

--- a/src/sentry/identity/slack/provider.py
+++ b/src/sentry/identity/slack/provider.py
@@ -111,13 +111,7 @@ class SlackOAuth2LoginView(OAuth2LoginView):
             self.user_scope = user_scope
 
     def get_authorize_params(self, state, redirect_uri):
-        data = {
-            "client_id": self.client_id,
-            "response_type": "code",
-            "scope": self.get_scope(),
-            "state": state,
-            "redirect_uri": redirect_uri,
-        }
+        data = super(SlackOAuth2LoginView, self).get_authorize_params(state, redirect_uri)
 
         # XXX(meredith): Bot apps must be added manually to channels, and link unfurling
         # only works for channels the bot is a part of, so in order to expand the usage

--- a/src/sentry/identity/slack/provider.py
+++ b/src/sentry/identity/slack/provider.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.conf import settings
 
 from sentry import options
-from sentry.identity.oauth2 import OAuth2Provider
+from sentry.identity.oauth2 import OAuth2Provider, OAuth2LoginView, OAuth2CallbackView
 
 
 class SlackIdentityProvider(OAuth2Provider):
@@ -13,7 +13,11 @@ class SlackIdentityProvider(OAuth2Provider):
     # This identity provider is used for authorizing the Slack application
     # through their Bot token (or legacy Workspace Token if enabled) flow.
 
-    oauth_scopes = ("identity.basic", "identity.email", "links:read")
+    oauth_scopes = ("identity.basic", "identity.email")
+
+    # Only used during installation for Bot apps in order to request "links:read"
+    # user_scope, needed for unfurling.
+    user_scopes = ()
 
     def get_oauth_authorize_url(self):
         if self.use_wst_app:
@@ -50,6 +54,24 @@ class SlackIdentityProvider(OAuth2Provider):
             return options.get("slack-v2.client-secret")
         return options.get("slack.client-secret")
 
+    def get_user_scopes(self):
+        return self.config.get("user_scopes", self.user_scopes)
+
+    def get_pipeline_views(self):
+        return [
+            SlackOAuth2LoginView(
+                authorize_url=self.get_oauth_authorize_url(),
+                client_id=self.get_oauth_client_id(),
+                scope=" ".join(self.get_oauth_scopes()),
+                user_scope=" ".join(self.get_user_scopes()),
+            ),
+            OAuth2CallbackView(
+                access_token_url=self.get_oauth_access_token_url(),
+                client_id=self.get_oauth_client_id(),
+                client_secret=self.get_oauth_client_secret(),
+            ),
+        ]
+
     def get_oauth_data(self, payload):
         # TODO(epurkhiser): This flow isn't actually used right now in sentry.
         # In slack-bot world we would need to make an API call to the 'me'
@@ -67,3 +89,48 @@ class SlackIdentityProvider(OAuth2Provider):
             "scopes": sorted(data["scope"].split(",")),
             "data": self.get_oauth_data(data),
         }
+
+
+class SlackOAuth2LoginView(OAuth2LoginView):
+    """
+    We need to customize the OAuth2LoginView in order to support passing through
+    the `user_scope` param in the request.
+
+    The `user_scope` param would not be used when requesting identity scopes.
+    """
+
+    user_scope = ""
+
+    def __init__(
+        self, authorize_url=None, client_id=None, scope=None, user_scope=None, *args, **kwargs
+    ):
+        super(SlackOAuth2LoginView, self).__init__(
+            authorize_url=authorize_url, client_id=client_id, scope=scope, *args, **kwargs
+        )
+        if user_scope is not None:
+            self.user_scope = user_scope
+
+    def get_authorize_params(self, state, redirect_uri):
+        data = {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "scope": self.get_scope(),
+            "state": state,
+            "redirect_uri": redirect_uri,
+        }
+
+        # XXX(meredith): Bot apps must be added manually to channels, and link unfurling
+        # only works for channels the bot is a part of, so in order to expand the usage
+        # of unfurling to work in channels the bot is not a part of we must request the
+        # `links:read` scope for the user. This way channels that the authorizing user
+        # are in will support link unfurling
+        #
+        # The way we can request scopes for users is by using the `user_scope` param. This
+        # will give us the user token...which I don't think we use, but requesting the scope
+        # seems to be enough to get the unfurling to work.
+        #
+        # Resources: https://api.slack.com/authentication/oauth-v2#asking
+        if self.user_scope:
+            data["user_scope"] = self.user_scope
+
+        return data

--- a/src/sentry/identity/slack/provider.py
+++ b/src/sentry/identity/slack/provider.py
@@ -13,7 +13,7 @@ class SlackIdentityProvider(OAuth2Provider):
     # This identity provider is used for authorizing the Slack application
     # through their Bot token (or legacy Workspace Token if enabled) flow.
 
-    oauth_scopes = ("identity.basic", "identity.email")
+    oauth_scopes = ("identity.basic", "identity.email", "links:read")
 
     def get_oauth_authorize_url(self):
         if self.use_wst_app:

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -122,6 +122,7 @@ class SlackIntegrationProvider(IntegrationProvider):
 
     def get_pipeline_views(self):
         identity_pipeline_config = {
+            "user_scopes": frozenset(["links:read"]),
             "oauth_scopes": self.identity_oauth_scopes,
             "redirect_url": absolute_uri("/extensions/slack/setup/"),
         }

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -122,8 +122,8 @@ class SlackIntegrationProvider(IntegrationProvider):
 
     def get_pipeline_views(self):
         identity_pipeline_config = {
-            "user_scopes": frozenset(["links:read"]),
             "oauth_scopes": self.identity_oauth_scopes,
+            "user_scopes": frozenset(["links:read"]) if not self.use_wst_app else (),
             "redirect_url": absolute_uri("/extensions/slack/setup/"),
         }
 

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -45,6 +45,8 @@ class SlackIntegrationTest(IntegrationTestCase):
         assert params["redirect_uri"] == ["http://testserver/extensions/slack/setup/"]
         assert params["response_type"] == ["code"]
         assert params["client_id"] == [expected_client_id]
+
+        assert params.get("user_scope") is None if is_wst_app else ["links:read"]
         # once we've asserted on it, switch to a singular values to make life
         # easier
         authorize_params = {k: v[0] for k, v in six.iteritems(params)}


### PR DESCRIPTION
**Context:**
In order for link unfurling to work for bot apps, the bot must have access to the channel (by being added to channel). In addition, for the classic bot tokens (used by on-prem users who couldn't create a workspace app since they were deprecated), were not supported in the [chat.unfurl](https://api.slack.com/methods/chat.unfurl) method, and so we were using the `user_access_token` instead. 

New bot tokens _are_ supported in the chat.unfurl method and we can post in channels that the bot is not a part of using the `chat:write:public` scope. However, we need to be able to subscribe to the user `linked_shared` webhooks, in addition to the bot `link_shared` webhooks to be able to actually get the data we need to then post to chat.unfurl. We need to request the `user_scope` parameter with the scope including `links:read` to be able to subscribe to the webhook events from channels the authorizing user has access to. 

**This PR:**
The `user_scope` parameter is not standard OAuth2 so I've subclassed the `OAuth2LoginView` so that we can pass through this scope just for Slack. This parameter is only used when authorizing the bot app with Sentry, and is not used when authorizing an individual user independently of the Slack app. 

Further reading: https://api.slack.com/authentication/oauth-v2#asking