### PR TITLE
fix(api) Don't 500 on invalid per_page values

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -253,7 +253,11 @@ class Endpoint(APIView):
             except ValueError:
                 raise ParseError(detail="Invalid cursor parameter.")
 
-        assert per_page <= max(max_per_page, default_per_page)
+        max_per_page = max(max_per_page, default_per_page)
+        if per_page > max_per_page:
+            raise ParseError(
+                detail="Invalid per_page value. Cannot exceed {}.".format(max_per_page)
+            )
 
         if not paginator:
             paginator = paginator_cls(**paginator_kwargs)

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -79,6 +79,11 @@ class PaginateTest(APITestCase):
         response = self.view(self.request)
         assert response.status_code == 400
 
+    def test_per_page_out_of_bounds(self):
+        self.request.GET = {"per_page": "101"}
+        response = self.view(self.request)
+        assert response.status_code == 400
+
 
 class EndpointJSONBodyTest(APITestCase):
     def setUp(self):


### PR DESCRIPTION
Instead return a 400 as the client has made a request we don't want to answer.

Fixes SENTRY-GBY