### PR TITLE
fix(sessions): Fix small inaccuracy for errored and add healthy response

### DIFF
--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -430,7 +430,7 @@ def get_project_release_stats(project_id, release, stat, rollup, start, end, env
         # as the data becomes available.
         if stat == "sessions":
             for k in totals:
-                totals[k] += rv[k]
+                totals[k] += stats[bucket][1][k]
 
     for idx, bucket in enumerate(stats):
         if bucket[1] is None:


### PR DESCRIPTION
This is the followup to a change in snuba where we will make sure that
all abnormal are always also errors so we can calculate the right
abnormal and healthy data.

This also adds healthy to the response so the UI does not have to
calculate it.

Refs https://github.com/getsentry/snuba/pull/945