### PR TITLE
fix(discover) Handle ms timestamps in aggregate conditions

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -121,7 +121,7 @@ def parse_datetime_string(value):
     except ValueError:
         pass
 
-    raise InvalidQuery(u"{} is not a valid datetime query".format(value))
+    raise InvalidQuery(u"{} is not a valid ISO8601 date query".format(value))
 
 
 def parse_datetime_comparison(value):

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1128,7 +1128,7 @@ class QueryTransformTest(TestCase):
                 ["avg", "duration", "avg_transaction_duration"],
                 ["max", "time", "max_time"],
             ],
-            having=[["max_time", ">", 1575158400000]],
+            having=[["max_time", ">", 1575158400]],
             end=end_time,
             start=start_time,
             orderby=None,


### PR DESCRIPTION
Fix the functionality for comparing date columns with +/- date ranges in
discover to mirror the functionality in issue search. Also with aggregate
conditions, the timestamp we were sending to snuba were in ms, but snuba expects
them to be in seconds.