### PR TITLE
fix(ui): Use slug and selected, bookmarked, alphabetical in sequence for project sort order

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/projectSelector.jsx
@@ -99,10 +99,14 @@ class ProjectSelector extends React.Component {
   }
 
   getProjects() {
-    const {multiProjects, nonMemberProjects} = this.props;
+    const {multiProjects, nonMemberProjects, selectedProjects} = this.props;
 
     return [
-      sortBy(multiProjects, project => [!project.isBookmarked, project.name]),
+      sortBy(multiProjects, project => [
+        !(selectedProjects || []).includes(project),
+        !project.isBookmarked,
+        project.slug,
+      ]),
       nonMemberProjects || [],
     ];
   }

--- a/src/sentry/static/sentry/app/components/organizations/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/projectSelector.jsx
@@ -107,7 +107,7 @@ class ProjectSelector extends React.Component {
         !project.isBookmarked,
         project.slug,
       ]),
-      nonMemberProjects || [],
+      sortBy(nonMemberProjects || [], project => [project.slug]),
     ];
   }
 

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -35,6 +35,7 @@ describe('GlobalSelectionHeader', function() {
     projects: [
       {
         id: 2,
+        slug: 'project-2',
       },
       {
         id: 3,
@@ -168,7 +169,7 @@ describe('GlobalSelectionHeader', function() {
     await tick();
     wrapper.update();
     expect(wrapper.find('MultipleProjectSelector Content').text()).toBe(
-      'project-slug, project-3'
+      'project-2, project-3'
     );
 
     // Select environment

--- a/tests/js/spec/components/organizations/projectSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/projectSelector.spec.jsx
@@ -245,10 +245,9 @@ describe('ProjectSelector', function() {
     expect(wrapper.text()).toContain("Projects I don't belong to");
     expect(wrapper.find('AutoCompleteItem')).toHaveLength(4);
 
-    expect(positionA).toBeGreaterThan(-1);
-    expect(positionB).toBeGreaterThan(-1);
-    expect(positionANonM).toBeGreaterThan(-1);
-    expect(positionBNonM).toBeGreaterThan(-1);
+    [positionA, positionB, positionANonM, positionBNonM].forEach(position =>
+      expect(position).toBeGreaterThan(-1)
+    );
 
     expect(positionA).toBeLessThan(positionB);
     expect(positionB).toBeLessThan(positionANonM);
@@ -337,5 +336,54 @@ describe('ProjectSelector', function() {
     expect(positionB).toBeLessThan(positionC);
     expect(positionC).toBeLessThan(positionA);
     expect(positionA).toBeLessThan(positionH);
+  });
+
+  it('displays non member projects in alphabetical sort order', function() {
+    const projectA = TestStubs.Project({id: '1', slug: 'a-project'});
+    const projectBBookmarked = TestStubs.Project({
+      id: '2',
+      slug: 'b-project',
+      isBookmarked: true,
+    });
+    const projectCSelected = TestStubs.Project({id: '3', slug: 'c-project'});
+    const projectDSelectedBookmarked = TestStubs.Project({
+      id: '4',
+      slug: 'd-project',
+      isBookmarked: true,
+    });
+
+    const multiProjectProps = {
+      ...props,
+      multiProjects: [],
+      nonMemberProjects: [
+        projectCSelected,
+        projectA,
+        projectDSelectedBookmarked,
+        projectBBookmarked,
+      ],
+      selectedProjects: [projectCSelected, projectDSelectedBookmarked],
+    };
+
+    const wrapper = mountWithTheme(
+      <ProjectSelector {...multiProjectProps} />,
+      routerContext
+    );
+    openMenu(wrapper);
+
+    const positionA = wrapper.text().indexOf(projectA.slug);
+    const positionB = wrapper.text().indexOf(projectBBookmarked.slug);
+    const positionC = wrapper.text().indexOf(projectCSelected.slug);
+    const positionD = wrapper.text().indexOf(projectDSelectedBookmarked.slug);
+
+    expect(wrapper.text()).toContain("Projects I don't belong to");
+    expect(wrapper.find('AutoCompleteItem')).toHaveLength(4);
+
+    [positionA, positionB, positionC, positionD].forEach(position =>
+      expect(position).toBeGreaterThan(-1)
+    );
+
+    expect(positionA).toBeLessThan(positionB);
+    expect(positionB).toBeLessThan(positionC);
+    expect(positionC).toBeLessThan(positionD);
   });
 });

--- a/tests/js/spec/components/organizations/projectSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/projectSelector.spec.jsx
@@ -216,4 +216,42 @@ describe('ProjectSelector', function() {
     expect(wrapper.text()).toContain("Projects I don't belong to");
     expect(wrapper.find('AutoCompleteItem')).toHaveLength(2);
   });
+
+  it('displays projects in alphabetical order partitioned by project membership', function() {
+    const projectA = TestStubs.Project({id: '1', slug: 'a-project'});
+    const projectB = TestStubs.Project({id: '2', slug: 'b-project'});
+    const projectANonM = TestStubs.Project({id: '3', slug: 'a-non-m-project'});
+    const projectBNonM = TestStubs.Project({id: '4', slug: 'b-non-m-project'});
+
+    const multiProjectProps = {
+      ...props,
+      multiProjects: [projectB, projectA],
+      nonMemberProjects: [projectBNonM, projectANonM],
+      selectedProjects: [],
+    };
+
+    const wrapper = mountWithTheme(
+      <ProjectSelector {...multiProjectProps} />,
+      routerContext
+    );
+    openMenu(wrapper);
+
+    const positionA = wrapper.text().indexOf(projectA.slug);
+    const positionB = wrapper.text().indexOf(projectB.slug);
+
+    const positionANonM = wrapper.text().indexOf(projectANonM.slug);
+    const positionBNonM = wrapper.text().indexOf(projectBNonM.slug);
+
+    expect(wrapper.text()).toContain("Projects I don't belong to");
+    expect(wrapper.find('AutoCompleteItem')).toHaveLength(4);
+
+    expect(positionA).toBeGreaterThan(-1);
+    expect(positionB).toBeGreaterThan(-1);
+    expect(positionANonM).toBeGreaterThan(-1);
+    expect(positionBNonM).toBeGreaterThan(-1);
+
+    expect(positionA).toBeLessThan(positionB);
+    expect(positionB).toBeLessThan(positionANonM);
+    expect(positionANonM).toBeLessThan(positionBNonM);
+  });
 });

--- a/tests/js/spec/components/organizations/projectSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/projectSelector.spec.jsx
@@ -254,4 +254,88 @@ describe('ProjectSelector', function() {
     expect(positionB).toBeLessThan(positionANonM);
     expect(positionANonM).toBeLessThan(positionBNonM);
   });
+
+  it('displays multi projects in sort order rules: selected, bookmarked, alphabetical', function() {
+    const projectA = TestStubs.Project({id: '1', slug: 'a-project'});
+    const projectBBookmarked = TestStubs.Project({
+      id: '2',
+      slug: 'b-project',
+      isBookmarked: true,
+    });
+    const projectCBookmarked = TestStubs.Project({
+      id: '3',
+      slug: 'c-project',
+      isBookmarked: true,
+    });
+    const projectDSelected = TestStubs.Project({id: '4', slug: 'd-project'});
+    const projectESelected = TestStubs.Project({id: '5', slug: 'e-project'});
+    const projectFSelectedBookmarked = TestStubs.Project({
+      id: '6',
+      slug: 'f-project',
+      isBookmarked: true,
+    });
+    const projectGSelectedBookmarked = TestStubs.Project({
+      id: '7',
+      slug: 'g-project',
+      isBookmarked: true,
+    });
+    const projectH = TestStubs.Project({id: '8', slug: 'h-project'});
+    const multiProjectProps = {
+      ...props,
+      multiProjects: [
+        projectA,
+        projectBBookmarked,
+        projectCBookmarked,
+        projectDSelected,
+        projectESelected,
+        projectFSelectedBookmarked,
+        projectGSelectedBookmarked,
+        projectH,
+      ],
+      nonMemberProjects: [],
+      selectedProjects: [
+        projectESelected,
+        projectDSelected,
+        projectGSelectedBookmarked,
+        projectFSelectedBookmarked,
+      ],
+    };
+
+    const wrapper = mountWithTheme(
+      <ProjectSelector {...multiProjectProps} />,
+      routerContext
+    );
+    openMenu(wrapper);
+
+    const positionA = wrapper.text().indexOf(projectA.slug);
+    const positionB = wrapper.text().indexOf(projectBBookmarked.slug);
+    const positionC = wrapper.text().indexOf(projectCBookmarked.slug);
+    const positionD = wrapper.text().indexOf(projectDSelected.slug);
+    const positionE = wrapper.text().indexOf(projectESelected.slug);
+    const positionF = wrapper.text().indexOf(projectFSelectedBookmarked.slug);
+    const positionG = wrapper.text().indexOf(projectGSelectedBookmarked.slug);
+    const positionH = wrapper.text().indexOf(projectH.slug);
+
+    expect(wrapper.text()).not.toContain("Projects I don't belong to");
+    expect(wrapper.find('AutoCompleteItem')).toHaveLength(8);
+
+    [
+      positionA,
+      positionB,
+      positionC,
+      positionD,
+      positionE,
+      positionF,
+      positionG,
+      positionH,
+    ].forEach(position => expect(position).toBeGreaterThan(-1));
+
+    expect(positionF).toBeLessThan(positionG);
+    expect(positionG).toBeLessThan(positionD);
+    expect(positionD).toBeLessThan(positionE);
+    expect(positionE).toBeLessThan(positionB);
+    expect(positionB).toBeLessThan(positionC);
+    expect(positionC).toBeLessThan(positionA);
+    expect(positionA).toBeLessThan(positionH);
+  });
 });

--- a/tests/js/spec/views/events/events.spec.jsx
+++ b/tests/js/spec/views/events/events.spec.jsx
@@ -309,8 +309,8 @@ describe('EventsContainer', function() {
 
   const {organization, router, routerContext} = initializeOrg({
     projects: [
-      {isMember: true, isBookmarked: true},
-      {isMember: true, slug: 'new-project', id: 3},
+      {isMember: true, slug: 'new-project-2', id: 2, isBookmarked: true},
+      {isMember: true, slug: 'new-project-3', id: 3},
     ],
     organization: {
       features: ['events', 'internal-catchall'],
@@ -414,14 +414,11 @@ describe('EventsContainer', function() {
   });
 
   it('updates when changing projects', async function() {
-    // Project id = 3 should be first selected because of ProjectsStore.getAll sorting by slug
-    expect(wrapper.find('MultipleProjectSelector').prop('value')).toEqual([3]);
+    // Project id = 2 should be first selected because of ProjectsStore.getAll sorting by slug
+    expect(wrapper.find('MultipleProjectSelector').prop('value')).toEqual([2]);
 
     wrapper.find('MultipleProjectSelector HeaderItem').simulate('click');
 
-    // TODO(billy): Fix this sorting, 2 gets moved up
-    // because the component (ProjectSelector) sorts it and
-    // orders isBookmarked to the top
     wrapper
       .find('MultipleProjectSelector AutoCompleteItem ProjectSelectorItem')
       .at(0)


### PR DESCRIPTION
Projects were sorted by name, now a deprecated property, but displayed by slugs. The order was inconsistent from user's perspective.

In this PR:
- use slug for sorting instead of name
- change the member project sorting, group by selected, bookmarked and other and alpha sort each group within itself

[Reported on JIRA](https://getsentry.atlassian.net/browse/ISSUE-833)