### PR TITLE
ref(ui) Consolidate tooltip icons and fix positioning

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/styles.tsx
+++ b/src/sentry/static/sentry/app/components/charts/styles.tsx
@@ -1,5 +1,8 @@
+import React from 'react';
 import styled from '@emotion/styled';
 
+import Tooltip from 'app/components/tooltip';
+import {IconQuestion} from 'app/icons';
 import space from 'app/styles/space';
 
 export const ChartControls = styled('div')`
@@ -43,3 +46,27 @@ export const InlineContainer = styled('div')`
     margin-left: 0;
   }
 `;
+
+const QuestionIconContainer = styled('span')`
+  margin-left: ${space(1)};
+  & svg {
+    color: ${p => p.theme.gray1};
+  }
+`;
+
+type QuestionProps = {
+  title: string;
+  size: string;
+} & Pick<React.ComponentProps<typeof Tooltip>, 'position'> &
+  Partial<Pick<React.ComponentProps<typeof Tooltip>, 'containerDisplayMode'>>;
+
+function QuestionTooltip({title, size, ...tooltipProps}: QuestionProps) {
+  return (
+    <QuestionIconContainer>
+      <Tooltip title={title} {...tooltipProps}>
+        <IconQuestion size={size} />
+      </Tooltip>
+    </QuestionIconContainer>
+  );
+}
+export {QuestionTooltip};

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
@@ -8,12 +8,10 @@ import {
   RawSpanType,
   TraceContextType,
 } from 'app/components/events/interfaces/spans/types';
-import {SectionHeading} from 'app/components/charts/styles';
+import {QuestionTooltip, SectionHeading} from 'app/components/charts/styles';
 import {pickSpanBarColour} from 'app/components/events/interfaces/spans/utils';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import Tooltip from 'app/components/tooltip';
-import {IconQuestion} from 'app/icons';
 
 type StartTimestamp = number;
 type EndTimestamp = number;
@@ -215,15 +213,14 @@ class OpsBreakdown extends React.Component<Props> {
       <StyledBreakdown>
         <BreakdownHeader>
           <SectionHeading>{t('Ops Breakdown')}</SectionHeading>
-          <Tooltip
+          <QuestionTooltip
             position="top"
+            size="sm"
             containerDisplayMode="block"
             title={t(
               'Durations are calculated by summing span durations over the course of the transaction. Percentages are then calculated by dividing the individual op duration by the sum of total op durations. Overlapping/parallel spans are only counted once.'
             )}
-          >
-            <StyledIconQuestion />
-          </Tooltip>
+          />
         </BreakdownHeader>
         {breakdown.map(currOp => {
           const {name, percentage, totalInterval} = currOp;
@@ -302,10 +299,6 @@ const Pct = styled('div')`
 const BreakdownHeader = styled('div')`
   display: flex;
   align-items: center;
-`;
-
-const StyledIconQuestion = styled(IconQuestion)`
-  color: ${p => p.theme.gray1};
 `;
 
 function mergeInterval(intervals: TimeWindowSpan[]): TimeWindowSpan[] {

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -7,7 +7,7 @@ import {Client} from 'app/api';
 import withApi from 'app/utils/withApi';
 import {getInterval} from 'app/components/charts/utils';
 import LoadingPanel from 'app/components/charts/loadingPanel';
-import Tooltip from 'app/components/tooltip';
+import {QuestionTooltip} from 'app/components/charts/styles';
 import getDynamicText from 'app/utils/getDynamicText';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel} from 'app/components/panels';
@@ -18,7 +18,7 @@ import {IconWarning} from 'app/icons';
 import theme from 'app/utils/theme';
 
 import {PERFORMANCE_TERMS} from '../constants';
-import {HeaderContainer, HeaderTitle, StyledIconQuestion, ErrorPanel} from '../styles';
+import {HeaderContainer, HeaderTitle, ErrorPanel} from '../styles';
 import Chart from './chart';
 import Footer from './footer';
 
@@ -104,9 +104,7 @@ class Container extends React.Component<Props> {
                   {YAXIS_OPTIONS.map(option => (
                     <HeaderTitle key={option.label}>
                       {option.label}
-                      <Tooltip position="top" title={option.tooltip}>
-                        <StyledIconQuestion size="sm" />
-                      </Tooltip>
+                      <QuestionTooltip position="top" size="sm" title={option.tooltip} />
                     </HeaderTitle>
                   ))}
                 </HeaderContainer>

--- a/src/sentry/static/sentry/app/views/performance/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/styles.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
-import {IconQuestion} from 'app/icons';
 
 export const GridBodyCell = styled('div')`
   font-size: 14px;
@@ -53,11 +52,6 @@ export const ChartsGrid = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-column-gap: ${space(1)};
-`;
-
-export const StyledIconQuestion = styled(IconQuestion)`
-  color: ${p => p.theme.gray1};
-  margin-left: ${space(1)};
 `;
 
 export const ErrorPanel = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/apdexThroughputChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/apdexThroughputChart.tsx
@@ -5,13 +5,13 @@ import * as ReactRouter from 'react-router';
 import {OrganizationSummary} from 'app/types';
 import {Client} from 'app/api';
 import {t} from 'app/locale';
-import Tooltip from 'app/components/tooltip';
 import AreaChart from 'app/components/charts/areaChart';
 import ChartZoom from 'app/components/charts/chartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import TransitionChart from 'app/components/charts/transitionChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
+import {QuestionTooltip} from 'app/components/charts/styles';
 import {getInterval} from 'app/components/charts/utils';
 import {IconWarning} from 'app/icons';
 import EventsRequest from 'app/views/events/utils/eventsRequest';
@@ -22,7 +22,7 @@ import withApi from 'app/utils/withApi';
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 
-import {HeaderTitleLegend, StyledIconQuestion} from '../styles';
+import {HeaderTitleLegend} from '../styles';
 
 const QUERY_KEYS = [
   'environment',
@@ -113,15 +113,11 @@ class ApdexThroughputChart extends React.Component<Props> {
       <React.Fragment>
         <HeaderTitleLegend key="apdex">
           {t('Apdex')}
-          <Tooltip position="top" title={PERFORMANCE_TERMS.apdex}>
-            <StyledIconQuestion size="sm" />
-          </Tooltip>
+          <QuestionTooltip position="top" size="sm" title={PERFORMANCE_TERMS.apdex} />
         </HeaderTitleLegend>
         <MiddleHeaderTitleLegend key="rpm">
           {t('Throughput')}
-          <Tooltip position="top" title={PERFORMANCE_TERMS.rpm}>
-            <StyledIconQuestion size="sm" />
-          </Tooltip>
+          <QuestionTooltip position="top" size="sm" title={PERFORMANCE_TERMS.rpm} />
         </MiddleHeaderTitleLegend>
         <ChartZoom
           router={router}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -4,13 +4,13 @@ import * as ReactRouter from 'react-router';
 import {OrganizationSummary} from 'app/types';
 import {Client} from 'app/api';
 import {t} from 'app/locale';
-import Tooltip from 'app/components/tooltip';
 import AreaChart from 'app/components/charts/areaChart';
 import ChartZoom from 'app/components/charts/chartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import TransitionChart from 'app/components/charts/transitionChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
+import {QuestionTooltip} from 'app/components/charts/styles';
 import {getInterval} from 'app/components/charts/utils';
 import {IconWarning} from 'app/icons';
 import EventsRequest from 'app/views/events/utils/eventsRequest';
@@ -21,7 +21,7 @@ import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 import {getDuration} from 'app/utils/formatters';
 
-import {HeaderTitleLegend, StyledIconQuestion} from '../styles';
+import {HeaderTitleLegend} from '../styles';
 
 const QUERY_KEYS = [
   'environment',
@@ -96,14 +96,13 @@ class DurationChart extends React.Component<Props> {
       <React.Fragment>
         <HeaderTitleLegend>
           {t('Duration Breakdown')}
-          <Tooltip
+          <QuestionTooltip
+            size="sm"
             position="top"
             title={t(
               `Duration Breakdown reflects transaction durations by percentile over time.`
             )}
-          >
-            <StyledIconQuestion size="sm" />
-          </Tooltip>
+          />
         </HeaderTitleLegend>
         <ChartZoom
           router={router}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
@@ -8,14 +8,14 @@ import {t} from 'app/locale';
 import AreaChart from 'app/components/charts/areaChart';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LoadingPanel from 'app/components/charts/loadingPanel';
+import {QuestionTooltip} from 'app/components/charts/styles';
 import AsyncComponent from 'app/components/asyncComponent';
-import Tooltip from 'app/components/tooltip';
 import {OrganizationSummary} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import theme from 'app/utils/theme';
 import {getDuration} from 'app/utils/formatters';
 
-import {HeaderTitleLegend, StyledIconQuestion} from '../styles';
+import {HeaderTitleLegend} from '../styles';
 
 const QUERY_KEYS = [
   'environment',
@@ -161,14 +161,13 @@ class DurationPercentileChart extends AsyncComponent<Props, State> {
       <React.Fragment>
         <HeaderTitleLegend>
           {t('Duration Percentiles')}
-          <Tooltip
+          <QuestionTooltip
             position="top"
+            size="sm"
             title={t(
               `Compare the duration at each percentile. Compare with Latency Histogram to see transaction volume at duration intervals.`
             )}
-          >
-            <StyledIconQuestion />
-          </Tooltip>
+          />
         </HeaderTitleLegend>
         {this.renderComponent()}
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -9,15 +9,15 @@ import {t} from 'app/locale';
 import BarChart from 'app/components/charts/barChart';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LoadingPanel from 'app/components/charts/loadingPanel';
+import {QuestionTooltip} from 'app/components/charts/styles';
 import AsyncComponent from 'app/components/asyncComponent';
-import Tooltip from 'app/components/tooltip';
 import {OrganizationSummary} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import theme from 'app/utils/theme';
 import {getDuration} from 'app/utils/formatters';
 
-import {HeaderTitleLegend, StyledIconQuestion} from '../styles';
+import {HeaderTitleLegend} from '../styles';
 
 const NUM_BUCKETS = 15;
 const QUERY_KEYS = [
@@ -239,14 +239,13 @@ class LatencyChart extends AsyncComponent<Props, State> {
       <React.Fragment>
         <HeaderTitleLegend>
           {t('Latency Distribution')}
-          <Tooltip
+          <QuestionTooltip
             position="top"
+            size="sm"
             title={t(
               `Latency Distribution reflects the volume of transactions per median duration.`
             )}
-          >
-            <StyledIconQuestion />
-          </Tooltip>
+          />
         </HeaderTitleLegend>
         {this.renderComponent()}
       </React.Fragment>


### PR DESCRIPTION
Consolidate the tooltip icons into a shared component and fix the
pointer position as it was off before.

### Before
![Screen Shot 2020-05-08 at 3 52 43 PM](https://user-images.githubusercontent.com/24086/81443785-12f3e980-9144-11ea-9da0-26a8102daaf0.png)

### After
![Screen Shot 2020-05-08 at 3 52 22 PM](https://user-images.githubusercontent.com/24086/81443811-1dae7e80-9144-11ea-9bd2-a3eb71f7c9fc.png)
