### PR TITLE
chore(discover) Add a comment explaining why we don't use eventstore

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -101,6 +101,9 @@ def find_reference_event(reference_event):
     if reference_event.end:
         end = reference_event.end + timedelta(seconds=5)
 
+    # We use raw_query here because generating conditions from an eventstore
+    # event requires non-trivial translation from the flat list of fields into
+    # structured fields like message, stack, and tags.
     event = raw_query(
         selected_columns=column_names,
         filter_keys={"project_id": [project.id], "event_id": [event_id]},


### PR DESCRIPTION
The reasoning behind this decision has come up a few times and having a comment might help future us.