### PR TITLE
feat: turn on releases v2 by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -834,7 +834,7 @@ SENTRY_FEATURES = {
     # Lets organizations manage grouping configs
     "organizations:set-grouping-config": False,
     # Enable Releases v2 feature
-    "organizations:releases-v2": False,
+    "organizations:releases-v2": True,
     # Enable rule page.
     "organizations:rule-page": False,
     # Enable incidents feature

--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -38,7 +38,6 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import withOrganization from 'app/utils/withOrganization';
 import {Organization} from 'app/types';
-import {wantsLegacyReleases} from 'app/views/releasesV2/utils';
 
 import {getSidebarPanelContainer} from './sidebarPanel';
 import Broadcasts from './broadcasts';
@@ -302,20 +301,6 @@ class Sidebar extends React.Component<Props, State> {
     return sidebarState;
   }
 
-  /**
-   * Determine which version of releases to show
-   */
-  shouldShowNewReleases() {
-    const {organization} = this.props;
-
-    // Bail as we can't do any more checks.
-    if (!organization || !organization.features) {
-      return false;
-    }
-
-    return organization.features.includes('releases-v2') && !wantsLegacyReleases();
-  }
-
   render() {
     const {organization, collapsed} = this.props;
     const {currentPanel, showPanel, horizontal} = this.state;
@@ -458,7 +443,6 @@ class Sidebar extends React.Component<Props, State> {
                     label={t('Releases')}
                     to={`/organizations/${organization.slug}/releases/`}
                     id="releases"
-                    isBeta={this.shouldShowNewReleases()}
                   />
                   <SidebarItem
                     {...sidebarItemProps}

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -7,7 +7,6 @@ import {forceCheck} from 'react-lazyload';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import AsyncView from 'app/views/asyncView';
-import FeatureBadge from 'app/components/featureBadge';
 import {Organization, Release} from 'app/types';
 import routeTitleGen from 'app/utils/routeTitle';
 import SearchBar from 'app/components/searchBar';
@@ -209,9 +208,7 @@ class ReleasesList extends AsyncView<Props, State> {
         <PageContent>
           <LightWeightNoProjectMessage organization={organization}>
             <StyledPageHeader>
-              <PageHeading>
-                {t('Releases')} <FeatureBadge type="beta" />
-              </PageHeading>
+              <PageHeading>{t('Releases')}</PageHeading>
               <SortAndFilterWrapper>
                 <ReleaseListSortOptions
                   selected={this.getSort()}

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -34,6 +34,7 @@ class OrganizationSerializerTest(TestCase):
                 "custom-symbol-sources",
                 "tweak-grouping-config",
                 "grouping-info",
+                "releases-v2",
             ]
         )
 


### PR DESCRIPTION
This removes the beta label and makes releases v2 available to everybody.