### PR TITLE
feat(releases): Added release meta endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -84,6 +84,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
                 "version": release.version,
                 "versionInfo": expose_version_info(release.version_info),
                 "projects": projects,
+                "newGroups": release.new_groups,
                 "deployCount": release.total_deploys,
                 "commitCount": release.commit_count,
                 "commitFilesChanged": commit_files_changed,

--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -45,7 +45,7 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
             commit_id__in=ReleaseCommit.objects.filter(release=release).values_list(
                 "commit_id", flat=True
             )
-        ).count()
+        ).values("filename").distinct().count()
 
         project_releases = ReleaseProject.objects.filter(release=release).values(
             "new_groups",

--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -1,0 +1,92 @@
+from __future__ import absolute_import
+
+from collections import defaultdict
+
+from rest_framework.response import Response
+
+from sentry.api.base import DocSection
+from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.models import (
+    Release,
+    CommitFileChange,
+    ReleaseFile,
+    ReleaseCommit,
+    ReleaseProject,
+    ProjectPlatform,
+)
+from sentry.api.serializers.models.release import expose_version_info
+
+
+class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
+    doc_section = DocSection.RELEASES
+
+    def get(self, request, organization, version):
+        """
+        Retrieve an Organization's Release's Associated Meta Data
+        `````````````````````````````````````````````````````````
+
+        The data returned from here is auxiliary meta data that the UI uses.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string version: the version identifier of the release.
+        :auth: required
+        """
+        try:
+            release = Release.objects.get(organization_id=organization.id, version=version)
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        if not self.has_release_permission(request, organization, release):
+            raise ResourceDoesNotExist
+
+        commit_files_changed = CommitFileChange.objects.filter(
+            commit_id__in=ReleaseCommit.objects.filter(release=release).values_list(
+                "commit_id", flat=True
+            )
+        ).count()
+
+        project_releases = ReleaseProject.objects.filter(release=release).values(
+            "new_groups",
+            "release_id",
+            "release__version",
+            "project__slug",
+            "project__name",
+            "project__id",
+            "project__platform",
+        )
+
+        platforms = ProjectPlatform.objects.filter(
+            project_id__in=set(x["project__id"] for x in project_releases)
+        ).values_list("project_id", "platform")
+        platforms_by_project = defaultdict(list)
+        for project_id, platform in platforms:
+            platforms_by_project[project_id].append(platform)
+
+        # This must match what is returned from the `Release` serializer
+        projects = [
+            {
+                "id": pr["project__id"],
+                "slug": pr["project__slug"],
+                "name": pr["project__name"],
+                "newGroups": pr["new_groups"],
+                "platform": pr["project__platform"],
+                "platforms": platforms_by_project.get(pr["project__id"]) or [],
+            }
+            for pr in project_releases
+        ]
+
+        release_file_count = ReleaseFile.objects.filter(release=release).count()
+
+        return Response(
+            {
+                "version": release.version,
+                "versionInfo": expose_version_info(release.version_info),
+                "projects": projects,
+                "deployCount": release.total_deploys,
+                "commitCount": release.commit_count,
+                "commitFilesChanged": commit_files_changed,
+                "releaseFileCount": release_file_count,
+            }
+        )

--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -15,6 +15,7 @@ from sentry.models import (
     ReleaseProject,
     ProjectPlatform,
 )
+
 from sentry.api.serializers.models.release import expose_version_info
 
 
@@ -41,11 +42,16 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        commit_files_changed = CommitFileChange.objects.filter(
-            commit_id__in=ReleaseCommit.objects.filter(release=release).values_list(
-                "commit_id", flat=True
+        commit_files_changed = (
+            CommitFileChange.objects.filter(
+                commit_id__in=ReleaseCommit.objects.filter(release=release).values_list(
+                    "commit_id", flat=True
+                )
             )
-        ).values("filename").distinct().count()
+            .values("filename")
+            .distinct()
+            .count()
+        )
 
         project_releases = ReleaseProject.objects.filter(release=release).values(
             "new_groups",

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -24,6 +24,29 @@ from sentry.models import (
 from sentry.utils.compat import zip
 
 
+def expose_version_info(info):
+    if info is None:
+        return None
+    version = {"raw": info["version_raw"]}
+    if info["version_parsed"]:
+        version.update(
+            {
+                "major": info["version_parsed"]["major"],
+                "minor": info["version_parsed"]["minor"],
+                "patch": info["version_parsed"]["patch"],
+                "pre": info["version_parsed"]["pre"],
+                "buildCode": info["version_parsed"]["build_code"],
+                "components": info["version_parsed"]["components"],
+            }
+        )
+    return {
+        "package": info["package"],
+        "version": version,
+        "description": info["description"],
+        "buildHash": info["build_hash"],
+    }
+
+
 def get_users_for_authors(organization_id, authors, user=None):
     """
     Returns a dictionary of author_id => user, if a Sentry
@@ -324,28 +347,6 @@ class ReleaseSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
-        def expose_version_info(info):
-            if info is None:
-                return None
-            version = {"raw": info["version_raw"]}
-            if info["version_parsed"]:
-                version.update(
-                    {
-                        "major": info["version_parsed"]["major"],
-                        "minor": info["version_parsed"]["minor"],
-                        "patch": info["version_parsed"]["patch"],
-                        "pre": info["version_parsed"]["pre"],
-                        "buildCode": info["version_parsed"]["build_code"],
-                        "components": info["version_parsed"]["components"],
-                    }
-                )
-            return {
-                "package": info["package"],
-                "version": version,
-                "description": info["description"],
-                "buildHash": info["build_hash"],
-            }
-
         def expose_health_data(data):
             if not data:
                 return None

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -143,6 +143,7 @@ from .endpoints.organization_recent_searches import OrganizationRecentSearchesEn
 from .endpoints.organization_release_assemble import OrganizationReleaseAssembleEndpoint
 from .endpoints.organization_release_commits import OrganizationReleaseCommitsEndpoint
 from .endpoints.organization_release_details import OrganizationReleaseDetailsEndpoint
+from .endpoints.organization_release_meta import OrganizationReleaseMetaEndpoint
 from .endpoints.organization_release_file_details import OrganizationReleaseFileDetailsEndpoint
 from .endpoints.organization_release_files import OrganizationReleaseFilesEndpoint
 from .endpoints.organization_releases import OrganizationReleasesEndpoint
@@ -966,6 +967,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/$",
                     OrganizationReleaseDetailsEndpoint.as_view(),
                     name="sentry-api-0-organization-release-details",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/meta/$",
+                    OrganizationReleaseMetaEndpoint.as_view(),
+                    name="sentry-api-0-organization-release-meta",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/assemble/$",

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -886,7 +886,17 @@ export type Release = {
   owner?: any; // TODO(ts)
   newGroups: number;
   projects: ReleaseProject[];
+  versionInfo: VersionInfo;
 } & BaseRelease;
+
+export type BaseRelease = {
+  dateReleased: string;
+  url: string;
+  dateCreated: string;
+  version: string;
+  shortVersion: string;
+  ref: string;
+};
 
 export type ReleaseProject = {
   slug: string;
@@ -898,13 +908,21 @@ export type ReleaseProject = {
   healthData: Health;
 };
 
-export type BaseRelease = {
-  dateReleased: string;
-  url: string;
-  dateCreated: string;
+export type ReleaseMeta = {
+  commitCount: number;
+  commitFilesChanged: number;
+  deployCount: number;
+  releaseFileCount: number;
   version: string;
-  shortVersion: string;
-  ref: string;
+  projects: ReleaseProject[];
+  versionInfo: VersionInfo;
+};
+
+export type VersionInfo = {
+  buildHash: string | null;
+  description: string;
+  package: string | null;
+  version: {raw: string};
 };
 
 export type Deploy = {

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
@@ -69,15 +69,15 @@ class ReleasesV2Detail extends AsyncView<Props, State> {
   getDefaultState() {
     return {
       ...super.getDefaultState(),
+      deploys: [],
     };
   }
 
-  getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {organization, location, params} = this.props;
+  getEndpoints() {
+    const {organization, location, params, releaseMeta} = this.props;
 
     const query = {
       ...pick(location.query, [...Object.values(URL_PARAM)]),
-      // TODO(releasesV2): summaryStatsPeriod + healthStatsPeriod?
       health: 1,
     };
 
@@ -85,10 +85,15 @@ class ReleasesV2Detail extends AsyncView<Props, State> {
       params.release
     )}/`;
 
-    return [
+    const endpoints: ReturnType<AsyncView['getEndpoints']> = [
       ['release', basePath, {query}],
-      ['deploys', `${basePath}deploys/`],
     ];
+
+    if (releaseMeta.deployCount > 0) {
+      endpoints.push(['deploys', `${basePath}deploys/`]);
+    }
+
+    return endpoints;
   }
 
   renderError(...args) {

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/index.tsx
@@ -4,7 +4,14 @@ import pick from 'lodash/pick';
 import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
-import {Organization, Release, ReleaseProject, Deploy, GlobalSelection} from 'app/types';
+import {
+  Organization,
+  Release,
+  ReleaseProject,
+  ReleaseMeta,
+  Deploy,
+  GlobalSelection,
+} from 'app/types';
 import AsyncView from 'app/views/asyncView';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
@@ -27,7 +34,7 @@ type ReleaseContext = {
   release: Release;
   project: ReleaseProject;
   deploys: Deploy[];
-  releaseProjects: ReleaseProject[];
+  releaseMeta: ReleaseMeta;
 };
 const ReleaseContext = React.createContext<ReleaseContext>({} as ReleaseContext);
 
@@ -39,7 +46,7 @@ type RouteParams = {
 type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
   selection: GlobalSelection;
-  releaseProjects: ReleaseProject[];
+  releaseMeta: ReleaseMeta;
 };
 
 type State = {
@@ -111,7 +118,7 @@ class ReleasesV2Detail extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {organization, location, selection, releaseProjects} = this.props;
+    const {organization, location, selection, releaseMeta} = this.props;
     const {release, deploys, reloading} = this.state;
     const project = release?.projects.find(p => p.id === selection.projects[0]);
 
@@ -131,10 +138,11 @@ class ReleasesV2Detail extends AsyncView<Props, State> {
             orgId={organization.slug}
             release={release}
             project={project}
+            releaseMeta={releaseMeta}
           />
 
           <ContentBox>
-            <ReleaseContext.Provider value={{release, project, deploys, releaseProjects}}>
+            <ReleaseContext.Provider value={{release, project, deploys, releaseMeta}}>
               {this.props.children}
             </ReleaseContext.Provider>
           </ContentBox>
@@ -144,7 +152,7 @@ class ReleasesV2Detail extends AsyncView<Props, State> {
   }
 }
 
-class ReleasesV2DetailContainer extends AsyncComponent<Omit<Props, 'releaseProjects'>> {
+class ReleasesV2DetailContainer extends AsyncComponent<Omit<Props, 'releaseMeta'>> {
   shouldReload = true;
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
@@ -152,10 +160,10 @@ class ReleasesV2DetailContainer extends AsyncComponent<Omit<Props, 'releaseProje
     // fetch projects this release belongs to
     return [
       [
-        'release',
+        'releaseMeta',
         `/organizations/${organization.slug}/releases/${encodeURIComponent(
           params.release
-        )}/`,
+        )}/meta/`,
       ],
     ];
   }
@@ -201,7 +209,8 @@ class ReleasesV2DetailContainer extends AsyncComponent<Omit<Props, 'releaseProje
 
   renderBody() {
     const {organization, params, router} = this.props;
-    const {projects} = this.state.release;
+    const {releaseMeta} = this.state;
+    const {projects} = releaseMeta;
 
     if (this.isProjectMissingInUrl()) {
       return (
@@ -224,7 +233,7 @@ class ReleasesV2DetailContainer extends AsyncComponent<Omit<Props, 'releaseProje
         showProjectSettingsLink
         projectsFooterMessage={this.renderProjectsFooterMessage()}
       >
-        <ReleasesV2Detail {...this.props} releaseProjects={projects} />
+        <ReleasesV2Detail {...this.props} releaseMeta={releaseMeta} />
       </GlobalSelectionHeader>
     );
   }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -75,7 +75,7 @@ class ReleaseOverview extends AsyncView<Props> {
 
     return (
       <ReleaseContext.Consumer>
-        {({release, project, deploys, releaseProjects}) => {
+        {({release, project, deploys, releaseMeta}) => {
           const {commitCount, version} = release;
           const {hasHealthData} = project.healthData || {};
           const hasDiscover = organization.features.includes('discover-basic');
@@ -128,9 +128,11 @@ class ReleaseOverview extends AsyncView<Props> {
                         projectSlug={project.slug}
                       />
                     )}
-                    {releaseProjects.length > 1 && (
+                    {releaseMeta.projects.length > 1 && (
                       <OtherProjects
-                        projects={releaseProjects.filter(p => p.slug !== project.slug)}
+                        projects={releaseMeta.projects.filter(
+                          p => p.slug !== project.slug
+                        )}
                         location={location}
                       />
                     )}

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseHeader.tsx
@@ -7,7 +7,7 @@ import {t} from 'app/locale';
 import ListLink from 'app/components/links/listLink';
 import ExternalLink from 'app/components/links/externalLink';
 import NavTabs from 'app/components/navTabs';
-import {Release, ReleaseProject} from 'app/types';
+import {Release, ReleaseProject, ReleaseMeta} from 'app/types';
 import Version from 'app/components/version';
 import Clipboard from 'app/components/clipboard';
 import {IconCopy, IconOpen} from 'app/icons';
@@ -27,10 +27,12 @@ type Props = {
   orgId: string;
   release: Release;
   project: ReleaseProject;
+  releaseMeta: ReleaseMeta;
 };
 
-const ReleaseHeader = ({location, orgId, release, project}: Props) => {
+const ReleaseHeader = ({location, orgId, release, project, releaseMeta}: Props) => {
   const {version, newGroups, url, lastDeploy, dateCreated} = release;
+  const {commitCount, commitFilesChanged, releaseFileCount} = releaseMeta;
   const {hasHealthData, sessionsCrashed} = project.healthData;
 
   const releasePath = `/organizations/${orgId}/releases/${encodeURIComponent(version)}/`;
@@ -40,14 +42,29 @@ const ReleaseHeader = ({location, orgId, release, project}: Props) => {
     {
       title: (
         <React.Fragment>
-          {t('Commits')}{' '}
-          <NavTabsBadge text={formatAbbreviatedNumber(release.commitCount)} />
+          {t('Commits')} <NavTabsBadge text={formatAbbreviatedNumber(commitCount)} />
         </React.Fragment>
       ),
       to: `${releasePath}commits/`,
     },
-    {title: t('Files Changed'), to: `${releasePath}files-changed/`},
-    {title: t('Artifacts'), to: `${releasePath}artifacts/`},
+    {
+      title: (
+        <React.Fragment>
+          {t('Files Changed')}
+          <NavTabsBadge text={formatAbbreviatedNumber(commitFilesChanged)} />
+        </React.Fragment>
+      ),
+      to: `${releasePath}files-changed/`,
+    },
+    {
+      title: (
+        <React.Fragment>
+          {t('Artifacts')}
+          <NavTabsBadge text={formatAbbreviatedNumber(releaseFileCount)} />
+        </React.Fragment>
+      ),
+      to: `${releasePath}artifacts/`,
+    },
   ];
 
   return (

--- a/tests/sentry/api/endpoints/test_organization_release_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_release_meta.py
@@ -1,0 +1,88 @@
+from __future__ import absolute_import
+
+import json
+from django.core.urlresolvers import reverse
+
+from sentry.models import (
+    File,
+    Release,
+    ReleaseCommit,
+    ReleaseFile,
+    Repository,
+    Commit,
+    CommitFileChange,
+)
+from sentry.testutils import APITestCase
+
+
+class ReleaseMetaTest(APITestCase):
+    def test_multiple_projects(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        team2 = self.create_team(organization=org)
+
+        project = self.create_project(teams=[team1], organization=org)
+        project2 = self.create_project(teams=[team2], organization=org)
+
+        release = Release.objects.create(organization_id=org.id, version="abcabcabc")
+        release.add_project(project)
+        release.add_project(project2)
+
+        ReleaseFile.objects.create(
+            organization_id=project.organization_id,
+            release=release,
+            file=File.objects.create(name="application.js", type="release.file"),
+            name="http://example.com/application.js",
+        )
+
+        repo = Repository.objects.create(organization_id=project.organization_id, name=project.name)
+        commit = Commit.objects.create(
+            organization_id=project.organization_id, repository_id=repo.id, key="a" * 40
+        )
+        commit2 = Commit.objects.create(
+            organization_id=project.organization_id, repository_id=repo.id, key="b" * 40
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id, release=release, commit=commit, order=1
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id, release=release, commit=commit2, order=0
+        )
+        CommitFileChange.objects.create(
+            organization_id=project.organization_id, commit=commit, filename=".gitignore", type="M"
+        )
+        CommitFileChange.objects.create(
+            organization_id=project.organization_id,
+            commit=commit2,
+            filename="/static/js/widget.js",
+            type="A",
+        )
+
+        release.commit_count = 2
+        release.total_deploys = 1
+        release.new_groups = 42
+        release.save()
+
+        self.create_member(teams=[team1, team2], user=user, organization=org)
+
+        self.login_as(user=user)
+
+        url = reverse(
+            "sentry-api-0-organization-release-meta",
+            kwargs={"organization_slug": org.slug, "version": release.version},
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+
+        data = json.loads(response.content)
+        assert data["deployCount"] == 1
+        assert data["commitCount"] == 2
+        assert data["newGroups"] == 42
+        assert data["commitFilesChanged"] == 2
+        assert data["releaseFileCount"] == 1
+        assert len(data["projects"]) == 2


### PR DESCRIPTION
This adds a meta endpoint that has summary information for a release.  This also
includes data that is not included in the main endpoint like the artifact count
and others.  This endpoint exists purely for the UI.

Tests will follow if we want to use this.

#sync-getsentry