### PR TITLE
feat(integrations): Request Integration Button

### DIFF
--- a/src/sentry/api/bases/organization_integrations.py
+++ b/src/sentry/api/bases/organization_integrations.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+from django.http import Http404
+
+from sentry.api.bases.integration import IntegrationEndpoint
+from sentry.models import Integration, Organization, OrganizationIntegration
+
+
+class OrganizationIntegrationBaseEndpoint(IntegrationEndpoint):
+    """
+    OrganizationIntegrationBaseEndpoints expect both Integration and
+    OrganizationIntegration DB entries to exist for a given organization and
+    integration_id.
+    """
+
+    @staticmethod
+    def get_organization_integration(organization, integration_id):
+        """
+        Get just the cross table entry.
+        Note: This will still return migrations that are pending deletion.
+
+        :param organization:
+        :param integration_id:
+        :return:
+        """
+        try:
+            return OrganizationIntegration.objects.get(
+                integration_id=integration_id,
+                organization=organization,
+            )
+        except OrganizationIntegration.DoesNotExist:
+            raise Http404
+
+    @staticmethod
+    def get_integration(organization, integration_id):
+        """
+        Note: The integration may still exist even when the
+        OrganizationIntegration cross table entry has been deleted.
+
+        :param organization:
+        :param integration_id:
+        :return:
+        """
+        try:
+            return Integration.objects.get(id=integration_id, organizations=organization)
+        except Integration.DoesNotExist:
+            raise Http404

--- a/src/sentry/api/bases/organization_integrations.py
+++ b/src/sentry/api/bases/organization_integrations.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.http import Http404
 
 from sentry.api.bases.integration import IntegrationEndpoint
-from sentry.models import Integration, Organization, OrganizationIntegration
+from sentry.models import Integration, OrganizationIntegration
 
 
 class OrganizationIntegrationBaseEndpoint(IntegrationEndpoint):
@@ -25,8 +25,7 @@ class OrganizationIntegrationBaseEndpoint(IntegrationEndpoint):
         """
         try:
             return OrganizationIntegration.objects.get(
-                integration_id=integration_id,
-                organization=organization,
+                integration_id=integration_id, organization=organization,
             )
         except OrganizationIntegration.DoesNotExist:
             raise Http404

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -3,38 +3,28 @@ from __future__ import absolute_import
 from uuid import uuid4
 
 import six
-from django.http import Http404
 
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
+from sentry.api.bases.organization import OrganizationIntegrationsPermission
+from sentry.api.bases.organization_integrations import OrganizationIntegrationBaseEndpoint
 from sentry.api.serializers import serialize
-from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.models import AuditLogEntryEvent, Integration, ObjectStatus, OrganizationIntegration
+from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.tasks.deletion import delete_organization_integration
 from sentry.utils.audit import create_audit_entry
 
 
-class OrganizationIntegrationDetailsEndpoint(OrganizationEndpoint):
+class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint):
     permission_classes = (OrganizationIntegrationsPermission,)
 
     def get(self, request, organization, integration_id):
-        try:
-            integration = OrganizationIntegration.objects.get(
-                integration_id=integration_id, organization=organization
-            )
-        except OrganizationIntegration.DoesNotExist:
-            raise Http404
+        org_integration = self.get_organization_integration(organization, integration_id)
 
-        return self.respond(serialize(integration, request.user))
+        return self.respond(serialize(org_integration, request.user))
 
     def delete(self, request, organization, integration_id):
         # Removing the integration removes the organization
         # integrations and all linked issues.
-        try:
-            org_integration = OrganizationIntegration.objects.get(
-                integration_id=integration_id, organization=organization
-            )
-        except OrganizationIntegration.DoesNotExist:
-            raise Http404
+        org_integration = self.get_organization_integration(organization, integration_id)
 
         updated = OrganizationIntegration.objects.filter(
             id=org_integration.id, status=ObjectStatus.VISIBLE
@@ -61,11 +51,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationEndpoint):
         return self.respond(status=204)
 
     def post(self, request, organization, integration_id):
-        try:
-            integration = Integration.objects.get(id=integration_id, organizations=organization)
-        except Integration.DoesNotExist:
-            raise Http404
-
+        integration = self.get_integration(organization, integration_id)
         installation = integration.get_installation(organization.id)
         try:
             installation.update_organization_config(request.data)

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -7,7 +7,7 @@ import six
 from sentry.api.bases.organization import OrganizationIntegrationsPermission
 from sentry.api.bases.organization_integrations import OrganizationIntegrationBaseEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import AuditLogEntryEvent, Integration, ObjectStatus, OrganizationIntegration
+from sentry.models import AuditLogEntryEvent, ObjectStatus, OrganizationIntegration
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.tasks.deletion import delete_organization_integration
 from sentry.utils.audit import create_audit_entry

--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -4,13 +4,13 @@ import six
 from django.http import Http404
 
 from sentry.constants import ObjectStatus
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
+from sentry.api.bases.organization import OrganizationIntegrationsPermission
+from sentry.api.bases.organization_integrations import OrganizationIntegrationBaseEndpoint
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.integrations.repositories import RepositoryMixin
-from sentry.models import Integration
 
 
-class OrganizationIntegrationReposEndpoint(OrganizationEndpoint):
+class OrganizationIntegrationReposEndpoint(OrganizationIntegrationBaseEndpoint):
     permission_classes = (OrganizationIntegrationsPermission,)
 
     def get(self, request, organization, integration_id):
@@ -24,10 +24,7 @@ class OrganizationIntegrationReposEndpoint(OrganizationEndpoint):
 
         :qparam string search: Name fragment to search repositories by.
         """
-        try:
-            integration = Integration.objects.get(id=integration_id, organizations=organization)
-        except Integration.DoesNotExist:
-            raise Http404
+        integration = self.get_integration(organization, integration_id)
 
         if integration.status == ObjectStatus.DISABLED:
             context = {"repos": []}

--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import six
-from django.http import Http404
 
 from sentry.constants import ObjectStatus
 from sentry.api.bases.organization import OrganizationIntegrationsPermission

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -94,9 +94,11 @@ class OrganizationIntegrationRequestEndpoint(OrganizationEndpoint):
         except Exception as error:
             return Response({"detail": error.message}, status=400)
 
-        # If for some reason the user had permissions all along, silently fail.
         requester = request.user
-        if requester.id in [user.id for user in organization.get_owners()]:
+        owners_list = organization.get_owners()
+
+        # If for some reason the user had permissions all along, silently fail.
+        if requester.id in [user.id for user in owners_list]:
             return Response({"detail": "User can install integration"}, status=200)
 
         msg = MessageBuilder(
@@ -120,6 +122,6 @@ class OrganizationIntegrationRequestEndpoint(OrganizationEndpoint):
             },
         )
 
-        msg.send_async([user.email for user in organization.get_owners()])
+        msg.send_async([user.email for user in owners_list])
 
         return Response(status=201)

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -42,7 +42,7 @@ def get_provider_name(provider_type, provider_slug):
     want and not what type they want. This function looks up the display name
     for the integration they want installed.
 
-    :param provider_type: One of: "integrations", "plugins", or "sentryapps".
+    :param provider_type: One of: "first_party", "plugin", or "sentry_app".
     :param provider_slug: The unique identifier for the provider.
     :return: The display name for the provider.
 
@@ -67,7 +67,7 @@ def get_provider_name(provider_type, provider_slug):
         except KeyError:
             raise Exception("Provider {} not found".format(provider_slug))
     else:
-        raise ValueError("Invalid provider_type")
+        raise ValueError("Invalid provider_type {}".format(provider_type))
 
 
 class OrganizationIntegrationRequestEndpoint(OrganizationEndpoint):
@@ -81,12 +81,12 @@ class OrganizationIntegrationRequestEndpoint(OrganizationEndpoint):
         they lack the ability to install them themselves. POSTing to this API
         alerts users with permission that there is demand for this integration.
 
-        :param string provider_slug: Unique string that identifies the integration.
-        :param string provider_name: One of: integration, plugin, sentryapp.
+        :param string providerSlug: Unique string that identifies the integration.
+        :param string providerType: One of: first_party, plugin, sentry_app.
         :param string message: Optional message from the requester to the owners.
         """
-        provider_type = request.data.get("provider_type")
-        provider_slug = request.data.get("provider_slug")
+        provider_type = request.data.get("providerType")
+        provider_slug = request.data.get("providerSlug")
         message_option = request.data.get("message", "").strip()
 
         try:

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -25,9 +25,9 @@ def get_url(organization, provider_type, provider_slug):
             u"/settings",
             organization.slug,
             {
-                "sentryapp": "sentry-apps",
+                "first_party": "integrations",
                 "plugin": "plugins",
-                "integration": "integrations",
+                "sentry_app": "sentry-apps",
             }.get(provider_type),
             provider_slug,
         ])
@@ -49,25 +49,17 @@ def get_provider_name(provider_type, provider_slug):
     :raises: ValueError if provider_type is not one of the three from above.
     :raises: Exception if the provider is not found.
     """
-    if provider_type == "sentry_app":
-        sentry_app = SentryApp.objects.get(slug=provider_slug)
-        if not sentry_app:
-            raise Exception("Provider {} not found".format(provider_slug))
-        return sentry_app.name
-
-    elif provider_type == "first_party":
-        try:
-            return integrations.get(provider_slug).name
-        except KeyError:
-            raise Exception("Provider {} not found".format(provider_slug))
-
-    elif provider_type == "plugin":
-        try:
+    try:
+        if provider_type == "first_party":
+            return integrations.get(provider_slug).name,
+        elif provider_type == "plugin":
             return plugins.get(provider_slug).title
-        except KeyError:
-            raise Exception("Provider {} not found".format(provider_slug))
-    else:
-        raise ValueError("Invalid provider_type {}".format(provider_type))
+        elif provider_type == "sentry_app":
+            return SentryApp.objects.get(slug=provider_slug).name
+        else:
+            raise ValueError(u"Invalid provider_type {}".format(provider_type))
+    except (KeyError, SentryApp.DoesNotExist):
+        raise Exception(u"Provider {} not found".format(provider_slug))
 
 
 class OrganizationIntegrationRequestEndpoint(OrganizationEndpoint):

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -1,0 +1,125 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from rest_framework.response import Response
+
+from sentry import integrations
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases import OrganizationPermission
+from sentry.plugins.base import plugins
+from sentry.models import SentryApp
+from sentry.utils.email import MessageBuilder
+from sentry.utils.http import absolute_uri
+
+
+class OrganizationIntegrationRequestPermission(OrganizationPermission):
+    scope_map = {
+        "POST": ["org:read"],
+    }
+
+
+def get_url(organization, provider_type, provider_slug):
+    return absolute_uri(
+        u"/".join([
+            u"/settings",
+            organization.slug,
+            {
+                "sentryapp": "sentry-apps",
+                "plugin": "plugins",
+                "integration": "integrations",
+            }.get(provider_type),
+            provider_slug,
+        ])
+    )
+
+
+def get_provider_name(provider_type, provider_slug):
+    """
+    The things that users think of as "integrations" are actually three
+    different things: integrations, plugins, and sentryapps. A user requesting
+    than an integration be installed only actually knows the "provider" they
+    want and not what type they want. This function looks up the display name
+    for the integration they want installed.
+
+    :param provider_type: One of: "integrations", "plugins", or "sentryapps".
+    :param provider_slug: The unique identifier for the provider.
+    :return: The display name for the provider.
+
+    :raises: ValueError if provider_type is not one of the three from above.
+    :raises: Exception if the provider is not found.
+    """
+    if provider_type == "sentryapp":
+        sentry_app = SentryApp.objects.get(slug=provider_slug)
+        if not sentry_app:
+            raise Exception("Provider {} not found".format(provider_slug))
+        return sentry_app.name
+
+    elif provider_type == "integration":
+        try:
+            return integrations.get(provider_slug).name
+        except KeyError:
+            raise Exception("Provider {} not found".format(provider_slug))
+
+    elif provider_type == "plugin":
+        try:
+            return plugins.get(provider_slug).title
+        except KeyError:
+            raise Exception("Provider {} not found".format(provider_slug))
+    else:
+        raise ValueError("Invalid provider_type")
+
+
+class OrganizationIntegrationRequestEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationIntegrationRequestPermission,)
+
+    def post(self, request, organization):
+        """
+        Email the organization owners asking them to install an integration.
+        ````````````````````````````````````````````````````````````````````
+        When a non-owner user views integrations in the integrations directory,
+        they lack the ability to install them themselves. POSTing to this API
+        alerts users with permission that there is demand for this integration.
+
+        :param string provider_slug: Unique string that identifies the integration.
+        :param string provider_name: One of: integration, plugin, sentryapp.
+        :param string message: Optional message from the requester to the owners.
+        """
+        provider_type = request.data.get("provider_type")
+        provider_slug = request.data.get("provider_slug")
+        message_option = request.data.get("message", "").strip()
+
+        try:
+            provider_name = get_provider_name(provider_type, provider_slug)
+        except Exception as error:
+            return Response({"detail": error.message}, status=400)
+
+        # If for some reason the user had permissions all along, silently fail.
+        requester = request.user
+        if requester.id in [user.id for user in organization.get_owners()]:
+            return Response({"detail": "User can install integration"}, status=200)
+
+        msg = MessageBuilder(
+            subject="Your team member requested the %s integration on Sentry" % provider_name,
+            template="sentry/emails/requests/organization-integration.txt",
+            html_template="sentry/emails/requests/organization-integration.html",
+            type="organization.integration.request",
+            context={
+                "integration_link": get_url(organization, provider_type, provider_slug),
+                "integration_name": provider_name,
+                "message": message_option,
+                "organization_name": organization.name,
+                "requester_name": requester.name or requester.username,
+                "requester_link": absolute_uri(
+                    "/settings/{organization_slug}/members/{user_id}/".format(
+                        organization_slug=organization.slug,
+                        user_id=requester.id,
+                    )
+                ),
+                "settings_link": reverse("sentry-organization-settings", args=[organization.slug])
+            },
+        )
+
+        msg.send_async([user.email for user in organization.get_owners()])
+
+        return Response(status=201)

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -49,13 +49,13 @@ def get_provider_name(provider_type, provider_slug):
     :raises: ValueError if provider_type is not one of the three from above.
     :raises: Exception if the provider is not found.
     """
-    if provider_type == "sentryapp":
+    if provider_type == "sentry_app":
         sentry_app = SentryApp.objects.get(slug=provider_slug)
         if not sentry_app:
             raise Exception("Provider {} not found".format(provider_slug))
         return sentry_app.name
 
-    elif provider_type == "integration":
+    elif provider_type == "first_party":
         try:
             return integrations.get(provider_slug).name
         except KeyError:

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -110,7 +110,9 @@ class OrganizationIntegrationRequestEndpoint(OrganizationEndpoint):
                         user_id=requester.id,
                     )
                 ),
-                "settings_link": reverse("sentry-organization-settings", args=[organization.slug])
+                "settings_link": absolute_uri(
+                    reverse("sentry-organization-settings", args=[organization.slug])
+                ),
             },
         )
 

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -51,13 +51,13 @@ def get_provider_name(provider_type, provider_slug):
     """
     try:
         if provider_type == "first_party":
-            return integrations.get(provider_slug).name,
+            return integrations.get(provider_slug).name
         elif provider_type == "plugin":
             return plugins.get(provider_slug).title
         elif provider_type == "sentry_app":
             return SentryApp.objects.get(slug=provider_slug).name
         else:
-            raise ValueError(u"Invalid provider_type {}".format(provider_type))
+            raise ValueError(u"Invalid providerType {}".format(provider_type))
     except (KeyError, SentryApp.DoesNotExist):
         raise Exception(u"Provider {} not found".format(provider_slug))
 

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -21,16 +21,18 @@ class OrganizationIntegrationRequestPermission(OrganizationPermission):
 
 def get_url(organization, provider_type, provider_slug):
     return absolute_uri(
-        u"/".join([
-            u"/settings",
-            organization.slug,
-            {
-                "first_party": "integrations",
-                "plugin": "plugins",
-                "sentry_app": "sentry-apps",
-            }.get(provider_type),
-            provider_slug,
-        ])
+        u"/".join(
+            [
+                u"/settings",
+                organization.slug,
+                {
+                    "first_party": "integrations",
+                    "plugin": "plugins",
+                    "sentry_app": "sentry-apps",
+                }.get(provider_type),
+                provider_slug,
+            ]
+        )
     )
 
 
@@ -106,8 +108,7 @@ class OrganizationIntegrationRequestEndpoint(OrganizationEndpoint):
                 "requester_name": requester.name or requester.username,
                 "requester_link": absolute_uri(
                     "/settings/{organization_slug}/members/{user_id}/".format(
-                        organization_slug=organization.slug,
-                        user_id=requester.id,
+                        organization_slug=organization.slug, user_id=requester.id,
                     )
                 ),
                 "settings_link": absolute_uri(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -101,6 +101,7 @@ from .endpoints.organization_group_index import OrganizationGroupIndexEndpoint
 from .endpoints.organization_index import OrganizationIndexEndpoint
 from .endpoints.organization_integration_details import OrganizationIntegrationDetailsEndpoint
 from .endpoints.organization_integration_repos import OrganizationIntegrationReposEndpoint
+from .endpoints.organization_integration_request import OrganizationIntegrationRequestEndpoint
 from .endpoints.organization_integrations import OrganizationIntegrationsEndpoint
 from .endpoints.organization_issues_new import OrganizationIssuesNewEndpoint
 from .endpoints.organization_issues_resolved_in_release import (
@@ -842,6 +843,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/members/$",
                     OrganizationMemberIndexEndpoint.as_view(),
                     name="sentry-api-0-organization-member-index",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/integration-requests/$",
+                    OrganizationIntegrationRequestEndpoint.as_view(),
+                    name="sentry-api-0-organization-integration-request",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/invite-requests/$",

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -73,7 +73,7 @@ FEATURES = [
     FeatureDescription(
         """
         Never forget to close a resolved workitem! Resolving an issue in Sentry
-        will resolve your linked workitems and viceversa.
+        will resolve your linked workitems and vice versa.
         """,
         IntegrationFeatures.ISSUE_SYNC,
     ),

--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -6,13 +6,13 @@ import {RouteComponentProps} from 'react-router/lib/Router';
 import {WithRouterProps} from 'react-router/lib/withRouter';
 
 import {Client} from 'app/api';
-import {metric} from 'app/utils/analytics';
 import {t} from 'app/locale';
 import AsyncComponentSearchInput from 'app/components/asyncComponentSearchInput';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import PermissionDenied from 'app/views/permissionDenied';
 import RouteError from 'app/views/routeError';
+import {metric} from 'app/utils/analytics';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 
 type AsyncComponentProps = {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -435,6 +435,12 @@ export type AppOrProviderOrPlugin =
   | PluginWithProjectList
   | DocumentIntegration;
 
+export type IntegrationType =
+  | 'document_integration'
+  | 'plugin'
+  | 'first_party'
+  | 'sentry_app';
+
 export type DocumentIntegration = {
   slug: string;
   name: string;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -435,11 +435,7 @@ export type AppOrProviderOrPlugin =
   | PluginWithProjectList
   | DocumentIntegration;
 
-export type IntegrationType =
-  | 'document_integration'
-  | 'plugin'
-  | 'first_party'
-  | 'sentry_app';
+export type IntegrationType = 'document' | 'plugin' | 'first_party' | 'sentry_app';
 
 export type DocumentIntegration = {
   slug: string;

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -301,7 +301,7 @@ export const convertIntegrationTypeToSnakeCase = (
     case 'sentryApp':
       return 'sentry_app';
     case 'documentIntegration':
-      return 'document_integration';
+      return 'document';
     default:
       return type;
   }

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -73,7 +73,7 @@ export type SingleIntegrationEvent = {
     | 'Integrations: Reauth Start'
     | 'Integrations: Reauth Complete';
   integration: string; //the slug
-  integration_type: 'plugin' | 'first_party' | 'sentry_app' | 'document_integration';
+  integration_type: IntegrationType;
   already_installed?: boolean;
   integration_tab?: 'configurations' | 'overview';
   plan?: string;

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -1,23 +1,24 @@
 import capitalize from 'lodash/capitalize';
 import React from 'react';
 
-import {uniqueId} from 'app/utils/guid';
-import {trackAnalyticsEvent} from 'app/utils/analytics';
+import HookStore from 'app/stores/hookStore';
 import {
-  Organization,
-  SentryAppInstallation,
-  IntegrationInstallationStatus,
-  SentryAppStatus,
-  IntegrationFeature,
   AppOrProviderOrPlugin,
-  SentryApp,
-  PluginWithProjectList,
   DocumentIntegration,
   Integration,
+  IntegrationFeature,
+  IntegrationInstallationStatus,
   IntegrationProvider,
+  IntegrationType,
+  Organization,
+  PluginWithProjectList,
+  SentryApp,
+  SentryAppInstallation,
+  SentryAppStatus,
 } from 'app/types';
 import {Hooks} from 'app/types/hooks';
-import HookStore from 'app/stores/hookStore';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
+import {uniqueId} from 'app/utils/guid';
 
 const INTEGRATIONS_ANALYTICS_SESSION_KEY = 'INTEGRATION_ANALYTICS_SESSION' as const;
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -109,7 +109,7 @@ class AbstractIntegrationDetailedView<
   }
 
   // Returns an array of RawIntegrationFeatures which is used in feature gating
-  // and displaying what the integraiton does
+  // and displaying what the integration does
   get featureData(): IntegrationFeature[] {
     // Allow children to implement this
     throw new Error('Not implemented');
@@ -181,7 +181,7 @@ class AbstractIntegrationDetailedView<
   }
 
   /***
-   * Actually implmeented methods below*
+   * Actually implemented methods below
    */
 
   get integrationSlug() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -16,6 +16,7 @@ import space from 'app/styles/space';
 import {
   IntegrationFeature,
   IntegrationInstallationStatus,
+  IntegrationType,
   Organization,
   SentryAppStatus,
 } from 'app/types';
@@ -72,7 +73,7 @@ class AbstractIntegrationDetailedView<
    */
 
   //The analytics type used in analytics which is snake case
-  get integrationType(): 'sentry_app' | 'first_party' | 'plugin' | 'document' {
+  get integrationType(): IntegrationType {
     // Allow children to implement this
     throw new Error('Not implemented');
   }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -31,6 +31,7 @@ import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import Tag from 'app/views/settings/components/tag';
 
 import IntegrationStatus from './integrationStatus';
+import RequestIntegrationButton from './integrationRequest/RequestIntegrationButton';
 
 type Tab = 'overview' | 'configurations';
 
@@ -236,6 +237,17 @@ class AbstractIntegrationDetailedView<
 
   cleanTags() {
     return getCategories(this.featureData);
+  }
+
+  renderRequestIntegrationButton(provider) {
+    return (
+      <RequestIntegrationButton
+        organization={this.props.organization}
+        name={provider.name}
+        slug={provider.slug}
+        type={this.integrationType}
+      />
+    );
   }
 
   renderAddInstallButton(hideButtonIfDisabled = false) {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -1,33 +1,33 @@
-import React from 'react';
-import styled from '@emotion/styled';
-import {RouteComponentProps} from 'react-router/lib/Router';
 import startCase from 'lodash/startCase';
+import React from 'react';
+import {RouteComponentProps} from 'react-router/lib/Router';
+import styled from '@emotion/styled';
 
-import {t} from 'app/locale';
-import AsyncComponent from 'app/components/asyncComponent';
-import space from 'app/styles/space';
-import Tag from 'app/views/settings/components/tag';
-import PluginIcon from 'app/plugins/components/pluginIcon';
 import Access from 'app/components/acl/access';
-import Tooltip from 'app/components/tooltip';
 import Alert, {Props as AlertProps} from 'app/components/alert';
+import AsyncComponent from 'app/components/asyncComponent';
 import ExternalLink from 'app/components/links/externalLink';
-import marked, {singleLineRenderer} from 'app/utils/marked';
-import {IconClose, IconGithub, IconGeneric, IconDocs, IconProject} from 'app/icons';
+import {Panel} from 'app/components/panels';
+import Tooltip from 'app/components/tooltip';
+import {IconClose, IconDocs, IconGeneric, IconGithub, IconProject} from 'app/icons';
+import {t} from 'app/locale';
+import PluginIcon from 'app/plugins/components/pluginIcon';
+import space from 'app/styles/space';
 import {
-  Organization,
   IntegrationFeature,
   IntegrationInstallationStatus,
+  Organization,
   SentryAppStatus,
 } from 'app/types';
 import {
-  getIntegrationFeatureGate,
-  trackIntegrationEvent,
-  SingleIntegrationEvent,
   getCategories,
+  getIntegrationFeatureGate,
+  SingleIntegrationEvent,
+  trackIntegrationEvent,
 } from 'app/utils/integrationUtil';
-import {Panel} from 'app/components/panels';
+import marked, {singleLineRenderer} from 'app/utils/marked';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import Tag from 'app/views/settings/components/tag';
 
 import IntegrationStatus from './integrationStatus';
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -239,12 +239,12 @@ class AbstractIntegrationDetailedView<
     return getCategories(this.featureData);
   }
 
-  renderRequestIntegrationButton(provider) {
+  renderRequestIntegrationButton() {
     return (
       <RequestIntegrationButton
         organization={this.props.organization}
-        name={provider.name}
-        slug={provider.slug}
+        name={this.integrationName}
+        slug={this.integrationSlug}
         type={this.integrationType}
       />
     );

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegrationButton.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import {t} from 'app/locale';
-import AddIntegration from 'app/views/organizationIntegrations/addIntegration';
 import Button from 'app/components/button';
 import Tooltip from 'app/components/tooltip';
-import {IntegrationProvider, Integration, Organization} from 'app/types';
+import {t} from 'app/locale';
+import {Integration, IntegrationProvider, Organization} from 'app/types';
+
+import AddIntegration from './addIntegration';
 
 type Props = {
   provider: IntegrationProvider;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'app/components/button';
-import space from 'app/styles/space';
-import {t} from 'app/locale';
-import {DocumentIntegration} from 'app/types';
-import withOrganization from 'app/utils/withOrganization';
 import ExternalLink from 'app/components/links/externalLink';
 import {IconOpen} from 'app/icons';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {DocumentIntegration} from 'app/types';
+import withOrganization from 'app/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 import {documentIntegrations} from './constants';

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -89,7 +89,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
     );
   }
 
-  //no configuratons
+  // No configurations.
   renderConfigurations() {
     return null;
   }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
@@ -1,20 +1,21 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {t} from 'app/locale';
 import Access from 'app/components/acl/access';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
+import CircleIndicator from 'app/components/circleIndicator';
 import Confirm from 'app/components/confirm';
-import IntegrationItem from 'app/views/organizationIntegrations/integrationItem';
 import Tooltip from 'app/components/tooltip';
+import {IconDelete, IconSettings, IconWarning} from 'app/icons';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
 import {IntegrationProvider, Integration, Organization, ObjectStatus} from 'app/types';
 import {SingleIntegrationEvent} from 'app/utils/integrationUtil';
-import CircleIndicator from 'app/components/circleIndicator';
 import theme from 'app/utils/theme';
-import space from 'app/styles/space';
-import {IconDelete, IconSettings, IconWarning} from 'app/icons';
-import AddIntegrationButton from 'app/views/organizationIntegrations/addIntegrationButton';
+
+import AddIntegrationButton from './addIntegrationButton';
+import IntegrationItem from './integrationItem';
 
 const CONFIGURABLE_FEATURES = ['commits', 'alert-rule'];
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -18,6 +18,7 @@ import withOrganization from 'app/utils/withOrganization';
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 import AddIntegrationButton from './addIntegrationButton';
 import InstalledIntegration from './installedIntegration';
+import RequestIntegrationButton from './integrationRequest/RequestIntegrationButton';
 
 type State = {
   configurations: Integration[];
@@ -197,8 +198,15 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
         </Button>
       );
     }
-    // should never happen but we can't return undefined without some refactoring
-    return <span />;
+
+    return (
+      <RequestIntegrationButton
+        organization={organization}
+        name={provider.name}
+        slug={provider.slug}
+        type="integration"
+      />
+    );
   }
 
   renderConfigurations() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -1,23 +1,23 @@
+import keyBy from 'lodash/keyBy';
 import React from 'react';
 import styled from '@emotion/styled';
-import keyBy from 'lodash/keyBy';
 
-import {IconWarning} from 'app/icons';
+import {addErrorMessage} from 'app/actionCreators/indicator';
+import {RequestOptions} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
-import {Integration, IntegrationProvider} from 'app/types';
-import {RequestOptions} from 'app/api';
-import {addErrorMessage} from 'app/actionCreators/indicator';
+import Button from 'app/components/button';
+import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import AddIntegrationButton from 'app/views/organizationIntegrations/addIntegrationButton';
-import Button from 'app/components/button';
-import InstalledIntegration from 'app/views/organizationIntegrations/installedIntegration';
-import withOrganization from 'app/utils/withOrganization';
+import {Integration, IntegrationProvider} from 'app/types';
 import {sortArray} from 'app/utils';
 import {isSlackWorkspaceApp, getReauthAlertText} from 'app/utils/integrationUtil';
+import withOrganization from 'app/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
+import AddIntegrationButton from './addIntegrationButton';
+import InstalledIntegration from './installedIntegration';
 
 type State = {
   configurations: Integration[];

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -18,7 +18,6 @@ import withOrganization from 'app/utils/withOrganization';
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 import AddIntegrationButton from './addIntegrationButton';
 import InstalledIntegration from './installedIntegration';
-import RequestIntegrationButton from './integrationRequest/RequestIntegrationButton';
 
 type State = {
   configurations: Integration[];
@@ -199,14 +198,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
       );
     }
 
-    return (
-      <RequestIntegrationButton
-        organization={organization}
-        name={provider.name}
-        slug={provider.slug}
-        type="integration"
-      />
-    );
+    return this.renderRequestIntegrationButton(provider);
   }
 
   renderConfigurations() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -198,7 +198,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
       );
     }
 
-    return this.renderRequestIntegrationButton(provider);
+    return this.renderRequestIntegrationButton();
   }
 
   renderConfigurations() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationButton.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationButton.tsx
@@ -16,14 +16,10 @@ type State = {
 };
 
 export default class RequestIntegrationButton extends React.Component<Props, State> {
-  constructor(props: Props, context) {
-    super(props, context);
-
-    this.state = {
-      isOpen: false,
-      isSent: false,
-    };
-  }
+  state = {
+    isOpen: false,
+    isSent: false,
+  };
 
   openRequestModal() {
     this.setState({isOpen: true});

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationButton.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationButton.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {openModal} from 'app/actionCreators/modal';
+import Button from 'app/components/button';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+
+import {RequestIntegrationProps} from '.';
+import RequestIntegrationModal from './RequestIntegrationModal';
+
+type Props = RequestIntegrationProps;
+type State = {
+  isOpen: boolean;
+  isSent: boolean;
+};
+
+export default class RequestIntegrationButton extends React.Component<Props, State> {
+  constructor(props: Props, context) {
+    super(props, context);
+
+    this.state = {
+      isOpen: false,
+      isSent: false,
+    };
+  }
+
+  openRequestModal() {
+    this.setState({isOpen: true});
+    openModal(
+      renderProps => (
+        <RequestIntegrationModal
+          {...this.props}
+          {...renderProps}
+          onSuccess={() => this.setState({isSent: true})}
+        />
+      ),
+      {
+        onClose: () => this.setState({isOpen: false}),
+      }
+    );
+  }
+
+  render() {
+    const {isOpen, isSent} = this.state;
+
+    let buttonText;
+    if (isOpen) {
+      buttonText = t('Requesting Installation');
+    } else if (isSent) {
+      buttonText = t('Installation Requested');
+    } else {
+      buttonText = t('Request Installation');
+    }
+
+    return (
+      <StyledRequestIntegrationButton
+        data-test-id="request-integration-button"
+        disabled={isOpen || isSent}
+        onClick={() => this.openRequestModal()}
+        priority="primary"
+        size="small"
+      >
+        {buttonText}
+      </StyledRequestIntegrationButton>
+    );
+  }
+}
+
+const StyledRequestIntegrationButton = styled(Button)`
+  margin-left: ${space(1)};
+`;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationButton.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationButton.tsx
@@ -5,11 +5,16 @@ import {openModal} from 'app/actionCreators/modal';
 import Button from 'app/components/button';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
+import {IntegrationType, Organization} from 'app/types';
 
-import {RequestIntegrationProps} from '.';
 import RequestIntegrationModal from './RequestIntegrationModal';
 
-type Props = RequestIntegrationProps;
+type Props = {
+  organization: Organization;
+  name: string;
+  slug: string;
+  type: IntegrationType;
+};
 type State = {
   isOpen: boolean;
   isSent: boolean;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {ModalRenderProps} from 'app/actionCreators/modal';
+import AsyncComponent from 'app/components/asyncComponent';
+import Button from 'app/components/button';
+import {t} from 'app/locale';
+import InputField from 'app/views/settings/components/forms/inputField';
+import TextBlock from 'app/views/settings/components/text/textBlock';
+
+import {RequestIntegrationProps} from '.';
+
+type Props = {
+  onSuccess: () => void;
+} & RequestIntegrationProps &
+  ModalRenderProps &
+  AsyncComponent['props'];
+type State = {
+  isSending: boolean;
+  message: string;
+} & AsyncComponent['state'];
+
+/**
+ * This modal serves as a non-owner's confirmation step before sending
+ * organization owners an email requesting a new organization integration. It
+ * lets the user attach an optional message to be included in the email.
+ */
+export default class RequestIntegrationModal extends AsyncComponent<Props, State> {
+  constructor(props: Props, context) {
+    super(props, context);
+
+    this.state = {
+      ...this.getDefaultState(),
+      isSending: false,
+      message: '',
+    };
+  }
+
+  sendRequest = () => {
+    const {organization, slug, type} = this.props;
+    const {message} = this.state;
+
+    const endpoint = `/organizations/${organization.slug}/integration-requests/`;
+    this.api.request(endpoint, {
+      method: 'POST',
+      data: {
+        provider_slug: slug,
+        provider_type: type,
+        message,
+      },
+      success: this.handleSubmitSuccess,
+      error: this.handleSubmitError,
+    });
+  };
+
+  handleSubmitSuccess = () => {
+    const {closeModal, onSuccess} = this.props;
+
+    addSuccessMessage(t('Request successfully sent.'));
+    this.setState({isSending: false});
+    onSuccess();
+    closeModal();
+  };
+
+  handleSubmitError = () => {
+    addErrorMessage('Error sending the request');
+    this.setState({isSending: false});
+  };
+
+  render() {
+    const {Header, Body, Footer, name} = this.props;
+
+    const buttonText = this.state.isSending ? t('Sending Request') : t('Send Request');
+
+    return (
+      <React.Fragment>
+        <Header>
+          <h4>{t('Request %s Installation', name)}</h4>
+        </Header>
+        <Body>
+          <TextBlock>
+            {t(
+              'Looks like your organization owner, manager, or admin needs to install %s. Want to send them a request?.',
+              name
+            )}
+          </TextBlock>
+          <InputField
+            inline={false}
+            flexibleControlStateSize
+            stacked
+            label={t(
+              '(Optional) You’ve got good reasons for installing the %s Integration. Share them with your organization owner.',
+              name
+            )}
+            name="message"
+            type="string"
+            onChange={value => this.setState({message: value})}
+            placeholder={t('Optional message…')}
+          />
+          <TextBlock>
+            {t(
+              'When you click “Send Request”, we’ll email your request to your organization’s owners. So just keep that in mind.'
+            )}
+          </TextBlock>
+        </Body>
+        <Footer>
+          <Button onClick={this.sendRequest}>{buttonText}</Button>
+        </Footer>
+      </React.Fragment>
+    );
+  }
+}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -26,15 +26,11 @@ type State = {
  * lets the user attach an optional message to be included in the email.
  */
 export default class RequestIntegrationModal extends AsyncComponent<Props, State> {
-  constructor(props: Props, context) {
-    super(props, context);
-
-    this.state = {
-      ...this.getDefaultState(),
-      isSending: false,
-      message: '',
-    };
-  }
+  state = {
+    ...this.getDefaultState(),
+    isSending: false,
+    message: '',
+  };
 
   sendRequest = () => {
     const {organization, slug, type} = this.props;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -8,11 +8,11 @@ import {t} from 'app/locale';
 import TextareaField from 'app/views/settings/components/forms/textareaField';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 
-import {RequestIntegrationProps} from '.';
+import RequestIntegrationButton from './RequestIntegrationButton';
 
 type Props = {
   onSuccess: () => void;
-} & RequestIntegrationProps &
+} & RequestIntegrationButton['props'] &
   ModalRenderProps &
   AsyncComponent['props'];
 type State = {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -40,8 +40,8 @@ export default class RequestIntegrationModal extends AsyncComponent<Props, State
     this.api.request(endpoint, {
       method: 'POST',
       data: {
-        provider_slug: slug,
-        provider_type: type,
+        providerSlug: slug,
+        providerType: type,
         message,
       },
       success: this.handleSubmitSuccess,

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -5,7 +5,7 @@ import {ModalRenderProps} from 'app/actionCreators/modal';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import {t} from 'app/locale';
-import InputField from 'app/views/settings/components/forms/inputField';
+import TextareaField from 'app/views/settings/components/forms/textareaField';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 
 import {RequestIntegrationProps} from '.';
@@ -80,7 +80,7 @@ export default class RequestIntegrationModal extends AsyncComponent<Props, State
               name
             )}
           </TextBlock>
-          <InputField
+          <TextareaField
             inline={false}
             flexibleControlStateSize
             stacked

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/index.tsx
@@ -1,9 +1,8 @@
-import {Organization} from 'app/types';
+import {IntegrationType, Organization} from 'app/types';
 
-export type ProviderType = 'sentryapp' | 'plugin' | 'integration';
 export type RequestIntegrationProps = {
   organization: Organization;
   name: string;
   slug: string;
-  type: ProviderType;
+  type: IntegrationType;
 };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/index.tsx
@@ -1,0 +1,9 @@
+import {Organization} from 'app/types';
+
+export type ProviderType = 'sentryapp' | 'plugin' | 'integration';
+export type RequestIntegrationProps = {
+  organization: Organization;
+  name: string;
+  slug: string;
+  type: ProviderType;
+};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/index.tsx
@@ -1,8 +1,0 @@
-import {IntegrationType, Organization} from 'app/types';
-
-export type RequestIntegrationProps = {
-  organization: Organization;
-  name: string;
-  slug: string;
-  type: IntegrationType;
-};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {PluginWithProjectList, PluginProjectItem} from 'app/types';
-import space from 'app/styles/space';
-import withOrganization from 'app/utils/withOrganization';
-import Button from 'app/components/button';
-import InstalledPlugin from 'app/views/organizationIntegrations/installedPlugin';
 import * as modal from 'app/actionCreators/modal';
+import Button from 'app/components/button';
 import ContextPickerModal from 'app/components/contextPickerModal';
 import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {PluginWithProjectList, PluginProjectItem} from 'app/types';
+import withOrganization from 'app/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
+import InstalledPlugin from './installedPlugin';
 
 type State = {
   plugins: PluginWithProjectList[];

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -11,7 +11,6 @@ import withOrganization from 'app/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 import InstalledPlugin from './installedPlugin';
-import RequestIntegrationButton from './integrationRequest/RequestIntegrationButton';
 
 type State = {
   plugins: PluginWithProjectList[];
@@ -148,14 +147,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
       );
     }
 
-    return (
-      <RequestIntegrationButton
-        organization={this.props.organization}
-        name={this.plugin.name}
-        slug={this.plugin.slug}
-        type="plugin"
-      />
-    );
+    return this.renderRequestIntegrationButton(this.plugin);
   }
 
   renderConfigurations() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -11,6 +11,7 @@ import withOrganization from 'app/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 import InstalledPlugin from './installedPlugin';
+import RequestIntegrationButton from './integrationRequest/RequestIntegrationButton';
 
 type State = {
   plugins: PluginWithProjectList[];
@@ -133,16 +134,27 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
   }
 
   renderTopButton(disabledFromFeatures: boolean, userHasAccess: boolean) {
+    if (userHasAccess) {
+      return (
+        <AddButton
+          data-test-id="install-button"
+          disabled={disabledFromFeatures}
+          onClick={this.handleAddToProject}
+          size="small"
+          priority="primary"
+        >
+          {t('Add to Project')}
+        </AddButton>
+      );
+    }
+
     return (
-      <AddButton
-        data-test-id="install-button"
-        disabled={disabledFromFeatures || !userHasAccess}
-        onClick={this.handleAddToProject}
-        size="small"
-        priority="primary"
-      >
-        {t('Add to Project')}
-      </AddButton>
+      <RequestIntegrationButton
+        organization={this.props.organization}
+        name={this.plugin.name}
+        slug={this.plugin.slug}
+        type="plugin"
+      />
     );
   }
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -54,9 +54,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get integrationName() {
-    const isLegacy = this.plugin.isHidden;
-    const displayName = `${this.plugin.name} ${isLegacy ? '(Legacy)' : ''}`;
-    return displayName;
+    return `${this.plugin.name}${this.plugin.isHidden ? ' (Legacy)' : ''}`;
   }
 
   get featureData() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -147,7 +147,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
       );
     }
 
-    return this.renderRequestIntegrationButton(this.plugin);
+    return this.renderRequestIntegrationButton();
   }
 
   renderConfigurations() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -21,7 +21,6 @@ import {recordInteraction} from 'app/utils/recordSentryAppInteraction';
 import withOrganization from 'app/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
-import RequestIntegrationButton from './integrationRequest/RequestIntegrationButton';
 import SplitInstallationIdModal from './SplitInstallationIdModal';
 
 type State = {
@@ -273,14 +272,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
       );
     }
 
-    return (
-      <RequestIntegrationButton
-        organization={this.props.organization}
-        name={this.sentryApp.name}
-        slug={this.sentryApp.slug}
-        type="sentryapp"
-      />
-    );
+    return this.renderRequestIntegrationButton(this.sentryApp);
   }
 
   //no configurations for sentry apps

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -21,6 +21,7 @@ import {recordInteraction} from 'app/utils/recordSentryAppInteraction';
 import withOrganization from 'app/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
+import RequestIntegrationButton from './integrationRequest/RequestIntegrationButton';
 import SplitInstallationIdModal from './SplitInstallationIdModal';
 
 type State = {
@@ -238,32 +239,47 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
 
   renderTopButton(disabledFromFeatures: boolean, userHasAccess: boolean) {
     const install = this.install;
-    return !install ? (
-      <InstallButton
-        size="small"
-        priority="primary"
-        disabled={disabledFromFeatures || !userHasAccess}
-        onClick={() => this.handleInstall()}
-        style={{marginLeft: space(1)}}
-        data-test-id="install-button"
-      >
-        {t('Accept & Install')}
-      </InstallButton>
-    ) : (
-      <Confirm
-        message={tct('Are you sure you want to remove the [slug] installation?', {
-          slug: this.integrationSlug,
-        })}
-        priority="danger"
-        onConfirm={() => this.handleUninstall(install)} //called when the user confirms the action
-        onConfirming={this.recordUninstallClicked} //called when the confirm modal opens
-        disabled={!userHasAccess}
-      >
-        <StyledUninstallButton size="small" data-test-id="sentry-app-uninstall">
-          <IconSubtract isCircled style={{marginRight: space(0.75)}} />
-          {t('Uninstall')}
-        </StyledUninstallButton>
-      </Confirm>
+    if (install) {
+      return (
+        <Confirm
+          disabled={!userHasAccess}
+          message={tct('Are you sure you want to remove the [slug] installation?', {
+            slug: this.integrationSlug,
+          })}
+          onConfirm={() => this.handleUninstall(install)} //called when the user confirms the action
+          onConfirming={this.recordUninstallClicked} //called when the confirm modal opens
+          priority="danger"
+        >
+          <StyledUninstallButton size="small" data-test-id="sentry-app-uninstall">
+            <IconSubtract isCircled style={{marginRight: space(0.75)}} />
+            {t('Uninstall')}
+          </StyledUninstallButton>
+        </Confirm>
+      );
+    }
+
+    if (userHasAccess) {
+      return (
+        <InstallButton
+          data-test-id="install-button"
+          disabled={disabledFromFeatures}
+          onClick={() => this.handleInstall()}
+          priority="primary"
+          size="small"
+          style={{marginLeft: space(1)}}
+        >
+          {t('Accept & Install')}
+        </InstallButton>
+      );
+    }
+
+    return (
+      <RequestIntegrationButton
+        organization={this.props.organization}
+        name={this.sentryApp.name}
+        slug={this.sentryApp.slug}
+        type="sentryapp"
+      />
     );
   }
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -2,26 +2,26 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
-import Button from 'app/components/button';
-import space from 'app/styles/space';
-import {t, tct} from 'app/locale';
-import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
+import {openModal} from 'app/actionCreators/modal';
 import {
   installSentryApp,
   uninstallSentryApp,
 } from 'app/actionCreators/sentryAppInstallations';
-import {toPermissions} from 'app/utils/consolidatedScopes';
+import Button from 'app/components/button';
 import CircleIndicator from 'app/components/circleIndicator';
-import {IntegrationFeature, SentryApp, SentryAppInstallation} from 'app/types';
-import withOrganization from 'app/utils/withOrganization';
-import SplitInstallationIdModal from 'app/views/organizationIntegrations/SplitInstallationIdModal';
-import {openModal} from 'app/actionCreators/modal';
-import {getSentryAppInstallStatus} from 'app/utils/integrationUtil';
 import Confirm from 'app/components/confirm';
 import {IconSubtract} from 'app/icons';
+import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
+import {IntegrationFeature, SentryApp, SentryAppInstallation} from 'app/types';
+import {toPermissions} from 'app/utils/consolidatedScopes';
+import {getSentryAppInstallStatus} from 'app/utils/integrationUtil';
+import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
 import {recordInteraction} from 'app/utils/recordSentryAppInteraction';
+import withOrganization from 'app/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
+import SplitInstallationIdModal from './SplitInstallationIdModal';
 
 type State = {
   sentryApp: SentryApp;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -272,7 +272,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
       );
     }
 
-    return this.renderRequestIntegrationButton(this.sentryApp);
+    return this.renderRequestIntegrationButton();
   }
 
   //no configurations for sentry apps

--- a/src/sentry/templates/sentry/emails/requests/organization-integration.html
+++ b/src/sentry/templates/sentry/emails/requests/organization-integration.html
@@ -1,0 +1,29 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+
+{% block main %}
+  <p>
+    Seems like your team could use some new tools. {{ requester_name }} from
+    {{ organization_name }} requested the installation of {{ integration_name }}.
+    {% if message %}
+        They’ve included some additional context:
+        <pre>{{ message }}</pre>
+    {% endif %}
+  </p>
+  <p>
+    <a href="{{ integration_link }}" class="btn">Install {{ integration_name }}</a>
+  </p>
+  <p>
+    If you’re not up for installation, you can
+    <a href="{{ requester_link }}">change {{ requester_name }}’s role</a>
+    to organization owner, manager, or admin. You can learn more about the
+    wonderful world of permissions in
+    <a href="https://docs.sentry.io/accounts/membership/">our docs</a>.
+  </p>
+  <p>Let’s get integrated.</p>
+  <p class="via">
+    You are receiving this email because you’re listed as an organization Owner or Manager.
+    Requests to join your organization can be disabled in <a href="{{ settings_link }}">Organization Settings</a>.
+  </p>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/requests/organization-integration.txt
+++ b/src/sentry/templates/sentry/emails/requests/organization-integration.txt
@@ -1,0 +1,16 @@
+Seems like your team could use some new tools. {{ requester_name }} from {{ organization_name }} requested the installation of {{ integration_name }}.
+{% if message %}
+They’ve included some additional context:
+    {{ message }}
+{% endif %}
+Install {{ provider_name }} by clicking the link below:
+
+    {{ provider_link }}
+
+If you’re not up for installation, you can change {{ requester_name }}’s role to organization owner, manager, or admin here: {{ requester_link }}.
+You can learn more about the wonderful world of permissions in our docs: https://docs.sentry.io/accounts/membership/.
+
+Let’s get integrated.
+
+You are receiving this email because you’re listed as an organization Owner or Manager.
+Requests to join your organization can be disabled in Organization Settings: {{ settings_link }}.

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -44,7 +44,7 @@ logger = logging.getLogger("sentry.mail")
 def inline_css(value):
     tree = lxml.html.document_fromstring(value)
     toronado.inline(tree)
-    # CSS media query support is inconistent when the DOCTYPE declaration is
+    # CSS media query support is inconsistent when the DOCTYPE declaration is
     # missing, so we force it to HTML5 here.
     return lxml.html.tostring(tree, doctype="<!DOCTYPE html>")
 

--- a/tests/js/spec/utils/withExperiment.spec.jsx
+++ b/tests/js/spec/utils/withExperiment.spec.jsx
@@ -62,7 +62,7 @@ describe('withConfig HoC', function() {
     expect(logExperiment).toHaveBeenCalledWith({key: 'orgExperiment', organization});
   });
 
-  it('deffers logging when injectLogExperiment is true', function() {
+  it('defers logging when injectLogExperiment is true', function() {
     const Container = withExperiment(MyComponent, {
       experiment: 'orgExperiment',
       injectLogExperiment: true,

--- a/tests/sentry/api/endpoints/test_organization_integration_request.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_request.py
@@ -19,7 +19,7 @@ class OrganizationIntegrationRequestTest(APITestCase):
         response = self.get_response(
             self.org.slug,
             providerSlug="github",
-            providerType="plugin",
+            providerType="first_party",
         )
 
         assert response.status_code == 201, response.content
@@ -53,7 +53,7 @@ class OrganizationIntegrationRequestTest(APITestCase):
         response = self.get_response(
             self.org.slug,
             providerSlug="github",
-            providerType="plugin",
+            providerType="first_party",
         )
         assert response.status_code == 200, response.content
         assert response.data["detail"] == "User can install integration"
@@ -63,6 +63,6 @@ class OrganizationIntegrationRequestTest(APITestCase):
         response = self.get_response(
             self.org.slug,
             providerSlug="github",
-            providerType="plugin",
+            providerType="first_party",
         )
         assert response.status_code == 403, response.content

--- a/tests/sentry/api/endpoints/test_organization_integration_request.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_request.py
@@ -18,18 +18,28 @@ class OrganizationIntegrationRequestTest(APITestCase):
         self.login_as(user=self.member)
         response = self.get_response(
             self.org.slug,
-            provider_slug="github",
-            provider_type="plugin",
+            providerSlug="github",
+            providerType="plugin",
         )
 
         assert response.status_code == 201, response.content
 
-    def test_integration_request_without_provider(self):
+    def test_integration_request_with_invalid_plugin(self):
         self.login_as(user=self.member)
         response = self.get_response(
             self.org.slug,
-            provider_slug="ERROR",
-            provider_type="plugin",
+            providerSlug="ERROR",
+            providerType="plugin",
+        )
+
+        assert response.status_code == 400, response.content
+
+    def test_integration_request_with_invalid_sentryapp(self):
+        self.login_as(user=self.member)
+        response = self.get_response(
+            self.org.slug,
+            providerSlug="ERROR",
+            providerType="sentry_app",
         )
 
         assert response.status_code == 400, response.content
@@ -42,8 +52,8 @@ class OrganizationIntegrationRequestTest(APITestCase):
         self.login_as(user=self.owner)
         response = self.get_response(
             self.org.slug,
-            provider_slug="github",
-            provider_type="plugin",
+            providerSlug="github",
+            providerType="plugin",
         )
         assert response.status_code == 200, response.content
         assert response.data["detail"] == "User can install integration"
@@ -52,7 +62,7 @@ class OrganizationIntegrationRequestTest(APITestCase):
         self.login_as(user=self.create_user(email="nonmember@example.com"))
         response = self.get_response(
             self.org.slug,
-            provider_slug="github",
-            provider_type="plugin",
+            providerSlug="github",
+            providerType="plugin",
         )
         assert response.status_code == 403, response.content

--- a/tests/sentry/api/endpoints/test_organization_integration_request.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_request.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import
+
+from sentry.testutils import APITestCase
+
+
+class OrganizationIntegrationRequestTest(APITestCase):
+    """Unit tests for emailing organization owners asking them to install an integration."""
+    endpoint = "sentry-api-0-organization-integration-request"
+    method = "post"
+
+    def setUp(self):
+        self.owner = self.create_user(email="owner@example.com", is_superuser=True)
+        self.member = self.create_user(email="member@example.com")
+        self.org = self.create_organization(owner=self.owner, name="My Org")
+        self.create_member(user=self.member, organization=self.org, role="member")
+
+    def test_integration_request(self):
+        self.login_as(user=self.member)
+        response = self.get_response(
+            self.org.slug,
+            provider_slug="github",
+            provider_type="plugin",
+        )
+
+        assert response.status_code == 201, response.content
+
+    def test_integration_request_without_provider(self):
+        self.login_as(user=self.member)
+        response = self.get_response(
+            self.org.slug,
+            provider_slug="ERROR",
+            provider_type="plugin",
+        )
+
+        assert response.status_code == 400, response.content
+
+    def test_integration_request_as_owner(self):
+        """
+        This is a little counter-intuitive. If the user has permissions to add
+        integrations, then they should NOT be able to hit this endpoint.
+        """
+        self.login_as(user=self.owner)
+        response = self.get_response(
+            self.org.slug,
+            provider_slug="github",
+            provider_type="plugin",
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["detail"] == "User can install integration"
+
+    def test_integration_request_without_permissions(self):
+        self.login_as(user=self.create_user(email="nonmember@example.com"))
+        response = self.get_response(
+            self.org.slug,
+            provider_slug="github",
+            provider_type="plugin",
+        )
+        assert response.status_code == 403, response.content

--- a/tests/sentry/api/endpoints/test_organization_integration_request.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_request.py
@@ -5,6 +5,7 @@ from sentry.testutils import APITestCase
 
 class OrganizationIntegrationRequestTest(APITestCase):
     """Unit tests for emailing organization owners asking them to install an integration."""
+
     endpoint = "sentry-api-0-organization-integration-request"
     method = "post"
 
@@ -17,29 +18,21 @@ class OrganizationIntegrationRequestTest(APITestCase):
     def test_integration_request(self):
         self.login_as(user=self.member)
         response = self.get_response(
-            self.org.slug,
-            providerSlug="github",
-            providerType="first_party",
+            self.org.slug, providerSlug="github", providerType="first_party",
         )
 
         assert response.status_code == 201, response.content
 
     def test_integration_request_with_invalid_plugin(self):
         self.login_as(user=self.member)
-        response = self.get_response(
-            self.org.slug,
-            providerSlug="ERROR",
-            providerType="plugin",
-        )
+        response = self.get_response(self.org.slug, providerSlug="ERROR", providerType="plugin",)
 
         assert response.status_code == 400, response.content
 
     def test_integration_request_with_invalid_sentryapp(self):
         self.login_as(user=self.member)
         response = self.get_response(
-            self.org.slug,
-            providerSlug="ERROR",
-            providerType="sentry_app",
+            self.org.slug, providerSlug="ERROR", providerType="sentry_app",
         )
 
         assert response.status_code == 400, response.content
@@ -47,9 +40,7 @@ class OrganizationIntegrationRequestTest(APITestCase):
     def test_integration_request_as_owner(self):
         self.login_as(user=self.owner)
         response = self.get_response(
-            self.org.slug,
-            providerSlug="github",
-            providerType="first_party",
+            self.org.slug, providerSlug="github", providerType="first_party",
         )
         assert response.status_code == 200, response.content
         assert response.data["detail"] == "User can install integration"
@@ -57,8 +48,6 @@ class OrganizationIntegrationRequestTest(APITestCase):
     def test_integration_request_without_permissions(self):
         self.login_as(user=self.create_user(email="nonmember@example.com"))
         response = self.get_response(
-            self.org.slug,
-            providerSlug="github",
-            providerType="first_party",
+            self.org.slug, providerSlug="github", providerType="first_party",
         )
         assert response.status_code == 403, response.content

--- a/tests/sentry/api/endpoints/test_organization_integration_request.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_request.py
@@ -45,10 +45,6 @@ class OrganizationIntegrationRequestTest(APITestCase):
         assert response.status_code == 400, response.content
 
     def test_integration_request_as_owner(self):
-        """
-        This is a little counter-intuitive. If the user has permissions to add
-        integrations, then they should NOT be able to hit this endpoint.
-        """
         self.login_as(user=self.owner)
         response = self.get_response(
             self.org.slug,


### PR DESCRIPTION
When a user lacks permissions to install an integration themselves, they should be able to request installation from their organization's owner. This feature replaces the disabled button with a new button that launches a confirmation modal: 
<img width="602" alt="Screen Shot 2020-06-01 at 12 40 06 PM" src="https://user-images.githubusercontent.com/31750075/83447283-0d1cbb80-a405-11ea-88a0-6514b7470065.png">
When the user hits "Send Request", we send an email with installation instructions to the organization owners:
<img width="703" alt="Screen Shot 2020-06-01 at 12 38 22 PM" src="https://user-images.githubusercontent.com/31750075/83447164-d777d280-a404-11ea-8f71-565aa6925767.png">
This PR contains the frontend code for displaying the modal and sending a request as well as a backend API for creating and sending the email. Storing the request in the DB is outside the scope of this feature.

Jira: [Allow members to request integration installation from owner](https://getsentry.atlassian.net/browse/API-900)
