### PR TITLE
meta: remove myself from requirements codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,10 +32,9 @@
 /docker             @getsentry/releases
 setup.py            @getsentry/releases
 setup.cfg           @getsentry/releases
-requirements*.txt   @joshuarli
 
 # Dev
-/config/                    @joshuarli
+/config/hooks               @joshuarli
 /scripts/                   @joshuarli
 Makefile                    @joshuarli
 .envrc                      @joshuarli


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry/pull/18853

This was fine for a while, but that's the second time this has become an issue.

And also /config/ as a whole, since I'm not very useful for the nginx/reverse_proxy stuff.
