### PR TITLE
fix(noise): Stop polling on status code 0 for `<EventWaiter>`

### DIFF
--- a/src/sentry/static/sentry/app/utils/eventWaiter.tsx
+++ b/src/sentry/static/sentry/app/utils/eventWaiter.tsx
@@ -76,7 +76,7 @@ class EventWaiter extends React.Component<Props, State> {
 
       // This means org or project does not exist, we need to stop polling
       // Also stop polling on auth-related errors (403/401)
-      if ([404, 403, 401].includes(resp.status)) {
+      if ([404, 403, 401, 0].includes(resp.status)) {
         // TODO: Add some UX around this... redirect? error message?
         this.stopPolling();
         return;


### PR DESCRIPTION
We should also stop polling when we get a response status code of 0.