### PR TITLE
feat(ui): Images loaded on event detail page with scrollable container

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -481,8 +481,8 @@ class DebugMetaInterface extends React.PureComponent {
         wrapTitle={false}
         isCentered
       >
-        <ClippedBox clipHeight={350}>
-          <DebugImagesPanel>
+        <DebugImagesPanel>
+          <ClippedBox clipHeight={560}>
             <PanelBody>
               {foundFrame && (
                 <ImageForBar
@@ -507,8 +507,8 @@ class DebugMetaInterface extends React.PureComponent {
                 </EmptyItem>
               )}
             </PanelBody>
-          </DebugImagesPanel>
-        </ClippedBox>
+          </ClippedBox>
+        </DebugImagesPanel>
       </StyledEventDataSection>
     );
   }
@@ -536,10 +536,8 @@ const StyledEventDataSection = styled(EventDataSection)`
 
 const DebugImagesPanel = styled(Panel)`
   margin-bottom: ${space(1)};
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    max-height: 600px;
-    overflow-y: auto;
-  }
+  max-height: 600px;
+  overflow-y: auto;
 `;
 
 const DebugImageItem = styled(PanelItem)`


### PR DESCRIPTION
When we expand Images loaded, we want to have container scrollable not only on mobile but desktop also.