### PR TITLE
ref(pii): Expose source example data to frontend

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
@@ -11,6 +11,7 @@ import {
   unaryOperatorSuggestions,
   binaryOperatorSuggestions,
 } from './dataPrivacyRulesFormSourceSuggestions';
+import SourceSuggestionExamples from './sourceSuggestionExamples';
 import {SourceSuggestion, SourceSuggestionType} from './types';
 
 type Props = {
@@ -37,10 +38,6 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
     showSuggestions: false,
   };
 
-  componentWillMount() {
-    document.addEventListener('mousedown', this.handleClickOutside, false);
-  }
-
   componentDidMount() {
     this.loadFieldValues(this.props.value);
     this.hideSuggestions();
@@ -51,10 +48,6 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
       this.loadFieldValues(this.props.value);
       this.hideSuggestions();
     }
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleClickOutside, false);
   }
 
   selectorField = React.createRef<HTMLDivElement>();
@@ -236,15 +229,7 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
     this.props.onChange(newValue);
   };
 
-  handleClickOutside = (event: MouseEvent) => {
-    if (
-      event.target instanceof HTMLElement &&
-      this.selectorField.current &&
-      this.selectorField.current.contains(event.target)
-    ) {
-      return;
-    }
-
+  handleClickOutside = () => {
     this.setState({
       showSuggestions: false,
     });
@@ -373,23 +358,33 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
           disabled={disabled}
         />
         {showSuggestions && suggestions.length > 0 && (
-          <SuggestionsWrapper ref={this.suggestionList} data-test-id="source-suggestions">
-            {suggestions.slice(0, 50).map((suggestion, index) => (
-              <SuggestionItem
-                key={suggestion.value}
-                onClick={this.handleClickSuggestionItem(suggestion)}
-                active={index === activeSuggestion}
-                tabIndex={-1}
-              >
-                <TextOverflow>{suggestion.value}</TextOverflow>
-                {suggestion?.description && (
+          <div>
+            <SuggestionsWrapper ref={this.suggestionList} data-test-id="source-suggestions">
+              {suggestions.slice(0, 50).map((suggestion, index) => (
+                <SuggestionItem
+                  key={suggestion.value}
+                  onClick={this.handleClickSuggestionItem(suggestion)}
+                  active={index === activeSuggestion}
+                  tabIndex={-1}
+                >
+                  <TextOverflow>{suggestion.value}</TextOverflow>
+
                   <SuggestionDescription>
-                    (<TextOverflow>{suggestion.description}</TextOverflow>)
+                    {suggestion.description && (
+                      (<TextOverflow>{suggestion.description}</TextOverflow>)
+                    )}
                   </SuggestionDescription>
-                )}
-              </SuggestionItem>
-            ))}
-          </SuggestionsWrapper>
+
+                  {suggestion.examples && (
+                    <SourceSuggestionExamples
+                      examples={suggestion.examples}
+                      sourceName={suggestion.value} />
+                  )}
+                </SuggestionItem>
+              ))}
+            </SuggestionsWrapper>
+            <SuggestionsOverlay onClick={this.handleClickOutside} />
+          </div>
         )}
       </Wrapper>
     );
@@ -397,6 +392,7 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
 }
 
 export default DataPrivacyRulesFormSource;
+
 
 const Wrapper = styled('div')`
   position: relative;
@@ -409,6 +405,8 @@ const StyledTextField = styled(TextField)`
   input {
     height: 40px;
   }
+
+  z-index: 1002;
 `;
 
 const SuggestionsWrapper = styled('ul')`
@@ -423,7 +421,7 @@ const SuggestionsWrapper = styled('ul')`
   background: ${p => p.theme.white};
   top: 35px;
   right: 0;
-  z-index: 1001;
+  z-index: 1002;
   overflow: hidden;
   max-height: 200px;
   overflow-y: auto;
@@ -431,7 +429,7 @@ const SuggestionsWrapper = styled('ul')`
 
 const SuggestionItem = styled('li')<{active: boolean}>`
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto 1fr max-content;
   grid-gap: ${space(1)};
   border-bottom: 1px solid ${p => p.theme.borderLight};
   padding: ${space(1)} ${space(2)};
@@ -447,4 +445,13 @@ const SuggestionDescription = styled('div')`
   display: flex;
   overflow: hidden;
   color: ${p => p.theme.gray2};
+`;
+
+const SuggestionsOverlay = styled('div')`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1001;
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
@@ -378,7 +378,7 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
                     )}
                   </SuggestionDescription>
 
-                  {suggestion.examples && (
+                  {suggestion.examples && suggestion.examples.length > 0 && (
                     <SourceSuggestionExamples
                       examples={suggestion.examples}
                       sourceName={suggestion.value}

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
@@ -358,7 +358,7 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
           disabled={disabled}
         />
         {showSuggestions && suggestions.length > 0 && (
-          <div>
+          <React.Fragment>
             <SuggestionsWrapper
               ref={this.suggestionList}
               data-test-id="source-suggestions"
@@ -388,7 +388,7 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
               ))}
             </SuggestionsWrapper>
             <SuggestionsOverlay onClick={this.handleClickOutside} />
-          </div>
+          </React.Fragment>
         )}
       </Wrapper>
     );

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
@@ -359,7 +359,10 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
         />
         {showSuggestions && suggestions.length > 0 && (
           <div>
-            <SuggestionsWrapper ref={this.suggestionList} data-test-id="source-suggestions">
+            <SuggestionsWrapper
+              ref={this.suggestionList}
+              data-test-id="source-suggestions"
+            >
               {suggestions.slice(0, 50).map((suggestion, index) => (
                 <SuggestionItem
                   key={suggestion.value}
@@ -371,14 +374,15 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
 
                   <SuggestionDescription>
                     {suggestion.description && (
-                      (<TextOverflow>{suggestion.description}</TextOverflow>)
+                      <TextOverflow>{suggestion.description}</TextOverflow>
                     )}
                   </SuggestionDescription>
 
                   {suggestion.examples && (
                     <SourceSuggestionExamples
                       examples={suggestion.examples}
-                      sourceName={suggestion.value} />
+                      sourceName={suggestion.value}
+                    />
                   )}
                 </SuggestionItem>
               ))}
@@ -392,7 +396,6 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
 }
 
 export default DataPrivacyRulesFormSource;
-
 
 const Wrapper = styled('div')`
   position: relative;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
@@ -372,11 +372,11 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
                 >
                   <TextOverflow>{suggestion.value}</TextOverflow>
 
-                  <SuggestionDescription>
-                    {suggestion.description && (
+                  {suggestion.description && (
+                    <SuggestionDescription>
                       <TextOverflow>{suggestion.description}</TextOverflow>
-                    )}
-                  </SuggestionDescription>
+                    </SuggestionDescription>
+                  )}
 
                   {suggestion.examples && suggestion.examples.length > 0 && (
                     <SourceSuggestionExamples

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSource.tsx
@@ -374,7 +374,7 @@ class DataPrivacyRulesFormSource extends React.Component<Props, State> {
 
                   {suggestion.description && (
                     <SuggestionDescription>
-                      <TextOverflow>{suggestion.description}</TextOverflow>
+                      (<TextOverflow>{suggestion.description}</TextOverflow>)
                     </SuggestionDescription>
                   )}
 

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -33,10 +33,6 @@ class SourceSuggestionExamples extends React.Component<Props, State> {
     const {isOpen} = this.state;
     const {examples, sourceName} = this.props;
 
-    if (examples.length === 0) {
-      return <span />;
-    }
-
     return (
       <span onClick={this.stopPropagation}>
         <Button size="xsmall" onClick={this.toggleModal}>

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -1,6 +1,7 @@
 import Modal from 'react-bootstrap/lib/Modal';
 import React from 'react';
 import styled from '@emotion/styled';
+import space from 'app/styles/space';
 
 import {t} from 'app/locale';
 import Button from 'app/components/button';
@@ -83,5 +84,5 @@ const StyledModal = styled(Modal)`
 `;
 
 const Wrapper = styled('span')`
-  grid-column: 3 3;
+  grid-column: 3/3;
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -24,7 +24,7 @@ class SourceSuggestionExamples extends React.Component<Props, State> {
     this.setState({isOpen: !this.state.isOpen});
   };
 
-  stopPropagation = (e) => {
+  stopPropagation = (e: React.MouseEvent<HTMLSpanElement>) => {
     // Necessary to stop propagation of click events from modal that we can't
     // catch otherwise.
     e.stopPropagation();
@@ -34,7 +34,7 @@ class SourceSuggestionExamples extends React.Component<Props, State> {
     const {isOpen} = this.state;
     const {examples, sourceName} = this.props;
 
-    if (examples.length == 0) {
+    if (examples.length === 0) {
       return (<span></span>);
     }
 

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -83,5 +83,5 @@ const StyledModal = styled(Modal)`
 `;
 
 const Wrapper = styled('span')`
-  grid-columns: span 3;
+  grid-column: 3 3;
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -1,0 +1,78 @@
+import Modal from 'react-bootstrap/lib/Modal';
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {t} from 'app/locale';
+import Button from 'app/components/button';
+
+
+type Props = {
+  examples: Array<string>;
+  sourceName: string;
+}
+
+type State = {
+  isOpen: boolean;
+}
+
+class SourceSuggestionExamples extends React.Component<Props, State> {
+  state: State = {
+    isOpen: false
+  };
+
+  toggleModal = () => {
+    this.setState({isOpen: !this.state.isOpen});
+  };
+
+  stopPropagation = (e) => {
+    // Necessary to stop propagation of click events from modal that we can't
+    // catch otherwise.
+    e.stopPropagation();
+  }
+
+  render() {
+    const {isOpen} = this.state;
+    const {examples, sourceName} = this.props;
+
+    if (examples.length == 0) {
+      return (<span></span>);
+    }
+
+    return (
+      <span onClick={this.stopPropagation}>
+        <Button size="xsmall" onClick={this.toggleModal}>{t("examples")}</Button>
+        {isOpen && (<StyledModal show onHide={this.toggleModal}>
+          <Modal.Header closeButton>
+            {t("Examples for %s in current event", (<code>{sourceName}</code>))}
+          </Modal.Header>
+          <Modal.Body>
+            {examples.map(example => (
+              <pre key={example}>{example}</pre>
+            ))}
+          </Modal.Body>
+        </StyledModal>)}
+      </span>
+    );
+  }
+}
+
+export default SourceSuggestionExamples;
+
+const StyledModal = styled(Modal)`
+  .modal-dialog {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) !important;
+    margin: 0;
+    z-index: 1003;
+    @media (max-width: ${p => p.theme.breakpoints[0]}) {
+      width: 100%;
+    }
+    max-height: 500px;
+    overflow-y: auto;
+  }
+  .close {
+    outline: none;
+  }
+`;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -1,8 +1,8 @@
 import Modal from 'react-bootstrap/lib/Modal';
 import React from 'react';
 import styled from '@emotion/styled';
-import space from 'app/styles/space';
 
+import space from 'app/styles/space';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -68,9 +68,15 @@ const StyledModal = styled(Modal)`
     @media (max-width: ${p => p.theme.breakpoints[0]}) {
       width: 100%;
     }
+  }
+
+  .modal-body {
     max-height: 500px;
     overflow-y: auto;
+    padding: 20px 30px;
+    margin: -20px -30px;
   }
+
   .close {
     outline: none;
   }

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -73,7 +73,7 @@ const StyledModal = styled(Modal)`
   .modal-body {
     max-height: 500px;
     overflow-y: auto;
-    padding: 20px 30px;
+    padding: ${space(3)} ${space(4)};
     margin: -20px -30px;
   }
 

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -34,7 +34,7 @@ class SourceSuggestionExamples extends React.Component<Props, State> {
     const {examples, sourceName} = this.props;
 
     return (
-      <span onClick={this.stopPropagation}>
+      <Wrapper onClick={this.stopPropagation}>
         <Button size="xsmall" onClick={this.toggleModal}>
           {t('examples')}
         </Button>
@@ -50,7 +50,7 @@ class SourceSuggestionExamples extends React.Component<Props, State> {
             </Modal.Body>
           </StyledModal>
         )}
-      </span>
+      </Wrapper>
     );
   }
 }
@@ -80,4 +80,8 @@ const StyledModal = styled(Modal)`
   .close {
     outline: none;
   }
+`;
+
+const Wrapper = styled('span')`
+  grid-columns: span 3;
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -75,7 +75,7 @@ const StyledModal = styled(Modal)`
     max-height: 500px;
     overflow-y: auto;
     padding: ${space(3)} ${space(4)};
-    margin: -20px -30px;
+    margin: -${space(3)} -${space(4)};
   }
 
   .close {

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/sourceSuggestionExamples.tsx
@@ -5,19 +5,18 @@ import styled from '@emotion/styled';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 
-
 type Props = {
   examples: Array<string>;
   sourceName: string;
-}
+};
 
 type State = {
   isOpen: boolean;
-}
+};
 
 class SourceSuggestionExamples extends React.Component<Props, State> {
   state: State = {
-    isOpen: false
+    isOpen: false,
   };
 
   toggleModal = () => {
@@ -28,29 +27,33 @@ class SourceSuggestionExamples extends React.Component<Props, State> {
     // Necessary to stop propagation of click events from modal that we can't
     // catch otherwise.
     e.stopPropagation();
-  }
+  };
 
   render() {
     const {isOpen} = this.state;
     const {examples, sourceName} = this.props;
 
     if (examples.length === 0) {
-      return (<span></span>);
+      return <span />;
     }
 
     return (
       <span onClick={this.stopPropagation}>
-        <Button size="xsmall" onClick={this.toggleModal}>{t("examples")}</Button>
-        {isOpen && (<StyledModal show onHide={this.toggleModal}>
-          <Modal.Header closeButton>
-            {t("Examples for %s in current event", (<code>{sourceName}</code>))}
-          </Modal.Header>
-          <Modal.Body>
-            {examples.map(example => (
-              <pre key={example}>{example}</pre>
-            ))}
-          </Modal.Body>
-        </StyledModal>)}
+        <Button size="xsmall" onClick={this.toggleModal}>
+          {t('examples')}
+        </Button>
+        {isOpen && (
+          <StyledModal show onHide={this.toggleModal}>
+            <Modal.Header closeButton>
+              {t('Examples for %s in current event', <code>{sourceName}</code>)}
+            </Modal.Header>
+            <Modal.Body>
+              {examples.map(example => (
+                <pre key={example}>{example}</pre>
+              ))}
+            </Modal.Body>
+          </StyledModal>
+        )}
       </span>
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/types.tsx
@@ -40,5 +40,5 @@ export type SourceSuggestion = {
   type: SourceSuggestionType;
   value: string;
   description?: string;
-  examples?: Array<any>;
+  examples?: Array<string>;
 };

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/types.tsx
@@ -40,4 +40,5 @@ export type SourceSuggestion = {
   type: SourceSuggestionType;
   value: string;
   description?: string;
+  examples?: Array<any>;
 };

--- a/tests/js/spec/views/settings/components/dataPrivacyRulesPanel/__snapshots__/dataPrivacyRulesFormSource.spec.tsx.snap
+++ b/tests/js/spec/views/settings/components/dataPrivacyRulesPanel/__snapshots__/dataPrivacyRulesFormSource.spec.tsx.snap
@@ -82,7 +82,7 @@ exports[`DataPrivacyRulesFormSource default render 1`] = `
       >
         <TextField
           autoComplete="off"
-          className="css-jvghga-StyledTextField e5vbseb1"
+          className="css-12y0yqb-StyledTextField e5vbseb1"
           disabled={false}
           hideErrorMessage={false}
           name="from"
@@ -94,7 +94,7 @@ exports[`DataPrivacyRulesFormSource default render 1`] = `
           value="$string"
         >
           <div
-            className="css-jvghga-StyledTextField e5vbseb1 control-group"
+            className="css-12y0yqb-StyledTextField e5vbseb1 control-group"
           >
             <div
               className="controls"


### PR DESCRIPTION
We want to help the user understand what they're actually going to scrub by showing example data of PII sources/sourcenames in the frontend. This is a follow-up to https://github.com/getsentry/relay/pull/575

