### PR TITLE
fix(integrations): record sentry app view on detail view

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -19,6 +19,7 @@ import {openModal} from 'app/actionCreators/modal';
 import {getSentryAppInstallStatus} from 'app/utils/integrationUtil';
 import Confirm from 'app/components/confirm';
 import {IconSubtract} from 'app/icons';
+import {recordInteraction} from 'app/utils/recordSentryAppInteraction';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 
@@ -65,6 +66,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
     }
 
     super.onLoadAllEndpointsSuccess();
+    recordInteraction(integrationSlug, 'sentry_app_viewed');
   }
 
   get integrationType() {

--- a/tests/js/spec/views/organizationIntegrations/sentryAppDetailedView.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/sentryAppDetailedView.spec.jsx
@@ -39,9 +39,17 @@ describe('SentryAppDetailedView', function() {
   describe('Published Sentry App', function() {
     let createRequest;
     let deleteRequest;
+    let sentryAppInteractionRequest;
 
     beforeEach(() => {
       Client.clearMockResponses();
+
+      sentryAppInteractionRequest = MockApiClient.addMockResponse({
+        url: `/sentry-apps/clickup/interaction/`,
+        method: 'POST',
+        statusCode: 200,
+        body: {},
+      });
 
       mockResponse([
         [
@@ -106,6 +114,18 @@ describe('SentryAppDetailedView', function() {
       );
     });
 
+    it('records interaction request', () => {
+      expect(sentryAppInteractionRequest).toHaveBeenCalledWith(
+        `/sentry-apps/clickup/interaction/`,
+        expect.objectContaining({
+          method: 'POST',
+          data: {
+            tsdbField: 'sentry_app_viewed',
+          },
+        })
+      );
+    });
+
     it('shows the Integration name and install status', async function() {
       expect(wrapper.find('Name').props().children).toEqual('ClickUp');
       expect(wrapper.find('IntegrationStatus').props().status).toEqual('Not Installed');
@@ -147,6 +167,13 @@ describe('SentryAppDetailedView', function() {
   describe('Internal Sentry App', function() {
     beforeEach(() => {
       Client.clearMockResponses();
+
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/my-headband-washer-289499/interaction/`,
+        method: 'POST',
+        statusCode: 200,
+        body: {},
+      });
 
       mockResponse([
         [
@@ -217,6 +244,13 @@ describe('SentryAppDetailedView', function() {
 
     beforeEach(() => {
       Client.clearMockResponses();
+
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/la-croix-monitor/interaction/`,
+        method: 'POST',
+        statusCode: 200,
+        body: {},
+      });
 
       mockResponse([
         [
@@ -305,6 +339,13 @@ describe('SentryAppDetailedView', function() {
     let createRequest;
     beforeEach(() => {
       Client.clearMockResponses();
+
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/go-to-google/interaction/`,
+        method: 'POST',
+        statusCode: 200,
+        body: {},
+      });
 
       mockResponse([
         [


### PR DESCRIPTION
Today I realized that the interaction views we used to record are no longer being recorded because the code wasn't copied from `SentryAppDetailsModal` which was used in the old integrations page.