### PR TITLE
perf(api): Suppress feature flags from paginated project view

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -106,18 +106,19 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         # TODO(davidenwang): remove this after frontend requires only paginated projects
         get_all_projects = request.GET.get("all_projects") == "1"
 
+        include_features = not features.has("organizations:enterprise-perf", organization)
         if get_all_projects:
             queryset = queryset.order_by("slug").select_related("organization")
-            serializer = ProjectSummarySerializer(
-                include_features=not features.has("organizations:enterprise-perf", organization)
-            )
+            serializer = ProjectSummarySerializer(include_features=include_features)
             return Response(serialize(list(queryset), request.user, serializer))
         else:
 
             def serialize_on_result(result):
                 environment_id = self._get_environment_id_from_request(request, organization.id)
                 serializer = ProjectSummarySerializer(
-                    environment_id=environment_id, stats_period=stats_period,
+                    environment_id=environment_id,
+                    stats_period=stats_period,
+                    include_features=include_features,
                 )
                 return serialize(result, request.user, serializer)
 

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -167,15 +167,23 @@ class OrganizationProjectsTest(APITestCase):
         for project in response.data:
             assert "features" in project
 
-    def test_all_projects_suppresses_flags(self):
+    def test_features_are_suppressed(self):
         self.login_as(user=self.user)
-        self.create_project(teams=[self.team], name="foo", slug="foo")
-        self.create_project(teams=[self.team], name="bar", slug="bar")
+        for i in range(3):
+            p = "project{}".format(i)
+            self.create_project(teams=[self.team], name=p, slug=p)
 
-        with self.feature("organizations:enterprise-perf"):
-            response = self.client.get(self.path + "?all_projects=1&per_page=1")
-        for project in response.data:
-            assert "features" not in project
+        queries = [
+            "",
+            "?all_projects=1",
+            "?per_page=2",
+            "?all_projects=1&per_page=2",
+        ]
+        for query in queries:
+            with self.feature("organizations:enterprise-perf"):
+                response = self.client.get(self.path + query)
+            for project in response.data:
+                assert "features" not in project
 
     def test_user_projects(self):
         self.foo_user = self.create_user("foo@example.com")


### PR DESCRIPTION
Generalize the change to the "all projects" endpoint, which omits
project-scoped feature flags, to also apply to the paginated projects
view. The rationale is that including the feature flags is a performance
liability, so we want to do it only when viewing a single project.