### PR TITLE
perf(features): Optimize for multiple calls to features.has

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -106,19 +106,18 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         # TODO(davidenwang): remove this after frontend requires only paginated projects
         get_all_projects = request.GET.get("all_projects") == "1"
 
-        include_features = not features.has("organizations:enterprise-perf", organization)
         if get_all_projects:
             queryset = queryset.order_by("slug").select_related("organization")
-            serializer = ProjectSummarySerializer(include_features=include_features)
+            serializer = ProjectSummarySerializer(
+                include_features=not features.has("organizations:enterprise-perf", organization)
+            )
             return Response(serialize(list(queryset), request.user, serializer))
         else:
 
             def serialize_on_result(result):
                 environment_id = self._get_environment_id_from_request(request, organization.id)
                 serializer = ProjectSummarySerializer(
-                    environment_id=environment_id,
-                    stats_period=stats_period,
-                    include_features=include_features,
+                    environment_id=environment_id, stats_period=stats_period,
                 )
                 return serialize(result, request.user, serializer)
 

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -5,7 +5,6 @@ import six
 from django.db.models import Q
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -108,10 +107,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         if get_all_projects:
             queryset = queryset.order_by("slug").select_related("organization")
-            serializer = ProjectSummarySerializer(
-                include_features=not features.has("organizations:enterprise-perf", organization)
-            )
-            return Response(serialize(list(queryset), request.user, serializer))
+            return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
         else:
 
             def serialize_on_result(result):

--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -42,7 +42,7 @@ def serialize(objects, user=None, serializer=None, **kwargs):
             )
 
         with sentry_sdk.start_span(op="serialize.iterate", description=type(serializer).__name__):
-            return [serializer(o, attrs=attrs.get(o, {}), user=user, **kwargs) for o in objects]
+            return serializer.serialize_all(objects, attrs=attrs, user=user, **kwargs)
 
 
 def register(type):
@@ -61,6 +61,11 @@ class Serializer(object):
 
     def get_attrs(self, item_list, user, **kwargs):
         return {}
+
+    def serialize_all(self, objects, attrs, user, **kwargs):
+        return [
+            self.serialize(obj, attrs=attrs.get(obj, {}), user=user, **kwargs) for obj in objects
+        ]
 
     def serialize(self, obj, attrs, user, **kwargs):
         return {}

--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -42,7 +42,7 @@ def serialize(objects, user=None, serializer=None, **kwargs):
             )
 
         with sentry_sdk.start_span(op="serialize.iterate", description=type(serializer).__name__):
-            return serializer.serialize_all(objects, attrs=attrs, user=user, **kwargs)
+            return [serializer(o, attrs=attrs.get(o, {}), user=user, **kwargs) for o in objects]
 
 
 def register(type):
@@ -61,11 +61,6 @@ class Serializer(object):
 
     def get_attrs(self, item_list, user, **kwargs):
         return {}
-
-    def serialize_all(self, objects, attrs, user, **kwargs):
-        return [
-            self.serialize(obj, attrs=attrs.get(obj, {}), user=user, **kwargs) for obj in objects
-        ]
 
     def serialize(self, obj, attrs, user, **kwargs):
         return {}

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -159,10 +159,10 @@ class ProjectSerializer(Serializer):
 
         with measure_span("features"):
             project_features = features.all(feature_type=ProjectFeature).keys()
-            has_feature = features.build()
+            feature_checker = features.build_checker()
             for item in item_list:
                 result[item]["features"] = self.get_feature_list(
-                    item, user, project_features, has_feature
+                    item, user, project_features, feature_checker
                 )
 
         with measure_span("other"):
@@ -181,14 +181,14 @@ class ProjectSerializer(Serializer):
                     result[item]["stats"] = stats[item.id]
         return result
 
-    def get_feature_list(self, obj, user, project_features, has_feature):
+    def get_feature_list(self, obj, user, project_features, feature_checker):
         # Retrieve all registered organization features
         feature_list = set()
 
         for feature_name in project_features:
             if not feature_name.startswith("projects:"):
                 continue
-            if has_feature(feature_name, obj, actor=user):
+            if feature_checker.has(feature_name, obj, actor=user):
                 # Remove the project scope prefix
                 feature_list.add(feature_name[len("projects:") :])
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 import sentry_sdk
 
-from sentry import options, roles, tsdb, projectoptions
+from sentry import options, roles, tsdb, projectoptions, features
 from sentry.api.serializers import register, serialize, Serializer
 from sentry.api.serializers.models.plugin import PluginSerializer
 from sentry.api.serializers.models.team import get_org_roles, get_team_memberships
@@ -20,6 +20,7 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.constants import StatsPeriod
 from sentry.digests import backend as digests
 from sentry.eventstore.models import DEFAULT_SUBJECT_TEMPLATE
+from sentry.features.base import ProjectFeature
 from sentry.lang.native.utils import convert_crashreport_count
 from sentry.models import (
     EnvironmentProject,
@@ -99,9 +100,6 @@ class ProjectSerializer(Serializer):
         return result
 
     def get_attrs(self, item_list, user):
-        from sentry import features
-        from sentry.features.base import ProjectFeature
-
         def measure_span(op_tag):
             span = sentry_sdk.start_span(op="serialize.get_attrs.project.{}".format(op_tag))
             span.set_data("Object Count", len(item_list))

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -58,13 +58,12 @@ class ProjectSerializer(Serializer):
     such as "show all projects for this organization", and its attributes be kept to a minimum.
     """
 
-    def __init__(self, environment_id=None, stats_period=None, include_features=True):
+    def __init__(self, environment_id=None, stats_period=None):
         if stats_period is not None:
             assert stats_period in STATS_PERIOD_CHOICES
 
         self.environment_id = environment_id
         self.stats_period = stats_period
-        self.include_features = include_features
 
     def get_access_by_project(self, item_list, user):
         request = env.request
@@ -166,9 +165,6 @@ class ProjectSerializer(Serializer):
         from sentry import features
         from sentry.features.base import ProjectFeature
 
-        if not self.include_features:
-            return None
-
         with sentry_sdk.start_span(
             op="project_feature_list", description=getattr(obj, "name")
         ) as span:
@@ -191,6 +187,8 @@ class ProjectSerializer(Serializer):
             return feature_list
 
     def serialize(self, obj, attrs, user):
+        feature_list = self.get_feature_list(obj, user)
+
         status_label = STATUS_LABELS.get(obj.status, "unknown")
 
         if attrs.get("avatar"):
@@ -210,6 +208,7 @@ class ProjectSerializer(Serializer):
             "color": obj.color,
             "dateCreated": obj.date_added,
             "firstEvent": obj.first_event,
+            "features": feature_list,
             "status": status_label,
             "platform": obj.platform,
             "isInternal": obj.is_internal_project(),
@@ -217,16 +216,8 @@ class ProjectSerializer(Serializer):
             "hasAccess": attrs["has_access"],
             "avatar": avatar,
         }
-        return self._add_conditional_attributes(obj, attrs, user, context)
-
-    def _add_conditional_attributes(self, obj, attrs, user, context):
-        feature_list = self.get_feature_list(obj, user)
-        if feature_list is not None:
-            context["features"] = feature_list
-
         if "stats" in attrs:
             context["stats"] = attrs["stats"]
-
         return context
 
 
@@ -367,6 +358,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
         return attrs
 
     def serialize(self, obj, attrs, user):
+        feature_list = self.get_feature_list(obj, user)
         context = {
             "team": attrs["teams"][0] if attrs["teams"] else None,
             "teams": attrs["teams"],
@@ -378,6 +370,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             "hasAccess": attrs["has_access"],
             "dateCreated": obj.date_added,
             "environments": attrs["environments"],
+            "features": feature_list,
             "firstEvent": obj.first_event,
             "platform": obj.platform,
             "platforms": attrs["platforms"],
@@ -385,7 +378,9 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             "latestRelease": attrs["latest_release"],
             "hasUserReports": attrs["has_user_reports"],
         }
-        return self._add_conditional_attributes(obj, attrs, user, context)
+        if "stats" in attrs:
+            context["stats"] = attrs["stats"]
+        return context
 
 
 def bulk_fetch_project_latest_releases(projects):

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -182,7 +182,6 @@ class ProjectSerializer(Serializer):
         return result
 
     def get_feature_list(self, obj, user, project_features, feature_checker):
-        # Retrieve all registered organization features
         feature_list = set()
 
         for feature_name in project_features:

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -149,7 +149,7 @@ class TeamWithProjectsSerializer(TeamSerializer):
         projects = [pt.project for pt in project_teams]
         project_serializer = ProjectSerializer(
             include_features=not all(
-                features.has("organizations:enterprise-perf", org) for org in orgs.values()
+                features.has("organizations:enterprise-perf", org) for org in orgs
             )
         )
         serialized_projects = serialize(projects, user, project_serializer)

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from django.db.models import Count
 
 
-from sentry import roles, features
+from sentry import roles
 from sentry.app import env
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.auth.superuser import is_active_superuser
@@ -132,8 +132,6 @@ class TeamSerializer(Serializer):
 
 class TeamWithProjectsSerializer(TeamSerializer):
     def get_attrs(self, item_list, user):
-        from sentry.api.serializers.models.project import ProjectSerializer
-
         project_teams = list(
             ProjectTeam.objects.filter(team__in=item_list, project__status=ProjectStatus.VISIBLE)
             .order_by("project__name", "project__slug")
@@ -147,13 +145,9 @@ class TeamWithProjectsSerializer(TeamSerializer):
             project_team.project._organization_cache = orgs[project_team.project.organization_id]
 
         projects = [pt.project for pt in project_teams]
-        project_serializer = ProjectSerializer(
-            include_features=not all(
-                features.has("organizations:enterprise-perf", org) for org in orgs
-            )
-        )
-        serialized_projects = serialize(projects, user, project_serializer)
-        projects_by_id = {project.id: data for project, data in zip(projects, serialized_projects)}
+        projects_by_id = {
+            project.id: data for project, data in zip(projects, serialize(projects, user))
+        }
 
         project_map = defaultdict(list)
         for project_team in project_teams:

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -132,3 +132,4 @@ add = default_manager.add
 get = default_manager.get
 has = default_manager.has
 all = default_manager.all
+build = default_manager.build

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -132,4 +132,4 @@ add = default_manager.add
 get = default_manager.get
 has = default_manager.has
 all = default_manager.all
-build = default_manager.build
+build_checker = default_manager.build_checker

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -68,23 +68,23 @@ class FeatureManager(object):
 
         >>> FeatureManager.has('organizations:feature', organization, actor=request.user)
         """
-        return self.build()(name, *args, **kwargs)
+        return self.build_checker().has(name, *args, **kwargs)
 
-    def build(self):
+    def build_checker(self):
         """
-        Set up delayed execution of ``has``.
+        Set up for a delayed execution of ``has``.
 
-        Successive calls to the returned predicate have better performance than
-        repeatedly calling ``FeatureManager.has``, because it retains the the
-        set of ``feature.handler.FeatureHandler`` objects. An instance of the
-        predicate should be kept only in a short-lived context, because any
+        Successive calls to the returned checker have better performance than
+        repeatedly calling ``FeatureManager.has``, because it retains the set
+        of ``feature.handler.FeatureHandler`` objects. An instance of the
+        checker should be kept only in a short-lived context, because any
         dynamic changes to plugins' feature handlers are not reflected in its
         behavior.
         """
-        return FeaturePredicate(self)
+        return FeatureChecker(self)
 
 
-class FeaturePredicate(object):
+class FeatureChecker(object):
     def __init__(self, manager):
         from sentry.plugins.base import plugins
 
@@ -96,7 +96,7 @@ class FeaturePredicate(object):
         ]
         self.handlers = tuple(itertools.chain(*handlers_per_plugin))
 
-    def __call__(self, name, *args, **kwargs):
+    def has(self, name, *args, **kwargs):
         actor = kwargs.pop("actor", None)
         feature = self.manager.get(name, *args, **kwargs)
 

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -167,23 +167,15 @@ class OrganizationProjectsTest(APITestCase):
         for project in response.data:
             assert "features" in project
 
-    def test_features_are_suppressed(self):
+    def test_all_projects_suppresses_flags(self):
         self.login_as(user=self.user)
-        for i in range(3):
-            p = "project{}".format(i)
-            self.create_project(teams=[self.team], name=p, slug=p)
+        self.create_project(teams=[self.team], name="foo", slug="foo")
+        self.create_project(teams=[self.team], name="bar", slug="bar")
 
-        queries = [
-            "",
-            "?all_projects=1",
-            "?per_page=2",
-            "?all_projects=1&per_page=2",
-        ]
-        for query in queries:
-            with self.feature("organizations:enterprise-perf"):
-                response = self.client.get(self.path + query)
-            for project in response.data:
-                assert "features" not in project
+        with self.feature("organizations:enterprise-perf"):
+            response = self.client.get(self.path + "?all_projects=1&per_page=1")
+        for project in response.data:
+            assert "features" not in project
 
     def test_user_projects(self):
         self.foo_user = self.create_user("foo@example.com")

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -34,7 +34,6 @@ class OrganizationProjectsTest(APITestCase):
         response = self.client.get(self.path)
         self.check_valid_response(response, [project])
         assert self.client.session["activeorg"] == self.org.slug
-        assert "features" in response.data[0]
 
     def test_with_stats(self):
         self.login_as(user=self.user)
@@ -163,19 +162,6 @@ class OrganizationProjectsTest(APITestCase):
         response = self.client.get(self.path + "?all_projects=1&per_page=1")
         # Verify all projects in the org are returned in sorted order
         self.check_valid_response(response, sorted_projects)
-
-        for project in response.data:
-            assert "features" in project
-
-    def test_all_projects_suppresses_flags(self):
-        self.login_as(user=self.user)
-        self.create_project(teams=[self.team], name="foo", slug="foo")
-        self.create_project(teams=[self.team], name="bar", slug="bar")
-
-        with self.feature("organizations:enterprise-perf"):
-            response = self.client.get(self.path + "?all_projects=1&per_page=1")
-        for project in response.data:
-            assert "features" not in project
 
     def test_user_projects(self):
         self.foo_user = self.create_user("foo@example.com")

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -12,7 +12,6 @@ from exam import fixture
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import (
     bulk_fetch_project_latest_releases,
-    ProjectSerializer,
     ProjectWithOrganizationSerializer,
     ProjectWithTeamSerializer,
     ProjectSummarySerializer,
@@ -40,17 +39,6 @@ class ProjectSerializerTest(TestCase):
         assert result["slug"] == project.slug
         assert result["name"] == project.name
         assert result["id"] == six.text_type(project.id)
-        assert result["features"] is not None
-
-    def test_suppress_features(self):
-        user = self.create_user(username="foo")
-        organization = self.create_organization(owner=user)
-        team = self.create_team(organization=organization)
-        project = self.create_project(teams=[team], organization=organization, name="foo")
-
-        result = serialize(project, user, ProjectSerializer(include_features=False))
-
-        assert "features" not in result
 
     def test_member_access(self):
         user = self.create_user(username="foo")
@@ -223,12 +211,6 @@ class ProjectSummarySerializerTest(TestCase):
         }
         assert result["latestRelease"] == {"version": self.release.version}
         assert result["environments"] == ["production", "staging"]
-
-    def test_suppress_features(self):
-        result = serialize(
-            self.project, self.user, ProjectSummarySerializer(include_features=False)
-        )
-        assert "features" not in result
 
     def test_user_reports(self):
         result = serialize(self.project, self.user, ProjectSummarySerializer())

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -6,7 +6,6 @@ import six
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamWithProjectsSerializer
-from sentry.api.serializers.models.project import ProjectSerializer
 from sentry.models import InviteStatus
 from sentry.testutils import TestCase
 
@@ -170,7 +169,7 @@ class TeamSerializerTest(TestCase):
 
 
 class TeamWithProjectsSerializerTest(TestCase):
-    def test_simple(self, project_serializer=None):
+    def test_simple(self):
         user = self.create_user(username="foo")
         organization = self.create_organization(owner=user)
         team = self.create_team(organization=organization)
@@ -178,7 +177,7 @@ class TeamWithProjectsSerializerTest(TestCase):
         project2 = self.create_project(teams=[team], organization=organization, name="bar")
 
         result = serialize(team, user, TeamWithProjectsSerializer())
-        serialized_projects = serialize([project2, project], user, project_serializer)
+        serialized_projects = serialize([project2, project], user)
 
         assert result == {
             "slug": team.slug,
@@ -192,7 +191,3 @@ class TeamWithProjectsSerializerTest(TestCase):
             "memberCount": 0,
             "dateCreated": team.date_added,
         }
-
-    def test_with_performance_flag(self):
-        with self.feature("organizations:enterprise-perf"):
-            self.test_simple(ProjectSerializer(include_features=False))


### PR DESCRIPTION
This targets a performance problem where ProjectSerializer must call
`features.has` a linear number of times. The cost was determined to be
associated with getting the feature handlers from all plugins; the
handlers may be reused because they are independent from the feature
being checked, but they should not be cached in case the list changes
dynamically.

As a solution, allow FeatureManager to return a functional predicate
that stores the set of handlers. This allows the caller to reuse them,
but only for the life of one logical operation (such as serializing a
single API response).

~~Modify `src.sentry.api.serializers.base` so that a value can be passed
to each iteration of the serializer. ProjectSerializer applies the new
solution by overriding the new `serialize_all` method. All other
Serializer subclasses should be unaffected.~~