### PR TITLE
build(js): Change `app` alias to `sentry`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -61,3 +61,15 @@ f736793749a7e0a120a3d5f8630959864e553adb
 # https://github.com/getsentry/sentry/pull/22104
 # build(eslint): Add `simple-import-sort` eslint plugin #22104
 b8bf85948d4c4832c60ab31e9f1a5a3c39fd53cf
+
+
+# https://github.com/getsentry/sentry/pull/30178
+# the below are all changing import alias `app` to `sentry`
+816acaa36cffc042f7f0434434882e9232805ee2
+654fae1b23f20ed765977ccc5d037675b901c5f4
+bdb9c9d3a26fc8a3b73d47776bb5d3009947b46d
+04b705571c2045718a4ef297128145436d061914
+dcbd3b621ebb4660c42fe207dd4fc4094dd2bddd
+1661de6b7b3a4f35fa48f8998437f92b96d1550f
+98b8f571e16cf9f089bab42212ff610e66152b07
+a0f7dbbe7ccb3ca0b286d4ab4d83a5f2594d0b7d

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -12,8 +12,8 @@ import Sample from 'docs-ui/components/sample';
 import TableOfContents from 'docs-ui/components/tableOfContents';
 import {ThemeProvider} from 'emotion-theming';
 
-import GlobalStyles from 'app/styles/global';
-import {darkTheme, lightTheme} from 'app/utils/theme';
+import GlobalStyles from 'sentry/styles/global';
+import {darkTheme, lightTheme} from 'sentry/utils/theme';
 
 import PreviewGlobalStyles from './previewGlobalStyles';
 

--- a/.storybook/previewGlobalStyles.tsx
+++ b/.storybook/previewGlobalStyles.tsx
@@ -1,7 +1,7 @@
 import {css, Global} from '@emotion/react';
 
-import space from 'app/styles/space';
-import {Theme} from 'app/utils/theme';
+import space from 'sentry/styles/space';
+import {Theme} from 'sentry/utils/theme';
 
 const styles = (theme: Theme) => css`
   html,

--- a/config/tsconfig.build.json
+++ b/config/tsconfig.build.json
@@ -35,7 +35,6 @@
     "baseUrl": "../",
     "outDir": "../src/sentry/static/sentry/dist",
     "paths": {
-      "app/*": ["static/app/*"],
       "sentry/*": ["static/app/*"],
       "sentry-test/*": ["tests/js/sentry-test/*"],
       "sentry-images/*": ["static/images/*"],

--- a/config/webpack.chartcuterie.config.ts
+++ b/config/webpack.chartcuterie.config.ts
@@ -28,7 +28,7 @@ const config: webpack.Configuration = {
 
   target: 'node',
   entry: {
-    config: 'app/chartcuterie/config',
+    config: 'sentry/chartcuterie/config',
   },
 
   module: {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -58,7 +58,6 @@ const config: Config.InitialOptions = {
     'integration-docs-platforms':
       '<rootDir>/tests/fixtures/integration-docs/_platforms.json',
   },
-  modulePaths: ['<rootDir>/static'],
   setupFiles: [
     '<rootDir>/static/app/utils/silence-react-unsafe-warnings.ts',
     '<rootDir>/tests/js/throw-on-react-error.js',

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -10,10 +10,10 @@ import {Config} from 'sentry/types';
 import {init as initApiSentryClient} from 'sentry/utils/apiSentryClient';
 
 /**
- * We accept a routes argument here because importing `app/routes`
+ * We accept a routes argument here because importing `static/routes`
  * is expensive in regards to bundle size. Some entrypoints may opt to forgo
  * having routing instrumentation in order to have a smaller bundle size.
- * (e.g.  `app/views/integrationPipeline`)
+ * (e.g.  `static/views/integrationPipeline`)
  */
 function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
   const integrations = [

--- a/static/app/views/performance/landing/vitalsCards.tsx
+++ b/static/app/views/performance/landing/vitalsCards.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 
-import Tooltip from 'app/components/tooltip';
 import Card from 'sentry/components/card';
 import EventsRequest from 'sentry/components/charts/eventsRequest';
 import {HeaderTitle} from 'sentry/components/charts/styles';
@@ -14,6 +13,7 @@ import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import Sparklines from 'sentry/components/sparklines';
 import SparklinesLine from 'sentry/components/sparklines/line';
+import Tooltip from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -221,12 +221,12 @@ let appConfig: Configuration = {
      *
      * The order here matters for `getsentry`
      */
-    app: ['app/utils/statics-setup', 'app'],
+    app: ['sentry/utils/statics-setup', 'sentry'],
 
     /**
      * Pipeline View for integrations
      */
-    pipeline: ['app/utils/statics-setup', 'app/views/integrationPipeline'],
+    pipeline: ['sentry/utils/statics-setup', 'sentry/views/integrationPipeline'],
 
     /**
      * Legacy CSS Webpack appConfig for Django-powered views.
@@ -378,7 +378,6 @@ let appConfig: Configuration = {
 
   resolve: {
     alias: {
-      app: path.join(staticPrefix, 'app'),
       sentry: path.join(staticPrefix, 'app'),
       'sentry-images': path.join(staticPrefix, 'images'),
       'sentry-logos': path.join(sentryDjangoAppPath, 'images', 'logos'),


### PR DESCRIPTION
This changes the `app` alias we use for imports (that points to `static/app`) to `sentry`.  This makes it consistent with `getsentry` aliases.

Follow-up:
- [ ] Remove `app` alias from `getsentry`