### PR TITLE
Fix(alerts): Fix `AlertRuleSerializer` incorrectly serializing environments.

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -29,6 +29,7 @@ class AlertRuleSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user):
+        env = obj.snuba_query.environment
         return {
             "id": six.text_type(obj.id),
             "name": obj.name,
@@ -43,7 +44,7 @@ class AlertRuleSerializer(Serializer):
             "aggregations": [obj.aggregation],
             # TODO: Start having the frontend expect seconds
             "timeWindow": obj.snuba_query.time_window / 60,
-            "environment": obj.snuba_query.environment,
+            "environment": env.name if env else None,
             # TODO: Start having the frontend expect seconds
             "resolution": obj.snuba_query.resolution / 60,
             "thresholdPeriod": obj.threshold_period,

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -32,6 +32,10 @@ class BaseAlertRuleSerializerTest(object):
         if not skip_dates:
             assert result["dateModified"] == alert_rule.date_modified
             assert result["dateCreated"] == alert_rule.date_added
+        if alert_rule.snuba_query.environment:
+            assert result["environment"] == alert_rule.snuba_query.environment.name
+        else:
+            assert result["environment"] is None
 
     def create_issue_alert_rule(self, data):
         """data format
@@ -87,6 +91,11 @@ class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
         result = serialize([alert_rule, other_alert_rule])
         assert result[0]["triggers"] == [serialize(trigger)]
         assert result[1]["triggers"] == []
+
+    def test_environment(self):
+        alert_rule = self.create_alert_rule(environment=self.environment)
+        result = serialize(alert_rule)
+        self.assert_alert_rule_serialized(alert_rule, result)
 
 
 class DetailedAlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):


### PR DESCRIPTION
We weren't testing serializing the env name in this serializer, and I accidentally changed to return
the environment instance, rather than the name. This fixes that bug.