### PR TITLE
feat(SentryApps): Raise exception on error statuses

### DIFF
--- a/src/sentry/mediators/external_requests/issue_link_requester.py
+++ b/src/sentry/mediators/external_requests/issue_link_requester.py
@@ -61,17 +61,17 @@ class IssueLinkRequester(Mediator):
 
     def _make_request(self):
         action_to_past_tense = {"create": "created", "link": "linked"}
-        req = send_and_save_sentry_app_request(
-            self._build_url(),
-            self.sentry_app,
-            self.install.organization_id,
-            "external_issue.{}".format(action_to_past_tense[self.action]),
-            headers=self._build_headers(),
-            method="POST",
-            data=self.body,
-        )
 
         try:
+            req = send_and_save_sentry_app_request(
+                self._build_url(),
+                self.sentry_app,
+                self.install.organization_id,
+                "external_issue.{}".format(action_to_past_tense[self.action]),
+                headers=self._build_headers(),
+                method="POST",
+                data=self.body,
+            )
             body = safe_urlread(req)
             response = json.loads(body)
         except Exception as e:

--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -56,6 +56,15 @@ def send_and_save_sentry_app_request(url, sentry_app, org_id, event, **kwargs):
 
     try:
         resp = safe_urlopen(url=url, **kwargs)
+
+    except Timeout:
+        track_response_code("timeout", slug, event)
+        # Response code of 0 represents timeout
+        buffer.add_request(response_code=0, org_id=org_id, event=event, url=url)
+        # Re-raise the exception because some of these tasks might retry on the exception
+        raise
+
+    finally:
         track_response_code(resp.status_code, slug, event)
         buffer.add_request(
             response_code=resp.status_code,
@@ -67,10 +76,3 @@ def send_and_save_sentry_app_request(url, sentry_app, org_id, event, **kwargs):
         )
         resp.raise_for_status()
         return resp
-
-    except Timeout:
-        track_response_code("timeout", slug, event)
-        # Response code of 0 represents timeout
-        buffer.add_request(response_code=0, org_id=org_id, event=event, url=url)
-        # Re-raise the exception because some of these tasks might retry on the exception
-        raise

--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -64,7 +64,7 @@ def send_and_save_sentry_app_request(url, sentry_app, org_id, event, **kwargs):
         # Re-raise the exception because some of these tasks might retry on the exception
         raise
 
-    finally:
+    else:
         track_response_code(resp.status_code, slug, event)
         buffer.add_request(
             response_code=resp.status_code,

--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from jsonschema import Draft4Validator
-from requests.exceptions import Timeout, HTTPError
+from requests.exceptions import Timeout
 
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 from sentry.http import safe_urlopen
@@ -72,9 +72,5 @@ def send_and_save_sentry_app_request(url, sentry_app, org_id, event, **kwargs):
         track_response_code("timeout", slug, event)
         # Response code of 0 represents timeout
         buffer.add_request(response_code=0, org_id=org_id, event=event, url=url)
-        # Re-raise the exception because some of these tasks might retry on the exception
-        raise
-
-    except HTTPError:
         # Re-raise the exception because some of these tasks might retry on the exception
         raise

--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -58,8 +58,8 @@ def send_and_save_sentry_app_request(url, sentry_app, org_id, event, **kwargs):
 
     try:
         resp = safe_urlopen(url=url, **kwargs)
-        error_id = (resp.headers.get("Sentry-Hook-Error"),)
-        project_id = (resp.headers.get("Sentry-Hook-Project"),)
+        error_id = resp.headers.get("Sentry-Hook-Error")
+        project_id = resp.headers.get("Sentry-Hook-Project")
         resp.raise_for_status()
 
     except Timeout as e:

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -311,7 +311,7 @@ def send_and_save_webhook_request(url, sentry_app, app_platform_event):
         # Re-raise the exception because some of these tasks might retry on the exception
         raise
 
-    finally:
+    else:
         track_response_code(resp.status_code, slug, event)
         buffer.add_request(
             response_code=resp.status_code,

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -4,7 +4,7 @@ import logging
 
 from celery.task import current
 from django.core.urlresolvers import reverse
-from requests.exceptions import RequestException, Timeout, HTTPError
+from requests.exceptions import RequestException, Timeout
 
 from sentry.eventstore.models import Event
 from sentry.http import safe_urlopen
@@ -319,9 +319,5 @@ def send_and_save_webhook_request(url, sentry_app, app_platform_event):
         track_response_code("timeout", slug, event)
         # Response code of 0 represents timeout
         buffer.add_request(response_code=0, org_id=org_id, event=event, url=url)
-        # Re-raise the exception because some of these tasks might retry on the exception
-        raise
-
-    except HTTPError:
         # Re-raise the exception because some of these tasks might retry on the exception
         raise

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -298,48 +298,30 @@ def send_and_save_webhook_request(url, sentry_app, app_platform_event):
     org_id = app_platform_event.install.organization_id
     event = "{}.{}".format(app_platform_event.resource, app_platform_event.action)
     slug = sentry_app.slug_for_metrics
-    error_id = None
-    project_id = None
 
     try:
         resp = safe_urlopen(
             url=url, data=app_platform_event.body, headers=app_platform_event.headers, timeout=5
         )
-        error_id = resp.headers.get("Sentry-Hook-Error")
-        project_id = resp.headers.get("Sentry-Hook-Project")
+        track_response_code(resp.status_code, slug, event)
+        buffer.add_request(
+            response_code=resp.status_code,
+            org_id=org_id,
+            event=event,
+            url=url,
+            error_id=resp.headers.get("Sentry-Hook-Error"),
+            project_id=resp.headers.get("Sentry-Hook-Project"),
+        )
         resp.raise_for_status()
+        return resp
 
-    except Timeout as e:
+    except Timeout:
         track_response_code("timeout", slug, event)
         # Response code of 0 represents timeout
         buffer.add_request(response_code=0, org_id=org_id, event=event, url=url)
         # Re-raise the exception because some of these tasks might retry on the exception
         raise
 
-    except HTTPError as e:
-        status_code = e.response.status_code
-        track_response_code(status_code, slug, event)
-        # Use the response code from the error
-        buffer.add_request(
-            response_code=status_code,
-            org_id=org_id,
-            event=event,
-            url=url,
-            error_id=error_id,
-            project_id=project_id,
-        )
+    except HTTPError:
         # Re-raise the exception because some of these tasks might retry on the exception
         raise
-
-    track_response_code(resp.status_code, slug, event)
-
-    buffer.add_request(
-        response_code=resp.status_code,
-        org_id=org_id,
-        event=event,
-        url=url,
-        error_id=error_id,
-        project_id=project_id,
-    )
-
-    return resp

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -124,7 +124,6 @@ class TestIssueLinkRequester(TestCase):
 
         buffer = SentryAppWebhookRequestsBuffer(self.sentry_app)
         requests = buffer.get_requests()
-
         assert len(requests) == 1
         assert requests[0]["response_code"] == 500
         assert requests[0]["event_type"] == "external_issue.created"

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -10,8 +10,15 @@ from sentry.testutils.helpers.faux import faux
 from sentry.utils import json
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 
-MockResponse = namedtuple("MockResponse", ["headers", "content", "ok", "status_code"])
-MockResponseInstance = MockResponse({}, {}, True, 200)
+
+def raiseStatusFalse():
+    return False
+
+
+MockResponse = namedtuple(
+    "MockResponse", ["headers", "content", "ok", "status_code", "raise_for_status"]
+)
+MockResponseInstance = MockResponse({}, {}, True, 200, raiseStatusFalse)
 
 
 class DictContaining(object):

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -7,7 +7,7 @@ from celery import Task
 from collections import namedtuple
 from django.core.urlresolvers import reverse
 from sentry.utils.compat.mock import patch
-from requests.exceptions import RequestException
+from requests.exceptions import Timeout
 
 from sentry.models import Rule, SentryApp, SentryAppInstallation
 from sentry.testutils import TestCase
@@ -30,16 +30,28 @@ from sentry.tasks.sentry_apps import (
     send_webhooks,
 )
 
+
+def raiseStatuseFalse():
+    return False
+
+
+def raiseStatusTrue():
+    return True
+
+
 RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
 
-MockResponse = namedtuple("MockResponse", ["headers", "content", "ok", "status_code"])
-MockResponseInstance = MockResponse({}, {}, True, 200)
-MockFailureResponseInstance = MockResponse({}, {}, False, 400)
+MockResponse = namedtuple(
+    "MockResponse", ["headers", "content", "ok", "status_code", "raise_for_status"]
+)
+MockResponseInstance = MockResponse({}, {}, True, 200, raiseStatuseFalse)
+MockFailureResponseInstance = MockResponse({}, {}, False, 400, raiseStatusTrue)
 MockResponseWithHeadersInstance = MockResponse(
     {"Sentry-Hook-Error": "d5111da2c28645c5889d072017e3445d", "Sentry-Hook-Project": "1"},
     {},
     False,
     400,
+    raiseStatusTrue,
 )
 
 
@@ -415,11 +427,11 @@ class TestWebhookRequests(TestCase):
         assert first_request["event_type"] == "issue.assigned"
         assert first_request["organization_id"] == self.install.organization.id
 
-    @patch("sentry.tasks.sentry_apps.safe_urlopen", side_effect=RequestException("Timeout"))
+    @patch("sentry.tasks.sentry_apps.safe_urlopen", side_effect=Timeout)
     def test_saves_error_for_request_timeout(self, safe_urlopen):
         data = {"issue": serialize(self.issue)}
 
-        with self.assertRaises(RequestException):
+        with self.assertRaises(Timeout):
             send_webhooks(
                 installation=self.install, event="issue.assigned", data=data, actor=self.user
             )


### PR DESCRIPTION
## Objective
We don't call `raise_for_status` so errors are not being raised when the API fails and our error logging isn't hitting. This is making it difficult to debug problems with Sentry Apps.

WIth this PR, errors at the API level should throw an error that can be caught and logged at higher levels

## Test Plan
I created a new Internal App with Webhook and UI Components. Then I added `print` statements in the different `Exceptions`. I used a local  server that I controlled to adjust responses to the POST requests and confirmed the expected behaviour.

<img width="1110" alt="Screen Shot 2020-05-14 at 5 09 59 PM" src="https://user-images.githubusercontent.com/10491193/81998066-65328000-9606-11ea-876d-b74e6d17e043.png">

