### PR TITLE
tests(perf-views) Add snapshot tests for performance pages

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -126,7 +126,7 @@ class Container extends React.Component<Props> {
                       environments={globalSelection.environment}
                     />
                   ),
-                  fixed: 'performance charts',
+                  fixed: 'apdex and throughput charts',
                 })}
               </React.Fragment>
             );

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -20,6 +20,7 @@ import withApi from 'app/utils/withApi';
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 import {getDuration} from 'app/utils/formatters';
+import getDynamicText from 'app/utils/getDynamicText';
 
 import {HeaderTitleLegend} from '../styles';
 
@@ -157,21 +158,26 @@ class DurationChart extends React.Component<Props> {
                     {({releaseSeries}) => (
                       <TransitionChart loading={loading} reloading={reloading}>
                         <TransparentLoadingMask visible={reloading} />
-                        <AreaChart
-                          {...zoomRenderProps}
-                          legend={legend}
-                          series={[...series, ...releaseSeries]}
-                          seriesOptions={{
-                            showSymbol: false,
-                          }}
-                          tooltip={tooltip}
-                          grid={{
-                            left: '10px',
-                            right: '10px',
-                            top: '40px',
-                            bottom: '0px',
-                          }}
-                        />
+                        {getDynamicText({
+                          value: (
+                            <AreaChart
+                              {...zoomRenderProps}
+                              legend={legend}
+                              series={[...series, ...releaseSeries]}
+                              seriesOptions={{
+                                showSymbol: false,
+                              }}
+                              tooltip={tooltip}
+                              grid={{
+                                left: '10px',
+                                right: '10px',
+                                top: '40px',
+                                bottom: '0px',
+                              }}
+                            />
+                          ),
+                          fixed: 'Duration Chart',
+                        })}
                       </TransitionChart>
                     )}
                   </ReleaseSeries>

--- a/tests/acceptance/page_objects/base.py
+++ b/tests/acceptance/page_objects/base.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import json
-
 
 class BasePage(object):
     """Base class for PageObjects"""
@@ -15,28 +13,6 @@ class BasePage(object):
 
     def wait_until_loaded(self):
         self.browser.wait_until_not(".loading-indicator")
-
-    def dismiss_assistant(self):
-        res = self.client.put(
-            "/api/0/assistant/?v2",
-            content_type="application/json",
-            data=json.dumps({"guide": "discover_sidebar", "status": "viewed", "useful": True}),
-        )
-        assert res.status_code == 201
-
-        res = self.client.put(
-            "/api/0/assistant/?v2",
-            content_type="application/json",
-            data=json.dumps({"guide": "issue", "status": "viewed", "useful": True}),
-        )
-        assert res.status_code == 201
-
-        res = self.client.put(
-            "/api/0/assistant/?v2",
-            content_type="application/json",
-            data=json.dumps({"guide": "issue_stream", "status": "viewed", "useful": True}),
-        )
-        assert res.status_code == 201
 
 
 class BaseElement(object):

--- a/tests/acceptance/page_objects/global_selection.py
+++ b/tests/acceptance/page_objects/global_selection.py
@@ -4,10 +4,6 @@ from .base import BasePage
 
 
 class GlobalSelectionPage(BasePage):
-    def __init__(self, browser, client):
-        super(GlobalSelectionPage, self).__init__(browser)
-        self.client = client
-
     def get_selected_project_slug(self):
         return self.browser.element('[data-test-id="global-header-project-selector"]').text
 

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -11,19 +11,16 @@ class IssueDetailsPage(BasePage):
         self.global_selection = GlobalSelectionPage(browser, client)
 
     def visit_issue(self, org, groupid):
-        self.dismiss_assistant()
         self.browser.get(u"/organizations/{}/issues/{}/".format(org, groupid))
         self.wait_until_loaded()
 
     def visit_issue_in_environment(self, org, groupid, environment):
-        self.dismiss_assistant()
         self.browser.get(
             u"/organizations/{}/issues/{}/?environment={}".format(org, groupid, environment)
         )
         self.browser.wait_until(".group-detail")
 
     def visit_tag_values(self, org, groupid, tag):
-        self.dismiss_assistant()
         self.browser.get(u"/organizations/{}/issues/{}/tags/{}".format(org, groupid, tag))
         self.browser.wait_until_not(".loading-indicator")
 

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -8,7 +8,7 @@ class IssueDetailsPage(BasePage):
     def __init__(self, browser, client):
         super(IssueDetailsPage, self).__init__(browser)
         self.client = client
-        self.global_selection = GlobalSelectionPage(browser, client)
+        self.global_selection = GlobalSelectionPage(browser)
 
     def visit_issue(self, org, groupid):
         self.browser.get(u"/organizations/{}/issues/{}/".format(org, groupid))

--- a/tests/acceptance/page_objects/issue_list.py
+++ b/tests/acceptance/page_objects/issue_list.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from .base import BasePage
 from .global_selection import GlobalSelectionPage
-from .issue_details import IssueDetailsPage
 
 
 class IssueListPage(BasePage):
@@ -25,7 +24,6 @@ class IssueListPage(BasePage):
     def navigate_to_issue(self, position):
         self.browser.click(u'[data-test-id="group"]:nth-child({}) a'.format(position))
         self.browser.wait_until(".group-detail")
-        self.issue_details = IssueDetailsPage(self.browser, self.client)
 
     def resolve_issues(self):
         self.browser.click('[aria-label="Resolve"]')

--- a/tests/acceptance/page_objects/issue_list.py
+++ b/tests/acceptance/page_objects/issue_list.py
@@ -2,16 +2,16 @@ from __future__ import absolute_import
 
 from .base import BasePage
 from .global_selection import GlobalSelectionPage
+from .issue_details import IssueDetailsPage
 
 
 class IssueListPage(BasePage):
     def __init__(self, browser, client):
         super(IssueListPage, self).__init__(browser)
         self.client = client
-        self.global_selection = GlobalSelectionPage(browser, client)
+        self.global_selection = GlobalSelectionPage(browser)
 
     def visit_issue_list(self, org, query=""):
-        self.dismiss_assistant()
         self.browser.get(u"/organizations/{}/issues/{}".format(org, query))
         self.wait_until_loaded()
 
@@ -24,6 +24,7 @@ class IssueListPage(BasePage):
     def navigate_to_issue(self, position):
         self.browser.click(u'[data-test-id="group"]:nth-child({}) a'.format(position))
         self.browser.wait_until(".group-detail")
+        self.issue_details = IssueDetailsPage(self.browser, self.client)
 
     def resolve_issues(self):
         self.browser.click('[aria-label="Resolve"]')

--- a/tests/acceptance/page_objects/transaction_summary.py
+++ b/tests/acceptance/page_objects/transaction_summary.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+
+from .base import BasePage
+
+
+class TransactionSummaryPage(BasePage):
+    def wait_until_loaded(self):
+        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_not('[data-test-id="loading-placeholder"]')

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -26,6 +26,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
         self.page = IssueDetailsPage(self.browser, self.client)
+        self.dismiss_assistant()
 
     def create_sample_event(self, platform, default=None, sample_name=None, time=None):
         event_data = load_data(platform, default=default, sample_name=sample_name)

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -19,6 +19,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
         self.page = IssueDetailsPage(self.browser, self.client)
+        self.dismiss_assistant()
 
     def create_sample_event(self, platform, default=None, sample_name=None):
         event_data = load_data(platform, default=default, sample_name=sample_name)

--- a/tests/acceptance/test_issue_tag_values.py
+++ b/tests/acceptance/test_issue_tag_values.py
@@ -15,6 +15,7 @@ class IssueTagValuesTest(AcceptanceTestCase, SnubaTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
         self.page = IssueDetailsPage(self.browser, self.client)
+        self.dismiss_assistant()
 
     def create_issue(self):
         event_data = load_data("javascript")

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import copy
-import json
 import six
 import pytest
 import pytz
@@ -152,14 +151,6 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         self.result_path = u"/organizations/{}/discover/results/".format(self.org.slug)
 
         self.dismiss_assistant()
-
-    def dismiss_assistant(self):
-        res = self.client.put(
-            "/api/0/assistant/?v2",
-            content_type="application/json",
-            data=json.dumps({"guide": "discover_sidebar", "status": "viewed", "useful": True}),
-        )
-        assert res.status_code == 201
 
     def wait_until_loaded(self):
         self.browser.wait_until_not(".loading-indicator")

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -68,6 +68,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         )
 
     def test_global_selection_header_dropdown(self):
+        self.dismiss_assistant()
         self.project.update(first_event=timezone.now())
         self.issues_list.visit_issue_list(
             self.org.slug, query="?query=assigned%3Ame&project=" + six.text_type(self.project_1.id)

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -29,6 +29,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
         )
         self.login_as(self.user)
         self.page = IssueListPage(self.browser, self.client)
+        self.dismiss_assistant()
 
     def create_issues(self):
         self.store_event(

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import
+
+from datetime import timedelta
+import pytz
+import time
+
+from mock import patch
+
+from sentry.testutils import AcceptanceTestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.samples import load_data
+
+from .page_objects.base import BasePage
+
+FEATURE_NAMES = (
+    "organizations:discover-basic",
+    "organizations:transaction-events",
+    "organizations:performance-view",
+)
+
+
+def make_event(event_data):
+    start_datetime = before_now(minutes=1)
+    end_datetime = start_datetime + timedelta(milliseconds=500)
+
+    def generate_timestamp(date_time):
+        return time.mktime(date_time.utctimetuple()) + date_time.microsecond / 1e6
+
+    event_data["start_timestamp"] = generate_timestamp(start_datetime)
+    event_data["timestamp"] = generate_timestamp(end_datetime)
+
+    return event_data
+
+
+class PerformanceOverviewTest(AcceptanceTestCase):
+    def setUp(self):
+        super(PerformanceOverviewTest, self).setUp()
+        self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
+        self.team = self.create_team(
+            organization=self.org, name="Mariachi Band", members=[self.user]
+        )
+        self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
+        self.group = self.create_group(project=self.project)
+        self.login_as(self.user)
+        self.path = u"/organizations/{}/performance/".format(self.org.slug)
+
+        self.page = BasePage(self.browser)
+        self.dismiss_assistant()
+
+    @patch("django.utils.timezone.now")
+    def test_empty_state(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+
+        with self.feature(FEATURE_NAMES):
+            self.browser.get(self.path)
+            self.page.wait_until_loaded()
+            self.browser.snapshot("performance overview - empty")
+
+    @patch("django.utils.timezone.now")
+    def test_with_data(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+
+        event = make_event(load_data("transaction"))
+        self.store_event(data=event, project_id=self.project.id)
+
+        with self.feature(FEATURE_NAMES):
+            self.browser.get(self.path)
+            self.page.wait_until_loaded()
+            self.browser.snapshot("performance overview - with data")

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import
+
+from datetime import timedelta
+import pytz
+import time
+
+from six.moves.urllib.parse import urlencode
+from mock import patch
+
+from sentry.testutils import AcceptanceTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.utils.samples import load_data
+
+from .page_objects.transaction_summary import TransactionSummaryPage
+
+FEATURE_NAMES = (
+    "organizations:discover-basic",
+    "organizations:transaction-events",
+    "organizations:performance-view",
+)
+
+
+def make_event(event_data):
+    start_datetime = before_now(minutes=1)
+    end_datetime = start_datetime + timedelta(milliseconds=500)
+
+    def generate_timestamp(date_time):
+        return time.mktime(date_time.utctimetuple()) + date_time.microsecond / 1e6
+
+    event_data["start_timestamp"] = generate_timestamp(start_datetime)
+    event_data["timestamp"] = generate_timestamp(end_datetime)
+
+    return event_data
+
+
+class PerformanceSummaryTest(AcceptanceTestCase):
+    def setUp(self):
+        super(PerformanceSummaryTest, self).setUp()
+        self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
+        self.team = self.create_team(
+            organization=self.org, name="Mariachi Band", members=[self.user]
+        )
+        self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
+        self.group = self.create_group(project=self.project)
+        self.login_as(self.user)
+        self.path = u"/organizations/{}/performance/summary/?{}".format(
+            self.org.slug,
+            urlencode({"transaction": "/country_by_code/", "project": self.project.id}),
+        )
+
+        self.page = TransactionSummaryPage(self.browser)
+        self.dismiss_assistant()
+
+    @patch("django.utils.timezone.now")
+    def test_with_data(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+
+        # Create a transaction
+        event = make_event(load_data("transaction"))
+        self.store_event(data=event, project_id=self.project.id)
+
+        self.store_event(
+            data={
+                "transaction": "/country_by_code/",
+                "message": "This is bad",
+                "event_id": "b" * 32,
+                "timestamp": iso_format(before_now(minutes=1)),
+            },
+            project_id=self.project.id,
+        )
+
+        with self.feature(FEATURE_NAMES):
+            self.browser.get(self.path)
+            self.page.wait_until_loaded()
+            self.browser.snapshot("performance summary - with data")


### PR DESCRIPTION
Add rudimentary snapshot tests for performance pages as the summary page has stabilized a bit.