### PR TITLE
ref(slack): Render multi-org note to users

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -256,7 +256,7 @@ class SlackReAuthIntro(PipelineView):
                 context={
                     "next_url": "%s%s" % (absolute_uri("/extensions/slack/setup/"), next_param),
                     "workspace": integration.name,
-                    "extra_orgs": extra_orgs.values(),
+                    "extra_orgs": extra_orgs,
                 },
                 request=request,
             )

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 
 import six
 
-from datetime import datetime
 from collections import namedtuple, defaultdict
 from django.db.models import Q
+from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.identity.pipeline import IdentityProviderPipeline
@@ -175,7 +175,7 @@ class SlackIntegrationProvider(IntegrationProvider):
         # are using in post_install to send messages to slack
         if state.get("integration_id"):
             metadata["installation_type"] = "migrated_to_bot"
-            metadata["migrated_at"] = six.text_type(datetime.utcnow()).split(".")[0]
+            metadata["migrated_at"] = timezone.now()
 
             post_install_data = {
                 "user_id": state["user_id"],

--- a/src/sentry/templates/sentry/integrations/slack-reauth-introduction.html
+++ b/src/sentry/templates/sentry/integrations/slack-reauth-introduction.html
@@ -26,6 +26,17 @@
     .section-info {
         font-size: 80%;
     }
+    .extra-org {
+        display: block;
+        margin-left: 10px;
+    }
+    .extra-org::before {
+        content: " • ";
+    }
+    .multi-org-alert {
+        display: flex;
+        flex-direction: column;
+    }
     .loader, .loader:after {
         border-radius: 50%;
         width: 10em;
@@ -110,6 +121,23 @@
             of slack channels in your alert rules this could take a hot minute...
          {% endblocktrans %}
      </p>
+
+    {% if extra_orgs %}
+    <p class="alert alert-block flex">
+        <i class="icon icon-exclamation"></i>
+        <span class="multi-org-alert">
+            <span>
+                {% blocktrans %}
+                    Your Slack workspace, <strong>{{workspace}}</strong>, is installed on additional organizations:
+                {% endblocktrans %}
+            </span>
+            {% for org in extra_orgs %}
+                <span class="extra-org">{{org}}</span>
+            {% endfor %}
+                {% trans "Once you've upgraded your integration, all other organizations with the same workspace will be upgraded as well." %}
+        </span>
+    </p>
+    {% endif %}
 
     <div id="loader"></div>
     <div class="form-actions clearfix">


### PR DESCRIPTION
**Context:**
For the Slack migration flow, users will start in one organization. However, it's possible that they will be upgrading a Slack workspace that is installed on other Sentry organizations. Since this upgrade updates the integration record, all organizations tied to that integration are essentially upgraded as well. 

This PR adds a note to the migration intro page to let the user which other organizations will be affected:
![Screen Shot 2020-05-18 at 11 05 04 AM](https://user-images.githubusercontent.com/15368179/82249825-53e7bd00-98ff-11ea-8437-6db6584ea974.png)

**How common is this case?** 
Roughly 5% of the integrations have more than one org attached. The assumption I'm making here is that many cases will be a "main" Sentry org and a "test" Sentry org that happens to have the same workspace. 

**How will users in the other organizations know about the upgrade?**
The `extra_org_ids` is binded to the state so that we can create audit log entries for those additional organizations as well as the organization the users started the migration in. 
