### PR TITLE
feat(apm): Compare transactions

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -146,7 +146,7 @@ const INTERSECTION_THRESHOLDS: Array<number> = [
 
 const TOGGLE_BUTTON_MARGIN_RIGHT = 16;
 const TOGGLE_BUTTON_MAX_WIDTH = 30;
-const TOGGLE_BORDER_BOX = TOGGLE_BUTTON_MAX_WIDTH + TOGGLE_BUTTON_MARGIN_RIGHT;
+export const TOGGLE_BORDER_BOX = TOGGLE_BUTTON_MAX_WIDTH + TOGGLE_BUTTON_MARGIN_RIGHT;
 const MARGIN_LEFT = 0;
 
 type DurationDisplay = 'left' | 'right' | 'inset';
@@ -172,7 +172,7 @@ const getDurationDisplay = ({
   return 'inset';
 };
 
-const getBackgroundColor = ({
+export const getBackgroundColor = ({
   showStriping,
   showDetail,
   theme,
@@ -859,7 +859,7 @@ type SpanRowCellProps = OmitHtmlDivProps<{
   showDetail?: boolean;
 }>;
 
-const SpanRowCell = styled('div')<SpanRowCellProps>`
+export const SpanRowCell = styled('div')<SpanRowCellProps>`
   position: relative;
   padding: ${space(0.5)} 1px;
   height: 100%;
@@ -869,7 +869,7 @@ const SpanRowCell = styled('div')<SpanRowCellProps>`
   color: ${p => (p.showDetail ? p.theme.white : 'inherit')};
 `;
 
-const SpanRowCellContainer = styled('div')<SpanRowCellProps>`
+export const SpanRowCellContainer = styled('div')<SpanRowCellProps>`
   display: flex;
   position: relative;
   height: ${SPAN_ROW_HEIGHT}px;
@@ -890,7 +890,7 @@ const CursorGuide = styled('div')`
   height: 100%;
 `;
 
-const DividerLine = styled('div')`
+export const DividerLine = styled('div')`
   background-color: ${p => p.theme.gray400};
   position: absolute;
   height: 100%;
@@ -924,13 +924,13 @@ const DividerLine = styled('div')`
   }
 `;
 
-const DividerLineGhostContainer = styled('div')`
+export const DividerLineGhostContainer = styled('div')`
   position: absolute;
   width: 100%;
   height: 100%;
 `;
 
-const SpanBarTitleContainer = styled('div')`
+export const SpanBarTitleContainer = styled('div')`
   display: flex;
   align-items: center;
   height: 100%;
@@ -941,7 +941,7 @@ const SpanBarTitleContainer = styled('div')`
   user-select: none;
 `;
 
-const SpanBarTitle = styled('div')`
+export const SpanBarTitle = styled('div')`
   position: relative;
   height: 100%;
   font-size: ${p => p.theme.fontSizeSmall};
@@ -956,7 +956,7 @@ type TogglerTypes = OmitHtmlDivProps<{
   isLast?: boolean;
 }>;
 
-const SpanTreeTogglerContainer = styled('div')<TogglerTypes>`
+export const SpanTreeTogglerContainer = styled('div')<TogglerTypes>`
   position: relative;
   height: ${SPAN_ROW_HEIGHT}px;
   width: ${p => (p.hasToggler ? '40px' : '12px')};
@@ -968,7 +968,7 @@ const SpanTreeTogglerContainer = styled('div')<TogglerTypes>`
   align-items: center;
 `;
 
-const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
+export const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
   height: ${p => (p.isLast ? SPAN_ROW_HEIGHT / 2 : SPAN_ROW_HEIGHT)}px;
   width: 100%;
   border-left: 1px ${p => (p.orphanBranch ? 'dashed' : 'solid')}
@@ -999,7 +999,7 @@ const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
   }
 `;
 
-const ConnectorBar = styled('div')<{orphanBranch: boolean}>`
+export const ConnectorBar = styled('div')<{orphanBranch: boolean}>`
   height: 250%;
 
   border-left: 1px ${p => (p.orphanBranch ? 'dashed' : 'solid')}
@@ -1040,7 +1040,7 @@ type SpanTreeTogglerAndDivProps = OmitHtmlDivProps<{
   disabled: boolean;
 }>;
 
-const SpanTreeToggler = styled('div')<SpanTreeTogglerAndDivProps>`
+export const SpanTreeToggler = styled('div')<SpanTreeTogglerAndDivProps>`
   height: 16px;
   white-space: nowrap;
   min-width: 30px;
@@ -1110,7 +1110,7 @@ const getHatchPattern = ({spanBarHatch}) => {
   return null;
 };
 
-const SpanBarRectangle = styled('div')<{spanBarHatch: boolean}>`
+export const SpanBarRectangle = styled('div')<{spanBarHatch: boolean}>`
   position: relative;
   height: 100%;
   min-width: 1px;
@@ -1125,12 +1125,12 @@ const StyledIconWarning = styled(IconWarning)`
   margin-bottom: ${space(0.25)};
 `;
 
-const StyledIconChevron = styled(IconChevron)`
+export const StyledIconChevron = styled(IconChevron)`
   width: 7px;
   margin-left: ${space(0.25)};
 `;
 
-const OperationName = styled('span')<{spanErrors: TableDataRow[]}>`
+export const OperationName = styled('span')<{spanErrors: TableDataRow[]}>`
   color: ${p => (p.spanErrors.length ? p.theme.error : 'inherit')};
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -474,12 +474,12 @@ const StyledDiscoverButton = styled(DiscoverButton)`
   right: ${space(0.5)};
 `;
 
-const SpanDetailContainer = styled('div')`
+export const SpanDetailContainer = styled('div')`
   border-bottom: 1px solid ${p => p.theme.borderDark};
   cursor: auto;
 `;
 
-const SpanDetails = styled('div')`
+export const SpanDetails = styled('div')`
   padding: ${space(2)};
 `;
 
@@ -494,7 +494,7 @@ const StyledLoadingIndicator = styled(LoadingIndicator)`
   margin: 0;
 `;
 
-const Row = ({
+export const Row = ({
   title,
   keep,
   children,
@@ -522,7 +522,7 @@ const Row = ({
   );
 };
 
-const Tags = ({span}: {span: RawSpanType}) => {
+export const Tags = ({span}: {span: RawSpanType}) => {
   const tags: {[tag_name: string]: string} | undefined = span?.tags;
 
   if (!tags) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -491,7 +491,7 @@ export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTrace
 
     // get any span children whose parent_span_id is equal to span.parent_span_id,
     // otherwise start with an empty array
-    const spanChildren: Array<SpanType> = acc.childSpans?.[span.parent_span_id] ?? [];
+    const spanChildren: Array<SpanType> = acc.childSpans[span.parent_span_id] ?? [];
 
     spanChildren.push(span);
 

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1677,6 +1677,24 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
           </Route>
+          <Route
+            path="/organizations/:orgId/performance/compare/:baselineEventSlug/:regressionEventSlug/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "PerformanceCompareTransactions" */ 'app/views/performance/compare'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
 
           {/* Admin/manage routes */}
           <Route

--- a/src/sentry/static/sentry/app/views/performance/breadcrumb.tsx
+++ b/src/sentry/static/sentry/app/views/performance/breadcrumb.tsx
@@ -14,12 +14,19 @@ type Props = {
   location: Location;
   transactionName?: string;
   eventSlug?: string;
+  transactionComparison?: boolean;
 };
 
 class Breadcrumb extends React.Component<Props> {
   getCrumbs() {
     const crumbs: Crumb[] = [];
-    const {organization, location, transactionName, eventSlug} = this.props;
+    const {
+      organization,
+      location,
+      transactionName,
+      eventSlug,
+      transactionComparison,
+    } = this.props;
 
     const performanceTarget: LocationDescriptor = {
       pathname: getPerformanceLandingUrl(organization),
@@ -55,6 +62,11 @@ class Breadcrumb extends React.Component<Props> {
       crumbs.push({
         to: '',
         label: t('Event Details'),
+      });
+    } else if (transactionComparison) {
+      crumbs.push({
+        to: '',
+        label: t('Compare to Baseline'),
       });
     }
 

--- a/src/sentry/static/sentry/app/views/performance/compare/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/content.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {Params} from 'react-router/lib/Router';
+import {Location} from 'history';
+
+import {t} from 'app/locale';
+import {Event, Organization} from 'app/types';
+import {Panel} from 'app/components/panels';
+import * as Layout from 'app/components/layouts/thirds';
+import Breadcrumb from 'app/views/performance/breadcrumb';
+
+import TraceView from './traceView';
+import TransactionSummary from './transactionSummary';
+import {isTransactionEvent} from './utils';
+
+type Props = {
+  organization: Organization;
+  location: Location;
+  params: Params;
+  baselineEvent: Event;
+  regressionEvent: Event;
+};
+
+class TransactionComparisonContent extends React.Component<Props> {
+  getTransactionName() {
+    const {baselineEvent, regressionEvent} = this.props;
+
+    if (isTransactionEvent(baselineEvent) && isTransactionEvent(regressionEvent)) {
+      if (baselineEvent.title === regressionEvent.title) {
+        return baselineEvent.title;
+      }
+
+      return t('mixed transaction names');
+    }
+
+    if (isTransactionEvent(baselineEvent)) {
+      return baselineEvent.title;
+    }
+
+    if (isTransactionEvent(regressionEvent)) {
+      return regressionEvent.title;
+    }
+
+    return t('no transaction title found');
+  }
+
+  render() {
+    const {baselineEvent, regressionEvent, organization, location, params} = this.props;
+
+    const transactionName =
+      baselineEvent.title === regressionEvent.title ? baselineEvent.title : undefined;
+
+    return (
+      <React.Fragment>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Breadcrumb
+              organization={organization}
+              location={location}
+              transactionName={transactionName}
+              transactionComparison
+            />
+            <Layout.Title>{this.getTransactionName()}</Layout.Title>
+          </Layout.HeaderContent>
+          <Layout.HeaderActions>
+            <TransactionSummary
+              organization={organization}
+              location={location}
+              params={params}
+              baselineEvent={baselineEvent}
+              regressionEvent={regressionEvent}
+            />
+          </Layout.HeaderActions>
+        </Layout.Header>
+        <Layout.Body>
+          <StyledPanel>
+            <TraceView baselineEvent={baselineEvent} regressionEvent={regressionEvent} />
+          </StyledPanel>
+        </Layout.Body>
+      </React.Fragment>
+    );
+  }
+}
+
+const StyledPanel = styled(Panel)`
+  grid-column: 1 / span 2;
+  overflow: hidden;
+`;
+
+export default TransactionComparisonContent;

--- a/src/sentry/static/sentry/app/views/performance/compare/fetchEvent.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/fetchEvent.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+
+import {Client} from 'app/api';
+import withApi from 'app/utils/withApi';
+import {Event} from 'app/types';
+
+export type ChildrenProps = {
+  isLoading: boolean;
+  error: null | string;
+  event: Event | undefined;
+};
+
+type Props = {
+  api: Client;
+
+  orgSlug: string;
+  eventSlug: string;
+
+  children: (props: ChildrenProps) => React.ReactNode;
+};
+
+type State = {
+  tableFetchID: symbol | undefined;
+} & ChildrenProps;
+
+class FetchEvent extends React.Component<Props, State> {
+  state: State = {
+    isLoading: true,
+    tableFetchID: undefined,
+    error: null,
+
+    event: undefined,
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const orgSlugChanged = prevProps.orgSlug !== this.props.orgSlug;
+    const eventSlugChanged = prevProps.eventSlug !== this.props.eventSlug;
+
+    if (!this.state.isLoading && (orgSlugChanged || eventSlugChanged)) {
+      this.fetchData();
+    }
+  }
+
+  fetchData() {
+    const {orgSlug, eventSlug} = this.props;
+
+    // note: eventSlug is of the form <project-slug>:<event-id>
+
+    const url = `/organizations/${orgSlug}/events/${eventSlug}/`;
+    const tableFetchID = Symbol('tableFetchID');
+
+    this.setState({isLoading: true, tableFetchID});
+
+    this.props.api
+      .requestPromise(url, {
+        method: 'GET',
+      })
+      .then(data => {
+        if (this.state.tableFetchID !== tableFetchID) {
+          // invariant: a different request was initiated after this request
+          return;
+        }
+
+        this.setState({
+          isLoading: false,
+          tableFetchID: undefined,
+          error: null,
+          event: data,
+        });
+      })
+      .catch(err => {
+        this.setState({
+          isLoading: false,
+          tableFetchID: undefined,
+          error: err?.responseJSON?.detail ?? null,
+          event: undefined,
+        });
+      });
+  }
+
+  render() {
+    const {isLoading, error, event} = this.state;
+
+    const childrenProps: ChildrenProps = {
+      isLoading,
+      error,
+      event,
+    };
+
+    return this.props.children(childrenProps);
+  }
+}
+
+export default withApi(FetchEvent);

--- a/src/sentry/static/sentry/app/views/performance/compare/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/index.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import {Params} from 'react-router/lib/Router';
+import {Location} from 'history';
+import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
+
+import {t} from 'app/locale';
+import withOrganization from 'app/utils/withOrganization';
+import {Organization} from 'app/types';
+import {PageContent} from 'app/styles/organization';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import NotFound from 'app/components/errors/notFound';
+import LoadingIndicator from 'app/components/loadingIndicator';
+import LoadingError from 'app/components/loadingError';
+
+import FetchEvent, {ChildrenProps} from './fetchEvent';
+import TransactionComparisonContent from './content';
+
+type Props = {
+  location: Location;
+  params: Params;
+  organization: Organization;
+};
+
+class TransactionComparisonPage extends React.PureComponent<Props> {
+  getEventSlugs() {
+    const {baselineEventSlug, regressionEventSlug} = this.props.params;
+
+    const validatedBaselineEventSlug =
+      typeof baselineEventSlug === 'string' ? baselineEventSlug.trim() : undefined;
+    const validatedRegressionEventSlug =
+      typeof regressionEventSlug === 'string' ? regressionEventSlug.trim() : undefined;
+
+    return {
+      baselineEventSlug: validatedBaselineEventSlug,
+      regressionEventSlug: validatedRegressionEventSlug,
+    };
+  }
+
+  fetchEvent(
+    eventSlug: string | undefined,
+    renderFunc: (props: ChildrenProps) => React.ReactNode
+  ) {
+    if (!eventSlug) {
+      return <NotFound />;
+    }
+
+    const {organization} = this.props;
+
+    return (
+      <FetchEvent orgSlug={organization.slug} eventSlug={eventSlug}>
+        {renderFunc}
+      </FetchEvent>
+    );
+  }
+
+  renderComparison({
+    baselineEventSlug,
+    regressionEventSlug,
+  }: {
+    baselineEventSlug: string | undefined;
+    regressionEventSlug: string | undefined;
+  }): React.ReactNode {
+    return this.fetchEvent(baselineEventSlug, baselineEventResults => {
+      return this.fetchEvent(regressionEventSlug, regressionEventResults => {
+        if (baselineEventResults.isLoading || regressionEventResults.isLoading) {
+          return <LoadingIndicator />;
+        }
+
+        if (baselineEventResults.error || regressionEventResults.error) {
+          if (baselineEventResults.error) {
+            Sentry.captureException(baselineEventResults.error);
+          }
+
+          if (regressionEventResults.error) {
+            Sentry.captureException(regressionEventResults.error);
+          }
+
+          return <LoadingError />;
+        }
+
+        if (!baselineEventResults.event || !regressionEventResults.event) {
+          return <NotFound />;
+        }
+
+        const {organization, location, params} = this.props;
+
+        return (
+          <TransactionComparisonContent
+            organization={organization}
+            location={location}
+            params={params}
+            baselineEvent={baselineEventResults.event}
+            regressionEvent={regressionEventResults.event}
+          />
+        );
+      });
+    });
+  }
+
+  getDocumentTitle({
+    baselineEventSlug,
+    regressionEventSlug,
+  }: {
+    baselineEventSlug: string | undefined;
+    regressionEventSlug: string | undefined;
+  }): string {
+    if (
+      typeof baselineEventSlug === 'string' &&
+      typeof regressionEventSlug === 'string'
+    ) {
+      const title = `Comparing ${baselineEventSlug} to ${regressionEventSlug}`;
+
+      return [title, t('Performance')].join(' - ');
+    }
+
+    return [t('Transaction Comparison'), t('Performance')].join(' - ');
+  }
+
+  render() {
+    const {organization} = this.props;
+    const {baselineEventSlug, regressionEventSlug} = this.getEventSlugs();
+
+    return (
+      <SentryDocumentTitle
+        title={this.getDocumentTitle({baselineEventSlug, regressionEventSlug})}
+        objSlug={organization.slug}
+      >
+        <React.Fragment>
+          <StyledPageContent>
+            <LightWeightNoProjectMessage organization={organization}>
+              {this.renderComparison({baselineEventSlug, regressionEventSlug})}
+            </LightWeightNoProjectMessage>
+          </StyledPageContent>
+        </React.Fragment>
+      </SentryDocumentTitle>
+    );
+  }
+}
+
+const StyledPageContent = styled(PageContent)`
+  padding: 0;
+`;
+
+export default withOrganization(TransactionComparisonPage);

--- a/src/sentry/static/sentry/app/views/performance/compare/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/index.tsx
@@ -106,7 +106,7 @@ class TransactionComparisonPage extends React.PureComponent<Props> {
       typeof baselineEventSlug === 'string' &&
       typeof regressionEventSlug === 'string'
     ) {
-      const title = `Comparing ${baselineEventSlug} to ${regressionEventSlug}`;
+      const title = t('Comparing %s to %s', baselineEventSlug, regressionEventSlug);
 
       return [title, t('Performance')].join(' - ');
     }

--- a/src/sentry/static/sentry/app/views/performance/compare/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/index.tsx
@@ -17,6 +17,11 @@ import LoadingError from 'app/components/loadingError';
 import FetchEvent, {ChildrenProps} from './fetchEvent';
 import TransactionComparisonContent from './content';
 
+type ComparedEventSlugs = {
+  baselineEventSlug: string | undefined;
+  regressionEventSlug: string | undefined;
+};
+
 type Props = {
   location: Location;
   params: Params;
@@ -24,7 +29,7 @@ type Props = {
 };
 
 class TransactionComparisonPage extends React.PureComponent<Props> {
-  getEventSlugs() {
+  getEventSlugs(): ComparedEventSlugs {
     const {baselineEventSlug, regressionEventSlug} = this.props.params;
 
     const validatedBaselineEventSlug =
@@ -58,10 +63,7 @@ class TransactionComparisonPage extends React.PureComponent<Props> {
   renderComparison({
     baselineEventSlug,
     regressionEventSlug,
-  }: {
-    baselineEventSlug: string | undefined;
-    regressionEventSlug: string | undefined;
-  }): React.ReactNode {
+  }: ComparedEventSlugs): React.ReactNode {
     return this.fetchEvent(baselineEventSlug, baselineEventResults => {
       return this.fetchEvent(regressionEventSlug, regressionEventResults => {
         if (baselineEventResults.isLoading || regressionEventResults.isLoading) {
@@ -99,13 +101,7 @@ class TransactionComparisonPage extends React.PureComponent<Props> {
     });
   }
 
-  getDocumentTitle({
-    baselineEventSlug,
-    regressionEventSlug,
-  }: {
-    baselineEventSlug: string | undefined;
-    regressionEventSlug: string | undefined;
-  }): string {
+  getDocumentTitle({baselineEventSlug, regressionEventSlug}: ComparedEventSlugs): string {
     if (
       typeof baselineEventSlug === 'string' &&
       typeof regressionEventSlug === 'string'

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -536,7 +536,6 @@ const ComparisonSpanBarRectangle = styled(SpanBarRectangle)`
 
 const ComparisonReportLabelContainer = styled('div')`
   position: absolute;
-  height: 100%;
   user-select: none;
   right: ${space(1)};
 

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -415,11 +415,7 @@ class SpanBar extends React.Component<Props, State> {
         spanBarHatch={spanBarStyles.foreground.hatch ?? false}
         style={{
           backgroundColor: spanBarStyles.foreground.color,
-          left: '1px',
           width: spanBarStyles.foreground.width,
-          position: 'absolute',
-          top: '4px',
-          height: '16px',
           display: hideSpanBarColumn ? 'none' : 'block',
         }}
       />
@@ -454,11 +450,7 @@ class SpanBar extends React.Component<Props, State> {
             spanBarHatch={spanBarStyles.background.hatch ?? false}
             style={{
               backgroundColor: spanBarStyles.background.color,
-              left: '1px',
               width: spanBarStyles.background.width,
-              position: 'absolute',
-              top: '4px',
-              height: '16px',
               display: hideSpanBarColumn ? 'none' : 'block',
             }}
           />
@@ -533,6 +525,12 @@ const getHatchPattern = ({spanBarHatch}) => {
 };
 
 const ComparisonSpanBarRectangle = styled(SpanBarRectangle)`
+  position: absolute;
+  top: 4px;
+  left: 1px;
+
+  height: 16px;
+
   ${getHatchPattern};
 `;
 

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -42,6 +42,7 @@ import {
 } from './utils';
 import {SpanBarRectangle} from './styles';
 import SpanDetail from './spanDetail';
+import {t} from 'app/locale';
 
 type Props = {
   span: Readonly<DiffSpanType>;
@@ -188,7 +189,10 @@ class SpanBar extends React.Component<Props, State> {
     ) : (
       ''
     );
-    const description = getSpanDescription(span) ?? getSpanID(span);
+
+    const description =
+      getSpanDescription(span) ??
+      (span.comparisonResult === 'matched' ? t('matched') : getSpanID(span));
 
     const left = treeDepth * (TOGGLE_BORDER_BOX / 2);
 

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -66,7 +66,7 @@ class SpanBar extends React.Component<Props, State> {
     showDetail: false,
   };
 
-  renderSpanTreeConnector = ({hasToggler}: {hasToggler: boolean}) => {
+  renderSpanTreeConnector({hasToggler}: {hasToggler: boolean}) {
     const {
       isLast,
       isRoot,
@@ -138,9 +138,9 @@ class SpanBar extends React.Component<Props, State> {
         {connectorBars}
       </SpanTreeConnector>
     );
-  };
+  }
 
-  renderSpanTreeToggler = ({left}: {left: number}) => {
+  renderSpanTreeToggler({left}: {left: number}) {
     const {numOfSpanChildren, isRoot, showSpanTree} = this.props;
 
     const chevron = <StyledIconChevron direction={showSpanTree ? 'up' : 'down'} />;
@@ -176,7 +176,7 @@ class SpanBar extends React.Component<Props, State> {
         </SpanTreeToggler>
       </SpanTreeTogglerContainer>
     );
-  };
+  }
 
   renderTitle() {
     const {span, treeDepth} = this.props;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -1,0 +1,550 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import theme from 'app/utils/theme';
+import space from 'app/styles/space';
+import Count from 'app/components/count';
+import {TreeDepthType} from 'app/components/events/interfaces/spans/types';
+import {SPAN_ROW_HEIGHT, SpanRow} from 'app/components/events/interfaces/spans/styles';
+import {
+  TOGGLE_BORDER_BOX,
+  SpanRowCellContainer,
+  SpanRowCell,
+  SpanBarTitleContainer,
+  SpanBarTitle,
+  OperationName,
+  StyledIconChevron,
+  SpanTreeTogglerContainer,
+  ConnectorBar,
+  SpanTreeConnector,
+  SpanTreeToggler,
+  DividerLine,
+  DividerLineGhostContainer,
+  getBackgroundColor,
+} from 'app/components/events/interfaces/spans/spanBar';
+import {
+  toPercent,
+  unwrapTreeDepth,
+  isOrphanTreeDepth,
+  getHumanDuration,
+} from 'app/components/events/interfaces/spans/utils';
+import * as DividerHandlerManager from 'app/components/events/interfaces/spans/dividerHandlerManager';
+
+import {
+  DiffSpanType,
+  getSpanID,
+  getSpanOperation,
+  getSpanDescription,
+  isOrphanDiffSpan,
+  SpanGeneratedBoundsType,
+  getSpanDuration,
+  generateCSSWidth,
+} from './utils';
+import {SpanBarRectangle} from './styles';
+import SpanDetail from './spanDetail';
+
+type Props = {
+  span: Readonly<DiffSpanType>;
+  treeDepth: number;
+  continuingTreeDepths: Array<TreeDepthType>;
+  spanNumber: number;
+  numOfSpanChildren: number;
+  isRoot: boolean;
+  isLast: boolean;
+  showSpanTree: boolean;
+  toggleSpanTree: () => void;
+  generateBounds: (span: DiffSpanType) => SpanGeneratedBoundsType;
+};
+
+type State = {
+  showDetail: boolean;
+};
+
+class SpanBar extends React.Component<Props, State> {
+  state: State = {
+    showDetail: false,
+  };
+
+  renderSpanTreeConnector = ({hasToggler}: {hasToggler: boolean}) => {
+    const {
+      isLast,
+      isRoot,
+      treeDepth: spanTreeDepth,
+      continuingTreeDepths,
+      span,
+      showSpanTree,
+    } = this.props;
+
+    const spanID = getSpanID(span);
+
+    if (isRoot) {
+      if (hasToggler) {
+        return (
+          <ConnectorBar
+            style={{right: '16px', height: '10px', bottom: '-5px', top: 'auto'}}
+            key={`${spanID}-last`}
+            orphanBranch={false}
+          />
+        );
+      }
+
+      return null;
+    }
+
+    const connectorBars: Array<React.ReactNode> = continuingTreeDepths.map(treeDepth => {
+      const depth: number = unwrapTreeDepth(treeDepth);
+
+      if (depth === 0) {
+        // do not render a connector bar at depth 0,
+        // if we did render a connector bar, this bar would be placed at depth -1
+        // which does not exist.
+        return null;
+      }
+      const left = ((spanTreeDepth - depth) * (TOGGLE_BORDER_BOX / 2) + 1) * -1;
+
+      return (
+        <ConnectorBar
+          style={{left}}
+          key={`${spanID}-${depth}`}
+          orphanBranch={isOrphanTreeDepth(treeDepth)}
+        />
+      );
+    });
+
+    if (hasToggler && showSpanTree) {
+      // if there is a toggle button, we add a connector bar to create an attachment
+      // between the toggle button and any connector bars below the toggle button
+      connectorBars.push(
+        <ConnectorBar
+          style={{
+            right: '16px',
+            height: '10px',
+            bottom: isLast ? `-${SPAN_ROW_HEIGHT / 2}px` : '0',
+            top: 'auto',
+          }}
+          key={`${spanID}-last`}
+          orphanBranch={false}
+        />
+      );
+    }
+
+    return (
+      <SpanTreeConnector
+        isLast={isLast}
+        hasToggler={hasToggler}
+        orphanBranch={isOrphanDiffSpan(span)}
+      >
+        {connectorBars}
+      </SpanTreeConnector>
+    );
+  };
+
+  renderSpanTreeToggler = ({left}: {left: number}) => {
+    const {numOfSpanChildren, isRoot, showSpanTree} = this.props;
+
+    const chevron = <StyledIconChevron direction={showSpanTree ? 'up' : 'down'} />;
+
+    if (numOfSpanChildren <= 0) {
+      return (
+        <SpanTreeTogglerContainer style={{left: `${left}px`}}>
+          {this.renderSpanTreeConnector({hasToggler: false})}
+        </SpanTreeTogglerContainer>
+      );
+    }
+
+    const chevronElement = !isRoot ? <div>{chevron}</div> : null;
+
+    return (
+      <SpanTreeTogglerContainer style={{left: `${left}px`}} hasToggler>
+        {this.renderSpanTreeConnector({hasToggler: true})}
+        <SpanTreeToggler
+          disabled={!!isRoot}
+          isExpanded={this.props.showSpanTree}
+          onClick={event => {
+            event.stopPropagation();
+
+            if (isRoot) {
+              return;
+            }
+
+            this.props.toggleSpanTree();
+          }}
+        >
+          <Count value={numOfSpanChildren} />
+          {chevronElement}
+        </SpanTreeToggler>
+      </SpanTreeTogglerContainer>
+    );
+  };
+
+  renderTitle() {
+    const {span, treeDepth} = this.props;
+
+    const operationName = getSpanOperation(span) ? (
+      <strong>
+        <OperationName spanErrors={[]}>{getSpanOperation(span)}</OperationName>
+        {` \u2014 `}
+      </strong>
+    ) : (
+      ''
+    );
+    const description = getSpanDescription(span) ?? getSpanID(span);
+
+    const left = treeDepth * (TOGGLE_BORDER_BOX / 2);
+
+    return (
+      <SpanBarTitleContainer>
+        {this.renderSpanTreeToggler({left})}
+        <SpanBarTitle
+          style={{
+            left: `${left}px`,
+            width: '100%',
+          }}
+        >
+          <span>
+            {operationName}
+            {description}
+          </span>
+        </SpanBarTitle>
+      </SpanBarTitleContainer>
+    );
+  }
+
+  renderDivider = (
+    dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
+  ) => {
+    if (this.state.showDetail) {
+      // Mock component to preserve layout spacing
+      return (
+        <DividerLine
+          style={{
+            position: 'relative',
+            backgroundColor: getBackgroundColor({
+              theme,
+              showDetail: true,
+            }),
+          }}
+        />
+      );
+    }
+
+    const {addDividerLineRef} = dividerHandlerChildrenProps;
+
+    return (
+      <DividerLine
+        ref={addDividerLineRef()}
+        style={{
+          position: 'relative',
+        }}
+        onMouseEnter={() => {
+          dividerHandlerChildrenProps.setHover(true);
+        }}
+        onMouseLeave={() => {
+          dividerHandlerChildrenProps.setHover(false);
+        }}
+        onMouseOver={() => {
+          dividerHandlerChildrenProps.setHover(true);
+        }}
+        onMouseDown={dividerHandlerChildrenProps.onDragStart}
+        onClick={event => {
+          // we prevent the propagation of the clicks from this component to prevent
+          // the span detail from being opened.
+          event.stopPropagation();
+        }}
+      />
+    );
+  };
+
+  getSpanBarStyles() {
+    const {span, generateBounds} = this.props;
+
+    const bounds = generateBounds(span);
+
+    function normalizePadding(width: string | undefined): string | undefined {
+      if (!width) {
+        return undefined;
+      }
+
+      // there is a "padding" of 1px on either side of the span rectangle
+      return `max(1px, calc(${width} - 2px))`;
+    }
+
+    switch (span.comparisonResult) {
+      case 'matched': {
+        const baselineDuration = getSpanDuration(span.baselineSpan);
+        const regressionDuration = getSpanDuration(span.regressionSpan);
+
+        if (baselineDuration === regressionDuration) {
+          return {
+            background: {
+              color: undefined,
+              width: normalizePadding(generateCSSWidth(bounds.background)),
+              hatch: true,
+            },
+            foreground: undefined,
+          };
+        }
+
+        if (baselineDuration > regressionDuration) {
+          return {
+            background: {
+              // baseline
+              color: theme.gray700,
+              width: normalizePadding(generateCSSWidth(bounds.background)),
+            },
+            foreground: {
+              // regression
+              color: undefined,
+              width: normalizePadding(generateCSSWidth(bounds.foreground)),
+              hatch: true,
+            },
+          };
+        }
+
+        // case: baselineDuration < regressionDuration
+
+        return {
+          background: {
+            // regression
+            color: theme.purple300,
+            width: normalizePadding(generateCSSWidth(bounds.background)),
+          },
+          foreground: {
+            // baseline
+            color: undefined,
+            width: normalizePadding(generateCSSWidth(bounds.foreground)),
+            hatch: true,
+          },
+        };
+      }
+      case 'regression': {
+        return {
+          background: {
+            color: theme.purple300,
+            width: normalizePadding(generateCSSWidth(bounds.background)),
+          },
+          foreground: undefined,
+        };
+      }
+      case 'baseline': {
+        return {
+          background: {
+            color: theme.gray700,
+            width: normalizePadding(generateCSSWidth(bounds.background)),
+          },
+          foreground: undefined,
+        };
+      }
+      default: {
+        const _exhaustiveCheck: never = span;
+        return _exhaustiveCheck;
+      }
+    }
+  }
+
+  renderComparisonReportLabel() {
+    const {span} = this.props;
+
+    switch (span.comparisonResult) {
+      case 'matched': {
+        const baselineDuration = getSpanDuration(span.baselineSpan);
+        const regressionDuration = getSpanDuration(span.regressionSpan);
+
+        let label: string = '';
+
+        if (baselineDuration === regressionDuration) {
+          label = 'no change';
+        }
+
+        if (baselineDuration > regressionDuration) {
+          const duration = getHumanDuration(
+            Math.abs(baselineDuration - regressionDuration)
+          );
+
+          label = `- ${duration} faster`;
+        }
+
+        if (baselineDuration < regressionDuration) {
+          const duration = getHumanDuration(
+            Math.abs(baselineDuration - regressionDuration)
+          );
+
+          label = `- ${duration} slower`;
+        }
+
+        return <ComparisonReportLabelContainer>{label}</ComparisonReportLabelContainer>;
+      }
+      case 'baseline': {
+        return (
+          <ComparisonReportLabelContainer>
+            removed from baseline
+          </ComparisonReportLabelContainer>
+        );
+      }
+      case 'regression': {
+        const regressionDuration = getSpanDuration(span.regressionSpan);
+
+        const duration = getHumanDuration(regressionDuration);
+
+        return (
+          <ComparisonReportLabelContainer>{`+ ${duration} added`}</ComparisonReportLabelContainer>
+        );
+      }
+      default: {
+        const _exhaustiveCheck: never = span;
+        return _exhaustiveCheck;
+      }
+    }
+  }
+
+  renderHeader(
+    dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
+  ) {
+    const {dividerPosition, addGhostDividerLineRef} = dividerHandlerChildrenProps;
+    const {spanNumber, span} = this.props;
+
+    const isMatched = span.comparisonResult === 'matched';
+    const hideSpanBarColumn = this.state.showDetail && isMatched;
+
+    const spanBarStyles = this.getSpanBarStyles();
+
+    const foregroundSpanBar = spanBarStyles.foreground ? (
+      <ComparisonSpanBarRectangle
+        spanBarHatch={spanBarStyles.foreground.hatch ?? false}
+        style={{
+          backgroundColor: spanBarStyles.foreground.color,
+          left: '1px',
+          width: spanBarStyles.foreground.width,
+          position: 'absolute',
+          top: '4px',
+          height: '16px',
+          display: hideSpanBarColumn ? 'none' : 'block',
+        }}
+      />
+    ) : null;
+    return (
+      <SpanRowCellContainer showDetail={this.state.showDetail}>
+        <SpanRowCell
+          data-type="span-row-cell"
+          showDetail={this.state.showDetail}
+          style={{
+            width: `calc(${toPercent(dividerPosition)} - 0.5px)`,
+          }}
+          onClick={() => {
+            this.toggleDisplayDetail();
+          }}
+        >
+          {this.renderTitle()}
+        </SpanRowCell>
+        {this.renderDivider(dividerHandlerChildrenProps)}
+        <SpanRowCell
+          data-type="span-row-cell"
+          showDetail={this.state.showDetail}
+          showStriping={spanNumber % 2 !== 0}
+          style={{
+            width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
+          }}
+          onClick={() => {
+            this.toggleDisplayDetail();
+          }}
+        >
+          <ComparisonSpanBarRectangle
+            spanBarHatch={spanBarStyles.background.hatch ?? false}
+            style={{
+              backgroundColor: spanBarStyles.background.color,
+              left: '1px',
+              width: spanBarStyles.background.width,
+              position: 'absolute',
+              top: '4px',
+              height: '16px',
+              display: hideSpanBarColumn ? 'none' : 'block',
+            }}
+          />
+          {foregroundSpanBar}
+          {this.renderComparisonReportLabel()}
+        </SpanRowCell>
+        {!this.state.showDetail && (
+          <DividerLineGhostContainer
+            style={{
+              width: `calc(${toPercent(dividerPosition)} + 0.5px)`,
+              display: 'none',
+            }}
+          >
+            <DividerLine
+              ref={addGhostDividerLineRef()}
+              style={{
+                right: 0,
+              }}
+              className="hovering"
+              onClick={event => {
+                // the ghost divider line should not be interactive.
+                // we prevent the propagation of the clicks from this component to prevent
+                // the span detail from being opened.
+                event.stopPropagation();
+              }}
+            />
+          </DividerLineGhostContainer>
+        )}
+      </SpanRowCellContainer>
+    );
+  }
+
+  toggleDisplayDetail = () => {
+    this.setState(state => ({
+      showDetail: !state.showDetail,
+    }));
+  };
+
+  renderDetail() {
+    if (!this.state.showDetail) {
+      return null;
+    }
+
+    const {span, generateBounds} = this.props;
+
+    return <SpanDetail span={this.props.span} bounds={generateBounds(span)} />;
+  }
+
+  render() {
+    return (
+      <SpanRow visible>
+        <DividerHandlerManager.Consumer>
+          {(
+            dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
+          ) => this.renderHeader(dividerHandlerChildrenProps)}
+        </DividerHandlerManager.Consumer>
+        {this.renderDetail()}
+      </SpanRow>
+    );
+  }
+}
+
+const getHatchPattern = ({spanBarHatch}) => {
+  if (spanBarHatch === true) {
+    return `
+        background-image: linear-gradient(135deg, #9f92fa 33.33%, #302839 33.33%, #302839 50%, #9f92fa 50%, #9f92fa 83.33%, #302839 83.33%, #302839 100%);
+        background-size: 4.24px 4.24px;
+    `;
+  }
+
+  return null;
+};
+
+const ComparisonSpanBarRectangle = styled(SpanBarRectangle)`
+  ${getHatchPattern};
+`;
+
+const ComparisonReportLabelContainer = styled('div')`
+  position: absolute;
+  height: 100%;
+  user-select: none;
+  right: ${space(1)};
+
+  line-height: 16px;
+  top: 4px;
+  height: 16px;
+
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+`;
+
+export default SpanBar;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -381,17 +381,15 @@ class SpanBar extends React.Component<Props, State> {
       case 'baseline': {
         return (
           <ComparisonReportLabelContainer>
-            removed from baseline
+            {t('removed from baseline')}
           </ComparisonReportLabelContainer>
         );
       }
       case 'regression': {
-        const regressionDuration = getSpanDuration(span.regressionSpan);
-
-        const duration = getHumanDuration(regressionDuration);
-
         return (
-          <ComparisonReportLabelContainer>{`+ ${duration} added`}</ComparisonReportLabelContainer>
+          <ComparisonReportLabelContainer>
+            {t('missing from regression')}
+          </ComparisonReportLabelContainer>
         );
       }
       default: {

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -365,7 +365,7 @@ class SpanBar extends React.Component<Props, State> {
             Math.abs(baselineDuration - regressionDuration)
           );
 
-          label = `- ${duration} faster`;
+          label = t('- %s faster', duration);
         }
 
         if (baselineDuration < regressionDuration) {
@@ -373,7 +373,7 @@ class SpanBar extends React.Component<Props, State> {
             Math.abs(baselineDuration - regressionDuration)
           );
 
-          label = `+ ${duration} slower`;
+          label = t('+ %s slower', duration);
         }
 
         return <ComparisonReportLabelContainer>{label}</ComparisonReportLabelContainer>;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import {t} from 'app/locale';
 import theme from 'app/utils/theme';
 import space from 'app/styles/space';
 import Count from 'app/components/count';
@@ -42,7 +43,6 @@ import {
 } from './utils';
 import {SpanBarRectangle} from './styles';
 import SpanDetail from './spanDetail';
-import {t} from 'app/locale';
 
 type Props = {
   span: Readonly<DiffSpanType>;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -369,7 +369,7 @@ class SpanBar extends React.Component<Props, State> {
             Math.abs(baselineDuration - regressionDuration)
           );
 
-          label = `- ${duration} slower`;
+          label = `+ ${duration} slower`;
         }
 
         return <ComparisonReportLabelContainer>{label}</ComparisonReportLabelContainer>;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -501,7 +501,7 @@ class SpanBar extends React.Component<Props, State> {
 
   render() {
     return (
-      <SpanRow visible>
+      <SpanRow visible data-test-id="span-row">
         <DividerHandlerManager.Consumer>
           {(
             dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps

--- a/src/sentry/static/sentry/app/views/performance/compare/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanDetail.tsx
@@ -1,0 +1,481 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import theme from 'app/utils/theme';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import getDynamicText from 'app/utils/getDynamicText';
+import DateTime from 'app/components/dateTime';
+import Pill from 'app/components/pill';
+import Pills from 'app/components/pills';
+import {SpanDetailContainer} from 'app/components/events/interfaces/spans/spanDetail';
+import {SpanType, rawSpanKeys} from 'app/components/events/interfaces/spans/types';
+import {getHumanDuration} from 'app/components/events/interfaces/spans/utils';
+
+import {
+  DiffSpanType,
+  SpanGeneratedBoundsType,
+  generateCSSWidth,
+  SpanWidths,
+  getSpanDuration,
+} from './utils';
+import {SpanBarRectangle} from './styles';
+import SpanDetailContent from './spanDetailContent';
+
+type DurationDisplay = 'right' | 'inset';
+
+const getDurationDisplay = (width: SpanWidths | undefined): DurationDisplay => {
+  if (!width) {
+    return 'right';
+  }
+
+  switch (width.type) {
+    case 'WIDTH_PIXEL': {
+      return 'right';
+    }
+    case 'WIDTH_PERCENTAGE': {
+      const spaceNeeded = 0.3;
+
+      if (width.width < 1 - spaceNeeded) {
+        return 'right';
+      }
+
+      return 'inset';
+    }
+    default: {
+      const _exhaustiveCheck: never = width;
+      return _exhaustiveCheck;
+    }
+  }
+};
+
+type Props = {
+  span: Readonly<DiffSpanType>;
+  bounds: SpanGeneratedBoundsType;
+};
+
+class SpanDetail extends React.Component<Props> {
+  renderContent() {
+    const {span, bounds} = this.props;
+
+    switch (span.comparisonResult) {
+      case 'matched': {
+        return (
+          <MatchedSpanDetailsContent
+            baselineSpan={span.baselineSpan}
+            regressionSpan={span.regressionSpan}
+            bounds={bounds}
+          />
+        );
+      }
+      case 'regression': {
+        return <SpanDetailContent span={span.regressionSpan} />;
+      }
+      case 'baseline': {
+        return <SpanDetailContent span={span.baselineSpan} />;
+      }
+      default: {
+        const _exhaustiveCheck: never = span;
+        return _exhaustiveCheck;
+      }
+    }
+  }
+
+  render() {
+    return (
+      <SpanDetailContainer
+        onClick={event => {
+          // prevent toggling the span detail
+          event.stopPropagation();
+        }}
+      >
+        {this.renderContent()}
+      </SpanDetailContainer>
+    );
+  }
+}
+
+const MatchedSpanDetailsContent = (props: {
+  baselineSpan: SpanType;
+  regressionSpan: SpanType;
+  bounds: SpanGeneratedBoundsType;
+}) => {
+  const {baselineSpan, regressionSpan, bounds} = props;
+
+  const dataKeys = new Set([
+    ...Object.keys(baselineSpan?.data ?? {}),
+    ...Object.keys(regressionSpan?.data ?? {}),
+  ]);
+
+  const unknownKeys = new Set([
+    ...Object.keys(baselineSpan).filter(key => {
+      return !rawSpanKeys.has(key as any);
+    }),
+    ...Object.keys(regressionSpan).filter(key => {
+      return !rawSpanKeys.has(key as any);
+    }),
+  ]);
+
+  return (
+    <div>
+      <SpanBars
+        bounds={bounds}
+        baselineSpan={baselineSpan}
+        regressionSpan={regressionSpan}
+      />
+      <Row
+        baselineTitle={t('Baseline Span ID')}
+        regressionTitle={t('Regressive Span ID')}
+        renderBaselineContent={() => baselineSpan.span_id}
+        renderRegressionContent={() => regressionSpan.span_id}
+      />
+      <Row
+        title={t('Parent Span ID')}
+        renderBaselineContent={() => baselineSpan.parent_span_id || ''}
+        renderRegressionContent={() => regressionSpan.parent_span_id || ''}
+      />
+      <Row
+        title={t('Trace ID')}
+        renderBaselineContent={() => baselineSpan.trace_id}
+        renderRegressionContent={() => regressionSpan.trace_id}
+      />
+      <Row
+        title={t('Description')}
+        renderBaselineContent={() => baselineSpan.description ?? ''}
+        renderRegressionContent={() => regressionSpan.description ?? ''}
+      />
+      <Row
+        title={t('Start Date')}
+        renderBaselineContent={() =>
+          getDynamicText({
+            fixed: 'Mar 16, 2020 9:10:12 AM UTC',
+            value: (
+              <React.Fragment>
+                <DateTime date={baselineSpan.start_timestamp * 1000} />
+                {` (${baselineSpan.start_timestamp})`}
+              </React.Fragment>
+            ),
+          })
+        }
+        renderRegressionContent={() =>
+          getDynamicText({
+            fixed: 'Mar 16, 2020 9:10:12 AM UTC',
+            value: (
+              <React.Fragment>
+                <DateTime date={regressionSpan.start_timestamp * 1000} />
+                {` (${baselineSpan.start_timestamp})`}
+              </React.Fragment>
+            ),
+          })
+        }
+      />
+      <Row
+        title={t('End Date')}
+        renderBaselineContent={() =>
+          getDynamicText({
+            fixed: 'Mar 16, 2020 9:10:12 AM UTC',
+            value: (
+              <React.Fragment>
+                <DateTime date={baselineSpan.timestamp * 1000} />
+                {` (${baselineSpan.timestamp})`}
+              </React.Fragment>
+            ),
+          })
+        }
+        renderRegressionContent={() =>
+          getDynamicText({
+            fixed: 'Mar 16, 2020 9:10:12 AM UTC',
+            value: (
+              <React.Fragment>
+                <DateTime date={regressionSpan.timestamp * 1000} />
+                {` (${regressionSpan.timestamp})`}
+              </React.Fragment>
+            ),
+          })
+        }
+      />
+      <Row
+        title={t('Duration')}
+        renderBaselineContent={() => {
+          const startTimestamp: number = baselineSpan.start_timestamp;
+          const endTimestamp: number = baselineSpan.timestamp;
+
+          const duration = (endTimestamp - startTimestamp) * 1000;
+          return `${duration.toFixed(3)}ms`;
+        }}
+        renderRegressionContent={() => {
+          const startTimestamp: number = regressionSpan.start_timestamp;
+          const endTimestamp: number = regressionSpan.timestamp;
+
+          const duration = (endTimestamp - startTimestamp) * 1000;
+          return `${duration.toFixed(3)}ms`;
+        }}
+      />
+      <Row
+        title={t('Operation')}
+        renderBaselineContent={() => baselineSpan.op || ''}
+        renderRegressionContent={() => regressionSpan.op || ''}
+      />
+      <Row
+        title={t('Same Process as Parent')}
+        renderBaselineContent={() => String(!!baselineSpan.same_process_as_parent)}
+        renderRegressionContent={() => String(!!regressionSpan.same_process_as_parent)}
+      />
+      <Tags baselineSpan={baselineSpan} regressionSpan={regressionSpan} />
+      {Array.from(dataKeys).map((dataTitle: string) => (
+        <Row
+          key={dataTitle}
+          title={dataTitle}
+          renderBaselineContent={() => {
+            const data = baselineSpan?.data ?? {};
+            const value: string | undefined = data[dataTitle];
+
+            return JSON.stringify(value, null, 4) || '';
+          }}
+          renderRegressionContent={() => {
+            const data = regressionSpan?.data ?? {};
+            const value: string | undefined = data[dataTitle];
+
+            return JSON.stringify(value, null, 4) || '';
+          }}
+        />
+      ))}
+      {Array.from(unknownKeys).map(key => (
+        <Row
+          key={key}
+          title={key}
+          renderBaselineContent={() => {
+            return JSON.stringify(baselineSpan[key], null, 4) || '';
+          }}
+          renderRegressionContent={() => {
+            return JSON.stringify(regressionSpan[key], null, 4) || '';
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+const RowSplitter = styled('div')`
+  display: flex;
+  flex-direction: row;
+
+  > * + * {
+    border-left: 1px solid ${p => p.theme.borderDark};
+  }
+`;
+
+const SpanBarContainer = styled('div')`
+  position: relative;
+  height: 16px;
+
+  margin-top: ${space(1)};
+  margin-bottom: ${space(1)};
+`;
+
+const SpanBars = (props: {
+  bounds: SpanGeneratedBoundsType;
+  baselineSpan: SpanType;
+  regressionSpan: SpanType;
+}) => {
+  const {bounds, baselineSpan, regressionSpan} = props;
+
+  const baselineDurationDisplay = getDurationDisplay(bounds.baseline);
+  const regressionDurationDisplay = getDurationDisplay(bounds.regression);
+
+  return (
+    <RowSplitter>
+      <RowContainer>
+        <SpanBarContainer>
+          <SpanBarRectangle
+            style={{
+              backgroundColor: theme.gray700,
+              width: generateCSSWidth(bounds.baseline),
+              position: 'absolute',
+              height: '16px',
+            }}
+          >
+            <DurationPill
+              durationDisplay={baselineDurationDisplay}
+              fontColors={{right: theme.gray700, inset: theme.white}}
+            >
+              {getHumanDuration(getSpanDuration(baselineSpan))}
+            </DurationPill>
+          </SpanBarRectangle>
+        </SpanBarContainer>
+      </RowContainer>
+      <RowContainer>
+        <SpanBarContainer>
+          <SpanBarRectangle
+            style={{
+              backgroundColor: theme.purple300,
+              width: generateCSSWidth(bounds.regression),
+              position: 'absolute',
+              height: '16px',
+            }}
+          >
+            <DurationPill
+              durationDisplay={regressionDurationDisplay}
+              fontColors={{right: theme.gray700, inset: theme.gray700}}
+            >
+              {getHumanDuration(getSpanDuration(regressionSpan))}
+            </DurationPill>
+          </SpanBarRectangle>
+        </SpanBarContainer>
+      </RowContainer>
+    </RowSplitter>
+  );
+};
+
+const Row = (props: {
+  title?: string;
+  baselineTitle?: string;
+  regressionTitle?: string;
+
+  renderBaselineContent: () => React.ReactNode;
+  renderRegressionContent: () => React.ReactNode;
+}) => {
+  const {title, baselineTitle, regressionTitle} = props;
+
+  const baselineContent = props.renderBaselineContent();
+  const regressionContent = props.renderRegressionContent();
+
+  if (!baselineContent && !regressionContent) {
+    return null;
+  }
+
+  return (
+    <RowSplitter>
+      <RowCell title={baselineTitle ?? title ?? ''}>{baselineContent}</RowCell>
+      <RowCell title={regressionTitle ?? title ?? ''}>{regressionContent}</RowCell>
+    </RowSplitter>
+  );
+};
+
+const RowContainer = styled('div')`
+  width: 50%;
+  min-width: 50%;
+  max-width: 50%;
+  flex-basis: 50%;
+
+  padding-left: ${space(2)};
+  padding-right: ${space(2)};
+`;
+
+const RowTitle = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: 600;
+`;
+
+const RowCell = ({title, children}: {title: string; children: React.ReactNode}) => {
+  return (
+    <RowContainer>
+      <RowTitle>{title}</RowTitle>
+      <div>
+        <pre className="val" style={{marginBottom: space(1)}}>
+          <span className="val-string">{children}</span>
+        </pre>
+      </div>
+    </RowContainer>
+  );
+};
+
+const getTags = (span: SpanType) => {
+  const tags: {[tag_name: string]: string} | undefined = span?.tags;
+
+  if (!tags) {
+    return undefined;
+  }
+
+  const keys = Object.keys(tags);
+
+  if (keys.length <= 0) {
+    return undefined;
+  }
+
+  return tags;
+};
+
+const TagPills = ({tags}: {tags: {[tag_name: string]: string} | undefined}) => {
+  if (!tags) {
+    return null;
+  }
+
+  const keys = Object.keys(tags);
+
+  if (keys.length <= 0) {
+    return null;
+  }
+
+  return (
+    <Pills>
+      {keys.map((key, index) => (
+        <Pill key={index} name={key} value={String(tags[key]) || ''} />
+      ))}
+    </Pills>
+  );
+};
+
+const Tags = ({
+  baselineSpan,
+  regressionSpan,
+}: {
+  baselineSpan: SpanType;
+  regressionSpan: SpanType;
+}) => {
+  const baselineTags = getTags(baselineSpan);
+  const regressionTags = getTags(regressionSpan);
+
+  if (!baselineTags && !regressionTags) {
+    return null;
+  }
+
+  return (
+    <RowSplitter>
+      <RowContainer>
+        <RowTitle>{t('Tags')}</RowTitle>
+        <div>
+          <TagPills tags={baselineTags} />
+        </div>
+      </RowContainer>
+      <RowContainer>
+        <RowTitle>{t('Tags')}</RowTitle>
+        <div>
+          <TagPills tags={regressionTags} />
+        </div>
+      </RowContainer>
+    </RowSplitter>
+  );
+};
+
+const DurationPill = styled('div')<{
+  durationDisplay: DurationDisplay;
+  fontColors: {right: string; inset: string};
+}>`
+  position: absolute;
+  top: 50%;
+  display: flex;
+  align-items: center;
+  transform: translateY(-50%);
+  white-space: nowrap;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  color: ${p => p.fontColors.right};
+
+  ${p => {
+    switch (p.durationDisplay) {
+      case 'right':
+        return `left: calc(100% + ${space(0.75)});`;
+      default:
+        return `
+          right: ${space(0.75)};
+          color: ${p.fontColors.inset};
+        `;
+    }
+  }};
+
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
+    font-size: 10px;
+  }
+`;
+
+export default SpanDetail;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanDetailContent.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanDetailContent.tsx
@@ -11,71 +11,69 @@ type Props = {
   span: Readonly<SpanType>;
 };
 
-class SpanDetailContent extends React.Component<Props> {
-  render() {
-    const {span} = this.props;
+const SpanDetailContent = (props: Props) => {
+  const {span} = props;
 
-    const startTimestamp: number = span.start_timestamp;
-    const endTimestamp: number = span.timestamp;
+  const startTimestamp: number = span.start_timestamp;
+  const endTimestamp: number = span.timestamp;
 
-    const duration = (endTimestamp - startTimestamp) * 1000;
-    const durationString = `${duration.toFixed(3)}ms`;
+  const duration = (endTimestamp - startTimestamp) * 1000;
+  const durationString = `${duration.toFixed(3)}ms`;
 
-    const unknownKeys = Object.keys(span).filter(key => {
-      return !rawSpanKeys.has(key as any);
-    });
+  const unknownKeys = Object.keys(span).filter(key => {
+    return !rawSpanKeys.has(key as any);
+  });
 
-    return (
-      <SpanDetails>
-        <table className="table key-value">
-          <tbody>
-            <Row title={t('Span ID')}>{span.span_id}</Row>
-            <Row title={t('Parent Span ID')}>{span.parent_span_id || ''}</Row>
-            <Row title={t('Trace ID')}>{span.trace_id}</Row>
-            <Row title={t('Description')}>{span?.description ?? ''}</Row>
-            <Row title={t('Start Date')}>
-              {getDynamicText({
-                fixed: 'Mar 16, 2020 9:10:12 AM UTC',
-                value: (
-                  <React.Fragment>
-                    <DateTime date={startTimestamp * 1000} />
-                    {` (${startTimestamp})`}
-                  </React.Fragment>
-                ),
-              })}
+  return (
+    <SpanDetails>
+      <table className="table key-value">
+        <tbody>
+          <Row title={t('Span ID')}>{span.span_id}</Row>
+          <Row title={t('Parent Span ID')}>{span.parent_span_id || ''}</Row>
+          <Row title={t('Trace ID')}>{span.trace_id}</Row>
+          <Row title={t('Description')}>{span?.description ?? ''}</Row>
+          <Row title={t('Start Date')}>
+            {getDynamicText({
+              fixed: 'Mar 16, 2020 9:10:12 AM UTC',
+              value: (
+                <React.Fragment>
+                  <DateTime date={startTimestamp * 1000} />
+                  {` (${startTimestamp})`}
+                </React.Fragment>
+              ),
+            })}
+          </Row>
+          <Row title={t('End Date')}>
+            {getDynamicText({
+              fixed: 'Mar 16, 2020 9:10:13 AM UTC',
+              value: (
+                <React.Fragment>
+                  <DateTime date={endTimestamp * 1000} />
+                  {` (${endTimestamp})`}
+                </React.Fragment>
+              ),
+            })}
+          </Row>
+          <Row title={t('Duration')}>{durationString}</Row>
+          <Row title={t('Operation')}>{span.op || ''}</Row>
+          <Row title={t('Same Process as Parent')}>
+            {String(!!span.same_process_as_parent)}
+          </Row>
+          <Tags span={span} />
+          {map(span?.data ?? {}, (value, key) => (
+            <Row title={key} key={key}>
+              {JSON.stringify(value, null, 4) || ''}
             </Row>
-            <Row title={t('End Date')}>
-              {getDynamicText({
-                fixed: 'Mar 16, 2020 9:10:13 AM UTC',
-                value: (
-                  <React.Fragment>
-                    <DateTime date={endTimestamp * 1000} />
-                    {` (${endTimestamp})`}
-                  </React.Fragment>
-                ),
-              })}
+          ))}
+          {unknownKeys.map(key => (
+            <Row title={key} key={key}>
+              {JSON.stringify(span[key], null, 4) || ''}
             </Row>
-            <Row title={t('Duration')}>{durationString}</Row>
-            <Row title={t('Operation')}>{span.op || ''}</Row>
-            <Row title={t('Same Process as Parent')}>
-              {String(!!span.same_process_as_parent)}
-            </Row>
-            <Tags span={span} />
-            {map(span?.data ?? {}, (value, key) => (
-              <Row title={key} key={key}>
-                {JSON.stringify(value, null, 4) || ''}
-              </Row>
-            ))}
-            {unknownKeys.map(key => (
-              <Row title={key} key={key}>
-                {JSON.stringify(span[key], null, 4) || ''}
-              </Row>
-            ))}
-          </tbody>
-        </table>
-      </SpanDetails>
-    );
-  }
-}
+          ))}
+        </tbody>
+      </table>
+    </SpanDetails>
+  );
+};
 
 export default SpanDetailContent;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanDetailContent.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanDetailContent.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import map from 'lodash/map';
+
+import {t} from 'app/locale';
+import getDynamicText from 'app/utils/getDynamicText';
+import DateTime from 'app/components/dateTime';
+import {SpanType, rawSpanKeys} from 'app/components/events/interfaces/spans/types';
+import {SpanDetails, Row, Tags} from 'app/components/events/interfaces/spans/spanDetail';
+
+type Props = {
+  span: Readonly<SpanType>;
+};
+
+class SpanDetailContent extends React.Component<Props> {
+  render() {
+    const {span} = this.props;
+
+    const startTimestamp: number = span.start_timestamp;
+    const endTimestamp: number = span.timestamp;
+
+    const duration = (endTimestamp - startTimestamp) * 1000;
+    const durationString = `${duration.toFixed(3)}ms`;
+
+    const unknownKeys = Object.keys(span).filter(key => {
+      return !rawSpanKeys.has(key as any);
+    });
+
+    return (
+      <SpanDetails>
+        <table className="table key-value">
+          <tbody>
+            <Row title={t('Span ID')}>{span.span_id}</Row>
+            <Row title={t('Parent Span ID')}>{span.parent_span_id || ''}</Row>
+            <Row title={t('Trace ID')}>{span.trace_id}</Row>
+            <Row title={t('Description')}>{span?.description ?? ''}</Row>
+            <Row title={t('Start Date')}>
+              {getDynamicText({
+                fixed: 'Mar 16, 2020 9:10:12 AM UTC',
+                value: (
+                  <React.Fragment>
+                    <DateTime date={startTimestamp * 1000} />
+                    {` (${startTimestamp})`}
+                  </React.Fragment>
+                ),
+              })}
+            </Row>
+            <Row title={t('End Date')}>
+              {getDynamicText({
+                fixed: 'Mar 16, 2020 9:10:13 AM UTC',
+                value: (
+                  <React.Fragment>
+                    <DateTime date={endTimestamp * 1000} />
+                    {` (${endTimestamp})`}
+                  </React.Fragment>
+                ),
+              })}
+            </Row>
+            <Row title={t('Duration')}>{durationString}</Row>
+            <Row title={t('Operation')}>{span.op || ''}</Row>
+            <Row title={t('Same Process as Parent')}>
+              {String(!!span.same_process_as_parent)}
+            </Row>
+            <Tags span={span} />
+            {map(span?.data ?? {}, (value, key) => (
+              <Row title={key} key={key}>
+                {JSON.stringify(value, null, 4) || ''}
+              </Row>
+            ))}
+            {unknownKeys.map(key => (
+              <Row title={key} key={key}>
+                {JSON.stringify(span[key], null, 4) || ''}
+              </Row>
+            ))}
+          </tbody>
+        </table>
+      </SpanDetails>
+    );
+  }
+}
+
+export default SpanDetailContent;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanGroup.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanGroup.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import {TreeDepthType} from 'app/components/events/interfaces/spans/types';
+
+import {DiffSpanType, SpanGeneratedBoundsType} from './utils';
+import SpanBar from './spanBar';
+
+type Props = {
+  span: Readonly<DiffSpanType>;
+  renderedSpanChildren: Array<JSX.Element>;
+  treeDepth: number;
+  continuingTreeDepths: Array<TreeDepthType>;
+  spanNumber: number;
+  isLast: boolean;
+  isRoot: boolean;
+  numOfSpanChildren: number;
+  generateBounds: (span: DiffSpanType) => SpanGeneratedBoundsType;
+};
+
+type State = {
+  showSpanTree: boolean;
+};
+
+class SpanGroup extends React.Component<Props, State> {
+  state: State = {
+    showSpanTree: true,
+  };
+
+  toggleSpanTree = () => {
+    this.setState(state => ({
+      showSpanTree: !state.showSpanTree,
+    }));
+  };
+
+  renderSpanChildren = () => {
+    if (!this.state.showSpanTree) {
+      return null;
+    }
+
+    return this.props.renderedSpanChildren;
+  };
+
+  render() {
+    const {
+      span,
+      treeDepth,
+      continuingTreeDepths,
+      spanNumber,
+      isLast,
+      isRoot,
+      numOfSpanChildren,
+      generateBounds,
+    } = this.props;
+
+    return (
+      <React.Fragment>
+        <SpanBar
+          span={span}
+          treeDepth={treeDepth}
+          continuingTreeDepths={continuingTreeDepths}
+          spanNumber={spanNumber}
+          isLast={isLast}
+          isRoot={isRoot}
+          numOfSpanChildren={numOfSpanChildren}
+          showSpanTree={this.state.showSpanTree}
+          toggleSpanTree={this.toggleSpanTree}
+          generateBounds={generateBounds}
+        />
+        {this.renderSpanChildren()}
+      </React.Fragment>
+    );
+  }
+}
+
+export default SpanGroup;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanGroup.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanGroup.tsx
@@ -32,13 +32,13 @@ class SpanGroup extends React.Component<Props, State> {
     }));
   };
 
-  renderSpanChildren = () => {
+  renderSpanChildren() {
     if (!this.state.showSpanTree) {
       return null;
     }
 
     return this.props.renderedSpanChildren;
-  };
+  }
 
   render() {
     const {

--- a/src/sentry/static/sentry/app/views/performance/compare/spanTree.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanTree.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {SentryTransactionEvent} from 'app/types';
+import {
+  TreeDepthType,
+  OrphanTreeDepth,
+} from 'app/components/events/interfaces/spans/types';
+import * as DividerHandlerManager from 'app/components/events/interfaces/spans/dividerHandlerManager';
+
+import {
+  diffTransactions,
+  DiffSpanType,
+  SpanChildrenLookupType,
+  getSpanID,
+  boundsGenerator,
+  SpanGeneratedBoundsType,
+  isOrphanDiffSpan,
+} from './utils';
+import SpanGroup from './spanGroup';
+
+type RenderedSpanTree = {
+  spanTree: JSX.Element | null;
+  nextSpanNumber: number;
+  // numOfSpansOutOfViewAbove: number;
+  // numOfFilteredSpansAbove: number;
+};
+
+type Props = {
+  baselineEvent: SentryTransactionEvent;
+  regressionEvent: SentryTransactionEvent;
+};
+
+class SpanTree extends React.Component<Props> {
+  traceViewRef = React.createRef<HTMLDivElement>();
+
+  renderSpan({
+    span,
+    childSpans,
+    spanNumber,
+    treeDepth,
+    continuingTreeDepths,
+    isLast,
+    isRoot,
+    generateBounds,
+  }: {
+    span: Readonly<DiffSpanType>;
+    childSpans: SpanChildrenLookupType;
+    spanNumber: number;
+    treeDepth: number;
+    continuingTreeDepths: Array<TreeDepthType>;
+    isLast: boolean;
+    isRoot: boolean;
+    generateBounds: (span: DiffSpanType) => SpanGeneratedBoundsType;
+  }): RenderedSpanTree {
+    const spanChildren: Array<DiffSpanType> = childSpans?.[getSpanID(span)] ?? [];
+
+    // Mark descendents as being rendered. This is to address potential recursion issues due to malformed data.
+    // For example if a span has a span_id that's identical to its parent_span_id.
+    childSpans = {
+      ...childSpans,
+    };
+    delete childSpans[getSpanID(span)];
+
+    type AccType = {
+      renderedSpanChildren: Array<JSX.Element>;
+      nextSpanNumber: number;
+    };
+
+    const treeDepthEntry = isOrphanDiffSpan(span)
+      ? ({type: 'orphan', depth: treeDepth} as OrphanTreeDepth)
+      : treeDepth;
+
+    const treeArr = isLast
+      ? continuingTreeDepths
+      : [...continuingTreeDepths, treeDepthEntry];
+
+    const reduced: AccType = spanChildren.reduce(
+      (acc: AccType, spanChild, index) => {
+        const key = `${getSpanID(spanChild)}`;
+
+        const results = this.renderSpan({
+          spanNumber: acc.nextSpanNumber,
+          isLast: index + 1 === spanChildren.length,
+          isRoot: false,
+          span: spanChild,
+          childSpans,
+          continuingTreeDepths: treeArr,
+          treeDepth: treeDepth + 1,
+          generateBounds,
+        });
+
+        acc.renderedSpanChildren.push(
+          <React.Fragment key={key}>{results.spanTree}</React.Fragment>
+        );
+
+        acc.nextSpanNumber = results.nextSpanNumber;
+
+        return acc;
+      },
+      {
+        renderedSpanChildren: [],
+        nextSpanNumber: spanNumber + 1,
+      }
+    );
+
+    const spanTree = (
+      <React.Fragment>
+        <SpanGroup
+          spanNumber={spanNumber}
+          span={span}
+          renderedSpanChildren={reduced.renderedSpanChildren}
+          treeDepth={treeDepth}
+          continuingTreeDepths={continuingTreeDepths}
+          isRoot={isRoot}
+          isLast={isLast}
+          numOfSpanChildren={spanChildren.length}
+          generateBounds={generateBounds}
+        />
+      </React.Fragment>
+    );
+
+    return {
+      nextSpanNumber: reduced.nextSpanNumber,
+      spanTree,
+    };
+  }
+
+  renderRootSpans(): RenderedSpanTree {
+    const {baselineEvent, regressionEvent} = this.props;
+
+    const comparisonReport = diffTransactions({
+      baselineEvent,
+      regressionEvent,
+    });
+
+    const {rootSpans, childSpans} = comparisonReport;
+
+    const generateBounds = boundsGenerator(rootSpans);
+
+    let nextSpanNumber = 1;
+
+    const spanTree = (
+      <React.Fragment key="root-spans-tree">
+        {rootSpans.map((rootSpan, index) => {
+          const renderedRootSpan = this.renderSpan({
+            isLast: index + 1 === rootSpans.length,
+            isRoot: true,
+            span: rootSpan,
+            childSpans,
+            spanNumber: nextSpanNumber,
+            treeDepth: 0,
+            continuingTreeDepths: [],
+            generateBounds,
+          });
+
+          nextSpanNumber = renderedRootSpan.nextSpanNumber;
+
+          return (
+            <React.Fragment key={String(index)}>
+              {renderedRootSpan.spanTree}
+            </React.Fragment>
+          );
+        })}
+      </React.Fragment>
+    );
+
+    return {
+      spanTree,
+      nextSpanNumber,
+    };
+  }
+
+  render() {
+    const {spanTree} = this.renderRootSpans();
+
+    return (
+      <DividerHandlerManager.Provider interactiveLayerRef={this.traceViewRef}>
+        <TraceViewContainer ref={this.traceViewRef}>{spanTree}</TraceViewContainer>
+      </DividerHandlerManager.Provider>
+    );
+  }
+}
+
+const TraceViewContainer = styled('div')`
+  overflow-x: hidden;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+`;
+
+export default SpanTree;

--- a/src/sentry/static/sentry/app/views/performance/compare/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/styles.tsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+export const SpanBarRectangle = styled('div')`
+  position: relative;
+  height: 100%;
+  min-width: 1px;
+  user-select: none;
+  transition: border-color 0.15s ease-in-out;
+  border-right: 1px solid rgba(0, 0, 0, 0);
+`;

--- a/src/sentry/static/sentry/app/views/performance/compare/traceView.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/traceView.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import {t} from 'app/locale';
+import {Event} from 'app/types';
+import {IconWarning} from 'app/icons';
+import {getTraceContext} from 'app/components/events/interfaces/spans/utils';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
+
+import {isTransactionEvent} from './utils';
+import SpanTree from './spanTree';
+
+type Props = {
+  baselineEvent: Event;
+  regressionEvent: Event;
+};
+
+const TraceView = (props: Props) => {
+  const {baselineEvent, regressionEvent} = props;
+
+  if (!isTransactionEvent(baselineEvent) || !isTransactionEvent(regressionEvent)) {
+    return (
+      <EmptyMessage>
+        <IconWarning color="gray500" size="lg" />
+        <p>{t('One of the given events is not a transaction.')}</p>
+      </EmptyMessage>
+    );
+  }
+
+  const baselineTraceContext = getTraceContext(baselineEvent);
+  const regressionTraceContext = getTraceContext(regressionEvent);
+
+  if (!baselineTraceContext || !regressionTraceContext) {
+    return (
+      <EmptyMessage>
+        <IconWarning color="gray500" size="lg" />
+        <p>{t('There is no trace found in either of the given transactions.')}</p>
+      </EmptyMessage>
+    );
+  }
+
+  return <SpanTree baselineEvent={baselineEvent} regressionEvent={regressionEvent} />;
+};
+
+export default TraceView;

--- a/src/sentry/static/sentry/app/views/performance/compare/transactionSummary.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/transactionSummary.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+import {Params} from 'react-router/lib/Router';
+
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {Event, Organization} from 'app/types';
+import Link from 'app/components/links/link';
+import {getHumanDuration, parseTrace} from 'app/components/events/interfaces/spans/utils';
+
+import {getTransactionDetailsUrl} from '../utils';
+import {isTransactionEvent} from './utils';
+
+type Props = {
+  organization: Organization;
+  location: Location;
+  params: Params;
+  baselineEvent: Event;
+  regressionEvent: Event;
+};
+
+class TransactionSummary extends React.Component<Props> {
+  render() {
+    const {baselineEvent, regressionEvent, organization, location, params} = this.props;
+    const {baselineEventSlug, regressionEventSlug} = params;
+
+    if (!isTransactionEvent(baselineEvent) || !isTransactionEvent(regressionEvent)) {
+      return null;
+    }
+
+    const baselineTrace = parseTrace(baselineEvent);
+    const regressionTrace = parseTrace(regressionEvent);
+
+    const baselineDuration = Math.abs(
+      baselineTrace.traceStartTimestamp - baselineTrace.traceEndTimestamp
+    );
+    const regressionDuration = Math.abs(
+      regressionTrace.traceStartTimestamp - regressionTrace.traceEndTimestamp
+    );
+
+    return (
+      <Container>
+        <EventRow>
+          <Baseline />
+          <EventRowContent>
+            <Content>
+              <ContentTitle>{t('Baseline Event')}</ContentTitle>
+              <EventId>
+                <span>{t('ID')}: </span>
+                <StyledLink
+                  to={getTransactionDetailsUrl(
+                    organization,
+                    baselineEventSlug.trim(),
+                    baselineEvent.title,
+                    location.query
+                  )}
+                >
+                  {shortEventId(baselineEvent.eventID)}
+                </StyledLink>
+              </EventId>
+            </Content>
+            <TimeDuration>
+              <span>{getHumanDuration(baselineDuration)}</span>
+            </TimeDuration>
+          </EventRowContent>
+        </EventRow>
+        <EventRow>
+          <Regression />
+          <EventRowContent>
+            <Content>
+              <ContentTitle>{t('Regressive Event')}</ContentTitle>
+              <EventId>
+                <span>{t('ID')}: </span>
+                <StyledLink
+                  to={getTransactionDetailsUrl(
+                    organization,
+                    regressionEventSlug.trim(),
+                    regressionEvent.title,
+                    location.query
+                  )}
+                >
+                  {shortEventId(regressionEvent.eventID)}
+                </StyledLink>
+              </EventId>
+            </Content>
+            <TimeDuration>
+              <span>{getHumanDuration(regressionDuration)}</span>
+            </TimeDuration>
+          </EventRowContent>
+        </EventRow>
+      </Container>
+    );
+  }
+}
+
+const Container = styled('div')`
+  display: flex;
+  flex-direction: column;
+
+  justify-content: space-between;
+  align-content: space-between;
+
+  padding-bottom: ${space(1)};
+
+  > * + * {
+    margin-top: ${space(0.75)};
+  }
+`;
+
+const EventRow = styled('div')`
+  display: flex;
+`;
+
+const Baseline = styled('div')`
+  background-color: ${p => p.theme.purple300};
+  height: 100%;
+  width: 4px;
+
+  margin-right: ${space(1)};
+`;
+
+const Regression = styled('div')`
+  background-color: ${p => p.theme.gray700};
+  height: 100%;
+  width: 4px;
+
+  margin-right: ${space(1)};
+`;
+
+const EventRowContent = styled('div')`
+  flex-grow: 1;
+  display: flex;
+`;
+
+const TimeDuration = styled('div')`
+  display: flex;
+  align-items: center;
+
+  font-size: ${p => p.theme.headerFontSize};
+  line-height: 1.2;
+
+  margin-left: ${space(1)};
+`;
+
+const Content = styled('div')`
+  flex-grow: 1;
+  width: 150px;
+
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const ContentTitle = styled('div')`
+  font-weight: 600;
+`;
+
+const EventId = styled('div')`
+  color: ${p => p.theme.gray500};
+`;
+
+const StyledLink = styled(Link)`
+  color: ${p => p.theme.gray500};
+`;
+
+function shortEventId(value: string): string {
+  return value.substring(0, 8);
+}
+
+export default TransactionSummary;

--- a/src/sentry/static/sentry/app/views/performance/compare/transactionSummary.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/transactionSummary.tsx
@@ -113,7 +113,7 @@ const EventRow = styled('div')`
 `;
 
 const Baseline = styled('div')`
-  background-color: ${p => p.theme.purple300};
+  background-color: ${p => p.theme.gray700};
   height: 100%;
   width: 4px;
 
@@ -121,7 +121,7 @@ const Baseline = styled('div')`
 `;
 
 const Regression = styled('div')`
-  background-color: ${p => p.theme.gray700};
+  background-color: ${p => p.theme.purple300};
   height: 100%;
   width: 4px;
 

--- a/src/sentry/static/sentry/app/views/performance/compare/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/utils.tsx
@@ -1,0 +1,771 @@
+import {SentryTransactionEvent} from 'app/types';
+import {RawSpanType, SpanType} from 'app/components/events/interfaces/spans/types';
+import {
+  parseTrace,
+  generateRootSpan,
+  isOrphanSpan,
+  toPercent,
+} from 'app/components/events/interfaces/spans/utils';
+
+export function isTransactionEvent(event: any): event is SentryTransactionEvent {
+  if (!event) {
+    return false;
+  }
+
+  return event?.type === 'transaction';
+}
+
+export type DiffSpanType =
+  | {
+      comparisonResult: 'matched';
+      span_id: SpanId; // baselineSpan.span_id + regressionSpan.span_id
+      op: string | undefined;
+      description: string | undefined;
+      baselineSpan: SpanType;
+      regressionSpan: SpanType;
+    }
+  | {
+      comparisonResult: 'baseline';
+      baselineSpan: SpanType;
+    }
+  | {
+      comparisonResult: 'regression';
+      regressionSpan: SpanType;
+    };
+
+type ComparableSpan = {
+  type: 'descendent';
+  parent_span_id: SpanId;
+  baselineSpan: SpanType;
+  regressionSpan: SpanType;
+};
+
+type SpanId = string;
+
+// map span_id to children whose parent_span_id is equal to span_id
+// invariant: spans that are matched will have children in this lookup map
+export type SpanChildrenLookupType = Record<SpanId, Array<DiffSpanType>>;
+
+export type ComparisonReport = {
+  rootSpans: Array<DiffSpanType>;
+
+  childSpans: SpanChildrenLookupType;
+};
+
+export function diffTransactions({
+  baselineEvent,
+  regressionEvent,
+}: {
+  baselineEvent: SentryTransactionEvent;
+  regressionEvent: SentryTransactionEvent;
+}): ComparisonReport {
+  const baselineTrace = parseTrace(baselineEvent);
+  const regressionTrace = parseTrace(regressionEvent);
+
+  const rootSpans: Array<DiffSpanType> = [];
+  const childSpans: SpanChildrenLookupType = {};
+
+  // merge childSpans of baselineTrace and regressionTrace together
+  for (const [parentSpanId, children] of Object.entries(baselineTrace.childSpans)) {
+    childSpans[parentSpanId] = children.map(baselineSpan => {
+      return {
+        comparisonResult: 'baseline',
+        baselineSpan,
+      };
+    });
+  }
+
+  for (const [parentSpanId, children] of Object.entries(regressionTrace.childSpans)) {
+    childSpans[parentSpanId] = children.map(regressionSpan => {
+      return {
+        comparisonResult: 'regression',
+        regressionSpan,
+      };
+    });
+  }
+
+  // merge the two transaction's span trees
+
+  // we maintain a stack of spans to be compared
+  const spansToBeCompared: Array<
+    | {
+        type: 'root';
+        baselineSpan: RawSpanType;
+        regressionSpan: RawSpanType;
+      }
+    | ComparableSpan
+  > = [
+    {
+      type: 'root',
+      baselineSpan: generateRootSpan(baselineTrace),
+      regressionSpan: generateRootSpan(regressionTrace),
+    },
+  ];
+
+  while (spansToBeCompared.length > 0) {
+    const currentSpans = spansToBeCompared.pop();
+
+    if (!currentSpans) {
+      // typescript assumes currentSpans is undefined due to the nature of Array.prototype.pop()
+      // returning undefined if spansToBeCompared is empty. the loop invariant guarantees that spansToBeCompared
+      // is a non-empty array. we handle this case for sake of completeness
+      break;
+    }
+
+    // invariant: the parents of currentSpans are matched spans; with the exception of the root spans of the baseline
+    //            transaction and the regression transaction.
+    // invariant: any unvisited siblings of currentSpans are in spansToBeCompared.
+    // invariant: currentSpans and their siblings are already in childSpans
+
+    const {baselineSpan, regressionSpan} = currentSpans;
+
+    // The span from the base transaction is considered 'identical' to the span from the regression transaction
+    // only if they share the same op name, depth level, and description.
+    //
+    // baselineSpan and regressionSpan have equivalent depth levels due to the nature of the tree traversal algorithm.
+
+    if (!matchableSpans({baselineSpan, regressionSpan})) {
+      if (currentSpans.type === 'root') {
+        const spanComparisonResults: [DiffSpanType, DiffSpanType] = [
+          {
+            comparisonResult: 'baseline',
+            baselineSpan,
+          },
+          {
+            comparisonResult: 'regression',
+            regressionSpan,
+          },
+        ];
+
+        rootSpans.push(...spanComparisonResults);
+      }
+
+      // since baselineSpan and regressionSpan are considered not identical, we do not
+      // need to compare their sub-trees
+
+      continue;
+    }
+
+    const spanComparisonResult: DiffSpanType = {
+      comparisonResult: 'matched',
+      span_id: generateMergedSpanId({baselineSpan, regressionSpan}),
+      op: baselineSpan.op,
+      description: baselineSpan.description,
+      baselineSpan,
+      regressionSpan,
+    };
+
+    if (currentSpans.type === 'root') {
+      rootSpans.push(spanComparisonResult);
+    }
+
+    const {comparablePairs, children} = createChildPairs({
+      parent_span_id: spanComparisonResult.span_id,
+      baseChildren: baselineTrace.childSpans[baselineSpan.span_id] ?? [],
+      regressionChildren: regressionTrace.childSpans[regressionSpan.span_id] ?? [],
+    });
+
+    spansToBeCompared.push(...comparablePairs);
+
+    if (children.length > 0) {
+      childSpans[spanComparisonResult.span_id] = children;
+    }
+  }
+
+  rootSpans.sort(sortByMostTimeAdded);
+
+  const report = {
+    rootSpans,
+    childSpans,
+  };
+
+  return report;
+}
+
+function createChildPairs({
+  parent_span_id,
+  baseChildren,
+  regressionChildren,
+}: {
+  parent_span_id: SpanId;
+  baseChildren: Array<SpanType>;
+  regressionChildren: Array<SpanType>;
+}): {
+  comparablePairs: Array<ComparableSpan>;
+  children: Array<DiffSpanType>;
+} {
+  // invariant: the parents of baseChildren and regressionChildren are matched spans
+
+  // for each child in baseChildren, pair them with the closest matching child in regressionChildren
+
+  const comparablePairs: Array<ComparableSpan> = [];
+  const children: Array<DiffSpanType> = [];
+
+  const remainingRegressionChildren = [...regressionChildren];
+
+  for (const baselineSpan of baseChildren) {
+    // reduce remainingRegressionChildren down to spans that are applicable candidate
+    // of spans that can be paired with baselineSpan
+
+    const candidates = remainingRegressionChildren.reduce(
+      (
+        acc: Array<{regressionSpan: SpanType; index: number}>,
+        regressionSpan: SpanType,
+        index: number
+      ) => {
+        if (matchableSpans({baselineSpan, regressionSpan})) {
+          acc.push({
+            regressionSpan,
+            index,
+          });
+        }
+
+        return acc;
+      },
+      []
+    );
+
+    if (candidates.length === 0) {
+      children.push({
+        comparisonResult: 'baseline',
+        baselineSpan,
+      });
+      continue;
+    }
+
+    // the best candidate span is one that has the closest start timestamp to baselineSpan;
+    // and one that has a duration that's close to baselineSpan
+
+    const baselineSpanDuration = Math.abs(
+      baselineSpan.timestamp - baselineSpan.start_timestamp
+    );
+
+    candidates.sort(({regressionSpan: thisSpan}, {regressionSpan: otherSpan}) => {
+      // calculate the deltas of the start timestamps relative to baselineSpan's
+      // start timestamp
+
+      const deltaStartTimestampThisSpan = Math.abs(
+        thisSpan.start_timestamp - baselineSpan.start_timestamp
+      );
+
+      const deltaStartTimestampOtherSpan = Math.abs(
+        otherSpan.start_timestamp - baselineSpan.start_timestamp
+      );
+
+      // calculate the deltas of the durations relative to the baselineSpan's
+      // duration
+
+      const thisSpanDuration = Math.abs(thisSpan.timestamp - thisSpan.start_timestamp);
+      const otherSpanDuration = Math.abs(otherSpan.timestamp - otherSpan.start_timestamp);
+
+      const deltaDurationThisSpan = Math.abs(thisSpanDuration - baselineSpanDuration);
+      const deltaDurationOtherSpan = Math.abs(otherSpanDuration - baselineSpanDuration);
+
+      const thisSpanScore = deltaDurationThisSpan + deltaStartTimestampThisSpan;
+      const otherSpanScore = deltaDurationOtherSpan + deltaStartTimestampOtherSpan;
+
+      if (thisSpanScore < otherSpanScore) {
+        // sort thisSpan before otherSpan
+        return -1;
+      }
+
+      if (thisSpanScore > otherSpanScore) {
+        // sort thisSpan after otherSpan
+        return 1;
+      }
+
+      return 0;
+    });
+
+    const {regressionSpan, index} = candidates[0];
+
+    // remove regressionSpan from list of remainingRegressionChildren
+    remainingRegressionChildren.splice(index, 1);
+
+    comparablePairs.push({
+      type: 'descendent',
+      parent_span_id,
+      baselineSpan,
+      regressionSpan,
+    });
+
+    children.push({
+      comparisonResult: 'matched',
+      span_id: generateMergedSpanId({baselineSpan, regressionSpan}),
+      op: baselineSpan.op,
+      description: baselineSpan.description,
+      baselineSpan,
+      regressionSpan,
+    });
+  }
+
+  // push any remaining un-matched regressionSpans
+  for (const regressionSpan of remainingRegressionChildren) {
+    children.push({
+      comparisonResult: 'regression',
+      regressionSpan,
+    });
+  }
+
+  // sort children by most time added
+
+  children.sort(sortByMostTimeAdded);
+
+  return {
+    comparablePairs,
+    children,
+  };
+}
+
+function matchableSpans({
+  baselineSpan,
+  regressionSpan,
+}: {
+  baselineSpan: SpanType;
+  regressionSpan: SpanType;
+}): boolean {
+  const opNamesEqual = baselineSpan.op === regressionSpan.op;
+  const descriptionsEqual = baselineSpan.description === regressionSpan.description;
+
+  return opNamesEqual && descriptionsEqual;
+}
+
+function generateMergedSpanId({
+  baselineSpan,
+  regressionSpan,
+}: {
+  baselineSpan: SpanType;
+  regressionSpan: SpanType;
+}): string {
+  return `${baselineSpan.span_id}${regressionSpan.span_id}`;
+}
+
+function getDiffSpanDuration(diffSpan: DiffSpanType): number {
+  switch (diffSpan.comparisonResult) {
+    case 'matched': {
+      return Math.max(
+        getSpanDuration(diffSpan.baselineSpan),
+        getSpanDuration(diffSpan.regressionSpan)
+      );
+    }
+    case 'baseline': {
+      return getSpanDuration(diffSpan.baselineSpan);
+    }
+    case 'regression': {
+      return getSpanDuration(diffSpan.regressionSpan);
+    }
+    default: {
+      throw Error('Unknown comparisonResult');
+    }
+  }
+}
+
+export function getSpanDuration(span: RawSpanType): number {
+  return Math.abs(span.timestamp - span.start_timestamp);
+}
+
+function getMatchedSpanDurationDeltas({
+  baselineSpan,
+  regressionSpan,
+}: {
+  baselineSpan: RawSpanType;
+  regressionSpan: RawSpanType;
+}): number {
+  return getSpanDuration(regressionSpan) - getSpanDuration(baselineSpan);
+}
+
+function sortDiffSpansByDuration(
+  firstSpan: DiffSpanType,
+  secondSpan: DiffSpanType
+): number {
+  const firstSpanDuration = getDiffSpanDuration(firstSpan);
+  const secondSpanDuration = getDiffSpanDuration(secondSpan);
+
+  if (firstSpanDuration > secondSpanDuration) {
+    // sort firstSpan before secondSpan
+    return -1;
+  }
+
+  if (firstSpanDuration < secondSpanDuration) {
+    // sort secondSpan before firstSpan
+    return 1;
+  }
+
+  return 0;
+}
+
+function sortSpans(firstSpan: RawSpanType, secondSpan: RawSpanType): number {
+  const firstSpanDuration = getSpanDuration(firstSpan);
+  const secondSpanDuration = getSpanDuration(secondSpan);
+
+  if (firstSpanDuration > secondSpanDuration) {
+    // sort firstSpan before secondSpan
+    return -1;
+  }
+
+  if (firstSpanDuration < secondSpanDuration) {
+    // sort secondSpan before firstSpan
+    return 1;
+  }
+
+  // try to break ties by sorting by start timestamp in ascending order
+
+  if (firstSpan.start_timestamp < secondSpan.start_timestamp) {
+    // sort firstSpan before secondSpan
+    return -1;
+  }
+
+  if (firstSpan.start_timestamp > secondSpan.start_timestamp) {
+    // sort secondSpan before firstSpan
+    return 1;
+  }
+
+  return 0;
+}
+
+function sortByMostTimeAdded(firstSpan: DiffSpanType, secondSpan: DiffSpanType): number {
+  // Sort the spans by most time added. This means that when comparing the spans of the regression transaction
+  // against the spans of the baseline transaction, we sort the spans by those that have regressed the most
+  // relative to their baseline counter parts first.
+  //
+  // In terms of sort, we display them in the following way:
+  // - Regression only spans; sorted first by duration (descending), and then start timestamps (ascending)
+  // - Matched spans:
+  //     - slower -- i.e. regression.duration - baseline.duration > 0 (sorted by duration deltas, and by duration)
+  //     - no change -- i.e. regression.duration - baseline.duration == 0 (sorted by duration)
+  //     - faster -- i.e. regression.duration - baseline.duration < 0 (sorted by duration deltas, and by duration)
+  // - Baseline only spans; sorted by duration
+
+  switch (firstSpan.comparisonResult) {
+    case 'regression': {
+      switch (secondSpan.comparisonResult) {
+        case 'regression': {
+          return sortSpans(firstSpan.regressionSpan, secondSpan.regressionSpan);
+        }
+        case 'baseline':
+        case 'matched': {
+          // sort firstSpan (regression) before secondSpan (baseline)
+          return -1;
+        }
+        default: {
+          throw Error('Unknown comparisonResult');
+        }
+      }
+    }
+    case 'baseline': {
+      switch (secondSpan.comparisonResult) {
+        case 'baseline': {
+          return sortSpans(firstSpan.baselineSpan, secondSpan.baselineSpan);
+        }
+        case 'regression':
+        case 'matched': {
+          // sort secondSpan (regression or matched) before firstSpan (baseline)
+          return 1;
+        }
+        default: {
+          throw Error('Unknown comparisonResult');
+        }
+      }
+    }
+    case 'matched': {
+      switch (secondSpan.comparisonResult) {
+        case 'regression': {
+          // sort secondSpan (regression) before firstSpan (matched)
+          return 1;
+        }
+        case 'baseline': {
+          // sort firstSpan (matched) before secondSpan (baseline)
+          return -1;
+        }
+        case 'matched': {
+          const firstSpanDurationDelta = getMatchedSpanDurationDeltas({
+            regressionSpan: firstSpan.regressionSpan,
+            baselineSpan: firstSpan.baselineSpan,
+          });
+
+          const secondSpanDurationDelta = getMatchedSpanDurationDeltas({
+            regressionSpan: secondSpan.regressionSpan,
+            baselineSpan: secondSpan.baselineSpan,
+          });
+
+          if (firstSpanDurationDelta > 0) {
+            // firstSpan has slower regression span relative to the baseline span
+            if (secondSpanDurationDelta > 0) {
+              // secondSpan has slower regression span relative to the baseline span
+              if (firstSpanDurationDelta > secondSpanDurationDelta) {
+                // sort firstSpan before secondSpan
+                return -1;
+              }
+
+              if (firstSpanDurationDelta < secondSpanDurationDelta) {
+                // sort secondSpan before firstSpan
+                return 1;
+              }
+
+              return sortDiffSpansByDuration(firstSpan, secondSpan);
+            }
+
+            // case: secondSpan is either "no change" or "faster"
+
+            // sort firstSpan before secondSpan
+            return -1;
+          }
+
+          if (firstSpanDurationDelta === 0) {
+            // firstSpan has a regression span relative that didn't change relative to the baseline span
+
+            if (secondSpanDurationDelta > 0) {
+              // secondSpan has slower regression span relative to the baseline span
+
+              // sort secondSpan before firstSpan
+              return 1;
+            }
+
+            if (secondSpanDurationDelta < 0) {
+              // faster
+              // sort firstSpan before secondSpan
+              return -1;
+            }
+
+            // secondSpan has a regression span relative that didn't change relative to the baseline span
+            return sortDiffSpansByDuration(firstSpan, secondSpan);
+          }
+
+          // case: firstSpanDurationDelta < 0
+
+          if (secondSpanDurationDelta >= 0) {
+            // either secondSpan has slower regression span relative to the baseline span,
+            // or the secondSpan has a regression span relative that didn't change relative to the baseline span
+
+            // sort secondSpan before firstSpan
+            return 1;
+          }
+
+          // case: secondSpanDurationDelta < 0
+
+          if (firstSpanDurationDelta < secondSpanDurationDelta) {
+            // sort firstSpan before secondSpan
+            return -1;
+          }
+
+          if (firstSpanDurationDelta > secondSpanDurationDelta) {
+            // sort secondSpan before firstSpan
+            return 1;
+          }
+
+          return sortDiffSpansByDuration(firstSpan, secondSpan);
+        }
+        default: {
+          throw Error('Unknown comparisonResult');
+        }
+      }
+    }
+    default: {
+      throw Error('Unknown comparisonResult');
+    }
+  }
+}
+
+export function getSpanID(diffSpan: DiffSpanType): string {
+  switch (diffSpan.comparisonResult) {
+    case 'matched': {
+      return diffSpan.span_id;
+    }
+    case 'baseline': {
+      return diffSpan.baselineSpan.span_id;
+    }
+    case 'regression': {
+      return diffSpan.regressionSpan.span_id;
+    }
+    default: {
+      throw Error('Unknown comparisonResult');
+    }
+  }
+}
+
+export function getSpanOperation(diffSpan: DiffSpanType): string | undefined {
+  switch (diffSpan.comparisonResult) {
+    case 'matched': {
+      return diffSpan.op;
+    }
+    case 'baseline': {
+      return diffSpan.baselineSpan.op;
+    }
+    case 'regression': {
+      return diffSpan.regressionSpan.op;
+    }
+    default: {
+      throw Error('Unknown comparisonResult');
+    }
+  }
+}
+
+export function getSpanDescription(diffSpan: DiffSpanType): string | undefined {
+  switch (diffSpan.comparisonResult) {
+    case 'matched': {
+      return diffSpan.description;
+    }
+    case 'baseline': {
+      return diffSpan.baselineSpan.description;
+    }
+    case 'regression': {
+      return diffSpan.regressionSpan.description;
+    }
+    default: {
+      throw Error('Unknown comparisonResult');
+    }
+  }
+}
+
+export function isOrphanDiffSpan(diffSpan: DiffSpanType): boolean {
+  switch (diffSpan.comparisonResult) {
+    case 'matched': {
+      return isOrphanSpan(diffSpan.baselineSpan) || isOrphanSpan(diffSpan.regressionSpan);
+    }
+    case 'baseline': {
+      return isOrphanSpan(diffSpan.baselineSpan);
+    }
+    case 'regression': {
+      return isOrphanSpan(diffSpan.regressionSpan);
+    }
+    default: {
+      throw Error('Unknown comparisonResult');
+    }
+  }
+}
+
+export type SpanWidths =
+  | {
+      type: 'WIDTH_PIXEL';
+      width: 1;
+    }
+  | {
+      type: 'WIDTH_PERCENTAGE';
+      width: number;
+    };
+
+export type SpanGeneratedBoundsType = {
+  background: SpanWidths;
+  foreground: SpanWidths | undefined;
+  baseline: SpanWidths | undefined;
+  regression: SpanWidths | undefined;
+};
+
+function generateWidth({
+  duration,
+  largestDuration,
+}: {
+  duration: number;
+  largestDuration: number;
+}): SpanWidths {
+  if (duration <= 0) {
+    return {
+      type: 'WIDTH_PIXEL',
+      width: 1,
+    };
+  }
+
+  return {
+    type: 'WIDTH_PERCENTAGE',
+    width: duration / largestDuration,
+  };
+}
+
+export function boundsGenerator(rootSpans: Array<DiffSpanType>) {
+  // get largest duration among the root spans.
+  // invariant: this is the largest duration among all of the spans on the transaction
+  //            comparison page.
+  const largestDuration = Math.max(
+    ...rootSpans.map(rootSpan => {
+      return getDiffSpanDuration(rootSpan);
+    })
+  );
+
+  return (span: DiffSpanType): SpanGeneratedBoundsType => {
+    switch (span.comparisonResult) {
+      case 'matched': {
+        const baselineDuration = getSpanDuration(span.baselineSpan);
+        const regressionDuration = getSpanDuration(span.regressionSpan);
+
+        const baselineWidth = generateWidth({
+          duration: baselineDuration,
+          largestDuration,
+        });
+        const regressionWidth = generateWidth({
+          duration: regressionDuration,
+          largestDuration,
+        });
+
+        if (baselineDuration >= regressionDuration) {
+          return {
+            background: baselineWidth,
+            foreground: regressionWidth,
+            baseline: baselineWidth,
+            regression: regressionWidth,
+          };
+        }
+
+        // case: baselineDuration < regressionDuration
+        return {
+          background: regressionWidth,
+          foreground: baselineWidth,
+          baseline: baselineWidth,
+          regression: regressionWidth,
+        };
+      }
+      case 'regression': {
+        const regressionDuration = getSpanDuration(span.regressionSpan);
+
+        const regressionWidth = generateWidth({
+          duration: regressionDuration,
+          largestDuration,
+        });
+
+        return {
+          background: regressionWidth,
+          foreground: undefined,
+          baseline: undefined,
+          regression: regressionWidth,
+        };
+      }
+      case 'baseline': {
+        const baselineDuration = getSpanDuration(span.baselineSpan);
+
+        const baselineWidth = generateWidth({
+          duration: baselineDuration,
+          largestDuration,
+        });
+
+        return {
+          background: baselineWidth,
+          foreground: undefined,
+          baseline: baselineWidth,
+          regression: undefined,
+        };
+      }
+      default: {
+        const _exhaustiveCheck: never = span;
+        return _exhaustiveCheck;
+      }
+    }
+  };
+}
+
+export function generateCSSWidth(width: SpanWidths | undefined): string | undefined {
+  if (!width) {
+    return undefined;
+  }
+
+  switch (width.type) {
+    case 'WIDTH_PIXEL': {
+      return `${width.width}px`;
+    }
+    case 'WIDTH_PERCENTAGE': {
+      return toPercent(width.width);
+    }
+    default: {
+      const _exhaustiveCheck: never = width;
+      return _exhaustiveCheck;
+    }
+  }
+}

--- a/src/sentry/static/sentry/app/views/performance/compare/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/utils.tsx
@@ -240,7 +240,10 @@ function createChildPairs({
       baselineSpan.timestamp - baselineSpan.start_timestamp
     );
 
-    candidates.sort(({regressionSpan: thisSpan}, {regressionSpan: otherSpan}) => {
+    const {regressionSpan, index} = candidates.reduce((bestCandidate, nextCandidate) => {
+      const {regressionSpan: thisSpan} = bestCandidate;
+      const {regressionSpan: otherSpan} = nextCandidate;
+
       // calculate the deltas of the start timestamps relative to baselineSpan's
       // start timestamp
 
@@ -266,18 +269,16 @@ function createChildPairs({
 
       if (thisSpanScore < otherSpanScore) {
         // sort thisSpan before otherSpan
-        return -1;
+        return bestCandidate;
       }
 
       if (thisSpanScore > otherSpanScore) {
         // sort thisSpan after otherSpan
-        return 1;
+        return nextCandidate;
       }
 
-      return 0;
+      return bestCandidate;
     });
-
-    const {regressionSpan, index} = candidates[0];
 
     // remove regressionSpan from list of remainingRegressionChildren
     remainingRegressionChildren.splice(index, 1);

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/baselineQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/baselineQuery.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import isEqual from 'lodash/isEqual';
+
+import {Client} from 'app/api';
+import withApi from 'app/utils/withApi';
+import EventView from 'app/utils/discover/eventView';
+
+export type BaselineQueryResults = {
+  'transaction.duration': number;
+  // event id of the transaction chosen to be the baseline transaction
+  id: string;
+  project: string;
+};
+
+type ChildrenProps = {
+  isLoading: boolean;
+  error: null | string;
+  results: null | BaselineQueryResults;
+};
+
+type Props = {
+  api: Client;
+  eventView: EventView;
+  orgSlug: string;
+
+  children: (props: ChildrenProps) => React.ReactNode;
+};
+
+type State = {
+  fetchID: symbol | undefined;
+} & ChildrenProps;
+
+class BaselineQuery extends React.PureComponent<Props> {
+  state: State = {
+    isLoading: true,
+    fetchID: undefined,
+    error: null,
+
+    results: null,
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    // Reload data if we aren't already loading,
+    const refetchCondition = !this.state.isLoading && this.shouldRefetchData(prevProps);
+
+    if (refetchCondition) {
+      this.fetchData();
+    }
+  }
+
+  generatePayload(eventView: EventView) {
+    return {
+      ...eventView.getGlobalSelection(),
+      query: eventView.query,
+    };
+  }
+
+  shouldRefetchData = (prevProps: Props): boolean => {
+    const thisAPIPayload = this.generatePayload(this.props.eventView);
+    const otherAPIPayload = this.generatePayload(prevProps.eventView);
+
+    return !isEqual(thisAPIPayload, otherAPIPayload);
+  };
+
+  fetchData = () => {
+    const {eventView, orgSlug} = this.props;
+
+    if (!eventView.isValid()) {
+      return;
+    }
+
+    const url = `/organizations/${orgSlug}/event-baseline/`;
+    const fetchID = Symbol('fetchID');
+
+    this.setState({isLoading: true, fetchID});
+
+    this.props.api
+      .requestPromise(url, {
+        method: 'GET',
+        query: {
+          ...eventView.getGlobalSelection(),
+          query: eventView.query,
+        },
+      })
+      .then(data => {
+        if (this.state.fetchID !== fetchID) {
+          // invariant: a different request was initiated after this request
+          return;
+        }
+
+        this.setState({
+          isLoading: false,
+          fetchID: undefined,
+          error: null,
+          results: data,
+        });
+      })
+      .catch(err => {
+        this.setState({
+          isLoading: false,
+          fetchID: undefined,
+          error: err?.responseJSON?.detail ?? null,
+          results: null,
+        });
+      });
+  };
+
+  render() {
+    const {isLoading, error, results} = this.state;
+
+    const childrenProps = {
+      isLoading,
+      error,
+      results,
+    };
+
+    return this.props.children(childrenProps);
+  }
+}
+
+export default withApi(BaselineQuery);

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/baselineQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/baselineQuery.tsx
@@ -54,7 +54,7 @@ class BaselineQuery extends React.PureComponent<Props> {
 
   generatePayload(eventView: EventView) {
     return {
-      ...eventView.getGlobalSelection(),
+      ...eventView.getGlobalSelectionQuery(),
       query: eventView.query,
     };
   }
@@ -82,7 +82,7 @@ class BaselineQuery extends React.PureComponent<Props> {
       .requestPromise(url, {
         method: 'GET',
         query: {
-          ...eventView.getGlobalSelection(),
+          ...eventView.getGlobalSelectionQuery(),
           query: eventView.query,
         },
       })

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
@@ -246,7 +246,7 @@ class TransactionTable extends React.PureComponent<Props> {
 
     if (organization.features.includes('internal-catchall')) {
       headerColumns.push(
-        <GridHeadCell key="baseline">
+        <HeadCellContainer key="baseline">
           <SortLink
             align="right"
             title={t('Compared to Baseline')}
@@ -254,7 +254,7 @@ class TransactionTable extends React.PureComponent<Props> {
             canSort={false}
             generateSortLink={generateSortLink}
           />
-        </GridHeadCell>
+        </HeadCellContainer>
       );
     }
 
@@ -371,14 +371,16 @@ class TransactionTable extends React.PureComponent<Props> {
         });
 
         resultsRow.push(
-          <GridBodyCell key={`${rowIndex}-baseline`} style={{textAlign: 'right'}}>
+          <BodyCellContainer key={`${rowIndex}-baseline`} style={{textAlign: 'right'}}>
             <Link to={target} onClick={this.handleViewDetailsClick}>
               {`${getHumanDuration(delta / 1000)} ${relativeSpeed}`}
             </Link>
-          </GridBodyCell>
+          </BodyCellContainer>
         );
       } else {
-        resultsRow.push(<GridBodyCell key={`${rowIndex}-baseline`}>-</GridBodyCell>);
+        resultsRow.push(
+          <BodyCellContainer key={`${rowIndex}-baseline`}>-</BodyCellContainer>
+        );
       }
     }
 

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
@@ -28,9 +28,11 @@ import {
   TOP_TRANSACTION_LIMIT,
   TOP_TRANSACTION_FILTERS,
 } from 'app/views/performance/constants';
+import {getHumanDuration} from 'app/components/events/interfaces/spans/utils';
 
 import {GridCell, GridCellNumber} from '../styles';
-import {getTransactionDetailsUrl} from '../utils';
+import {getTransactionDetailsUrl, getTransactionComparisonUrl} from '../utils';
+import BaselineQuery, {BaselineQueryResults} from './baselineQuery';
 
 type WrapperProps = {
   eventView: EventView;
@@ -114,14 +116,23 @@ class TransactionList extends React.Component<WrapperProps> {
           limit={TOP_TRANSACTION_LIMIT}
         >
           {({isLoading, tableData}) => (
-            <TransactionTable
-              organization={organization}
-              location={location}
-              transactionName={transactionName}
-              eventView={eventView}
-              tableData={tableData}
-              isLoading={isLoading}
-            />
+            <React.Fragment>
+              <BaselineQuery eventView={sortedEventView} orgSlug={organization.slug}>
+                {baselineQueryProps => {
+                  return (
+                    <TransactionTable
+                      organization={organization}
+                      location={location}
+                      transactionName={transactionName}
+                      eventView={eventView}
+                      tableData={tableData}
+                      isLoading={isLoading || baselineQueryProps.isLoading}
+                      baselineTransaction={baselineQueryProps.results}
+                    />
+                  );
+                }}
+              </BaselineQuery>
+            </React.Fragment>
           )}
         </DiscoverQuery>
       </React.Fragment>
@@ -134,6 +145,7 @@ type Props = {
   location: Location;
   organization: Organization;
   transactionName: string;
+  baselineTransaction: BaselineQueryResults | null;
 
   isLoading: boolean;
   tableData: TableData | null | undefined;
@@ -181,7 +193,7 @@ class TransactionTable extends React.PureComponent<Props> {
     const columnOrder = eventView.getColumns();
     const generateSortLink = () => undefined;
 
-    return columnOrder.map((column, index) => (
+    const headerColumns = columnOrder.map((column, index) => (
       <HeaderCell column={column} tableMeta={tableMeta} key={index}>
         {({align}) => {
           return (
@@ -198,6 +210,22 @@ class TransactionTable extends React.PureComponent<Props> {
         }}
       </HeaderCell>
     ));
+
+    // add baseline transaction column
+
+    headerColumns.push(
+      <GridHeadCell key="baseline">
+        <SortLink
+          align="right"
+          title={t('Compared to Baseline')}
+          direction={undefined}
+          canSort={false}
+          generateSortLink={generateSortLink}
+        />
+      </GridHeadCell>
+    );
+
+    return headerColumns;
   }
 
   renderResults() {
@@ -229,9 +257,9 @@ class TransactionTable extends React.PureComponent<Props> {
     columnOrder: TableColumn<React.ReactText>[],
     tableMeta: MetaType
   ) {
-    const {organization, location, transactionName} = this.props;
+    const {organization, location, transactionName, baselineTransaction} = this.props;
 
-    return columnOrder.map((column, index) => {
+    const resultsRow = columnOrder.map((column, index) => {
       const field = String(column.key);
       // TODO add a better abstraction for this in fieldRenderers.
       const fieldName = getAggregateAlias(field);
@@ -282,6 +310,43 @@ class TransactionTable extends React.PureComponent<Props> {
         </BodyCellContainer>
       );
     });
+
+    // add baseline transaction column
+
+    if (baselineTransaction) {
+      const currentTransactionDuration: number = Number(row['transaction.duration']) || 0;
+
+      const delta = Math.abs(
+        currentTransactionDuration - baselineTransaction['transaction.duration']
+      );
+
+      const relativeSpeed =
+        currentTransactionDuration < baselineTransaction['transaction.duration']
+          ? t('faster')
+          : currentTransactionDuration > baselineTransaction['transaction.duration']
+          ? t('slower')
+          : '';
+
+      const target = getTransactionComparisonUrl({
+        organization,
+        baselineEventSlug: generateEventSlug(baselineTransaction),
+        regressionEventSlug: generateEventSlug(row),
+        transaction: transactionName,
+        query: location.query,
+      });
+
+      resultsRow.push(
+        <GridBodyCell key={`${rowIndex}-baseline`} style={{textAlign: 'right'}}>
+          <Link to={target} onClick={this.handleViewDetailsClick}>
+            {`${getHumanDuration(delta / 1000)} ${relativeSpeed}`}
+          </Link>
+        </GridBodyCell>
+      );
+    } else {
+      resultsRow.push(<GridBodyCell key={`${rowIndex}-baseline`}>-</GridBodyCell>);
+    }
+
+    return resultsRow;
   }
 
   render() {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
@@ -372,9 +372,11 @@ class TransactionTable extends React.PureComponent<Props> {
 
         resultsRow.push(
           <BodyCellContainer key={`${rowIndex}-baseline`} style={{textAlign: 'right'}}>
-            <Link to={target} onClick={this.handleViewDetailsClick}>
-              {`${getHumanDuration(delta / 1000)} ${relativeSpeed}`}
-            </Link>
+            <GridCell>
+              <Link to={target} onClick={this.handleViewDetailsClick}>
+                {`${getHumanDuration(delta / 1000)} ${relativeSpeed}`}
+              </Link>
+            </GridCell>
           </BodyCellContainer>
         );
       } else {

--- a/src/sentry/static/sentry/app/views/performance/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/utils.tsx
@@ -20,3 +20,25 @@ export function getTransactionDetailsUrl(
     },
   };
 }
+
+export function getTransactionComparisonUrl({
+  organization,
+  baselineEventSlug,
+  regressionEventSlug,
+  transaction,
+  query,
+}: {
+  organization: OrganizationSummary;
+  baselineEventSlug: string;
+  regressionEventSlug: string;
+  transaction: string;
+  query: Query;
+}): LocationDescriptor {
+  return {
+    pathname: `/organizations/${organization.slug}/performance/compare/${baselineEventSlug}/${regressionEventSlug}/`,
+    query: {
+      ...query,
+      transaction,
+    },
+  };
+}

--- a/tests/acceptance/test_transaction_comparison.py
+++ b/tests/acceptance/test_transaction_comparison.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import
+
+import copy
+import pytz
+from sentry.utils.compat.mock import patch
+from datetime import timedelta, datetime
+
+from sentry.testutils import AcceptanceTestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now, timestamp_format
+from tests.acceptance.test_organization_events_v2 import generate_transaction
+
+FEATURE_NAMES = ["organizations:performance-view"]
+
+
+class TransactionComparison(AcceptanceTestCase, SnubaTestCase):
+    def setUp(self):
+        super(TransactionComparison, self).setUp()
+        self.user = self.create_user("foo@example.com", is_superuser=True)
+        self.org = self.create_organization(name="Rowdy Tiger")
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
+        self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
+
+        self.login_as(self.user)
+
+    def wait_until_loaded(self):
+        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
+
+    @patch("django.utils.timezone.now")
+    def test_transaction_comparison(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+
+        baseline_event_data = generate_transaction()
+        baseline_event = self.store_event(
+            data=baseline_event_data, project_id=self.project.id, assert_no_errors=True
+        )
+        baseline_event_slug = u"{}:{}".format(self.project.slug, baseline_event.event_id)
+
+        regression_event_data = generate_transaction()
+        regression_event_data.update({"event_id": "b" * 32})
+
+        def regress_spans(original_spans):
+            spans = []
+            last_index = len(original_spans) - 1
+            for index, reference_span in enumerate(original_spans):
+                end_datetime = datetime.utcfromtimestamp(reference_span["timestamp"]).replace(
+                    tzinfo=pytz.utc
+                )
+                span = copy.deepcopy(reference_span)
+                if index % 2 == 0:
+                    # for every even indexed span, increase its duration.
+                    # this implies the span was slower.
+                    regression_time = timedelta(milliseconds=10)
+                    span["timestamp"] = timestamp_format(end_datetime + regression_time)
+                else:
+                    # for every odd indexed span, decrease its duration.
+                    # this implies the span was faster
+                    regression_time = timedelta(milliseconds=5)
+                    span["timestamp"] = timestamp_format(end_datetime - regression_time)
+
+                if index == last_index:
+                    # change the op name of the last span.
+                    # the last span would be removed from the baseline transaction;
+                    # and the last span of the baseline transaction would be missing from
+                    # the regression transaction
+                    span["op"] = "resource"
+
+                spans.append(span)
+            return spans
+
+        regression_event_data["spans"] = regress_spans(regression_event_data["spans"])
+
+        regression_event = self.store_event(
+            data=regression_event_data, project_id=self.project.id, assert_no_errors=True
+        )
+        regression_event_slug = u"{}:{}".format(self.project.slug, regression_event.event_id)
+
+        comparison_page_path = u"/organizations/{}/performance/compare/{}/{}/".format(
+            self.org.slug, baseline_event_slug, regression_event_slug
+        )
+
+        with self.feature(FEATURE_NAMES):
+            self.browser.get(comparison_page_path)
+            self.wait_until_loaded()
+
+            # screenshot for un-expanded span details are visually different from
+            # when a matched span is expanded
+            self.browser.snapshot("transaction comparison page")
+
+            self.browser.elements('[data-test-id="span-row"]')[0].click()
+            self.browser.elements('[data-test-id="span-row"]')[1].click()
+            self.browser.elements('[data-test-id="span-row"]')[2].click()
+            self.browser.elements('[data-test-id="span-row"]')[10].click()
+
+            self.browser.snapshot("transaction comparison page - expanded span details")


### PR DESCRIPTION
## TODO

**UI:**
- [x] loading state
- [x] error state (e.g. event slugs not found)
- [x] breadcrumbs
- [x] transaction name title
- [x] span details
- [x] basic info on transactions being compared
- [x] place comparison links behind `internal-catchall`

**Extras:**
- [ ] split `fetchEvent` out if it's worth keeping

## Screenshots

**CTA links to transaction comparison relative to baseline (transaction summary page):**

<img width="1295" alt="Screen Shot 2020-07-24 at 7 10 17 PM" src="https://user-images.githubusercontent.com/139499/88442309-021d5080-cde2-11ea-8f0e-3788d7e5875d.png">

**Transaction comparison page:**


<img width="1671" alt="Screen Shot 2020-07-24 at 7 08 51 PM" src="https://user-images.githubusercontent.com/139499/88442340-1e20f200-cde2-11ea-93d4-bbf0c53fbac0.png">

**Matched spans' details pane:**


<img width="1646" alt="Screen Shot 2020-07-24 at 7 09 56 PM" src="https://user-images.githubusercontent.com/139499/88442344-20834c00-cde2-11ea-9d27-b767cc4002d6.png">
