### PR TITLE
feat(ui): Add sort by active users to releases

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -150,7 +150,7 @@ class ReleasesList extends AsyncView<Props, State> {
       return (
         <EmptyStateWarning small>
           {t(
-            'There are no releases with active users data (users in the last 24 hours).'
+            'There are no releases with active user data (users in the last 24 hours).'
           )}
         </EmptyStateWarning>
       );

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -149,9 +149,7 @@ class ReleasesList extends AsyncView<Props, State> {
     if (activeSort === 'users_24h') {
       return (
         <EmptyStateWarning small>
-          {t(
-            'There are no releases with active user data (users in the last 24 hours).'
-          )}
+          {t('There are no releases with active user data (users in the last 24 hours).')}
         </EmptyStateWarning>
       );
     }

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -136,6 +136,7 @@ class ReleasesList extends AsyncView<Props, State> {
     const {location, organization} = this.props;
     const {statsPeriod} = location.query;
     const searchQuery = this.getQuery();
+    const activeSort = this.getSort();
 
     if (searchQuery && searchQuery.length) {
       return (
@@ -145,7 +146,17 @@ class ReleasesList extends AsyncView<Props, State> {
       );
     }
 
-    if (this.getSort() !== 'date') {
+    if (activeSort === 'users_24h') {
+      return (
+        <EmptyStateWarning small>
+          {t(
+            'There are no releases with active users data (users in the last 24 hours).'
+          )}
+        </EmptyStateWarning>
+      );
+    }
+
+    if (activeSort !== 'date') {
       const relativePeriod = getRelativeSummary(
         statsPeriod || DEFAULT_STATS_PERIOD
       ).toLowerCase();

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releaseListSortOptions.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releaseListSortOptions.tsx
@@ -20,6 +20,10 @@ const ReleaseListSortOptions = ({selected, onSelect}: Props) => {
       label: t('Total Sessions'),
     },
     {
+      key: 'users_24h',
+      label: t('Active users'),
+    },
+    {
       key: 'crash_free_users',
       label: t('Crash Free Users'),
     },

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releaseListSortOptions.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releaseListSortOptions.tsx
@@ -21,7 +21,7 @@ const ReleaseListSortOptions = ({selected, onSelect}: Props) => {
     },
     {
       key: 'users_24h',
-      label: t('Active users'),
+      label: t('Active Users'),
     },
     {
       key: 'crash_free_users',

--- a/tests/js/spec/views/releasesV2/list/index.spec.jsx
+++ b/tests/js/spec/views/releasesV2/list/index.spec.jsx
@@ -108,6 +108,15 @@ describe('ReleasesV2List', function() {
     expect(wrapper.find('EmptyMessage').text()).toEqual(
       'There are no releases with data in the last 7 days.'
     );
+
+    location = {query: {sort: 'users_24h', statsPeriod: '7d'}};
+    wrapper = mountWithTheme(
+      <ReleaseList {...props} location={location} />,
+      routerContext
+    );
+    expect(wrapper.find('EmptyMessage').text()).toEqual(
+      'There are no releases with active users data (users in the last 24 hours).'
+    );
   });
 
   it('searches for a release', function() {
@@ -141,7 +150,7 @@ describe('ReleasesV2List', function() {
     const sortOptions = sortDropdown.find('DropdownItem span');
     const sortByDateOption = sortOptions.at(0);
 
-    expect(sortOptions).toHaveLength(4);
+    expect(sortOptions).toHaveLength(5);
     expect(sortByDateOption.text()).toEqual('Date Created');
 
     sortByDateOption.simulate('click');

--- a/tests/js/spec/views/releasesV2/list/index.spec.jsx
+++ b/tests/js/spec/views/releasesV2/list/index.spec.jsx
@@ -115,7 +115,7 @@ describe('ReleasesV2List', function() {
       routerContext
     );
     expect(wrapper.find('EmptyMessage').text()).toEqual(
-      'There are no releases with active users data (users in the last 24 hours).'
+      'There are no releases with active user data (users in the last 24 hours).'
     );
   });
 


### PR DESCRIPTION
This PR adds the ability to sort releases by Active users.