### PR TITLE
fix(ui): Reset start/end in selectionHeader if showAbsolute is false

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -94,6 +94,7 @@ type InitializeUrlStateParams = {
   skipLoadLastUsed?: boolean;
   defaultSelection?: Partial<GlobalSelection>;
   forceProject?: MinimalProject | null;
+  showAbsolute?: boolean;
 };
 
 export function initializeUrlState({
@@ -106,11 +107,12 @@ export function initializeUrlState({
   shouldEnforceSingleProject,
   defaultSelection,
   forceProject,
+  showAbsolute = true,
 }: InitializeUrlStateParams) {
   const orgSlug = organization.slug;
   const query = pick(queryParams, [URL_PARAM.PROJECT, URL_PARAM.ENVIRONMENT]);
   const hasProjectOrEnvironmentInUrl = Object.keys(query).length > 0;
-  const parsed = getStateFromQuery(queryParams);
+  const parsed = getStateFromQuery(queryParams, {allowAbsoluteDatetime: showAbsolute});
 
   let globalSelection: Omit<GlobalSelection, 'datetime'> & {
     datetime: {
@@ -192,6 +194,7 @@ export function initializeUrlState({
   // To keep URLs clean, don't push default period if url params are empty
   const parsedWithNoDefaultPeriod = getStateFromQuery(queryParams, {
     allowEmptyPeriod: true,
+    allowAbsoluteDatetime: showAbsolute,
   });
 
   const newDatetime = {

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/getParams.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/getParams.tsx
@@ -137,17 +137,21 @@ type InputParams = {
   [others: string]: any;
 };
 
+type GetParamsOptions = {
+  allowEmptyPeriod?: boolean;
+  allowAbsoluteDatetime?: boolean;
+};
 export function getParams(
   params: InputParams,
-  {allowEmptyPeriod = false}: {allowEmptyPeriod?: boolean} = {}
+  {allowEmptyPeriod = false, allowAbsoluteDatetime = true}: GetParamsOptions = {}
 ): ParsedParams {
   const {start, end, period, statsPeriod, utc, ...otherParams} = params;
 
   // `statsPeriod` takes precedence for now
   let coercedPeriod = getStatsPeriodValue(statsPeriod) || getStatsPeriodValue(period);
 
-  const dateTimeStart = getDateTimeString(start);
-  const dateTimeEnd = getDateTimeString(end);
+  const dateTimeStart = allowAbsoluteDatetime ? getDateTimeString(start) : null;
+  const dateTimeEnd = allowAbsoluteDatetime ? getDateTimeString(end) : null;
 
   if (!(dateTimeStart && dateTimeEnd)) {
     if (!coercedPeriod && !allowEmptyPeriod) {

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.tsx
@@ -62,6 +62,7 @@ class GlobalSelectionHeaderContainer extends React.Component<Props> {
       shouldForceProject,
       hasCustomRouting,
       skipLoadLastUsed,
+      showAbsolute,
       ...props
     } = this.props;
     const enforceSingleProject = !organization.features.includes('global-views');
@@ -82,6 +83,7 @@ class GlobalSelectionHeaderContainer extends React.Component<Props> {
             shouldForceProject={!!shouldForceProject}
             shouldEnforceSingleProject={!hasCustomRouting && enforceSingleProject}
             memberProjects={memberProjects}
+            showAbsolute={showAbsolute}
           />
         )}
         <GlobalSelectionHeader
@@ -96,6 +98,7 @@ class GlobalSelectionHeaderContainer extends React.Component<Props> {
           forceProject={forceProject}
           memberProjects={memberProjects}
           nonMemberProjects={nonMemberProjects}
+          showAbsolute={showAbsolute}
         />
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/initializeGlobalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/initializeGlobalSelectionHeader.tsx
@@ -23,6 +23,7 @@ type Props = {
     | 'shouldForceProject'
     | 'memberProjects'
     | 'organization'
+    | 'showAbsolute'
   >;
 
 /**
@@ -46,6 +47,7 @@ class InitializeGlobalSelectionHeader extends React.Component<Props> {
       shouldForceProject,
       shouldEnforceSingleProject,
       skipLoadLastUsed,
+      showAbsolute,
     } = this.props;
 
     //
@@ -59,6 +61,7 @@ class InitializeGlobalSelectionHeader extends React.Component<Props> {
       forceProject,
       shouldForceProject,
       shouldEnforceSingleProject,
+      showAbsolute,
     });
   }
 

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.tsx
@@ -20,7 +20,7 @@ export function getStateFromQuery(
   query: Location['query'],
   {allowEmptyPeriod = false, allowAbsoluteDatetime = true}: GetStateFromQueryOptions = {}
 ) {
-  const parsedParams = getParams(query, {allowEmptyPeriod});
+  const parsedParams = getParams(query, {allowEmptyPeriod, allowAbsoluteDatetime});
 
   const projectFromQuery = query[URL_PARAM.PROJECT];
   const environmentFromQuery = query[URL_PARAM.ENVIRONMENT];

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.tsx
@@ -12,9 +12,13 @@ import {getParams} from './getParams';
 const DEFAULT_PARAMS = getParams({});
 
 // Parses URL query parameters for values relevant to global selection header
+type GetStateFromQueryOptions = {
+  allowEmptyPeriod?: boolean;
+  allowAbsoluteDatetime?: boolean;
+};
 export function getStateFromQuery(
   query: Location['query'],
-  {allowEmptyPeriod = false}: {allowEmptyPeriod?: boolean} = {}
+  {allowEmptyPeriod = false, allowAbsoluteDatetime = true}: GetStateFromQueryOptions = {}
 ) {
   const parsedParams = getParams(query, {allowEmptyPeriod});
 
@@ -23,7 +27,7 @@ export function getStateFromQuery(
   const period = parsedParams.statsPeriod;
   const utc = parsedParams.utc;
 
-  const hasAbsolute = !!parsedParams.start && !!parsedParams.end;
+  const hasAbsolute = allowAbsoluteDatetime && !!parsedParams.start && !!parsedParams.end;
 
   let project: number[] | null | undefined;
   if (defined(projectFromQuery) && Array.isArray(projectFromQuery)) {

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -315,6 +315,32 @@ describe('GlobalSelectionHeader', function() {
     });
   });
 
+  it('resets start&end if showAbsolute prop is false', async function() {
+    mountWithTheme(
+      <GlobalSelectionHeader organization={organization} showAbsolute={false} />,
+      changeQuery(routerContext, {
+        start: '2020-05-05T07:26:53.000',
+        end: '2020-05-05T09:19:12.000',
+      })
+    );
+
+    await tick();
+
+    expect(GlobalSelectionStore.get()).toEqual({
+      isReady: true,
+      selection: {
+        datetime: {
+          period: '14d',
+          utc: null,
+          start: null,
+          end: null,
+        },
+        environments: [],
+        projects: [],
+      },
+    });
+  });
+
   /**
    * I don't think this test is really applicable anymore
    */


### PR DESCRIPTION
There's a showAbsolute prop on globalSelectionHeader which hides the absolute datetime selection and thus allows to select only predefined periods (1h, 24h, 14d, etc,).

This PR fixes the following use case:
We are on a page that allows absolute datetime, we select start&end and then navigate (via globalSelectionLink) to another page that does not allow it. Right now the behavior is faulty because selection stays absolute - this PR changes it so that it resets to default.