### PR TITLE
fix(ui): Dont reset cursor during initial load

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -333,7 +333,7 @@ export function updateParamsWithoutHistory(
 
 /**
  * Creates a new query parameter object given new params and old params
- * Preserves the old query params, except for `cursor`
+ * Preserves the old query params, except for `cursor` (can be overriden with keepCursor option)
  *
  * @param obj New query params
  * @param oldQueryParams Old query params
@@ -344,7 +344,6 @@ function getNewQueryParams(
   oldQueryParams: UrlParams,
   {resetParams, keepCursor}: Options = {}
 ) {
-  // Reset cursor when changing parameters
   const {cursor, statsPeriod, ...oldQuery} = oldQueryParams;
   const oldQueryWithoutResetParams = !!resetParams?.length
     ? omit(oldQuery, resetParams)

--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -38,6 +38,7 @@ type Options = {
    */
   resetParams?: string[];
   save?: boolean;
+  keepCursor?: boolean;
 };
 
 /**
@@ -204,7 +205,9 @@ export function initializeUrlState({
         : datetime.period,
     utc: !parsedWithNoDefaultPeriod.utc ? null : datetime.utc,
   };
-  updateParamsWithoutHistory({project, environment, ...newDatetime}, router);
+  updateParamsWithoutHistory({project, environment, ...newDatetime}, router, {
+    keepCursor: true,
+  });
 }
 
 /**
@@ -339,10 +342,10 @@ export function updateParamsWithoutHistory(
 function getNewQueryParams(
   obj: UrlParams,
   oldQueryParams: UrlParams,
-  {resetParams}: Options = {}
+  {resetParams, keepCursor}: Options = {}
 ) {
   // Reset cursor when changing parameters
-  const {cursor: _cursor, statsPeriod, ...oldQuery} = oldQueryParams;
+  const {cursor, statsPeriod, ...oldQuery} = oldQueryParams;
   const oldQueryWithoutResetParams = !!resetParams?.length
     ? omit(oldQuery, resetParams)
     : oldQuery;
@@ -360,6 +363,10 @@ function getNewQueryParams(
 
   if (newQuery.end) {
     newQuery.end = getUtcDateString(newQuery.end);
+  }
+
+  if (keepCursor) {
+    newQuery.cursor = cursor;
   }
 
   return newQuery;


### PR DESCRIPTION
We are resetting cursor in globalSelection, which is nice, however we should not do that for initial load, because then you can't link to a specific page.

For example, if you visit this URL:
https://sentry.io/organizations/sentry/performance/?cursor=0%3A50%3A0
Cursor will get stripped away and you end up on the first page.

@billyvg can we deal with it like this? I think you have the most recent experience with globalSelection.