### PR TITLE
fix(discover) Fix errant bullet in discover query saving

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -321,7 +321,7 @@ const ButtonSaveAs = styled(DropdownButton)`
 const ButtonSaved = styled(Button)`
   cursor: not-allowed;
 `;
-const ButtonSaveDropDown = styled('li')`
+const ButtonSaveDropDown = styled('div')`
   padding: ${space(1)};
 `;
 const ButtonSaveInput = styled(Input)`


### PR DESCRIPTION
DropdownControl no longer wraps the menu with `ul` element, and thus using an `li` as the button element is causing bullet artifacts in chrome.