### PR TITLE
fix(ui): remove titlecase when displaying environment names

### DIFF
--- a/src/sentry/static/sentry/app/stores/organizationEnvironmentsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationEnvironmentsStore.jsx
@@ -1,9 +1,7 @@
 import Reflux from 'reflux';
 
 import EnvironmentActions from 'app/actions/environmentActions';
-
-const DEFAULT_EMPTY_ENV_NAME = '(No Environment)';
-const DEFAULT_EMPTY_ROUTING_NAME = 'none';
+import {getDisplayName, getUrlRoutingName} from 'app/utils/environment';
 
 const OrganizationEnvironmentsStore = Reflux.createStore({
   init() {
@@ -26,10 +24,10 @@ const OrganizationEnvironmentsStore = Reflux.createStore({
       id: item.id,
       name: item.name,
       get displayName() {
-        return item.name || DEFAULT_EMPTY_ENV_NAME;
+        return getDisplayName(item);
       },
       get urlRoutingName() {
-        return encodeURIComponent(item.name) || DEFAULT_EMPTY_ROUTING_NAME;
+        return getUrlRoutingName(item);
       },
     };
   },

--- a/src/sentry/static/sentry/app/stores/organizationEnvironmentsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationEnvironmentsStore.jsx
@@ -1,6 +1,5 @@
 import Reflux from 'reflux';
 
-import {toTitleCase} from 'app/utils';
 import EnvironmentActions from 'app/actions/environmentActions';
 
 const DEFAULT_EMPTY_ENV_NAME = '(No Environment)';
@@ -27,7 +26,7 @@ const OrganizationEnvironmentsStore = Reflux.createStore({
       id: item.id,
       name: item.name,
       get displayName() {
-        return toTitleCase(item.name) || DEFAULT_EMPTY_ENV_NAME;
+        return item.name || DEFAULT_EMPTY_ENV_NAME;
       },
       get urlRoutingName() {
         return encodeURIComponent(item.name) || DEFAULT_EMPTY_ROUTING_NAME;

--- a/src/sentry/static/sentry/app/utils/environment.tsx
+++ b/src/sentry/static/sentry/app/utils/environment.tsx
@@ -1,5 +1,4 @@
 import {Environment} from 'app/types';
-import {toTitleCase} from 'app/utils';
 
 const DEFAULT_EMPTY_ROUTING_NAME = 'none';
 const DEFAULT_EMPTY_ENV_NAME = '(No Environment)';
@@ -9,5 +8,5 @@ export function getUrlRoutingName(env: Omit<Environment, 'id'>) {
 }
 
 export function getDisplayName(env: Omit<Environment, 'id'>) {
-  return toTitleCase(env.name) || DEFAULT_EMPTY_ENV_NAME;
+  return env.name || DEFAULT_EMPTY_ENV_NAME;
 }

--- a/tests/js/sentry-test/fixtures/environments.js
+++ b/tests/js/sentry-test/fixtures/environments.js
@@ -5,6 +5,7 @@ export function Environments(hidden) {
     return [
       {id: '1', name: 'production', displayName: 'Production', isHidden: false},
       {id: '2', name: 'staging', displayName: 'Staging', isHidden: false},
+      {id: '3', name: 'STAGING', displayName: 'STAGING', isHidden: true},
     ];
   }
 }

--- a/tests/js/spec/components/group/releaseStats.spec.jsx
+++ b/tests/js/spec/components/group/releaseStats.spec.jsx
@@ -41,7 +41,9 @@ describe('GroupReleaseStats', function() {
 
   it('renders specific environments', function() {
     const wrapper = createWrapper({environments: TestStubs.Environments()});
-    expect(wrapper.find('[data-test-id="env-label"]').text()).toBe('Production, Staging');
+    expect(wrapper.find('[data-test-id="env-label"]').text()).toBe(
+      'Production, Staging, STAGING'
+    );
     expect(wrapper.find('GroupReleaseChart')).toHaveLength(2);
     expect(wrapper.find('SeenInfo')).toHaveLength(2);
   });

--- a/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
+++ b/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
@@ -21,7 +21,7 @@ describe('OrganizationEnvironmentsStore', function() {
 
     expect(environments.length).toBe(2);
     expect(environments.map(env => env.name)).toEqual(['production', 'staging']);
-    expect(environments.map(env => env.displayName)).toEqual(['Production', 'Staging']);
+    expect(environments.map(env => env.displayName)).toEqual(['production', 'staging']);
   });
 
   it('has the correct loading state', async function() {

--- a/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
+++ b/tests/js/spec/stores/organizationEnvironmentsStore.spec.jsx
@@ -19,9 +19,17 @@ describe('OrganizationEnvironmentsStore', function() {
 
     const {environments} = OrganizationEnvironmentsStore.get();
 
-    expect(environments.length).toBe(2);
-    expect(environments.map(env => env.name)).toEqual(['production', 'staging']);
-    expect(environments.map(env => env.displayName)).toEqual(['production', 'staging']);
+    expect(environments).toHaveLength(3);
+    expect(environments.map(env => env.name)).toEqual([
+      'production',
+      'staging',
+      'STAGING',
+    ]);
+    expect(environments.map(env => env.displayName)).toEqual([
+      'production',
+      'staging',
+      'STAGING',
+    ]);
   });
 
   it('has the correct loading state', async function() {

--- a/tests/js/spec/views/settings/projectAlerts/list.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/list.spec.jsx
@@ -59,7 +59,7 @@ describe('ProjectAlertsList', function() {
         .find('RuleDescription')
         .at(0)
         .text()
-    ).toBe('Environment: Staging');
+    ).toBe('Environment: staging');
 
     expect(
       wrapper
@@ -94,7 +94,7 @@ describe('ProjectAlertsList', function() {
         .find('RuleDescription')
         .at(0)
         .text()
-    ).toBe('Environment: Staging');
+    ).toBe('Environment: staging');
     expect(wrapper.find('RuleName')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Environments are case sensitive, applying titlecase creates confusion around which environment is being changed/selected.

When hiding or showing an environment, the success toast will now show the environment with the case sensitive environment name.

Closes https://getsentry.atlassian.net/browse/ISSUE-794