### PR TITLE
feat: Don't emit processing errors on symbolicated frame

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -754,6 +754,15 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         changed_raw = sourcemap_applied and self.expand_frame(raw_frame)
 
         if sourcemap_applied or all_errors or changed_frame or changed_raw:
+            # In case we are done processing, we iterate over all errors that we got
+            # and we filter out all `JS_MISSING_SOURCE` errors since we consider if we have
+            # a `context_line` we have a symbolicated frame and we don't need to show the error
+            has_context_line = bool(new_frame.get("context_line"))
+            if has_context_line:
+                all_errors[:] = [
+                    x for x in all_errors if x.get("type") is not EventError.JS_MISSING_SOURCE
+                ]
+
             if in_app is not None:
                 new_frame["in_app"] = in_app
                 raw_frame["in_app"] = in_app


### PR DESCRIPTION
# Motivation

In React Native we do local device symbolication and therefore do not need to do anything on the server.
Right now we emit an error because we try to fetch the source file resulting in this confusing error on the top even though the stacktrace is there:

![image](https://user-images.githubusercontent.com/363802/81670252-a16bb200-9447-11ea-903e-a3115c6296ac.png)

After this change, we hide the error when there is an existing `context_line` and therefore we consider it as fully symbolicated.

![image](https://user-images.githubusercontent.com/363802/81670178-88fb9780-9447-11ea-98a2-d43280ca7017.png)
