### PR TITLE
feat(integrations): adds JIRA_USE_EMAIL_SCOPE setting

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1800,6 +1800,11 @@ KAFKA_TOPICS = {
     KAFKA_INGEST_TRANSACTIONS: {"cluster": "default", "topic": KAFKA_INGEST_TRANSACTIONS},
 }
 
+# For Jira, only approved apps can use the access_email_addresses scope
+# This scope allows Sentry to use the email endpoint (https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-user-email-get)
+# We use the email with Jira 2-way sync in order to match the user
+JIRA_USE_EMAIL_SCOPE = False
+
 """
 Fields are:
  - south_app_name: Which app to apply the conversion to

--- a/src/sentry/integrations/jira/descriptor.py
+++ b/src/sentry/integrations/jira/descriptor.py
@@ -1,11 +1,19 @@
 from __future__ import absolute_import
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from sentry.api.base import Endpoint
 from sentry.utils.http import absolute_uri
 
 from .client import JIRA_KEY
+
+scopes = ["read", "write", "act_as_user"]
+# For Jira, only approved apps can use the access_email_addresses scope
+# This scope allows Sentry to use the email endpoint (https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-user-email-get)
+# We use the email with Jira 2-way sync in order to match the user
+if settings.JIRA_USE_EMAIL_SCOPE:
+    scopes.append("access_email_addresses")
 
 
 class JiraDescriptorEndpoint(Endpoint):
@@ -46,6 +54,6 @@ class JiraDescriptorEndpoint(Endpoint):
                     ],
                 },
                 "apiMigrations": {"gdpr": True},
-                "scopes": ["read", "write", "act_as_user"],
+                "scopes": scopes,
             }
         )


### PR DESCRIPTION
This PR is a pre-cursor to the PR that actually uses the feature: https://github.com/getsentry/sentry/pull/18709

This PR just adds the scope to the settings so we can re-upload the descriptor and get the new scope and verify it works with the production app.

A getsentry PR will be added to set the setting to True.