### PR TITLE
fix(subscriptions): Don't rely on aggregate names in subscription processor.

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -23,7 +23,7 @@ from sentry.incidents.models import (
     TriggerStatus,
 )
 from sentry.incidents.tasks import handle_trigger_action
-from sentry.snuba.models import query_aggregation_to_snuba, QueryAggregations
+from sentry.snuba.models import QueryAggregations
 from sentry.utils import metrics, redis
 from sentry.utils.dates import to_datetime, to_timestamp
 from sentry.utils.compat import zip
@@ -122,8 +122,6 @@ class SubscriptionProcessor(object):
 
         self.last_update = subscription_update["timestamp"]
 
-        aggregation = QueryAggregations(self.alert_rule.aggregation)
-        aggregation_name = query_aggregation_to_snuba[aggregation][2]
         if len(subscription_update["values"]["data"]) > 1:
             logger.warning(
                 "Subscription returned more than 1 row of data",
@@ -134,7 +132,7 @@ class SubscriptionProcessor(object):
                     "result": subscription_update,
                 },
             )
-        aggregation_value = subscription_update["values"]["data"][0][aggregation_name]
+        aggregation_value = subscription_update["values"]["data"][0].values()[0]
 
         for trigger in self.triggers:
             alert_operator, resolve_operator = self.THRESHOLD_TYPE_OPERATORS[


### PR DESCRIPTION
This fixes an issue where the aggregate name unintentionally changed and it broke the subscription
consumer.

I originally implemented this code to use the name explicitly, in case we start receiving mulitple
values at some point. I don't see any reason that this will be happening any time soon, so just
assuming a single value and grabbing it instead. This should be less brittle when we're migrating
data.

Fixes SENTRY-GCR