### PR TITLE
feat(ui): Add open in issues button to release detail page

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/styles.tsx
+++ b/src/sentry/static/sentry/app/components/charts/styles.tsx
@@ -40,10 +40,10 @@ export const InlineContainer = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-left: ${space(2)};
+  margin-right: ${space(2)};
 
-  &:first-child {
-    margin-left: 0;
+  &:last-child {
+    margin-right: 0;
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -178,19 +178,19 @@ class Issues extends React.Component<Props, State> {
 
           <ButtonBar gap={1}>
             <Feature features={['discover-basic']}>
-              <StyledButton to={this.getDiscoverUrl()}>
+              <OpenInButton to={this.getDiscoverUrl()}>
                 {t('Open in Discover')}
-              </StyledButton>
+              </OpenInButton>
             </Feature>
 
-            <StyledButton
+            <OpenInButton
               to={{
                 pathname: `/organizations/${orgId}/issues/`,
                 query: {...queryParams, query: `first-release:${version}`},
               }}
             >
               {t('Open in Issues')}
-            </StyledButton>
+            </OpenInButton>
           </ButtonBar>
         </ControlsWrapper>
 
@@ -212,7 +212,7 @@ class Issues extends React.Component<Props, State> {
 
 // used in media query
 const FilterButton = styled(DropdownButton)``;
-const StyledButton = styled(Button)``;
+const OpenInButton = styled(Button)``;
 
 const ControlsWrapper = styled('div')`
   display: flex;
@@ -220,7 +220,7 @@ const ControlsWrapper = styled('div')`
   justify-content: space-between;
   margin-bottom: ${space(1)};
   @media (max-width: ${p => p.theme.breakpoints[2]}) {
-    ${FilterButton}, ${StyledButton} {
+    ${FilterButton}, ${OpenInButton} {
       font-size: ${p => p.theme.fontSizeSmall};
     }
   }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -19,6 +19,7 @@ import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {getUtcDateString} from 'app/utils/dates';
 import DropdownButton from 'app/components/dropdownButton';
 import ButtonBar from 'app/components/buttonBar';
+import {stringifyQueryObject} from 'app/utils/tokenizeSearch';
 
 enum IssuesType {
   NEW = 'new',
@@ -75,15 +76,19 @@ class Issues extends React.Component<Props, State> {
     const {version, orgId} = this.props;
     const {issuesType} = this.state;
     const {queryParams} = this.getIssuesEndpoint();
+    const query = {query: []};
+
+    if (issuesType === IssuesType.NEW) {
+      query['first-release'] = [version];
+    } else {
+      query.release = [version];
+    }
 
     return {
       pathname: `/organizations/${orgId}/issues/`,
       query: {
         ...queryParams,
-        query:
-          issuesType === IssuesType.NEW
-            ? `first-release:${version}`
-            : `release:${version}`,
+        query: stringifyQueryObject(query),
       },
     };
   }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -19,7 +19,7 @@ import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {getUtcDateString} from 'app/utils/dates';
 import DropdownButton from 'app/components/dropdownButton';
 import ButtonBar from 'app/components/buttonBar';
-import {stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {stringifyQueryObject, QueryResults} from 'app/utils/tokenizeSearch';
 
 enum IssuesType {
   NEW = 'new',
@@ -76,7 +76,7 @@ class Issues extends React.Component<Props, State> {
     const {version, orgId} = this.props;
     const {issuesType} = this.state;
     const {queryParams} = this.getIssuesEndpoint();
-    const query = {query: []};
+    const query: QueryResults = {query: []};
 
     if (issuesType === IssuesType.NEW) {
       query['first-release'] = [version];

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -71,6 +71,23 @@ class Issues extends React.Component<Props, State> {
     return discoverView.getResultsViewUrlTarget(orgId);
   }
 
+  getIssuesUrl() {
+    const {version, orgId} = this.props;
+    const {issuesType} = this.state;
+    const {queryParams} = this.getIssuesEndpoint();
+
+    return {
+      pathname: `/organizations/${orgId}/issues/`,
+      query: {
+        ...queryParams,
+        query:
+          issuesType === IssuesType.NEW
+            ? `first-release:${version}`
+            : `release:${version}`,
+      },
+    };
+  }
+
   getIssuesEndpoint(): {path: string; queryParams: IssuesQueryParams} {
     const {version, orgId, location} = this.props;
     const {issuesType} = this.state;
@@ -144,7 +161,7 @@ class Issues extends React.Component<Props, State> {
 
   render() {
     const {issuesType} = this.state;
-    const {orgId, version} = this.props;
+    const {orgId} = this.props;
     const {path, queryParams} = this.getIssuesEndpoint();
     const issuesTypes = [
       {value: 'new', label: t('New Issues')},
@@ -183,14 +200,7 @@ class Issues extends React.Component<Props, State> {
               </OpenInButton>
             </Feature>
 
-            <OpenInButton
-              to={{
-                pathname: `/organizations/${orgId}/issues/`,
-                query: {...queryParams, query: `first-release:${version}`},
-              }}
-            >
-              {t('Open in Issues')}
-            </OpenInButton>
+            <OpenInButton to={this.getIssuesUrl()}>{t('Open in Issues')}</OpenInButton>
           </ButtonBar>
         </ControlsWrapper>
 

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -178,19 +178,19 @@ class Issues extends React.Component<Props, State> {
 
           <ButtonBar gap={1}>
             <Feature features={['discover-basic']}>
-              <DiscoverButton to={this.getDiscoverUrl()}>
+              <StyledButton to={this.getDiscoverUrl()}>
                 {t('Open in Discover')}
-              </DiscoverButton>
+              </StyledButton>
             </Feature>
 
-            <IssuesButton
+            <StyledButton
               to={{
                 pathname: `/organizations/${orgId}/issues/`,
                 query: {...queryParams, query: `first-release:${version}`},
               }}
             >
               {t('Open in Issues')}
-            </IssuesButton>
+            </StyledButton>
           </ButtonBar>
         </ControlsWrapper>
 
@@ -212,8 +212,7 @@ class Issues extends React.Component<Props, State> {
 
 // used in media query
 const FilterButton = styled(DropdownButton)``;
-const DiscoverButton = styled(Button)``;
-const IssuesButton = styled(Button)``;
+const StyledButton = styled(Button)``;
 
 const ControlsWrapper = styled('div')`
   display: flex;
@@ -221,7 +220,7 @@ const ControlsWrapper = styled('div')`
   justify-content: space-between;
   margin-bottom: ${space(1)};
   @media (max-width: ${p => p.theme.breakpoints[2]}) {
-    ${FilterButton}, ${DiscoverButton}, ${IssuesButton} { /* stylelint-disable-line selector-type-no-unknown */
+    ${FilterButton}, ${StyledButton} {
       font-size: ${p => p.theme.fontSizeSmall};
     }
   }
@@ -229,7 +228,7 @@ const ControlsWrapper = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: block;
     ${FilterButton} {
-      margin-bottom: ${space(1)}
+      margin-bottom: ${space(1)};
     }
   }
 `;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -18,6 +18,7 @@ import Feature from 'app/components/acl/feature';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {getUtcDateString} from 'app/utils/dates';
 import DropdownButton from 'app/components/dropdownButton';
+import ButtonBar from 'app/components/buttonBar';
 
 enum IssuesType {
   NEW = 'new',
@@ -143,7 +144,7 @@ class Issues extends React.Component<Props, State> {
 
   render() {
     const {issuesType} = this.state;
-    const {orgId} = this.props;
+    const {orgId, version} = this.props;
     const {path, queryParams} = this.getIssuesEndpoint();
     const issuesTypes = [
       {value: 'new', label: t('New Issues')},
@@ -175,11 +176,22 @@ class Issues extends React.Component<Props, State> {
             ))}
           </DropdownControl>
 
-          <Feature features={['discover-basic']}>
-            <DiscoverButton to={this.getDiscoverUrl()}>
-              {t('Open in Discover')}
-            </DiscoverButton>
-          </Feature>
+          <ButtonBar gap={1}>
+            <Feature features={['discover-basic']}>
+              <DiscoverButton to={this.getDiscoverUrl()}>
+                {t('Open in Discover')}
+              </DiscoverButton>
+            </Feature>
+
+            <IssuesButton
+              to={{
+                pathname: `/organizations/${orgId}/issues/`,
+                query: {...queryParams, query: `first-release:${version}`},
+              }}
+            >
+              {t('Open in Issues')}
+            </IssuesButton>
+          </ButtonBar>
         </ControlsWrapper>
 
         <TableWrapper>
@@ -198,17 +210,26 @@ class Issues extends React.Component<Props, State> {
   }
 }
 
+// used in media query
 const FilterButton = styled(DropdownButton)``;
 const DiscoverButton = styled(Button)``;
+const IssuesButton = styled(Button)``;
 
 const ControlsWrapper = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: ${space(1)};
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    ${FilterButton}, ${DiscoverButton} {
+  @media (max-width: ${p => p.theme.breakpoints[2]}) {
+    ${FilterButton}, ${DiscoverButton}, ${IssuesButton} { /* stylelint-disable-line selector-type-no-unknown */
       font-size: ${p => p.theme.fontSizeSmall};
+    }
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    display: block;
+    ${FilterButton} {
+      margin-bottom: ${space(1)}
     }
   }
 `;


### PR DESCRIPTION
This PR adds "Open in Issues" button to release detail page.

![image](https://user-images.githubusercontent.com/9060071/81747128-d9a2dd00-94a7-11ea-8e9d-f7e0a57e1518.png)
