### PR TITLE
fix: Update Apdex help tooltip

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/constants.tsx
+++ b/src/sentry/static/sentry/app/views/performance/constants.tsx
@@ -2,7 +2,7 @@ import {t} from 'app/locale';
 
 export const PERFORMANCE_TERMS: Record<string, string> = {
   apdex: t(
-    'Apdex is the ratio of satisfactory or tolerable response times to all response times.'
+    'Apdex is the ratio of both satisfactory and tolerable response times to all response times.'
   ),
   rpm: t('Throughput is the number of recorded transactions per minute (tpm).'),
   errorRate: t(

--- a/src/sentry/static/sentry/app/views/performance/constants.tsx
+++ b/src/sentry/static/sentry/app/views/performance/constants.tsx
@@ -2,7 +2,7 @@ import {t} from 'app/locale';
 
 export const PERFORMANCE_TERMS: Record<string, string> = {
   apdex: t(
-    'Apdex is a ratio of satisfactory response times to unsatisfactory response times.'
+    'Apdex is the ratio of satisfactory or tolerable response times to all response times.'
   ),
   rpm: t('Throughput is the number of recorded transactions per minute (tpm).'),
   errorRate: t(


### PR DESCRIPTION
The ratio is implemented as (satisfied + tolerable/2)/all, same as
described in https://en.wikipedia.org/wiki/Apdex#Apdex_method.

For reference, here's the implementation in Snuba:
https://github.com/getsentry/snuba/blob/1e522577d7b700880f92e41580ebdd9ede073187/snuba/query/processors/performance_expressions.py