### PR TITLE
perf(api): Instrumentation for GET OrganizationTeams endpoint

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -243,7 +243,8 @@ class OrganizationEndpoint(Endpoint):
         return projects
 
     def get_environments(self, request, organization):
-        return get_environments(request, organization)
+        with sentry_sdk.start_span(op="PERF: Org.get_environments"):
+            return get_environments(request, organization)
 
     def get_filter_params(self, request, organization, date_filter_optional=False):
         """
@@ -268,10 +269,11 @@ class OrganizationEndpoint(Endpoint):
         except InvalidParams as e:
             raise ParseError(detail=u"Invalid date range: {}".format(e))
 
-        try:
-            projects = self.get_projects(request, organization)
-        except ValueError:
-            raise ParseError(detail="Invalid project ids")
+        with sentry_sdk.start_span(op="PERF: org.get_filter_params - projects"):
+            try:
+                projects = self.get_projects(request, organization)
+            except ValueError:
+                raise ParseError(detail="Invalid project ids")
 
         if not projects:
             raise NoProjects
@@ -284,10 +286,11 @@ class OrganizationEndpoint(Endpoint):
         return params
 
     def convert_args(self, request, organization_slug, *args, **kwargs):
-        try:
-            organization = Organization.objects.get_from_cache(slug=organization_slug)
-        except Organization.DoesNotExist:
-            raise ResourceDoesNotExist
+        with sentry_sdk.start_span(op="PERF: org.convert_args - organization (cache)"):
+            try:
+                organization = Organization.objects.get_from_cache(slug=organization_slug)
+            except Organization.DoesNotExist:
+                raise ResourceDoesNotExist
 
         with sentry_sdk.start_span(
             op="check_object_permissions_on_organization", description=organization_slug


### PR DESCRIPTION
This should shed light on `Missing instrumentation` found in the trace for `/api/0/organizations/{organization_slug}/teams/`.