### PR TITLE
feat(workflow): Adding title field to 'View in Discover' link

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -60,7 +60,7 @@ export default class DetailsBody extends React.Component<Props> {
     const discoverQuery: NewQuery = {
       id: undefined,
       name: (incident && incident.title) || '',
-      fields: ['issue', 'count(id)', 'count_unique(user.id)'],
+      fields: ['issue', 'count(id)', 'count_unique(user.id)', 'title'],
       widths: ['400', '200', '-1'],
       orderby:
         incident.aggregation === AlertRuleAggregations.UNIQUE_USERS

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -61,7 +61,6 @@ export default class DetailsBody extends React.Component<Props> {
       id: undefined,
       name: (incident && incident.title) || '',
       fields: ['issue', 'count(id)', 'count_unique(user.id)', 'title'],
-      widths: ['400', '200', '-1'],
       orderby:
         incident.aggregation === AlertRuleAggregations.UNIQUE_USERS
           ? '-count_unique_user_id'

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -60,7 +60,7 @@ export default class DetailsBody extends React.Component<Props> {
     const discoverQuery: NewQuery = {
       id: undefined,
       name: (incident && incident.title) || '',
-      fields: ['issue', 'count(id)', 'count_unique(user.id)', 'title'],
+      fields: ['issue', 'title', 'count(id)', 'count_unique(user.id)'],
       orderby:
         incident.aggregation === AlertRuleAggregations.UNIQUE_USERS
           ? '-count_unique_user_id'


### PR DESCRIPTION
Adds the title field to the discover link to display it in the results
Addresses https://app.asana.com/0/1143846759074121/1173781193610793

Also removes width to address https://app.asana.com/0/1143846759074121/1172291683110568
