### PR TITLE
fix(integrations): properly check email being an empty string

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -728,7 +728,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 for possible_user in possible_users:
                     email = possible_user.get("emailAddress")
                     # pull email from API if we can use it
-                    if email is None and self.use_email_scope:
+                    if not email and self.use_email_scope:
                         account_id = possible_user.get("accountId")
                         email = client.get_email(account_id)
                     # match on lowercase email

--- a/src/sentry/integrations/jira/webhooks.py
+++ b/src/sentry/integrations/jira/webhooks.py
@@ -34,7 +34,7 @@ def handle_assignee_change(integration, data, use_email_scope=False):
         return
     email = assignee.get("emailAddress")
     # pull email from API if we can use it
-    if email is None and use_email_scope:
+    if not email and use_email_scope:
         account_id = assignee.get("accountId")
         client = JiraApiClient(
             integration.metadata["base_url"],
@@ -44,7 +44,7 @@ def handle_assignee_change(integration, data, use_email_scope=False):
         email = client.get_email(account_id)
 
     # TODO(steve) check display name
-    if email is None:
+    if not email:
         logger.info(
             "missing-assignee-email",
             extra={"issue_key": issue_key, "integration_id": integration.id},

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -877,7 +877,7 @@ class JiraIntegrationTest(APITestCase):
         responses.add(
             responses.GET,
             "https://example.atlassian.net/rest/api/2/user/assignable/search",
-            json=[{"accountId": "deadbeef123", "displayName": "Dead Beef"}],
+            json=[{"accountId": "deadbeef123", "displayName": "Dead Beef", "emailAddress": ""}],
             match_querystring=False,
         )
 

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -164,7 +164,7 @@ class JiraWebhooksTest(APITestCase):
             "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
         ):
             data = json.loads(SAMPLE_EDIT_ISSUE_PAYLOAD_ASSIGNEE.strip())
-            data["issue"]["fields"]["assignee"].pop("emailAddress")
+            data["issue"]["fields"]["assignee"]["emailAddress"] = ""
             resp = self.client.post(path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
             assert resp.status_code == 200
             assert mock_sync_group_assignee_inbound.called
@@ -183,7 +183,7 @@ class JiraWebhooksTest(APITestCase):
             "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
         ):
             data = json.loads(SAMPLE_EDIT_ISSUE_PAYLOAD_ASSIGNEE.strip())
-            data["issue"]["fields"]["assignee"].pop("emailAddress")
+            data["issue"]["fields"]["assignee"]["emailAddress"] = ""
             resp = self.client.post(path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
             assert resp.status_code == 200
             assert not mock_sync_group_assignee_inbound.called


### PR DESCRIPTION
This fixes a bug where Jira gives us an empty string for the email instead of setting it to `None` which we use in 2 way syncing. This is a follow up to this PR: https://github.com/getsentry/sentry/pull/18709