### PR TITLE
refs(alert_rules): Convert action handlers to use aggregate field

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -31,7 +31,9 @@ class AlertRuleSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         env = obj.snuba_query.environment
-        aggregation = aggregate_to_query_aggregation.get(obj.snuba_query.aggregate).value
+        aggregation = aggregate_to_query_aggregation.get(obj.snuba_query.aggregate, None)
+        if aggregation:
+            aggregation = aggregation.value
         return {
             "id": six.text_type(obj.id),
             "name": obj.name,

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -18,16 +18,17 @@ from sentry.testutils import TestCase, APITestCase
 
 class BaseAlertRuleSerializerTest(object):
     def assert_alert_rule_serialized(self, alert_rule, result, skip_dates=False):
+        aggregation = aggregate_to_query_aggregation.get(alert_rule.snuba_query.aggregate, None)
+        if aggregation:
+            aggregation = aggregation.value
+
         assert result["id"] == six.text_type(alert_rule.id)
         assert result["organizationId"] == six.text_type(alert_rule.organization_id)
         assert result["name"] == alert_rule.name
         assert result["dataset"] == alert_rule.snuba_query.dataset
         assert result["query"] == alert_rule.snuba_query.query
         assert result["aggregate"] == alert_rule.snuba_query.aggregate
-        assert (
-            result["aggregation"]
-            == aggregate_to_query_aggregation[alert_rule.snuba_query.aggregate].value
-        )
+        assert result["aggregation"] == aggregation
         assert result["timeWindow"] == alert_rule.snuba_query.time_window / 60
         assert result["resolution"] == alert_rule.snuba_query.resolution / 60
         assert result["thresholdPeriod"] == alert_rule.threshold_period

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -22,7 +22,6 @@ from sentry.incidents.models import (
 )
 from sentry.integrations.slack.utils import build_incident_attachment
 from sentry.models import Integration, UserOption
-from sentry.snuba.subscriptions import aggregate_to_query_aggregation
 from sentry.testutils import TestCase
 from sentry.utils.http import absolute_uri
 
@@ -87,6 +86,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
         action = self.create_alert_rule_trigger_action()
         incident = self.create_incident()
         handler = EmailActionHandler(action, incident, self.project)
+        aggregate = action.alert_rule_trigger.alert_rule.snuba_query.aggregate
         expected = {
             "link": absolute_uri(
                 reverse(
@@ -108,11 +108,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
                 )
             ),
             "incident_name": incident.title,
-            "aggregate": handler.query_aggregations_display[
-                aggregate_to_query_aggregation[
-                    action.alert_rule_trigger.alert_rule.snuba_query.aggregate
-                ]
-            ],
+            "aggregate": handler.query_aggregates_display.get(aggregate, aggregate),
             "query": action.alert_rule_trigger.alert_rule.snuba_query.query,
             "threshold": action.alert_rule_trigger.alert_threshold,
             "status": INCIDENT_STATUS[IncidentStatus(incident.status)],


### PR DESCRIPTION
This converts the slack and email action handlers to correctly use the aggregate field. We continue
to return the aggregation conversion from the serializer, but if we can't make the conversion then
the value will just be `None`.

Depends on https://github.com/getsentry/sentry/pull/18875