### PR TITLE
Revert "refs(mail): Cleanup digests task key migration code. (#18429)"

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -11,7 +11,6 @@ from six.moves import reduce
 from sentry.app import tsdb
 from sentry.digests import Record
 from sentry.models import Project, Group, GroupStatus, Rule
-from sentry.utils import metrics
 from sentry.utils.dates import to_timestamp
 
 logger = logging.getLogger("sentry.digests")
@@ -24,13 +23,13 @@ def split_key(key):
 
     key_parts = key.split(":", 4)
     project_id = key_parts[2]
+    # XXX: We transitioned to new style keys (len == 5) a while ago on sentry.io. But
+    # on-prem users might transition at any time, so we need to keep this transition
+    # code around for a while, maybe indefinitely.
     if len(key_parts) == 5:
         target_type = ActionTargetType(key_parts[3])
         target_identifier = key_parts[4] if key_parts[4] else None
-        metrics.incr("digests.new_key_seen")
     else:
-        metrics.incr("digests.old_key_seen")
-
         target_type = ActionTargetType.ISSUE_OWNERS
         target_identifier = None
     return Project.objects.get(pk=project_id), target_type, target_identifier

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -11,6 +11,7 @@ from six.moves import reduce
 from sentry.app import tsdb
 from sentry.digests import Record
 from sentry.models import Project, Group, GroupStatus, Rule
+from sentry.utils import metrics
 from sentry.utils.dates import to_timestamp
 
 logger = logging.getLogger("sentry.digests")
@@ -23,8 +24,15 @@ def split_key(key):
 
     key_parts = key.split(":", 4)
     project_id = key_parts[2]
-    target_type = ActionTargetType(key_parts[3])
-    target_identifier = key_parts[4] if key_parts[4] else None
+    if len(key_parts) == 5:
+        target_type = ActionTargetType(key_parts[3])
+        target_identifier = key_parts[4] if key_parts[4] else None
+        metrics.incr("digests.new_key_seen")
+    else:
+        metrics.incr("digests.old_key_seen")
+
+        target_type = ActionTargetType.ISSUE_OWNERS
+        target_identifier = None
     return Project.objects.get(pk=project_id), target_type, target_identifier
 
 

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -118,6 +118,13 @@ class SortRecordsTestCase(TestCase):
 
 
 class SplitKeyTestCase(TestCase):
+    def test_old_style_key(self):
+        assert split_key("mail:p:{}".format(self.project.id)) == (
+            self.project,
+            ActionTargetType.ISSUE_OWNERS,
+            None,
+        )
+
     def test_new_style_key_no_identifier(self):
         assert split_key(
             "mail:p:{}:{}:".format(self.project.id, ActionTargetType.ISSUE_OWNERS.value)


### PR DESCRIPTION
This reverts commit 8e335c7b070cb6d2e9dc1fdc3ce7e1964469346f.

We're reverting this because it causes an issue when on-prem users migrate and have old digest tasks
hanging around. We'll have to keep this transition code around indefinitely, unfortunately.