### PR TITLE
feat(ui): Add tooltip to event and user counts on issues page

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/actions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.jsx
@@ -563,30 +563,24 @@ const IssueListActions = createReactClass({
               </GraphToggle>
             </GraphHeader>
           </GraphHeaderWrapper>
-          <ToolbarHeader>
-            <EventsOrUsersLabel className="align-right">
-              <React.Fragment>
-                {t('Events')}
-                <QuestionTooltip
-                  className="hidden-xs"
-                  title={t('Number of events since the issue was created')}
-                  size="xs"
-                />
-              </React.Fragment>
-            </EventsOrUsersLabel>
-          </ToolbarHeader>
-          <ToolbarHeader>
-            <EventsOrUsersLabel className="align-right">
-              <React.Fragment>
-                {t('Users')}
-                <QuestionTooltip
-                  className="hidden-xs"
-                  title={t('Unique users affected since the issue was created')}
-                  size="xs"
-                />
-              </React.Fragment>
-            </EventsOrUsersLabel>
-          </ToolbarHeader>
+          <EventsOrUsersLabel className="align-right">
+            <React.Fragment>
+              {t('Events')}
+              <StyledQuestionTooltip
+                title={t('Number of events since the issue was created')}
+                size="xs"
+              />
+            </React.Fragment>
+          </EventsOrUsersLabel>
+          <EventsOrUsersLabel className="align-right">
+            <React.Fragment>
+              {t('Users')}
+              <StyledQuestionTooltip
+                title={t('Unique users affected since the issue was created')}
+                size="xs"
+              />
+            </React.Fragment>
+          </EventsOrUsersLabel>
           <AssigneesLabel className="align-right hidden-xs hidden-sm">
             <ToolbarHeader>{t('Assignee')}</ToolbarHeader>
           </AssigneesLabel>
@@ -707,14 +701,20 @@ const GraphToggle = styled('a')`
   }
 `;
 
-const EventsOrUsersLabel = styled('div')`
+const StyledQuestionTooltip = styled(QuestionTooltip)`
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    display: none;
+  }
+`;
+
+const EventsOrUsersLabel = styled(ToolbarHeader)`
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: ${space(0.5)};
   align-items: center;
 
-  margin-left: ${space(1)};
-  margin-right: ${space(1)};
+  margin-left: ${space(1.5)};
+  margin-right: ${space(1.5)};
   @media (min-width: ${theme.breakpoints[0]}) {
     width: 60px;
   }

--- a/src/sentry/static/sentry/app/views/issueList/actions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.jsx
@@ -564,22 +564,18 @@ const IssueListActions = createReactClass({
             </GraphHeader>
           </GraphHeaderWrapper>
           <EventsOrUsersLabel className="align-right">
-            <React.Fragment>
-              {t('Events')}
-              <StyledQuestionTooltip
-                title={t('Number of events since the issue was created')}
-                size="xs"
-              />
-            </React.Fragment>
+            {t('Events')}
+            <StyledQuestionTooltip
+              title={t('Number of events since the issue was created')}
+              size="xs"
+            />
           </EventsOrUsersLabel>
           <EventsOrUsersLabel className="align-right">
-            <React.Fragment>
-              {t('Users')}
-              <StyledQuestionTooltip
-                title={t('Unique users affected since the issue was created')}
-                size="xs"
-              />
-            </React.Fragment>
+            {t('Users')}
+            <StyledQuestionTooltip
+              title={t('Unique users affected since the issue was created')}
+              size="xs"
+            />
           </EventsOrUsersLabel>
           <AssigneesLabel className="align-right hidden-xs hidden-sm">
             <ToolbarHeader>{t('Assignee')}</ToolbarHeader>

--- a/src/sentry/static/sentry/app/views/issueList/actions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.jsx
@@ -24,6 +24,7 @@ import SentryTypes from 'app/sentryTypes';
 import ToolbarHeader from 'app/components/toolbarHeader';
 import Tooltip from 'app/components/tooltip';
 import withApi from 'app/utils/withApi';
+import QuestionTooltip from 'app/components/questionTooltip';
 
 const BULK_LIMIT = 1000;
 const BULK_LIMIT_STR = BULK_LIMIT.toLocaleString();
@@ -562,12 +563,30 @@ const IssueListActions = createReactClass({
               </GraphToggle>
             </GraphHeader>
           </GraphHeaderWrapper>
-          <EventsOrUsersLabel className="align-right">
-            <ToolbarHeader>{t('Events')}</ToolbarHeader>
-          </EventsOrUsersLabel>
-          <EventsOrUsersLabel className="align-right">
-            <ToolbarHeader>{t('Users')}</ToolbarHeader>
-          </EventsOrUsersLabel>
+          <ToolbarHeader>
+            <EventsOrUsersLabel className="align-right">
+              <React.Fragment>
+                {t('Events')}
+                <QuestionTooltip
+                  className="hidden-xs"
+                  title={t('Number of events since the issue was created')}
+                  size="xs"
+                />
+              </React.Fragment>
+            </EventsOrUsersLabel>
+          </ToolbarHeader>
+          <ToolbarHeader>
+            <EventsOrUsersLabel className="align-right">
+              <React.Fragment>
+                {t('Users')}
+                <QuestionTooltip
+                  className="hidden-xs"
+                  title={t('Unique users affected since the issue was created')}
+                  size="xs"
+                />
+              </React.Fragment>
+            </EventsOrUsersLabel>
+          </ToolbarHeader>
           <AssigneesLabel className="align-right hidden-xs hidden-sm">
             <ToolbarHeader>{t('Assignee')}</ToolbarHeader>
           </AssigneesLabel>
@@ -689,17 +708,24 @@ const GraphToggle = styled('a')`
 `;
 
 const EventsOrUsersLabel = styled('div')`
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: ${space(0.5)};
+  align-items: center;
+
+  margin-left: ${space(1)};
+  margin-right: ${space(1)};
   @media (min-width: ${theme.breakpoints[0]}) {
-    width: 40px;
+    width: 60px;
   }
   @media (min-width: ${theme.breakpoints[1]}) {
     width: 60px;
   }
   @media (min-width: ${theme.breakpoints[2]}) {
     width: 80px;
+    margin-left: ${space(2)};
+    margin-right: ${space(2)};
   }
-  margin-left: ${space(2)};
-  margin-right: ${space(2)};
 `;
 
 const AssigneesLabel = styled('div')`


### PR DESCRIPTION
With sort issues by users coming soon, it makes sense to clarify why the users column may not match what the user expects. The counts shown are totals, while the sort option will be within the current time range.

figma: https://www.figma.com/file/4lWcyL2GbAstiohJm77KAz/Alerts-Research?node-id=279%3A22

![image](https://user-images.githubusercontent.com/1400464/81969059-34d0ee80-95d2-11ea-81bf-48c0a585cbb8.png)
