### PR TITLE
fix(ui): Fixed project config content

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationSecurityAndPrivacy/organizationSecurityAndPrivacyContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationSecurityAndPrivacy/organizationSecurityAndPrivacyContent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {RouteComponentProps} from 'react-router/lib/Router';
-import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
@@ -11,25 +10,14 @@ import {Organization} from 'app/types';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {updateOrganization} from 'app/actionCreators/organizations';
 import organizationSecurityAndPrivacy from 'app/data/forms/organizationSecurityAndPrivacy';
-import SentryTypes from 'app/sentryTypes';
 
 import DataPrivacyRules from '../components/dataPrivacyRules/dataPrivacyRules';
 
-type Props = {
+type Props = RouteComponentProps<{orgId: string; projectId: string}, {}> & {
   organization: Organization;
-  params: {
-    orgId: string;
-    projectId: string;
-  };
-} & RouteComponentProps<{}, {}>;
+};
 
 class OrganizationSecurityAndPrivacyContent extends AsyncView<Props> {
-  static contextTypes = {
-    organization: SentryTypes.Organization,
-    // left router contextType to satisfy the compiler
-    router: PropTypes.object,
-  };
-
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {orgId} = this.props.params;
     return [
@@ -45,7 +33,7 @@ class OrganizationSecurityAndPrivacyContent extends AsyncView<Props> {
   };
 
   renderBody() {
-    const {organization} = this.context;
+    const {organization} = this.props;
     const {orgId} = this.props.params;
     const {authProvider} = this.state;
     const initialData = this.props.organization;

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacy.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacy.tsx
@@ -4,11 +4,12 @@ import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
 import {PanelAlert} from 'app/components/panels';
 import {t} from 'app/locale';
-import {Organization} from 'app/types';
 
 import ProjectDataPrivacyContent from './projectDataPrivacyContent';
 
-const ProjectDataPrivacy = ({organization}: {organization: Organization}) => (
+type Props = ProjectDataPrivacyContent['props'];
+
+const ProjectDataPrivacy = ({organization, ...props}: Props) => (
   <Feature
     features={['datascrubbers-v2']}
     organization={organization}
@@ -20,7 +21,7 @@ const ProjectDataPrivacy = ({organization}: {organization: Organization}) => (
       />
     )}
   >
-    <ProjectDataPrivacyContent />
+    <ProjectDataPrivacyContent {...props} organization={organization} />
   </Feature>
 );
 

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
@@ -17,6 +17,7 @@ type Props = RouteComponentProps<{orgId: string; projectId: string}, {}> & {
   organization: Organization;
   project: Project;
 };
+
 class ProjectDataPrivacyContent extends AsyncView<Props> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {organization, project} = this.props;

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
 import Link from 'app/components/links/link';
 import {t, tct} from 'app/locale';
@@ -9,25 +9,22 @@ import Form from 'app/views/settings/components/forms/form';
 import {fields} from 'app/data/forms/projectGeneralSettings';
 import AsyncView from 'app/views/asyncView';
 import ProjectActions from 'app/actions/projectActions';
-import SentryTypes from 'app/sentryTypes';
+import {Organization, Project} from 'app/types';
 
 import DataPrivacyRules from '../components/dataPrivacyRules/dataPrivacyRules';
 
-class ProjectDataPrivacyContent extends AsyncView<{}> {
-  static contextTypes = {
-    organization: SentryTypes.Organization,
-    project: SentryTypes.Project,
-    // left the router contextType to satisfy the compiler
-    router: PropTypes.object,
-  };
-
+type Props = RouteComponentProps<{orgId: string; projectId: string}, {}> & {
+  organization: Organization;
+  project: Project;
+};
+class ProjectDataPrivacyContent extends AsyncView<Props> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {organization, project} = this.context;
+    const {organization, project} = this.props;
     return [['data', `/projects/${organization.slug}/${project.slug}/`]];
   }
 
   renderBody() {
-    const {organization, project} = this.context;
+    const {organization, project} = this.props;
     const initialData = this.state.data;
     const endpoint = `/projects/${organization.slug}/${project.slug}/`;
     const access = new Set(organization.access);


### PR DESCRIPTION
**Type:** Fix

**Description:** 
A bug was reported for the data privacy page. switching projects in the dropdown updates the project in the UI but doesn’t actually switch the content of the settings. This PR fixed this bug