### PR TITLE
fix(ui): Fix browser navigation button breaking `<GlobalSelectionHeader>`

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -212,11 +212,15 @@ export function initializeUrlState({
 
 /**
  * Updates store and global project selection URL param if `router` is supplied
+ *
+ * This accepts `environments` from `options` to also update environments simultaneously
+ * as environments are tied to a project, so if you change projects, you may need
+ * to clear environments.
  */
 export function updateProjects(
   projects: ProjectId[],
   router?: Router,
-  options?: Options
+  options?: Options & {environments?: EnvironmentId[]}
 ) {
   if (!isProjectsValid(projects)) {
     Sentry.withScope(scope => {
@@ -226,8 +230,8 @@ export function updateProjects(
     return;
   }
 
-  GlobalSelectionActions.updateProjects(projects);
-  updateParams({project: projects}, router, options);
+  GlobalSelectionActions.updateProjects(projects, options?.environments);
+  updateParams({project: projects, environment: options?.environments}, router, options);
 }
 
 function isProjectsValid(projects: ProjectId[]) {

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -284,8 +284,10 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
     const {projects} = this.state;
 
     // Clear environments when switching projects
-    updateEnvironments([], this.getRouter(), this.getUpdateOptions());
-    updateProjects(projects || [], this.getRouter(), this.getUpdateOptions());
+    updateProjects(projects || [], this.getRouter(), {
+      ...this.getUpdateOptions(),
+      environments: [],
+    });
     this.setState({projects: null, environments: null});
     callIfFunction(this.props.onUpdateProjects, projects);
   };

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -37,7 +37,6 @@ const GlobalSelectionStore = Reflux.createStore({
 
   /**
    * Initializes the global selection store data
-   * Use query params if they exist, otherwise check local storage
    */
   onInitializeUrlState(newSelection) {
     this._hasInitialState = true;
@@ -57,7 +56,7 @@ const GlobalSelectionStore = Reflux.createStore({
     this.trigger(this.get());
   },
 
-  updateProjects(projects = []) {
+  updateProjects(projects = [], environments = null) {
     if (isEqual(this.selection.projects, projects)) {
       return;
     }
@@ -65,6 +64,7 @@ const GlobalSelectionStore = Reflux.createStore({
     this.selection = {
       ...this.selection,
       projects,
+      environments: environments === null ? this.selection.environments : environments,
     };
     this.trigger(this.get());
   },

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -123,6 +123,34 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         self.issues_list.wait_until_loaded()
         assert u"project={}".format(self.project_3.id) in self.browser.current_url
 
+    def test_global_selection_header_navigates_with_browser_back_button(self):
+        """
+        Global Selection Header should:
+        1) load project from URL if it exists
+        2) enforce a single project if loading issues list with no project in URL
+           a) last selected project via local storage if it exists
+           b) otherwise need to just select first project
+        """
+        self.create_issues()
+        # Issues list with project 1 selected
+        self.issues_list.visit_issue_list(
+            self.org.slug, query="?project=" + six.text_type(self.project_1.id)
+        )
+        self.issues_list.visit_issue_list(self.org.slug)
+        assert self.issues_list.global_selection.get_selected_project_slug() == self.project_1.slug
+
+        # selects a different project
+        self.issues_list.global_selection.select_project_by_slug(self.project_3.slug)
+        self.issues_list.wait_until_loaded()
+        assert u"project={}".format(self.project_3.id) in self.browser.current_url
+        assert self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
+
+        # simulate pressing the browser back button
+        self.browser.back()
+        self.issues_list.wait_until_loaded()
+        assert u"project={}".format(self.project_1.id) in self.browser.current_url
+        assert self.issues_list.global_selection.get_selected_project_slug() == self.project_1.slug
+
     def test_global_selection_header_loads_with_correct_project_with_multi_project(self):
         """
         Global Selection Header should:

--- a/tests/js/spec/actionCreators/globalSelection.spec.jsx
+++ b/tests/js/spec/actionCreators/globalSelection.spec.jsx
@@ -98,7 +98,10 @@ describe('GlobalSelection ActionCreators', function() {
   describe('updateProjects()', function() {
     it('updates', function() {
       updateProjects([1, 2]);
-      expect(GlobalSelectionActions.updateProjects).toHaveBeenCalledWith([1, 2]);
+      expect(GlobalSelectionActions.updateProjects).toHaveBeenCalledWith(
+        [1, 2],
+        undefined
+      );
     });
 
     it('does not update invalid projects', function() {

--- a/tests/js/spec/views/events/index.spec.jsx
+++ b/tests/js/spec/views/events/index.spec.jsx
@@ -174,9 +174,10 @@ describe('EventsContainer', function() {
       await tick();
       wrapper.update();
 
-      expect(router.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenLastCalledWith({
         pathname: '/organizations/org-slug/events/',
         query: {
+          environment: [],
           project: [2],
         },
       });
@@ -204,9 +205,10 @@ describe('EventsContainer', function() {
 
       wrapper.find('MultipleProjectSelector StyledChevron').simulate('click');
 
-      expect(router.push).toHaveBeenCalledWith({
+      expect(router.push).toHaveBeenLastCalledWith({
         pathname: '/organizations/org-slug/events/',
         query: {
+          environment: [],
           project: [2, 3],
         },
       });


### PR DESCRIPTION
This fixes browser navigation breaking the header and adds a test. Changes `updateProjects` to additionally accept an argument for updating environments as well as we generally need to update environments if we change projects.

This bug was introduced in #18499 