### PR TITLE
fix(api): Allow members to create sample events

### DIFF
--- a/src/sentry/api/endpoints/project_create_sample.py
+++ b/src/sentry/api/endpoints/project_create_sample.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
+from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.serializers import serialize
 from sentry.utils.samples import create_sample_event
 
 
 class ProjectCreateSampleEndpoint(ProjectEndpoint):
-    permission_classes = (ProjectPermission,)
+    permission_classes = (ProjectEventPermission,)
 
     def post(self, request, project):
         event = create_sample_event(project, platform=project.platform, default="javascript")

--- a/src/sentry/api/endpoints/project_create_sample.py
+++ b/src/sentry/api/endpoints/project_create_sample.py
@@ -8,6 +8,8 @@ from sentry.utils.samples import create_sample_event
 
 
 class ProjectCreateSampleEndpoint(ProjectEndpoint):
+    # Members should be able to create sample events.
+    # This is the same scope that allows members to view all issues for a project.
     permission_classes = (ProjectEventPermission,)
 
     def post(self, request, project):


### PR DESCRIPTION
Allow non-superuser, non-admin members to create sample events via the "Create Sample Event" button on the Issues List page. This matches the permissions for viewing the issues on the Issues List page (defined here: https://github.com/getsentry/sentry/blob/a3a39997bce0c290122909a156d16a2b18752e83/src/sentry/api/bases/project.py#L87).

Part of [ENT-106](https://getsentry.atlassian.net/browse/ENT-106).