### PR TITLE
test(incidents): Make sure an exception is set for incident tests

### DIFF
--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -247,6 +247,9 @@ class BaseIncidentsTest(SnubaTestCase):
             "fingerprint": [fingerprint],
             "timestamp": iso_format(timestamp),
             "type": "error",
+            # This is necessary because event type error should not exist without
+            # an exception being in the payload
+            "exception": [{"type": "Foo"}],
         }
         if user:
             data["user"] = user


### PR DESCRIPTION
The incident test incorrectly created an error event without an exception
which with recent normalization changes reverted this error type back to
default.