### PR TITLE
fix(ui): Fix Discover results facets for team plans

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -194,6 +194,7 @@ class Sidebar extends React.Component<Props, State> {
       'releases',
       'user-feedback',
       'discover',
+      'discover/results', // Team plans do not have query landing page
       'performance',
       'releasesv2',
     ].map(route => `/organizations/${this.props.organization.slug}/${route}/`);


### PR DESCRIPTION
Fixes a regression from https://github.com/getsentry/sentry/pull/18704.

Team plans do not have access to the query landing page, and instead goes
directly to an "All Events" query. The `fetchTagFacets` action uses the routers
`location` query params inteaad of global selection store (which ideally should
be changed, since we use that as our source of truth everywhere else). Since
we do not navigate with global selection store query params theres a bit of a
race condition where URL does not contain any query params while the GSH
component attempts to bring everything into the correct state, but `fetchTagFacets`
fetches before it becomes consistent.

Users affected by this are able to see everything correctly, except the facets.