### PR TITLE
ref(alerts): Drop aggregation from incident type

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -62,7 +62,7 @@ export default class DetailsBody extends React.Component<Props> {
       name: (incident && incident.title) || '',
       fields: ['issue', 'title', 'count(id)', 'count_unique(user.id)'],
       orderby:
-        incident.aggregation === AlertRuleAggregations.UNIQUE_USERS
+        incident.alertRule.aggregation === AlertRuleAggregations.UNIQUE_USERS
           ? '-count_unique_user_id'
           : '-count_id',
       query: incident?.discoverQuery ?? '',
@@ -173,7 +173,7 @@ export default class DetailsBody extends React.Component<Props> {
         <ChartWrapper>
           {incident && stats ? (
             <Chart
-              aggregation={incident.aggregation}
+              aggregation={incident.alertRule.aggregation}
               data={stats.eventStats.data}
               detected={incident.dateDetected}
               closed={incident.dateClosed}

--- a/src/sentry/static/sentry/app/views/alerts/types.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/types.tsx
@@ -1,7 +1,4 @@
-import {
-  AlertRuleAggregations,
-  IncidentRule,
-} from 'app/views/settings/incidentRules/types';
+import {IncidentRule} from 'app/views/settings/incidentRules/types';
 import {User, Repository} from 'app/types';
 
 type Data = [number, {count: number}[]][];
@@ -25,7 +22,6 @@ export type Incident = {
   title: string;
   hasSeen: boolean;
   alertRule: IncidentRule;
-  aggregation: AlertRuleAggregations;
 };
 
 export type IncidentStats = {


### PR DESCRIPTION
We can use the alertRule.aggregation on the incident instead.