### PR TITLE
feat(performance) Add the user misery score bar component

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -15,6 +15,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import {formatFloat, formatPercentage} from 'app/utils/formatters';
 import {getAggregateAlias} from 'app/utils/discover/fields';
 import Projects from 'app/utils/projects';
+import theme from 'app/utils/theme';
 
 import {
   Container,
@@ -293,7 +294,7 @@ const SPECIAL_FUNCTIONS: SpecialFunctions = {
         );
       }
 
-      const palette = new Array(10).fill('#1a1772');
+      const palette = new Array(10).fill(theme.purpleDarkest);
       const score = Math.floor((userMisery / Math.max(uniqueUsers, 1)) * palette.length);
       const miseryLimit = parseInt(userMiseryField.split('_').pop(), 10);
       const title = `${userMisery} out of ${uniqueUsers} unique users waited more than ${4 *

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -5,12 +5,14 @@ import partial from 'lodash/partial';
 import {Organization} from 'app/types';
 import {t} from 'app/locale';
 import Count from 'app/components/count';
-import ProjectBadge from 'app/components/idBadge/projectBadge';
-import UserBadge from 'app/components/idBadge/userBadge';
-import getDynamicText from 'app/utils/getDynamicText';
 import Duration from 'app/components/duration';
-import {formatFloat, formatPercentage} from 'app/utils/formatters';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
+import ScoreBar from 'app/components/scoreBar';
+import Tooltip from 'app/components/tooltip';
+import UserBadge from 'app/components/idBadge/userBadge';
 import Version from 'app/components/version';
+import getDynamicText from 'app/utils/getDynamicText';
+import {formatFloat, formatPercentage} from 'app/utils/formatters';
 import {getAggregateAlias} from 'app/utils/discover/fields';
 import Projects from 'app/utils/projects';
 
@@ -258,6 +260,53 @@ const SPECIAL_FIELDS: SpecialFields = {
   },
 };
 
+type SpecialFunctions = {
+  user_misery: SpecialField;
+};
+
+/**
+ * "Special functions" are functions whose values either do not map 1:1 to a single column,
+ * or they require custom UI formatting that can't be handled by the datatype formatters.
+ */
+const SPECIAL_FUNCTIONS: SpecialFunctions = {
+  user_misery: {
+    sortField: null,
+    renderFunc: data => {
+      const uniqueUsers = data.count_unique_user;
+      let userMiseryField;
+      for (const field in data) {
+        if (field.startsWith('user_misery')) {
+          userMiseryField = field;
+        }
+      }
+      if (!userMiseryField) {
+        return <NumberContainer>{emptyValue}</NumberContainer>;
+      }
+
+      const userMisery = data[userMiseryField];
+
+      if (!uniqueUsers && uniqueUsers !== 0) {
+        return (
+          <NumberContainer>
+            {typeof userMisery === 'number' ? formatFloat(userMisery, 4) : emptyValue}
+          </NumberContainer>
+        );
+      }
+
+      const palette = new Array(10).fill('#1a1772');
+      const score = Math.floor((userMisery / Math.max(uniqueUsers, 1)) * palette.length);
+      const miseryLimit = parseInt(userMiseryField.split('_').pop(), 10);
+      const title = `${userMisery} out of ${uniqueUsers} unique users waited more than ${4 *
+        miseryLimit}ms`;
+      return (
+        <Tooltip title={title} disabled={false}>
+          <ScoreBar size={20} score={score} palette={palette} />
+        </Tooltip>
+      );
+    },
+  },
+};
+
 /**
  * Get the sort field name for a given field if it is special or fallback
  * to the generic type formatter.
@@ -300,6 +349,12 @@ export function getFieldRenderer(
   }
   const fieldName = getAggregateAlias(field);
   const fieldType = meta[fieldName];
+
+  for (const alias in SPECIAL_FUNCTIONS) {
+    if (fieldName.startsWith(alias)) {
+      return SPECIAL_FUNCTIONS[alias].renderFunc;
+    }
+  }
 
   if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
     return partial(FIELD_FORMATTERS[fieldType].renderFunc, fieldName);

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -21,8 +21,8 @@ export const PERFORMANCE_EVENT_VIEW: Readonly<NewQuery> = {
     'p95()',
     'error_rate()',
     'apdex(300)',
-    'user_misery(300)',
     'count_unique(user)',
+    'user_misery(300)',
   ],
   version: 2,
 };


### PR DESCRIPTION
Change user misery to use the score bar component on the performance page.
![Screen Shot 2020-05-11 at 4 34 13 PM](https://user-images.githubusercontent.com/2727124/81611324-db39ab80-93a8-11ea-8a68-4c740c963994.png)

With tooltip:
![Screen Shot 2020-05-11 at 4 56 03 PM](https://user-images.githubusercontent.com/2727124/81611341-e1c82300-93a8-11ea-91bf-99d562d9a4ba.png)

