### PR TITLE
refs(subscriptions): Use more fields from `snuba_query` to replace fields on the alert rule.

### DIFF
--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -53,7 +53,7 @@ class IncidentSerializer(Serializer):
 class DetailedIncidentSerializer(IncidentSerializer):
     def get_attrs(self, item_list, user, **kwargs):
         results = super(DetailedIncidentSerializer, self).get_attrs(item_list, user=user, **kwargs)
-        attach_foreignkey(item_list, Incident.alert_rule)
+        attach_foreignkey(item_list, Incident.alert_rule, related=("snuba_query",))
         subscribed_incidents = set()
         if user.is_authenticated():
             subscribed_incidents = set(
@@ -108,9 +108,9 @@ class DetailedIncidentSerializer(IncidentSerializer):
         query = incident.query
         if (
             incident.alert_rule
-            and QueryDatasets(incident.alert_rule.dataset) == QueryDatasets.EVENTS
+            and QueryDatasets(incident.alert_rule.snuba_query.dataset) == QueryDatasets.EVENTS
         ):
-            query = incident.alert_rule.query
+            query = incident.alert_rule.snuba_query.query
             condition = "event.type:error"
             query = "{} {}".format(condition, query) if query else condition
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -819,6 +819,10 @@ class Factories(object):
     ):
         if not title:
             title = petname.Generate(2, " ", letters=10).title()
+        if alert_rule is None:
+            alert_rule = Factories.create_alert_rule(
+                organization, projects, query=query, time_window=1
+            )
 
         incident = Incident.objects.create(
             organization=organization,

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -111,7 +111,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             "aggregate": handler.query_aggregations_display[
                 QueryAggregations(action.alert_rule_trigger.alert_rule.aggregation)
             ],
-            "query": action.alert_rule_trigger.alert_rule.query,
+            "query": action.alert_rule_trigger.alert_rule.snuba_query.query,
             "threshold": action.alert_rule_trigger.alert_threshold,
             "status": INCIDENT_STATUS[IncidentStatus(incident.status)],
             "environment": "All",

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -664,12 +664,10 @@ class CreateIncidentSnapshotTest(TestCase, BaseIncidentsTest):
 @freeze_time()
 class BulkGetIncidentStatsTest(TestCase, BaseIncidentsTest):
     def test(self):
-        closed_incident = create_incident(
+        closed_incident = self.create_incident(
             self.organization,
-            IncidentType.ALERT_TRIGGERED,
-            "Closed",
-            "",
-            QueryAggregations.TOTAL,
+            title="Closed",
+            query="",
             groups=[self.group],
             date_started=timezone.now() - timedelta(days=30),
         )
@@ -678,12 +676,10 @@ class BulkGetIncidentStatsTest(TestCase, BaseIncidentsTest):
             IncidentStatus.CLOSED,
             status_method=IncidentStatusMethod.RULE_TRIGGERED,
         )
-        open_incident = create_incident(
+        open_incident = self.create_incident(
             self.organization,
-            IncidentType.ALERT_TRIGGERED,
-            "Open",
-            "",
-            QueryAggregations.TOTAL,
+            title="Open",
+            query="",
             groups=[self.group],
             date_started=timezone.now() - timedelta(days=30),
         )

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -111,9 +111,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
                 timedelta(minutes=1),
                 None,
             )
-            sub = create_snuba_subscription(
-                self.project, registration_key, snuba_query, QueryAggregations.TOTAL
-            )
+            sub = create_snuba_subscription(self.project, registration_key, snuba_query)
         sub.refresh_from_db()
 
         data = self.valid_wrapper

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -59,7 +59,7 @@ class CreateSnubaSubscriptionTest(TestCase):
         snuba_query = create_snuba_query(
             dataset, query, aggregation, time_window, resolution, self.environment
         )
-        subscription = create_snuba_subscription(self.project, type, snuba_query, aggregation)
+        subscription = create_snuba_subscription(self.project, type, snuba_query)
 
         assert subscription.status == QuerySubscription.Status.CREATING.value
         assert subscription.project == self.project
@@ -82,7 +82,7 @@ class CreateSnubaSubscriptionTest(TestCase):
             snuba_query = create_snuba_query(
                 dataset, query, aggregation, time_window, resolution, self.environment
             )
-            subscription = create_snuba_subscription(self.project, type, snuba_query, aggregation)
+            subscription = create_snuba_subscription(self.project, type, snuba_query)
             subscription = QuerySubscription.objects.get(id=subscription.id)
             assert subscription.status == QuerySubscription.Status.ACTIVE.value
             assert subscription.project == self.project
@@ -105,7 +105,7 @@ class CreateSnubaSubscriptionTest(TestCase):
             snuba_query = create_snuba_query(
                 dataset, query, aggregation, time_window, resolution, self.environment
             )
-            subscription = create_snuba_subscription(self.project, type, snuba_query, aggregation)
+            subscription = create_snuba_subscription(self.project, type, snuba_query)
         subscription = QuerySubscription.objects.get(id=subscription.id)
         assert subscription.status == QuerySubscription.Status.ACTIVE.value
         assert subscription.project == self.project
@@ -175,7 +175,7 @@ class UpdateSnubaQueryTest(TestCase):
             timedelta(minutes=2),
             self.environment,
         )
-        sub = create_snuba_subscription(self.project, "hi", snuba_query, QueryAggregations.TOTAL)
+        sub = create_snuba_subscription(self.project, "hi", snuba_query)
 
         new_env = self.create_environment()
         query = "level:error"
@@ -201,9 +201,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
                 timedelta(minutes=1),
                 None,
             )
-            subscription = create_snuba_subscription(
-                self.project, "something", snuba_query, QueryAggregations.TOTAL
-            )
+            subscription = create_snuba_subscription(self.project, "something", snuba_query)
 
         query = "level:warning"
         aggregation = QueryAggregations.UNIQUE_USERS
@@ -219,7 +217,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
             aggregate=aggregation_function_translations[aggregation],
         )
         assert subscription_id is not None
-        update_snuba_subscription(subscription, snuba_query, aggregation)
+        update_snuba_subscription(subscription, snuba_query)
         assert subscription.status == QuerySubscription.Status.UPDATING.value
         assert subscription.subscription_id == subscription_id
         assert subscription.snuba_query.query == query
@@ -241,9 +239,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
                 timedelta(minutes=1),
                 None,
             )
-            subscription = create_snuba_subscription(
-                self.project, "something", snuba_query, QueryAggregations.TOTAL
-            )
+            subscription = create_snuba_subscription(self.project, "something", snuba_query)
 
             query = "level:warning"
             aggregation = QueryAggregations.UNIQUE_USERS
@@ -257,8 +253,9 @@ class UpdateSnubaSubscriptionTest(TestCase):
                 time_window=int(time_window.total_seconds()),
                 resolution=int(resolution.total_seconds()),
                 environment=self.environment,
+                aggregate=translate_aggregation(aggregation),
             )
-            update_snuba_subscription(subscription, snuba_query, aggregation)
+            update_snuba_subscription(subscription, snuba_query)
             subscription = QuerySubscription.objects.get(id=subscription.id)
             assert subscription.status == QuerySubscription.Status.ACTIVE.value
             assert subscription.subscription_id is not None
@@ -280,9 +277,7 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
                 timedelta(minutes=1),
                 None,
             )
-            subscription = create_snuba_subscription(
-                self.project, "something", snuba_query, QueryAggregations.TOTAL
-            )
+            subscription = create_snuba_subscription(self.project, "something", snuba_query)
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "level:error",
@@ -292,10 +287,7 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
                 None,
             )
             other_subscription = create_snuba_subscription(
-                self.create_project(organization=self.organization),
-                "something",
-                snuba_query,
-                QueryAggregations.TOTAL,
+                self.create_project(organization=self.organization), "something", snuba_query
             )
         subscription_ids = [subscription.id, other_subscription.id]
         bulk_delete_snuba_subscriptions([subscription, other_subscription])
@@ -320,9 +312,7 @@ class DeleteSnubaSubscriptionTest(TestCase):
                 timedelta(minutes=1),
                 None,
             )
-            subscription = create_snuba_subscription(
-                self.project, "something", snuba_query, QueryAggregations.TOTAL
-            )
+            subscription = create_snuba_subscription(self.project, "something", snuba_query)
         # Refetch since snuba creation happens in a task
         subscription = QuerySubscription.objects.get(id=subscription.id)
         subscription_id = subscription.subscription_id
@@ -341,9 +331,7 @@ class DeleteSnubaSubscriptionTest(TestCase):
                 timedelta(minutes=1),
                 None,
             )
-            subscription = create_snuba_subscription(
-                self.project, "something", snuba_query, QueryAggregations.TOTAL
-            )
+            subscription = create_snuba_subscription(self.project, "something", snuba_query)
             subscription_id = subscription.id
             delete_snuba_subscription(subscription)
             assert not QuerySubscription.objects.filter(id=subscription_id).exists()

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -94,9 +94,7 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
                 timedelta(minutes=1),
                 None,
             )
-            sub = create_snuba_subscription(
-                self.project, self.registration_key, snuba_query, QueryAggregations.TOTAL
-            )
+            sub = create_snuba_subscription(self.project, self.registration_key, snuba_query)
             sub.subscription_id = self.subscription_id
             sub.status = 0
             sub.save()


### PR DESCRIPTION
This continues the work from https://github.com/getsentry/sentry/pull/18751. This converts most of
the fields in Sentry to use this new model. Will follow this up with a pr to remove the old fields.