### PR TITLE
ref(ui): Refactor `skipLastLast` to not depend on Router

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -91,7 +91,7 @@ type InitializeUrlStateParams = {
   /**
    * If true, do not load from local storage
    */
-  skipLastUsed?: boolean;
+  skipLoadLastUsed?: boolean;
   defaultSelection?: Partial<GlobalSelection>;
   forceProject?: MinimalProject | null;
 };
@@ -101,7 +101,7 @@ export function initializeUrlState({
   queryParams,
   router,
   memberProjects,
-  skipLastUsed,
+  skipLoadLastUsed,
   shouldForceProject,
   shouldEnforceSingleProject,
   defaultSelection,
@@ -132,7 +132,7 @@ export function initializeUrlState({
   if (hasProjectOrEnvironmentInUrl) {
     globalSelection.projects = parsed.project || [];
     globalSelection.environments = parsed.environment || [];
-  } else if (!skipLastUsed) {
+  } else if (!skipLoadLastUsed) {
     try {
       const localStorageKey = `${LOCAL_STORAGE_KEY}:${orgSlug}`;
       const storedValue = localStorage.getItem(localStorageKey);

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.tsx
@@ -18,9 +18,18 @@ type GlobalSelectionHeaderProps = Omit<
 type Props = {
   organization: Organization;
   projects: Project[];
+
+  /**
+   * If this is true, do not attempt to control routing. This is only used in discover v1
+   *
+   * TODO(discoverv1): Removeme
+   */
   hasCustomRouting?: boolean;
 } & ReactRouter.WithRouterProps &
-  GlobalSelectionHeaderProps;
+  GlobalSelectionHeaderProps &
+  Partial<
+    Pick<React.ComponentProps<typeof InitializeGlobalSelectionHeader>, 'skipLoadLastUsed'>
+  >;
 
 class GlobalSelectionHeaderContainer extends React.Component<Props> {
   getProjects = () => {
@@ -52,6 +61,7 @@ class GlobalSelectionHeaderContainer extends React.Component<Props> {
       forceProject,
       shouldForceProject,
       hasCustomRouting,
+      skipLoadLastUsed,
       ...props
     } = this.props;
     const enforceSingleProject = !organization.features.includes('global-views');
@@ -63,8 +73,8 @@ class GlobalSelectionHeaderContainer extends React.Component<Props> {
         {(!loadingProjects || (!shouldForceProject && !enforceSingleProject)) && (
           <InitializeGlobalSelectionHeader
             location={location}
+            skipLoadLastUsed={!!skipLoadLastUsed}
             router={router}
-            routes={routes}
             organization={organization}
             defaultSelection={defaultSelection}
             forceProject={forceProject}

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/initializeGlobalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/initializeGlobalSelectionHeader.tsx
@@ -8,6 +8,13 @@ import GlobalSelectionHeader from './globalSelectionHeader';
 type Props = {
   isDisabled: boolean;
   shouldEnforceSingleProject: boolean;
+  /**
+   * Skip loading from local storage
+   * An example is Issue Details, in the case where it is accessed directly (e.g. from email).
+   * We do not want to load the user's last used env/project in this case, otherwise will
+   * lead to very confusing behavior.
+   */
+  skipLoadLastUsed: boolean;
 } & Pick<ReactRouter.WithRouterProps, 'location' | 'router'> &
   Pick<
     React.ComponentPropsWithoutRef<typeof GlobalSelectionHeader>,
@@ -16,13 +23,7 @@ type Props = {
     | 'shouldForceProject'
     | 'memberProjects'
     | 'organization'
-  > & {
-    routes: Array<
-      ReactRouter.PlainRoute<any> & {
-        globalSelectionSkipLastUsed?: boolean;
-      }
-    >;
-  };
+  >;
 
 /**
  * Initializes GlobalSelectionHeader
@@ -38,28 +39,21 @@ class InitializeGlobalSelectionHeader extends React.Component<Props> {
     const {
       location,
       router,
-      routes,
       organization,
       defaultSelection,
       forceProject,
       memberProjects,
       shouldForceProject,
       shouldEnforceSingleProject,
+      skipLoadLastUsed,
     } = this.props;
 
-    // Make an exception for routes (e.g. issue details, in the case where it is accessed directly (e.g. from email))
-    // We do not want to load the user's last used env/project in this case, otherwise will
-    // lead to very confusing behavior.
     //
-    // `routes` is only ever undefined in tests
-    const skipLastUsed = !!routes?.find(
-      ({globalSelectionSkipLastUsed}) => globalSelectionSkipLastUsed
-    );
     initializeUrlState({
       organization,
       queryParams: location.query,
       router,
-      skipLastUsed,
+      skipLoadLastUsed,
       memberProjects,
       defaultSelection,
       forceProject,

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1158,7 +1158,6 @@ function routes() {
           /organizations/:orgId/issues */}
         <Route
           path="/organizations/:orgId/issues/:groupId/"
-          globalSelectionSkipLastUsed
           componentPromise={() =>
             import(
               /* webpackChunkName: "OrganizationGroupDetails" */ 'app/views/organizationGroupDetails'

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -257,6 +257,7 @@ class GroupDetails extends React.Component<Props, State> {
       <DocumentTitle title={this.getTitle()}>
         <React.Fragment>
           <GlobalSelectionHeader
+            skipLoadLastUsed
             forceProject={project}
             showDateSelector={false}
             shouldForceProject

--- a/tests/js/spec/actionCreators/globalSelection.spec.jsx
+++ b/tests/js/spec/actionCreators/globalSelection.spec.jsx
@@ -1,4 +1,5 @@
 import {
+  initializeUrlState,
   updateProjects,
   updateEnvironments,
   updateDateTime,
@@ -6,22 +7,103 @@ import {
   updateParamsWithoutHistory,
 } from 'app/actionCreators/globalSelection';
 import GlobalSelectionActions from 'app/actions/globalSelectionActions';
+import localStorage from 'app/utils/localStorage';
+
+jest.mock('app/utils/localStorage');
 
 describe('GlobalSelection ActionCreators', function() {
-  let updateProjectsMock;
+  const organization = TestStubs.Organization();
   beforeEach(function() {
-    updateProjectsMock = GlobalSelectionActions.updateProjects = jest.fn();
+    localStorage.getItem.mockClear();
+    jest.spyOn(GlobalSelectionActions, 'updateProjects');
+    jest.spyOn(GlobalSelectionActions, 'initializeUrlState').mockImplementation();
+    GlobalSelectionActions.updateProjects.mockClear();
+  });
+
+  describe('initializeUrlState', function() {
+    let router;
+    beforeEach(() => {
+      router = TestStubs.router();
+    });
+    it('loads from local storage when no query params', function() {
+      const key = `global-selection:${organization.slug}`;
+      localStorage.setItem(key, JSON.stringify({environments: [], projects: [1]}));
+      initializeUrlState({
+        organization,
+        queryParams: {},
+        router,
+      });
+
+      expect(localStorage.getItem).toHaveBeenCalledWith(
+        `global-selection:${organization.slug}`
+      );
+      expect(GlobalSelectionActions.initializeUrlState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environments: [],
+          projects: [1],
+        })
+      );
+      expect(router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            environment: [],
+            project: [1],
+          },
+        })
+      );
+    });
+    it('does not load from local storage when no query params and `skipLoadLastUsed` is true', function() {
+      jest.spyOn(localStorage, 'getItem');
+      initializeUrlState({
+        organization,
+        queryParams: {},
+        skipLoadLastUsed: true,
+        router,
+      });
+
+      expect(localStorage.getItem).not.toHaveBeenCalled();
+    });
+
+    it('does not load from local storage when there are query params', function() {
+      initializeUrlState({
+        organization,
+        queryParams: {
+          project: '1',
+        },
+        router,
+      });
+
+      expect(localStorage.getItem).not.toHaveBeenCalled();
+      expect(GlobalSelectionActions.initializeUrlState).toHaveBeenCalledWith({
+        datetime: {
+          start: null,
+          end: null,
+          period: '14d',
+          utc: null,
+        },
+        projects: [1],
+        environments: [],
+      });
+      expect(router.replace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            environment: [],
+            project: [1],
+          },
+        })
+      );
+    });
   });
 
   describe('updateProjects()', function() {
     it('updates', function() {
       updateProjects([1, 2]);
-      expect(updateProjectsMock).toHaveBeenCalledWith([1, 2]);
+      expect(GlobalSelectionActions.updateProjects).toHaveBeenCalledWith([1, 2]);
     });
 
     it('does not update invalid projects', function() {
       updateProjects(['1']);
-      expect(updateProjectsMock).not.toHaveBeenCalled();
+      expect(GlobalSelectionActions.updateProjects).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Previously, we had to depend on routes for this prop, but since the refactor we can simplify this by declaring it as needed when rendering the component itself.