### PR TITLE
feat(analytics): Add helper `trackDeprecated` to track usage of deprecated features

### DIFF
--- a/src/sentry/static/sentry/app/utils/analytics.tsx
+++ b/src/sentry/static/sentry/app/utils/analytics.tsx
@@ -54,6 +54,21 @@ export const logExperiment: Hooks['analytics:log-experiment'] = options =>
   HookStore.get('analytics:log-experiment').forEach(cb => cb(options));
 
 /**
+ * Helper function for `trackAnalyticsEvent` to generically track usage of deprecated features
+ *
+ * @param feature A name to identify the feature you are tracking
+ * @param orgId The organization id
+ * @param url [optional] The URL
+ */
+export const trackDeprecated = (feature: string, orgId: number, url: string = '') =>
+  trackAdhocEvent({
+    eventKey: 'deprecated.feature',
+    feature,
+    url,
+    org_id: orgId && Number(orgId),
+  });
+
+/**
  * Legacy analytics tracking.
  *
  * @deprecated Prefer `trackAnalyticsEvent` and `trackAdhocEvent`.


### PR DESCRIPTION
Adds a helper function `trackDeprecated` to track usage of deprecated features. See https://github.com/getsentry/reload/blob/master/reload_app/events.py\#L103