### PR TITLE
fix(ui): Translate notification settings footers lookup object keys and values

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/accountNotifications.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotifications.jsx
@@ -14,28 +14,43 @@ import {PanelFooter} from 'app/components/panels';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import accountNotificationFields from 'app/data/forms/accountNotificationSettings';
 
-const FINE_TUNE_FOOTERS = {
-  Alerts: {
-    text: 'Fine tune alerts by project',
-    path: 'alerts/',
-  },
-  'Workflow Notifications': {
-    text: 'Fine tune workflow notifications by project',
-    path: 'workflow/',
-  },
-  'Email Routing': {
-    text: 'Fine tune email routing by project',
-    path: 'email/',
-  },
-  'Weekly Reports': {
-    text: 'Fine tune weekly reports by organization',
-    path: 'reports/',
-  },
-  'Deploy Notifications': {
-    text: 'Fine tune deploy notifications by organization',
-    path: 'deploy/',
-  },
-};
+const FINE_TUNE_FOOTERS = Object.fromEntries([
+  [
+    t('Alerts'),
+    {
+      text: t('Fine tune alerts by project'),
+      path: 'alerts/',
+    },
+  ],
+  [
+    t('Workflow Notifications'),
+    {
+      text: t('Fine tune workflow notifications by project'),
+      path: 'workflow/',
+    },
+  ],
+  [
+    t('Email Routing'),
+    {
+      text: t('Fine tune email routing by project'),
+      path: 'email/',
+    },
+  ],
+  [
+    t('Weekly Reports'),
+    {
+      text: t('Fine tune weekly reports by organization'),
+      path: 'reports/',
+    },
+  ],
+  [
+    t('Deploy Notifications'),
+    {
+      text: t('Fine tune deploy notifications by organization'),
+      path: 'deploy/',
+    },
+  ],
+]);
 
 export default class AccountNotifications extends AsyncView {
   getEndpoints() {

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotifications.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotifications.jsx
@@ -14,43 +14,28 @@ import {PanelFooter} from 'app/components/panels';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import accountNotificationFields from 'app/data/forms/accountNotificationSettings';
 
-const FINE_TUNE_FOOTERS = Object.fromEntries([
-  [
-    t('Alerts'),
-    {
-      text: t('Fine tune alerts by project'),
-      path: 'alerts/',
-    },
-  ],
-  [
-    t('Workflow Notifications'),
-    {
-      text: t('Fine tune workflow notifications by project'),
-      path: 'workflow/',
-    },
-  ],
-  [
-    t('Email Routing'),
-    {
-      text: t('Fine tune email routing by project'),
-      path: 'email/',
-    },
-  ],
-  [
-    t('Weekly Reports'),
-    {
-      text: t('Fine tune weekly reports by organization'),
-      path: 'reports/',
-    },
-  ],
-  [
-    t('Deploy Notifications'),
-    {
-      text: t('Fine tune deploy notifications by organization'),
-      path: 'deploy/',
-    },
-  ],
-]);
+const FINE_TUNE_FOOTERS = {
+  [t('Alerts')]: {
+    text: t('Fine tune alerts by project'),
+    path: 'alerts/',
+  },
+  [t('Workflow Notifications')]: {
+    text: t('Fine tune workflow notifications by project'),
+    path: 'workflow/',
+  },
+  [t('Email Routing')]: {
+    text: t('Fine tune email routing by project'),
+    path: 'email/',
+  },
+  [t('Weekly Reports')]: {
+    text: t('Fine tune weekly reports by organization'),
+    path: 'reports/',
+  },
+  [t('Deploy Notifications')]: {
+    text: t('Fine tune deploy notifications by organization'),
+    path: 'deploy/',
+  },
+};
 
 export default class AccountNotifications extends AsyncView {
   getEndpoints() {


### PR DESCRIPTION
This adds translation to keys and values of the notifications' `FINE_TUNE_FOOTERS` object.

Using settings in a different language was causing some options to disappear. Cause of this was the notifications footers titles lookup object had the titles not translated so fine tune footer lookup was always undefined. The footers for notification settings are now always shown. 

Reported in [ISSUE-818](https://getsentry.atlassian.net/browse/ISSUE-818)