### PR TITLE
refs(alert_rules): Remove bulk methods for fetching incident stats.

### DIFF
--- a/src/sentry/incidents/endpoints/organization_incident_stats.py
+++ b/src/sentry/incidents/endpoints/organization_incident_stats.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
-from sentry.incidents.logic import bulk_get_incident_stats
+from sentry.incidents.logic import get_incident_stats
 
 
 class OrganizationIncidentStatsEndpoint(IncidentEndpoint):
@@ -16,7 +16,7 @@ class OrganizationIncidentStatsEndpoint(IncidentEndpoint):
         ``````````````````
         :auth: required
         """
-        stats = bulk_get_incident_stats([incident], windowed_stats=True)[0]
+        stats = get_incident_stats(incident, windowed_stats=True)
         event_stats_serializer = SnubaTSResultSerializer(organization, None, request.user)
         results = {
             "eventStats": event_stats_serializer.serialize(stats["event_stats"]),


### PR DESCRIPTION
We no longer use these methods since we moved this parallelization to the frontend. These just make
it harder to understand how these functions work, so simplifying them back down to single fetch.