### PR TITLE
fix(UI): Fix text overflow in User Feedback

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/item/index.tsx
+++ b/src/sentry/static/sentry/app/components/activity/item/index.tsx
@@ -154,6 +154,7 @@ const ActivityFooter = styled(HeaderAndFooter)`
 
 const ActivityBody = styled('div')`
   padding: ${space(2)} ${space(2)};
+  word-break: break-all;
   ${textStyles}
 `;
 


### PR DESCRIPTION
Fix text overflow in User Feedback when a single word has too many characters.

Fixes [ISSUE-786](https://getsentry.atlassian.net/browse/ISSUE-786)

**Before**:
<img width="1217" alt="Screen Shot 2020-05-07 at 8 01 02 PM" src="https://user-images.githubusercontent.com/20312973/81366438-84c62780-909f-11ea-9e67-dbf2c83b49b2.png">
<img width="1435" alt="Screen Shot 2020-05-07 at 8 00 48 PM" src="https://user-images.githubusercontent.com/20312973/81366445-8b549f00-909f-11ea-87b3-16c8966b1387.png">

**After**:
<img width="878" alt="Screen Shot 2020-05-07 at 7 58 39 PM" src="https://user-images.githubusercontent.com/20312973/81366480-a3c4b980-909f-11ea-955b-86a4c4d53bf8.png">
<img width="911" alt="Screen Shot 2020-05-07 at 7 58 12 PM" src="https://user-images.githubusercontent.com/20312973/81366520-bf2fc480-909f-11ea-9dc1-cfb34be06e0c.png">
