### PR TITLE
misc: Enable sending Transactions to /envelope

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -74,6 +74,7 @@ Sentry.init({
   ...window.__SENTRY__OPTIONS,
   integrations: getSentryIntegrations(hasReplays),
   tracesSampleRate,
+  _experiments: {useEnvelope: true},
 });
 
 if (window.__SENTRY__USER) {


### PR DESCRIPTION
Since @sentry/browser 5.16.0-beta.2, envelopes are opt-in as an experiment.

We may want to wait until https://github.com/getsentry/sentry-javascript/issues/2602 is investigated and fixed before merging this.