### PR TITLE
perf(api): Omit feature flags from API views of multiple projects

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -5,6 +5,7 @@ import six
 from django.db.models import Q
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -107,7 +108,10 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         if get_all_projects:
             queryset = queryset.order_by("slug").select_related("organization")
-            return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
+            serializer = ProjectSummarySerializer(
+                include_features=not features.has("organizations:enterprise-perf", organization)
+            )
+            return Response(serialize(list(queryset), request.user, serializer))
         else:
 
             def serialize_on_result(result):

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -58,12 +58,13 @@ class ProjectSerializer(Serializer):
     such as "show all projects for this organization", and its attributes be kept to a minimum.
     """
 
-    def __init__(self, environment_id=None, stats_period=None):
+    def __init__(self, environment_id=None, stats_period=None, include_features=True):
         if stats_period is not None:
             assert stats_period in STATS_PERIOD_CHOICES
 
         self.environment_id = environment_id
         self.stats_period = stats_period
+        self.include_features = include_features
 
     def get_access_by_project(self, item_list, user):
         request = env.request
@@ -164,6 +165,9 @@ class ProjectSerializer(Serializer):
     def get_feature_list(self, obj, user):
         from sentry import features
         from sentry.features.base import ProjectFeature
+
+        if not self.include_features:
+            return None
 
         with sentry_sdk.start_span(
             op="project_feature_list", description=getattr(obj, "name")

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -191,8 +191,6 @@ class ProjectSerializer(Serializer):
             return feature_list
 
     def serialize(self, obj, attrs, user):
-        feature_list = self.get_feature_list(obj, user)
-
         status_label = STATUS_LABELS.get(obj.status, "unknown")
 
         if attrs.get("avatar"):
@@ -212,7 +210,6 @@ class ProjectSerializer(Serializer):
             "color": obj.color,
             "dateCreated": obj.date_added,
             "firstEvent": obj.first_event,
-            "features": feature_list,
             "status": status_label,
             "platform": obj.platform,
             "isInternal": obj.is_internal_project(),
@@ -220,8 +217,16 @@ class ProjectSerializer(Serializer):
             "hasAccess": attrs["has_access"],
             "avatar": avatar,
         }
+        return self._add_conditional_attributes(obj, attrs, user, context)
+
+    def _add_conditional_attributes(self, obj, attrs, user, context):
+        feature_list = self.get_feature_list(obj, user)
+        if feature_list is not None:
+            context["features"] = feature_list
+
         if "stats" in attrs:
             context["stats"] = attrs["stats"]
+
         return context
 
 
@@ -362,7 +367,6 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
         return attrs
 
     def serialize(self, obj, attrs, user):
-        feature_list = self.get_feature_list(obj, user)
         context = {
             "team": attrs["teams"][0] if attrs["teams"] else None,
             "teams": attrs["teams"],
@@ -374,7 +378,6 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             "hasAccess": attrs["has_access"],
             "dateCreated": obj.date_added,
             "environments": attrs["environments"],
-            "features": feature_list,
             "firstEvent": obj.first_event,
             "platform": obj.platform,
             "platforms": attrs["platforms"],
@@ -382,9 +385,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             "latestRelease": attrs["latest_release"],
             "hasUserReports": attrs["has_user_reports"],
         }
-        if "stats" in attrs:
-            context["stats"] = attrs["stats"]
-        return context
+        return self._add_conditional_attributes(obj, attrs, user, context)
 
 
 def bulk_fetch_project_latest_releases(projects):

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from django.db.models import Count
 
 
-from sentry import roles
+from sentry import roles, features
 from sentry.app import env
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.auth.superuser import is_active_superuser
@@ -132,6 +132,8 @@ class TeamSerializer(Serializer):
 
 class TeamWithProjectsSerializer(TeamSerializer):
     def get_attrs(self, item_list, user):
+        from sentry.api.serializers.models.project import ProjectSerializer
+
         project_teams = list(
             ProjectTeam.objects.filter(team__in=item_list, project__status=ProjectStatus.VISIBLE)
             .order_by("project__name", "project__slug")
@@ -145,9 +147,13 @@ class TeamWithProjectsSerializer(TeamSerializer):
             project_team.project._organization_cache = orgs[project_team.project.organization_id]
 
         projects = [pt.project for pt in project_teams]
-        projects_by_id = {
-            project.id: data for project, data in zip(projects, serialize(projects, user))
-        }
+        project_serializer = ProjectSerializer(
+            include_features=not all(
+                features.has("organizations:enterprise-perf", org) for org in orgs
+            )
+        )
+        serialized_projects = serialize(projects, user, project_serializer)
+        projects_by_id = {project.id: data for project, data in zip(projects, serialized_projects)}
 
         project_map = defaultdict(list)
         for project_team in project_teams:

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -34,6 +34,7 @@ class OrganizationProjectsTest(APITestCase):
         response = self.client.get(self.path)
         self.check_valid_response(response, [project])
         assert self.client.session["activeorg"] == self.org.slug
+        assert "features" in response.data[0]
 
     def test_with_stats(self):
         self.login_as(user=self.user)
@@ -162,6 +163,19 @@ class OrganizationProjectsTest(APITestCase):
         response = self.client.get(self.path + "?all_projects=1&per_page=1")
         # Verify all projects in the org are returned in sorted order
         self.check_valid_response(response, sorted_projects)
+
+        for project in response.data:
+            assert "features" in project
+
+    def test_all_projects_suppresses_flags(self):
+        self.login_as(user=self.user)
+        self.create_project(teams=[self.team], name="foo", slug="foo")
+        self.create_project(teams=[self.team], name="bar", slug="bar")
+
+        with self.feature("organizations:enterprise-perf"):
+            response = self.client.get(self.path + "?all_projects=1&per_page=1")
+        for project in response.data:
+            assert "features" not in project
 
     def test_user_projects(self):
         self.foo_user = self.create_user("foo@example.com")

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -50,7 +50,7 @@ class ProjectSerializerTest(TestCase):
 
         result = serialize(project, user, ProjectSerializer(include_features=False))
 
-        assert result["features"] is None
+        assert "features" not in result
 
     def test_member_access(self):
         user = self.create_user(username="foo")
@@ -228,7 +228,7 @@ class ProjectSummarySerializerTest(TestCase):
         result = serialize(
             self.project, self.user, ProjectSummarySerializer(include_features=False)
         )
-        assert result["features"] is None
+        assert "features" not in result
 
     def test_user_reports(self):
         result = serialize(self.project, self.user, ProjectSummarySerializer())

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -12,6 +12,7 @@ from exam import fixture
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import (
     bulk_fetch_project_latest_releases,
+    ProjectSerializer,
     ProjectWithOrganizationSerializer,
     ProjectWithTeamSerializer,
     ProjectSummarySerializer,
@@ -39,6 +40,17 @@ class ProjectSerializerTest(TestCase):
         assert result["slug"] == project.slug
         assert result["name"] == project.name
         assert result["id"] == six.text_type(project.id)
+        assert result["features"] is not None
+
+    def test_suppress_features(self):
+        user = self.create_user(username="foo")
+        organization = self.create_organization(owner=user)
+        team = self.create_team(organization=organization)
+        project = self.create_project(teams=[team], organization=organization, name="foo")
+
+        result = serialize(project, user, ProjectSerializer(include_features=False))
+
+        assert result["features"] is None
 
     def test_member_access(self):
         user = self.create_user(username="foo")
@@ -211,6 +223,12 @@ class ProjectSummarySerializerTest(TestCase):
         }
         assert result["latestRelease"] == {"version": self.release.version}
         assert result["environments"] == ["production", "staging"]
+
+    def test_suppress_features(self):
+        result = serialize(
+            self.project, self.user, ProjectSummarySerializer(include_features=False)
+        )
+        assert result["features"] is None
 
     def test_user_reports(self):
         result = serialize(self.project, self.user, ProjectSummarySerializer())


### PR DESCRIPTION
Suppress the list of feature flags from the "all projects" API endpoint,
and from the projects nested in a team. This is intended to improve
performance where an organization has many projects.

This may be considered a breaking change, so for now the change occurs
only behind a feature flag for experimental performance improvements.