### PR TITLE
ref(ui): Fix styling of discover column-editor parameter inputs

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -5,6 +5,7 @@ import cloneDeep from 'lodash/cloneDeep';
 // eslint-disable-next-line import/named
 import {components, SingleValueProps, OptionProps} from 'react-select';
 
+import Input from 'app/views/settings/components/forms/controls/input';
 import SelectControl from 'app/components/forms/selectControl';
 import {SelectValue} from 'app/types';
 import {t} from 'app/locale';
@@ -459,14 +460,10 @@ class BufferedInput extends React.Component<InputProps, InputState> {
 }
 
 // Set a min-width to allow shrinkage in grid.
-const StyledInput = styled('input')`
+const StyledInput = styled(Input)`
   /* Match the height of the select boxes */
   height: 37px;
   min-width: 50px;
-
-  &:not([disabled='true']):invalid {
-    border-color: ${p => p.theme.red};
-  }
 `;
 
 const BlankSpace = styled('div')`


### PR DESCRIPTION
old

![image](https://user-images.githubusercontent.com/1421724/82101874-97091c80-96c2-11ea-828a-3fe0e30042a1.png)

new 

![image](https://user-images.githubusercontent.com/1421724/82101889-a12b1b00-96c2-11ea-85e0-00e5669da9b3.png)

more gray