### PR TITLE
feat(metrics): Capture first-meaningful-paint for IssueList on Reload

### DIFF
--- a/src/sentry/static/sentry/app/utils/withOrganization.tsx
+++ b/src/sentry/static/sentry/app/utils/withOrganization.tsx
@@ -29,4 +29,11 @@ const withOrganization = <P extends InjectedOrganizationProps>(
     }
   };
 
+export function isLightweightOrganization(
+  organization: Organization | LightWeightOrganization
+) {
+  const castedOrg = organization as Organization;
+  return !(castedOrg.projects && castedOrg.teams);
+}
+
 export default withOrganization;

--- a/src/sentry/static/sentry/app/utils/withOrganization.tsx
+++ b/src/sentry/static/sentry/app/utils/withOrganization.tsx
@@ -31,7 +31,7 @@ const withOrganization = <P extends InjectedOrganizationProps>(
 
 export function isLightweightOrganization(
   organization: Organization | LightWeightOrganization
-) {
+): organization is LightWeightOrganization {
   const castedOrg = organization as Organization;
   return !(castedOrg.projects && castedOrg.teams);
 }

--- a/src/sentry/static/sentry/app/views/issueList/container.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/container.jsx
@@ -5,12 +5,34 @@ import {PageContent} from 'app/styles/organization';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryTypes from 'app/sentryTypes';
-import withOrganization from 'app/utils/withOrganization';
+import {metric} from 'app/utils/analytics';
+import withOrganization, {isLightweightOrganization} from 'app/utils/withOrganization';
 
 class IssueListContainer extends React.Component {
   static propTypes = {
     organization: SentryTypes.Organization,
   };
+
+  constructor(props) {
+    super(props);
+
+    // Setup in the constructor as render() may be expensive
+    this.startMetricCollection();
+  }
+
+  /**
+   * The user can (1) land on IssueList as the first page as they enter Sentry,
+   * or (2) navigate into IssueList with the stores preloaded with data.
+   *
+   * Case (1) will be slower and we can easily identify it as it uses the
+   * lightweight organization
+   */
+  startMetricCollection() {
+    const startType = isLightweightOrganization(this.props.organization)
+      ? 'cold-start'
+      : 'hot-start';
+    metric.mark({name: 'page-issue-list-start', data: {start_type: startType}});
+  }
 
   getTitle() {
     return `Issues - ${this.props.organization.slug} - Sentry`;

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -12,7 +12,7 @@ import qs from 'query-string';
 import {Client} from 'app/api';
 import {DEFAULT_QUERY, DEFAULT_STATS_PERIOD} from 'app/constants';
 import {Panel, PanelBody} from 'app/components/panels';
-import {analytics} from 'app/utils/analytics';
+import {analytics, metric} from 'app/utils/analytics';
 import {defined} from 'app/utils';
 import {
   deleteSavedSearch,
@@ -110,6 +110,29 @@ const IssueListOverview = createReactClass({
   },
 
   componentDidUpdate(prevProps, prevState) {
+    // Fire off profiling/metrics first
+    if (prevState.issuesLoading && !this.state.issuesLoading) {
+      if (typeof this.props.finishProfile === 'function') {
+        this.props.finishProfile();
+      }
+
+      // First Meaningful Paint for IssueList page
+      if (prevState.queryCount === null) {
+        metric.measure({
+          name: 'app.page.perf.issue-list',
+          start: 'page-issue-list-start',
+          data: {
+            organization_slug: this.props.organization.slug,
+            group: this.props.organization.features.has('enterprise-perf')
+              ? 'enterprise-perf'
+              : 'control',
+            milestone: 'first-meaningful-paint',
+            // start_type is set on 'page-issue-list-start'
+          },
+        });
+      }
+    }
+
     if (prevState.realtimeActive !== this.state.realtimeActive) {
       // User toggled realtime button
       if (this.state.realtimeActive) {
@@ -126,9 +149,6 @@ const IssueListOverview = createReactClass({
       this.fetchTags();
     }
 
-    const prevQuery = prevProps.location.query;
-    const newQuery = this.props.location.query;
-
     // Wait for saved searches to load before we attempt to fetch stream data
     if (this.props.savedSearchLoading) {
       return;
@@ -136,6 +156,9 @@ const IssueListOverview = createReactClass({
       this.fetchData();
       return;
     }
+
+    const prevQuery = prevProps.location.query;
+    const newQuery = this.props.location.query;
 
     // If any important url parameter changed or saved search changed
     // reload data.
@@ -157,14 +180,6 @@ const IssueListOverview = createReactClass({
       // Reload if we issues are loading or their loading state changed.
       // This can happen when transitionTo is called
       this.fetchData();
-    }
-
-    if (
-      prevState.issuesLoading &&
-      !this.state.issuesLoading &&
-      typeof this.props.finishProfile === 'function'
-    ) {
-      this.props.finishProfile();
     }
   },
 

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -123,7 +123,7 @@ const IssueListOverview = createReactClass({
           start: 'page-issue-list-start',
           data: {
             organization_slug: this.props.organization.slug,
-            group: this.props.organization.features.has('enterprise-perf')
+            group: this.props.organization.features.includes('enterprise-perf')
               ? 'enterprise-perf'
               : 'control',
             milestone: 'first-meaningful-paint',


### PR DESCRIPTION
This PR is blocked by 

1. ~#18752: it is using `metric.mark` with the breaking API change~
2. ~getsentry/reload#162: it is using the new metric keys~
