### PR TITLE
ref(ui) Consolidate ? icon + tooltip pattern

### DIFF
--- a/docs-ui/components/questionTooltip.stories.js
+++ b/docs-ui/components/questionTooltip.stories.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+import {text, select} from '@storybook/addon-knobs';
+
+import QuestionTooltip from 'app/components/questionTooltip';
+import theme from 'app/utils/theme';
+
+storiesOf('UI|QuestionTooltip', module).add(
+  'QuestionTooltip',
+  withInfo({
+    text:
+      'Show a question mark icon with a tooltip to provide in context help information.',
+  })(() => {
+    const title = text('tooltip', 'This is a neat word that needs some help');
+    const displayMode = select('Container display mode', [
+      'block',
+      'inline-block',
+      'inline',
+    ]);
+    const position = select(
+      'position',
+      {top: 'top', bottom: 'bottom', left: 'left', right: 'right'},
+      'top'
+    );
+    const size = select('size', theme.iconSizes, theme.iconSizes.sm);
+
+    return (
+      <React.Fragment>
+        <h3>
+          Some Jargon Term
+          <QuestionTooltip
+            title={title}
+            position={position}
+            size={size}
+            containerDisplayMode={displayMode}
+          />
+        </h3>
+      </React.Fragment>
+    );
+  })
+);

--- a/src/sentry/static/sentry/app/components/charts/styles.tsx
+++ b/src/sentry/static/sentry/app/components/charts/styles.tsx
@@ -20,7 +20,7 @@ export const SubHeading = styled('h3')`
 `;
 
 export const SectionHeading = styled('h4')`
-  display: inline-grid;
+  display: grid;
   grid-auto-flow: column;
   grid-gap: ${space(1.5)};
   align-items: center;

--- a/src/sentry/static/sentry/app/components/charts/styles.tsx
+++ b/src/sentry/static/sentry/app/components/charts/styles.tsx
@@ -1,8 +1,5 @@
-import React from 'react';
 import styled from '@emotion/styled';
 
-import Tooltip from 'app/components/tooltip';
-import {IconQuestion} from 'app/icons';
 import space from 'app/styles/space';
 
 export const ChartControls = styled('div')`
@@ -23,6 +20,11 @@ export const SubHeading = styled('h3')`
 `;
 
 export const SectionHeading = styled('h4')`
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: ${space(1.5)};
+  align-items: center;
+
   color: ${p => p.theme.gray3};
   font-size: ${p => p.theme.fontSizeMedium};
   margin: ${space(1)} 0;
@@ -46,27 +48,3 @@ export const InlineContainer = styled('div')`
     margin-left: 0;
   }
 `;
-
-const QuestionIconContainer = styled('span')`
-  margin-left: ${space(1)};
-  & svg {
-    color: ${p => p.theme.gray1};
-  }
-`;
-
-type QuestionProps = {
-  title: string;
-  size: string;
-} & Pick<React.ComponentProps<typeof Tooltip>, 'position'> &
-  Partial<Pick<React.ComponentProps<typeof Tooltip>, 'containerDisplayMode'>>;
-
-function QuestionTooltip({title, size, ...tooltipProps}: QuestionProps) {
-  return (
-    <QuestionIconContainer>
-      <Tooltip title={title} {...tooltipProps}>
-        <IconQuestion size={size} />
-      </Tooltip>
-    </QuestionIconContainer>
-  );
-}
-export {QuestionTooltip};

--- a/src/sentry/static/sentry/app/components/forms/formField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/formField.tsx
@@ -4,8 +4,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {defined} from 'app/utils';
-import InlineSvg from 'app/components/inlineSvg';
-import Tooltip from 'app/components/tooltip';
+import QuestionTooltip from 'app/components/questionTooltip';
 import {Context} from 'app/components/forms/form';
 import {Meta} from 'app/types';
 
@@ -32,11 +31,6 @@ type FormFieldState = {
   error: string | null;
   value: Value;
 };
-
-const StyledInlineSvg = styled(InlineSvg)`
-  display: block;
-  color: ${p => p.theme.gray3};
-`;
 
 export default class FormField<
   Props extends FormFieldProps = FormFieldProps,
@@ -175,11 +169,7 @@ export default class FormField<
     if (!disabledReason) {
       return null;
     }
-    return (
-      <Tooltip title={disabledReason}>
-        <StyledInlineSvg src="icon-circle-question" size="18px" />
-      </Tooltip>
-    );
+    return <QuestionTooltip title={disabledReason} position="top" size="sm" />;
   }
 
   render() {

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -10,6 +10,7 @@ import {uniqueId} from 'app/utils/guid';
 import InlineSvg from 'app/components/inlineSvg';
 import Button from 'app/components/button';
 import HookOrDefault from 'app/components/hookOrDefault';
+import QuestionTooltip from 'app/components/questionTooltip';
 import {IconAdd, IconMail} from 'app/icons';
 import space from 'app/styles/space';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -17,7 +18,6 @@ import {Organization, Team} from 'app/types';
 import withLatestContext from 'app/utils/withLatestContext';
 import withTeams from 'app/utils/withTeams';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import Tooltip from 'app/components/tooltip';
 
 import {InviteRow, InviteStatus, NormalizedInvite} from './types';
 import InviteRowControl from './inviteRowControl';
@@ -311,16 +311,16 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
           <IconMail size="lg" />
           {t('Invite New Members')}
           {!this.willInvite && (
-            <Tooltip
+            <QuestionTooltip
               title={t(
                 `You do not have permission to directly invite members. Email
                  addresses entered here will be forwarded to organization
                  managers and owners; they will be prompted to approve the
                  invitation.`
               )}
-            >
-              <InlineSvg src="icon-circle-question" size="16px" />
-            </Tooltip>
+              size="sm"
+              position="bottom"
+            />
           )}
         </Heading>
         <Subtext>

--- a/src/sentry/static/sentry/app/components/questionTooltip.tsx
+++ b/src/sentry/static/sentry/app/components/questionTooltip.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {IconSize} from 'app/utils/theme';
+import Tooltip from 'app/components/tooltip';
+import {IconQuestion} from 'app/icons';
+
+type ContainerProps = {
+  className?: string;
+  size: IconSize | string;
+};
+
+const QuestionIconContainer = styled('span')<ContainerProps>`
+  display: inline-block;
+  height: ${p => p.theme.iconSizes[p.size] ?? p.size};
+  line-height: ${p => p.theme.iconSizes[p.size] ?? p.size};
+
+  & svg {
+    transition: 0.15s color;
+    color: ${p => p.theme.gray1};
+
+    &:hover {
+      color: ${p => p.theme.gray2};
+    }
+  }
+`;
+
+type QuestionProps = {
+  className?: string;
+  title: React.ReactNode;
+  size: string;
+} & Pick<React.ComponentProps<typeof Tooltip>, 'position'> &
+  Partial<Pick<React.ComponentProps<typeof Tooltip>, 'containerDisplayMode'>>;
+
+function QuestionTooltip({title, size, className, ...tooltipProps}: QuestionProps) {
+  return (
+    <QuestionIconContainer size={size} className={className}>
+      <Tooltip title={title} {...tooltipProps}>
+        <IconQuestion size={size} />
+      </Tooltip>
+    </QuestionIconContainer>
+  );
+}
+export default QuestionTooltip;

--- a/src/sentry/static/sentry/app/views/admin/adminEnvironment.jsx
+++ b/src/sentry/static/sentry/app/views/admin/adminEnvironment.jsx
@@ -6,7 +6,7 @@ import {t, tct} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
-import Tooltip from 'app/components/tooltip';
+import {IconQuestion} from 'app/icons';
 import space from 'app/styles/space';
 
 export default class AdminEnvironment extends AsyncView {
@@ -33,20 +33,17 @@ export default class AdminEnvironment extends AsyncView {
             <VersionLabel>
               {t('Server Version')}
               {version.upgradeAvailable && (
-                <Tooltip
+                <Button
                   title={t(
                     "You're running an old version of Sentry, did you know %s is available?",
                     version.latest
                   )}
-                >
-                  <Button
-                    priority="link"
-                    href="https://github.com/getsentry/sentry/releases"
-                    icon="icon-circle-question"
-                    size="small"
-                    external
-                  />
-                </Tooltip>
+                  priority="link"
+                  href="https://github.com/getsentry/sentry/releases"
+                  icon={<IconQuestion size="sm" />}
+                  size="small"
+                  external
+                />
               )}
             </VersionLabel>
             <dd>

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/transaction/opsBreakdown.tsx
@@ -8,7 +8,8 @@ import {
   RawSpanType,
   TraceContextType,
 } from 'app/components/events/interfaces/spans/types';
-import {QuestionTooltip, SectionHeading} from 'app/components/charts/styles';
+import QuestionTooltip from 'app/components/questionTooltip';
+import {SectionHeading} from 'app/components/charts/styles';
 import {pickSpanBarColour} from 'app/components/events/interfaces/spans/utils';
 import {t} from 'app/locale';
 import space from 'app/styles/space';

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -163,21 +163,16 @@ class Tags extends React.Component<Props, State> {
 
   render() {
     return (
-      <TagSection>
-        <StyledHeading>{t('Event Tag Summary')}</StyledHeading>
+      <React.Fragment>
+        <StyledSectionHeading>{t('Event Tag Summary')}</StyledSectionHeading>
         {this.renderBody()}
-      </TagSection>
+      </React.Fragment>
     );
   }
 }
 
-// These styled components are used in getsentry for a paywall.
-export const StyledHeading = styled(SectionHeading)`
-  margin: 0 0 ${space(1.5)} 0;
-`;
-
-export const TagSection = styled('div')`
-  margin: ${space(0.5)} 0;
+const StyledSectionHeading = styled(SectionHeading)`
+  margin-top: ${space(0.5)};
 `;
 
 const StyledError = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -7,7 +7,7 @@ import {Client} from 'app/api';
 import withApi from 'app/utils/withApi';
 import {getInterval} from 'app/components/charts/utils';
 import LoadingPanel from 'app/components/charts/loadingPanel';
-import {QuestionTooltip} from 'app/components/charts/styles';
+import QuestionTooltip from 'app/components/questionTooltip';
 import getDynamicText from 'app/utils/getDynamicText';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel} from 'app/components/panels';
@@ -102,10 +102,16 @@ class Container extends React.Component<Props> {
               <React.Fragment>
                 <HeaderContainer>
                   {YAXIS_OPTIONS.map(option => (
-                    <HeaderTitle key={option.label}>
-                      {option.label}
-                      <QuestionTooltip position="top" size="sm" title={option.tooltip} />
-                    </HeaderTitle>
+                    <div key={option.label}>
+                      <HeaderTitle>
+                        {option.label}
+                        <QuestionTooltip
+                          position="top"
+                          size="sm"
+                          title={option.tooltip}
+                        />
+                      </HeaderTitle>
+                    </div>
                   ))}
                 </HeaderContainer>
                 {getDynamicText({

--- a/src/sentry/static/sentry/app/views/performance/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/styles.tsx
@@ -28,14 +28,17 @@ export const HeaderContainer = styled('div')`
   padding: ${space(2)} ${space(1.5)};
 `;
 
-export const HeaderTitle = styled('div')`
+export const HeaderTitle = styled('h3')`
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: ${space(1.5)};
+  align-items: center;
+
   font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: normal;
+  line-height: 1.2;
   color: ${p => p.theme.gray4};
   padding: 0 ${space(1)};
-
-  span {
-    vertical-align: middle;
-  }
 `;
 
 export const HeaderTitleLegend = styled(HeaderTitle)`

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/apdexThroughputChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/apdexThroughputChart.tsx
@@ -11,7 +11,7 @@ import ErrorPanel from 'app/components/charts/errorPanel';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import TransitionChart from 'app/components/charts/transitionChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
-import {QuestionTooltip} from 'app/components/charts/styles';
+import QuestionTooltip from 'app/components/questionTooltip';
 import {getInterval} from 'app/components/charts/utils';
 import {IconWarning} from 'app/icons';
 import EventsRequest from 'app/views/events/utils/eventsRequest';

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -10,7 +10,7 @@ import ErrorPanel from 'app/components/charts/errorPanel';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import TransitionChart from 'app/components/charts/transitionChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
-import {QuestionTooltip} from 'app/components/charts/styles';
+import QuestionTooltip from 'app/components/questionTooltip';
 import {getInterval} from 'app/components/charts/utils';
 import {IconWarning} from 'app/icons';
 import EventsRequest from 'app/views/events/utils/eventsRequest';

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
@@ -8,7 +8,7 @@ import {t} from 'app/locale';
 import AreaChart from 'app/components/charts/areaChart';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LoadingPanel from 'app/components/charts/loadingPanel';
-import {QuestionTooltip} from 'app/components/charts/styles';
+import QuestionTooltip from 'app/components/questionTooltip';
 import AsyncComponent from 'app/components/asyncComponent';
 import {OrganizationSummary} from 'app/types';
 import EventView from 'app/utils/discover/eventView';

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -9,7 +9,7 @@ import {t} from 'app/locale';
 import BarChart from 'app/components/charts/barChart';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LoadingPanel from 'app/components/charts/loadingPanel';
-import {QuestionTooltip} from 'app/components/charts/styles';
+import QuestionTooltip from 'app/components/questionTooltip';
 import AsyncComponent from 'app/components/asyncComponent';
 import {OrganizationSummary} from 'app/types';
 import EventView from 'app/utils/discover/eventView';

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -10,7 +10,8 @@ import EventView from 'app/utils/discover/eventView';
 import ChartZoom from 'app/components/charts/chartZoom';
 import LineChart from 'app/components/charts/lineChart';
 import ErrorPanel from 'app/components/charts/errorPanel';
-import {SectionHeading, QuestionTooltip} from 'app/components/charts/styles';
+import QuestionTooltip from 'app/components/questionTooltip';
+import {SectionHeading} from 'app/components/charts/styles';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import TransitionChart from 'app/components/charts/transitionChart';
 import {getInterval} from 'app/components/charts/utils';
@@ -219,8 +220,6 @@ const RelativeBox = styled('div')`
 
 const ChartTitle = styled(SectionHeading)<{top: string}>`
   background: ${p => p.theme.white};
-  display: flex;
-  align-items: center;
   position: absolute;
   top: ${p => p.top};
   margin: 0;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormField.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {css} from '@emotion/core';
 
-import {IconQuestion} from 'app/icons';
-import Tooltip from 'app/components/tooltip';
+import QuestionTooltip from 'app/components/questionTooltip';
 import space from 'app/styles/space';
 
 type Props = {
@@ -22,9 +21,7 @@ const DataPrivacyRulesFormField = ({
   <Wrapper isFullWidth={isFullWidth}>
     <Label>
       <LabelDescription>{label}</LabelDescription>
-      <Tooltip title={tooltipInfo} position="top">
-        <IconQuestion color="gray1" />
-      </Tooltip>
+      <QuestionTooltip title={tooltipInfo} position="top" size="sm" />
     </Label>
     {children}
   </Wrapper>

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldControl.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldControl.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import FieldControlState from 'app/views/settings/components/forms/field/fieldControlState';
-import InlineSvg from 'app/components/inlineSvg';
-import Tooltip from 'app/components/tooltip';
+import QuestionTooltip from 'app/components/questionTooltip';
 import space from 'app/styles/space';
 
 const defaultProps = {
@@ -52,9 +51,7 @@ class FieldControl extends React.Component<Props> {
 
           {disabled && disabledReason && (
             <DisabledIndicator className="disabled-indicator">
-              <Tooltip title={disabledReason}>
-                <StyledInlineSvg src="icon-circle-question" size="18px" />
-              </Tooltip>
+              <StyledQuestionTooltip title={disabledReason} size="sm" position="top" />
             </DisabledIndicator>
           )}
 
@@ -91,16 +88,9 @@ const FieldControlWrapper = styled('div')`
   flex-shrink: 0;
 `;
 
-const StyledInlineSvg = styled(InlineSvg)`
+const StyledQuestionTooltip = styled(QuestionTooltip)`
   display: block;
-  color: ${p => p.theme.gray1};
   margin: 0 auto;
-  cursor: pointer;
-  transition: 0.15s color;
-
-  &:hover {
-    color: ${p => p.theme.gray3};
-  }
 `;
 
 const DisabledIndicator = styled('div')`


### PR DESCRIPTION
Consolidate and normalize the ? icon + tooltip pattern we have in a few places. I've pulled in the hover effect from one of the implementations and also made form field icons 2px smaller as 18px is not a standard icon size for us.