### PR TITLE
ref(devservices): Disable access log output

### DIFF
--- a/config/reverse_proxy/nginx.conf
+++ b/config/reverse_proxy/nginx.conf
@@ -18,7 +18,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  off;
 
     sendfile              on;
     keepalive_timeout     65;


### PR DESCRIPTION
Does anyone ACTUALLY need this by default