### PR TITLE
feat(ui): Make lines invisible in health area charts

### DIFF
--- a/src/sentry/static/sentry/app/types/echarts.tsx
+++ b/src/sentry/static/sentry/app/types/echarts.tsx
@@ -1,4 +1,4 @@
-import {ECharts} from 'echarts';
+import {ECharts, EChartOption} from 'echarts';
 
 export type SeriesDataUnit = {
   value: number;
@@ -16,6 +16,7 @@ export type Series = {
     color: string;
     opacity: number;
   };
+  lineStyle?: EChartOption.LineStyle;
 };
 
 export type ReactEchartsRef = {

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/deploys.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/deploys.tsx
@@ -39,7 +39,7 @@ const Row = styled('div')`
   justify-content: space-between;
   margin-bottom: ${space(1)};
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray4};
+  color: ${p => p.theme.gray3};
 `;
 
 const StyledDeployBadge = styled(DeployBadge)`

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/releaseStatsRequest.tsx
@@ -237,6 +237,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         },
         lineStyle: {
           opacity: 0,
+          width: 0.4,
         },
       },
       abnormal: {
@@ -249,6 +250,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         },
         lineStyle: {
           opacity: 0,
+          width: 0.4,
         },
       },
       errored: {
@@ -261,6 +263,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         },
         lineStyle: {
           opacity: 0,
+          width: 0.4,
         },
       },
       healthy: {
@@ -273,6 +276,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         },
         lineStyle: {
           opacity: 0,
+          width: 0.4,
         },
       },
     };

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/releaseStatsRequest.tsx
@@ -235,6 +235,9 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
           color: CHART_PALETTE[3][0],
           opacity: 1,
         },
+        lineStyle: {
+          opacity: 0,
+        },
       },
       abnormal: {
         seriesName: t('Abnormal'),
@@ -243,6 +246,9 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         areaStyle: {
           color: CHART_PALETTE[3][1],
           opacity: 1,
+        },
+        lineStyle: {
+          opacity: 0,
         },
       },
       errored: {
@@ -253,6 +259,9 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
           color: CHART_PALETTE[3][2],
           opacity: 1,
         },
+        lineStyle: {
+          opacity: 0,
+        },
       },
       healthy: {
         seriesName: t('Healthy'),
@@ -261,6 +270,9 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         areaStyle: {
           color: CHART_PALETTE[3][3],
           opacity: 1,
+        },
+        lineStyle: {
+          opacity: 0,
         },
       },
     };
@@ -352,6 +364,9 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
     const chartData: Series = {
       seriesName: t('Session Duration'),
       data: [],
+      lineStyle: {
+        opacity: 0,
+      },
     };
 
     const sessionDurationAverage = Math.round(


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9060071/82029160-df124a00-9696-11ea-9741-386fe9cf5da9.png)


After:
![image](https://user-images.githubusercontent.com/9060071/82029092-c99d2000-9696-11ea-8503-54c2210a7a16.png)
