### PR TITLE
feat(ui): Sort health rows inside release card

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -7,12 +7,13 @@ import {forceCheck} from 'react-lazyload';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import AsyncView from 'app/views/asyncView';
-import {Organization, Release} from 'app/types';
+import {Organization, Release, GlobalSelection} from 'app/types';
 import routeTitleGen from 'app/utils/routeTitle';
 import SearchBar from 'app/components/searchBar';
 import Pagination from 'app/components/pagination';
 import PageHeading from 'app/components/pageHeading';
 import withOrganization from 'app/utils/withOrganization';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import IntroBanner from 'app/views/releasesV2/list/introBanner';
@@ -34,6 +35,7 @@ type RouteParams = {
 
 type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
+  selection: GlobalSelection;
 };
 
 type State = {releases: Release[]} & AsyncView['state'];
@@ -173,7 +175,7 @@ class ReleasesList extends AsyncView<Props, State> {
   }
 
   renderInnerBody() {
-    const {location, organization} = this.props;
+    const {location, selection, organization} = this.props;
     const {releases, reloading} = this.state;
 
     if (this.shouldShowLoadingIndicator()) {
@@ -189,6 +191,7 @@ class ReleasesList extends AsyncView<Props, State> {
         release={release}
         orgSlug={organization.slug}
         location={location}
+        selection={selection}
         reloading={reloading}
         key={`${release.version}-${release.projects[0].slug}`}
       />
@@ -258,5 +261,5 @@ const SortAndFilterWrapper = styled('div')`
   }
 `;
 
-export default withOrganization(ReleasesList);
+export default withOrganization(withGlobalSelection(ReleasesList));
 export {ReleasesList};

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releaseCard.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releaseCard.tsx
@@ -7,7 +7,7 @@ import Count from 'app/components/count';
 import Version from 'app/components/version';
 import {Panel, PanelBody, PanelItem} from 'app/components/panels';
 import ReleaseStats from 'app/components/releaseStats';
-import {Release} from 'app/types';
+import {Release, GlobalSelection} from 'app/types';
 import TimeSince from 'app/components/timeSince';
 import {t, tn} from 'app/locale';
 import {AvatarListWrapper} from 'app/components/avatar/avatarList';
@@ -26,10 +26,11 @@ type Props = {
   release: Release;
   orgSlug: string;
   location: Location;
+  selection: GlobalSelection;
   reloading: boolean;
 };
 
-const ReleaseCard = ({release, orgSlug, location, reloading}: Props) => {
+const ReleaseCard = ({release, orgSlug, location, selection, reloading}: Props) => {
   const {version, commitCount, lastDeploy, authors, dateCreated} = release;
 
   return (
@@ -107,7 +108,12 @@ const ReleaseCard = ({release, orgSlug, location, reloading}: Props) => {
         </StyledPanelItem>
       </PanelBody>
 
-      <ReleaseHealth release={release} orgSlug={orgSlug} location={location} />
+      <ReleaseHealth
+        release={release}
+        orgSlug={orgSlug}
+        location={location}
+        selection={selection}
+      />
     </StyledPanel>
   );
 };

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releaseHealth.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releaseHealth.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
+import partition from 'lodash/partition';
+import flatten from 'lodash/flatten';
 
-import {Release, GlobalSelection, ReleaseProject} from 'app/types';
+import {Release, GlobalSelection} from 'app/types';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import {PanelHeader, PanelBody, PanelItem} from 'app/components/panels';
 import {t, tn} from 'app/locale';
@@ -43,17 +45,12 @@ const ReleaseHealth = ({release, orgSlug, location, selection}: Props) => {
 
   // sort health rows inside release card alphabetically by project name,
   // but put the ones with project selected in global header to top
-  const selectedProjects: ReleaseProject[] = [];
-  const otherProjects: ReleaseProject[] = [];
-  release.projects
-    .sort((a, b) => a.slug.localeCompare(b.slug))
-    .forEach(p => {
-      if (selection.projects.includes(p.id)) {
-        selectedProjects.push(p);
-      } else {
-        otherProjects.push(p);
-      }
-    });
+  const sortedProjects = flatten(
+    partition(
+      release.projects.sort((a, b) => a.slug.localeCompare(b.slug)),
+      p => selection.projects.includes(p.id)
+    )
+  );
 
   return (
     <React.Fragment>
@@ -83,7 +80,7 @@ const ReleaseHealth = ({release, orgSlug, location, selection}: Props) => {
 
       <PanelBody>
         <ClippedBox clipHeight={200}>
-          {[...selectedProjects, ...otherProjects].map(project => {
+          {sortedProjects.map(project => {
             const {id, slug, healthData, newGroups} = project;
             const {
               hasHealthData,


### PR DESCRIPTION
Sort health rows inside release card alphabetically by project name, but put the ones with the project selected in the global header to top.