### PR TITLE
ref: Tweak rrweb configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@sentry/browser": "5.15.0",
     "@sentry/integrations": "5.15.0",
     "@sentry/release-parser": "^0.4.0",
-    "@sentry/rrweb": "^0.1.0",
+    "@sentry/rrweb": "^0.1.1",
     "@sentry/utils": "5.15.0",
     "@types/classnames": "^2.2.0",
     "@types/clipboard": "^2.0.1",
@@ -115,7 +115,7 @@
     "reflexbox": "^4.0.6",
     "reflux": "0.4.1",
     "regenerator-runtime": "^0.13.3",
-    "rrweb-player": "^0.4.0",
+    "rrweb-player": "^0.4.6",
     "scroll-to-element": "^2.0.0",
     "sentry-dreamy-components": "^2.0.1",
     "sprintf-js": "1.0.3",
@@ -176,7 +176,7 @@
     "fsevents": "^2.1.2"
   },
   "resolutions": {
-    "**/rrweb": "^0.7.30"
+    "**/rrweb": "^0.7.33"
   },
   "APIMethod": "stub",
   "proxyURL": "http://localhost:8000",

--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -46,7 +46,11 @@ function getSentryIntegrations() {
     // should fix.
     if (process.env.NODE_ENV === 'production') {
       // Only use this in prod as there seem to be issues with hot reload in dev
-      integrations.push(new SentryRRWeb() as any);
+      integrations.push(
+        new SentryRRWeb({
+          checkoutEveryNms: 60 * 1000, // 60 seconds
+        }) as any
+      );
     }
   }
   return integrations;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,10 +1902,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-0.4.0.tgz#9b8e868d8ecee8313dc32bdef1478cd06ea7b7fd"
   integrity sha512-wnXqyFZrOlnsnI8qcY6T2wlEih5zWXwPMcmh6/F9iyyhG/NmcK8zJ67aOZrkT1X7MYN6kssUm8Gfa3DR7aT0Zg==
 
-"@sentry/rrweb@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@sentry/rrweb/-/rrweb-0.1.0.tgz#935258d214dd5482d925c96db8d4e60279154ec7"
-  integrity sha512-uOHGJ7rR8gm4LfSdJ2Oz5vlu4d74VdEj1SaRktoB8tTUOFBXWsPgCkEsUQ7hj0KufMrWGmerVsV3hg9me3gKMQ==
+"@sentry/rrweb@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@sentry/rrweb/-/rrweb-0.1.1.tgz#1e2ef7381d5c5725ea3bf3ac20987d50eee83dd1"
+  integrity sha512-bFzZ+NVaGFpkmBvSHsvM/Pc/wiy7UeP/ICofkY2iY5PwiRHpZCX5hLrLYA7o921VR847EKZB44fQYWZC1YFB1Q==
 
 "@sentry/types@5.15.0":
   version "5.15.0"
@@ -11249,6 +11249,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+pako@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 pako@~1.0.5:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
@@ -13773,25 +13778,26 @@ rollup-pluginutils@2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rrweb-player@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/rrweb-player/-/rrweb-player-0.4.0.tgz#b55a2396525c6d6c50b2c45f2b69d905e51814c8"
-  integrity sha512-eC5vMZjdWOokrLUO3csU7TaztkiNodwyUiXmM8V6BlJCsEi/8vGnyidG5+js+YVY7JYIbsujiKo7AN2rlPGz/w==
+rrweb-player@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/rrweb-player/-/rrweb-player-0.4.6.tgz#e58fc3fc670f03bf3f99238604e3c3ad53436f34"
+  integrity sha512-Jit+7Eq+Y0RzSfcI7UR+cacQhhflRfbA9tRmooUdudFzyKQTHlQiH9R3mQetkyP/WcI6D7x70s1eGnvgfRnDCg==
   dependencies:
-    rrweb "^0.7.25"
+    rrweb "^0.7.32"
 
 rrweb-snapshot@^0.7.26:
   version "0.7.26"
   resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-0.7.26.tgz#339769cdcfc53db4fec279501706ff6129671cb2"
   integrity sha512-z4k6swLNI5YPDFFcYp19Ggo2kE12cWG1OZCanlaMvwSOi82OOZ229ckYBCPYHbYQnCwuBF5KSMZi2i0CwpWHng==
 
-rrweb@^0.7.25, rrweb@^0.7.30:
-  version "0.7.30"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-0.7.30.tgz#5a2ba3e667b5f663fc207574188fcfcd450467df"
-  integrity sha512-ODA0W2cas5yoU1jLO/UVNUrr99jIfv5nQ7jrD7gfFG09O0YaMV9I9p5SkAztQe6gv2QvxgFsyFxzWjpfD7btvw==
+rrweb@^0.7.32, rrweb@^0.7.33:
+  version "0.7.33"
+  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-0.7.33.tgz#9505b3f94f9c5291377044a065f3148994081be6"
+  integrity sha512-TJIkNlejmyBScUbnBRCzeSgRFANx2dX0kGRZLeWKz6ZkSbWs4UhWv0DuRHEPSXH4/BV1b4PVtKBOMsY9wvm0jg==
   dependencies:
     "@types/smoothscroll-polyfill" "^0.3.0"
     mitt "^1.1.3"
+    pako "^1.0.11"
     rrweb-snapshot "^0.7.26"
     smoothscroll-polyfill "^0.4.3"
 


### PR DESCRIPTION
- Reduce snapshot to 1 minute (should reduce total filesize)
- Update to 0.1.1 which supports upstream maskAllInputs configuration