### PR TITLE
perf: remove costly assert_package_not_installed

### DIFF
--- a/src/sentry_plugins/base.py
+++ b/src/sentry_plugins/base.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import pkg_resources
 import sentry_plugins
 import six
 import sys
@@ -68,14 +67,3 @@ class CorePluginMixin(object):
         else:
             self.logger.exception(six.text_type(exc))
             six.reraise(PluginError, PluginError(self.message_from_error(exc)), sys.exc_info()[2])
-
-
-def assert_package_not_installed(name):
-    try:
-        pkg_resources.get_distribution(name)
-    except pkg_resources.DistributionNotFound:
-        return
-    else:
-        raise RuntimeError(
-            "Found %r. This has been superseded by 'sentry-plugins', so please uninstall." % name
-        )

--- a/src/sentry_plugins/bitbucket/__init__.py
+++ b/src/sentry_plugins/bitbucket/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-bitbucket")

--- a/src/sentry_plugins/github/__init__.py
+++ b/src/sentry_plugins/github/__init__.py
@@ -1,7 +1,3 @@
 from __future__ import absolute_import
 
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-github")
-
 from sentry_plugins.github import options  # NOQA

--- a/src/sentry_plugins/gitlab/__init__.py
+++ b/src/sentry_plugins/gitlab/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-gitlab")

--- a/src/sentry_plugins/heroku/__init__.py
+++ b/src/sentry_plugins/heroku/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-heroku")

--- a/src/sentry_plugins/jira/__init__.py
+++ b/src/sentry_plugins/jira/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-jira")

--- a/src/sentry_plugins/pagerduty/__init__.py
+++ b/src/sentry_plugins/pagerduty/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-pagerduty")

--- a/src/sentry_plugins/pivotal/__init__.py
+++ b/src/sentry_plugins/pivotal/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-pivotal")

--- a/src/sentry_plugins/pushover/__init__.py
+++ b/src/sentry_plugins/pushover/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-pushover")

--- a/src/sentry_plugins/slack/__init__.py
+++ b/src/sentry_plugins/slack/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import absolute_import
-
-from sentry_plugins.base import assert_package_not_installed
-
-assert_package_not_installed("sentry-slack")


### PR DESCRIPTION
It was only helpful during plugins transition. See https://github.com/getsentry/sentry/pull/18611 for perf impact.

(cherry picked from commit 29fd7dbcf66daae1c47c824085e235f051d3d38f)
