### PR TITLE
feat(discover) Add deprecation warning for events v1

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -25,7 +25,6 @@ import {
   IconTelescope,
 } from 'app/icons';
 import {extractSelectionParameters} from 'app/components/organizations/globalSelectionHeader/utils';
-import {getDiscoverLandingUrl} from 'app/views/eventsV2/utils';
 import {hideSidebar, showSidebar} from 'app/actionCreators/preferences';
 import {t} from 'app/locale';
 import ConfigStore from 'app/stores/configStore';
@@ -34,6 +33,7 @@ import GuideAnchor from 'app/components/assistant/guideAnchor';
 import HookStore from 'app/stores/hookStore';
 import PreferencesStore from 'app/stores/preferencesStore';
 import localStorage from 'app/utils/localStorage';
+import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import withOrganization from 'app/utils/withOrganization';

--- a/src/sentry/static/sentry/app/utils/discover/urls.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/urls.tsx
@@ -1,3 +1,5 @@
+import {OrganizationSummary} from 'app/types';
+
 import EventView, {EventData} from './eventView';
 
 /**
@@ -45,4 +47,15 @@ export function eventDetailsRouteWithEventView({
     pathname,
     query: eventView.generateQueryStringObject(),
   };
+}
+
+/**
+ * Get the URL for the discover entry page which changes based on organization
+ * feature flags.
+ */
+export function getDiscoverLandingUrl(organization: OrganizationSummary): string {
+  if (organization.features.includes('discover-query')) {
+    return `/organizations/${organization.slug}/discover/queries/`;
+  }
+  return `/organizations/${organization.slug}/discover/results/`;
 }

--- a/src/sentry/static/sentry/app/views/discover/discover.tsx
+++ b/src/sentry/static/sentry/app/views/discover/discover.tsx
@@ -6,15 +6,18 @@ import styled from '@emotion/styled';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {getUtcDateString} from 'app/utils/dates';
 import {t, tct} from 'app/locale';
+import {IconWarning} from 'app/icons';
 import {updateProjects, updateDateTime} from 'app/actionCreators/globalSelection';
 import ConfigStore from 'app/stores/configStore';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
+import Alert from 'app/components/alert';
 import Feature from 'app/components/acl/feature';
+import Link from 'app/components/links/link';
 import PageHeading from 'app/components/pageHeading';
 import {Organization} from 'app/types';
 import space from 'app/styles/space';
 import localStorage from 'app/utils/localStorage';
-import {getDiscoverLandingUrl} from 'app/views/eventsV2/utils';
+import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
 
 import {
   DiscoverContainer,
@@ -406,6 +409,7 @@ export default class Discover extends React.Component<Props, State> {
     } = this.props;
 
     const shouldDisplayResult = resultManager.shouldDisplayResult();
+    const discoverUrl = getDiscoverLandingUrl(organization);
 
     return (
       <DiscoverContainer>
@@ -482,6 +486,11 @@ export default class Discover extends React.Component<Props, State> {
                     <PageHeading>{t('Discover')}</PageHeading>
                   </HeadingContainer>
                 </div>
+                <Alert type="warning" icon={<IconWarning size="sm" />}>
+                  This discover view is deprecated. Check out our new visualization and
+                  querying capabilities in <Link to={discoverUrl}>the new Discover</Link>{' '}
+                  today.
+                </Alert>
                 <Intro updateQuery={this.updateAndRunQuery} />
               </React.Fragment>
             )}

--- a/src/sentry/static/sentry/app/views/discover/discover.tsx
+++ b/src/sentry/static/sentry/app/views/discover/discover.tsx
@@ -477,6 +477,7 @@ export default class Discover extends React.Component<Props, State> {
                 savedQuery={savedQuery}
                 onToggleEdit={toggleEditMode}
                 onFetchPage={this.onFetchPage}
+                discover2Url={discoverUrl}
               />
             )}
             {!shouldDisplayResult && (

--- a/src/sentry/static/sentry/app/views/discover/result/index.tsx
+++ b/src/sentry/static/sentry/app/views/discover/result/index.tsx
@@ -7,7 +7,9 @@ import getDynamicText from 'app/utils/getDynamicText';
 import BarChart from 'app/components/charts/barChart';
 import LineChart from 'app/components/charts/lineChart';
 import PageHeading from 'app/components/pageHeading';
-import {IconEdit} from 'app/icons';
+import {IconEdit, IconWarning} from 'app/icons';
+import Alert from 'app/components/alert';
+import Link from 'app/components/links/link';
 
 import {
   getChartData,
@@ -40,6 +42,7 @@ import {SavedQuery} from '../types';
 type ResultProps = {
   data: any;
   location: any;
+  discover2Url: string;
   savedQuery: SavedQuery | null; // Provided if it's a saved search
   onFetchPage: (nextOrPrev: string) => void;
   onToggleEdit: () => void;
@@ -201,6 +204,7 @@ class Result extends React.Component<ResultProps, ResultState> {
   render() {
     const {
       data: {baseQuery, byDayQuery},
+      discover2Url,
       savedQuery,
       onFetchPage,
       utc,
@@ -228,6 +232,10 @@ class Result extends React.Component<ResultProps, ResultState> {
           <HeadingContainer>
             {savedQuery ? this.renderSavedQueryHeader() : this.renderQueryResultHeader()}
           </HeadingContainer>
+          <Alert type="warning" icon={<IconWarning size="sm" />}>
+            This discover view is deprecated. Check out our new visualization and querying
+            capabilities in <Link to={discover2Url}>the new Discover</Link> today.
+          </Alert>
           {this.renderToggle()}
         </div>
         <ResultInnerContainer ref={this.setDimensions}>

--- a/src/sentry/static/sentry/app/views/events/index.jsx
+++ b/src/sentry/static/sentry/app/views/events/index.jsx
@@ -6,16 +6,21 @@ import isEqual from 'lodash/isEqual';
 import {loadOrganizationTags} from 'app/actionCreators/tags';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {t} from 'app/locale';
+import Alert from 'app/components/alert';
 import FeatureBadge from 'app/components/featureBadge';
 import Feature from 'app/components/acl/feature';
+import Link from 'app/components/links/link';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
+import {IconWarning} from 'app/icons';
 import SentryTypes from 'app/sentryTypes';
 import PageHeading from 'app/components/pageHeading';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
+import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
 import {PageContent, PageHeader} from 'app/styles/organization';
+import space from 'app/styles/space';
 
 import SearchBar from './searchBar';
 
@@ -55,6 +60,7 @@ class EventsContainer extends React.Component {
 
   render() {
     const {organization, location, children, selection} = this.props;
+    const discoverUrl = getDiscoverLandingUrl(organization);
 
     return (
       <Feature
@@ -70,6 +76,13 @@ class EventsContainer extends React.Component {
                   <HeaderTitle>
                     {t('Events')} <FeatureBadge type="beta" />
                   </HeaderTitle>
+                </PageHeader>
+                <div>
+                  <Alert type="warning" icon={<IconWarning size="sm" />}>
+                    The events view is deprecated. Check out our new visualization and
+                    querying capabilities in{' '}
+                    <Link to={discoverUrl}>the new Discover</Link> today.
+                  </Alert>
                   <StyledSearchBar
                     organization={organization}
                     projectIds={selection.projects}
@@ -79,7 +92,7 @@ class EventsContainer extends React.Component {
                     )}
                     onSearch={this.handleSearch}
                   />
-                </PageHeader>
+                </div>
                 {children}
               </Body>
             </LightWeightNoProjectMessage>
@@ -104,4 +117,5 @@ const HeaderTitle = styled(PageHeading)`
 
 const StyledSearchBar = styled(SearchBar)`
   flex: 1;
+  margin-bottom: ${space(2)};
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
@@ -5,8 +5,7 @@ import {t} from 'app/locale';
 import {Event, Organization} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import Breadcrumbs, {Crumb} from 'app/components/breadcrumbs';
-
-import {getDiscoverLandingUrl} from './utils';
+import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
 
 type DefaultProps = {
   event: Event | undefined;

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -17,8 +17,8 @@ import Feature from 'app/components/acl/feature';
 import EventView from 'app/utils/discover/eventView';
 import withProjects from 'app/utils/withProjects';
 import Tooltip from 'app/components/tooltip';
+import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
 
-import {getDiscoverLandingUrl} from '../utils';
 import {handleCreateQuery, handleUpdateQuery, handleDeleteQuery} from './utils';
 
 type DefaultProps = {

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -420,13 +420,6 @@ function generateExpandedConditions(
   return stringifyQueryObject(parsedQuery);
 }
 
-export function getDiscoverLandingUrl(organization: OrganizationSummary): string {
-  if (organization.features.includes('discover-query')) {
-    return `/organizations/${organization.slug}/discover/queries/`;
-  }
-  return `/organizations/${organization.slug}/discover/results/`;
-}
-
 type FieldGeneratorOpts = {
   organization: OrganizationSummary;
   tagKeys?: string[] | null;

--- a/tests/js/spec/utils/discover/urls.spec.jsx
+++ b/tests/js/spec/utils/discover/urls.spec.jsx
@@ -1,0 +1,13 @@
+import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
+
+describe('getDiscoverLandingUrl', function() {
+  it('is correct for with discover-query and discover-basic features', function() {
+    const org = TestStubs.Organization({features: ['discover-query', 'discover-basic']});
+    expect(getDiscoverLandingUrl(org)).toBe('/organizations/org-slug/discover/queries/');
+  });
+
+  it('is correct for with only discover-basic feature', function() {
+    const org = TestStubs.Organization({features: ['discover-basic']});
+    expect(getDiscoverLandingUrl(org)).toBe('/organizations/org-slug/discover/results/');
+  });
+});

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -5,7 +5,6 @@ import {
   decodeColumnOrder,
   pushEventViewToLocation,
   getExpandedResults,
-  getDiscoverLandingUrl,
   downloadAsCsv,
 } from 'app/views/eventsV2/utils';
 import {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
@@ -435,18 +434,6 @@ describe('getExpandedResults()', function() {
     const event = {'project.name': 'whoosh'};
     const result = getExpandedResults(view, {}, event);
     expect(result.query).toEqual('project.name:whoosh');
-  });
-});
-
-describe('getDiscoverLandingUrl', function() {
-  it('is correct for with discover-query and discover-basic features', function() {
-    const org = TestStubs.Organization({features: ['discover-query', 'discover-basic']});
-    expect(getDiscoverLandingUrl(org)).toBe('/organizations/org-slug/discover/queries/');
-  });
-
-  it('is correct for with only discover-basic feature', function() {
-    const org = TestStubs.Organization({features: ['discover-basic']});
-    expect(getDiscoverLandingUrl(org)).toBe('/organizations/org-slug/discover/results/');
   });
 });
 


### PR DESCRIPTION
These views will be removed in the near future for most accounts as we  transition over to the new am plans and feature sets. The plans in production that have access to events and discover also have access to discover-basic and or discover-query

There is no firm date for removal so that we trap future us.


![Screen Shot 2020-06-26 at 11 53 01 AM](https://user-images.githubusercontent.com/24086/85877508-44cd1800-b7a5-11ea-8e71-0af9c302c86f.png)
![Screen Shot 2020-06-26 at 11 53 35 AM](https://user-images.githubusercontent.com/24086/85877512-4565ae80-b7a5-11ea-99e3-8518bb9c55fa.png)
