### PR TITLE
fix(integrations): make email check inexact for group assignee

### DIFF
--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -78,7 +78,7 @@ def sync_group_assignee_inbound(integration, email, external_issue_key, assign=T
     users = {
         u.id: u
         for u in User.objects.filter(
-            id__in=UserEmail.objects.filter(is_verified=True, email=email).values_list(
+            id__in=UserEmail.objects.filter(is_verified=True, email__iexact=email).values_list(
                 "user_id", flat=True
             )
         )

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -185,6 +185,8 @@ class GroupAssigneeTestCase(TestCase):
 
     def test_assignee_sync_inbound_assign(self):
         group = self.group
+        self.user = self.create_user(email="myemail@gmail.com")
+        self.create_member(teams=[self.team], user=self.user, organization=group.organization)
         user_no_access = self.create_user()
         user_w_access = self.user
         integration = Integration.objects.create(provider="example", external_id="123456")
@@ -217,14 +219,14 @@ class GroupAssigneeTestCase(TestCase):
         with self.feature("organizations:integrations-issue-sync"):
             # no permissions
             groups_updated = sync_group_assignee_inbound(
-                integration, user_no_access.email, "APP-123"
+                integration, "user_no_access.email", "APP-123"
             )
 
             assert not groups_updated
 
             # w permissions
             groups_updated = sync_group_assignee_inbound(
-                integration, user_w_access.email, "APP-123"
+                integration, "MyEmail@gmail.com", "APP-123"
             )
 
             assert groups_updated[0] == group

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -219,7 +219,7 @@ class GroupAssigneeTestCase(TestCase):
         with self.feature("organizations:integrations-issue-sync"):
             # no permissions
             groups_updated = sync_group_assignee_inbound(
-                integration, "user_no_access.email", "APP-123"
+                integration, user_no_access.email, "APP-123"
             )
 
             assert not groups_updated


### PR DESCRIPTION
This fixes an issue with 2-way sync when the user has an email address that has upper case letters in one system (often Azure) but not in Sentry. This fix should be safe because even if we end up matching the email to the wrong user, we check the teams of that user to see if it matches the project for this issue so on one who shouldn't get assigned the Sentry issue will get assigned.