### PR TITLE
fix(ui): Fix React "key" warning in Deploy Previews

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/deployPreview.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/deployPreview.tsx
@@ -24,6 +24,7 @@ export function displayDeployPreviewAlert() {
   );
 
   AlertActions.addAlert({
+    id: 'deploy-preview',
     message: tct(
       'You are viewing a frontend deploy preview of [commitLink] ([branchLink])',
       {commitLink, branchLink}


### PR DESCRIPTION
This fixes a React "key" warning that happens only in Deploy Previews. The action creator creating an alert is missing an `id`.