### PR TITLE
fix(apm): Set the transaction name for JavaScript transactions before they are flushed

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -26,6 +26,7 @@ import ConfigStore from 'app/stores/configStore';
 import Main from 'app/main';
 import ajaxCsrfSetup from 'app/utils/ajaxCsrfSetup';
 import plugins from 'app/plugins';
+import routes from 'app/routes';
 import {normalizeTransactionName} from 'app/utils/apm';
 
 function getSentryIntegrations(hasReplays: boolean = false) {
@@ -75,13 +76,15 @@ const tracesSampleRate = config ? config.apmSampling : 0;
 const hasReplays =
   window.__SENTRY__USER && window.__SENTRY__USER.isStaff && !!process.env.DISABLE_RR_WEB;
 
+const appRoutes = Router.createRoutes(routes());
+
 Sentry.init({
   ...window.__SENTRY__OPTIONS,
   integrations: getSentryIntegrations(hasReplays),
   tracesSampleRate,
   _experiments: {useEnvelope: true},
   async beforeSend(event) {
-    return normalizeTransactionName(event);
+    return normalizeTransactionName(appRoutes, event);
   },
 });
 

--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Reflux from 'reflux';
 import * as Router from 'react-router';
+import {createMemoryHistory} from 'history';
 import * as Sentry from '@sentry/browser';
 import {ExtraErrorData} from '@sentry/integrations';
 import {Integrations} from '@sentry/apm';
@@ -77,6 +78,7 @@ const hasReplays =
   window.__SENTRY__USER && window.__SENTRY__USER.isStaff && !!process.env.DISABLE_RR_WEB;
 
 const appRoutes = Router.createRoutes(routes());
+const createLocation = createMemoryHistory().createLocation;
 
 Sentry.init({
   ...window.__SENTRY__OPTIONS,
@@ -88,9 +90,22 @@ Sentry.init({
       // for JavaScript transactions, set the transaction name based on the current window.location
       // object against the application react-router routes
 
+      let prevTransactionName = event.transaction;
+
+      if (typeof prevTransactionName === 'string') {
+        if (prevTransactionName.startsWith('/')) {
+          return event;
+        }
+      } else {
+        prevTransactionName = window.location.pathname;
+      }
+
       const transactionName: string | undefined = await new Promise(function(resolve) {
         Router.match(
-          {routes: appRoutes, location: window.location},
+          {
+            routes: appRoutes,
+            location: createLocation(prevTransactionName),
+          },
           (error, _redirectLocation, renderProps) => {
             if (error) {
               return resolve(undefined);
@@ -104,6 +119,14 @@ Sentry.init({
 
       if (typeof transactionName === 'string' && transactionName.length) {
         event.transaction = transactionName;
+
+        if (event.tags) {
+          event.tags['ui.route'] = transactionName;
+        } else {
+          event.tags = {
+            'ui.route': transactionName,
+          };
+        }
       }
     }
 

--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -26,6 +26,8 @@ import ConfigStore from 'app/stores/configStore';
 import Main from 'app/main';
 import ajaxCsrfSetup from 'app/utils/ajaxCsrfSetup';
 import plugins from 'app/plugins';
+import routes from 'app/routes';
+import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 
 function getSentryIntegrations(hasReplays: boolean = false) {
   const integrations = [
@@ -74,11 +76,39 @@ const tracesSampleRate = config ? config.apmSampling : 0;
 const hasReplays =
   window.__SENTRY__USER && window.__SENTRY__USER.isStaff && !!process.env.DISABLE_RR_WEB;
 
+const appRoutes = Router.createRoutes(routes());
+
 Sentry.init({
   ...window.__SENTRY__OPTIONS,
   integrations: getSentryIntegrations(hasReplays),
   tracesSampleRate,
   _experiments: {useEnvelope: true},
+  async beforeSend(event) {
+    if (event.type === 'transaction') {
+      // for JavaScript transactions, set the transaction name based on the current window.location
+      // object against the application react-router routes
+
+      const transactionName: string | undefined = await new Promise(function(resolve) {
+        Router.match(
+          {routes: appRoutes, location: window.location},
+          (error, _redirectLocation, renderProps) => {
+            if (error) {
+              return resolve(undefined);
+            }
+
+            const routePath = getRouteStringFromRoutes(renderProps.routes ?? []);
+            return resolve(routePath);
+          }
+        );
+      });
+
+      if (typeof transactionName === 'string' && transactionName.length) {
+        event.transaction = transactionName;
+      }
+    }
+
+    return event;
+  },
 });
 
 if (window.__SENTRY__USER) {

--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -87,8 +87,9 @@ Sentry.init({
   _experiments: {useEnvelope: true},
   async beforeSend(event) {
     if (event.type === 'transaction') {
-      // for JavaScript transactions, set the transaction name based on the current window.location
-      // object against the application react-router routes
+      // For JavaScript transactions, translate the transaction name if it exists and doesn't start with /
+      // using the app's react-router routes. If the transaction name doesn't exist, use the window.location.pathname
+      // as the fallback.
 
       let prevTransactionName = event.transaction;
 

--- a/src/sentry/static/sentry/app/utils/apm.tsx
+++ b/src/sentry/static/sentry/app/utils/apm.tsx
@@ -1,11 +1,9 @@
 import * as Sentry from '@sentry/browser';
-import {createMemoryHistory} from 'history';
 import * as Router from 'react-router';
+import {createMemoryHistory} from 'history';
 
-import routes from 'app/routes';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 
-const appRoutes = Router.createRoutes(routes());
 const createLocation = createMemoryHistory().createLocation;
 
 /**
@@ -19,6 +17,7 @@ export function setTransactionName(name: string) {
 }
 
 export async function normalizeTransactionName(
+  appRoutes: Router.PlainRoute[],
   event: Sentry.Event
 ): Promise<Sentry.Event> {
   if (event.type === 'transaction') {

--- a/src/sentry/static/sentry/app/utils/apm.tsx
+++ b/src/sentry/static/sentry/app/utils/apm.tsx
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import * as Router from 'react-router';
 import {createMemoryHistory} from 'history';
+import set from 'lodash/set';
 
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 
@@ -20,49 +21,55 @@ export async function normalizeTransactionName(
   appRoutes: Router.PlainRoute[],
   event: Sentry.Event
 ): Promise<Sentry.Event> {
-  if (event.type === 'transaction') {
-    // For JavaScript transactions, translate the transaction name if it exists and doesn't start with /
-    // using the app's react-router routes. If the transaction name doesn't exist, use the window.location.pathname
-    // as the fallback.
+  if (event.type !== 'transaction') {
+    return event;
+  }
 
-    let prevTransactionName = event.transaction;
+  // For JavaScript transactions, translate the transaction name if it exists and doesn't start with /
+  // using the app's react-router routes. If the transaction name doesn't exist, use the window.location.pathname
+  // as the fallback.
 
-    if (typeof prevTransactionName === 'string') {
-      if (prevTransactionName.startsWith('/')) {
-        return event;
-      }
-    } else {
-      prevTransactionName = window.location.pathname;
+  let prevTransactionName = event.transaction;
+
+  if (typeof prevTransactionName === 'string') {
+    if (prevTransactionName.startsWith('/')) {
+      return event;
     }
 
-    const transactionName: string | undefined = await new Promise(function(resolve) {
-      Router.match(
-        {
-          routes: appRoutes,
-          location: createLocation(prevTransactionName),
-        },
-        (error, _redirectLocation, renderProps) => {
-          if (error) {
-            return resolve(undefined);
-          }
+    set(event, ['tags', 'transaction.rename.source'], 'existing transaction name');
+  } else {
+    set(event, ['tags', 'transaction.rename.source'], 'window.location.pathname');
 
-          const routePath = getRouteStringFromRoutes(renderProps.routes ?? []);
-          return resolve(routePath);
+    prevTransactionName = window.location.pathname;
+  }
+
+  const transactionName: string | undefined = await new Promise(function(resolve) {
+    Router.match(
+      {
+        routes: appRoutes,
+        location: createLocation(prevTransactionName),
+      },
+      (error, _redirectLocation, renderProps) => {
+        if (error) {
+          set(event, ['tags', 'transaction.rename.react-router-match'], 'error');
+          return resolve(undefined);
         }
-      );
-    });
 
-    if (typeof transactionName === 'string' && transactionName.length) {
-      event.transaction = transactionName;
+        set(event, ['tags', 'transaction.rename.react-router-match'], 'success');
 
-      if (event.tags) {
-        event.tags['ui.route'] = transactionName;
-      } else {
-        event.tags = {
-          'ui.route': transactionName,
-        };
+        const routePath = getRouteStringFromRoutes(renderProps.routes ?? []);
+        return resolve(routePath);
       }
-    }
+    );
+  });
+
+  if (typeof transactionName === 'string' && transactionName.length) {
+    event.transaction = transactionName;
+
+    set(event, ['tags', 'transaction.rename.before'], prevTransactionName);
+    set(event, ['tags', 'transaction.rename.after'], transactionName);
+
+    set(event, ['tags', 'ui.route'], transactionName);
   }
 
   return event;

--- a/src/sentry/static/sentry/app/utils/apm.tsx
+++ b/src/sentry/static/sentry/app/utils/apm.tsx
@@ -1,4 +1,12 @@
 import * as Sentry from '@sentry/browser';
+import {createMemoryHistory} from 'history';
+import * as Router from 'react-router';
+
+import routes from 'app/routes';
+import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
+
+const appRoutes = Router.createRoutes(routes());
+const createLocation = createMemoryHistory().createLocation;
 
 /**
  * Sets the transaction name
@@ -8,4 +16,55 @@ export function setTransactionName(name: string) {
     scope.setTransaction(name);
     scope.setTag('ui.route', name);
   });
+}
+
+export async function normalizeTransactionName(
+  event: Sentry.Event
+): Promise<Sentry.Event> {
+  if (event.type === 'transaction') {
+    // For JavaScript transactions, translate the transaction name if it exists and doesn't start with /
+    // using the app's react-router routes. If the transaction name doesn't exist, use the window.location.pathname
+    // as the fallback.
+
+    let prevTransactionName = event.transaction;
+
+    if (typeof prevTransactionName === 'string') {
+      if (prevTransactionName.startsWith('/')) {
+        return event;
+      }
+    } else {
+      prevTransactionName = window.location.pathname;
+    }
+
+    const transactionName: string | undefined = await new Promise(function(resolve) {
+      Router.match(
+        {
+          routes: appRoutes,
+          location: createLocation(prevTransactionName),
+        },
+        (error, _redirectLocation, renderProps) => {
+          if (error) {
+            return resolve(undefined);
+          }
+
+          const routePath = getRouteStringFromRoutes(renderProps.routes ?? []);
+          return resolve(routePath);
+        }
+      );
+    });
+
+    if (typeof transactionName === 'string' && transactionName.length) {
+      event.transaction = transactionName;
+
+      if (event.tags) {
+        event.tags['ui.route'] = transactionName;
+      } else {
+        event.tags = {
+          'ui.route': transactionName,
+        };
+      }
+    }
+  }
+
+  return event;
 }


### PR DESCRIPTION
For JavaScript transactions, translate the transaction name if it exists and doesn't start with `/`
using the app's react-router routes; the expected transaction name would be the URL, which is set by the JS SDK. 

If the transaction name doesn't exist, use the `window.location.pathname` as the fallback.

The transaction name is translated based on the app react-router routes using the react-router utility functions.

- React router utility functions used https://github.com/ReactTraining/react-router/blob/v3.2.0/docs/API.md#utilities

This should deal with the race condition between setting the transaction name during the React render reconciliation and when transactions are flushed. 

## TODO

- [x] update `ui.route` tag
