### PR TITLE
fix(perf-views) Start performance overview charts at data min

### DIFF
--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -658,7 +658,7 @@ export const EChartsAxis = PropTypes.shape({
   // if a catergory axis has data: ['categoryA', 'categoryB', 'categoryC'], and
   // the ordinal 2 represents 'categoryC'. Moreover, it can be set as negative
   // number, like -3.
-  min: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.func]),
+  min: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   // The maximum value of axis.
   // It can be set to a special value 'dataMax' so that the minimum value on
@@ -671,7 +671,7 @@ export const EChartsAxis = PropTypes.shape({
   // if a catergory axis has data: ['categoryA', 'categoryB', 'categoryC'], and
   // the ordinal 2 represents 'categoryC'. Moreover, it can be set as negative
   // number, like -3.
-  max: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.func]),
+  max: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   // It is available only in numerical axis, i.e., type: 'value'.
   //

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -658,7 +658,7 @@ export const EChartsAxis = PropTypes.shape({
   // if a catergory axis has data: ['categoryA', 'categoryB', 'categoryC'], and
   // the ordinal 2 represents 'categoryC'. Moreover, it can be set as negative
   // number, like -3.
-  min: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  min: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.func]),
 
   // The maximum value of axis.
   // It can be set to a special value 'dataMax' so that the minimum value on
@@ -671,7 +671,7 @@ export const EChartsAxis = PropTypes.shape({
   // if a catergory axis has data: ['categoryA', 'categoryB', 'categoryC'], and
   // the ordinal 2 represents 'categoryC'. Moreover, it can be set as negative
   // number, like -3.
-  max: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  max: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.func]),
 
   // It is available only in numerical axis, i.e., type: 'value'.
   //

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -57,7 +57,16 @@ class Chart extends React.Component<Props> {
           type: 'time',
         },
       ],
-      yAxes: [{gridIndex: 0}, {gridIndex: 1}],
+      yAxes: [
+        {
+          gridIndex: 0,
+          min: 'dataMin',
+        },
+        {
+          gridIndex: 1,
+          min: 'dataMin',
+        },
+      ],
       utc,
       isGroupedByDate: true,
       showTimeInTooltip: true,

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -60,11 +60,17 @@ class Chart extends React.Component<Props> {
       yAxes: [
         {
           gridIndex: 0,
-          min: 'dataMin',
+          min({min}: {min: number}) {
+            // Scale to the nearest 0.x
+            return Math.floor(min * 10) / 10;
+          },
         },
         {
           gridIndex: 1,
-          min: 'dataMin',
+          min({min}: {min: number}) {
+            // Round to the nearest integer.
+            return Math.floor(min);
+          },
         },
       ],
       utc,

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -60,17 +60,11 @@ class Chart extends React.Component<Props> {
       yAxes: [
         {
           gridIndex: 0,
-          min({min}: {min: number}) {
-            // Scale to the nearest 0.x
-            return Math.floor(min * 10) / 10;
-          },
+          scale: true,
         },
         {
           gridIndex: 1,
-          min({min}: {min: number}) {
-            // Round to the nearest integer.
-            return Math.floor(min);
-          },
+          scale: true,
         },
       ],
       utc,


### PR DESCRIPTION
Starting y-axis at dataMin allows the charts to start their yaxis in the middle allowing smaller differences to be seen as the charts don't start at 0.

### Old
![Screen Shot 2020-05-07 at 4 23 56 PM](https://user-images.githubusercontent.com/24086/81346370-2b9ec980-9088-11ea-86fd-15ca1d4d1ce0.png)


### New
![Screen Shot 2020-05-07 at 5 25 00 PM](https://user-images.githubusercontent.com/24086/81346347-22156180-9088-11ea-9fdf-26b07deddc5f.png)
