### PR TITLE
fix(ui): Sidebar gradient

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -373,7 +373,6 @@ class Sidebar extends React.Component<Props, State> {
                     to={`/organizations/${organization.slug}/issues/`}
                     id="issues"
                   />
-
                   {discoverState.events && (
                     <Feature
                       features={['events']}
@@ -395,7 +394,6 @@ class Sidebar extends React.Component<Props, State> {
                       />
                     </Feature>
                   )}
-
                   {discoverState.discover2 && (
                     <Feature
                       hookName="feature-disabled:discover2-sidebar-item"
@@ -659,7 +657,7 @@ const responsiveFlex = css`
 
 const StyledSidebar = styled('div')<{collapsed: boolean}>`
   background: ${p => p.theme.sidebar.background};
-  background: linear-gradient(${p => p.theme.gray4}, ${p => p.theme.gray5});
+  background: linear-gradient(294.17deg, #2f1937 35.57%, #452650 92.42%, #452650 92.42%);
   color: ${p => p.theme.sidebar.color};
   line-height: 1;
   padding: 12px 0 2px; /* Allows for 32px avatars  */


### PR DESCRIPTION
Updates the gradient of the sidebar to make it 124.5% more delightful. 

#### Before 
![Screen Shot 2020-05-08 at 3 35 02 PM](https://user-images.githubusercontent.com/1900676/81455107-0753f300-9143-11ea-99c0-b3dcdef525c2.png)

#### After
![Screen Shot 2020-05-08 at 3 35 14 PM](https://user-images.githubusercontent.com/1900676/81455119-0e7b0100-9143-11ea-95b3-12d27b98b368.png)
