### PR TITLE
fix(ui): Replace first-release with firstRelease

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/releaseNewEvents.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseNewEvents.jsx
@@ -16,7 +16,7 @@ const ReleaseNewEvents = props => {
         <Link
           to={{
             pathname: `/organizations/${orgId}/issues/`,
-            query: {query: 'first-release:' + release.version},
+            query: {query: 'firstRelease:' + release.version},
           }}
         >
           {t('View new issues seen in this release in the stream')}

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseNewEvents.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseNewEvents.jsx
@@ -16,7 +16,7 @@ const ReleaseNewEvents = props => {
         <Link
           to={{
             pathname: `/organizations/${orgId}/issues/`,
-            query: {query: 'firstRelease:' + release.version},
+            query: {query: `firstRelease:${release.version}`},
           }}
         >
           {t('View new issues seen in this release in the stream')}

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -79,7 +79,7 @@ class Issues extends React.Component<Props, State> {
     const query: QueryResults = {query: []};
 
     if (issuesType === IssuesType.NEW) {
-      query['first-release'] = [version];
+      query.firstRelease = [version];
     } else {
       query.release = [version];
     }

--- a/src/sentry/static/sentry/app/views/releasesV2/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/utils/index.tsx
@@ -113,7 +113,7 @@ export const getReleaseNewIssuesUrl = (
       project: projectId,
       query: stringifyQueryObject({
         query: [],
-        'first-release': [version],
+        firstRelease: [version],
       }),
     },
   };


### PR DESCRIPTION
Replacing first-release with firstRelease in links to issues.
Both of them work, firstRelease is just better supported.