### PR TITLE
feat(analytics): Extend metric.mark to accept a data field

### DIFF
--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -252,7 +252,7 @@ export class Client {
     }
 
     const id: string = uniqueId();
-    metric.mark(`api-request-start-${id}`);
+    metric.mark({name: `api-request-start-${id}`});
 
     let fullUrl: string;
     if (path.indexOf(this.baseUrl) === -1) {

--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -81,7 +81,7 @@ if (window.__SENTRY__VERSION) {
 
 // Used for operational metrics to determine that the application js
 // bundle was loaded by browser.
-metric.mark('sentry-app-init');
+metric.mark({name: 'sentry-app-init'});
 
 // setup jquery for CSRF tokens
 jQuery.ajaxSetup({

--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -115,7 +115,7 @@ export default class AsyncComponent<
       hasMeasured: false,
     };
     if (props.routes && props.routes) {
-      metric.mark(`async-component-${getRouteStringFromRoutes(props.routes)}`);
+      metric.mark({name: `async-component-${getRouteStringFromRoutes(props.routes)}`});
     }
   }
 

--- a/src/sentry/static/sentry/app/utils/withTeamsForUser.tsx
+++ b/src/sentry/static/sentry/app/utils/withTeamsForUser.tsx
@@ -45,7 +45,7 @@ const withTeamsForUser = <P extends InjectedTeamsProps>(
       });
 
       try {
-        metric.mark('user-teams-fetch-start');
+        metric.mark({name: 'user-teams-fetch-start'});
         const teamsWithProjects: TeamWithProjects[] = await this.props.api.requestPromise(
           this.getUsersTeamsEndpoint()
         );

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -84,7 +84,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
     setError(undefined);
 
     this.setState({isLoading: true, tableFetchID});
-    metric.mark(`discover-events-start-${apiPayload.query}`);
+    metric.mark({name: `discover-events-start-${apiPayload.query}`});
 
     this.props.api
       .requestPromise(url, {

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -176,7 +176,7 @@ const OrganizationContext = createReactClass({
       return;
     }
 
-    metric.mark('organization-details-fetch-start');
+    metric.mark({name: 'organization-details-fetch-start'});
     fetchOrganizationDetails(
       this.props.api,
       this.getOrganizationSlug(),


### PR DESCRIPTION
This allows us to pass along data at start of the transaction, which may change
by the end of the transaction.