### PR TITLE
feat(dev): Add pretty formatting option to devserver

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 import click
 import six
+import types
 from six.moves.urllib.parse import urlparse
 import threading
 
@@ -37,6 +38,9 @@ def _get_daemon(name):
     "--prefix/--no-prefix", default=True, help="Show the service name prefix and timestamp"
 )
 @click.option(
+    "--pretty/--no-pretty", default=False, help="Styleize various outputs from the devserver"
+)
+@click.option(
     "--styleguide/--no-styleguide",
     default=False,
     help="Start local styleguide web server on port 9001",
@@ -59,7 +63,16 @@ def _get_daemon(name):
 @log_options()
 @configuration
 def devserver(
-    reload, watchers, workers, experimental_spa, styleguide, prefix, environment, debug_server, bind
+    reload,
+    watchers,
+    workers,
+    experimental_spa,
+    styleguide,
+    prefix,
+    pretty,
+    environment,
+    debug_server,
+    bind,
 ):
     "Starts a lightweight web server for development."
 
@@ -221,9 +234,9 @@ def devserver(
     # A better log-format for local dev when running through honcho,
     # but if there aren't any other daemons, we don't want to override.
     if daemons:
-        uwsgi_overrides["log-format"] = '"%(method) %(status) %(uri) %(proto)" %(size)'
+        uwsgi_overrides["log-format"] = "%(method) %(status) %(uri) %(proto) %(size)"
     else:
-        uwsgi_overrides["log-format"] = '[%(ltime)] "%(method) %(status) %(uri) %(proto)" %(size)'
+        uwsgi_overrides["log-format"] = "[%(ltime)] %(method) %(status) %(uri) %(proto) %(size)"
 
     server = SentryHTTPServer(
         host=host, port=port, workers=1, extra_options=uwsgi_overrides, debug=debug_server
@@ -254,7 +267,14 @@ def devserver(
 
     cwd = os.path.realpath(os.path.join(settings.PROJECT_ROOT, os.pardir, os.pardir))
 
-    manager = Manager(Printer(prefix=prefix))
+    honcho_printer = Printer(prefix=prefix)
+
+    if pretty:
+        from sentry.runner.formatting import monkeypatch_honcho_write
+
+        honcho_printer.write = types.MethodType(monkeypatch_honcho_write, honcho_printer)
+
+    manager = Manager(honcho_printer)
     for name, cmd in daemons:
         manager.add_process(name, list2cmdline(cmd), quiet=False, cwd=cwd)
 

--- a/src/sentry/runner/formatting.py
+++ b/src/sentry/runner/formatting.py
@@ -1,0 +1,106 @@
+# -*- coding: utf8 -*-
+
+from __future__ import absolute_import, print_function
+
+import re
+
+# Sentry colors taken from our design system. Might not look good on all
+# termianl themes tbh
+COLORS = {
+    "white": (255, 255, 255),
+    "green": (77, 199, 13),
+    "orange": (255, 119, 56),
+    "red": (250, 71, 71),
+}
+
+SERVICE_COLORS = {
+    "server": (108, 95, 199),
+    "worker": (255, 194, 39),
+    "webpack": (61, 116, 219),
+    "cron": (255, 86, 124),
+    "relay": (250, 71, 71),
+}
+
+
+def colorize_code(pattern):
+    code = int(pattern.group("code"))
+    method = pattern.group("method")
+
+    style = (COLORS["red"], COLORS["white"])
+
+    if code >= 200 and code < 300:
+        style = (COLORS["green"], COLORS["white"])
+    if code >= 400 and code < 500:
+        style = (COLORS["orange"], COLORS["white"])
+    if code >= 500:
+        style = (COLORS["red"], COLORS["white"])
+
+    return u"{bg}{fg} {code} {reset} {method:4}".format(
+        bg="\x1b[48;2;%s;%s;%sm" % (style[0]),
+        fg="\x1b[38;2;%s;%s;%sm" % (style[1]),
+        reset="\x1b[0m",
+        code=code,
+        method=method,
+    )
+
+
+def colorize_reboot(pattern):
+    return u"{bg}{fg}[ RELOADING ]{reset} {info_fg}{info}".format(
+        bg="\x1b[48;2;%s;%s;%sm" % COLORS["red"],
+        fg="\x1b[38;2;%s;%s;%sm" % COLORS["white"],
+        info_fg="\x1b[38;2;%s;%s;%sm" % COLORS["white"],
+        reset="\x1b[0m",
+        info=pattern.group(0),
+    )
+
+
+def colorize_booted(pattern):
+    return u"{bg}{fg}[ UWSGI READY ]{reset} {info_fg}{info}".format(
+        bg="\x1b[48;2;%s;%s;%sm" % COLORS["green"],
+        fg="\x1b[38;2;%s;%s;%sm" % COLORS["white"],
+        info_fg="\x1b[38;2;%s;%s;%sm" % COLORS["white"],
+        reset="\x1b[0m",
+        info=pattern.group(0),
+    )
+
+
+def colorize_traceback(pattern):
+    return u"{bg}  {reset} {info_fg}{info}".format(
+        bg="\x1b[48;2;%s;%s;%sm" % COLORS["red"],
+        info_fg="\x1b[38;2;%s;%s;%sm" % COLORS["red"],
+        reset="\x1b[0m",
+        info=pattern.group(0),
+    )
+
+
+def monkeypatch_honcho_write(self, message):
+    name = message.name if message.name is not None else ""
+    name = name.rjust(self.width)
+
+    if isinstance(message.data, bytes):
+        string = message.data.decode("utf-8", "replace")
+    else:
+        string = message.data
+
+    # Colorize requests
+    string = re.sub(
+        r"(?P<method>GET|POST|PUT|HEAD|DELETE) (?P<code>[0-9]{3})", colorize_code, string
+    )
+    # Colorize reboots
+    string = re.sub(r"Gracefully killing worker [0-9]+ .*\.\.\.", colorize_reboot, string)
+    # Colorize reboot complete
+    string = re.sub(r"WSGI app [0-9]+ \(.*\) ready in [0-9]+ seconds .*", colorize_booted, string)
+    # Mark python tracebacks
+    string = re.sub(r"Traceback \(most recent call last\).*", colorize_traceback, string)
+
+    blank_color = (74, 62, 86)
+
+    prefix = u"{name_fg}{name}{reset} {indicator_bg} {reset} ".format(
+        name=name.ljust(self.width),
+        name_fg="\x1b[38;2;%s;%s;%sm" % SERVICE_COLORS.get(message.name, blank_color),
+        indicator_bg="\x1b[48;2;%s;%s;%sm" % SERVICE_COLORS.get(message.name, blank_color),
+        reset="\x1b[0m",
+    )
+
+    for line in string.splitlines():
+        self.output.write(u"{}{}\n".format(prefix, line))


### PR DESCRIPTION
- Color prefix with a bar to clearly see separation
 - Add status code colors, with padding to align URLs
 - Highlight uwsgi server reboots
 - Highlight stacktrace errors

Caveats:

 - Uses 24bit escape code, not totally standard

![image](https://user-images.githubusercontent.com/1421724/81864685-d3514700-9521-11ea-9efe-2652e6a556d6.png)
