### PR TITLE
ref(ui): Remove `hideCloseButton` prop from `<AlertMessage>`

### DIFF
--- a/src/sentry/static/sentry/app/components/alertMessage.tsx
+++ b/src/sentry/static/sentry/app/components/alertMessage.tsx
@@ -19,10 +19,9 @@ type AlertType = {
 type Props = {
   alert: AlertType;
   system: boolean;
-  hideCloseButton?: boolean;
 };
 
-const AlertMessage = ({alert, system, hideCloseButton}: Props) => {
+const AlertMessage = ({alert, system}: Props) => {
   const handleCloseAlert = () => {
     AlertActions.closeAlert(alert);
   };
@@ -35,22 +34,18 @@ const AlertMessage = ({alert, system, hideCloseButton}: Props) => {
       <IconWarning size="md" />
     );
 
-  const closeButton = hideCloseButton ? null : (
-    <StyledCloseButton
-      icon={<IconClose size="md" isCircled />}
-      aria-label={t('Close')}
-      onClick={handleCloseAlert}
-      size="zero"
-      borderless
-    />
-  );
-
   return (
     <StyledAlert type={type} icon={icon} system={system}>
       <StyledMessage>
         {url ? <ExternalLink href={url}>{message}</ExternalLink> : message}
       </StyledMessage>
-      {closeButton}
+      <StyledCloseButton
+        icon={<IconClose size="md" isCircled />}
+        aria-label={t('Close')}
+        onClick={handleCloseAlert}
+        size="zero"
+        borderless
+      />
     </StyledAlert>
   );
 };


### PR DESCRIPTION
`<AlertMessage>` is being refactored to be a more "private" component and this prop will no longer be needed. This reverts #18173 as we have removed the only usage of this prop.

See https://github.com/getsentry/sentry/pull/18738 for information.
