### PR TITLE
ref(ui): Added new breadcrumbs icons and colors

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntriesBreadcrumbs.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntriesBreadcrumbs.tsx
@@ -5,6 +5,7 @@ import BreadcrumbsInterface from 'app/components/events/interfaces/breadcrumbs/b
 import BreadcrumbsInterfaceV2 from 'app/components/events/interfaces/breadcrumbsV2/breadcrumbs';
 
 type Props = React.ComponentProps<typeof BreadcrumbsInterfaceV2>;
+type BreadcrumbsInterfaceProps = React.ComponentProps<typeof BreadcrumbsInterface>;
 
 const EventEntriesBreadcrumbs = (props: Props) => (
   <Feature features={['breadcrumbs-v2']}>
@@ -12,7 +13,7 @@ const EventEntriesBreadcrumbs = (props: Props) => (
       hasFeature ? (
         <BreadcrumbsInterfaceV2 {...props} />
       ) : (
-        <BreadcrumbsInterface {...props} />
+        <BreadcrumbsInterface {...(props as BreadcrumbsInterfaceProps)} />
       )
     }
   </Feature>

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbCategory.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbCategory.tsx
@@ -13,11 +13,9 @@ type Props = {
 const BreadcrumbCategory = ({category}: Props) => {
   const title = !defined(category) ? t('generic') : category;
   return (
-    <div>
-      <Tooltip title={title}>
-        <Category title={title}>{title}</Category>
-      </Tooltip>
-    </div>
+    <Tooltip title={title}>
+      <Category title={title}>{title}</Category>
+    </Tooltip>
   );
 };
 
@@ -27,5 +25,6 @@ const Category = styled('div')`
   color: ${p => p.theme.gray5};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 700;
+  line-height: 26px;
   ${overflowEllipsis};
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbCollapsed.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbCollapsed.tsx
@@ -5,7 +5,7 @@ import {tct} from 'app/locale';
 import {IconEllipsis} from 'app/icons';
 import space from 'app/styles/space';
 
-import {GridCell, IconWrapper} from './styles';
+import {GridCellLeft, IconWrapper} from './styles';
 
 type Props = {
   onClick: () => void;
@@ -13,22 +13,20 @@ type Props = {
 };
 
 const BreadcrumbCollapsed = ({quantity, onClick}: Props) => (
-  <StyledGridCell data-test-id="breadcrumb-collapsed" withBeforeContent onClick={onClick}>
+  <Wrapper data-test-id="breadcrumb-collapsed" onClick={onClick}>
     <IconWrapper>
       <IconEllipsis />
     </IconWrapper>
     {tct('Show [quantity] collapsed crumbs', {quantity})}
-  </StyledGridCell>
+  </Wrapper>
 );
 
 export default BreadcrumbCollapsed;
 
-const StyledGridCell = styled(GridCell)`
+const Wrapper = styled(GridCellLeft)`
+  border-right: 1px solid ${p => p.theme.borderDark};
   cursor: pointer;
   background: ${p => p.theme.whiteDark};
-  margin: 0 -1px;
-  border-left: 1px solid ${p => p.theme.borderLight};
-  border-right: 1px solid ${p => p.theme.borderLight};
   font-size: ${p => p.theme.fontSizeMedium};
   grid-column-start: 1;
   grid-column-end: -1;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbCollapsed.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbCollapsed.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {tct} from 'app/locale';
+import {IconEllipsis} from 'app/icons';
+import space from 'app/styles/space';
+
+import {GridCell, IconWrapper} from './styles';
+
+type Props = {
+  onClick: () => void;
+  quantity: number;
+};
+
+const BreadcrumbCollapsed = ({quantity, onClick}: Props) => (
+  <StyledGridCell data-test-id="breadcrumb-collapsed" withBeforeContent onClick={onClick}>
+    <IconWrapper>
+      <IconEllipsis />
+    </IconWrapper>
+    {tct('Show [quantity] collapsed crumbs', {quantity})}
+  </StyledGridCell>
+);
+
+export default BreadcrumbCollapsed;
+
+const StyledGridCell = styled(GridCell)`
+  cursor: pointer;
+  background: ${p => p.theme.whiteDark};
+  margin: 0 -1px;
+  border-left: 1px solid ${p => p.theme.borderLight};
+  border-right: 1px solid ${p => p.theme.borderLight};
+  font-size: ${p => p.theme.fontSizeMedium};
+  grid-column-start: 1;
+  grid-column-end: -1;
+  display: grid;
+  grid-gap: ${space(1.5)};
+  grid-template-columns: max-content 1fr;
+`;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbData.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbData.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import BreadcrumbDataDefault from './breadcrumbDataDefault';
 import BreadcrumbDataException from './breadcrumbDataException';
 import BreadcrumbDataHttp from './breadcrumbDataHttp';
-import {Breadcrumb, BreadcrumbType} from '../../breadcrumbs/types';
+import {Breadcrumb, BreadcrumbType} from '../types';
 
 type Props = {
   breadcrumb: Breadcrumb;
@@ -16,8 +16,6 @@ const BreadcrumbData = ({breadcrumb}: Props) => {
 
   if (
     breadcrumb.type === BreadcrumbType.WARNING ||
-    breadcrumb.type === BreadcrumbType.MESSAGE ||
-    breadcrumb.type === BreadcrumbType.EXCEPTION ||
     breadcrumb.type === BreadcrumbType.ERROR
   ) {
     return <BreadcrumbDataException breadcrumb={breadcrumb} />;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbDataDefault.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbDataDefault.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {getMeta} from 'app/components/events/meta/metaProxy';
 
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
-import {BreadcrumbTypeDefault, BreadcrumbTypeNavigation} from '../../breadcrumbs/types';
+import {BreadcrumbTypeDefault, BreadcrumbTypeNavigation} from '../types';
 import BreadcrumbDataSummary from './breadcrumbDataSummary';
 
 type Props = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbDataException.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbDataException.tsx
@@ -5,7 +5,7 @@ import {getMeta} from 'app/components/events/meta/metaProxy';
 import {defined} from 'app/utils';
 
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
-import {BreadcrumbTypeDefault} from '../../breadcrumbs/types';
+import {BreadcrumbTypeDefault} from '../types';
 import BreadcrumbDataSummary from './breadcrumbDataSummary';
 
 type Props = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbDataHttp.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbDataHttp.tsx
@@ -7,7 +7,7 @@ import {t} from 'app/locale';
 import {defined} from 'app/utils';
 
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
-import {BreadcrumbTypeHTTP} from '../../breadcrumbs/types';
+import {BreadcrumbTypeHTTP} from '../types';
 import BreadcrumbDataSummary from './breadcrumbDataSummary';
 
 type Props = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbDataSummary.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbDataSummary.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {getMeta} from 'app/components/events/meta/metaProxy';
-import space from 'app/styles/space';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {defined} from 'app/utils';
 
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
@@ -39,34 +39,35 @@ class BreadcrumbDataSummary extends React.Component<Props, State> {
 
     return Object.keys(kvData)
       .filter(key => defined(kvData[key]) && !!kvData[key])
-      .map(key => (
-        <BreadcrumbDataSummaryData key={key}>
-          <BreadcrumbDataSummaryDataLabel>{`${key}: `}</BreadcrumbDataSummaryDataLabel>
-          <StyledPre>
-            {getBreadcrumbCustomRendererValue({
-              value:
-                typeof kvData[key] === 'object'
-                  ? JSON.stringify(kvData[key])
-                  : kvData[key],
-              meta: getMeta(kvData, key),
-            })}
-          </StyledPre>
-        </BreadcrumbDataSummaryData>
-      ));
+      .map(key => {
+        const value =
+          typeof kvData[key] === 'object' ? JSON.stringify(kvData[key]) : kvData[key];
+        return (
+          <BreadcrumbDataSummaryData key={key}>
+            <StyledPre>
+              <BreadcrumbDataSummaryDataLabel>{`${key}: `}</BreadcrumbDataSummaryDataLabel>
+              {getBreadcrumbCustomRendererValue({
+                value,
+                meta: getMeta(kvData, key),
+              })}
+            </StyledPre>
+          </BreadcrumbDataSummaryData>
+        );
+      });
   };
 
   // TODO(Priscila): implement Summary lifecycles
   render() {
     const {children} = this.props;
     return (
-      <div>
+      <React.Fragment>
         <div onClick={this.onToggle} ref={this.summaryNode}>
           <StyledPre>
-            <code>{children}</code>
+            <StyledCode>{children}</StyledCode>
           </StyledPre>
         </div>
         {this.renderData()}
-      </div>
+      </React.Fragment>
     );
   }
 }
@@ -81,11 +82,20 @@ const StyledPre = styled('pre')`
   word-break: break-all;
   margin: 0;
   font-size: ${p => p.theme.fontSizeSmall};
-  display: inline;
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    ${overflowEllipsis};
+  }
+`;
+
+const StyledCode = styled('code')`
+  white-space: nowrap;
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    white-space: pre-wrap;
+  }
+  line-height: 26px;
 `;
 
 const BreadcrumbDataSummaryData = styled('div')`
-  margin: ${space(1)} 0;
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbFilter/breadcrumbFilterGroupIcon.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbFilter/breadcrumbFilterGroupIcon.tsx
@@ -1,22 +1,20 @@
 import React from 'react';
 
-import {BreadCrumbIconWrapper} from '../styles';
-import {IconProps} from '../../breadcrumbs/types';
+import {IconWrapper} from '../styles';
+import {IconProps} from '../types';
 import {BreadcrumbDetails} from './types';
 
-const BreadcrumbFilterGroupIcon = ({
-  icon,
-  color,
-  borderColor,
-}: Omit<BreadcrumbDetails, 'description'>) => {
+type Props = Omit<BreadcrumbDetails, 'description'>;
+
+const BreadcrumbFilterGroupIcon = ({icon, color}: Props) => {
   if (!icon) return null;
 
   const Icon = icon as React.ComponentType<IconProps>;
 
   return (
-    <BreadCrumbIconWrapper color={color} borderColor={borderColor} size={20}>
+    <IconWrapper color={color} size={20}>
       <Icon size="xs" />
-    </BreadCrumbIconWrapper>
+    </IconWrapper>
   );
 };
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbFilter/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbFilter/types.tsx
@@ -1,8 +1,4 @@
-import {
-  BreadcrumbDetails,
-  BreadcrumbType,
-  BreadcrumbLevelType,
-} from '../../breadcrumbs/types';
+import {BreadcrumbDetails, BreadcrumbType, BreadcrumbLevelType} from '../types';
 
 export enum FilterGroupType {
   LEVEL = 'level',

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbIcon.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbIcon.tsx
@@ -4,17 +4,17 @@ import SvgIcon from 'app/icons/svgIcon';
 
 type SvgIconProps = React.ComponentProps<typeof SvgIcon>;
 
-import {BreadCrumbIconWrapper} from './styles';
-import {BreadcrumbDetails} from '../breadcrumbs/types';
+import {IconWrapper} from './styles';
+import {BreadcrumbDetails} from './types';
 
 type Props = Omit<BreadcrumbDetails, 'description'> & Pick<SvgIconProps, 'size'>;
 
-const BreadcrumbIcon = ({icon, color, borderColor, size}: Props) => {
+const BreadcrumbIcon = ({icon, color, size}: Props) => {
   const Icon = icon as React.ComponentType<SvgIconProps>;
   return (
-    <BreadCrumbIconWrapper color={color} borderColor={borderColor}>
+    <IconWrapper color={color}>
       <Icon size={size} />
-    </BreadCrumbIconWrapper>
+    </IconWrapper>
   );
 };
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbLevel.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbLevel.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import Tag from 'app/views/settings/components/tag';
 import {t} from 'app/locale';
 
-import {BreadcrumbLevelType} from '../breadcrumbs/types';
+import {BreadcrumbLevelType} from './types';
 
 type Props = {
   level?: BreadcrumbLevelType;
 };
 
-const BreadcrumbLevelTag = ({level}: Props) => {
+const BreadcrumbLevel = ({level}: Props) => {
   switch (level) {
     case BreadcrumbLevelType.FATAL:
     case BreadcrumbLevelType.ERROR:
@@ -22,11 +22,5 @@ const BreadcrumbLevelTag = ({level}: Props) => {
       return <Tag>{level || t('undefined')}</Tag>;
   }
 };
-
-const BreadcrumbLevel = ({level}: Props) => (
-  <div>
-    <BreadcrumbLevelTag level={level} />
-  </div>
-);
 
 export default BreadcrumbLevel;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbTime.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbTime.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import moment from 'moment';
+
+import {defined} from 'app/utils';
+import Tooltip from 'app/components/tooltip';
+import getDynamicText from 'app/utils/getDynamicText';
+
+const getBreadcrumbTimeTooltipTitle = (timestamp: string) => {
+  const parsedTimestamp = moment(timestamp);
+  const timestampFormat = parsedTimestamp.milliseconds() ? 'll H:mm:ss.SSS A' : 'lll';
+  return parsedTimestamp.format(timestampFormat);
+};
+
+type Props = {
+  timestamp?: string;
+};
+
+const BreadcrumbTime = ({timestamp}: Props) =>
+  defined(timestamp) ? (
+    <Tooltip title={getBreadcrumbTimeTooltipTitle(timestamp)}>
+      <Time>
+        {getDynamicText({
+          value: moment(timestamp).format('HH:mm:ss'),
+          fixed: '00:00:00',
+        })}
+      </Time>
+    </Tooltip>
+  ) : null;
+
+export default BreadcrumbTime;
+
+const Time = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.gray4};
+`;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbs.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbs.tsx
@@ -20,7 +20,7 @@ import {
   BreadcrumbDetails,
   BreadcrumbType,
   BreadcrumbLevelType,
-} from '../breadcrumbs/types';
+} from './types';
 import BreadcrumbFilter from './breadcrumbFilter/breadcrumbFilter';
 import convertBreadcrumbType from './convertBreadcrumbType';
 import getBreadcrumbTypeDetails from './getBreadcrumbTypeDetails';
@@ -29,6 +29,7 @@ import BreadcrumbsListHeader from './breadcrumbsListHeader';
 import BreadcrumbsListBody from './breadcrumbsListBody';
 import BreadcrumbLevel from './breadcrumbLevel';
 import BreadcrumbIcon from './breadcrumbIcon';
+import {Grid} from './styles';
 
 const MAX_CRUMBS_WHEN_COLLAPSED = 10;
 
@@ -79,7 +80,7 @@ class BreadcrumbsContainer extends React.Component<Props, State> {
     this.loadBreadCrumbListHeight();
   }
 
-  listRef = React.createRef<HTMLUListElement>();
+  listRef = React.createRef<HTMLDivElement>();
 
   loadBreadCrumbListHeight = () => {
     const offsetHeight = this.listRef?.current?.offsetHeight;
@@ -175,7 +176,7 @@ class BreadcrumbsContainer extends React.Component<Props, State> {
     if (exception) {
       const {type, value, module: mdl} = exception.data.values[0];
       return {
-        type: BreadcrumbType.EXCEPTION,
+        type: BreadcrumbType.ERROR,
         level: BreadcrumbLevelType.ERROR,
         category: this.moduleToCategory(mdl) || 'exception',
         data: {
@@ -189,7 +190,7 @@ class BreadcrumbsContainer extends React.Component<Props, State> {
     const levelTag = (event.tags || []).find(tag => tag.key === 'level');
 
     return {
-      type: BreadcrumbType.MESSAGE,
+      type: BreadcrumbType.ERROR,
       level: levelTag?.value as BreadcrumbLevelType,
       category: 'message',
       message: event.message,
@@ -349,14 +350,14 @@ class BreadcrumbsContainer extends React.Component<Props, State> {
       >
         <Content>
           {filteredCollapsedBreadcrumbs.length > 0 ? (
-            <BreadcrumbList maxHeight={breadCrumbListHeight} ref={this.listRef}>
+            <Grid maxHeight={breadCrumbListHeight} ref={this.listRef}>
               <BreadcrumbsListHeader />
               <BreadcrumbsListBody
                 onToggleCollapse={this.handleToggleCollapse}
                 collapsedQuantity={collapsedQuantity}
                 breadcrumbs={filteredCollapsedBreadcrumbs}
               />
-            </BreadcrumbList>
+            </Grid>
           ) : (
             <EmptyMessage
               icon={<IconWarning size="xl" />}
@@ -378,18 +379,10 @@ class BreadcrumbsContainer extends React.Component<Props, State> {
 export default BreadcrumbsContainer;
 
 const Content = styled('div')`
-  border: 1px solid ${p => p.theme.borderLight};
+  border: 1px solid ${p => p.theme.borderDark};
   border-radius: 3px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
   margin-bottom: ${space(3)};
-`;
-
-const BreadcrumbList = styled('ul')<{maxHeight: React.CSSProperties['maxHeight']}>`
-  padding-left: 0;
-  list-style: none;
-  margin-bottom: 0;
-  overflow-y: auto;
-  max-height: ${p => p.maxHeight};
 `;
 
 const Search = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbs.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbs.tsx
@@ -379,7 +379,7 @@ class BreadcrumbsContainer extends React.Component<Props, State> {
 export default BreadcrumbsContainer;
 
 const Content = styled('div')`
-  border: 1px solid ${p => p.theme.borderDark};
+  border-top: 1px solid ${p => p.theme.borderDark};
   border-radius: 3px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
   margin-bottom: ${space(3)};

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListBody.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListBody.tsx
@@ -10,7 +10,7 @@ import BreadcrumbData from './breadcrumbData/breadcrumbData';
 import BreadcrumbCategory from './breadcrumbCategory';
 import BreadcrumbIcon from './breadcrumbIcon';
 import BreadcrumbLevel from './breadcrumbLevel';
-import {GridCell} from './styles';
+import {GridCell, GridCellLeft, GridCellRight} from './styles';
 import {Breadcrumb, BreadcrumbDetails, BreadcrumbType} from './types';
 
 type Breadcrumbs = Array<Breadcrumb & BreadcrumbDetails & {id: number}>;
@@ -34,23 +34,23 @@ const BreadcrumbsListBody = ({
       const hasError = crumb.type === BreadcrumbType.ERROR;
       return (
         <React.Fragment key={idx}>
-          <GridCell hasError={hasError} withoutBorder={['right']} withBeforeContent>
+          <StyledGridCellLeft hasError={hasError}>
             <Tooltip title={crumb.description}>
               <BreadcrumbIcon icon={icon} color={color} />
             </Tooltip>
-          </GridCell>
-          <GridCellCategory hasError={hasError} withoutBorder={['left', 'right']}>
+          </StyledGridCellLeft>
+          <GridCellCategory hasError={hasError}>
             <BreadcrumbCategory category={crumb?.category} />
           </GridCellCategory>
-          <GridCell hasError={hasError} withoutBorder={['left', 'right']}>
+          <GridCell hasError={hasError}>
             <BreadcrumbData breadcrumb={crumb as Breadcrumb} />
           </GridCell>
-          <GridCell hasError={hasError} withoutBorder={['left', 'right']}>
+          <GridCell hasError={hasError}>
             <BreadcrumbLevel level={crumb.level} />
           </GridCell>
-          <GridCell hasError={hasError} withoutBorder={['left']}>
+          <StyledGridCellRight hasError={hasError}>
             <BreadcrumbTime timestamp={crumb.timestamp} />
-          </GridCell>
+          </StyledGridCellRight>
         </React.Fragment>
       );
     })}
@@ -63,4 +63,12 @@ const GridCellCategory = styled(GridCell)`
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     padding-left: ${space(1)};
   }
+`;
+
+const StyledGridCellLeft = styled(GridCellLeft)`
+  border-bottom-left-radius: ${space(0.5)};
+`;
+
+const StyledGridCellRight = styled(GridCellRight)`
+  border-bottom-right-radius: ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListBody.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListBody.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
+import styled from '@emotion/styled';
 
-import BreadcrumbTime from '../breadcrumbs/breadcrumbTime';
-import BreadcrumbCollapsed from '../breadcrumbs/breadcrumbCollapsed';
-import {Breadcrumb, BreadcrumbDetails, BreadcrumbType} from '../breadcrumbs/types';
+import Tooltip from 'app/components/tooltip';
+import space from 'app/styles/space';
+
+import BreadcrumbTime from './breadcrumbTime';
+import BreadcrumbCollapsed from './breadcrumbCollapsed';
 import BreadcrumbData from './breadcrumbData/breadcrumbData';
 import BreadcrumbCategory from './breadcrumbCategory';
 import BreadcrumbIcon from './breadcrumbIcon';
 import BreadcrumbLevel from './breadcrumbLevel';
-import {BreadcrumbListItem} from './styles';
+import {GridCell} from './styles';
+import {Breadcrumb, BreadcrumbDetails, BreadcrumbType} from './types';
 
 type Breadcrumbs = Array<Breadcrumb & BreadcrumbDetails & {id: number}>;
 
@@ -26,20 +30,37 @@ const BreadcrumbsListBody = ({
     {collapsedQuantity > 0 && (
       <BreadcrumbCollapsed onClick={onToggleCollapse} quantity={collapsedQuantity} />
     )}
-    {breadcrumbs.map(({color, borderColor, icon, ...crumb}, idx) => {
-      const hasError =
-        crumb.type === BreadcrumbType.MESSAGE || crumb.type === BreadcrumbType.EXCEPTION;
+    {breadcrumbs.map(({color, icon, ...crumb}, idx) => {
+      const hasError = crumb.type === BreadcrumbType.ERROR;
       return (
-        <BreadcrumbListItem key={idx} data-test-id="breadcrumb" hasError={hasError}>
-          <BreadcrumbIcon icon={icon} color={color} borderColor={borderColor} />
-          <BreadcrumbCategory category={crumb.category} />
-          <BreadcrumbData breadcrumb={crumb as Breadcrumb} />
-          <BreadcrumbLevel level={crumb.level} />
-          <BreadcrumbTime timestamp={crumb.timestamp} />
-        </BreadcrumbListItem>
+        <React.Fragment key={idx}>
+          <GridCell hasError={hasError} withoutBorder={['right']} withBeforeContent>
+            <Tooltip title={crumb.description}>
+              <BreadcrumbIcon icon={icon} color={color} />
+            </Tooltip>
+          </GridCell>
+          <GridCellCategory hasError={hasError} withoutBorder={['left', 'right']}>
+            <BreadcrumbCategory category={crumb?.category} />
+          </GridCellCategory>
+          <GridCell hasError={hasError} withoutBorder={['left', 'right']}>
+            <BreadcrumbData breadcrumb={crumb as Breadcrumb} />
+          </GridCell>
+          <GridCell hasError={hasError} withoutBorder={['left', 'right']}>
+            <BreadcrumbLevel level={crumb.level} />
+          </GridCell>
+          <GridCell hasError={hasError} withoutBorder={['left']}>
+            <BreadcrumbTime timestamp={crumb.timestamp} />
+          </GridCell>
+        </React.Fragment>
       );
     })}
   </React.Fragment>
 );
 
 export default BreadcrumbsListBody;
+
+const GridCellCategory = styled(GridCell)`
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    padding-left: ${space(1)};
+  }
+`;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListBody.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListBody.tsx
@@ -34,11 +34,11 @@ const BreadcrumbsListBody = ({
       const hasError = crumb.type === BreadcrumbType.ERROR;
       return (
         <React.Fragment key={idx}>
-          <StyledGridCellLeft hasError={hasError}>
+          <GridCellLeft hasError={hasError}>
             <Tooltip title={crumb.description}>
               <BreadcrumbIcon icon={icon} color={color} />
             </Tooltip>
-          </StyledGridCellLeft>
+          </GridCellLeft>
           <GridCellCategory hasError={hasError}>
             <BreadcrumbCategory category={crumb?.category} />
           </GridCellCategory>
@@ -48,9 +48,9 @@ const BreadcrumbsListBody = ({
           <GridCell hasError={hasError}>
             <BreadcrumbLevel level={crumb.level} />
           </GridCell>
-          <StyledGridCellRight hasError={hasError}>
+          <GridCellRight hasError={hasError}>
             <BreadcrumbTime timestamp={crumb.timestamp} />
-          </StyledGridCellRight>
+          </GridCellRight>
         </React.Fragment>
       );
     })}
@@ -63,12 +63,4 @@ const GridCellCategory = styled(GridCell)`
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     padding-left: ${space(1)};
   }
-`;
-
-const StyledGridCellLeft = styled(GridCellLeft)`
-  border-bottom-left-radius: ${space(0.5)};
-`;
-
-const StyledGridCellRight = styled(GridCellRight)`
-  border-bottom-right-radius: ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListHeader.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListHeader.tsx
@@ -4,33 +4,39 @@ import styled from '@emotion/styled';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 
-import {BreadcrumbListItem} from './styles';
+import {GridCell} from './styles';
 
 const BreadcrumbsListHeader = () => {
   return (
-    <BreadcrumbListHeaderWrapper>
-      <BreadcrumbListHeaderItem>{t('Type')}</BreadcrumbListHeaderItem>
-      <BreadcrumbListHeaderItem>{t('Category')}</BreadcrumbListHeaderItem>
-      <BreadcrumbListHeaderItem>{t('Description')}</BreadcrumbListHeaderItem>
-      <BreadcrumbListHeaderItem>{t('Level')}</BreadcrumbListHeaderItem>
-      <BreadcrumbListHeaderItem>{t('Datetime')}</BreadcrumbListHeaderItem>
-    </BreadcrumbListHeaderWrapper>
+    <React.Fragment>
+      <StyledGridCell>{t('Type')}</StyledGridCell>
+      <StyledGridCellCategory>{t('Category')}</StyledGridCellCategory>
+      <StyledGridCell>{t('Description')}</StyledGridCell>
+      <StyledGridCell>{t('Level')}</StyledGridCell>
+      <StyledGridCell>{t('Time')}</StyledGridCell>
+    </React.Fragment>
   );
 };
 
 export default BreadcrumbsListHeader;
 
-const BreadcrumbListHeaderWrapper = styled(BreadcrumbListItem)`
-  padding: ${space(2)} ${space(2)} ${space(2)} ${space(3)};
+const StyledGridCell = styled(GridCell)`
   border-bottom: 1px solid ${p => p.theme.borderDark};
   background: ${p => p.theme.offWhite};
-`;
-
-const BreadcrumbListHeaderItem = styled('div')`
   color: ${p => p.theme.gray3};
-  font-size: ${p => p.theme.fontSizeSmall};
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   font-weight: 600;
   text-transform: uppercase;
   line-height: 1;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    padding: ${space(2)} ${space(2)};
+    font-size: ${p => p.theme.fontSizeSmall};
+  }
+`;
+
+const StyledGridCellCategory = styled(StyledGridCell)`
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    padding-left: ${space(1)};
+  }
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListHeader.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListHeader.tsx
@@ -22,12 +22,14 @@ export default BreadcrumbsListHeader;
 
 const StyledGridCell = styled(GridCell)`
   border-top: 0;
+  border-bottom: 1px solid ${p => p.theme.borderLight};
   background: ${p => p.theme.offWhite};
   color: ${p => p.theme.gray3};
   font-weight: 600;
   text-transform: uppercase;
   line-height: 1;
   font-size: ${p => p.theme.fontSizeExtraSmall};
+
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     padding: ${space(2)} ${space(2)};
     font-size: ${p => p.theme.fontSizeSmall};

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListHeader.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListHeader.tsx
@@ -9,11 +9,11 @@ import {GridCell} from './styles';
 const BreadcrumbsListHeader = () => {
   return (
     <React.Fragment>
-      <StyledGridCell>{t('Type')}</StyledGridCell>
+      <StyledGridCellLeft>{t('Type')}</StyledGridCellLeft>
       <StyledGridCellCategory>{t('Category')}</StyledGridCellCategory>
       <StyledGridCell>{t('Description')}</StyledGridCell>
       <StyledGridCell>{t('Level')}</StyledGridCell>
-      <StyledGridCell>{t('Time')}</StyledGridCell>
+      <StyledGridCellRight>{t('Time')}</StyledGridCellRight>
     </React.Fragment>
   );
 };
@@ -21,10 +21,9 @@ const BreadcrumbsListHeader = () => {
 export default BreadcrumbsListHeader;
 
 const StyledGridCell = styled(GridCell)`
-  border-bottom: 1px solid ${p => p.theme.borderDark};
+  border-top: 0;
   background: ${p => p.theme.offWhite};
   color: ${p => p.theme.gray3};
-  border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   font-weight: 600;
   text-transform: uppercase;
   line-height: 1;
@@ -33,6 +32,16 @@ const StyledGridCell = styled(GridCell)`
     padding: ${space(2)} ${space(2)};
     font-size: ${p => p.theme.fontSizeSmall};
   }
+`;
+
+const StyledGridCellLeft = styled(StyledGridCell)`
+  border-radius: ${p => p.theme.borderRadius} 0 0 0;
+  border-left: 1px solid ${p => p.theme.borderDark};
+`;
+
+const StyledGridCellRight = styled(StyledGridCell)`
+  border-radius: 0 ${p => p.theme.borderRadius} 0 0;
+  border-right: 1px solid ${p => p.theme.borderDark};
 `;
 
 const StyledGridCellCategory = styled(StyledGridCell)`

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/convertBreadcrumbType.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/convertBreadcrumbType.tsx
@@ -1,8 +1,14 @@
 import {defined} from 'app/utils';
 
-import {Breadcrumb, BreadcrumbType} from '../breadcrumbs/types';
+import {Breadcrumb, BreadcrumbType} from './types';
 
 function convertBreadcrumbType(breadcrumb: Breadcrumb): Breadcrumb {
+  if (breadcrumb.type === BreadcrumbType.EXCEPTION) {
+    return {
+      ...breadcrumb,
+      type: BreadcrumbType.ERROR,
+    };
+  }
   // special case for 'ui.' and `sentry.` category breadcrumbs
   // TODO: find a better way to customize UI around non-schema data
   if (breadcrumb.type === BreadcrumbType.DEFAULT && defined(breadcrumb?.category)) {
@@ -14,10 +20,17 @@ function convertBreadcrumbType(breadcrumb: Breadcrumb): Breadcrumb {
       };
     }
 
-    if (category === 'console' || category === 'navigation') {
+    if (category === 'console') {
       return {
         ...breadcrumb,
         type: BreadcrumbType.DEBUG,
+      };
+    }
+
+    if (category === 'navigation') {
+      return {
+        ...breadcrumb,
+        type: BreadcrumbType.NAVIGATION,
       };
     }
 
@@ -27,7 +40,7 @@ function convertBreadcrumbType(breadcrumb: Breadcrumb): Breadcrumb {
     ) {
       return {
         ...breadcrumb,
-        type: BreadcrumbType.EXCEPTION,
+        type: BreadcrumbType.ERROR,
       };
     }
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/getBreadcrumbTypeDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/getBreadcrumbTypeDetails.tsx
@@ -4,69 +4,99 @@ import {
   IconLocation,
   IconUser,
   IconRefresh,
+  IconFix,
+  IconFire,
   IconTerminal,
+  IconStack,
+  IconMobile,
+  IconSwitch,
 } from 'app/icons';
 import {t} from 'app/locale';
 
-import {BreadcrumbType, BreadcrumbDetails} from '../breadcrumbs/types';
+import {BreadcrumbType, BreadcrumbDetails} from './types';
 
 function getBreadcrumbTypeDetails(breadcrumbType: BreadcrumbType): BreadcrumbDetails {
   switch (breadcrumbType) {
     case BreadcrumbType.USER:
-    case BreadcrumbType.UI: {
+    case BreadcrumbType.UI:
       return {
         color: 'purple',
         icon: IconUser,
         description: t('User Action'),
       };
-    }
-    case BreadcrumbType.NAVIGATION: {
+
+    case BreadcrumbType.NAVIGATION:
       return {
-        color: 'blue',
+        // TODO(style): replace the color below, as soon as it is part of the theme
+        color: '#1C8952',
         icon: IconLocation,
         description: t('Navigation'),
       };
-    }
-    case BreadcrumbType.INFO: {
+
+    case BreadcrumbType.DEBUG:
       return {
-        color: 'blue',
+        // TODO(style): replace the color below, as soon as it is part of the theme
+        color: '#3E2C73',
+        icon: IconFix,
+        description: t('Debug'),
+      };
+
+    case BreadcrumbType.INFO:
+      return {
+        // TODO(style): replace the color below, as soon as it is part of the theme
+        color: '#3D74DB',
         icon: IconInfo,
         description: t('Info'),
       };
-    }
-    case BreadcrumbType.WARNING: {
+
+    case BreadcrumbType.ERROR:
       return {
-        color: 'yellowOrange',
-        borderColor: 'yellowOrangeDark',
+        // TODO(style): replace the color below, as soon as it is part of the theme
+        color: '#FA4747',
+        icon: IconFire,
+        description: t('Error'),
+      };
+
+    case BreadcrumbType.HTTP:
+      return {
+        // TODO(style): replace the color below, as soon as it is part of the theme
+        color: '#4DC771',
+        icon: IconSwitch,
+        description: t('HTTP request'),
+      };
+
+    case BreadcrumbType.WARNING:
+      return {
+        // TODO(style): replace the color below, as soon as it is part of the theme
+        color: '#FF7738',
         icon: IconWarning,
         description: t('Warning'),
       };
-    }
-    case BreadcrumbType.DEBUG: {
+    case BreadcrumbType.QUERY:
       return {
-        icon: IconTerminal,
-        description: t('Debug'),
+        // TODO(style): replace the color below, as soon as it is part of the theme
+        color: '#194591',
+        icon: IconStack,
+        description: t('Query'),
       };
-    }
-    case BreadcrumbType.EXCEPTION:
-    case BreadcrumbType.MESSAGE: {
+    case BreadcrumbType.SYSTEM:
       return {
-        color: 'red',
-        icon: IconWarning,
-        description: t('Error'),
+        // TODO(style): replace the color below, as soon as it is part of the theme
+        color: '#FF99BC',
+        icon: IconMobile,
+        description: t('System'),
       };
-    }
-    case BreadcrumbType.HTTP: {
+    case BreadcrumbType.SESSION:
       return {
-        color: 'green',
+        // TODO(style): replace the color below, as soon as it is part of the theme
+        color: '#BA4A23',
         icon: IconRefresh,
-        description: t('HTTP request'),
+        description: t('Session'),
       };
-    }
     default:
       return {
-        icon: IconRefresh,
-        description: t('Others'),
+        icon: IconTerminal,
+        description: t('Default'),
       };
   }
 }

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/styles.tsx
@@ -29,77 +29,58 @@ const IconWrapper = styled('div', {
     `}
 `;
 
-const removeGridCellBorders = (withoutBorder?: Array<'left' | 'right'>) => {
-  if (!withoutBorder || withoutBorder.length === 0) {
-    return '';
-  }
-
-  if (withoutBorder.includes('left') && withoutBorder.includes('right')) {
-    return css`
-      border-left: 0;
-      border-right: 0;
-    `;
-  }
-
-  if (withoutBorder.includes('left')) {
-    return css`
-      border-left: 0;
-    `;
-  }
-
-  return css`
-    border-right: 0;
-  `;
-};
-
 const GridCell = styled('div')<{
   hasError?: boolean;
-  withoutBorder?: Array<'left' | 'right'>;
-  withBeforeContent?: boolean;
 }>`
   line-height: 26px;
+  border-top: 1px solid ${p => p.theme.borderDark};
   border-bottom: 1px solid ${p => p.theme.borderDark};
-  ${p =>
-    p.withBeforeContent &&
-    css`
-      position: relative;
-      :before {
-        content: '';
-        display: block;
-        width: 1px;
-        top: 0;
-        bottom: 0;
-        left: 21px;
-        background: ${p.hasError ? '#fa4747' : p.theme.borderLight};
-        position: absolute;
-        @media (min-width: ${p.theme.breakpoints[0]}) {
-          left: 29px;
-        }
-      }
-    `}
-  ${p =>
-    p.hasError &&
-    css`
-      background: #fffcfb;
-      border: 1px solid #fa4747;
-    `}
-  ${p => removeGridCellBorders(p.withoutBorder)};
+  margin-bottom: -1px;
   text-overflow: ellipsis;
   overflow: hidden;
   padding: ${space(1)};
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     padding: ${space(1)} ${space(2)};
   }
+  ${p =>
+    p.hasError &&
+    css`
+      background: #fffcfb;
+      border-color: #fa4747;
+    `}
+`;
+
+const GridCellLeft = styled(GridCell)`
+  position: relative;
+  :before {
+    content: '';
+    display: block;
+    width: 1px;
+    top: 0;
+    bottom: 0;
+    left: 21px;
+    background: ${p => (p.hasError ? '#fa4747' : p.theme.borderLight)};
+    position: absolute;
+    @media (min-width: ${p => p.theme.breakpoints[0]}) {
+      left: 29px;
+    }
+  }
+  border-left: 1px solid ${p => (p.hasError ? '#fa4747' : p.theme.borderDark)};
+`;
+
+const GridCellRight = styled(GridCell)`
+  border-right: 1px solid ${p => (p.hasError ? '#fa4747' : p.theme.borderDark)};
 `;
 
 const Grid = styled('div')<{maxHeight: React.CSSProperties['maxHeight']}>`
   display: grid;
+  overflow-y: auto;
   max-height: ${p => p.maxHeight};
   > *:nth-last-child(5):before {
     bottom: calc(100% - ${space(1)});
   }
   > *:nth-last-child(-n + 5) {
-    margin: -1px;
+    margin-bottom: 0;
   }
   grid-template-columns: max-content 55px 1fr max-content max-content;
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
@@ -107,4 +88,4 @@ const Grid = styled('div')<{maxHeight: React.CSSProperties['maxHeight']}>`
   }
 `;
 
-export {Grid, GridCell, IconWrapper};
+export {Grid, GridCell, GridCellLeft, GridCellRight, IconWrapper};

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/styles.tsx
@@ -33,8 +33,8 @@ const GridCell = styled('div')<{
   hasError?: boolean;
 }>`
   line-height: 26px;
-  border-top: 1px solid ${p => p.theme.borderDark};
-  border-bottom: 1px solid ${p => p.theme.borderDark};
+  border-top: 1px solid ${p => p.theme.borderLight};
+  border-bottom: 1px solid ${p => p.theme.borderLight};
   margin-bottom: -1px;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/styles.tsx
@@ -60,7 +60,7 @@ const GridCell = styled('div')<{
       background: #fffcfb;
       border: 1px solid #fa4747;
     `}
-  ${p => p.withoutBorder && p.withoutBorder.map(border => css`border-${border}: 0`)}
+  ${p => (p.withoutBorder ? p.withoutBorder.map(border => css`border-${border}: 0`) : '')}
   text-overflow: ellipsis;
   overflow: hidden;
   padding: ${space(1)};
@@ -78,9 +78,9 @@ const Grid = styled('div')<{maxHeight: React.CSSProperties['maxHeight']}>`
   > *:nth-last-child(-n + 5) {
     margin: -1px;
   }
-  grid-template-columns: max-content 55px 1fr 60px 65px;
+  grid-template-columns: max-content 55px 1fr max-content max-content;
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    grid-template-columns: max-content 110px 1fr 75px 80px;
+    grid-template-columns: max-content 110px 1fr max-content max-content;
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/styles.tsx
@@ -4,63 +4,84 @@ import {css} from '@emotion/core';
 import {Color} from 'app/utils/theme';
 import space from 'app/styles/space';
 
-// TODO(style): the color #fffcfb and  #e7c0bc are not yet in theme and no similar theme's color was found.
-const BreadcrumbListItem = styled('li')<{hasError?: boolean}>`
-  font-size: ${p => p.theme.fontSizeMedium};
-  position: relative;
-  padding: ${space(1)} ${space(2)} ${space(1)} ${space(3)};
-  display: grid;
-  grid-template-columns: 50px 100px 1fr 80px 80px;
-  grid-gap: ${space(2)};
-  border-bottom: 1px solid ${p => p.theme.borderLight};
-  :before {
-    content: '';
-    display: block;
-    width: 2px;
-    top: 0;
-    bottom: 0;
-    left: 32px;
-    background: ${p => p.theme.borderLight};
-    position: absolute;
-  }
-  :first-child:before {
-    content: none;
-  }
-  :last-child:before {
-    bottom: calc(100% - ${space(1)});
-  }
-  :last-child {
-    ${p =>
-      p.hasError
-        ? css`
-            background: #fffcfb;
-            border: 1px solid #e7c0bc;
-            margin: -1px;
-          `
-        : css`
-            border-bottom: 0;
-          `}
-  }
-`;
-
-const BreadCrumbIconWrapper = styled('div')<{
-  color?: Color;
-  borderColor?: Color;
+const IconWrapper = styled('div', {
+  shouldForwardProp: prop => prop !== 'color',
+})<{
+  color?: Color | React.CSSProperties['color'];
   size?: number;
 }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${p => (p.size ? `${p.size}px` : '26px')};
-  height: ${p => (p.size ? `${p.size}px` : '26px')};
+  width: 26px;
+  height: 26px;
   background: ${p => p.theme.white};
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
   border-radius: 32px;
   z-index: 1;
   position: relative;
-  color: ${p => (p.color ? p.theme[p.color] : 'inherit')};
-  border-color: ${p => (p.borderColor ? p.theme[p.borderColor] : 'currentColor')};
-  border: 1px solid ${p => (p.color ? p.theme[p.color] : p.theme.gray2)};
+  border: 1px solid ${p => p.theme.gray2};
+  ${p =>
+    p.color &&
+    css`
+      color: ${p.theme[p.color] || p.color};
+      border-color: ${p.theme[p.color] || p.color};
+    `}
 `;
 
-export {BreadcrumbListItem, BreadCrumbIconWrapper};
+const GridCell = styled('div')<{
+  hasError?: boolean;
+  withoutBorder?: Array<'left' | 'right'>;
+  withBeforeContent?: boolean;
+}>`
+  line-height: 26px;
+  border-bottom: 1px solid ${p => p.theme.borderDark};
+  ${p =>
+    p.withBeforeContent &&
+    css`
+      position: relative;
+      :before {
+        content: '';
+        display: block;
+        width: 1px;
+        top: 0;
+        bottom: 0;
+        left: 21px;
+        background: ${p.hasError ? '#fa4747' : p.theme.borderLight};
+        position: absolute;
+        @media (min-width: ${p.theme.breakpoints[0]}) {
+          left: 29px;
+        }
+      }
+    `}
+  ${p =>
+    p.hasError &&
+    css`
+      background: #fffcfb;
+      border: 1px solid #fa4747;
+    `}
+  ${p => p.withoutBorder && p.withoutBorder.map(border => css`border-${border}: 0`)}
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding: ${space(1)};
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    padding: ${space(1)} ${space(2)};
+  }
+`;
+
+const Grid = styled('div')<{maxHeight: React.CSSProperties['maxHeight']}>`
+  display: grid;
+  max-height: ${p => p.maxHeight};
+  > *:nth-last-child(5):before {
+    bottom: calc(100% - ${space(1)});
+  }
+  > *:nth-last-child(-n + 5) {
+    margin: -1px;
+  }
+  grid-template-columns: max-content 55px 1fr 60px 65px;
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: max-content 110px 1fr 75px 80px;
+  }
+`;
+
+export {Grid, GridCell, IconWrapper};

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/styles.tsx
@@ -29,6 +29,29 @@ const IconWrapper = styled('div', {
     `}
 `;
 
+const removeGridCellBorders = (withoutBorder?: Array<'left' | 'right'>) => {
+  if (!withoutBorder || withoutBorder.length === 0) {
+    return '';
+  }
+
+  if (withoutBorder.includes('left') && withoutBorder.includes('right')) {
+    return css`
+      border-left: 0;
+      border-right: 0;
+    `;
+  }
+
+  if (withoutBorder.includes('left')) {
+    return css`
+      border-left: 0;
+    `;
+  }
+
+  return css`
+    border-right: 0;
+  `;
+};
+
 const GridCell = styled('div')<{
   hasError?: boolean;
   withoutBorder?: Array<'left' | 'right'>;
@@ -60,7 +83,7 @@ const GridCell = styled('div')<{
       background: #fffcfb;
       border: 1px solid #fa4747;
     `}
-  ${p => (p.withoutBorder ? p.withoutBorder.map(border => css`border-${border}: 0`) : '')}
+  ${p => removeGridCellBorders(p.withoutBorder)};
   text-overflow: ellipsis;
   overflow: hidden;
   padding: ${space(1)};

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/types.tsx
@@ -1,0 +1,104 @@
+import {Color} from 'app/utils/theme';
+import SvgIcon from 'app/icons/svgIcon';
+
+export type IconProps = React.ComponentProps<typeof SvgIcon>;
+
+export enum BreadcrumbLevelType {
+  FATAL = 'fatal',
+  ERROR = 'error',
+  WARNING = 'warning',
+  INFO = 'info',
+  DEBUG = 'debug',
+}
+
+export enum BreadcrumbType {
+  INFO = 'info',
+  DEBUG = 'debug',
+  MESSAGE = 'message',
+  QUERY = 'query',
+  UI = 'ui',
+  USER = 'user',
+  EXCEPTION = 'exception',
+  WARNING = 'warning',
+  ERROR = 'error',
+  DEFAULT = 'default',
+  HTTP = 'http',
+  NAVIGATION = 'navigation',
+  SYSTEM = 'system',
+  SESSION = 'session',
+}
+
+type BreadcrumbTypeBase = {
+  timestamp?: string; //it's recommended
+  category?: string | null;
+  message?: string;
+  level?: BreadcrumbLevelType;
+  event_id?: string;
+};
+
+export type BreadcrumbTypeSystem = {
+  type: BreadcrumbType.SYSTEM;
+  action: string;
+  extras: Record<string, any>;
+} & BreadcrumbTypeBase;
+
+export type BreadcrumbTypeSession = {
+  type: BreadcrumbType.SESSION;
+  action: string;
+  extras: Record<string, any>;
+} & BreadcrumbTypeBase;
+
+export type BreadcrumbTypeNavigation = {
+  type: BreadcrumbType.NAVIGATION;
+  data?: {
+    to?: string;
+    from?: string;
+  };
+} & BreadcrumbTypeBase;
+
+export type BreadcrumbTypeHTTP = {
+  type: BreadcrumbType.HTTP;
+  data?: {
+    url?: string;
+    method?:
+      | 'POST'
+      | 'PUT'
+      | 'GET'
+      | 'HEAD'
+      | 'DELETE'
+      | 'CONNECT'
+      | 'OPTIONS'
+      | 'TRACE'
+      | 'PATCH';
+    status_code?: number;
+    reason?: string;
+  };
+} & BreadcrumbTypeBase;
+
+export type BreadcrumbTypeDefault = {
+  type:
+    | BreadcrumbType.INFO
+    | BreadcrumbType.DEBUG
+    | BreadcrumbType.QUERY
+    | BreadcrumbType.UI
+    | BreadcrumbType.USER
+    | BreadcrumbType.EXCEPTION
+    | BreadcrumbType.WARNING
+    | BreadcrumbType.ERROR
+    | BreadcrumbType.DEFAULT
+    | BreadcrumbType.SESSION
+    | BreadcrumbType.SYSTEM
+    | BreadcrumbType.SESSION;
+  data?: {[key: string]: any};
+} & BreadcrumbTypeBase;
+
+export type Breadcrumb =
+  | BreadcrumbTypeNavigation
+  | BreadcrumbTypeHTTP
+  | BreadcrumbTypeDefault;
+
+export type BreadcrumbDetails = {
+  color?: Color | React.CSSProperties['color'];
+  icon?: React.ComponentType<IconProps>;
+  description: string;
+};


### PR DESCRIPTION
**Description:** 

. Converted the whole breadcrumb section to grid
. Updated colors according to [figma.com/file/qzNXBjiupPlz5G486Cb1tw/Breadcrumbs?node-id=1%3A2](figma.com/file/qzNXBjiupPlz5G486Cb1tw/Breadcrumbs?node-id=1%3A2)
. Added two new types: System and Session
. Made it mobile Friendly 
. Fixed small spaces issues


**Next Steps:**

. Make some tooltips appers only on smaller devices (this will need some Tooltip.tsx refactor)
. Make possible to collapse the breadcrumbs again, once it is expanded
. Update Filter ( filter by level must be in accordance with the checked types)
