### PR TITLE
feat(metrics): Capture first-meaning-paint for IssueDetails on Reload

### DIFF
--- a/src/sentry/static/sentry/app/utils/__mocks__/withOrganization.tsx
+++ b/src/sentry/static/sentry/app/utils/__mocks__/withOrganization.tsx
@@ -19,4 +19,7 @@ const withOrganizationMock = WrappedComponent =>
     }
   };
 
+const isLightweightOrganization = () => {};
+
 export default withOrganizationMock;
+export {isLightweightOrganization};

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -116,13 +116,13 @@ const IssueListOverview = createReactClass({
         this.props.finishProfile();
       }
 
-      // First Meaningful Paint for IssueList page
+      // First Meaningful Paint for /organizations/:orgId/issues/
       if (prevState.queryCount === null) {
         metric.measure({
           name: 'app.page.perf.issue-list',
           start: 'page-issue-list-start',
           data: {
-            organization_slug: this.props.organization.slug,
+            org_id: parseInt(this.props.organization.id, 10),
             group: this.props.organization.features.includes('enterprise-perf')
               ? 'enterprise-perf'
               : 'control',

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {Client} from 'app/api';
+import {metric} from 'app/utils/analytics';
 import {fetchSentryAppComponents} from 'app/actionCreators/sentryAppComponents';
 import {withMeta} from 'app/components/events/meta/metaProxy';
 import EventEntries from 'app/components/events/eventEntries';
@@ -93,6 +94,22 @@ class GroupEventDetails extends React.Component<Props, State> {
 
     if (eventHasChanged || environmentsHaveChanged) {
       this.fetchData();
+    }
+
+    // First Meaningful Paint for /organizations/:orgId/issues/:groupId/
+    if (prevState.loading && !this.state.loading && prevState.event === null) {
+      metric.measure({
+        name: 'app.page.perf.issue-details',
+        start: 'page-issue-details-start',
+        data: {
+          org_id: parseInt(this.props.organization.id, 10),
+          group: this.props.organization.features.includes('enterprise-perf')
+            ? 'enterprise-perf'
+            : 'control',
+          milestone: 'first-meaningful-paint',
+          // start_type is set on 'page-issue-details-start'
+        },
+      });
     }
   }
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/index.tsx
@@ -1,9 +1,9 @@
 import * as ReactRouter from 'react-router';
 import React from 'react';
 
-import {analytics} from 'app/utils/analytics';
+import {analytics, metric} from 'app/utils/analytics';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
-import withOrganization from 'app/utils/withOrganization';
+import withOrganization, {isLightweightOrganization} from 'app/utils/withOrganization';
 import {GlobalSelection, Organization} from 'app/types';
 
 import GroupDetails from './groupDetails';
@@ -16,11 +16,28 @@ type Props = {
 } & ReactRouter.RouteComponentProps<{orgId: string; groupId: string}, {}>;
 
 class OrganizationGroupDetails extends React.Component<Props> {
+  constructor(props) {
+    super(props);
+
+    // Setup in the constructor as render() may be expensive
+    this.startMetricCollection();
+  }
+
   componentDidMount() {
     analytics('issue_page.viewed', {
       group_id: parseInt(this.props.params.groupId, 10),
       org_id: parseInt(this.props.organization.id, 10),
     });
+  }
+
+  /**
+   * See "page-issue-list-start" for explanation on hot/cold-starts
+   */
+  startMetricCollection() {
+    const startType = isLightweightOrganization(this.props.organization)
+      ? 'cold-start'
+      : 'hot-start';
+    metric.mark({name: 'page-issue-details-start', data: {start_type: startType}});
   }
 
   render() {


### PR DESCRIPTION
* Switched from `organization_slug` to `org_id` as slugs can change.