### PR TITLE
fix(perf-views): Latency Distribution couldn't load with env

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -186,8 +186,9 @@ def find_histogram_buckets(field, params, conditions):
     conditions = deepcopy(conditions) if conditions else []
     found = False
     for cond in conditions:
-        if (cond[0], cond[1], cond[2]) == ("event.type", "=", "transaction"):
+        if len(cond) == 3 and (cond[0], cond[1], cond[2]) == ("event.type", "=", "transaction"):
             found = True
+            break
     if not found:
         conditions.append(["event.type", "=", "transaction"])
     snuba_filter = eventstore.Filter(conditions=conditions)

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1249,7 +1249,7 @@ class QueryTransformTest(TestCase):
         discover.query(
             selected_columns=["histogram(transaction.duration, 10)", "count()"],
             query="",
-            params={"project_id": [self.project.id]},
+            params={"project_id": [self.project.id], "environment": self.environment.name},
             auto_fields=True,
             use_aggregate_conditions=False,
         )
@@ -1276,7 +1276,7 @@ class QueryTransformTest(TestCase):
             filter_keys={"project_id": [self.project.id]},
             dataset=Dataset.Discover,
             groupby=["histogram_transaction_duration_10_1000_0"],
-            conditions=[],
+            conditions=[[["environment", "=", self.environment.name]]],
             end=None,
             start=None,
             orderby=None,


### PR DESCRIPTION
- This was a bug with ORs in the conditions list, since they have length 1. Fixed by adding a break, and checking cond is length 3 (fine if
  there are other ORs since we're just looking for event.type)
- Fixes SENTRY-GCK