### PR TITLE
Fix(ui) Add error message regex data scrubbing

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSelectControl.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSelectControl.tsx
@@ -9,20 +9,40 @@ type Props = Pick<
   'value' | 'placeholder' | 'name' | 'onChange' | 'options' | 'isDisabled'
 >;
 
-const DataPrivacyRulesPanelFormSelectControl = ({...props}: Props) => (
-  <SelectControl
-    {...props}
-    isSearchable={false}
-    styles={{
-      control: (provided: {[x: string]: string | number | boolean}) => ({
-        ...provided,
-        minHeight: '40px',
-        height: '40px',
-      }),
-    }}
-    openOnFocus
-    required
-  />
-);
+class DataPrivacyRulesPanelFormSelectControl extends React.Component<Props> {
+  componentDidMount() {
+    if (!this.selectRef.current) {
+      return;
+    }
+
+    if (this.selectRef.current?.select) {
+      const input = this.selectRef.current.select?.inputRef;
+      if (input) {
+        input.autocomplete = 'off';
+      }
+    }
+  }
+
+  selectRef = React.createRef<typeof SelectControl>();
+
+  render() {
+    return (
+      <SelectControl
+        {...this.props}
+        isSearchable={false}
+        styles={{
+          control: (provided: {[x: string]: string | number | boolean}) => ({
+            ...provided,
+            minHeight: '40px',
+            height: '40px',
+          }),
+        }}
+        ref={this.selectRef}
+        openOnFocus
+        required
+      />
+    );
+  }
+}
 
 export default DataPrivacyRulesPanelFormSelectControl;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSelectControl.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSelectControl.tsx
@@ -15,11 +15,8 @@ class DataPrivacyRulesPanelFormSelectControl extends React.Component<Props> {
       return;
     }
 
-    if (this.selectRef.current?.select) {
-      const input = this.selectRef.current.select?.inputRef;
-      if (input) {
-        input.autocomplete = 'off';
-      }
+    if (this.selectRef.current?.select?.inputRef) {
+      this.selectRef.current.select.inputRef.autocomplete = 'off';
     }
   }
 


### PR DESCRIPTION
closes: https://app.asana.com/0/1158284503473033/1171537772136779

**Problem:**

When the second selector option is a credit card, the from field in some browsers opens the browser autocomplete together with the suggestions 

**Solution:**

Add autocomplete="off" in the input element