### PR TITLE
fix(metrics) Fix missing event metric parameter

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -120,6 +120,7 @@ export default class CellAction extends React.Component<Props, State> {
     trackAnalyticsEvent({
       eventKey: 'discover_v2.results.cellaction',
       eventName: 'Discoverv2: Cell Action Clicked',
+      organization_id: parseInt(organization.id, 10),
       action,
     });
     const nextView = eventView.clone();


### PR DESCRIPTION
I forgot to include organization_id before.