### PR TITLE
fix(ui): remove titlecase when displaying environment names

### DIFF
--- a/src/sentry/static/sentry/app/stores/organizationEnvironmentsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationEnvironmentsStore.jsx
@@ -1,6 +1,5 @@
 import Reflux from 'reflux';
 
-import {toTitleCase} from 'app/utils';
 import EnvironmentActions from 'app/actions/environmentActions';
 
 const DEFAULT_EMPTY_ENV_NAME = '(No Environment)';
@@ -27,7 +26,7 @@ const OrganizationEnvironmentsStore = Reflux.createStore({
       id: item.id,
       name: item.name,
       get displayName() {
-        return toTitleCase(item.name) || DEFAULT_EMPTY_ENV_NAME;
+        return item.name || DEFAULT_EMPTY_ENV_NAME;
       },
       get urlRoutingName() {
         return encodeURIComponent(item.name) || DEFAULT_EMPTY_ROUTING_NAME;

--- a/src/sentry/static/sentry/app/utils/environment.tsx
+++ b/src/sentry/static/sentry/app/utils/environment.tsx
@@ -1,5 +1,4 @@
 import {Environment} from 'app/types';
-import {toTitleCase} from 'app/utils';
 
 const DEFAULT_EMPTY_ROUTING_NAME = 'none';
 const DEFAULT_EMPTY_ENV_NAME = '(No Environment)';
@@ -9,5 +8,5 @@ export function getUrlRoutingName(env: Omit<Environment, 'id'>) {
 }
 
 export function getDisplayName(env: Omit<Environment, 'id'>) {
-  return toTitleCase(env.name) || DEFAULT_EMPTY_ENV_NAME;
+  return env.name || DEFAULT_EMPTY_ENV_NAME;
 }

--- a/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
+++ b/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
@@ -21,7 +21,7 @@ describe('OrganizationEnvironmentsStore', function() {
 
     expect(environments.length).toBe(2);
     expect(environments.map(env => env.name)).toEqual(['production', 'staging']);
-    expect(environments.map(env => env.displayName)).toEqual(['Production', 'Staging']);
+    expect(environments.map(env => env.displayName)).toEqual(['production', 'staging']);
   });
 
   it('has the correct loading state', async function() {

--- a/tests/js/spec/views/settings/projectAlerts/list.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/list.spec.jsx
@@ -59,7 +59,7 @@ describe('ProjectAlertsList', function() {
         .find('RuleDescription')
         .at(0)
         .text()
-    ).toBe('Environment: Staging');
+    ).toBe('Environment: staging');
 
     expect(
       wrapper
@@ -94,7 +94,7 @@ describe('ProjectAlertsList', function() {
         .find('RuleDescription')
         .at(0)
         .text()
-    ).toBe('Environment: Staging');
+    ).toBe('Environment: staging');
     expect(wrapper.find('RuleName')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Environments are case sensitive, applying titlecase creates confusion around which environment is being changed/selected.

When hiding or showing an environment, the success toast will now show the environment with the case sensitive environment name.

Closes https://getsentry.atlassian.net/browse/ISSUE-794