### PR TITLE
fix(alerts): Send null for all environments

### DIFF
--- a/src/sentry/api/serializers/rest_framework/environment.py
+++ b/src/sentry/api/serializers/rest_framework/environment.py
@@ -12,6 +12,8 @@ class EnvironmentField(serializers.Field):
         return value
 
     def to_internal_value(self, data):
+        if data is None:
+            return None
         try:
             environment = Environment.objects.get(
                 organization_id=self.context["organization"].id, name=data

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -268,7 +268,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
      - `access`: An access object (from `request.access`)
     """
 
-    environment = EnvironmentField(required=False)
+    environment = EnvironmentField(required=False, allow_null=True)
     # TODO: These might be slow for many projects, since it will query for each
     # individually. If we find this to be a problem then we can look into batching.
     projects = serializers.ListField(child=ProjectField(), required=False)

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
@@ -27,13 +27,7 @@ export async function addOrUpdateRule(
 
   return api.requestPromise(endpoint, {
     method,
-    data: {
-      ...rule,
-
-      // Clearing environments from the UI will result in a null value
-      // which will error in API, make sure we normalize to empty array
-      environment: rule.environment ?? [],
-    },
+    data: rule,
   });
 }
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -25,6 +25,6 @@ export function createDefaultRule(): UnsavedIncidentRule {
     timeWindow: 1,
     triggers: [createDefaultTrigger()],
     projects: [],
-    environment: '',
+    environment: null,
   };
 }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -15,7 +15,7 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import Tooltip from 'app/components/tooltip';
 
-import {AlertRuleAggregations, TimeWindow} from './types';
+import {AlertRuleAggregations, TimeWindow, IncidentRule} from './types';
 import getMetricDisplayName from './utils/getMetricDisplayName';
 
 type TimeWindowMapType = {[key in TimeWindow]: string};
@@ -76,7 +76,9 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
     const {organization, disabled, onFilterUpdate} = this.props;
     const {environments} = this.state;
 
-    const environmentList: [string, React.ReactNode][] = defined(environments)
+    const environmentList: [IncidentRule['environment'], React.ReactNode][] = defined(
+      environments
+    )
       ? environments.map((env: Environment) => [env.name, getDisplayName(env)])
       : [];
 
@@ -93,7 +95,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
         </div>
       </React.Fragment>
     );
-    environmentList.unshift(['', anyEnvironmentLabel]);
+    environmentList.unshift([null, anyEnvironmentLabel]);
 
     return (
       <Panel>
@@ -167,7 +169,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
           <SelectField
             name="environment"
             label={t('Environment')}
-            placeholder={t('Select an environment')}
+            placeholder={t('All Environments')}
             help={t('Choose which environment events must match')}
             styles={{
               singleValue: (base: any) => ({

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -426,10 +426,11 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
               aggregation: rule.aggregation,
               query: rule.query || '',
               timeWindow: rule.timeWindow,
+              // TODO(epurkhiser): Remove when the API response with a single env
               environment:
                 (Array.isArray(rule.environment)
                   ? rule.environment[0]
-                  : rule.environment) || '',
+                  : rule.environment) || null,
             }}
             saveOnBlur={false}
             onSubmit={this.handleSubmit}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -45,7 +45,7 @@ export type UnsavedIncidentRule = {
   aggregation: AlertRuleAggregations;
   aggregations: AlertRuleAggregations[];
   projects: string[];
-  environment: string | string[]; // Temporarily can be either
+  environment: string | string[] | null; // Temporarily can be either a string or string list
   query: string;
   timeWindow: number;
   triggers: Trigger[];


### PR DESCRIPTION
Using `''` sets to the default no environment, using null will be more
explicit about no environment