### PR TITLE
feat(ui): Add error message when wrong project in url for given release

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
@@ -83,19 +83,22 @@ class ReleasesV2Detail extends AsyncView<Props, State> {
     ];
   }
 
-  handleError(e, args) {
-    const {router, location} = this.props;
-    const possiblyWrongProject = e.status === 403;
+  renderError(...args) {
+    const possiblyWrongProject = Object.values(this.state.errors).find(
+      e => e?.status === 404 || e?.status === 403
+    );
 
     if (possiblyWrongProject) {
-      // refreshing this page without project ID will bring up a project selector
-      router.replace({
-        ...location,
-        query: {...location.query, project: undefined},
-      });
-      return;
+      return (
+        <PageContent>
+          <Alert type="error" icon={<IconWarning />}>
+            {t('This release may not be in your selected project')}
+          </Alert>
+        </PageContent>
+      );
     }
-    super.handleError(e, args);
+
+    return super.renderError(...args);
   }
 
   renderBody() {

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
@@ -92,7 +92,7 @@ class ReleasesV2Detail extends AsyncView<Props, State> {
       return (
         <PageContent>
           <Alert type="error" icon={<IconWarning />}>
-            {t('This release may not be in your selected project')}
+            {t('This release may not be in your selected project.')}
           </Alert>
         </PageContent>
       );


### PR DESCRIPTION
This PR adds error message to release detail page when you have wrong project in the URL.
This should not happen unless someone tinkers with URL manually.