### PR TITLE
feat(features): Replace plugin-based FeatureHandlers

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -51,6 +51,8 @@ STATS_PERIOD_CHOICES = {
     "24h": StatsPeriod(24, timedelta(hours=1)),
 }
 
+_PROJECT_SCOPE_PREFIX = "projects:"
+
 
 @register(Project)
 class ProjectSerializer(Serializer):
@@ -156,36 +158,37 @@ class ProjectSerializer(Serializer):
             result = self.get_access_by_project(item_list, user)
 
         with measure_span("features"):
-            for item in item_list:
-                result[item]["features"] = self.get_feature_list(item, user)
+            project_features = [
+                feature_name
+                for feature_name in features.all(feature_type=ProjectFeature).keys()
+                if feature_name.startswith(_PROJECT_SCOPE_PREFIX)
+            ]
+            for project, serialized in result.items():
+                serialized["features"] = self._get_feature_list(project, user, project_features)
 
         with measure_span("other"):
-            for item in item_list:
-                result[item].update(
+            for project, serialized in result.items():
+                serialized.update(
                     {
-                        "is_bookmarked": item.id in bookmarks,
+                        "is_bookmarked": project.id in bookmarks,
                         "is_subscribed": bool(
-                            user_options.get((item.id, "mail:alert"), default_subscribe)
+                            user_options.get((project.id, "mail:alert"), default_subscribe)
                         ),
-                        "avatar": avatars.get(item.id),
-                        "platforms": platforms_by_project[item.id],
+                        "avatar": avatars.get(project.id),
+                        "platforms": platforms_by_project[project.id],
                     }
                 )
                 if stats:
-                    result[item]["stats"] = stats[item.id]
+                    serialized["stats"] = stats[project.id]
         return result
 
-    def get_feature_list(self, obj, user):
-        # Retrieve all registered organization features
-        project_features = features.all(feature_type=ProjectFeature).keys()
-        feature_list = set()
-
-        for feature_name in project_features:
-            if not feature_name.startswith("projects:"):
-                continue
-            if features.has(feature_name, obj, actor=user):
-                # Remove the project scope prefix
-                feature_list.add(feature_name[len("projects:") :])
+    @staticmethod
+    def _get_feature_list(obj, user, project_features):
+        feature_list = set(
+            feature_name[len(_PROJECT_SCOPE_PREFIX) :]  # Remove the project scope prefix
+            for feature_name in project_features
+            if features.has(feature_name, obj, actor=user)
+        )
 
         if obj.flags.has_releases:
             feature_list.add("releases")

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -131,4 +131,4 @@ add = default_manager.add
 get = default_manager.get
 has = default_manager.has
 all = default_manager.all
-build_checker = default_manager.build_checker
+add_handler = default_manager.add_handler

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -12,7 +12,7 @@ from .exceptions import FeatureNotRegistered
 class FeatureManager(object):
     def __init__(self):
         self._feature_registry = {}
-        self._handler_registry = defaultdict(set)
+        self._handler_registry = defaultdict(list)
 
     def all(self, feature_type=Feature):
         """
@@ -53,7 +53,7 @@ class FeatureManager(object):
         method checks.
         """
         for feature_name in handler.features:
-            self._handler_registry[feature_name].add(handler)
+            self._handler_registry[feature_name].append(handler)
 
     def has(self, name, *args, **kwargs):
         """

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -11,7 +11,7 @@ from .exceptions import FeatureNotRegistered
 class FeatureManager(object):
     def __init__(self):
         self._feature_registry = {}
-        self._handler_registry = []
+        self._handler_registry = {}
 
     def all(self, feature_type=Feature):
         """
@@ -51,7 +51,10 @@ class FeatureManager(object):
         one feature name, but will be applied to every flag that the ``has``
         method checks.
         """
-        self._handler_registry.append(handler)
+        for feature_name in handler.features:
+            handlers = self._handler_registry.get(feature_name, set())
+            handlers.add(handler)
+            self._handler_registry[feature_name] = handlers
 
     def has(self, name, *args, **kwargs):
         """
@@ -92,7 +95,8 @@ class FeatureManager(object):
         return False
 
     def _get_handler(self, feature, actor):
-        for handler in self._handler_registry:
+        handlers = self._handler_registry.get(feature.name, ())
+        for handler in handlers:
             rv = handler(feature, actor)
             if rv is not None:
                 return rv

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 __all__ = ["FeatureManager"]
 
+from collections import defaultdict
 from django.conf import settings
 
 from .base import Feature
@@ -11,7 +12,7 @@ from .exceptions import FeatureNotRegistered
 class FeatureManager(object):
     def __init__(self):
         self._feature_registry = {}
-        self._handler_registry = {}
+        self._handler_registry = defaultdict(set)
 
     def all(self, feature_type=Feature):
         """
@@ -52,9 +53,7 @@ class FeatureManager(object):
         method checks.
         """
         for feature_name in handler.features:
-            handlers = self._handler_registry.get(feature_name, set())
-            handlers.add(handler)
-            self._handler_registry[feature_name] = handlers
+            self._handler_registry[feature_name].add(handler)
 
     def has(self, name, *args, **kwargs):
         """
@@ -95,7 +94,7 @@ class FeatureManager(object):
         return False
 
     def _get_handler(self, feature, actor):
-        for handler in self._handler_registry.get(feature.name, ()):
+        for handler in self._handler_registry[feature.name]:
             rv = handler(feature, actor)
             if rv is not None:
                 return rv

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -2,11 +2,7 @@ from __future__ import absolute_import
 
 __all__ = ["FeatureManager"]
 
-import itertools
-
 from django.conf import settings
-
-from sentry.utils.safe import safe_execute
 
 from .base import Feature
 from .exceptions import FeatureNotRegistered
@@ -14,14 +10,15 @@ from .exceptions import FeatureNotRegistered
 
 class FeatureManager(object):
     def __init__(self):
-        self._registry = {}
+        self._feature_registry = {}
+        self._handler_registry = []
 
     def all(self, feature_type=Feature):
         """
         Get a mapping of feature name -> feature class, optionally specific to a
         particular feature type.
         """
-        return {k: v for k, v in self._registry.items() if v == feature_type}
+        return {k: v for k, v in self._feature_registry.items() if v == feature_type}
 
     def add(self, name, cls=Feature):
         """
@@ -32,7 +29,7 @@ class FeatureManager(object):
 
         >>> FeatureManager.has('my:feature', actor=request.user)
         """
-        self._registry[name] = cls
+        self._feature_registry[name] = cls
 
     def get(self, name, *args, **kwargs):
         """
@@ -41,10 +38,20 @@ class FeatureManager(object):
         >>> FeatureManager.get('my:feature', actor=request.user)
         """
         try:
-            cls = self._registry[name]
+            cls = self._feature_registry[name]
         except KeyError:
             raise FeatureNotRegistered(name)
         return cls(name, *args, **kwargs)
+
+    def add_handler(self, handler):
+        """
+        Register a feature handler.
+
+        The passed object is a FeatureHandler that is not associated with any
+        one feature name, but will be applied to every flag that the ``has``
+        method checks.
+        """
+        self._handler_registry.append(handler)
 
     def has(self, name, *args, **kwargs):
         """
@@ -52,13 +59,13 @@ class FeatureManager(object):
 
         Features are checked in the following order:
 
-        1. Execute Plugin feature handlers. Any plugin which returns a list of
-           instantiated ``feature.handler.FeatureHandler`` objects will have
-           each of their handlers executed in the order they are declared.
+        1. Execute registered feature handlers. Any
+           ``feature.handler.FeatureHandler`` objects that have been registered
+           with ``add_handler` will be executed in the order they are declared.
 
-           When each handler is executed should the handler return None instead
-           of True or False (feature enabled / disabled), the next registered
-           plugin feature handler will be executed.
+           When each handler is executed, should the handler return None
+           instead of True or False (feature enabled / disabled), the
+           next registered feature handler will be executed.
 
         2. The default configuration of the feature. This can be located in
            sentry.conf.server.SENTRY_FEATURES.
@@ -67,41 +74,13 @@ class FeatureManager(object):
         provided to assign organization or project context to the feature.
 
         >>> FeatureManager.has('organizations:feature', organization, actor=request.user)
+
         """
-        return self.build_checker().has(name, *args, **kwargs)
-
-    def build_checker(self):
-        """
-        Set up for a delayed execution of ``has``.
-
-        Successive calls to the returned checker have better performance than
-        repeatedly calling ``FeatureManager.has``, because it retains the set
-        of ``feature.handler.FeatureHandler`` objects. An instance of the
-        checker should be kept only in a short-lived context, because any
-        dynamic changes to plugins' feature handlers are not reflected in its
-        behavior.
-        """
-        return FeatureChecker(self)
-
-
-class FeatureChecker(object):
-    def __init__(self, manager):
-        from sentry.plugins.base import plugins
-
-        self.manager = manager
-
-        handlers_per_plugin = [
-            safe_execute(plugin.get_feature_hooks, _with_transaction=False) or ()
-            for plugin in plugins.all(version=2)
-        ]
-        self.handlers = tuple(itertools.chain(*handlers_per_plugin))
-
-    def has(self, name, *args, **kwargs):
         actor = kwargs.pop("actor", None)
-        feature = self.manager.get(name, *args, **kwargs)
+        feature = self.get(name, *args, **kwargs)
 
-        # Check plugin feature handlers
-        rv = self._get_plugin_value(feature, actor)
+        # Check registered feature handlers
+        rv = self._get_handler(feature, actor)
         if rv is not None:
             return rv
 
@@ -112,8 +91,8 @@ class FeatureChecker(object):
         # Features are by default disabled if no plugin or default enables them
         return False
 
-    def _get_plugin_value(self, feature, actor):
-        for handler in self.handlers:
+    def _get_handler(self, feature, actor):
+        for handler in self._handler_registry:
             rv = handler(feature, actor)
             if rv is not None:
                 return rv

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -48,9 +48,8 @@ class FeatureManager(object):
         """
         Register a feature handler.
 
-        The passed object is a FeatureHandler that is not associated with any
-        one feature name, but will be applied to every flag that the ``has``
-        method checks.
+        The passed object is a FeatureHandler that is associated with all
+        features defined in the ``handler.features`` property.
         """
         for feature_name in handler.features:
             self._handler_registry[feature_name].append(handler)

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -95,8 +95,7 @@ class FeatureManager(object):
         return False
 
     def _get_handler(self, feature, actor):
-        handlers = self._handler_registry.get(feature.name, ())
-        for handler in handlers:
+        for handler in self._handler_registry.get(feature.name, ()):
             rv = handler(feature, actor)
             if rv is not None:
                 return rv


### PR DESCRIPTION
Based on conversation with @wedamija and @dcramer in #18668. Introduces a global way to inject `FeatureHandler` objects directly, which replaces both
1. the hack of using a plugin as a container for doing so and
2. the recently created `FeatureChecker` abstraction that fixes a performance liability.
Gets rid of the ability to associate `FeatureHandler`s with plugins, which is not otherwise in use.

Remove the one invocation of the `FeatureChecker` abstraction from `ProjectSerializer`. Also does some incidental refactoring and cleanup near the same code (see the second commit; I can split that into a separate PR if anyone objects).