### PR TITLE
ref(ui): Move `<Alerts>` and `<AlertMessages>`

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -170,7 +170,7 @@ globals.SentryApp = {
   passwordStrength: {load: loadPasswordStrength},
   U2fSign: require('app/components/u2f/u2fsign').default,
   ConfigStore: require('app/stores/configStore').default,
-  Alerts: require('app/components/alerts').default,
+  SystemAlerts: require('app/views/app/systemAlerts').default,
   Indicators: require('app/components/indicators').default,
   SetupWizard: require('app/components/setupWizard').default,
 };

--- a/src/sentry/static/sentry/app/views/app/alertMessage.tsx
+++ b/src/sentry/static/sentry/app/views/app/alertMessage.tsx
@@ -10,7 +10,10 @@ import {IconCheckmark, IconClose, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 
 type AlertType = {
-  id: string;
+  /**
+   * A lot of alerts coming from getsentry do not have an `id`
+   */
+  id?: string;
   message: React.ReactNode;
   type: 'success' | 'error' | 'warning' | 'info';
   url?: string;

--- a/src/sentry/static/sentry/app/views/app/index.tsx
+++ b/src/sentry/static/sentry/app/views/app/index.tsx
@@ -17,7 +17,6 @@ import {openCommandPalette} from 'app/actionCreators/modal';
 import {setTransactionName} from 'app/utils/apm';
 import {t} from 'app/locale';
 import AlertActions from 'app/actions/alertActions';
-import Alerts from 'app/components/alerts';
 import ConfigStore from 'app/stores/configStore';
 import ErrorBoundary from 'app/components/errorBoundary';
 import GlobalModal from 'app/components/globalModal';
@@ -31,6 +30,8 @@ import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 import withConfig from 'app/utils/withConfig';
+
+import SystemAlerts from './systemAlerts';
 
 // TODO: Need better way of identifying anonymous pages that don't trigger redirect
 const ALLOWED_ANON_PAGES = [
@@ -260,7 +261,7 @@ class App extends React.Component<Props, State> {
         <GlobalStyles theme={theme} />
         <div className="main-container" tabIndex={-1} ref={this.mainContainerRef}>
           <GlobalModal onClose={this.handleGlobalModalClose} />
-          <Alerts className="messages-container" />
+          <SystemAlerts className="messages-container" />
           <Indicators className="indicators-container" />
           <ErrorBoundary>{this.renderBody()}</ErrorBoundary>
         </div>

--- a/src/sentry/static/sentry/app/views/app/systemAlerts.tsx
+++ b/src/sentry/static/sentry/app/views/app/systemAlerts.tsx
@@ -4,8 +4,9 @@ import Reflux from 'reflux';
 import {ThemeProvider} from 'emotion-theming';
 
 import AlertStore from 'app/stores/alertStore';
-import AlertMessage from 'app/components/alertMessage';
 import theme from 'app/utils/theme';
+
+import AlertMessage from './alertMessage';
 
 type Props = {className?: string};
 type Alert = React.ComponentProps<typeof AlertMessage>['alert'];
@@ -29,8 +30,8 @@ const Alerts = createReactClass<Props, State>({
     return (
       <ThemeProvider theme={theme}>
         <div className={className}>
-          {alerts.map(alert => (
-            <AlertMessage alert={alert} key={alert.id} system />
+          {alerts.map((alert, index) => (
+            <AlertMessage alert={alert} key={`${alert.id}-${index}`} system />
           ))}
         </div>
       </ThemeProvider>

--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -2,7 +2,7 @@
 <div id="blk_alerts" class="messages-container"></div>
 <script>
 $(function(){
-  ReactDOM.render(React.createFactory(SentryApp.Alerts)({
+  ReactDOM.render(React.createFactory(SentryApp.SystemAlerts)({
      className: "alert-list"
   }), document.getElementById('blk_alerts'));
 });


### PR DESCRIPTION
These are not re-usable components, they are containers to display alerts
messages that [generally] come from django. As such, these components are
moved and renamed to be closer to where they are used. There are also
changes required in `getsentry`