### PR TITLE
feat: Add sort by users in issue stream

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -235,6 +235,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         "freq": "times_seen",
         "new": "first_seen",
         "priority": "priority",
+        "user": "user_count",
     }
 
     aggregation_defs = {
@@ -245,6 +246,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         "priority": ["toUInt64(plus(multiply(log(times_seen), 600), last_seen))", ""],
         # Only makes sense with WITH TOTALS, returns 1 for an individual group.
         "total": ["uniq", ISSUE_FIELD_NAME],
+        "user_count": ["uniq", "tags[sentry:user]"],
     }
 
     @property

--- a/src/sentry/static/sentry/app/views/issueList/sortOptions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/sortOptions.jsx
@@ -50,6 +50,8 @@ class IssueListSortOptions extends React.PureComponent {
         return t('Priority');
       case 'freq':
         return t('Frequency');
+      case 'user':
+        return t('Users');
       case 'date':
       default:
         return t('Last Seen');
@@ -71,6 +73,7 @@ class IssueListSortOptions extends React.PureComponent {
           {this.getMenuItem('date')}
           {this.getMenuItem('new')}
           {this.getMenuItem('freq')}
+          {this.getMenuItem('user')}
         </DropdownControl>
       </Container>
     );

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -43,7 +43,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 "event_id": "a" * 32,
                 "message": "foo. Also, this message is intended to be greater than 256 characters so that we can put some unique string identifier after that point in the string. The purpose of this is in order to verify we are using snuba to search messages instead of Postgres (postgres truncates at 256 characters and clickhouse does not). santryrox.",
                 "environment": "production",
-                "tags": {"server": "example.com"},
+                "tags": {"server": "example.com", "sentry:user": "event1@example.com"},
                 "timestamp": event1_timestamp,
                 "stacktrace": {"frames": [{"module": "group1"}]},
             },
@@ -55,7 +55,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 "event_id": "c" * 32,
                 "message": "group1",
                 "environment": "production",
-                "tags": {"server": "example.com"},
+                "tags": {"server": "example.com", "sentry:user": "event3@example.com"},
                 "timestamp": iso_format(self.base_datetime),
                 "stacktrace": {"frames": [{"module": "group1"}]},
             },
@@ -82,7 +82,11 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 "message": "bar",
                 "stacktrace": {"frames": [{"module": "group2"}]},
                 "environment": "staging",
-                "tags": {"server": "example.com", "url": "http://example.com"},
+                "tags": {
+                    "server": "example.com",
+                    "url": "http://example.com",
+                    "sentry:user": "event2@example.com",
+                },
             },
             project_id=self.project.id,
         )
@@ -257,6 +261,9 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         results = self.make_query(sort_by="priority")
         assert list(results) == [self.group1, self.group2]
 
+        results = self.make_query(sort_by="user")
+        assert list(results) == [self.group1, self.group2]
+
     def test_sort_with_environment(self):
         for dt in [
             self.group1.first_seen + timedelta(days=1),
@@ -286,6 +293,9 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             environments=[self.environments["production"]], sort_by="priority"
         )
         assert list(results) == [self.group2, self.group1]
+
+        results = self.make_query(environments=[self.environments["production"]], sort_by="user")
+        assert list(results) == [self.group1, self.group2]
 
     def test_status(self):
         results = self.make_query(search_filter_query="is:unresolved")
@@ -947,6 +957,17 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             **common_args
         )
 
+        self.make_query(search_filter_query="foo", sort_by="user")
+        assert query_mock.call_args == mock.call(
+            orderby=["-user_count", "group_id"],
+            aggregations=[
+                ["uniq", "group_id", "total"],
+                ["uniq", "tags[sentry:user]", "user_count"],
+            ],
+            having=[],
+            **common_args
+        )
+
     def test_pre_and_post_filtering(self):
         prev_max_pre = options.get("snuba.search.max-pre-snuba-candidates")
         options.set("snuba.search.max-pre-snuba-candidates", 1)
@@ -1244,6 +1265,9 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         assert list(results) == [self.group1, self.group_p2, self.group2]
 
         results = self.make_query([self.project, self.project2], sort_by="priority")
+        assert list(results) == [self.group1, self.group2, self.group_p2]
+
+        results = self.make_query([self.project, self.project2], sort_by="user")
         assert list(results) == [self.group1, self.group2, self.group_p2]
 
     def test_first_release_any_or_no_environments(self):


### PR DESCRIPTION
closes #2874
https://app.asana.com/0/1143846759074121/1173934306766147/f

Adds "Users" to the sort by option in issues stream. Issues are sorted by user totals in the current date range, however it may be confusing because the user column shows total lifetime users impacted. This confusion is somewhat addressed via a tooltip in #18832

![image](https://user-images.githubusercontent.com/1400464/81997150-cc026a00-9603-11ea-95c6-040c01ecb14b.png)
