### PR TITLE
test: Replace require.requireActual and require.requireMock

### DIFF
--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -53,7 +53,7 @@ jest.mock('app/utils/domId');
 jest.mock('app/utils/withOrganization');
 jest.mock('scroll-to-element', () => jest.fn());
 jest.mock('react-router', () => {
-  const ReactRouter = require.requireActual('react-router');
+  const ReactRouter = jest.requireActual('react-router');
   return {
     IndexRedirect: ReactRouter.IndexRedirect,
     IndexRoute: ReactRouter.IndexRoute,
@@ -75,7 +75,7 @@ jest.mock('react-lazyload', () => {
 });
 
 jest.mock('react-virtualized', () => {
-  const ActualReactVirtualized = require.requireActual('react-virtualized');
+  const ActualReactVirtualized = jest.requireActual('react-virtualized');
   return {
     ...ActualReactVirtualized,
     AutoSizer: ({children}) => children({width: 100, height: 100}),
@@ -97,7 +97,7 @@ jest.mock('echarts-for-react/lib/core', () => {
 });
 
 jest.mock('@sentry/browser', () => {
-  const SentryBrowser = require.requireActual('@sentry/browser');
+  const SentryBrowser = jest.requireActual('@sentry/browser');
   return {
     init: jest.fn(),
     configureScope: jest.fn(),
@@ -148,7 +148,7 @@ window.$ = window.jQuery = jQuery;
 window.scrollTo = jest.fn();
 
 // This is very commonly used, so expose it globally.
-window.MockApiClient = require.requireMock('app/api').Client;
+window.MockApiClient = jest.requireMock('app/api').Client;
 
 window.TestStubs = {
   // react-router's 'router' context

--- a/tests/js/spec/components/charts/components/xAxis.spec.jsx
+++ b/tests/js/spec/components/charts/components/xAxis.spec.jsx
@@ -1,7 +1,7 @@
 import XAxis from 'app/components/charts/components/xAxis';
 
 jest.mock('moment', () => {
-  const moment = require.requireActual('moment-timezone');
+  const moment = jest.requireActual('moment-timezone');
   moment.tz.setDefault('America/Los_Angeles'); // Whatever timezone you want
   return moment;
 });


### PR DESCRIPTION
`require.requireActual` and `require.requireMock` have been removed in jest 26 in favor of `jest.requireActual` and `jest.requireMock`

https://jestjs.io/blog/2020/05/05/jest-26#other-breaking-changes-in-jest-26