### PR TITLE
refs(alert_rules): Switch alert rule create/update code to use aggregate.

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -663,7 +663,7 @@ def main(num_events=1, extra_events=False):
             try:
                 # Metric alerts
                 alert_rule = create_alert_rule(
-                    org, [project], "My Alert Rule", "level:error", QueryAggregations.TOTAL, 10, 1
+                    org, [project], "My Alert Rule", "level:error", "count()", 10, 1
                 )
                 create_alert_rule_trigger(alert_rule, "critical", AlertRuleThresholdType.ABOVE, 10)
                 create_incident(

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -34,6 +34,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.snuba.models import QueryAggregations
+from sentry.snuba.subscriptions import aggregation_function_translations
 from sentry.utils.compat import zip
 
 
@@ -279,7 +280,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         required=True, min_value=1, max_value=int(timedelta(days=1).total_seconds() / 60)
     )
     threshold_period = serializers.IntegerField(default=1, min_value=1, max_value=20)
-    aggregation = serializers.IntegerField(required=False)
+    aggregation = serializers.IntegerField(required=True)
 
     class Meta:
         model = AlertRule
@@ -314,6 +315,8 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         This includes ensuring there is either 1 or 2 triggers, which each have actions, and have proper thresholds set.
         The critical trigger should both alert and resolve 'after' the warning trigger (whether that means > or < the value depends on threshold type).
         """
+        data["aggregate"] = aggregation_function_translations[data.pop("aggregation")]
+
         triggers = data.get("triggers", [])
         if not triggers:
             raise serializers.ValidationError("Must include at least one trigger")

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -22,17 +22,7 @@ aggregate_to_query_aggregation = {
 }
 
 
-def translate_aggregation(aggregation):
-    """
-    Temporary function to translate `QueryAggregations` into the discover aggregation
-    function format
-    :param aggregation:
-    :return: A string representing the aggregate function
-    """
-    return aggregation_function_translations[aggregation]
-
-
-def create_snuba_query(dataset, query, aggregation, time_window, resolution, environment):
+def create_snuba_query(dataset, query, aggregate, time_window, resolution, environment):
     """
     Creates a SnubaQuery.
 
@@ -48,14 +38,14 @@ def create_snuba_query(dataset, query, aggregation, time_window, resolution, env
     return SnubaQuery.objects.create(
         dataset=dataset.value,
         query=query,
-        aggregate=translate_aggregation(aggregation),
+        aggregate=aggregate,
         time_window=int(time_window.total_seconds()),
         resolution=int(resolution.total_seconds()),
         environment=environment,
     )
 
 
-def update_snuba_query(snuba_query, query, aggregation, time_window, resolution, environment):
+def update_snuba_query(snuba_query, query, aggregate, time_window, resolution, environment):
     """
     Updates a SnubaQuery. Triggers updates to any related QuerySubscriptions.
 
@@ -63,7 +53,7 @@ def update_snuba_query(snuba_query, query, aggregation, time_window, resolution,
     :param dataset: The snuba dataset to query and aggregate over
     :param query: An event search query that we can parse and convert into a
     set of Snuba conditions
-    :param aggregation: An aggregation to calculate over the time window
+    :param aggregate: An aggregate to calculate over the time window
     :param time_window: The time window to aggregate over
     :param resolution: How often to receive updates/bucket size
     :param environment: An optional environment to filter by
@@ -73,7 +63,7 @@ def update_snuba_query(snuba_query, query, aggregation, time_window, resolution,
         query_subscriptions = list(snuba_query.subscriptions.all())
         snuba_query.update(
             query=query,
-            aggregate=translate_aggregation(aggregation),
+            aggregate=aggregate,
             time_window=int(time_window.total_seconds()),
             resolution=int(resolution.total_seconds()),
             environment=environment,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -73,7 +73,6 @@ from sentry.models import (
 )
 from sentry.models.integrationfeature import Feature, IntegrationFeature
 from sentry.signals import project_created
-from sentry.snuba.models import QueryAggregations
 from sentry.utils import loremipsum, json
 
 
@@ -336,7 +335,7 @@ class Factories(object):
                 "workspace": integration_id,
                 "channel_id": channel_id or "123453",
                 "channel": channel_name or "#general",
-            },
+            }
         ]
         return Factories.create_project_rule(project, action_data)
 
@@ -858,7 +857,7 @@ class Factories(object):
         projects,
         name=None,
         query="level:error",
-        aggregation=QueryAggregations.TOTAL,
+        aggregate="count()",
         time_window=10,
         threshold_period=1,
         include_all_projects=False,
@@ -874,7 +873,7 @@ class Factories(object):
             projects,
             name,
             query,
-            aggregation,
+            aggregate,
             time_window,
             threshold_period,
             environment=environment,

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -28,13 +28,7 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
 
     def test_incidents_list(self):
         alert_rule = create_alert_rule(
-            self.organization,
-            [self.project],
-            "hello",
-            "level:error",
-            QueryAggregations.TOTAL,
-            10,
-            1,
+            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
         )
 
         incident = create_incident(

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -12,7 +12,6 @@ from sentry.api.serializers.models.alert_rule import (
 from sentry.models import Rule
 from sentry.incidents.logic import create_alert_rule, create_alert_rule_trigger
 from sentry.incidents.models import AlertRuleThresholdType
-from sentry.snuba.models import QueryAggregations
 from sentry.snuba.subscriptions import aggregate_to_query_aggregation
 from sentry.testutils import TestCase, APITestCase
 
@@ -77,13 +76,7 @@ class BaseAlertRuleSerializerTest(object):
 class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
     def test_simple(self):
         alert_rule = create_alert_rule(
-            self.organization,
-            [self.project],
-            "hello",
-            "level:error",
-            QueryAggregations.TOTAL,
-            10,
-            1,
+            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
         )
         result = serialize(alert_rule)
         self.assert_alert_rule_serialized(alert_rule, result)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -6,10 +6,7 @@ from freezegun import freeze_time
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_alert_rule
 from sentry.incidents.models import AlertRule
-from sentry.snuba.models import QueryAggregations
 from sentry.testutils import APITestCase
-
-# from sentry.incidents.endpoints.serializers import CRITICAL_TRIGGER_LABEL, WARNING_TRIGGER_LABEL
 
 
 class AlertRuleListEndpointTest(APITestCase):
@@ -30,13 +27,7 @@ class AlertRuleListEndpointTest(APITestCase):
     def test_simple(self):
         self.create_team(organization=self.organization, members=[self.user])
         alert_rule = create_alert_rule(
-            self.organization,
-            [self.project],
-            "hello",
-            "level:error",
-            QueryAggregations.TOTAL,
-            10,
-            1,
+            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
         )
 
         self.login_as(self.user)

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -5,8 +5,6 @@ from exam import fixture
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_alert_rule
 from sentry.incidents.models import AlertRule, AlertRuleStatus, Incident, IncidentStatus
-from sentry.snuba.models import QueryAggregations
-from sentry.snuba.subscriptions import aggregate_to_query_aggregation
 from sentry.testutils import APITestCase
 
 
@@ -77,13 +75,7 @@ class AlertRuleDetailsBase(object):
     @fixture
     def alert_rule(self):
         return create_alert_rule(
-            self.organization,
-            [self.project],
-            "hello",
-            "level:error",
-            QueryAggregations.TOTAL,
-            10,
-            1,
+            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
         )
 
     def test_invalid_rule_id(self):
@@ -148,13 +140,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
     def test_not_updated_fields(self):
         test_params = self.valid_params.copy()
-        test_params.update(
-            {
-                "aggregation": aggregate_to_query_aggregation[
-                    self.alert_rule.snuba_query.aggregate
-                ].value
-            }
-        )
+        test_params["aggregate"] = self.alert_rule.snuba_query.aggregate
 
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -11,7 +11,6 @@ from freezegun import freeze_time
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_alert_rule
 from sentry.incidents.models import AlertRule
-from sentry.snuba.models import QueryAggregations
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils import TestCase, APITestCase
 from tests.sentry.api.serializers.test_alert_rule import BaseAlertRuleSerializerTest
@@ -38,13 +37,7 @@ class AlertRuleListEndpointTest(APITestCase):
     def test_simple(self):
         self.create_team(organization=self.organization, members=[self.user])
         alert_rule = create_alert_rule(
-            self.organization,
-            [self.project],
-            "hello",
-            "level:error",
-            QueryAggregations.TOTAL,
-            10,
-            1,
+            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
         )
 
         self.login_as(self.user)

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -87,6 +87,7 @@ class TestAlertRuleSerializer(TestCase):
             "timeWindow": field_is_required,
             "query": field_is_required,
             "triggers": field_is_required,
+            "aggregation": field_is_required,
         }
 
     def test_environment_non_list(self):

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -38,7 +38,7 @@ from sentry.incidents.subscription_processor import (
     SubscriptionProcessor,
     update_alert_rule_stats,
 )
-from sentry.snuba.models import QueryAggregations, QuerySubscription
+from sentry.snuba.models import QuerySubscription
 from sentry.testutils import TestCase
 from sentry.utils.dates import to_timestamp
 from sentry.utils.compat import map
@@ -83,7 +83,7 @@ class ProcessUpdateTest(TestCase):
             [self.project, self.other_project],
             "some rule",
             query="",
-            aggregation=QueryAggregations.TOTAL,
+            aggregate="count()",
             time_window=1,
             threshold_period=1,
         )

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from exam import fixture, patcher
 
 from sentry.utils.compat.mock import Mock
-from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription
+from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.snuba.query_subscription_consumer import (
     InvalidMessageError,
     InvalidSchemaError,
@@ -99,7 +99,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "hello",
-                QueryAggregations.TOTAL,
+                "count()",
                 timedelta(minutes=10),
                 timedelta(minutes=1),
                 None,

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -2,14 +2,12 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 
-from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription
+from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.snuba.subscriptions import (
-    aggregation_function_translations,
     bulk_delete_snuba_subscriptions,
     create_snuba_query,
     create_snuba_subscription,
     delete_snuba_subscription,
-    translate_aggregation,
     update_snuba_query,
     update_snuba_subscription,
 )
@@ -20,13 +18,13 @@ class CreateSnubaQueryTest(TestCase):
     def test(self):
         dataset = QueryDatasets.EVENTS
         query = "level:error"
-        aggregation = QueryAggregations.TOTAL
+        aggregate = "count()"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
-        snuba_query = create_snuba_query(dataset, query, aggregation, time_window, resolution, None)
+        snuba_query = create_snuba_query(dataset, query, aggregate, time_window, resolution, None)
         assert snuba_query.dataset == dataset.value
         assert snuba_query.query == query
-        assert snuba_query.aggregate == translate_aggregation(aggregation)
+        assert snuba_query.aggregate == aggregate
         assert snuba_query.time_window == int(time_window.total_seconds())
         assert snuba_query.resolution == int(resolution.total_seconds())
         assert snuba_query.environment is None
@@ -34,15 +32,15 @@ class CreateSnubaQueryTest(TestCase):
     def test_environment(self):
         dataset = QueryDatasets.EVENTS
         query = "level:error"
-        aggregation = QueryAggregations.TOTAL
+        aggregate = "count()"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
         snuba_query = create_snuba_query(
-            dataset, query, aggregation, time_window, resolution, self.environment
+            dataset, query, aggregate, time_window, resolution, self.environment
         )
         assert snuba_query.dataset == dataset.value
         assert snuba_query.query == query
-        assert snuba_query.aggregate == translate_aggregation(aggregation)
+        assert snuba_query.aggregate == aggregate
         assert snuba_query.time_window == int(time_window.total_seconds())
         assert snuba_query.resolution == int(resolution.total_seconds())
         assert snuba_query.environment == self.environment
@@ -53,11 +51,10 @@ class CreateSnubaSubscriptionTest(TestCase):
         type = "something"
         dataset = QueryDatasets.EVENTS
         query = "level:error"
-        aggregation = QueryAggregations.TOTAL
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
         snuba_query = create_snuba_query(
-            dataset, query, aggregation, time_window, resolution, self.environment
+            dataset, query, "count()", time_window, resolution, self.environment
         )
         subscription = create_snuba_subscription(self.project, type, snuba_query)
 
@@ -71,11 +68,10 @@ class CreateSnubaSubscriptionTest(TestCase):
             type = "something"
             dataset = QueryDatasets.EVENTS
             query = "level:error"
-            aggregation = QueryAggregations.TOTAL
             time_window = timedelta(minutes=10)
             resolution = timedelta(minutes=1)
             snuba_query = create_snuba_query(
-                dataset, query, aggregation, time_window, resolution, self.environment
+                dataset, query, "count()", time_window, resolution, self.environment
             )
             subscription = create_snuba_subscription(self.project, type, snuba_query)
             subscription = QuerySubscription.objects.get(id=subscription.id)
@@ -88,12 +84,11 @@ class CreateSnubaSubscriptionTest(TestCase):
         type = "something"
         dataset = QueryDatasets.EVENTS
         query = "event.type:error"
-        aggregation = QueryAggregations.TOTAL
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
         with self.tasks():
             snuba_query = create_snuba_query(
-                dataset, query, aggregation, time_window, resolution, self.environment
+                dataset, query, "count()", time_window, resolution, self.environment
             )
             subscription = create_snuba_subscription(self.project, type, snuba_query)
         subscription = QuerySubscription.objects.get(id=subscription.id)
@@ -109,19 +104,19 @@ class UpdateSnubaQueryTest(TestCase):
         snuba_query = create_snuba_query(
             dataset,
             "hello",
-            QueryAggregations.UNIQUE_USERS,
+            "count_unique(tags[sentry:user])",
             timedelta(minutes=100),
             timedelta(minutes=2),
             self.environment,
         )
         query = "level:error"
-        aggregation = QueryAggregations.TOTAL
+        aggregate = "count()"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
-        update_snuba_query(snuba_query, query, aggregation, time_window, resolution, None)
+        update_snuba_query(snuba_query, query, aggregate, time_window, resolution, None)
         assert snuba_query.dataset == dataset.value
         assert snuba_query.query == query
-        assert snuba_query.aggregate == translate_aggregation(aggregation)
+        assert snuba_query.aggregate == aggregate
         assert snuba_query.time_window == int(time_window.total_seconds())
         assert snuba_query.resolution == int(resolution.total_seconds())
         assert snuba_query.environment is None
@@ -131,7 +126,7 @@ class UpdateSnubaQueryTest(TestCase):
         snuba_query = create_snuba_query(
             dataset,
             "hello",
-            QueryAggregations.UNIQUE_USERS,
+            "count_unique(tags[sentry:user])",
             timedelta(minutes=100),
             timedelta(minutes=2),
             self.environment,
@@ -139,13 +134,13 @@ class UpdateSnubaQueryTest(TestCase):
 
         new_env = self.create_environment()
         query = "level:error"
-        aggregation = QueryAggregations.TOTAL
+        aggregate = "count()"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
-        update_snuba_query(snuba_query, query, aggregation, time_window, resolution, new_env)
+        update_snuba_query(snuba_query, query, aggregate, time_window, resolution, new_env)
         assert snuba_query.dataset == dataset.value
         assert snuba_query.query == query
-        assert snuba_query.aggregate == translate_aggregation(aggregation)
+        assert snuba_query.aggregate == aggregate
         assert snuba_query.time_window == int(time_window.total_seconds())
         assert snuba_query.resolution == int(resolution.total_seconds())
         assert snuba_query.environment == new_env
@@ -155,7 +150,7 @@ class UpdateSnubaQueryTest(TestCase):
         snuba_query = create_snuba_query(
             dataset,
             "hello",
-            QueryAggregations.UNIQUE_USERS,
+            "count_unique(tags[sentry:user])",
             timedelta(minutes=100),
             timedelta(minutes=2),
             self.environment,
@@ -164,10 +159,10 @@ class UpdateSnubaQueryTest(TestCase):
 
         new_env = self.create_environment()
         query = "level:error"
-        aggregation = QueryAggregations.TOTAL
+        aggregate = "count()"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
-        update_snuba_query(snuba_query, query, aggregation, time_window, resolution, new_env)
+        update_snuba_query(snuba_query, query, aggregate, time_window, resolution, new_env)
         sub.refresh_from_db()
         assert sub.snuba_query == snuba_query
         assert sub.status == QuerySubscription.Status.UPDATING.value
@@ -179,7 +174,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "level:error",
-                QueryAggregations.TOTAL,
+                "count()",
                 timedelta(minutes=10),
                 timedelta(minutes=1),
                 None,
@@ -187,7 +182,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
             subscription = create_snuba_subscription(self.project, "something", snuba_query)
 
         query = "level:warning"
-        aggregation = QueryAggregations.UNIQUE_USERS
+        aggregate = "count_unique(tags[sentry:user])"
         time_window = timedelta(minutes=20)
         resolution = timedelta(minutes=2)
         subscription = QuerySubscription.objects.get(id=subscription.id)
@@ -197,14 +192,14 @@ class UpdateSnubaSubscriptionTest(TestCase):
             time_window=int(time_window.total_seconds()),
             resolution=int(resolution.total_seconds()),
             environment=self.environment,
-            aggregate=aggregation_function_translations[aggregation],
+            aggregate=aggregate,
         )
         assert subscription_id is not None
         update_snuba_subscription(subscription, snuba_query)
         assert subscription.status == QuerySubscription.Status.UPDATING.value
         assert subscription.subscription_id == subscription_id
         assert subscription.snuba_query.query == query
-        assert subscription.snuba_query.aggregate == aggregation_function_translations[aggregation]
+        assert subscription.snuba_query.aggregate == aggregate
         assert subscription.snuba_query.time_window == int(time_window.total_seconds())
         assert subscription.snuba_query.resolution == int(resolution.total_seconds())
 
@@ -213,7 +208,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "level:error",
-                QueryAggregations.TOTAL,
+                "count()",
                 timedelta(minutes=10),
                 timedelta(minutes=1),
                 None,
@@ -221,7 +216,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
             subscription = create_snuba_subscription(self.project, "something", snuba_query)
 
             query = "level:warning"
-            aggregation = QueryAggregations.UNIQUE_USERS
+            aggregate = "count_unique(tags[sentry:user])"
             time_window = timedelta(minutes=20)
             resolution = timedelta(minutes=2)
             subscription = QuerySubscription.objects.get(id=subscription.id)
@@ -232,7 +227,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
                 time_window=int(time_window.total_seconds()),
                 resolution=int(resolution.total_seconds()),
                 environment=self.environment,
-                aggregate=translate_aggregation(aggregation),
+                aggregate=aggregate,
             )
             update_snuba_subscription(subscription, snuba_query)
             subscription = QuerySubscription.objects.get(id=subscription.id)
@@ -247,7 +242,7 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "level:error",
-                QueryAggregations.TOTAL,
+                "count()",
                 timedelta(minutes=10),
                 timedelta(minutes=1),
                 None,
@@ -256,7 +251,7 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "level:error",
-                QueryAggregations.TOTAL,
+                "count()",
                 timedelta(minutes=10),
                 timedelta(minutes=1),
                 None,
@@ -282,7 +277,7 @@ class DeleteSnubaSubscriptionTest(TestCase):
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "level:error",
-                QueryAggregations.TOTAL,
+                "count()",
                 timedelta(minutes=10),
                 timedelta(minutes=1),
                 None,
@@ -301,7 +296,7 @@ class DeleteSnubaSubscriptionTest(TestCase):
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "level:error",
-                QueryAggregations.TOTAL,
+                "count()",
                 timedelta(minutes=10),
                 timedelta(minutes=1),
                 None,

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -9,8 +9,7 @@ from exam import patcher
 from mock import Mock, patch
 from six import add_metaclass
 
-from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription, SnubaQuery
-from sentry.snuba.subscriptions import translate_aggregation
+from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery
 from sentry.snuba.tasks import (
     create_subscription_in_snuba,
     update_subscription_in_snuba,
@@ -41,14 +40,14 @@ class BaseSnubaTaskTest(object):
         if status is None:
             status = self.expected_status
         dataset = QueryDatasets.EVENTS.value
-        aggregate = QueryAggregations.UNIQUE_USERS
+        aggregate = "count_unique(tags[sentry:user])"
         query = "hello"
         time_window = 60
         resolution = 60
 
         snuba_query = SnubaQuery.objects.create(
             dataset=dataset,
-            aggregate=translate_aggregation(aggregate),
+            aggregate=aggregate,
             query=query,
             time_window=time_window,
             resolution=resolution,

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -27,7 +27,6 @@ from sentry.incidents.models import (
     TriggerStatus,
 )
 from sentry.incidents.tasks import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
-from sentry.snuba.models import QueryAggregations
 from sentry.snuba.query_subscription_consumer import QuerySubscriptionConsumer, subscriber_registry
 
 from sentry.testutils import TestCase
@@ -61,7 +60,7 @@ class HandleSnubaQueryUpdateTest(TestCase):
                 [self.project],
                 "some rule",
                 query="",
-                aggregation=QueryAggregations.TOTAL,
+                aggregate="count()",
                 time_window=1,
                 threshold_period=1,
             )

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -13,7 +13,7 @@ from django.test.utils import override_settings
 from exam import fixture
 from sentry.utils.compat.mock import call, Mock
 
-from sentry.snuba.models import QueryAggregations, QueryDatasets
+from sentry.snuba.models import QueryDatasets
 from sentry.snuba.query_subscription_consumer import (
     QuerySubscriptionConsumer,
     register_subscriber,
@@ -89,7 +89,7 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "hello",
-                QueryAggregations.TOTAL,
+                "count()",
                 timedelta(minutes=1),
                 timedelta(minutes=1),
                 None,


### PR DESCRIPTION
This moves all code to use the new `SnubaQuery.aggregate` field, and pass `aggregate` around
(almost) everywhere. We still need to update this in the api, and there are still some places that
need to change to be able to support aggregates that don't map to our previous default aggregates.

Depends on https://github.com/getsentry/sentry/pull/18845