### PR TITLE
feat(workflow): Performance metric selector

### DIFF
--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -21,10 +21,6 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         """
         Fetches alert rules and legacy rules for an organization
         """
-        import sentry_sdk;
-        sentry_sdk.init("http://8ac75874a33e4f10afaeef699f918f1a@dev.getsentry.net:8000/4")
-        sentry_sdk.capture_message("testing a test message!")
-        division = 1/0
 
         return self.paginate(
             request,

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -21,6 +21,11 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
         """
         Fetches alert rules and legacy rules for an organization
         """
+        import sentry_sdk;
+        sentry_sdk.init("http://8ac75874a33e4f10afaeef699f918f1a@dev.getsentry.net:8000/4")
+        sentry_sdk.capture_message("testing a test message!")
+        division = 1/0
+
         return self.paginate(
             request,
             paginator_cls=CombinedQuerysetPaginator,

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -84,7 +84,7 @@ export function isFieldSortable(field: Field, tableMeta?: MetaType): boolean {
   return !!getSortKeyFromField(field, tableMeta);
 }
 
-const generateFieldAsString = (col: Column): string => {
+export const generateFieldAsString = (col: Column): string => {
   if (col.kind === 'field') {
     return col.field;
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -16,6 +16,7 @@ import theme from 'app/utils/theme';
 import {Column, FIELDS, AGGREGATIONS, TRACING_FIELDS} from 'app/utils/discover/fields';
 
 import {FieldValue, FieldValueKind} from './types';
+import { ColumnEditRow } from './columnEditRow';
 
 type Props = {
   // Input columns

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -44,66 +44,69 @@ enum PlaceholderPosition {
   BOTTOM,
 }
 
-export function generateFieldOptions(organization: OrganizationSummary, tagKeys: null | string[]) {
-    let fields = Object.keys(FIELDS);
-    let functions = Object.keys(AGGREGATIONS);
+export function generateFieldOptions(
+  organization: OrganizationSummary,
+  tagKeys: null | string[]
+) {
+  let fields = Object.keys(FIELDS);
+  let functions = Object.keys(AGGREGATIONS);
 
-    // Strip tracing features if the org doesn't have access.
-    if (!organization.features.includes('transaction-events')) {
-      fields = fields.filter(item => !TRACING_FIELDS.includes(item));
-      functions = functions.filter(item => !TRACING_FIELDS.includes(item));
-    }
-    const fieldOptions: Record<string, SelectValue<FieldValue>> = {};
-
-    // Index items by prefixed keys as custom tags
-    // can overlap both fields and function names.
-    // Having a mapping makes finding the value objects easier
-    // later as well.
-    functions.forEach(func => {
-      const ellipsis = AGGREGATIONS[func].parameters.length ? '\u2026' : '';
-      fieldOptions[`function:${func}`] = {
-        label: `${func}(${ellipsis})`,
-        value: {
-          kind: FieldValueKind.FUNCTION,
-          meta: {
-            name: func,
-            parameters: AGGREGATIONS[func].parameters,
-          },
-        },
-      };
-    });
-
-    fields.forEach(field => {
-      fieldOptions[`field:${field}`] = {
-        label: field,
-        value: {
-          kind: FieldValueKind.FIELD,
-          meta: {
-            name: field,
-            dataType: FIELDS[field],
-          },
-        },
-      };
-    });
-
-    if (tagKeys !== null && tagKeys !== undefined) {
-      tagKeys.forEach(tag => {
-        const tagValue =
-          FIELDS.hasOwnProperty(tag) || AGGREGATIONS.hasOwnProperty(tag)
-            ? `tags[${tag}]`
-            : tag;
-        fieldOptions[`tag:${tag}`] = {
-          label: tag,
-          value: {
-            kind: FieldValueKind.TAG,
-            meta: {name: tagValue, dataType: 'string'},
-          },
-        };
-      });
-    }
-
-    return fieldOptions;
+  // Strip tracing features if the org doesn't have access.
+  if (!organization.features.includes('transaction-events')) {
+    fields = fields.filter(item => !TRACING_FIELDS.includes(item));
+    functions = functions.filter(item => !TRACING_FIELDS.includes(item));
   }
+  const fieldOptions: Record<string, SelectValue<FieldValue>> = {};
+
+  // Index items by prefixed keys as custom tags
+  // can overlap both fields and function names.
+  // Having a mapping makes finding the value objects easier
+  // later as well.
+  functions.forEach(func => {
+    const ellipsis = AGGREGATIONS[func].parameters.length ? '\u2026' : '';
+    fieldOptions[`function:${func}`] = {
+      label: `${func}(${ellipsis})`,
+      value: {
+        kind: FieldValueKind.FUNCTION,
+        meta: {
+          name: func,
+          parameters: AGGREGATIONS[func].parameters,
+        },
+      },
+    };
+  });
+
+  fields.forEach(field => {
+    fieldOptions[`field:${field}`] = {
+      label: field,
+      value: {
+        kind: FieldValueKind.FIELD,
+        meta: {
+          name: field,
+          dataType: FIELDS[field],
+        },
+      },
+    };
+  });
+
+  if (tagKeys !== null && tagKeys !== undefined) {
+    tagKeys.forEach(tag => {
+      const tagValue =
+        FIELDS.hasOwnProperty(tag) || AGGREGATIONS.hasOwnProperty(tag)
+          ? `tags[${tag}]`
+          : tag;
+      fieldOptions[`tag:${tag}`] = {
+        label: tag,
+        value: {
+          kind: FieldValueKind.TAG,
+          meta: {name: tagValue, dataType: 'string'},
+        },
+      };
+    });
+  }
+
+  return fieldOptions;
+}
 
 class ColumnEditCollection extends React.Component<Props, State> {
   state = {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -14,9 +14,9 @@ import {SelectValue, OrganizationSummary} from 'app/types';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import {Column} from 'app/utils/discover/fields';
-
-import {FieldValue } from './types';
 import {generateFieldOptions} from 'app/views/eventsV2/utils.tsx';
+
+import {FieldValue} from './types';
 
 type Props = {
   // Input columns
@@ -88,7 +88,9 @@ class ColumnEditCollection extends React.Component<Props, State> {
   dragGhostRef = React.createRef<HTMLDivElement>();
 
   syncFields() {
-    this.setState({fieldOptions: generateFieldOptions(this.props.organization, this.props.tagKeys)});
+    this.setState({
+      fieldOptions: generateFieldOptions(this.props.organization, this.props.tagKeys),
+    });
   }
 
   keyForColumn(column: Column, isGhost: boolean): string {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -16,7 +16,7 @@ import theme from 'app/utils/theme';
 import {Column, FIELDS, AGGREGATIONS, TRACING_FIELDS} from 'app/utils/discover/fields';
 
 import {FieldValue, FieldValueKind} from './types';
-import { ColumnEditRow } from './columnEditRow';
+import {ColumnEditRow} from './columnEditRow';
 
 type Props = {
   // Input columns

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -335,12 +335,12 @@ class ColumnEditRow extends React.Component<Props> {
     const {className, takeFocus, gridColumns, showFunctionsOnly} = this.props;
     const {field, fieldOptions, parameterDescriptions} = this.getFieldData();
 
-    let selectFields = Object.values(fieldOptions);
-    if (showFunctionsOnly) {
-      selectFields = selectFields.filter(
-        selectField => selectField.value.kind === FieldValueKind.FUNCTION
-      );
-    }
+    let selectFields = showFunctionsOnly ?
+        selectFields = Object.values(fieldOptions).filter(
+          selectField => selectField.value.kind === FieldValueKind.FUNCTION
+        )
+      :
+        Object.values(fieldOptions);
 
     const selectProps: React.ComponentProps<SelectControl> = {
       name: 'field',

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -335,8 +335,8 @@ class ColumnEditRow extends React.Component<Props> {
     const {className, takeFocus, gridColumns, showFunctionsOnly} = this.props;
     const {field, fieldOptions, parameterDescriptions} = this.getFieldData();
 
-    const selectFields = showFunctionsOnly
-      ? Object.values(fieldOptions).filter(
+    const selectFields = showFunctionsOnly ?
+        Object.values(fieldOptions).filter(
           selectField => selectField.value.kind === FieldValueKind.FUNCTION
         )
       : Object.values(fieldOptions);

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -34,11 +34,12 @@ type ParameterDescription =
 
 type Props = {
   className?: string;
-  takeFocus: boolean;
-  parentIndex: number;
+  takeFocus?: boolean;
+  parentIndex?: number;
   column: Column;
   gridColumns: number;
   fieldOptions: FieldOptions;
+  showFunctionsOnly?: boolean;
   onChange: (index: number, column: Column) => void;
 };
 
@@ -331,12 +332,19 @@ class ColumnEditRow extends React.Component<Props> {
   }
 
   render() {
-    const {className, takeFocus, gridColumns} = this.props;
+    const {className, takeFocus, gridColumns, showFunctionsOnly} = this.props;
     const {field, fieldOptions, parameterDescriptions} = this.getFieldData();
+
+    let selectFields = Object.values(fieldOptions);
+    if (showFunctionsOnly) {
+      selectFields = selectFields.filter(
+        selectField => selectField.value.kind === FieldValueKind.FUNCTION
+      );
+    }
 
     const selectProps: React.ComponentProps<SelectControl> = {
       name: 'field',
-      options: Object.values(fieldOptions),
+      options: selectFields,
       placeholder: t('(Required)'),
       value: field,
       onChange: this.handleFieldChange,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -335,12 +335,11 @@ class ColumnEditRow extends React.Component<Props> {
     const {className, takeFocus, gridColumns, showFunctionsOnly} = this.props;
     const {field, fieldOptions, parameterDescriptions} = this.getFieldData();
 
-    let selectFields = showFunctionsOnly ?
-        Object.values(fieldOptions).filter(
+    const selectFields = showFunctionsOnly
+      ? Object.values(fieldOptions).filter(
           selectField => selectField.value.kind === FieldValueKind.FUNCTION
         )
-      :
-        Object.values(fieldOptions);
+      : Object.values(fieldOptions);
 
     const selectProps: React.ComponentProps<SelectControl> = {
       name: 'field',

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -336,7 +336,7 @@ class ColumnEditRow extends React.Component<Props> {
     const {field, fieldOptions, parameterDescriptions} = this.getFieldData();
 
     let selectFields = showFunctionsOnly ?
-        selectFields = Object.values(fieldOptions).filter(
+        Object.values(fieldOptions).filter(
           selectField => selectField.value.kind === FieldValueKind.FUNCTION
         )
       :

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -335,8 +335,8 @@ class ColumnEditRow extends React.Component<Props> {
     const {className, takeFocus, gridColumns, showFunctionsOnly} = this.props;
     const {field, fieldOptions, parameterDescriptions} = this.getFieldData();
 
-    const selectFields = showFunctionsOnly ?
-        Object.values(fieldOptions).filter(
+    const selectFields = showFunctionsOnly
+      ? Object.values(fieldOptions).filter(
           selectField => selectField.value.kind === FieldValueKind.FUNCTION
         )
       : Object.values(fieldOptions);

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -15,14 +15,13 @@ import {
   Field,
   Column,
   AGGREGATIONS,
-  TRACING_FIELDS,
   FIELDS,
   explodeFieldString,
   getAggregateAlias,
 } from 'app/utils/discover/fields';
 
 import {ALL_VIEWS, TRANSACTION_VIEWS} from './data';
-import {TableColumn, TableDataRow, FieldValue, FieldValueKind} from './table/types';
+import {TableColumn, TableDataRow} from './table/types';
 
 export type QueryWithColumnState =
   | Query
@@ -377,64 +376,3 @@ export function getDiscoverLandingUrl(organization: OrganizationSummary): string
   }
   return `/organizations/${organization.slug}/discover/results/`;
 }
-
-export function generateFieldOptions(organization: OrganizationSummary, tagKeys: null | string[]) {
-    let fields = Object.keys(FIELDS);
-    let functions = Object.keys(AGGREGATIONS);
-
-    // Strip tracing features if the org doesn't have access.
-    if (!organization.features.includes('transaction-events')) {
-      fields = fields.filter(item => !TRACING_FIELDS.includes(item));
-      functions = functions.filter(item => !TRACING_FIELDS.includes(item));
-    }
-    const fieldOptions: Record<string, SelectValue<FieldValue>> = {};
-
-    // Index items by prefixed keys as custom tags
-    // can overlap both fields and function names.
-    // Having a mapping makes finding the value objects easier
-    // later as well.
-    functions.forEach(func => {
-      const ellipsis = AGGREGATIONS[func].parameters.length ? '\u2026' : '';
-      fieldOptions[`function:${func}`] = {
-        label: `${func}(${ellipsis})`,
-        value: {
-          kind: FieldValueKind.FUNCTION,
-          meta: {
-            name: func,
-            parameters: AGGREGATIONS[func].parameters,
-          },
-        },
-      };
-    });
-
-    fields.forEach(field => {
-      fieldOptions[`field:${field}`] = {
-        label: field,
-        value: {
-          kind: FieldValueKind.FIELD,
-          meta: {
-            name: field,
-            dataType: FIELDS[field],
-          },
-        },
-      };
-    });
-
-    if (tagKeys !== null && tagKeys !== undefined) {
-      tagKeys.forEach(tag => {
-        const tagValue =
-          FIELDS.hasOwnProperty(tag) || AGGREGATIONS.hasOwnProperty(tag)
-            ? `tags[${tag}]`
-            : tag;
-        fieldOptions[`tag:${tag}`] = {
-          label: tag,
-          value: {
-            kind: FieldValueKind.TAG,
-            meta: {name: tagValue, dataType: 'string'},
-          },
-        };
-      });
-    }
-
-    return fieldOptions;
-  }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
@@ -24,7 +24,6 @@ export async function addOrUpdateRule(
     isSavedRule(rule) ? `${rule.id}/` : ''
   }`;
   const method = isExisting ? 'PUT' : 'POST';
-
   return api.requestPromise(endpoint, {
     method,
     data: rule,

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -16,11 +16,13 @@ export function createDefaultTrigger(): Trigger {
 }
 
 export const DEFAULT_METRIC = AlertRuleAggregations.TOTAL;
+export const DEFAULT_AGGREGATE = 'count()';
 
 export function createDefaultRule(): UnsavedIncidentRule {
   return {
     aggregation: DEFAULT_METRIC,
     aggregations: [DEFAULT_METRIC],
+    aggregate: DEFAULT_AGGREGATE,
     query: '',
     timeWindow: 1,
     triggers: [createDefaultTrigger()],

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -111,7 +111,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
     );
     environmentList.unshift([null, anyEnvironmentLabel]);
 
-    const fieldOptions = generateFieldOptions(this.props.organization);
+    const fieldOptions = generateFieldOptions(organization, null);
     const gridColumns =
       aggregate.kind === 'function' && aggregate.function[2] !== undefined ? 3 : 2;
     return (

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -195,7 +195,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             )}
           </FormField>
 
-          <Feature features={['performance_alerts']}>
+          <Feature features={['performance-alerts']}>
             {({hasFeature}) =>
               hasFeature ? (
                 <Field

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -195,7 +195,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             )}
           </FormField>
 
-          <Feature features={['advanced-metric-alerts-alpha']}>
+          <Feature features={['performance-alerts']}>
             {({hasFeature}) =>
               hasFeature ? (
                 <Field

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -150,7 +150,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
 
           <Feature features={['performance-alerts']}>
             {({hasFeature}) =>
-              !hasFeature ? (
+              hasFeature ? (
                 <Field
                   label="Metric"
                   help={t('Choose an aggregate function and event property.')}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -195,7 +195,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             )}
           </FormField>
 
-          <Feature features={['performance-alerts']}>
+          <Feature features={['performance_alerts']}>
             {({hasFeature}) =>
               hasFeature ? (
                 <Field

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -18,8 +18,7 @@ import Tooltip from 'app/components/tooltip';
 import {Column, AGGREGATIONS, FIELDS, TRACING_FIELDS} from 'app/utils/discover/fields';
 import Field from 'app/views/settings/components/forms/field';
 import {ColumnEditRow} from 'app/views/eventsV2/table/columnEditRow';
-import {FieldValue, FieldValueKind} from 'app/views/eventsV2/table/types';
-import {generateFieldOptions} from 'app/views/eventsV2/utils.tsx';
+import {generateFieldOptions} from 'app/views/eventsV2/table/columnEditCollection';
 
 import {AlertRuleAggregations, TimeWindow, IncidentRule} from './types';
 import getMetricDisplayName from './utils/getMetricDisplayName';
@@ -151,7 +150,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
 
           <Feature features={['performance-alerts']}>
             {({hasFeature}) =>
-              hasFeature ? (
+              !hasFeature ? (
                 <Field
                   label="Metric"
                   help={t('Choose an aggregate function and event property.')}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -279,9 +279,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       this.setState({[name]: value});
       if (name === 'aggregation') {
         if (value === 0) {
-          this.props.rule.aggregate = 'count()';
+          this.setState({aggregate: 'count()'})
         } else if (value === 1) {
-          this.props.rule.aggregate = 'count_unique(tags[sentry:user])';
+          this.setState({aggregate: 'count_unique(tags[sentry:user])'});
         }
       }
     }
@@ -292,10 +292,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   };
 
   handleAggregateUpdate = (_index: number, column: Column) => {
-    const string_aggregate = generateFieldAsString(column);
-    this.setState({aggregate: string_aggregate});
-    // TODO: This should bind differently? Its used for when the rule saves
-    this.props.rule.aggregate = string_aggregate;
+    const aggregateString = generateFieldAsString(column);
+    this.setState({aggregate: aggregateString});
   };
 
   handleSubmit = async (
@@ -333,6 +331,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       const resp = await addOrUpdateRule(this.api, organization.slug, params.projectId, {
         ...rule,
         ...model.getTransformedData(),
+        aggregate: this.state.aggregate,
         triggers: this.state.triggers.map(sanitizeTrigger),
       });
       addSuccessMessage(ruleId ? t('Updated alert rule') : t('Created alert rule'));
@@ -416,7 +415,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const queryAndAlwaysErrorEvents = !query.includes('event.type')
       ? `${query} ${this.getEventType()}`.trim()
       : query;
-    const aggregate_column = explodeFieldString(aggregate);
+    const aggregateColumn = explodeFieldString(aggregate);
 
     const chart = (
       <TriggersChart
@@ -481,7 +480,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
               disabled={!hasAccess}
               onFilterUpdate={this.handleFilterUpdate}
               thresholdChart={chart}
-              aggregate={aggregate_column}
+              aggregate={aggregateColumn}
               onAggregateUpdate={this.handleAggregateUpdate}
             />
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -22,6 +22,7 @@ type Props = {
   query: IncidentRule['query'];
   timeWindow: IncidentRule['timeWindow'];
   aggregation: IncidentRule['aggregation'];
+  aggregate: IncidentRule['aggregate'];
   triggers: Trigger[];
 };
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -49,6 +49,7 @@ export type UnsavedIncidentRule = {
   query: string;
   timeWindow: number;
   triggers: Trigger[];
+  aggregate: string;
 };
 
 export type SavedIncidentRule = UnsavedIncidentRule & {

--- a/tests/js/sentry-test/fixtures/incidentRule.js
+++ b/tests/js/sentry-test/fixtures/incidentRule.js
@@ -10,7 +10,7 @@ export function IncidentRule(params) {
     name: 'My Incident Rule',
     timeWindow: 60,
     aggregation: 0,
-    aggregate: "count()",
+    aggregate: 'count()',
     projects: ['project-slug'],
     dateModified: '2019-07-31T23:02:02.731Z',
     triggers: [IncidentTrigger()],

--- a/tests/js/sentry-test/fixtures/incidentRule.js
+++ b/tests/js/sentry-test/fixtures/incidentRule.js
@@ -10,6 +10,7 @@ export function IncidentRule(params) {
     name: 'My Incident Rule',
     timeWindow: 60,
     aggregation: 0,
+    aggregate: "count()",
     projects: ['project-slug'],
     dateModified: '2019-07-31T23:02:02.731Z',
     triggers: [IncidentTrigger()],


### PR DESCRIPTION
This PR is an attempt at using the Discover column editor in the alert rule builder.

If you have the feature `performance-alerts`, you'll see this in the alert builder.

We also set the rule's `aggregate` value when `aggregation` changes. This will keep `aggregate` in sync for people not using this feature (The migration run synced this up for current alerts, but alerts going forward that change their aggregate need this - I believe right now a new alert rule would be created with the previous aggregate and when we switch over they would be out of sync).

This also adds a `showFunctionsOnly` to `ColumnEditRow` component to only show functions in the first selector.

![Screen Shot 2020-05-11 at 8 42 29 PM](https://user-images.githubusercontent.com/6395250/81625821-fe278800-93c7-11ea-9c9b-bf61232591ff.png)

Things to be done on top/around this but in separate PRs:
- Data source selection - not sure if the backend actually needs to be passed the datasource, but at the very least the frontend will be filtering fields in the metric dropdown based on data source.
- Pretty labels like the mock.
- Some clickable fields that can auto populate the selector? Like click "latency" -> get converted function filled. (In discussion around this)
- Graph needs to change based on new selector. Need to likely find the endpoint discover is using that accepts a function (since our current just seems to accept "user_count", "event_count"?)