### PR TITLE
perf: WIP speedup sentry warmup ~10% further by deferring initial ua-parser import

### DIFF
--- a/src/sentry/plugins/sentry_useragents/models.py
+++ b/src/sentry/plugins/sentry_useragents/models.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from ua_parser.user_agent_parser import Parse
-
 import sentry
 from sentry.plugins.bases.tag import TagPlugin
 
@@ -33,12 +31,19 @@ class UserAgentPlugin(TagPlugin):
         for key, value in headers:
             if key != "User-Agent":
                 continue
+
+            # ua_parser is imported here, and not module level, because it takes ~300ms to warmup,
+            # and that penalty is seen even in running sentry cli or pytest.
+            from ua_parser.user_agent_parser import Parse
+
             ua = Parse(value)
             if not ua:
                 continue
+
             result = self.get_tag_from_ua(ua)
             if result:
                 output.append(result)
+
         return output
 
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/18611.

ua-parser takes ~300ms to warmup on initial import because it has to compile a bunch of regexes. This makes it all the way through to sentry initialization (e.g. django configure, pytest setup).

If it's deferred, things like `sentry shell` and `pytest tests/...` take ~300ms less time, which is a noticeable latency improvement.

Profiling `pytest_configure` of `src/sentry/utils/pytest/sentry.py` (where we configure pytest to first start running):

Before:

<img width="1005" alt="before" src="https://user-images.githubusercontent.com/14209781/81323750-5e938e00-9085-11ea-8f59-f9c008d0e136.png">

After (notice `__import__` cumtime drops ~300ms):

<img width="1009" alt="after" src="https://user-images.githubusercontent.com/14209781/81323753-62271500-9085-11ea-8703-25d2ddee7b1f.png">

Example:

```
# before
$ time pytest tests/sentry/utils/test_zip.py
-- snip --
Exit: 0
pytest tests/sentry/utils/test_zip.py  2.50s user 0.55s system 98% cpu 3.108 total

# after
$ time pytest tests/sentry/utils/test_zip.py
-- snip --
Exit: 0
pytest tests/sentry/utils/test_zip.py  2.15s user 0.54s system 98% cpu 2.722 total
```

Pretty much identical improvements in `sentry shell -c exit`.
