### PR TITLE
chore(webpack): Quiet up FixStyleOnlyEntriesPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -323,7 +323,7 @@ let appConfig = {
     /**
      * This removes empty js files for style only entries (e.g. sentry.less)
      */
-    new FixStyleOnlyEntriesPlugin(),
+    new FixStyleOnlyEntriesPlugin({silent: true}),
 
     new SentryInstrumentation(),
 


### PR DESCRIPTION
Just turns off the `removing getsentry.css` or whatever