### PR TITLE
feat: Add rrweb.active tag to Sentry events

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -44,7 +44,6 @@ function getSentryIntegrations(hasReplays: boolean = false) {
     // TODO(ts): The type returned by SentryRRWeb seems to be somewhat
     // incompatible. It's a newer plugin, so this can be expected, but we
     // should fix.
-    // Only use this in prod as there seem to be issues with hot reload in dev
     integrations.push(
       new SentryRRWeb({
         checkoutEveryNms: 60 * 1000, // 60 seconds
@@ -71,7 +70,7 @@ const tracesSampleRate = config ? config.apmSampling : 0;
 const hasReplays =
   window.__SENTRY__USER &&
   window.__SENTRY__USER.isStaff &&
-  process.env.NODE_ENV === 'production';
+  !!process.env.DISABLE_RR_WEB;
 
 Sentry.init({
   ...window.__SENTRY__OPTIONS,

--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -27,7 +27,7 @@ import Main from 'app/main';
 import ajaxCsrfSetup from 'app/utils/ajaxCsrfSetup';
 import plugins from 'app/plugins';
 
-function getSentryIntegrations() {
+function getSentryIntegrations(hasReplays: boolean = false) {
   const integrations = [
     new ExtraErrorData({
       // 6 is arbitrary, seems like a nice number
@@ -37,21 +37,19 @@ function getSentryIntegrations() {
       tracingOrigins: ['localhost', 'sentry.io', /^\//],
     }),
   ];
-  if (window.__SENTRY__USER && window.__SENTRY__USER.isStaff) {
+  if (hasReplays) {
     // eslint-disable-next-line no-console
     console.log('[sentry] Instrumenting session with rrweb');
 
     // TODO(ts): The type returned by SentryRRWeb seems to be somewhat
     // incompatible. It's a newer plugin, so this can be expected, but we
     // should fix.
-    if (process.env.NODE_ENV === 'production') {
-      // Only use this in prod as there seem to be issues with hot reload in dev
-      integrations.push(
-        new SentryRRWeb({
-          checkoutEveryNms: 60 * 1000, // 60 seconds
-        }) as any
-      );
-    }
+    // Only use this in prod as there seem to be issues with hot reload in dev
+    integrations.push(
+      new SentryRRWeb({
+        checkoutEveryNms: 60 * 1000, // 60 seconds
+      }) as any
+    );
   }
   return integrations;
 }
@@ -70,9 +68,14 @@ const config = ConfigStore.getConfig();
 
 const tracesSampleRate = config ? config.apmSampling : 0;
 
+const hasReplays =
+  window.__SENTRY__USER &&
+  window.__SENTRY__USER.isStaff &&
+  process.env.NODE_ENV === 'production';
+
 Sentry.init({
   ...window.__SENTRY__OPTIONS,
-  integrations: getSentryIntegrations(),
+  integrations: getSentryIntegrations(hasReplays),
   tracesSampleRate,
 });
 
@@ -81,6 +84,9 @@ if (window.__SENTRY__USER) {
 }
 if (window.__SENTRY__VERSION) {
   Sentry.setTag('sentry_version', window.__SENTRY__VERSION);
+}
+if (hasReplays) {
+  Sentry.setTag('rrweb.active', hasReplays ? 'yes' : 'no');
 }
 
 // Used for operational metrics to determine that the application js

--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -68,9 +68,7 @@ const config = ConfigStore.getConfig();
 const tracesSampleRate = config ? config.apmSampling : 0;
 
 const hasReplays =
-  window.__SENTRY__USER &&
-  window.__SENTRY__USER.isStaff &&
-  !!process.env.DISABLE_RR_WEB;
+  window.__SENTRY__USER && window.__SENTRY__USER.isStaff && !!process.env.DISABLE_RR_WEB;
 
 Sentry.init({
   ...window.__SENTRY__OPTIONS,


### PR DESCRIPTION
Add a new tag of rrweb.active with value yes/no to determine which events had rrweb active.