### PR TITLE
fix(ui) Rename none to default

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/types.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/types.tsx
@@ -2,14 +2,14 @@ import {t} from 'app/locale';
 import {SelectValue} from 'app/types';
 
 export enum DisplayModes {
-  NONE = 'none',
+  DEFAULT = 'default',
   PREVIOUS = 'previous',
   RELEASES = 'releases',
   TOP5 = 'top5',
 }
 
 export const DISPLAY_MODE_OPTIONS: SelectValue<string>[] = [
-  {value: DisplayModes.NONE, label: t('None')},
+  {value: DisplayModes.DEFAULT, label: t('Default')},
   {value: DisplayModes.PREVIOUS, label: t('Previous Period')},
   {value: DisplayModes.RELEASES, label: t('Release Markers')},
   {value: DisplayModes.TOP5, label: t('Top 5 Breakdown')},

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -139,7 +139,7 @@ class ResultsChartContainer extends React.Component<ContainerProps> {
           yAxisOptions={eventView.getYAxisOptions()}
           onAxisChange={onAxisChange}
           displayOptions={eventView.getDisplayOptions()}
-          displayMode={eventView.display || DisplayModes.NONE}
+          displayMode={eventView.display || DisplayModes.DEFAULT}
           onDisplayChange={onDisplayChange}
         />
       </StyledPanel>


### PR DESCRIPTION
The name 'none' is misleading as you don't get no graph, you get a default 'all things' view. Saved queries and bookmarks could contain 'none' but because that is now an invalid option the fallback is 'default' so there should be no user impact of this change.