### PR TITLE
ref(ui): Polish column editor

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -340,7 +340,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
             <Button
               aria-label={t('Drag to reorder')}
               onMouseDown={event => this.startDrag(event, i)}
-              icon={<IconGrabbable color={theme.gray4} />}
+              icon={<IconGrabbable size="xs" color={theme.gray4} />}
               borderless
             />
           ) : (
@@ -423,10 +423,10 @@ const Ghost = styled('div')`
   background: ${p => p.theme.white};
   display: block;
   position: absolute;
-  padding: 4px;
-  border: 4px solid ${p => p.theme.borderLight};
-  border-radius: 4px;
-  width: 450px;
+  padding: ${space(0.5)};
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid ${p => p.theme.borderLight};
+  width: 600px;
   opacity: 0.8;
   cursor: grabbing;
 
@@ -440,10 +440,10 @@ const Ghost = styled('div')`
 `;
 
 const DragPlaceholder = styled('div')`
-  margin: 0 ${space(1)} ${space(1)} ${space(1)};
+  margin: 0 ${space(4)} ${space(1)} ${space(4)};
   border: 2px dashed ${p => p.theme.borderLight};
-  width: 100%;
-  height: 38px;
+  border-radius: ${p => p.theme.borderRadius};
+  height: 40px;
 `;
 
 const Actions = styled('div')`

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditRow.tsx
@@ -316,14 +316,7 @@ class ColumnEditRow extends React.Component<Props> {
     const requiredInputs = gridColumns - inputs.length - 1;
     if (requiredInputs > 0) {
       for (let i = 0; i < requiredInputs; i++) {
-        inputs.push(
-          <StyledInput
-            className="form-control"
-            key={`disabled:${i}`}
-            placeholder={t('N/A')}
-            disabled
-          />
-        );
+        inputs.push(<BlankSpace key={i} />);
       }
     }
 
@@ -465,12 +458,29 @@ class BufferedInput extends React.Component<InputProps, InputState> {
 
 // Set a min-width to allow shrinkage in grid.
 const StyledInput = styled('input')`
-  min-width: 50px;
   /* Match the height of the select boxes */
   height: 37px;
+  min-width: 50px;
 
   &:not([disabled='true']):invalid {
     border-color: ${p => p.theme.red};
+  }
+`;
+
+const BlankSpace = styled('div')`
+  /* Match the height of the select boxes */
+  height: 37px;
+  min-width: 50px;
+  background: ${p => p.theme.offWhite};
+  border-radius: ${p => p.theme.borderRadius};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:after {
+    content: '${t('No parameter')}';
+    font-size: ${p => p.theme.fontSizeSmall};
+    color: ${p => p.theme.gray2};
   }
 `;
 

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -114,7 +114,7 @@ describe('EventsV2 -> ColumnEditModal', function() {
         fieldRow.find('SelectControl[name="field"] span[data-test-id="label"]').text()
       ).toBe('user-def');
       expect(fieldRow.find('SelectControl[name="field"] Badge')).toHaveLength(1);
-      expect(fieldRow.find('StyledInput[disabled]')).toHaveLength(1);
+      expect(fieldRow.find('BlankSpace')).toHaveLength(1);
     });
   });
 
@@ -166,12 +166,12 @@ describe('EventsV2 -> ColumnEditModal', function() {
       const countRow = wrapper.find('ColumnEditRow').first();
       // Has a select and 2 disabled inputs
       expect(countRow.find('SelectControl')).toHaveLength(1);
-      expect(countRow.find('StyledInput[disabled]')).toHaveLength(2);
+      expect(countRow.find('BlankSpace')).toHaveLength(2);
 
       const percentileRow = wrapper.find('ColumnEditRow').last();
       // two select fields, and one number input.
       expect(percentileRow.find('SelectControl')).toHaveLength(2);
-      expect(percentileRow.find('StyledInput[disabled]')).toHaveLength(0);
+      expect(percentileRow.find('BlankSpace')).toHaveLength(0);
       expect(percentileRow.find('StyledInput[inputMode="numeric"]')).toHaveLength(1);
     });
   });
@@ -205,8 +205,7 @@ describe('EventsV2 -> ColumnEditModal', function() {
     it('shows no options for parameterless functions', function() {
       selectByLabel(wrapper, 'p95()', {name: 'field', at: 0, control: true});
 
-      const parameter = wrapper.find('ColumnEditRow StyledInput[disabled]');
-      expect(parameter).toHaveLength(1);
+      expect(wrapper.find('ColumnEditRow BlankSpace')).toHaveLength(1);
     });
 
     it('shows additional inputs for multi-parameter functions', function() {


### PR DESCRIPTION
- Visually align dashed ghost column drag location
 - Use a styled filler box instead of an empty input for missing columns
 - Better borders + spacing on ghost dragging elements