### PR TITLE
feat(workflow): Using environment in chart api requests

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -59,6 +59,7 @@ type State = {
   query: string;
   aggregation: AlertRuleAggregations;
   timeWindow: number;
+  environment: Environment[] | null;
 } & AsyncComponent['state'];
 
 const isEmpty = (str: unknown): boolean => str === '' || !defined(str);
@@ -79,6 +80,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       aggregation: rule.aggregation,
       query: rule.query || '',
       timeWindow: rule.timeWindow,
+      environment: null,
       triggerErrors: new Map(),
       availableActions: null,
       triggers: this.props.rule.triggers,
@@ -272,7 +274,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   }
 
   handleFieldChange = (name: string, value: unknown) => {
-    if (['timeWindow', 'aggregation'].includes(name)) {
+    if (['timeWindow', 'environment', 'aggregation'].includes(name)) {
       this.setState({[name]: value});
     }
   };
@@ -394,7 +396,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
   renderBody() {
     const {organization, ruleId, rule, params, onSubmitSuccess} = this.props;
-    const {query, aggregation, timeWindow, triggers} = this.state;
+    const {query, aggregation, timeWindow, triggers, environment} = this.state;
 
     const queryAndAlwaysErrorEvents = !query.includes('event.type')
       ? `${query} ${this.getEventType()}`.trim()
@@ -409,6 +411,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         query={queryAndAlwaysErrorEvents}
         aggregation={aggregation}
         timeWindow={timeWindow}
+        environment={environment}
       />
     );
 
@@ -426,11 +429,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
               aggregation: rule.aggregation,
               query: rule.query || '',
               timeWindow: rule.timeWindow,
-              // TODO(epurkhiser): Remove when the API response with a single env
-              environment:
-                (Array.isArray(rule.environment)
-                  ? rule.environment[0]
-                  : rule.environment) || null,
+              environment: rule.environment || null,
             }}
             saveOnBlur={false}
             onSubmit={this.handleSubmit}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -59,7 +59,7 @@ type State = {
   query: string;
   aggregation: AlertRuleAggregations;
   timeWindow: number;
-  environment: Environment[] | null;
+  environment: string | string[] | null;
 } & AsyncComponent['state'];
 
 const isEmpty = (str: unknown): boolean => str === '' || !defined(str);
@@ -80,7 +80,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       aggregation: rule.aggregation,
       query: rule.query || '',
       timeWindow: rule.timeWindow,
-      environment: null,
+      environment: rule.environment || null,
       triggerErrors: new Map(),
       availableActions: null,
       triggers: this.props.rule.triggers,

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -21,7 +21,7 @@ type Props = {
 
   query: IncidentRule['query'];
   timeWindow: IncidentRule['timeWindow'];
-  environment: Environment | null;
+  environment: string | string[] | null;
   aggregation: IncidentRule['aggregation'];
   triggers: Trigger[];
 };
@@ -50,7 +50,13 @@ class TriggersChart extends React.PureComponent<Props> {
         api={api}
         organization={organization}
         query={query}
-        environment={[environment]}
+        environment={
+          environment
+            ? Array.isArray(environment)
+              ? environment
+              : [environment]
+            : undefined
+        }
         project={projects.map(({id}) => Number(id))}
         interval={`${timeWindow}m`}
         period={period}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -21,6 +21,7 @@ type Props = {
 
   query: IncidentRule['query'];
   timeWindow: IncidentRule['timeWindow'];
+  environment: Environment | null;
   aggregation: IncidentRule['aggregation'];
   triggers: Trigger[];
 };
@@ -39,6 +40,7 @@ class TriggersChart extends React.PureComponent<Props> {
       query,
       aggregation,
       triggers,
+      environment,
     } = this.props;
 
     const period = getPeriodForTimeWindow(timeWindow);
@@ -48,6 +50,7 @@ class TriggersChart extends React.PureComponent<Props> {
         api={api}
         organization={organization}
         query={query}
+        environment={[environment]}
         project={projects.map(({id}) => Number(id))}
         interval={`${timeWindow}m`}
         period={period}

--- a/tests/js/spec/views/settings/incidentRules/create.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/create.spec.jsx
@@ -57,7 +57,6 @@ describe('Incident Rules Create', function() {
           project: [2],
           query: 'event.type:error',
           statsPeriod: '12h',
-          environment: [null],
           yAxis: 'event_count',
         },
       })

--- a/tests/js/spec/views/settings/incidentRules/create.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/create.spec.jsx
@@ -57,6 +57,7 @@ describe('Incident Rules Create', function() {
           project: [2],
           query: 'event.type:error',
           statsPeriod: '12h',
+          environment: [null],
           yAxis: 'event_count',
         },
       })


### PR DESCRIPTION
It seems we weren't passing an environment to the chart, and in turn, the EventsRequest component.

This solves that. Treats environment as a single string until the chart passes it for the request, then we wrap it.

Resolves https://app.asana.com/0/1143846759074121/1175681126036433