### PR TITLE
fix(perf-views) Update headings on performance overview

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/sortLink.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/sortLink.tsx
@@ -5,55 +5,45 @@ import omit from 'lodash/omit';
 
 import {IconArrow} from 'app/icons';
 import Link from 'app/components/links/link';
-import {Field, Sort} from 'app/utils/discover/fields';
-import EventView, {MetaType, isFieldSortable} from 'app/utils/discover/eventView';
 
 export type Alignments = 'left' | 'right' | undefined;
+export type Directions = 'desc' | 'asc' | undefined;
 
 type Props = {
   align: Alignments;
-  field: Field;
-  eventView: EventView;
+  title: string;
+  direction: Directions;
+  canSort: boolean;
+
   generateSortLink: () => LocationDescriptorObject | undefined;
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
-  tableDataMeta?: MetaType; // Will not be defined if data is not loaded
 };
 
 class SortLink extends React.Component<Props> {
-  isCurrentColumnSorted(): Sort | undefined {
-    const {eventView, field, tableDataMeta} = this.props;
-    if (!tableDataMeta) {
-      return undefined;
-    }
-
-    return eventView.isFieldSorted(field, tableDataMeta);
-  }
-
   renderArrow() {
-    const currentSort = this.isCurrentColumnSorted();
-
-    if (!currentSort) {
+    const {direction} = this.props;
+    if (!direction) {
       return null;
     }
 
-    if (currentSort.kind === 'desc') {
+    if (direction === 'desc') {
       return <StyledIconArrow size="xs" direction="down" />;
     }
     return <StyledIconArrow size="xs" direction="up" />;
   }
 
   render() {
-    const {align, field, tableDataMeta, generateSortLink, onClick} = this.props;
+    const {align, title, canSort, generateSortLink, onClick} = this.props;
 
     const target = generateSortLink();
 
-    if (!target || !isFieldSortable(field, tableDataMeta)) {
-      return <StyledNonLink align={align}>{field.field}</StyledNonLink>;
+    if (!target || !canSort) {
+      return <StyledNonLink align={align}>{title}</StyledNonLink>;
     }
 
     return (
       <StyledLink align={align} to={target} onClick={onClick}>
-        {field.field} {this.renderArrow()}
+        {title} {this.renderArrow()}
       </StyledLink>
     );
   }

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -913,10 +913,11 @@ class EventView {
     };
   }
 
-  isFieldSorted(field: Field, tableMeta: MetaType): Sort | undefined {
-    const needle = this.sorts.find(sort => isSortEqualToField(sort, field, tableMeta));
-
-    return needle;
+  sortForField(field: Field, tableMeta: MetaType | undefined): Sort | undefined {
+    if (!tableMeta) {
+      return undefined;
+    }
+    return this.sorts.find(sort => isSortEqualToField(sort, field, tableMeta));
   }
 
   sortOnField(field: Field, tableMeta: MetaType): EventView {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/headerCell.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/headerCell.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import {ColumnValueType, getAggregateAlias} from 'app/utils/discover/fields';
+import {Alignments} from 'app/components/gridEditable/sortLink';
 
-import {Alignments} from '../sortLink';
 import {TableColumn, TableData, TableDataRow} from './types';
 
 type ChildrenProps = {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -6,6 +6,7 @@ import {Location, LocationDescriptorObject} from 'history';
 import {Organization, OrganizationSummary} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
+import SortLink from 'app/components/gridEditable/sortLink';
 import Feature from 'app/components/acl/feature';
 import DataExport, {ExportQueryType} from 'app/components/dataExport';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
@@ -16,6 +17,7 @@ import {openModal} from 'app/actionCreators/modal';
 import Link from 'app/components/links/link';
 import Tooltip from 'app/components/tooltip';
 import EventView, {
+  isFieldSortable,
   MetaType,
   pickRelevantLocationQueryStrings,
 } from 'app/utils/discover/eventView';
@@ -25,7 +27,6 @@ import {generateEventSlug, eventDetailsRouteWithEventView} from 'app/utils/disco
 import space from 'app/styles/space';
 
 import {downloadAsCsv, getExpandedResults, pushEventViewToLocation} from '../utils';
-import SortLink from '../sortLink';
 import ColumnEditModal, {modalCss} from './columnEditModal';
 import {TableColumn, TableData, TableDataRow} from './types';
 import HeaderCell from './headerCell';
@@ -128,13 +129,15 @@ class TableView extends React.Component<TableViewProps> {
               query: queryStringObject,
             };
           }
+          const currentSort = eventView.sortForField(field, tableMeta);
+          const canSort = isFieldSortable(field, tableMeta);
 
           return (
             <SortLink
               align={align}
-              field={field}
-              eventView={eventView}
-              tableDataMeta={tableMeta}
+              title={column.name}
+              direction={currentSort ? currentSort.kind : undefined}
+              canSort={canSort}
               generateSortLink={generateSortLink}
             />
           );

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -26,6 +26,17 @@ export const PERFORMANCE_EVENT_VIEW: Readonly<NewQuery> = {
   ],
   version: 2,
 };
+export const COLUMN_TITLES = [
+  'transaction',
+  'project',
+  'throughput',
+  'p50',
+  'p95',
+  'error rate',
+  'apdex(300)',
+  'users',
+  'user misery',
+];
 
 export function generatePerformanceQuery(location: Location): Readonly<NewQuery> {
   const extra: {[key: string]: string} = {};

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/table.tsx
@@ -11,8 +11,8 @@ import PanelTable from 'app/components/panels/panelTable';
 import Link from 'app/components/links/link';
 import {TableData, TableDataRow, TableColumn} from 'app/views/eventsV2/table/types';
 import HeaderCell from 'app/views/eventsV2/table/headerCell';
-import SortLink from 'app/views/eventsV2/sortLink';
-import EventView, {MetaType} from 'app/utils/discover/eventView';
+import EventView, {isFieldSortable, MetaType} from 'app/utils/discover/eventView';
+import SortLink from 'app/components/gridEditable/sortLink';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 import {getAggregateAlias} from 'app/utils/discover/fields';
 import {generateEventSlug, eventDetailsRouteWithEventView} from 'app/utils/discover/urls';
@@ -60,14 +60,16 @@ class SummaryContentTable extends React.Component<Props> {
       <HeaderCell column={column} tableMeta={tableMeta} key={index}>
         {({align}) => {
           const field = {field: column.name, width: column.width};
+          const currentSort = eventView.sortForField(field, tableMeta);
+          const canSort = isFieldSortable(field, tableMeta);
 
           return (
             <GridHeadCell>
               <SortLink
                 align={align}
-                field={field}
-                eventView={eventView}
-                tableDataMeta={tableMeta}
+                title={column.name}
+                direction={currentSort ? currentSort.kind : undefined}
+                canSort={canSort}
                 generateSortLink={generateSortLink}
               />
             </GridHeadCell>

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -1840,7 +1840,7 @@ describe('EventView.getQuery()', function() {
   });
 });
 
-describe('EventView.isFieldSorted()', function() {
+describe('EventView.sortForField()', function() {
   const state = {
     id: '1234',
     name: 'best query',
@@ -1853,18 +1853,15 @@ describe('EventView.isFieldSorted()', function() {
     statsPeriod: '14d',
     environment: ['staging'],
   };
-
+  const eventView = new EventView(state);
   const meta = {count: 'integer'};
 
   it('returns the sort when selected field is sorted', function() {
-    const eventView = new EventView(state);
-    expect(eventView).toMatchObject(state);
-
     const field = {
       field: 'count()',
     };
 
-    const actual = eventView.isFieldSorted(field, meta);
+    const actual = eventView.sortForField(field, meta);
 
     expect(actual).toEqual({
       field: 'count',
@@ -1873,14 +1870,19 @@ describe('EventView.isFieldSorted()', function() {
   });
 
   it('returns undefined when selected field is not sorted', function() {
-    const eventView = new EventView(state);
-    expect(eventView).toMatchObject(state);
-
     const field = {
       field: 'project.id',
     };
 
-    expect(eventView.isFieldSorted(field, meta)).toBe(void 0);
+    expect(eventView.sortForField(field, meta)).toBeUndefined();
+  });
+
+  it('returns undefined when no meta is provided', function() {
+    const field = {
+      field: 'project.id',
+    };
+
+    expect(eventView.sortForField(field, undefined)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
* Fix the broken sort links on performance overview.
* Make the SortLink component free of dependencies on EventView and move  it with the other GridEditable components.
* Add new titles for performance overview that match the terminology
  used elsewhere in performance views.