### PR TITLE
feat(api): Move GitHub authentication to header

### DIFF
--- a/src/sentry/auth/providers/github/client.py
+++ b/src/sentry/auth/providers/github/client.py
@@ -21,15 +21,12 @@ class GitHubClient(object):
         self.http = http.build_session()
 
     def _request(self, path, access_token):
-        params = {"client_id": self.client_id, "client_secret": self.client_secret}
-
         headers = {"Authorization": "token {0}".format(access_token)}
+        auth = (self.client_id, self.client_secret)
 
         try:
             req = self.http.get(
-                "https://{0}/{1}".format(API_DOMAIN, path.lstrip("/")),
-                params=params,
-                headers=headers,
+                "https://{0}/{1}".format(API_DOMAIN, path.lstrip("/")), auth=auth, headers=headers,
             )
         except RequestException as e:
             raise GitHubApiError(six.text_type(e), status=getattr(e, "status_code", 0))

--- a/src/sentry/auth/providers/github/client.py
+++ b/src/sentry/auth/providers/github/client.py
@@ -22,11 +22,10 @@ class GitHubClient(object):
 
     def _request(self, path, access_token):
         headers = {"Authorization": "token {0}".format(access_token)}
-        auth = (self.client_id, self.client_secret)
 
         try:
             req = self.http.get(
-                "https://{0}/{1}".format(API_DOMAIN, path.lstrip("/")), auth=auth, headers=headers,
+                "https://{0}/{1}".format(API_DOMAIN, path.lstrip("/")), headers=headers,
             )
         except RequestException as e:
             raise GitHubApiError(six.text_type(e), status=getattr(e, "status_code", 0))

--- a/src/sentry/auth/providers/github/client.py
+++ b/src/sentry/auth/providers/github/client.py
@@ -15,11 +15,12 @@ class GitHubApiError(Exception):
 
 
 class GitHubClient(object):
-    def __init__(self):
+    def __init__(self, access_token):
         self.http = http.build_session()
+        self.access_token = access_token
 
-    def _request(self, path, access_token):
-        headers = {"Authorization": "token {0}".format(access_token)}
+    def _request(self, path):
+        headers = {"Authorization": "token {0}".format(self.access_token)}
 
         try:
             req = self.http.get(
@@ -31,19 +32,18 @@ class GitHubClient(object):
             raise GitHubApiError(req.content, status=req.status_code)
         return json.loads(req.content)
 
-    def get_org_list(self, access_token):
-        return self._request("/user/orgs", access_token)
+    def get_org_list(self):
+        return self._request("/user/orgs")
 
-    def get_user(self, access_token):
-        return self._request("/user", access_token)
+    def get_user(self):
+        return self._request("/user")
 
-    def get_user_emails(self, access_token):
-        return self._request("/user/emails", access_token)
+    def get_user_emails(self):
+        return self._request("/user/emails")
 
-    def is_org_member(self, access_token, org_id):
-        org_list = self.get_org_list(access_token)
+    def is_org_member(self, org_id):
         org_id = six.text_type(org_id)
-        for o in org_list:
+        for o in self.get_org_list():
             if six.text_type((o["id"])) == org_id:
                 return True
         return False

--- a/src/sentry/auth/providers/github/client.py
+++ b/src/sentry/auth/providers/github/client.py
@@ -15,9 +15,7 @@ class GitHubApiError(Exception):
 
 
 class GitHubClient(object):
-    def __init__(self, client_id, client_secret):
-        self.client_id = client_id
-        self.client_secret = client_secret
+    def __init__(self):
         self.http = http.build_session()
 
     def _request(self, path, access_token):

--- a/src/sentry/auth/providers/github/provider.py
+++ b/src/sentry/auth/providers/github/provider.py
@@ -30,15 +30,13 @@ class GitHubOAuth2Provider(OAuth2Provider):
                 client_id=self.client_id,
                 client_secret=self.client_secret,
             ),
-            FetchUser(client_id=self.client_id, client_secret=self.client_secret, org=self.org),
+            FetchUser(org=self.org),
             ConfirmEmail(),
         ]
 
     def get_setup_pipeline(self):
         pipeline = self.get_auth_pipeline()
-        pipeline.append(
-            SelectOrganization(client_id=self.client_id, client_secret=self.client_secret)
-        )
+        pipeline.append(SelectOrganization())
         return pipeline
 
     def get_refresh_token_url(self):
@@ -58,7 +56,7 @@ class GitHubOAuth2Provider(OAuth2Provider):
         }
 
     def refresh_identity(self, auth_identity):
-        client = GitHubClient(self.client_id, self.client_secret)
+        client = GitHubClient()
         access_token = auth_identity.data["access_token"]
 
         try:

--- a/src/sentry/auth/providers/github/provider.py
+++ b/src/sentry/auth/providers/github/provider.py
@@ -56,11 +56,10 @@ class GitHubOAuth2Provider(OAuth2Provider):
         }
 
     def refresh_identity(self, auth_identity):
-        client = GitHubClient()
-        access_token = auth_identity.data["access_token"]
+        client = GitHubClient(auth_identity.data["access_token"])
 
         try:
-            if not client.is_org_member(access_token, self.org["id"]):
+            if not client.is_org_member(self.org["id"]):
                 raise IdentityNotValid
         except GitHubApiError as e:
             raise IdentityNotValid(e)

--- a/src/sentry/auth/providers/github/views.py
+++ b/src/sentry/auth/providers/github/views.py
@@ -26,9 +26,9 @@ def _get_name_from_email(email):
 
 
 class FetchUser(AuthView):
-    def __init__(self, client_id, client_secret, org=None, *args, **kwargs):
+    def __init__(self, org=None, *args, **kwargs):
         self.org = org
-        self.client = GitHubClient(client_id, client_secret)
+        self.client = GitHubClient()
         super(FetchUser, self).__init__(*args, **kwargs)
 
     def handle(self, request, helper):
@@ -114,8 +114,8 @@ class SelectOrganizationForm(forms.Form):
 
 
 class SelectOrganization(AuthView):
-    def __init__(self, client_id, client_secret, *args, **kwargs):
-        self.client = GitHubClient(client_id, client_secret)
+    def __init__(self, *args, **kwargs):
+        self.client = GitHubClient()
         super(SelectOrganization, self).__init__(*args, **kwargs)
 
     def handle(self, request, helper):

--- a/src/sentry/auth/providers/github/views.py
+++ b/src/sentry/auth/providers/github/views.py
@@ -28,20 +28,19 @@ def _get_name_from_email(email):
 class FetchUser(AuthView):
     def __init__(self, org=None, *args, **kwargs):
         self.org = org
-        self.client = GitHubClient()
         super(FetchUser, self).__init__(*args, **kwargs)
 
     def handle(self, request, helper):
-        access_token = helper.fetch_state("data")["access_token"]
+        client = GitHubClient(helper.fetch_state("data")["access_token"])
 
         if self.org is not None:
-            if not self.client.is_org_member(access_token, self.org["id"]):
+            if not client.is_org_member(self.org["id"]):
                 return helper.error(ERR_NO_ORG_ACCESS)
 
-        user = self.client.get_user(access_token)
+        user = client.get_user()
 
         if not user.get("email"):
-            emails = self.client.get_user_emails(access_token)
+            emails = client.get_user_emails()
             email = [
                 e["email"]
                 for e in emails
@@ -115,12 +114,11 @@ class SelectOrganizationForm(forms.Form):
 
 class SelectOrganization(AuthView):
     def __init__(self, *args, **kwargs):
-        self.client = GitHubClient()
         super(SelectOrganization, self).__init__(*args, **kwargs)
 
     def handle(self, request, helper):
-        access_token = helper.fetch_state("data")["access_token"]
-        org_list = self.client.get_org_list(access_token)
+        client = GitHubClient(helper.fetch_state("data")["access_token"])
+        org_list = client.get_org_list()
 
         form = SelectOrganizationForm(org_list, request.POST or None)
         if form.is_valid():

--- a/tests/sentry/auth/providers/github/test_client.py
+++ b/tests/sentry/auth/providers/github/test_client.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase
+from sentry.utils.compat.mock import patch
+
+from sentry.auth.providers.github.client import GitHubClient
+
+
+class MockReq:
+    def __init__(self, status_code=200, content=None):
+        self.status_code = status_code
+        self.content = content
+
+
+class MockHttp:
+    def __init__(self):
+        self.calledArgs = []
+        self.calledKwargs = {}
+
+    def get(self, *args, **kwargs):
+        for arg in args:
+            self.calledArgs.append(arg)
+        self.calledKwargs = kwargs
+        return MockReq()
+
+
+@patch("sentry.utils.json.loads")
+class GitHubClientTest(TestCase):
+    def test_request_sends_client_id_and_secret(self, mock_loads):
+        client = GitHubClient("clientId", "clientSecret")
+        mock = MockHttp()
+        client.http = mock
+        client._request("/", "accessToken")
+
+        assert "auth" in mock.calledKwargs.keys()
+        assert "clientId" in mock.calledKwargs["auth"]
+        assert "clientSecret" in mock.calledKwargs["auth"]

--- a/tests/sentry/auth/providers/github/test_client.py
+++ b/tests/sentry/auth/providers/github/test_client.py
@@ -14,12 +14,9 @@ class MockReq:
 
 class MockHttp:
     def __init__(self):
-        self.calledArgs = []
         self.calledKwargs = {}
 
     def get(self, *args, **kwargs):
-        for arg in args:
-            self.calledArgs.append(arg)
         self.calledKwargs = kwargs
         return MockReq()
 
@@ -32,6 +29,4 @@ class GitHubClientTest(TestCase):
         client.http = mock
         client._request("/", "accessToken")
 
-        assert "auth" in mock.calledKwargs.keys()
-        assert "clientId" in mock.calledKwargs["auth"]
-        assert "clientSecret" in mock.calledKwargs["auth"]
+        assert mock.calledKwargs["headers"]["Authorization"] == "token accessToken"

--- a/tests/sentry/auth/providers/github/test_client.py
+++ b/tests/sentry/auth/providers/github/test_client.py
@@ -24,7 +24,7 @@ class MockHttp:
 @patch("sentry.utils.json.loads")
 class GitHubClientTest(TestCase):
     def test_request_sends_client_id_and_secret(self, mock_loads):
-        client = GitHubClient("clientId", "clientSecret")
+        client = GitHubClient()
         mock = MockHttp()
         client.http = mock
         client._request("/", "accessToken")

--- a/tests/sentry/auth/providers/github/test_client.py
+++ b/tests/sentry/auth/providers/github/test_client.py
@@ -11,9 +11,6 @@ from sentry.auth.providers.github.constants import API_DOMAIN
 class GitHubClientTest(TestCase):
     @responses.activate
     def test_request_sends_client_id_and_secret(self):
-
-        # headers = {"Authorization": "token {0}".format(access_token)}
-
         responses.add(
             responses.GET, "https://{0}/".format(API_DOMAIN), json={"status": "SUCCESS"}, status=200
         )

--- a/tests/sentry/auth/providers/github/test_client.py
+++ b/tests/sentry/auth/providers/github/test_client.py
@@ -1,22 +1,48 @@
 from __future__ import absolute_import
 
+import pytest
 import responses
-
-from sentry.testutils import TestCase
 
 from sentry.auth.providers.github.client import GitHubClient
 from sentry.auth.providers.github.constants import API_DOMAIN
+from sentry.utils.compat import mock
 
 
-class GitHubClientTest(TestCase):
-    @responses.activate
-    def test_request_sends_client_id_and_secret(self):
-        responses.add(
-            responses.GET, "https://{0}/".format(API_DOMAIN), json={"status": "SUCCESS"}, status=200
-        )
+@pytest.fixture
+def client():
+    return GitHubClient("accessToken")
 
-        client = GitHubClient()
-        client._request("/", "accessToken")
 
-        assert len(responses.calls) == 1
-        assert responses.calls[0].request.headers["Authorization"] == "token accessToken"
+@responses.activate
+def test_request_sends_access_token(client):
+    responses.add(
+        responses.GET, "https://{0}/".format(API_DOMAIN), json={"status": "SUCCESS"}, status=200
+    )
+    client._request("/")
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.headers["Authorization"] == "token accessToken"
+
+
+@mock.patch.object(GitHubClient, "_request")
+def test_get_org_list(mock_request, client):
+    client.get_org_list()
+    mock_request.assert_called_once_with("/user/orgs")
+
+
+@mock.patch.object(GitHubClient, "_request")
+def test_get_user(mock_request, client):
+    client.get_user()
+    mock_request.assert_called_once_with("/user")
+
+
+@mock.patch.object(GitHubClient, "_request")
+def test_get_user_emails(mock_request, client):
+    client.get_user_emails()
+    mock_request.assert_called_once_with("/user/emails")
+
+
+@mock.patch.object(GitHubClient, "_request", return_value=[{"id": 1396951}])
+def test_is_org_member(mock_request, client):
+    got = client.is_org_member(1396951)
+    assert got is True


### PR DESCRIPTION
Move GitHub API authentication to header, in response to GItHub deprecating API authentication via query parameters. The code updated in this PR seems to be the only place in the codebase that was authenticating via query params, but if we missed a spot, we'll be alerted by emails from GitHub and a "brownout" well before the official removal date of November 13, 2020.

More info: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

Addresses [ENT-16](https://getsentry.atlassian.net/browse/ENT-16).