### PR TITLE
ref(ui): Replace `<AlertMessage>` usage in spans interface

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -1,19 +1,20 @@
-import React from 'react';
-import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
+import React from 'react';
 import * as ReactRouter from 'react-router';
+import styled from '@emotion/styled';
 
+import {IconWarning} from 'app/icons';
+import {Panel} from 'app/components/panels';
 import {SentryTransactionEvent, Organization} from 'app/types';
+import {TableData} from 'app/views/eventsV2/table/types';
+import {stringifyQueryObject, QueryResults} from 'app/utils/tokenizeSearch';
 import {t, tn} from 'app/locale';
+import Alert from 'app/components/alert';
+import DiscoverQuery from 'app/utils/discover/discoverQuery';
+import EventView from 'app/utils/discover/eventView';
 import SearchBar from 'app/components/searchBar';
 import SentryTypes from 'app/sentryTypes';
-import {Panel} from 'app/components/panels';
 import space from 'app/styles/space';
-import EventView from 'app/utils/discover/eventView';
-import DiscoverQuery from 'app/utils/discover/discoverQuery';
-import {stringifyQueryObject, QueryResults} from 'app/utils/tokenizeSearch';
-import AlertMessage from 'app/components/alertMessage';
-import {TableData} from 'app/views/eventsV2/table/types';
 import withOrganization from 'app/utils/withOrganization';
 
 import {ParsedTraceType} from './types';
@@ -78,17 +79,11 @@ class SpansInterface extends React.Component<Props, State> {
     );
 
     return (
-      <AlertMessageContainer>
-        <AlertMessage
-          alert={{
-            id: 'transaction-alert',
-            message: <span>{label}</span>,
-            type: 'error',
-          }}
-          system={false}
-          hideCloseButton
-        />
-      </AlertMessageContainer>
+      <AlertContainer>
+        <Alert type="error" icon={<IconWarning size="md" />}>
+          {label}
+        </Alert>
+      </AlertContainer>
     );
   }
 
@@ -183,7 +178,7 @@ const StyledSearchBar = styled(SearchBar)`
   margin-bottom: ${space(1)};
 `;
 
-const AlertMessageContainer = styled('div')`
+const AlertContainer = styled('div')`
   margin-bottom: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -1,24 +1,25 @@
 import React from 'react';
-import styled from '@emotion/styled';
 import map from 'lodash/map';
+import styled from '@emotion/styled';
 
-import {t, tct} from 'app/locale';
+import {Client} from 'app/api';
+import {IconWarning} from 'app/icons';
+import {TableDataRow} from 'app/views/eventsV2/table/types';
+import {assert} from 'app/types/utils';
+import {generateEventSlug, eventDetailsRoute} from 'app/utils/discover/urls';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import {t, tct} from 'app/locale';
+import Alert from 'app/components/alert';
+import Button from 'app/components/button';
 import DateTime from 'app/components/dateTime';
+import EventView from 'app/utils/discover/eventView';
+import Link from 'app/components/links/link';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import Pills from 'app/components/pills';
 import Pill from 'app/components/pill';
+import Pills from 'app/components/pills';
+import getDynamicText from 'app/utils/getDynamicText';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
-import {Client} from 'app/api';
-import Button from 'app/components/button';
-import {generateEventSlug, eventDetailsRoute} from 'app/utils/discover/urls';
-import EventView from 'app/utils/discover/eventView';
-import getDynamicText from 'app/utils/getDynamicText';
-import {assert} from 'app/types/utils';
-import AlertMessage from 'app/components/alertMessage';
-import {TableDataRow} from 'app/views/eventsV2/table/types';
-import Link from 'app/components/links/link';
 
 import {ProcessedSpanType, RawSpanType, ParsedTraceType} from './types';
 import {isGapSpan, isOrphanSpan, getTraceDateTimeRange} from './utils';
@@ -217,21 +218,11 @@ class SpanDetail extends React.Component<Props, State> {
     }
 
     return (
-      <AlertMessage
-        alert={{
-          id: `orphan-span-${span.span_id}`,
-          message: (
-            <span>
-              {t(
-                'This is a span that has no parent span within this transaction. It has been attached to the transaction root span by default.'
-              )}
-            </span>
-          ),
-          type: 'info',
-        }}
-        system
-        hideCloseButton
-      />
+      <Alert system type="info" icon={<IconWarning size="md" />}>
+        {t(
+          'This is a span that has no parent span within this transaction. It has been attached to the transaction root span by default.'
+        )}
+      </Alert>
     );
   }
 
@@ -303,15 +294,9 @@ class SpanDetail extends React.Component<Props, State> {
       );
 
     return (
-      <AlertMessage
-        alert={{
-          id: `span-error-${span.span_id}`,
-          message,
-          type: 'error',
-        }}
-        system
-        hideCloseButton
-      />
+      <Alert system type="error" icon={<IconWarning size="md" />}>
+        {message}
+      </Alert>
     );
   }
 


### PR DESCRIPTION
This replaces the usage of `<AlertMessage>` in spans interface that was added in https://github.com/getsentry/sentry/pull/18025. It was not obvious, but `<AlertMessage>` should only be used in the `<Alerts>` component (e.g. via the Alerts store and not directly). There will be some follow-up PRs that address this, as this has been a common question.


![image](https://user-images.githubusercontent.com/79684/81607435-889cc700-9389-11ea-94dd-c819763b78ad.png)

![image](https://user-images.githubusercontent.com/79684/81607604-cdc0f900-9389-11ea-977a-610d18047c05.png)
