### PR TITLE
perf: speedup sentry shell initialization by ~30%

### DIFF
--- a/src/sentry/lang/javascript/errorlocale.py
+++ b/src/sentry/lang/javascript/errorlocale.py
@@ -11,31 +11,36 @@ LOCALES_DIR = os.path.join(os.path.dirname(__file__), "../../data/error-locale")
 TARGET_LOCALE = "en-US"
 
 translation_lookup_table = set()
-target_locale_lookup_table = {}
+target_locale_lookup_table = dict()
 
-for locale in os.listdir(LOCALES_DIR):
-    fn = os.path.join(LOCALES_DIR, locale)
-    if not os.path.isfile(fn):
-        continue
 
-    with io.open(fn, encoding="utf-8") as f:
-        for line in f:
-            key, translation = line.split(",", 1)
-            translation = translation.strip()
+def populate_target_locale_lookup_table():
+    for locale in os.listdir(LOCALES_DIR):
+        fn = os.path.join(LOCALES_DIR, locale)
+        if not os.path.isfile(fn):
+            continue
 
-            if TARGET_LOCALE in locale:
-                target_locale_lookup_table[key] = translation
-            else:
-                translation_regexp = re.escape(translation)
-                translation_regexp = translation_regexp.replace(
-                    "\%s", r"(?P<format_string_data>[a-zA-Z0-9-_\$]+)"
-                )
-                # Some errors are substrings of more detailed ones, so we need exact match
-                translation_regexp = re.compile("^" + translation_regexp + "$")
-                translation_lookup_table.add((translation_regexp, key))
+        with io.open(fn, encoding="utf-8") as f:
+            for line in f:
+                key, translation = line.split(",", 1)
+                translation = translation.strip()
+
+                if TARGET_LOCALE in locale:
+                    target_locale_lookup_table[key] = translation
+                else:
+                    translation_regexp = re.escape(translation)
+                    translation_regexp = translation_regexp.replace(
+                        "\%s", r"(?P<format_string_data>[a-zA-Z0-9-_\$]+)"
+                    )
+                    # Some errors are substrings of more detailed ones, so we need exact match
+                    translation_regexp = re.compile("^" + translation_regexp + "$")
+                    translation_lookup_table.add((translation_regexp, key))
 
 
 def find_translation(message):
+    if not target_locale_lookup_table:
+        populate_target_locale_lookup_table()
+
     for translation in translation_lookup_table:
         translation_regexp, key = translation
         match = translation_regexp.search(message)

--- a/src/sentry_plugins/base.py
+++ b/src/sentry_plugins/base.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import pkg_resources
 import sentry_plugins
 import six
 import sys
@@ -68,14 +67,3 @@ class CorePluginMixin(object):
         else:
             self.logger.exception(six.text_type(exc))
             six.reraise(PluginError, PluginError(self.message_from_error(exc)), sys.exc_info()[2])
-
-
-def assert_package_not_installed(name):
-    try:
-        pkg_resources.get_distribution(name)
-    except pkg_resources.DistributionNotFound:
-        return
-    else:
-        raise RuntimeError(
-            "Found %r. This has been superseded by 'sentry-plugins', so please uninstall." % name
-        )

--- a/src/sentry_plugins/bitbucket/__init__.py
+++ b/src/sentry_plugins/bitbucket/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-bitbucket")

--- a/src/sentry_plugins/github/__init__.py
+++ b/src/sentry_plugins/github/__init__.py
@@ -1,7 +1,3 @@
 from __future__ import absolute_import
 
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-github")
-
 from sentry_plugins.github import options  # NOQA

--- a/src/sentry_plugins/gitlab/__init__.py
+++ b/src/sentry_plugins/gitlab/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-gitlab")

--- a/src/sentry_plugins/heroku/__init__.py
+++ b/src/sentry_plugins/heroku/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-heroku")

--- a/src/sentry_plugins/jira/__init__.py
+++ b/src/sentry_plugins/jira/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-jira")

--- a/src/sentry_plugins/pagerduty/__init__.py
+++ b/src/sentry_plugins/pagerduty/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-pagerduty")

--- a/src/sentry_plugins/pivotal/__init__.py
+++ b/src/sentry_plugins/pivotal/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-pivotal")

--- a/src/sentry_plugins/pushover/__init__.py
+++ b/src/sentry_plugins/pushover/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-pushover")

--- a/src/sentry_plugins/slack/__init__.py
+++ b/src/sentry_plugins/slack/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-slack")


### PR DESCRIPTION
I was working with `devservices` a lot recently, and sentry cli startup time was getting pretty annoying. `sentry devservices attach foo` which basically noops but goes through the entire initialization takes around 4.5 - 5 seconds on my machine. I sped it up to 3 - 3.5 seconds.

I generated a cProfile of `initialize_app`, a large portion of it was spent in regex CPU at module-level in this one module. Lazily populating it is the easiest fix, I'm hoping all tests pass.

Before:

![before](https://user-images.githubusercontent.com/14209781/81031841-2f123500-8e7d-11ea-9493-d1c72145662d.png)

After:

![after](https://user-images.githubusercontent.com/14209781/81031845-32a5bc00-8e7d-11ea-9b2d-d1e8a7ad34ba.png)
