### PR TITLE
fix(ts): Change `pickRelevantLocationQueryStrings()` types

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -1030,9 +1030,9 @@ export const isAPIPayloadSimilar = (
   return true;
 };
 
-export function pickRelevantLocationQueryStrings(location: Location): LocationQuery {
+export function pickRelevantLocationQueryStrings(location: Location) {
   const query = location.query || {};
-  const picked = pick<LocationQuery>(query || {}, EXTERNAL_QUERY_STRING_KEYS);
+  const picked = pick(query || {}, EXTERNAL_QUERY_STRING_KEYS);
 
   return picked;
 }


### PR DESCRIPTION
Relax the types a bit here because this is failing in getsentry (not sure why it does not fail in sentry...

See https://github.com/getsentry/getsentry/pull/3882