### PR TITLE
feat(workflow): Additional metrics for our SLO

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -85,13 +85,13 @@ def track_group_async_operation(function):
         try:
             response = function(*args, **kwargs)
             metrics.incr(
-                "group.update.http_response",
+                "group.update.async_response",
                 sample_rate=1.0,
                 tags={"status": 500 if response is False else 200},
             )
             return response
         except Exception:
-            metrics.incr("group.update.http_response", sample_rate=1.0, tags={"status": 500})
+            metrics.incr("group.update.async_response", sample_rate=1.0, tags={"status": 500})
             # Continue raising the error now that we've incr the metric
             raise
 

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -78,3 +78,21 @@ def retry(func=None, on=(Exception,), exclude=()):
         return wrapped
 
     return inner
+
+
+def track_group_async_operation(function):
+    def wrapper(*args, **kwargs):
+        try:
+            response = function(*args, **kwargs)
+        except Exception:
+            metrics.incr("group.update.async_task", sample_rate=1.0, tags={"status": 500})
+            # Continue raising the error now that we've incr the metric
+            raise
+        metrics.incr(
+            "group.update.async_task",
+            sample_rate=1.0,
+            tags={"status": 200 if response is True else 500},
+        )
+        return response
+
+    return wrapper

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -84,15 +84,15 @@ def track_group_async_operation(function):
     def wrapper(*args, **kwargs):
         try:
             response = function(*args, **kwargs)
+            metrics.incr(
+                "group.update.http_response",
+                sample_rate=1.0,
+                tags={"status": 500 if response is False else 200},
+            )
+            return response
         except Exception:
-            metrics.incr("group.update.async_task", sample_rate=1.0, tags={"status": 500})
+            metrics.incr("group.update.http_response", sample_rate=1.0, tags={"status": 500})
             # Continue raising the error now that we've incr the metric
             raise
-        metrics.incr(
-            "group.update.async_task",
-            sample_rate=1.0,
-            tags={"status": 200 if response is True else 500},
-        )
-        return response
 
     return wrapper

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from sentry.constants import ObjectStatus
 from sentry.exceptions import DeleteAborted
 from sentry.signals import pending_delete
-from sentry.tasks.base import instrumented_task, retry
+from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
 
 # in prod we run with infinite retries to recover from errors
 # in debug/development, we assume these tasks generally shouldn't fail
@@ -209,6 +209,7 @@ def delete_project(object_id, transaction_id=None, **kwargs):
     max_retries=MAX_RETRIES,
 )
 @retry(exclude=(DeleteAborted,))
+@track_group_async_operation
 def delete_groups(object_ids, transaction_id=None, eventstream_state=None, **kwargs):
     from sentry import deletions, eventstream
     from sentry.models import Group
@@ -235,6 +236,8 @@ def delete_groups(object_ids, transaction_id=None, eventstream_state=None, **kwa
         # all groups have been deleted
         if eventstream_state:
             eventstream.end_delete_groups(eventstream_state)
+
+    return True
 
 
 @instrumented_task(

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -237,8 +237,6 @@ def delete_groups(object_ids, transaction_id=None, eventstream_state=None, **kwa
         if eventstream_state:
             eventstream.end_delete_groups(eventstream_state)
 
-    return True
-
 
 @instrumented_task(
     name="sentry.tasks.deletion.delete_api_application",

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -199,11 +199,11 @@ def sync_status_outbound(group_id, external_issue_id, **kwargs):
             id=group_id, status__in=[GroupStatus.UNRESOLVED, GroupStatus.RESOLVED]
         )[0]
     except IndexError:
-        return
+        return False
 
     has_issue_sync = features.has("organizations:integrations-issue-sync", group.organization)
     if not has_issue_sync:
-        return
+        return False
 
     try:
         external_issue = ExternalIssue.objects.get(id=external_issue_id)
@@ -222,7 +222,6 @@ def sync_status_outbound(group_id, external_issue_id, **kwargs):
             id=integration.id,
             organization_id=external_issue.organization_id,
         )
-    return True
 
 
 @instrumented_task(
@@ -245,7 +244,6 @@ def kick_off_status_syncs(project_id, group_id, **kwargs):
         sync_status_outbound.apply_async(
             kwargs={"group_id": group_id, "external_issue_id": external_issue_id}
         )
-    return True
 
 
 @instrumented_task(

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -51,7 +51,7 @@ def merge_groups(
 
     if not (from_object_ids and to_object_id):
         logger.error("group.malformed.missing_params", extra={"transaction_id": transaction_id})
-        return
+        return False
 
     # Operate on one "from" group per task iteration. The task is recursed
     # until each group has been merged.
@@ -64,7 +64,7 @@ def merge_groups(
             "group.malformed.invalid_id",
             extra={"transaction_id": transaction_id, "old_object_ids": from_object_ids},
         )
-        return
+        return False
 
     if not recursed:
         logger.info(
@@ -194,7 +194,6 @@ def merge_groups(
     elif eventstream_state:
         # All `from_object_ids` have been merged!
         eventstream.end_merge(eventstream_state)
-    return True
 
 
 def _get_event_environment(event, project, cache):


### PR DESCRIPTION
This PR aims to make our SLO query more representative of what our endpoints are doing.

It adds additional logging around some of our async tasks for deleting, updating status, and merging issues. It also adds a couple of metrics on our group_details endpoints so we can also track success/failure there.