### PR TITLE
feat(ui): Sort projects inside release card, replace n/a with dash

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/list/notAvailable.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/notAvailable.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {t} from 'app/locale';
-
 const NotAvailable = () => {
-  return <Wrapper>{t('n/a')}</Wrapper>;
+  return <Wrapper>{'\u2014'}</Wrapper>;
 };
 
 const Wrapper = styled('div')`

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releaseHealth.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releaseHealth.tsx
@@ -66,126 +66,132 @@ const ReleaseHealth = ({release, orgSlug, location}: Props) => {
 
       <PanelBody>
         <ClippedBox clipHeight={200}>
-          {release.projects.map(project => {
-            const {id, slug, healthData, newGroups} = project;
-            const {
-              hasHealthData,
-              adoption,
-              stats,
-              crashFreeUsers,
-              crashFreeSessions,
-              sessionsCrashed,
-              totalUsers,
-              totalUsers24h,
-              totalSessions,
-              totalSessions24h,
-            } = healthData;
+          {release.projects
+            .sort((a, b) => a.slug.localeCompare(b.slug))
+            .map(project => {
+              const {id, slug, healthData, newGroups} = project;
+              const {
+                hasHealthData,
+                adoption,
+                stats,
+                crashFreeUsers,
+                crashFreeSessions,
+                sessionsCrashed,
+                totalUsers,
+                totalUsers24h,
+                totalSessions,
+                totalSessions24h,
+              } = healthData;
 
-            return (
-              <StyledPanelItem key={`${release.version}-${slug}-health`}>
-                <Layout>
-                  <ProjectColumn>
-                    <GlobalSelectionLink
-                      to={{
-                        pathname: `/organizations/${orgSlug}/releases/${encodeURIComponent(
-                          release.version
-                        )}/`,
-                        query: {project: id},
-                      }}
-                    >
-                      <ProjectBadge project={project} avatarSize={16} key={slug} />
-                    </GlobalSelectionLink>
-                  </ProjectColumn>
+              return (
+                <StyledPanelItem key={`${release.version}-${slug}-health`}>
+                  <Layout>
+                    <ProjectColumn>
+                      <GlobalSelectionLink
+                        to={{
+                          pathname: `/organizations/${orgSlug}/releases/${encodeURIComponent(
+                            release.version
+                          )}/`,
+                          query: {project: id},
+                        }}
+                      >
+                        <ProjectBadge project={project} avatarSize={16} key={slug} />
+                      </GlobalSelectionLink>
+                    </ProjectColumn>
 
-                  <AdoptionColumn>
-                    {defined(adoption) ? (
-                      <AdoptionWrapper>
-                        <Tooltip
-                          title={
-                            <AdoptionTooltip
-                              totalUsers={totalUsers}
-                              totalSessions={totalSessions}
-                              totalUsers24h={totalUsers24h}
-                              totalSessions24h={totalSessions24h}
+                    <AdoptionColumn>
+                      {defined(adoption) ? (
+                        <AdoptionWrapper>
+                          <Tooltip
+                            title={
+                              <AdoptionTooltip
+                                totalUsers={totalUsers}
+                                totalSessions={totalSessions}
+                                totalUsers24h={totalUsers24h}
+                                totalSessions24h={totalSessions24h}
+                              />
+                            }
+                          >
+                            <StyledScoreBar
+                              score={convertAdoptionToProgress(adoption)}
+                              size={20}
+                              thickness={5}
+                              radius={0}
+                              palette={Array(10).fill(theme.green)}
                             />
-                          }
-                        >
-                          <StyledScoreBar
-                            score={convertAdoptionToProgress(adoption)}
-                            size={20}
-                            thickness={5}
-                            radius={0}
-                            palette={Array(10).fill(theme.green)}
+                          </Tooltip>
+                          <TextOverflow>
+                            <Count value={totalUsers24h ?? 0} />{' '}
+                            {tn('user', 'users', totalUsers24h)}
+                          </TextOverflow>
+                        </AdoptionWrapper>
+                      ) : (
+                        <NotAvailable />
+                      )}
+                    </AdoptionColumn>
+
+                    <CrashFreeUsersColumn>
+                      {defined(crashFreeUsers) ? (
+                        <React.Fragment>
+                          <StyledProgressRing
+                            progressColor={getCrashFreePercentColor}
+                            value={crashFreeUsers}
                           />
-                        </Tooltip>
-                        <TextOverflow>
-                          <Count value={totalUsers24h ?? 0} />{' '}
-                          {tn('user', 'users', totalUsers24h)}
-                        </TextOverflow>
-                      </AdoptionWrapper>
-                    ) : (
-                      <NotAvailable />
-                    )}
-                  </AdoptionColumn>
+                          <ProgressRingCaption>
+                            {displayCrashFreePercent(crashFreeUsers)}
+                          </ProgressRingCaption>
+                        </React.Fragment>
+                      ) : (
+                        <NotAvailable />
+                      )}
+                    </CrashFreeUsersColumn>
 
-                  <CrashFreeUsersColumn>
-                    {defined(crashFreeUsers) ? (
-                      <React.Fragment>
-                        <StyledProgressRing
-                          progressColor={getCrashFreePercentColor}
-                          value={crashFreeUsers}
-                        />
-                        <ProgressRingCaption>
-                          {displayCrashFreePercent(crashFreeUsers)}
-                        </ProgressRingCaption>
-                      </React.Fragment>
-                    ) : (
-                      <NotAvailable />
-                    )}
-                  </CrashFreeUsersColumn>
+                    <CrashFreeSessionsColumn>
+                      {defined(crashFreeSessions) ? (
+                        <React.Fragment>
+                          <StyledProgressRing
+                            progressColor={getCrashFreePercentColor}
+                            value={crashFreeSessions}
+                          />
+                          <ProgressRingCaption>
+                            {displayCrashFreePercent(crashFreeSessions)}
+                          </ProgressRingCaption>
+                        </React.Fragment>
+                      ) : (
+                        <NotAvailable />
+                      )}
+                    </CrashFreeSessionsColumn>
 
-                  <CrashFreeSessionsColumn>
-                    {defined(crashFreeSessions) ? (
-                      <React.Fragment>
-                        <StyledProgressRing
-                          progressColor={getCrashFreePercentColor}
-                          value={crashFreeSessions}
-                        />
-                        <ProgressRingCaption>
-                          {displayCrashFreePercent(crashFreeSessions)}
-                        </ProgressRingCaption>
-                      </React.Fragment>
-                    ) : (
-                      <NotAvailable />
-                    )}
-                  </CrashFreeSessionsColumn>
+                    <DailyUsersColumn>
+                      {hasHealthData ? (
+                        <ChartWrapper>
+                          <HealthStatsChart
+                            data={stats}
+                            height={20}
+                            period={activeStatsPeriod}
+                            subject={activeStatsSubject}
+                          />
+                        </ChartWrapper>
+                      ) : (
+                        <NotAvailable />
+                      )}
+                    </DailyUsersColumn>
 
-                  <DailyUsersColumn>
-                    {hasHealthData ? (
-                      <ChartWrapper>
-                        <HealthStatsChart
-                          data={stats}
-                          height={20}
-                          period={activeStatsPeriod}
-                          subject={activeStatsSubject}
-                        />
-                      </ChartWrapper>
-                    ) : (
-                      <NotAvailable />
-                    )}
-                  </DailyUsersColumn>
+                    <CrashesColumn>
+                      {hasHealthData ? (
+                        <Count value={sessionsCrashed} />
+                      ) : (
+                        <NotAvailable />
+                      )}
+                    </CrashesColumn>
 
-                  <CrashesColumn>
-                    {hasHealthData ? <Count value={sessionsCrashed} /> : <NotAvailable />}
-                  </CrashesColumn>
-
-                  <NewIssuesColumn>
-                    <Count value={newGroups || 0} />
-                  </NewIssuesColumn>
-                </Layout>
-              </StyledPanelItem>
-            );
-          })}
+                    <NewIssuesColumn>
+                      <Count value={newGroups || 0} />
+                    </NewIssuesColumn>
+                  </Layout>
+                </StyledPanelItem>
+              );
+            })}
         </ClippedBox>
       </PanelBody>
     </React.Fragment>

--- a/tests/js/spec/views/releasesV2/list/index.spec.jsx
+++ b/tests/js/spec/views/releasesV2/list/index.spec.jsx
@@ -65,7 +65,7 @@ describe('ReleasesV2List', function() {
         .find('DailyUsersColumn')
         .at(1)
         .text()
-    ).toContain('n/a');
+    ).toContain('\u2014');
   });
 
   it('displays the right empty state', function() {


### PR DESCRIPTION
Improvements on the releases overview page:

- Sort projects inside release card
- Replace n/a with a dash