### PR TITLE
refs(subscriptions): Update subscriptions to support v2 format. Log request data.

### DIFF
--- a/src/sentry/snuba/json_schemas.py
+++ b/src/sentry/snuba/json_schemas.py
@@ -33,5 +33,30 @@ SUBSCRIPTION_PAYLOAD_VERSIONS = {
         },
         "required": ["subscription_id", "values", "timestamp"],
         "additionalProperties": False,
-    }
+    },
+    2: {
+        "type": "object",
+        "properties": {
+            "subscription_id": {"type": "string", "minLength": 1},
+            "request": {"type": "object"},
+            "result": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "minProperties": 1,
+                            "additionalProperties": {"type": "number"},
+                        },
+                    }
+                },
+                "required": ["data"],
+            },
+            "timestamp": {"type": "string", "format": "date-time"},
+        },
+        "required": ["subscription_id", "request", "result", "timestamp"],
+        "additionalProperties": False,
+    },
 }

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -200,6 +200,7 @@ class QuerySubscriptionConsumer(object):
                     "timestamp": contents["timestamp"],
                     "query_subscription_id": contents["subscription_id"],
                     "project_id": subscription.project_id,
+                    "request": contents.get("request"),
                     "subscription_dataset": subscription.dataset,
                     "subscription_query": subscription.query,
                     "subscription_aggregation": subscription.aggregation,
@@ -248,6 +249,11 @@ class QuerySubscriptionConsumer(object):
             except jsonschema.ValidationError:
                 metrics.incr("snuba_query_subscriber.message_payload_invalid")
                 raise InvalidSchemaError("Message payload does not match schema")
+        # XXX: Since we just return the raw dict here, when the payload changes it'll
+        # break things. This should convert the payload into a class rather than passing
+        # the dict around, but until we get time to refactor we can keep things working
+        # here.
+        payload.setdefault("values", payload.get("result"))
 
         payload["timestamp"] = parse_date(payload["timestamp"]).replace(tzinfo=pytz.utc)
         return payload

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -30,13 +30,22 @@ class BaseQuerySubscriptionTest(object):
 
     @fixture
     def valid_wrapper(self):
-        return {"version": 1, "payload": self.valid_payload}
+        return {"version": 2, "payload": self.valid_payload}
+
+    @fixture
+    def old_payload(self):
+        return {
+            "subscription_id": "1234",
+            "values": {"data": [{"hello": 50}]},
+            "timestamp": "2020-01-01T01:23:45.1234",
+        }
 
     @fixture
     def valid_payload(self):
         return {
             "subscription_id": "1234",
-            "values": {"data": [{"hello": 50}]},
+            "result": {"data": [{"hello": 50}]},
+            "request": {"some": "data"},
             "timestamp": "2020-01-01T01:23:45.1234",
         }
 
@@ -104,6 +113,8 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
         data = self.valid_wrapper
         data["payload"]["subscription_id"] = sub.subscription_id
         self.consumer.handle_message(self.build_mock_message(data))
+        data = deepcopy(data)
+        data["payload"]["values"] = data["payload"]["result"]
         data["payload"]["timestamp"] = parse_date(data["payload"]["timestamp"]).replace(
             tzinfo=pytz.utc
         )
@@ -125,15 +136,15 @@ class ParseMessageValueTest(BaseQuerySubscriptionTest, unittest.TestCase):
                 payload.pop(field)
         if update_fields:
             payload.update(update_fields)
-        self.run_invalid_schema_test({"version": 1, "payload": payload})
+        self.run_invalid_schema_test({"version": 2, "payload": payload})
 
     def test_invalid_payload(self):
         self.run_invalid_payload_test(remove_fields=["subscription_id"])
-        self.run_invalid_payload_test(remove_fields=["values"])
+        self.run_invalid_payload_test(remove_fields=["result"])
         self.run_invalid_payload_test(remove_fields=["timestamp"])
         self.run_invalid_payload_test(update_fields={"subscription_id": ""})
-        self.run_invalid_payload_test(update_fields={"values": {}})
-        self.run_invalid_payload_test(update_fields={"values": {"hello": "hi"}})
+        self.run_invalid_payload_test(update_fields={"result": {}})
+        self.run_invalid_payload_test(update_fields={"result": {"hello": "hi"}})
         self.run_invalid_payload_test(update_fields={"timestamp": -1})
 
     def test_invalid_version(self):
@@ -142,7 +153,10 @@ class ParseMessageValueTest(BaseQuerySubscriptionTest, unittest.TestCase):
         assert six.text_type(cm.exception) == "Version specified in wrapper has no schema"
 
     def test_valid(self):
-        self.run_test({"version": 1, "payload": self.valid_payload})
+        self.run_test({"version": 2, "payload": self.valid_payload})
+
+    def test_old_version(self):
+        self.run_test({"version": 1, "payload": self.old_payload})
 
     def test_invalid_wrapper(self):
         self.run_invalid_schema_test({})


### PR DESCRIPTION
As part of investigating some data inconsistencies we want to log the details of the query we made.
We've updated the payload format to support this.

We should stop using the raw dict at some point and convert it into an object, but until we get time
there's a hack in place for compatibility.