### PR TITLE
fix(ui): Global Selection values should not be "sticky" in Discover

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -195,8 +195,6 @@ class Sidebar extends React.Component<Props, State> {
       'releases',
       'user-feedback',
       'discover',
-      'discover/queries',
-      'discover/results',
       'performance',
       'releasesv2',
     ].map(route => `/organizations/${this.props.organization.slug}/${route}/`);

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -1,27 +1,28 @@
+import {browserHistory} from 'react-router';
 import React, {MouseEvent} from 'react';
-import {Location, Query} from 'history';
-import styled from '@emotion/styled';
 import classNames from 'classnames';
 import moment from 'moment';
-import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+import {Location, Query} from 'history';
 
-import {t} from 'app/locale';
-import space from 'app/styles/space';
-import {Organization, SavedQuery} from 'app/types';
-import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {Client} from 'app/api';
+import {IconEllipsis} from 'app/icons';
+import {Organization, SavedQuery} from 'app/types';
+import {resetGlobalSelection} from 'app/actionCreators/globalSelection';
+import {t} from 'app/locale';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import DropdownMenu from 'app/components/dropdownMenu';
+import EventView from 'app/utils/discover/eventView';
 import MenuItem from 'app/components/menuItem';
 import Pagination from 'app/components/pagination';
-import {IconEllipsis} from 'app/icons';
-import withApi from 'app/utils/withApi';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
-import EventView from 'app/utils/discover/eventView';
+import space from 'app/styles/space';
+import withApi from 'app/utils/withApi';
 
-import QueryCard from './querycard';
-import MiniGraph from './miniGraph';
 import {getPrebuiltQueries} from './utils';
 import {handleDeleteQuery, handleCreateQuery} from './savedQuery/utils';
+import MiniGraph from './miniGraph';
+import QueryCard from './querycard';
 
 type Props = {
   api: Client;
@@ -34,6 +35,14 @@ type Props = {
 };
 
 class QueryList extends React.Component<Props> {
+  componentDidMount() {
+    /**
+     * We need to reset global selection here because the saved queries can define their own projects
+     * in the query. This can lead to mismatched queries for the project
+     */
+    resetGlobalSelection();
+  }
+
   handleDeleteQuery = (eventView: EventView) => (event: React.MouseEvent<Element>) => {
     event.preventDefault();
     event.stopPropagation();

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -221,50 +221,46 @@ class Results extends React.Component<Props, State> {
 
     return (
       <SentryDocumentTitle title={title} objSlug={organization.slug}>
-        <React.Fragment>
-          <GlobalSelectionHeader>
-            <StyledPageContent>
-              <LightWeightNoProjectMessage organization={organization}>
-                <ResultsHeader
+        <StyledPageContent>
+          <LightWeightNoProjectMessage organization={organization}>
+            <ResultsHeader
+              organization={organization}
+              location={location}
+              eventView={eventView}
+            />
+            <ContentBox>
+              <Top>
+                {this.renderError(error)}
+                <StyledSearchBar
                   organization={organization}
-                  location={location}
-                  eventView={eventView}
+                  projectIds={eventView.project}
+                  query={query}
+                  onSearch={this.handleSearch}
                 />
-                <ContentBox>
-                  <Top>
-                    {this.renderError(error)}
-                    <StyledSearchBar
-                      organization={organization}
-                      projectIds={eventView.project}
-                      query={query}
-                      onSearch={this.handleSearch}
-                    />
-                    <ResultsChart
-                      api={api}
-                      router={router}
-                      organization={organization}
-                      eventView={eventView}
-                      location={location}
-                      onAxisChange={this.handleYAxisChange}
-                      onDisplayChange={this.handleDisplayChange}
-                      total={totalValues}
-                    />
-                  </Top>
-                  <Main>
-                    <Table
-                      organization={organization}
-                      eventView={eventView}
-                      location={location}
-                      title={title}
-                      setError={this.setError}
-                    />
-                  </Main>
-                  <Side>{this.renderTagsTable()}</Side>
-                </ContentBox>
-              </LightWeightNoProjectMessage>
-            </StyledPageContent>
-          </GlobalSelectionHeader>
-        </React.Fragment>
+                <ResultsChart
+                  api={api}
+                  router={router}
+                  organization={organization}
+                  eventView={eventView}
+                  location={location}
+                  onAxisChange={this.handleYAxisChange}
+                  onDisplayChange={this.handleDisplayChange}
+                  total={totalValues}
+                />
+              </Top>
+              <Main>
+                <Table
+                  organization={organization}
+                  eventView={eventView}
+                  location={location}
+                  title={title}
+                  setError={this.setError}
+                />
+              </Main>
+              <Side>{this.renderTagsTable()}</Side>
+            </ContentBox>
+          </LightWeightNoProjectMessage>
+        </StyledPageContent>
       </SentryDocumentTitle>
     );
   }
@@ -286,4 +282,22 @@ export const Top = styled('div')`
   flex-grow: 0;
 `;
 
-export default withApi(withOrganization(withGlobalSelection(Results)));
+function ResultsContainer(props: Props) {
+  /**
+   * Block `<Results>` from mounting until GSH is ready since there are API
+   * requests being performed on mount.
+   *
+   * Also, we skip loading last used projects if you have multiple projects feature as
+   * you no longer need to enforce a project if it is empty. We assume an empty project is
+   * the desired behavior because saved queries can contain a project filter.
+   */
+  return (
+    <GlobalSelectionHeader
+      skipLoadLastUsed={props.organization.features.includes('global-views')}
+    >
+      <Results {...props} />
+    </GlobalSelectionHeader>
+  );
+}
+
+export default withApi(withOrganization(withGlobalSelection(ResultsContainer)));


### PR DESCRIPTION
If you do not have multiple projects, we need to keep a project selected
for a better experience. If your query has a project defined, it should use
that, otherwise keep the project that you have previously selected,
selected.

However if you *do* have multiple projects feature, we do not want to load
your last selected projects as saved queries can either have a project
defined or have no project defined (in which case we want to see "My
Projects").

Requires https://github.com/getsentry/sentry/pull/18702