### PR TITLE
feat(integrationDirectory): Make category a query parameter

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -1,46 +1,48 @@
-import groupBy from 'lodash/groupBy';
-import debounce from 'lodash/debounce';
-import React from 'react';
 import styled from '@emotion/styled';
-import {RouteComponentProps} from 'react-router/lib/Router';
+import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
-import uniq from 'lodash/uniq';
+import groupBy from 'lodash/groupBy';
 import startCase from 'lodash/startCase';
+import uniq from 'lodash/uniq';
+import queryString from 'query-string';
+import React from 'react';
+import {browserHistory} from 'react-router';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
-import {
-  Organization,
-  Integration,
-  SentryApp,
-  IntegrationProvider,
-  DocumentIntegration,
-  SentryAppInstallation,
-  PluginWithProjectList,
-  AppOrProviderOrPlugin,
-} from 'app/types';
-import {Panel, PanelBody} from 'app/components/panels';
-import {
-  trackIntegrationEvent,
-  getSentryAppInstallStatus,
-  isSentryApp,
-  isPlugin,
-  isDocumentIntegration,
-  getCategoriesForIntegration,
-  isSlackWorkspaceApp,
-  getReauthAlertText,
-} from 'app/utils/integrationUtil';
-import {t, tct} from 'app/locale';
-import AsyncComponent from 'app/components/asyncComponent';
-import PermissionAlert from 'app/views/settings/organization/permissionAlert';
-import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
-import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
-import withOrganization from 'app/utils/withOrganization';
-import SearchBar from 'app/components/searchBar';
-import {createFuzzySearch} from 'app/utils/createFuzzySearch';
-import space from 'app/styles/space';
-import SelectControl from 'app/components/forms/selectControl';
 import Feature from 'app/components/acl/feature';
+import AsyncComponent from 'app/components/asyncComponent';
+import SelectControl from 'app/components/forms/selectControl';
+import {Panel, PanelBody} from 'app/components/panels';
+import SearchBar from 'app/components/searchBar';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
+import {
+  AppOrProviderOrPlugin,
+  DocumentIntegration,
+  Integration,
+  IntegrationProvider,
+  Organization,
+  PluginWithProjectList,
+  SentryApp,
+  SentryAppInstallation,
+} from 'app/types';
+import {createFuzzySearch} from 'app/utils/createFuzzySearch';
+import {
+  getCategoriesForIntegration,
+  getReauthAlertText,
+  getSentryAppInstallStatus,
+  isDocumentIntegration,
+  isPlugin,
+  isSentryApp,
+  isSlackWorkspaceApp,
+  trackIntegrationEvent,
+} from 'app/utils/integrationUtil';
+import withOrganization from 'app/utils/withOrganization';
+import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+import PermissionAlert from 'app/views/settings/organization/permissionAlert';
 
-import {POPULARITY_WEIGHT, documentIntegrations} from './constants';
+import {documentIntegrations, POPULARITY_WEIGHT} from './constants';
 import IntegrationRow from './integrationRow';
 
 type Props = RouteComponentProps<{orgId: string}, {}> & {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -119,7 +119,7 @@ export class IntegrationListDirectory extends AsyncComponent<
     const {searchInput, selectedCategory} = this.getFilterParameters();
 
     this.setState({list, searchInput, selectedCategory}, () => {
-      this.calculateDisplayedList();
+      this.updateDisplayedList();
       this.trackPageViewed();
     });
   }
@@ -311,7 +311,7 @@ export class IntegrationListDirectory extends AsyncComponent<
   /**
    * Filter the integrations list by ANDing together the search query and the category select.
    */
-  calculateDisplayedList = (): AppOrProviderOrPlugin[] => {
+  updateDisplayedList = (): AppOrProviderOrPlugin[] => {
     const {fuzzy, list, searchInput, selectedCategory} = this.state;
 
     let displayedList = list;
@@ -335,7 +335,7 @@ export class IntegrationListDirectory extends AsyncComponent<
   handleSearchChange = async (value: string) => {
     this.setState({searchInput: value}, () => {
       this.updateQueryString();
-      const result = this.calculateDisplayedList();
+      const result = this.updateDisplayedList();
       if (value) {
         this.debouncedTrackIntegrationSearch(value, result.length);
       }
@@ -345,7 +345,7 @@ export class IntegrationListDirectory extends AsyncComponent<
   onCategorySelect = ({value: category}: {value: string}) => {
     this.setState({selectedCategory: category}, () => {
       this.updateQueryString();
-      this.calculateDisplayedList();
+      this.updateDisplayedList();
 
       if (category) {
         trackIntegrationEvent(

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -336,7 +336,9 @@ export class IntegrationListDirectory extends AsyncComponent<
     this.setState({searchInput: value}, () => {
       this.updateQueryString();
       const result = this.calculateDisplayedList();
-      this.debouncedTrackIntegrationSearch(value, result.length);
+      if (value) {
+        this.debouncedTrackIntegrationSearch(value, result.length);
+      }
     });
   };
 
@@ -345,15 +347,17 @@ export class IntegrationListDirectory extends AsyncComponent<
       this.updateQueryString();
       this.calculateDisplayedList();
 
-      trackIntegrationEvent(
-        {
-          eventKey: 'integrations.directory_category_selected',
-          eventName: 'Integrations: Directory Category Selected',
-          view: 'integrations_directory',
-          category,
-        },
-        this.props.organization
-      );
+      if (category) {
+        trackIntegrationEvent(
+          {
+            eventKey: 'integrations.directory_category_selected',
+            eventName: 'Integrations: Directory Category Selected',
+            view: 'integrations_directory',
+            category,
+          },
+          this.props.organization
+        );
+      }
     });
   };
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -273,12 +273,31 @@ export class IntegrationListDirectory extends AsyncComponent<
     );
   }, TEXT_SEARCH_ANALYTICS_DEBOUNCE_IN_MS);
 
+  /**
+   * Update the query string with the current filter parameter values.
+   */
+  updateQueryString = () => {
+    const {searchInput, selectedCategory} = this.state;
+
+    const searchString = queryString.stringify({
+      ...queryString.parse(this.props.location.search),
+      search: searchInput ? searchInput : undefined,
+      category: selectedCategory ? selectedCategory : undefined,
+    });
+
+    browserHistory.replace({
+      pathname: this.props.location.pathname,
+      search: searchString ? `?${searchString}` : undefined,
+    });
+  };
+
   handleSearchChange = async (value: string) => {
     this.setState({searchInput: value}, () => {
       if (!value) {
         return this.setState({displayedList: this.state.list});
       }
       const result = this.state.fuzzy && this.state.fuzzy.search(value);
+      this.updateQueryString();
       this.debouncedTrackIntegrationSearch(value, result.length);
       return this.setState({
         displayedList: this.sortIntegrations(result.map(i => i.item)),
@@ -294,6 +313,7 @@ export class IntegrationListDirectory extends AsyncComponent<
       const result = this.state.list.filter(integration => {
         return getCategoriesForIntegration(integration).includes(category);
       });
+      this.updateQueryString();
 
       return this.setState({displayedList: result}, () =>
         trackIntegrationEvent(

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -114,7 +114,9 @@ export class IntegrationListDirectory extends AsyncComponent<
 
     const list = this.sortIntegrations(combined);
 
-    this.setState({list, displayedList: list}, () => this.trackPageViewed());
+    const {searchInput, selectedCategory} = this.getFilterParameters();
+
+    this.setState({list, searchInput, selectedCategory}, () => this.trackPageViewed());
   }
 
   trackPageViewed() {
@@ -270,6 +272,18 @@ export class IntegrationListDirectory extends AsyncComponent<
       this.props.organization
     );
   }, TEXT_SEARCH_ANALYTICS_DEBOUNCE_IN_MS);
+
+  /**
+   * Get filter parameters and guard against `queryString.parse` returning arrays.
+   */
+  getFilterParameters = (): {searchInput: string; selectedCategory: string} => {
+    const {category, search} = queryString.parse(this.props.location.search);
+
+    const selectedCategory = Array.isArray(category) ? category[0] : category || "";
+    const searchInput = Array.isArray(search) ? search[0] : search || "";
+
+    return {searchInput, selectedCategory};
+  };
 
   /**
    * Update the query string with the current filter parameter values.

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -322,12 +322,12 @@ export class IntegrationListDirectory extends AsyncComponent<
     }
 
     if (selectedCategory) {
-      displayedList = displayedList.filter(
-        integration => getCategoriesForIntegration(integration).includes(selectedCategory)
+      displayedList = displayedList.filter(integration =>
+        getCategoriesForIntegration(integration).includes(selectedCategory)
       );
     }
 
-    this.setState({displayedList})
+    this.setState({displayedList});
 
     return displayedList;
   };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -317,9 +317,9 @@ export class IntegrationListDirectory extends AsyncComponent<
     }
 
     if (selectedCategory) {
-      displayedList = displayedList.filter(integration => {
-        return getCategoriesForIntegration(integration).includes(selectedCategory);
-      });
+      displayedList = displayedList.filter(
+        integration => getCategoriesForIntegration(integration).includes(selectedCategory)
+      );
     }
 
     return displayedList;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -279,8 +279,8 @@ export class IntegrationListDirectory extends AsyncComponent<
   getFilterParameters = (): {searchInput: string; selectedCategory: string} => {
     const {category, search} = queryString.parse(this.props.location.search);
 
-    const selectedCategory = Array.isArray(category) ? category[0] : category || "";
-    const searchInput = Array.isArray(search) ? search[0] : search || "";
+    const selectedCategory = Array.isArray(category) ? category[0] : category || '';
+    const searchInput = Array.isArray(search) ? search[0] : search || '';
 
     return {searchInput, selectedCategory};
   };
@@ -349,6 +349,7 @@ export class IntegrationListDirectory extends AsyncComponent<
       );
     });
   };
+
   // Rendering
   renderProvider = (provider: IntegrationProvider) => {
     const {organization} = this.props;
@@ -390,7 +391,7 @@ export class IntegrationListDirectory extends AsyncComponent<
     const {organization} = this.props;
 
     const isLegacy = plugin.isHidden;
-    const displayName = `${plugin.name} ${!!isLegacy ? '(Legacy)' : ''}`;
+    const displayName = `${plugin.name} ${isLegacy ? '(Legacy)' : ''}`;
     //hide legacy integrations if we don't have any projects with them
     if (isLegacy && !plugin.projectList.length) {
       return null;
@@ -489,7 +490,7 @@ export class IntegrationListDirectory extends AsyncComponent<
                   ]}
                 />
                 <SearchBar
-                  query={this.state.searchInput || ''}
+                  query={searchInput || ''}
                   onChange={this.handleSearchChange}
                   placeholder={t('Filter Integrations...')}
                   width="25em"
@@ -508,7 +509,7 @@ export class IntegrationListDirectory extends AsyncComponent<
               <EmptyResultsContainer>
                 <EmptyResultsBody>
                   {tct('No Integrations found for "[searchTerm]".', {
-                    searchTerm: this.state.searchInput,
+                    searchTerm: searchInput,
                   })}
                 </EmptyResultsBody>
               </EmptyResultsContainer>


### PR DESCRIPTION
The integrations directory filters stop working when the window loses focus. This PR saves the filters as query parameters so that they can be re-applied whenever they are expected, including on page load.

Fixes https://getsentry.atlassian.net/browse/API-926