### PR TITLE
feat(permissions): Option to disable event:admin for members

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -7,9 +7,9 @@ from django.http import StreamingHttpResponse
 
 from sentry import eventstore, features, roles
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
-from sentry.api.serializers.models.organization import ATTACHMENTS_ROLE_DEFAULT
 from sentry.auth.superuser import is_active_superuser
 from sentry.auth.system import is_system_auth
+from sentry.constants import ATTACHMENTS_ROLE_DEFAULT
 from sentry.models import EventAttachment, OrganizationMember
 
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -78,6 +78,12 @@ ORG_OPTIONS = (
         org_serializers.ATTACHMENTS_ROLE_DEFAULT,
     ),
     (
+        "eventsMemberAdmin",
+        "sentry:events_member_admin",
+        bool,
+        org_serializers.EVENTS_MEMBER_ADMIN_DEFAULT,
+    ),
+    (
         "scrubIPAddresses",
         "sentry:require_scrub_ip_address",
         bool,
@@ -135,6 +141,7 @@ class OrganizationSerializer(serializers.Serializer):
     safeFields = ListField(child=serializers.CharField(), required=False)
     storeCrashReports = serializers.IntegerField(min_value=-1, max_value=20, required=False)
     attachmentsRole = serializers.CharField(required=True)
+    eventsMemberAdmin = serializers.BooleanField(required=False)
     scrubIPAddresses = serializers.BooleanField(required=False)
     scrapeJavaScript = serializers.BooleanField(required=False)
     isEarlyAdopter = serializers.BooleanField(required=False)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -2,13 +2,26 @@ from __future__ import absolute_import
 
 import six
 
-from django.conf import settings
-
 from sentry import roles
 from sentry.app import quotas
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models import UserSerializer
-from sentry.constants import LEGACY_RATE_LIMIT_OPTIONS
+from sentry.constants import (
+    LEGACY_RATE_LIMIT_OPTIONS,
+    PROJECT_RATE_LIMIT_DEFAULT,
+    ACCOUNT_RATE_LIMIT_DEFAULT,
+    REQUIRE_SCRUB_DATA_DEFAULT,
+    REQUIRE_SCRUB_DEFAULTS_DEFAULT,
+    SENSITIVE_FIELDS_DEFAULT,
+    SAFE_FIELDS_DEFAULT,
+    ATTACHMENTS_ROLE_DEFAULT,
+    REQUIRE_SCRUB_IP_ADDRESS_DEFAULT,
+    SCRAPE_JAVASCRIPT_DEFAULT,
+    TRUSTED_RELAYS_DEFAULT,
+    JOIN_REQUESTS_DEFAULT,
+    EVENTS_MEMBER_ADMIN_DEFAULT,
+)
+
 from sentry.lang.native.utils import convert_crashreport_count
 from sentry.models import (
     ApiKey,
@@ -23,19 +36,6 @@ from sentry.models import (
     Team,
     TeamStatus,
 )
-
-# org option default values
-PROJECT_RATE_LIMIT_DEFAULT = 100
-ACCOUNT_RATE_LIMIT_DEFAULT = 0
-REQUIRE_SCRUB_DATA_DEFAULT = False
-REQUIRE_SCRUB_DEFAULTS_DEFAULT = False
-SENSITIVE_FIELDS_DEFAULT = None
-SAFE_FIELDS_DEFAULT = None
-ATTACHMENTS_ROLE_DEFAULT = settings.SENTRY_DEFAULT_ROLE
-REQUIRE_SCRUB_IP_ADDRESS_DEFAULT = False
-SCRAPE_JAVASCRIPT_DEFAULT = True
-TRUSTED_RELAYS_DEFAULT = None
-JOIN_REQUESTS_DEFAULT = True
 
 
 @register(Organization)
@@ -192,6 +192,9 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 ),
                 "attachmentsRole": six.text_type(
                     obj.get_option("sentry:attachments_role", ATTACHMENTS_ROLE_DEFAULT)
+                ),
+                "eventsMemberAdmin": bool(
+                    obj.get_option("sentry:events_member_admin", EVENTS_MEMBER_ADMIN_DEFAULT)
                 ),
                 "scrubIPAddresses": bool(
                     obj.get_option(

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -521,3 +521,21 @@ class DataCategory(IntEnum):
 
     def api_name(self):
         return self.name.lower()
+
+
+# org option default values
+PROJECT_RATE_LIMIT_DEFAULT = 100
+ACCOUNT_RATE_LIMIT_DEFAULT = 0
+REQUIRE_SCRUB_DATA_DEFAULT = False
+REQUIRE_SCRUB_DEFAULTS_DEFAULT = False
+SENSITIVE_FIELDS_DEFAULT = None
+SAFE_FIELDS_DEFAULT = None
+ATTACHMENTS_ROLE_DEFAULT = settings.SENTRY_DEFAULT_ROLE
+EVENTS_ADMIN_ROLE_DEFAULT = settings.SENTRY_DEFAULT_ROLE
+REQUIRE_SCRUB_IP_ADDRESS_DEFAULT = False
+SCRAPE_JAVASCRIPT_DEFAULT = True
+TRUSTED_RELAYS_DEFAULT = None
+JOIN_REQUESTS_DEFAULT = True
+
+# `sentry:events_member_admin` - controls whether the 'member' role gets the event:admin scope
+EVENTS_MEMBER_ADMIN_DEFAULT = True

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.tsx
@@ -63,6 +63,25 @@ const formGroups: JsonFormObject[] = [
         label: t('Open Membership'),
         help: t('Allow organization members to freely join or leave any team'),
       },
+      {
+        name: 'eventsMemberAdmin',
+        type: 'boolean',
+        label: t('Grant Members Events Admin'),
+        help: t(
+          'Allow members to delete events (including the delete & discard action) by granting them the `event:admin` scope.'
+        ),
+      },
+      {
+        name: 'attachmentsRole',
+        type: 'array',
+        choices: ({initialData = {}}) =>
+          initialData?.availableRoles?.map((r: MemberRole) => [r.id, r.name]) ?? [],
+        label: t('Attachments Access'),
+        help: t(
+          'Permissions required to download event attachments, such as native crash reports or log files.'
+        ),
+        visible: ({features}) => features.has('event-attachments'),
+      },
     ],
   },
 ];

--- a/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacy.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacy.tsx
@@ -5,7 +5,6 @@ import {
   formatStoreCrashReports,
 } from 'app/utils/crashReports';
 import {JsonFormObject} from 'app/views/settings/components/forms/type';
-import {MemberRole} from 'app/types';
 
 const organizationSecurityAndPrivacy: JsonFormObject[] = [
   {
@@ -143,17 +142,6 @@ const organizationSecurityAndPrivacy: JsonFormObject[] = [
         visible: ({features}) => features.has('event-attachments'),
         allowedValues: STORE_CRASH_REPORTS_VALUES,
         formatLabel: formatStoreCrashReports,
-      },
-      {
-        name: 'attachmentsRole',
-        type: 'array',
-        choices: ({initialData = {}}) =>
-          initialData?.availableRoles?.map((r: MemberRole) => [r.id, r.name]) ?? [],
-        label: t('Attachments Access'),
-        help: t(
-          'Permissions required to download event attachments, such as native crash reports or log files'
-        ),
-        visible: ({features}) => features.has('event-attachments'),
       },
       {
         name: 'trustedRelays',

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -98,6 +98,7 @@ export type OrganizationSummary = {
 export type LightWeightOrganization = OrganizationSummary & {
   scrubIPAddresses: boolean;
   attachmentsRole: string;
+  eventsMemberAdmin: boolean;
   sensitiveFields: string[];
   openMembership: boolean;
   quota: {

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -198,6 +198,7 @@ class OrganizationUpdateTest(APITestCase):
             "dataScrubber": True,
             "dataScrubberDefaults": True,
             "sensitiveFields": [u"password"],
+            "eventsMemberAdmin": False,
             "safeFields": [u"email"],
             "storeCrashReports": 10,
             "scrubIPAddresses": True,
@@ -234,6 +235,7 @@ class OrganizationUpdateTest(APITestCase):
         assert options.get("sentry:store_crash_reports") == 10
         assert options.get("sentry:scrape_javascript") is False
         assert options.get("sentry:join_requests") is False
+        assert options.get("sentry:events_member_admin") is False
 
         # log created
         log = AuditLogEntry.objects.get(organization=org)
@@ -254,6 +256,7 @@ class OrganizationUpdateTest(APITestCase):
         assert u"to {}".format(data["scrubIPAddresses"]) in log.data["scrubIPAddresses"]
         assert u"to {}".format(data["scrapeJavaScript"]) in log.data["scrapeJavaScript"]
         assert u"to {}".format(data["allowJoinRequests"]) in log.data["allowJoinRequests"]
+        assert u"to {}".format(data["eventsMemberAdmin"]) in log.data["eventsMemberAdmin"]
 
     def test_setting_trusted_relays_forbidden(self):
         org = self.create_organization(owner=self.user)

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -186,3 +186,19 @@ class OrganizationMemberTest(TestCase):
         member.approve_invite()
         assert member.invite_approved
         member.invite_status == InviteStatus.APPROVED.value
+
+    def test_scopes_with_member_admin_config(self):
+        organization = self.create_organization()
+        member = OrganizationMember.objects.create(
+            organization=organization, role="member", email="test@example.com",
+        )
+
+        assert "event:admin" in member.get_scopes()
+
+        organization.update_option("sentry:events_member_admin", True)
+
+        assert "event:admin" in member.get_scopes()
+
+        organization.update_option("sentry:events_member_admin", False)
+
+        assert "event:admin" not in member.get_scopes()

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from uuid import uuid4
 
 import six
+from django.conf import settings
 from django.utils import timezone
 from exam import fixture
 from sentry.utils.compat.mock import patch, Mock
@@ -1283,6 +1284,23 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert tombstone.culprit == group1.culprit
         assert tombstone.project == group1.project
         assert tombstone.data == group1.data
+
+    @patch(
+        "sentry.models.OrganizationMember.get_scopes",
+        return_value=frozenset(s for s in settings.SENTRY_SCOPES if s != "event:admin"),
+    )
+    def test_discard_requires_events_admin(self, mock_get_scopes):
+        group1 = self.create_group(checksum="a" * 32, is_public=True)
+        user = self.user
+
+        self.login_as(user=user)
+
+        url = u"{url}?id={group1.id}".format(url=self.path, group1=group1)
+        with self.tasks(), self.feature("projects:discard-groups"):
+            response = self.client.put(url, data={"discard": True})
+
+        assert response.status_code == 400
+        assert Group.objects.filter(id=group1.id).exists()
 
 
 class GroupDeleteTest(APITestCase, SnubaTestCase):


### PR DESCRIPTION
Add an organization-level option to change the default permissions for the member role to include or exclude the 'event:admin' role, and couple Discard & Delete to event:admin.