### PR TITLE
feat(alerts): Start dual writing to new model and fields

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -34,13 +34,14 @@ from sentry.incidents.models import (
     IncidentSubscription,
     TimeSeriesSnapshot,
 )
-from sentry.models import Environment, Integration, Project
+from sentry.models import Integration, Project
 from sentry.snuba.discover import resolve_discover_aliases
 from sentry.snuba.models import query_aggregation_to_snuba, QueryAggregations, QueryDatasets
 from sentry.snuba.subscriptions import (
     bulk_create_snuba_subscriptions,
     bulk_delete_snuba_subscriptions,
-    bulk_update_snuba_subscriptions,
+    create_snuba_query,
+    update_snuba_query,
 )
 from sentry.snuba.tasks import apply_dataset_conditions
 from sentry.utils.db import attach_foreignkey
@@ -575,8 +576,17 @@ def create_alert_rule(
     if AlertRule.objects.filter(organization=organization, name=name).exists():
         raise AlertRuleNameAlreadyUsedError()
     with transaction.atomic():
+        snuba_query = create_snuba_query(
+            dataset,
+            query,
+            aggregation,
+            timedelta(minutes=time_window),
+            timedelta(minutes=resolution),
+            environment,
+        )
         alert_rule = AlertRule.objects.create(
             organization=organization,
+            snuba_query=snuba_query,
             name=name,
             dataset=dataset.value,
             query=query,
@@ -612,9 +622,13 @@ def snapshot_alert_rule(alert_rule):
     with transaction.atomic():
         triggers = AlertRuleTrigger.objects.filter(alert_rule=alert_rule)
         incidents = Incident.objects.filter(alert_rule=alert_rule)
+        snuba_query_snapshot = deepcopy(alert_rule.snuba_query)
+        snuba_query_snapshot.id = None
+        snuba_query_snapshot.save()
         alert_rule_snapshot = deepcopy(alert_rule)
         alert_rule_snapshot.id = None
         alert_rule_snapshot.status = AlertRuleStatus.SNAPSHOT.value
+        alert_rule_snapshot.snuba_query = snuba_query_snapshot
         alert_rule_snapshot.save()
 
         incidents.update(alert_rule=alert_rule_snapshot)
@@ -633,6 +647,26 @@ def snapshot_alert_rule(alert_rule):
     tasks.auto_resolve_snapshot_incidents.apply_async(
         kwargs={"alert_rule_id": alert_rule_snapshot.id}, countdown=3
     )
+
+
+def convert_alert_rule_to_snuba_query(alert_rule):
+    """
+    Temporary method to convert existing alert rules to have a snuba query
+    """
+    if alert_rule.snuba_query:
+        return
+
+    with transaction.atomic():
+        snuba_query = create_snuba_query(
+            QueryDatasets(alert_rule.dataset),
+            alert_rule.query,
+            QueryAggregations(alert_rule.aggregation),
+            timedelta(minutes=alert_rule.time_window),
+            timedelta(minutes=alert_rule.resolution),
+            alert_rule.environment,
+        )
+        alert_rule.update(snuba_query=snuba_query)
+        alert_rule.query_subscriptions.all().update(snuba_query=snuba_query)
 
 
 def update_alert_rule(
@@ -673,17 +707,21 @@ def update_alert_rule(
         and AlertRule.objects.filter(organization=alert_rule.organization, name=name).exists()
     ):
         raise AlertRuleNameAlreadyUsedError()
+    convert_alert_rule_to_snuba_query(alert_rule)
 
     updated_fields = {}
+    updated_query_fields = {}
     if name:
         updated_fields["name"] = name
     if query is not None:
         validate_alert_rule_query(query)
-        updated_fields["query"] = query
+        updated_query_fields["query"] = updated_fields["query"] = query
     if aggregation is not None:
         updated_fields["aggregation"] = aggregation.value
+        updated_query_fields["aggregation"] = aggregation
     if time_window:
         updated_fields["time_window"] = time_window
+        updated_query_fields["time_window"] = timedelta(minutes=time_window)
     if threshold_period:
         updated_fields["threshold_period"] = threshold_period
     if include_all_projects is not None:
@@ -694,6 +732,24 @@ def update_alert_rule(
         if incidents:
             snapshot_alert_rule(alert_rule)
         alert_rule.update(**updated_fields)
+
+        if updated_query_fields or environment != alert_rule.snuba_query.environment:
+            snuba_query = alert_rule.snuba_query
+            updated_query_fields.setdefault("query", snuba_query.query)
+            # XXX: We use the alert rule aggregation here since currently we're
+            # expecting the enum value to be passed.
+            updated_query_fields.setdefault(
+                "aggregation", QueryAggregations(alert_rule.aggregation)
+            )
+            updated_query_fields.setdefault(
+                "time_window", timedelta(seconds=snuba_query.time_window)
+            )
+            update_snuba_query(
+                alert_rule.snuba_query,
+                resolution=timedelta(minutes=DEFAULT_ALERT_RULE_RESOLUTION),
+                environment=environment,
+                **updated_query_fields
+            )
 
         existing_subs = []
         if (
@@ -757,11 +813,6 @@ def update_alert_rule(
 
         if deleted_subs:
             bulk_delete_snuba_subscriptions(deleted_subs)
-            # Remove any deleted subscriptions from `existing_subscriptions`, so that
-            # if we need to update any subscriptions we don't end up doing it twice. We
-            # don't add new subscriptions here since they'll already have the updated
-            # values
-            existing_subs = [sub for sub in existing_subs if sub.id]
 
         if environment:
             # Delete rows we don't have present in the updated data.
@@ -774,25 +825,6 @@ def update_alert_rule(
         else:
             AlertRuleEnvironment.objects.filter(alert_rule=alert_rule).delete()
 
-        if existing_subs and (
-            query is not None or aggregation is not None or time_window is not None
-        ):
-            try:
-                environment = alert_rule.environment.all()[:1].get()
-            except Environment.DoesNotExist:
-                environment = None
-
-            # If updating any subscription details, update related Snuba subscriptions
-            # too
-            bulk_update_snuba_subscriptions(
-                existing_subs,
-                alert_rule.query,
-                QueryAggregations(alert_rule.aggregation),
-                timedelta(minutes=alert_rule.time_window),
-                timedelta(minutes=DEFAULT_ALERT_RULE_RESOLUTION),
-                environment,
-            )
-
     return alert_rule
 
 
@@ -801,20 +833,11 @@ def subscribe_projects_to_alert_rule(alert_rule, projects):
     Subscribes a list of projects to an alert rule
     :return: The list of created subscriptions
     """
-    try:
-        environment = alert_rule.environment.all()[:1].get()
-    except Environment.DoesNotExist:
-        environment = None
-
     subscriptions = bulk_create_snuba_subscriptions(
         projects,
         tasks.INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
-        QueryDatasets(alert_rule.dataset),
-        alert_rule.query,
+        alert_rule.snuba_query,
         QueryAggregations(alert_rule.aggregation),
-        timedelta(minutes=alert_rule.time_window),
-        timedelta(minutes=alert_rule.resolution),
-        environment,
     )
     subscription_links = [
         AlertRuleQuerySubscription(query_subscription=subscription, alert_rule=alert_rule)

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -2,7 +2,14 @@ from __future__ import absolute_import
 
 import logging
 
-from sentry.snuba.models import QuerySubscription, QuerySubscriptionEnvironment
+from django.db import transaction
+
+from sentry.snuba.models import (
+    QueryAggregations,
+    QuerySubscription,
+    QuerySubscriptionEnvironment,
+    SnubaQuery,
+)
 from sentry.snuba.tasks import (
     create_subscription_in_snuba,
     delete_subscription_from_snuba,
@@ -11,16 +18,26 @@ from sentry.snuba.tasks import (
 
 logger = logging.getLogger(__name__)
 
+aggregation_function_translations = {
+    QueryAggregations.TOTAL: "count()",
+    QueryAggregations.UNIQUE_USERS: "count_unique(user)",
+}
 
-def bulk_create_snuba_subscriptions(
-    projects, subscription_type, dataset, query, aggregation, time_window, resolution, environment
-):
+
+def translate_aggregation(aggregation):
     """
-    Creates a subscription to a snuba query for each project.
+    Temporary function to translate `QueryAggregations` into the discover aggregation
+    function format
+    :param aggregation:
+    :return: A string representing the aggregate function
+    """
+    return aggregation_function_translations[aggregation]
 
-    :param projects: The projects we're applying the query to
-    :param subscription_type: Text identifier for the subscription type this is. Used
-    to identify the registered callback associated with this subscription.
+
+def create_snuba_query(dataset, query, aggregation, time_window, resolution, environment):
+    """
+    Creates a SnubaQuery.
+
     :param dataset: The snuba dataset to query and aggregate over
     :param query: An event search query that we can parse and convert into a
     set of Snuba conditions
@@ -30,33 +47,21 @@ def bulk_create_snuba_subscriptions(
     :param environment: An optional environment to filter by
     :return: A list of QuerySubscriptions
     """
-    subscriptions = []
-    # TODO: Batch this up properly once we care about multi-project rules.
-    for project in projects:
-        subscriptions.append(
-            create_snuba_subscription(
-                project,
-                subscription_type,
-                dataset,
-                query,
-                aggregation,
-                time_window,
-                resolution,
-                environment,
-            )
-        )
-    return subscriptions
+    return SnubaQuery.objects.create(
+        dataset=dataset.value,
+        query=query,
+        aggregate=translate_aggregation(aggregation),
+        time_window=int(time_window.total_seconds()),
+        resolution=int(resolution.total_seconds()),
+        environment=environment,
+    )
 
 
-def create_snuba_subscription(
-    project, subscription_type, dataset, query, aggregation, time_window, resolution, environment
-):
+def update_snuba_query(snuba_query, query, aggregation, time_window, resolution, environment):
     """
-    Creates a subscription to a snuba query.
+    Updates a SnubaQuery. Triggers updates to any related QuerySubscriptions.
 
-    :param project: The project we're applying the query to
-    :param subscription_type: Text identifier for the subscription type this is. Used
-    to identify the registered callback associated with this subscription.
+    :param snuba_query: The `SnubaQuery` to update.
     :param dataset: The snuba dataset to query and aggregate over
     :param query: An event search query that we can parse and convert into a
     set of Snuba conditions
@@ -64,21 +69,67 @@ def create_snuba_subscription(
     :param time_window: The time window to aggregate over
     :param resolution: How often to receive updates/bucket size
     :param environment: An optional environment to filter by
+    :return: A list of QuerySubscriptions
+    """
+    with transaction.atomic():
+        query_subscriptions = list(snuba_query.subscriptions.all())
+        snuba_query.update(
+            query=query,
+            aggregate=translate_aggregation(aggregation),
+            time_window=int(time_window.total_seconds()),
+            resolution=int(resolution.total_seconds()),
+            environment=environment,
+        )
+        bulk_update_snuba_subscriptions(query_subscriptions, snuba_query, aggregation)
+
+
+def bulk_create_snuba_subscriptions(projects, subscription_type, snuba_query, aggregation):
+    """
+    Creates a subscription to a snuba query for each project.
+
+    :param projects: The projects we're applying the query to
+    :param subscription_type: Text identifier for the subscription type this is. Used
+    to identify the registered callback associated with this subscription.
+    :param snuba_query: A `SnubaQuery` instance to subscribe the projects to.
+    :param aggregation: An aggregation to calculate over the time window. This will be
+    removed soon, once we're relying entirely on `snuba_query`.
+    :return: A list of QuerySubscriptions
+    """
+    subscriptions = []
+    # TODO: Batch this up properly once we care about multi-project rules.
+    for project in projects:
+        subscriptions.append(
+            create_snuba_subscription(project, subscription_type, snuba_query, aggregation)
+        )
+    return subscriptions
+
+
+def create_snuba_subscription(project, subscription_type, snuba_query, aggregation):
+    """
+    Creates a subscription to a snuba query.
+
+    :param project: The project we're applying the query to
+    :param subscription_type: Text identifier for the subscription type this is. Used
+    to identify the registered callback associated with this subscription.
+    :param snuba_query: A `SnubaQuery` instance to subscribe the project to.
+    :param aggregation: An aggregation to calculate over the time window. This will be
+    removed soon, once we're relying entirely on `snuba_query`.
     :return: The QuerySubscription representing the subscription
     """
     subscription = QuerySubscription.objects.create(
         status=QuerySubscription.Status.CREATING.value,
         project=project,
+        snuba_query=snuba_query,
         type=subscription_type,
-        dataset=dataset.value,
-        query=query,
+        dataset=snuba_query.dataset,
+        query=snuba_query.query,
         aggregation=aggregation.value,
-        time_window=int(time_window.total_seconds()),
-        resolution=int(resolution.total_seconds()),
+        time_window=snuba_query.time_window,
+        resolution=snuba_query.resolution,
     )
-    if environment:
+    if snuba_query.environment:
         QuerySubscriptionEnvironment.objects.create(
-            query_subscription=subscription, environment=environment
+            query_subscription=subscription, environment=snuba_query.environment
         )
 
     create_subscription_in_snuba.apply_async(
@@ -88,64 +139,55 @@ def create_snuba_subscription(
     return subscription
 
 
-def bulk_update_snuba_subscriptions(
-    subscriptions, query, aggregation, time_window, resolution, environment
-):
+def bulk_update_snuba_subscriptions(subscriptions, snuba_query, aggregation):
     """
     Updates a list of query subscriptions.
 
     :param subscriptions: The subscriptions we're updating
-    :param query: An event search query that we can parse and convert into a
-    set of Snuba conditions
-    :param aggregation: An aggregation to calculate over the time window
-    :param time_window: The time window to aggregate over
-    :param resolution: How often to receive updates/bucket size
-    :param environment: An optional environment to filter by
+    :param snuba_query: A `SnubaQuery` instance to subscribe the project to.
+    :param aggregation: An aggregation to calculate over the time window. This will be
+    removed soon, once we're relying entirely on `snuba_query`.
     :return: A list of QuerySubscriptions
     """
     updated_subscriptions = []
     # TODO: Batch this up properly once we care about multi-project rules.
     for subscription in subscriptions:
         updated_subscriptions.append(
-            update_snuba_subscription(
-                subscription, query, aggregation, time_window, resolution, environment
-            )
+            update_snuba_subscription(subscription, snuba_query, aggregation)
         )
     return subscriptions
 
 
-def update_snuba_subscription(
-    subscription, query, aggregation, time_window, resolution, environment
-):
+def update_snuba_subscription(subscription, snuba_query, aggregation):
     """
     Updates a subscription to a snuba query.
 
     :param query: An event search query that we can parse and convert into a
     set of Snuba conditions
-    :param aggregation: An aggregation to calculate over the time window
-    :param time_window: The time window to aggregate over
-    :param resolution: How often to receive updates/bucket size
-    :param environment: An optional environment to filter by
+    :param snuba_query: A `SnubaQuery` instance to subscribe the project to.
+    :param aggregation: An aggregation to calculate over the time window. This will be
+    removed soon, once we're relying entirely on `snuba_query`.
     :return: The QuerySubscription representing the subscription
     """
-    subscription.update(
-        status=QuerySubscription.Status.UPDATING.value,
-        query=query,
-        aggregation=aggregation.value,
-        time_window=int(time_window.total_seconds()),
-        resolution=int(resolution.total_seconds()),
-    )
-    QuerySubscriptionEnvironment.objects.filter(query_subscription=subscription).exclude(
-        environment=environment
-    ).delete()
-    if environment:
-        QuerySubscriptionEnvironment.objects.get_or_create(
-            query_subscription=subscription, environment=environment
+    with transaction.atomic():
+        subscription.update(
+            status=QuerySubscription.Status.UPDATING.value,
+            query=snuba_query.query,
+            aggregation=aggregation.value,
+            time_window=snuba_query.time_window,
+            resolution=snuba_query.resolution,
         )
+        QuerySubscriptionEnvironment.objects.filter(query_subscription=subscription).exclude(
+            environment=snuba_query.environment
+        ).delete()
+        if snuba_query.environment:
+            QuerySubscriptionEnvironment.objects.get_or_create(
+                query_subscription=subscription, environment=snuba_query.environment
+            )
 
-    update_subscription_in_snuba.apply_async(
-        kwargs={"query_subscription_id": subscription.id}, countdown=5
-    )
+        update_subscription_in_snuba.apply_async(
+            kwargs={"query_subscription_id": subscription.id}, countdown=5
+        )
 
     return subscription
 


### PR DESCRIPTION
This starts dual-writing to the new `SnubaQuery` model. This model will replace all query related
fields on `AlertRule` and `QuerySubscription` once we're finished. Next steps are to backfill, verify
that the data is consistent between the tables, and then finally start using these new fields.