### PR TITLE
fix(kafka): Call poll after produce

### DIFF
--- a/src/sentry/utils/pubsub.py
+++ b/src/sentry/utils/pubsub.py
@@ -73,5 +73,7 @@ class KafkaPublisher(object):
 
     def publish(self, channel, value, key=None):
         self.producer.produce(topic=channel, value=value, key=key)
-        if not self.asynchronous:
+        if self.asynchronous:
+            self.producer.poll(0)
+        else:
             self.producer.flush()


### PR DESCRIPTION
Fixes #18624.

Kafka needs `poll()` to be called at regular intervals to clear its in-memory buffer and triggering any callbacks for producers. This patch adds the missing `poll(0)` call which is essentially free, to the main `KafkaProducer` class, mainly affecting the `track_outcomes` producer as the other user uses the synchronous mode, calling `flush()` which calls `poll()` behind the scenes already.