### PR TITLE
fix(apm): Set transaction name on componentDidMount()

### DIFF
--- a/src/sentry/static/sentry/app/views/app/index.tsx
+++ b/src/sentry/static/sentry/app/views/app/index.tsx
@@ -82,6 +82,8 @@ class App extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    this.updateTracing();
+
     this.props.api.request('/organizations/', {
       query: {
         member: '1',


### PR DESCRIPTION
@billyvg suggested we should also set the transaction name on the `componentDidMount()` React lifecycle method.

And to see if this alleviates some race conditions between setting the transaction name, and flushing the transaction event.



Related to https://github.com/getsentry/sentry/pull/18822