### PR TITLE
fix(releases): Do not permit negative error counts

### DIFF
--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -407,7 +407,9 @@ def get_project_release_stats(project_id, release, stat, rollup, start, end, env
             stat: rv[stat],
             stat + "_crashed": rv[stat + "_crashed"],
             stat + "_abnormal": rv[stat + "_abnormal"],
-            stat + "_errored": rv[stat + "_errored"] - rv[stat + "_crashed"],
+            # Due to the nature of the probabilistic data structures this
+            # subtraction can become negative.
+            stat + "_errored": max(0, rv[stat + "_errored"] - rv[stat + "_crashed"]),
             "duration_p50": _convert_duration(rv["duration_quantiles"][0]),
             "duration_p90": _convert_duration(rv["duration_quantiles"][1]),
         }
@@ -445,7 +447,9 @@ def get_project_release_stats(project_id, release, stat, rollup, start, end, env
                 "users": rv["users"],
                 "users_crashed": rv["users_crashed"],
                 "users_abnormal": rv["users_abnormal"],
-                "users_errored": rv["users_errored"] - rv["users_crashed"],
+                # Due to the nature of the probabilistic data structures this
+                # subtraction can become negative.
+                "users_errored": max(0, rv["users_errored"] - rv["users_crashed"]),
             }
 
     return stats, totals


### PR DESCRIPTION
Due to the use of the merge states in clickhouse it's possible for the first
number to be greater than the second.  In that case the number of errors
becomes negative which makes no sense.

We cannot really fix this inaccuracy but we can clamp it to zero.