### PR TITLE
feat(ui): Collapse similar frames in event grouping info

### DIFF
--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponent.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import isObject from 'lodash/isObject';
 import styled from '@emotion/styled';
 
 import space from 'app/styles/space';
 import {EventGroupComponent} from 'app/types';
 
 import {shouldInlineComponentValue} from './utils';
+import GroupingComponentStacktrace from './groupingComponentStacktrace';
+import GroupingComponentChildren from './groupingComponentChildren';
 
 type Props = {
   component: EventGroupComponent;
@@ -15,32 +16,10 @@ type Props = {
 const GroupingComponent = ({component, showNonContributing}: Props) => {
   const shouldInlineValue = shouldInlineComponentValue(component);
 
-  const children = (component.values as EventGroupComponent[]).map((value, idx) => {
-    let rv;
-    if (isObject(value)) {
-      // no point rendering such nodes at all, we never show them
-      if (!value.contributes && !value.hint && value.values.length === 0) {
-        return null;
-      }
-      // non contributing values are otherwise optional
-      if (!showNonContributing && !value.contributes) {
-        return null;
-      }
-      rv = (
-        <GroupingComponent component={value} showNonContributing={showNonContributing} />
-      );
-    } else {
-      rv = (
-        <GroupingValue valueType={component.name || component.id}>
-          {typeof value === 'string' || typeof value === 'number'
-            ? value
-            : JSON.stringify(value, null, 2)}
-        </GroupingValue>
-      );
-    }
-
-    return <GroupingComponentListItem key={idx}>{rv}</GroupingComponentListItem>;
-  });
+  const GroupingComponentListItems =
+    component.id === 'stacktrace'
+      ? GroupingComponentStacktrace
+      : GroupingComponentChildren;
 
   return (
     <GroupingComponentWrapper isContributing={component.contributes}>
@@ -50,7 +29,10 @@ const GroupingComponent = ({component, showNonContributing}: Props) => {
       </span>
 
       <GroupingComponentList isInline={shouldInlineValue}>
-        {children}
+        <GroupingComponentListItems
+          component={component}
+          showNonContributing={showNonContributing}
+        />
       </GroupingComponentList>
     </GroupingComponentWrapper>
   );
@@ -66,12 +48,12 @@ const GroupingComponentList = styled('ul')<{isInline: boolean}>`
   }
 `;
 
-const GroupingComponentListItem = styled('li')`
+export const GroupingComponentListItem = styled('li')`
   padding: 0;
   margin: ${space(0.25)} 0 ${space(0.25)} ${space(1.5)};
 `;
 
-const GroupingValue = styled('code')<{valueType: string}>`
+export const GroupingValue = styled('code')<{valueType: string}>`
   display: inline-block;
   margin: ${space(0.25)} ${space(0.5)} ${space(0.25)} 0;
   font-size: ${p => p.theme.fontSizeSmall};

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponent.tsx
@@ -72,7 +72,7 @@ export const GroupingValue = styled('code')<{valueType: string}>`
 const GroupingComponentWrapper = styled('div')<{isContributing: boolean}>`
   color: ${p => (p.isContributing ? null : p.theme.gray6)};
 
-  ${GroupingValue} {
+  ${GroupingValue}, button {
     opacity: ${p => (p.isContributing ? 1 : 0.6)};
   }
 `;

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import isObject from 'lodash/isObject';
+
+import {EventGroupComponent} from 'app/types';
+
+import GroupingComponent, {
+  GroupingValue,
+  GroupingComponentListItem,
+} from './groupingComponent';
+import {groupingComponentFilter} from './utils';
+
+type Props = {
+  component: EventGroupComponent;
+  showNonContributing: boolean;
+};
+
+const GroupingComponentChildren = ({component, showNonContributing}: Props) => {
+  return (
+    <React.Fragment>
+      {(component.values as EventGroupComponent[])
+        .filter(value => groupingComponentFilter(value, showNonContributing))
+        .map((value, idx) => (
+          <GroupingComponentListItem key={idx}>
+            {isObject(value) ? (
+              <GroupingComponent
+                component={value}
+                showNonContributing={showNonContributing}
+              />
+            ) : (
+              <GroupingValue valueType={component.name || component.id}>
+                {typeof value === 'string' || typeof value === 'number'
+                  ? value
+                  : JSON.stringify(value, null, 2)}
+              </GroupingValue>
+            )}
+          </GroupingComponentListItem>
+        ))}
+    </React.Fragment>
+  );
+};
+
+export default GroupingComponentChildren;

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -1,0 +1,80 @@
+// TODO(matej): I would like to refactor this to reusable component
+import React from 'react';
+
+import {tct} from 'app/locale';
+import Button from 'app/components/button';
+
+import {GroupingComponentListItem} from './groupingComponent';
+
+type DefaultProps = {
+  maxVisibleItems: number;
+};
+
+type Props = DefaultProps & {
+  items: React.ReactNode[];
+};
+
+type State = {
+  collapsed: boolean;
+};
+
+class GroupingComponentFrames extends React.Component<Props, State> {
+  static defaultProps: DefaultProps = {
+    maxVisibleItems: 2,
+  };
+
+  state: State = {
+    collapsed: true,
+  };
+
+  render() {
+    const {items, maxVisibleItems} = this.props;
+    const {collapsed} = this.state;
+
+    return (
+      <React.Fragment>
+        {items.map((item, index) => {
+          if (!collapsed || index < maxVisibleItems) {
+            return item;
+          }
+
+          if (index === maxVisibleItems) {
+            return (
+              <GroupingComponentListItem>
+                <Button
+                  size="small"
+                  priority="link"
+                  onClick={() => this.setState({collapsed: false})}
+                >
+                  +{' '}
+                  {tct('show [numberOfFrames] similiar', {
+                    numberOfFrames: items.length - maxVisibleItems,
+                  })}
+                </Button>
+              </GroupingComponentListItem>
+            );
+          }
+
+          return null;
+        })}
+
+        {!collapsed && items.length > maxVisibleItems && (
+          <GroupingComponentListItem>
+            <Button
+              size="small"
+              priority="link"
+              onClick={() => this.setState({collapsed: true})}
+            >
+              -{' '}
+              {tct('collapse [numberOfFrames] similiar', {
+                numberOfFrames: items.length - maxVisibleItems,
+              })}
+            </Button>
+          </GroupingComponentListItem>
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+export default GroupingComponentFrames;

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -1,8 +1,11 @@
 // TODO(matej): I would like to refactor this to reusable component
 import React from 'react';
+import styled from '@emotion/styled';
 
 import {tct} from 'app/locale';
 import Button from 'app/components/button';
+import space from 'app/styles/space';
+import {IconAdd, IconSubtract} from 'app/icons';
 
 import {GroupingComponentListItem} from './groupingComponent';
 
@@ -46,7 +49,7 @@ class GroupingComponentFrames extends React.Component<Props, State> {
                   priority="link"
                   onClick={() => this.setState({collapsed: false})}
                 >
-                  +{' '}
+                  <StyledIconAdd size="8px" />
                   {tct('show [numberOfFrames] similiar', {
                     numberOfFrames: items.length - maxVisibleItems,
                   })}
@@ -65,7 +68,7 @@ class GroupingComponentFrames extends React.Component<Props, State> {
               priority="link"
               onClick={() => this.setState({collapsed: true})}
             >
-              -{' '}
+              <StyledIconSubtract size="8px" />
               {tct('collapse [numberOfFrames] similiar', {
                 numberOfFrames: items.length - maxVisibleItems,
               })}
@@ -76,5 +79,13 @@ class GroupingComponentFrames extends React.Component<Props, State> {
     );
   }
 }
+
+const StyledIconAdd = styled(IconAdd)`
+  margin-right: ${space(0.5)};
+`;
+
+const StyledIconSubtract = styled(IconSubtract)`
+  margin-right: ${space(0.5)};
+`;
 
 export default GroupingComponentFrames;

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -1,10 +1,8 @@
 // TODO(matej): I would like to refactor this to reusable component
 import React from 'react';
-import styled from '@emotion/styled';
 
 import {tct} from 'app/locale';
 import Button from 'app/components/button';
-import space from 'app/styles/space';
 import {IconAdd, IconSubtract} from 'app/icons';
 
 import {GroupingComponentListItem} from './groupingComponent';
@@ -47,9 +45,9 @@ class GroupingComponentFrames extends React.Component<Props, State> {
                 <Button
                   size="small"
                   priority="link"
+                  icon={<IconAdd size="8px" />}
                   onClick={() => this.setState({collapsed: false})}
                 >
-                  <StyledIconAdd size="8px" />
                   {tct('show [numberOfFrames] similiar', {
                     numberOfFrames: items.length - maxVisibleItems,
                   })}
@@ -66,9 +64,9 @@ class GroupingComponentFrames extends React.Component<Props, State> {
             <Button
               size="small"
               priority="link"
+              icon={<IconSubtract size="8px" />}
               onClick={() => this.setState({collapsed: true})}
             >
-              <StyledIconSubtract size="8px" />
               {tct('collapse [numberOfFrames] similiar', {
                 numberOfFrames: items.length - maxVisibleItems,
               })}
@@ -79,13 +77,5 @@ class GroupingComponentFrames extends React.Component<Props, State> {
     );
   }
 }
-
-const StyledIconAdd = styled(IconAdd)`
-  margin-right: ${space(0.5)};
-`;
-
-const StyledIconSubtract = styled(IconSubtract)`
-  margin-right: ${space(0.5)};
-`;
 
 export default GroupingComponentFrames;

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import {EventGroupComponent} from 'app/types';
+
+import GroupingComponent, {GroupingComponentListItem} from './groupingComponent';
+import {groupingComponentFilter} from './utils';
+import GroupingComponentFrames from './groupingComponentFrames';
+
+type FrameGroup = {
+  key: string;
+  data: EventGroupComponent[];
+};
+
+type Props = {
+  component: EventGroupComponent;
+  showNonContributing: boolean;
+};
+
+const GroupingComponentStacktrace = ({component, showNonContributing}: Props) => {
+  const getFrameGroups = () => {
+    const frameGroups: FrameGroup[] = [];
+
+    (component.values as EventGroupComponent[])
+      .filter(value => groupingComponentFilter(value, showNonContributing))
+      .forEach(value => {
+        const key = (value.values as EventGroupComponent[])
+          .filter(v => groupingComponentFilter(v, showNonContributing))
+          .map(v => v.id)
+          .sort((a, b) => a.localeCompare(b))
+          .join('');
+
+        const lastGroup = frameGroups[frameGroups.length - 1];
+
+        if (lastGroup?.key === key) {
+          lastGroup.data.push(value);
+        } else {
+          frameGroups.push({key, data: [value]});
+        }
+      });
+
+    return frameGroups;
+  };
+
+  return (
+    <React.Fragment>
+      {getFrameGroups().map((group, index) => (
+        <GroupingComponentFrames
+          key={index}
+          items={group.data.map((v, idx) => (
+            <GroupingComponentListItem key={idx}>
+              <GroupingComponent
+                component={v}
+                showNonContributing={showNonContributing}
+              />
+            </GroupingComponentListItem>
+          ))}
+        />
+      ))}
+    </React.Fragment>
+  );
+};
+
+export default GroupingComponentStacktrace;

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/utils.tsx
@@ -17,3 +17,21 @@ export function hasNonContributingComponent(component: EventGroupComponent | und
 export function shouldInlineComponentValue(component: EventGroupComponent) {
   return component.values.every(value => !isObject(value));
 }
+
+export function groupingComponentFilter(
+  value: EventGroupComponent | string,
+  showNonContributing: boolean
+) {
+  if (isObject(value)) {
+    // no point rendering such nodes at all, we never show them
+    if (!value.contributes && !value.hint && value.values.length === 0) {
+      return false;
+    }
+    // non contributing values are otherwise optional
+    if (!showNonContributing && !value.contributes) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9060071/82325445-8d8df600-99db-11ea-9adf-a065e23e6479.png)

This PR adds ability to collapse similar frames in event grouping info.

Grouping info feature is behind `grouping-info` feature flag.