### PR TITLE
feat(ui): Release detail page improvements

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/otherProjects.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/otherProjects.tsx
@@ -7,8 +7,8 @@ import space from 'app/styles/space';
 import Link from 'app/components/links/link';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {ReleaseProject} from 'app/types';
-import {IconProject} from 'app/icons';
 import Button from 'app/components/button';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
 
 import {SectionHeading, Wrapper} from './styles';
 
@@ -57,15 +57,14 @@ class OtherProjects extends React.Component<Props, State> {
         </SectionHeading>
         {projectsToRender.map(project => (
           <Row key={project.id}>
-            <Link
+            <StyledLink
               to={{
                 pathname: location.pathname,
                 query: {...location.query, project: project.id, yAxis: undefined},
               }}
             >
-              <StyledIconProject size="sm" />
-              {project.slug}
-            </Link>
+              <ProjectBadge project={project} avatarSize={16} key={project.slug} />
+            </StyledLink>
           </Row>
         ))}
         {numberOfCollapsedProjects > 0 && (
@@ -88,16 +87,14 @@ class OtherProjects extends React.Component<Props, State> {
 }
 
 const Row = styled('div')`
-  margin-bottom: ${space(0.75)};
+  margin-bottom: ${space(0.25)};
   font-size: ${p => p.theme.fontSizeMedium};
   color: ${p => p.theme.blue};
   ${overflowEllipsis}
 `;
 
-const StyledIconProject = styled(IconProject)`
-  margin-right: ${space(1)};
-  position: relative;
-  top: ${space(0.25)};
+const StyledLink = styled(Link)`
+  display: inline-block;
 `;
 
 const CollapseToggle = styled(Button)`

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/projectReleaseDetails.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/projectReleaseDetails.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 
 const ProjectReleaseDetails = ({release}: Props) => {
-  const {version, dateCreated, firstEvent, lastEvent} = release;
+  const {version, dateCreated, firstEvent, lastEvent, lastDeploy} = release;
 
   return (
     <Wrapper>
@@ -28,6 +28,15 @@ const ProjectReleaseDetails = ({release}: Props) => {
               <DateTime date={dateCreated} seconds={false} />
             </TagValue>
           </StyledTr>
+
+          {lastDeploy?.dateFinished && (
+            <StyledTr>
+              <TagKey>{t('Last Deploy')}</TagKey>
+              <TagValue>
+                <DateTime date={lastDeploy.dateFinished} seconds={false} />
+              </TagValue>
+            </StyledTr>
+          )}
 
           <StyledTr>
             <TagKey>{t('Version')}</TagKey>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/projectReleaseDetails.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/projectReleaseDetails.tsx
@@ -7,6 +7,7 @@ import {Release} from 'app/types';
 import Version from 'app/components/version';
 import TimeSince from 'app/components/timeSince';
 import DateTime from 'app/components/dateTime';
+import Tooltip from 'app/components/tooltip';
 
 import {SectionHeading, Wrapper} from './styles';
 
@@ -33,7 +34,9 @@ const ProjectReleaseDetails = ({release}: Props) => {
             <StyledTr>
               <TagKey>{t('Last Deploy')}</TagKey>
               <TagValue>
-                <DateTime date={lastDeploy.dateFinished} seconds={false} />
+                <Tooltip title={lastDeploy.environment}>
+                  <DateTime date={lastDeploy.dateFinished} seconds={false} />
+                </Tooltip>
               </TagValue>
             </StyledTr>
           )}

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
@@ -32,7 +32,7 @@ type Props = {
 
 const ReleaseHeader = ({location, orgId, release, deploys, project}: Props) => {
   const {version, newGroups, url} = release;
-  const {hasHealthData, sessionsCrashed, sessionsErrored} = project.healthData;
+  const {hasHealthData, sessionsCrashed} = project.healthData;
 
   const releasePath = `/organizations/${orgId}/releases/${encodeURIComponent(version)}/`;
 
@@ -84,9 +84,6 @@ const ReleaseHeader = ({location, orgId, release, deploys, project}: Props) => {
               <Count value={sessionsCrashed} />
             </ReleaseStat>
           )}
-          <ReleaseStat label={t('Errors')}>
-            <Count value={sessionsErrored} />
-          </ReleaseStat>
           <ReleaseStat label={t('New Issues')}>
             <Count value={newGroups} />
           </ReleaseStat>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
@@ -32,7 +32,7 @@ type Props = {
 
 const ReleaseHeader = ({location, orgId, release, deploys, project}: Props) => {
   const {version, newGroups, url} = release;
-  const {healthData} = project;
+  const {hasHealthData, sessionsCrashed, sessionsErrored} = project.healthData;
 
   const releasePath = `/organizations/${orgId}/releases/${encodeURIComponent(version)}/`;
 
@@ -79,19 +79,18 @@ const ReleaseHeader = ({location, orgId, release, deploys, project}: Props) => {
               </DeploysWrapper>
             </ReleaseStat>
           )}
-          {healthData?.hasHealthData && (
+          {hasHealthData && (
             <ReleaseStat label={t('Crashes')}>
-              <Count value={healthData?.sessionsCrashed ?? 0} />
+              <Count value={sessionsCrashed} />
             </ReleaseStat>
           )}
+          <ReleaseStat label={t('Errors')}>
+            <Count value={sessionsErrored} />
+          </ReleaseStat>
           <ReleaseStat label={t('New Issues')}>
             <Count value={newGroups} />
           </ReleaseStat>
-          <ReleaseActions
-            version={version}
-            orgId={orgId}
-            hasHealthData={healthData?.hasHealthData}
-          />
+          <ReleaseActions version={version} orgId={orgId} hasHealthData={hasHealthData} />
         </StatsWrapper>
       </Layout>
 

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
@@ -13,7 +13,7 @@ import Version from 'app/components/version';
 import Clipboard from 'app/components/clipboard';
 import {IconCopy, IconOpen} from 'app/icons';
 import Tooltip from 'app/components/tooltip';
-import Badge from 'app/components/badge';
+import Tag from 'app/views/settings/components/tag';
 import Count from 'app/components/count';
 import TimeSince from 'app/components/timeSince';
 import {formatVersion} from 'app/utils/formatters';
@@ -72,7 +72,7 @@ const ReleaseHeader = ({location, orgId, release, deploys, project}: Props) => {
                         version
                       )}&environment=${encodeURIComponent(deploy.environment)}`}
                     >
-                      <StyledBadge text={deploy.environment} />
+                      <StyledBadge>{deploy.environment}</StyledBadge>
                     </Link>
                   </Tooltip>
                 ))}
@@ -165,12 +165,16 @@ const StatsWrapper = styled('div')`
 const DeploysWrapper = styled('div')`
   display: flex;
   margin-top: ${space(0.5)};
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    flex-wrap: wrap;
+  }
 `;
 
-const StyledBadge = styled(Badge)`
+const StyledBadge = styled(Tag)`
   background-color: ${p => p.theme.gray4};
   font-size: ${p => p.theme.fontSizeSmall};
-  font-weight: 400;
+  color: ${p => p.theme.white};
+  margin-left: ${space(0.5)};
 `;
 
 const ReleaseName = styled('div')`

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseStat.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseStat.tsx
@@ -28,6 +28,7 @@ const Label = styled('div')`
   color: ${p => p.theme.gray2};
   line-height: 1.3;
   margin-bottom: ${space(0.25)};
+  white-space: nowrap;
 `;
 const Value = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};


### PR DESCRIPTION
Improvements on release detail page:

- add errors to release header
- add last deploy to sidebar
- change deploys to use Tag component
- change other projects in this release to use ProjectBadge component