### PR TITLE
feat(discover): quantize query periods

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -86,6 +86,22 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
         return snuba_args
 
+    def quantize_date_params(self, request, params):
+        # We only need to perform this rounding on relative date periods
+        if "statsPeriod" not in request.GET:
+            return params
+        results = params.copy()
+        duration = (params["end"] - params["start"]).total_seconds()
+        # Only perform rounding on durations longer than an hour
+        if duration > 3600:
+            # Round to 15 minutes if over 30 days, otherwise round to the minute
+            round_to = 15 * 60 if duration >= 30 * 24 * 3600 else 60
+            for key in ["start", "end"]:
+                results[key] = snuba.quantize_time(
+                    params[key], params.get("organization_id", 0), duration=round_to
+                )
+        return results
+
 
 class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
     def handle_results_with_meta(self, request, organization, project_ids, results):
@@ -146,6 +162,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     params = self.get_filter_params(request, organization)
                 except NoProjects:
                     return {"data": []}
+                params = self.quantize_date_params(request, params)
                 rollup = get_rollup_from_request(
                     request,
                     params,

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -125,6 +125,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
                 params = self.get_filter_params(request, organization)
             except NoProjects:
                 return Response([])
+            params = self.quantize_date_params(request, params)
 
             has_global_views = features.has(
                 "organizations:global-views", organization, actor=request.user

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -23,6 +23,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsEndpointBase):
                 params = self.get_filter_params(request, organization)
             except NoProjects:
                 return Response([])
+            params = self.quantize_date_params(request, params)
             self._validate_project_ids(request, organization, params)
 
         with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -26,6 +26,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
                 params = self.get_filter_params(request, organization)
             except NoProjects:
                 return Response({"count": 0})
+            params = self.quantize_date_params(request, params)
 
         try:
             result = discover.query(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1041,7 +1041,7 @@ def quantize_time(time, key_hash, duration=300):
     # Use the hash so that seconds past the hour gets rounded differently per query.
     jitter = key_hash % duration
     seconds_past_hour = time.minute * 60 + time.second
-    # Round seconds to a multiple of duration, cause this uses "floor" division shouldn't give us a future window
+    # Round seconds to a multiple of duration, because this uses "floor" division shouldn't give us a future window
     time_window_start = seconds_past_hour // duration * duration + jitter
     # If the time is past the rounded seconds then we want our key to be for this timewindow
     if time_window_start < seconds_past_hour:

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
 
+import mock
+
+from pytz import utc
+
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
@@ -111,6 +115,39 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
                 },
             )
         assert response.status_code == 400
+
+    @mock.patch("sentry.utils.snuba.quantize_time")
+    def test_quantize_dates(self, mock_quantize):
+        mock_quantize.return_value = before_now(days=1).replace(tzinfo=utc)
+        with self.feature("organizations:discover-basic"):
+            # Don't quantize short time periods
+            self.client.get(
+                self.url,
+                format="json",
+                data={"statsPeriod": "1h", "query": "", "field": ["id", "timestamp"]},
+            )
+            # Don't quantize absolute date periods
+            self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "start": iso_format(before_now(days=20)),
+                    "end": iso_format(before_now(days=15)),
+                    "query": "",
+                    "field": ["id", "timestamp"],
+                },
+            )
+
+            assert len(mock_quantize.mock_calls) == 0
+
+            # Quantize long date periods
+            self.client.get(
+                self.url,
+                format="json",
+                data={"field": ["id", "timestamp"], "statsPeriod": "90d", "query": ""},
+            )
+
+            assert len(mock_quantize.mock_calls) == 2
 
 
 class OrganizationEventsRelatedIssuesEndpoint(APITestCase, SnubaTestCase):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import calendar
-from datetime import timedelta, datetime
+from datetime import timedelta
 import json
 import pytest
 import requests
@@ -17,7 +17,7 @@ from sentry.tagstore.exceptions import (
     TagKeyNotFound,
     TagValueNotFound,
 )
-from sentry.tagstore.snuba.backend import SnubaTagStorage, cache_suffix_time
+from sentry.tagstore.snuba.backend import SnubaTagStorage
 from sentry.testutils import SnubaTestCase, TestCase
 
 
@@ -601,77 +601,3 @@ class TagStorageTest(TestCase, SnubaTestCase):
             )
             == {}
         )
-
-    def test_cache_suffix_time(self):
-        starting_key = cache_suffix_time(self.now, 0)
-        finishing_key = cache_suffix_time(self.now + timedelta(seconds=300), 0)
-
-        assert starting_key != finishing_key
-
-    def test_cache_suffix_hour_edges(self):
-        """ a suffix should still behave correctly around the end of the hour
-
-            At a duration of 10 only one key between 0-10 should flip on the hour, the other 9
-            should flip at different times.
-        """
-        before = datetime(2019, 9, 5, 17, 59, 59)
-        on_hour = datetime(2019, 9, 5, 18, 0, 0)
-        changed_on_hour = 0
-        # Check multiple keyhashes so that this test doesn't depend on implementation
-        for key_hash in range(10):
-            before_key = cache_suffix_time(before, key_hash, duration=10)
-            on_key = cache_suffix_time(on_hour, key_hash, duration=10)
-            if before_key != on_key:
-                changed_on_hour += 1
-
-        assert changed_on_hour == 1
-
-    def test_cache_suffix_day_edges(self):
-        """ a suffix should still behave correctly around the end of a day
-
-            This test is nearly identical to test_cache_suffix_hour_edges, but is to confirm that date changes don't
-            cause a different behaviour
-        """
-        before = datetime(2019, 9, 5, 23, 59, 59)
-        next_day = datetime(2019, 9, 6, 0, 0, 0)
-        changed_on_hour = 0
-        for key_hash in range(10):
-            before_key = cache_suffix_time(before, key_hash, duration=10)
-            next_key = cache_suffix_time(next_day, key_hash, duration=10)
-            if before_key != next_key:
-                changed_on_hour += 1
-
-        assert changed_on_hour == 1
-
-    def test_cache_suffix_time_matches_duration(self):
-        """ The number of seconds between keys changing should match duration """
-        previous_key = cache_suffix_time(self.now, 0, duration=10)
-        changes = []
-        for i in range(21):
-            current_time = self.now + timedelta(seconds=i)
-            current_key = cache_suffix_time(current_time, 0, duration=10)
-            if current_key != previous_key:
-                changes.append(current_time)
-                previous_key = current_key
-
-        assert len(changes) == 2
-        assert (changes[1] - changes[0]).total_seconds() == 10
-
-    def test_cache_suffix_time_jitter(self):
-        """ Different key hashes should change keys at different times
-
-            While starting_key and other_key might begin as the same values they should change at different times
-        """
-        starting_key = cache_suffix_time(self.now, 0, duration=10)
-        for i in range(11):
-            current_key = cache_suffix_time(self.now + timedelta(seconds=i), 0, duration=10)
-            if current_key != starting_key:
-                break
-
-        other_key = cache_suffix_time(self.now, 5, duration=10)
-        for j in range(11):
-            current_key = cache_suffix_time(self.now + timedelta(seconds=j), 5, duration=10)
-            if current_key != other_key:
-                break
-
-        assert i != j


### PR DESCRIPTION
- When dates are set by statsPeriod, this means that they're relative and always changing. This quantizes the start/end using the same method that was used for caching tag keys.
- Note that the `quantize_time` function is not new, and is identical to `cache_suffix_time`