### PR TITLE
fix(ui): Fix environments potentially `null` in GlobalSelectionStore

### DIFF
--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -81,14 +81,14 @@ const GlobalSelectionStore = Reflux.createStore({
     this.trigger(this.get());
   },
 
-  updateEnvironments(environments = []) {
+  updateEnvironments(environments) {
     if (isEqual(this.selection.environments, environments)) {
       return;
     }
 
     this.selection = {
       ...this.selection,
-      environments,
+      environments: environments ?? [],
     };
     this.trigger(this.get());
   },


### PR DESCRIPTION
`updateEnvironments` action creator can be called with a `null` value, but store expected either an array or undefined. (TS would have helped here).

Fixes JAVASCRIPT-226V
Fixes JAVASCRIPT-226J