### PR TITLE
feat(discover/perf) Change from rp(m|s) to ep(m|s)

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -179,8 +179,8 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 column_map = {
                     "user_count": "count_unique(user)",
                     "event_count": "count()",
-                    "rpm()": "rpm(%d)" % rollup,
-                    "rps()": "rps(%d)" % rollup,
+                    "epm()": "epm(%d)" % rollup,
+                    "eps()": "eps(%d)" % rollup,
                 }
                 query_columns = [column_map.get(column, column) for column in columns]
                 reference_event = self.reference_event(

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1104,14 +1104,14 @@ FUNCTIONS = {
         "aggregate": [u"max", "transaction.duration", None],
         "result_type": "duration",
     },
-    "rps": {
-        "name": "rps",
+    "eps": {
+        "name": "eps",
         "args": [IntervalDefault("interval", 1, None)],
         "transform": u"divide(count(), {interval:g})",
         "result_type": "number",
     },
-    "rpm": {
-        "name": "rpm",
+    "epm": {
+        "name": "epm",
         "args": [IntervalDefault("interval", 60, None)],
         "transform": u"divide(count(), divide({interval:g}, 60))",
         "result_type": "number",
@@ -1264,7 +1264,7 @@ def resolve_function(field, match=None, params=None):
     function = FUNCTIONS[match.group("function")]
     columns = [c.strip() for c in match.group("columns").split(",") if len(c.strip()) > 0]
 
-    # Some functions can optionally take no parameters (rpm(), rps()). In that case use the
+    # Some functions can optionally take no parameters (epm(), eps()). In that case use the
     # passed in params to create a default argument if necessary.
     used_default = False
     if len(columns) == 0 and len(function["args"]) == 1:

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -494,6 +494,8 @@ OLD_FUNCTIONS_TO_NEW = {
     "latest_event": "latest_event()",
     "apdex": "apdex(300)",
     "impact": "impact(300)",
+    "rpm": "epm()",
+    "rps": "eps()",
 }
 
 

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -210,12 +210,12 @@ export const AGGREGATIONS = {
     outputType: 'number',
     isSortable: true,
   },
-  rps: {
+  eps: {
     parameters: [],
     outputType: 'number',
     isSortable: true,
   },
-  rpm: {
+  epm: {
     parameters: [],
     outputType: 'number',
     isSortable: true,
@@ -332,8 +332,8 @@ export const TRACING_FIELDS = [
   'apdex',
   'impact',
   'user_misery',
-  'rps',
-  'rpm',
+  'eps',
+  'epm',
 ];
 
 const AGGREGATE_PATTERN = /^([^\(]+)\((.*?)(?:\s*,\s*(.*))?\)$/;

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -30,8 +30,8 @@ const YAXIS_OPTIONS = [
   },
   {
     label: 'Throughput',
-    value: 'rpm()',
-    tooltip: PERFORMANCE_TERMS.rpm,
+    value: 'epm()',
+    tooltip: PERFORMANCE_TERMS.epm,
   },
 ];
 

--- a/src/sentry/static/sentry/app/views/performance/constants.tsx
+++ b/src/sentry/static/sentry/app/views/performance/constants.tsx
@@ -4,7 +4,7 @@ export const PERFORMANCE_TERMS: Record<string, string> = {
   apdex: t(
     'Apdex is the ratio of both satisfactory and tolerable response times to all response times.'
   ),
-  rpm: t('Throughput is the number of recorded transactions per minute (tpm).'),
+  epm: t('Throughput is the number of recorded events per minute (epm).'),
   errorRate: t(
     'Error rate is the percentage of recorded transactions that had a known and unsuccessful status.'
   ),

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -16,7 +16,7 @@ export const PERFORMANCE_EVENT_VIEW: Readonly<NewQuery> = {
   fields: [
     'transaction',
     'project',
-    'rpm()',
+    'epm()',
     'p50()',
     'p95()',
     'error_rate()',
@@ -39,7 +39,7 @@ export function generatePerformanceQuery(location: Location): Readonly<NewQuery>
   }
 
   if (!query?.sort) {
-    extra.orderby = '-rpm';
+    extra.orderby = '-epm';
   } else {
     const sort = query?.sort;
     extra.orderby =
@@ -47,7 +47,7 @@ export function generatePerformanceQuery(location: Location): Readonly<NewQuery>
         ? sort[sort.length - 1]
         : typeof sort === 'string'
         ? sort
-        : '-rpm';
+        : '-epm';
   }
 
   if (query?.query) {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -181,7 +181,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
             showLoading={false}
             query={eventView.query}
             includePrevious={false}
-            yAxis={['apdex(300)', 'rpm()', 'error_rate()']}
+            yAxis={['apdex(300)', 'epm()', 'error_rate()']}
           >
             {({results, errored, loading, reloading}) => {
               if (errored) {

--- a/tests/js/spec/views/events/utils/eventsRequest.spec.jsx
+++ b/tests/js/spec/views/events/utils/eventsRequest.spec.jsx
@@ -362,7 +362,7 @@ describe('EventsRequest', function() {
     it('supports multiple yAxis', async function() {
       doEventsRequest.mockImplementation(() =>
         Promise.resolve({
-          'rpm()': {
+          'epm()': {
             data: [
               [
                 new Date(),
@@ -390,7 +390,7 @@ describe('EventsRequest', function() {
       );
 
       wrapper = mount(
-        <EventsRequest {...DEFAULTS} includePrevious yAxis={['apdex()', 'rpm()']}>
+        <EventsRequest {...DEFAULTS} includePrevious yAxis={['apdex()', 'epm()']}>
           {mock}
         </EventsRequest>
       );
@@ -412,7 +412,7 @@ describe('EventsRequest', function() {
         expect.objectContaining({
           loading: false,
 
-          results: [generateExpected('rpm()'), generateExpected('apdex()')],
+          results: [generateExpected('epm()'), generateExpected('apdex()')],
         })
       );
     });

--- a/tests/js/spec/views/performance/data.spec.jsx
+++ b/tests/js/spec/views/performance/data.spec.jsx
@@ -10,7 +10,7 @@ describe('generatePerformanceQuery()', function() {
     expect(result).toEqual({
       ...PERFORMANCE_EVENT_VIEW,
 
-      orderby: '-rpm',
+      orderby: '-epm',
       range: '24h',
     });
   });
@@ -40,7 +40,7 @@ describe('generatePerformanceQuery()', function() {
     expect(result).toEqual({
       ...PERFORMANCE_EVENT_VIEW,
 
-      orderby: '-rpm',
+      orderby: '-epm',
     });
   });
 
@@ -55,7 +55,7 @@ describe('generatePerformanceQuery()', function() {
     expect(result).toEqual({
       ...PERFORMANCE_EVENT_VIEW,
 
-      orderby: '-rpm',
+      orderby: '-epm',
     });
   });
 });

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1294,8 +1294,8 @@ class GetSnubaQueryArgsTest(TestCase):
         assert [[["isNull", ["user.id"]], "=", 1], ["user.id", "!=", "123"]] == conditions[3]
 
     def test_function_with_default_arguments(self):
-        result = get_filter("rpm():>100", {"start": before_now(minutes=5), "end": before_now()})
-        assert result.having == [["rpm", ">", 100]]
+        result = get_filter("epm():>100", {"start": before_now(minutes=5), "end": before_now()})
+        assert result.having == [["epm", ">", 100]]
 
     def test_function_with_alias(self):
         result = get_filter("percentile(transaction.duration, 0.95):>100")
@@ -1515,12 +1515,12 @@ class ResolveFieldListTest(unittest.TestCase):
             in six.text_type(err)
         )
 
-    def test_rpm_function(self):
-        fields = ["rpm(3600)"]
+    def test_epm_function(self):
+        fields = ["epm(3600)"]
         result = resolve_field_list(fields, eventstore.Filter())
         assert result["selected_columns"] == []
         assert result["aggregations"] == [
-            ["divide(count(), divide(3600, 60))", None, "rpm_3600"],
+            ["divide(count(), divide(3600, 60))", None, "epm_3600"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
             ["transform(projectid, array(), array(), '')", None, "project.name"],
@@ -1528,45 +1528,45 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["groupby"] == []
 
         with pytest.raises(InvalidSearchQuery) as err:
-            fields = ["rpm(30)"]
+            fields = ["epm(30)"]
             resolve_field_list(fields, eventstore.Filter())
         assert (
-            "rpm(30): interval argument invalid: 30 must be greater than or equal to 60"
+            "epm(30): interval argument invalid: 30 must be greater than or equal to 60"
             in six.text_type(err)
         )
 
         with pytest.raises(InvalidSearchQuery) as err:
-            fields = ["rpm()"]
+            fields = ["epm()"]
             resolve_field_list(fields, eventstore.Filter())
-        assert "rpm(): invalid arguments: function called without default" in six.text_type(err)
+        assert "epm(): invalid arguments: function called without default" in six.text_type(err)
 
         with pytest.raises(InvalidSearchQuery) as err:
-            fields = ["rpm()"]
+            fields = ["epm()"]
             resolve_field_list(fields, eventstore.Filter(start="abc", end="def"))
-        assert "rpm(): invalid arguments: function called with invalid default" in six.text_type(
+        assert "epm(): invalid arguments: function called with invalid default" in six.text_type(
             err
         )
 
-        fields = ["rpm()"]
+        fields = ["epm()"]
         result = resolve_field_list(
             fields, eventstore.Filter(start=before_now(hours=2), end=before_now(hours=1))
         )
         assert result["selected_columns"] == []
         assert result["aggregations"] == [
-            ["divide(count(), divide(3600, 60))", None, "rpm"],
+            ["divide(count(), divide(3600, 60))", None, "epm"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
             ["transform(projectid, array(), array(), '')", None, "project.name"],
         ]
         assert result["groupby"] == []
 
-    def test_rps_function(self):
-        fields = ["rps(3600)"]
+    def test_eps_function(self):
+        fields = ["eps(3600)"]
         result = resolve_field_list(fields, eventstore.Filter())
 
         assert result["selected_columns"] == []
         assert result["aggregations"] == [
-            ["divide(count(), 3600)", None, "rps_3600"],
+            ["divide(count(), 3600)", None, "eps_3600"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project.id", "timestamp"], "projectid"],
             ["transform(projectid, array(), array(), '')", None, "project.name"],
@@ -1574,10 +1574,10 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["groupby"] == []
 
         with pytest.raises(InvalidSearchQuery) as err:
-            fields = ["rps(0)"]
+            fields = ["eps(0)"]
             result = resolve_field_list(fields, eventstore.Filter())
         assert (
-            "rps(0): interval argument invalid: 0 must be greater than or equal to 1"
+            "eps(0): interval argument invalid: 0 must be greater than or equal to 1"
             in six.text_type(err)
         )
 

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -192,7 +192,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
                         "transaction",
                         "transaction_status",
                         "project",
-                        "rpm()",
+                        "epm()",
                         "error_rate()",
                         "percentile(transaction.duration, 0.95)",
                     ],
@@ -275,7 +275,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
                         "transaction",
                         "transaction_status",
                         "project",
-                        "rpm()",
+                        "epm()",
                         "error_rate()",
                         "percentile(transaction.duration, 0.95)",
                     ],
@@ -325,7 +325,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
                         "transaction",
                         "transaction_status",
                         "project",
-                        "rpm()",
+                        "epm()",
                         "error_rate()",
                         "percentile(transaction.duration, 0.95)",
                     ],
@@ -370,7 +370,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
                         "transaction",
                         "transaction_status",
                         "project",
-                        "rpm()",
+                        "epm()",
                         "error_rate()",
                         "percentile(transaction.duration, 0.95)",
                     ],
@@ -415,7 +415,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
                         "transaction",
                         "transaction_status",
                         "project",
-                        "rpm()",
+                        "epm()",
                         "error_rate()",
                         "percentile(transaction.duration, 0.95)",
                     ],
@@ -749,20 +749,20 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
                     "start": iso_format(before_now(hours=2)),
                     "end": iso_format(before_now()),
                     "interval": "1h",
-                    "yAxis": ["rps()", "rpm()"],
+                    "yAxis": ["eps()", "epm()"],
                     "project": [self.project.id],
                 },
             )
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert len(response.data["rpm()"]["data"]) == 3
-        assert len(response.data["rps()"]["data"]) == 3
+        assert len(response.data["epm()"]["data"]) == 3
+        assert len(response.data["eps()"]["data"]) == 3
         assert [{"count": 3.0 / (3600.0 / 60.0)}] in [
-            attrs for time, attrs in response.data["rpm()"]["data"]
+            attrs for time, attrs in response.data["epm()"]["data"]
         ]
         assert [{"count": 3.0 / 3600.0}] in [
-            attrs for time, attrs in response.data["rps()"]["data"]
+            attrs for time, attrs in response.data["eps()"]["data"]
         ]
 
     @patch("django.utils.timezone.now")
@@ -790,21 +790,21 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
                     "start": iso_format(before_now(hours=2)),
                     "end": iso_format(before_now()),
                     "interval": "1h",
-                    "yAxis": ["rps()", "rpm()"],
+                    "yAxis": ["eps()", "epm()"],
                     "project": [self.project.id],
                 },
             )
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert len(response.data["rpm()"]["data"]) == 3
-        assert len(response.data["rps()"]["data"]) == 3
-        assert [attrs for time, attrs in response.data["rpm()"]["data"]] == [
+        assert len(response.data["epm()"]["data"]) == 3
+        assert len(response.data["eps()"]["data"]) == 3
+        assert [attrs for time, attrs in response.data["epm()"]["data"]] == [
             [{"count": 0}],
             [{"count": 0}],
             [{"count": 0}],
         ]
-        assert [attrs for time, attrs in response.data["rps()"]["data"]] == [
+        assert [attrs for time, attrs in response.data["eps()"]["data"]] == [
             [{"count": 0}],
             [{"count": 0}],
             [{"count": 0}],

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -239,7 +239,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             )
         assert response.status_code == 400, response.content
 
-    def test_throughput_rpm_hour_rollup(self):
+    def test_throughput_epm_hour_rollup(self):
         project = self.create_project()
         # Each of these denotes how many events to create in each hour
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -266,7 +266,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                     "start": iso_format(self.day_ago),
                     "end": iso_format(self.day_ago + timedelta(hours=6)),
                     "interval": "1h",
-                    "yAxis": "rpm()",
+                    "yAxis": "epm()",
                     "project": project.id,
                 },
             )
@@ -278,7 +278,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         for test in zip(event_counts, rows):
             assert test[1][1][0]["count"] == test[0] / (3600.0 / 60.0)
 
-    def test_throughput_rpm_day_rollup(self):
+    def test_throughput_epm_day_rollup(self):
         project = self.create_project()
         # Each of these denotes how many events to create in each minute
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -305,7 +305,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                     "start": iso_format(self.day_ago),
                     "end": iso_format(self.day_ago + timedelta(hours=6)),
                     "interval": "24h",
-                    "yAxis": "rpm()",
+                    "yAxis": "epm()",
                     "project": project.id,
                 },
             )
@@ -315,7 +315,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
 
         assert data[0][1][0]["count"] == sum(event_counts) / (86400.0 / 60.0)
 
-    def test_throughput_rps_minute_rollup(self):
+    def test_throughput_eps_minute_rollup(self):
         project = self.create_project()
         # Each of these denotes how many events to create in each minute
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -342,7 +342,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                     "start": iso_format(self.day_ago),
                     "end": iso_format(self.day_ago + timedelta(minutes=6)),
                     "interval": "1m",
-                    "yAxis": "rps()",
+                    "yAxis": "eps()",
                     "project": project.id,
                 },
             )
@@ -354,7 +354,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         for test in zip(event_counts, rows):
             assert test[1][1][0]["count"] == test[0] / 60.0
 
-    def test_throughput_rps_no_rollup(self):
+    def test_throughput_eps_no_rollup(self):
         project = self.create_project()
         # Each of these denotes how many events to create in each minute
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -381,7 +381,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                     "start": iso_format(self.day_ago),
                     "end": iso_format(self.day_ago + timedelta(minutes=1)),
                     "interval": "1s",
-                    "yAxis": "rps()",
+                    "yAxis": "eps()",
                     "project": project.id,
                 },
             )
@@ -570,7 +570,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                     "start": iso_format(self.day_ago),
                     "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                     "interval": "1h",
-                    "yAxis": ["user_count", "event_count", "rpm()", "rps()"],
+                    "yAxis": ["user_count", "event_count", "epm()", "eps()"],
                 },
                 format="json",
             )
@@ -958,7 +958,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             [{"count": 0}],
         ]
 
-    def test_top_events_with_rpm(self):
+    def test_top_events_with_epm(self):
         with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
@@ -966,7 +966,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "start": iso_format(self.day_ago),
                     "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                     "interval": "1h",
-                    "yAxis": "rpm()",
+                    "yAxis": "epm()",
                     "orderby": ["-count()"],
                     "field": ["message", "user.email", "count()"],
                     "topEvents": 5,
@@ -996,7 +996,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "start": iso_format(self.day_ago),
                     "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                     "interval": "1h",
-                    "yAxis": ["rpm()", "count()"],
+                    "yAxis": ["epm()", "count()"],
                     "orderby": ["-count()"],
                     "field": ["message", "user.email", "count()"],
                     "topEvents": 5,
@@ -1014,10 +1014,10 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                 ",".join([message, self.event_data[index]["data"]["user"].get("email", "None")])
             ]
             assert results["order"] == index
-            assert results["rpm()"]["order"] == 0
+            assert results["epm()"]["order"] == 0
             assert results["count()"]["order"] == 1
             assert [{"count": self.event_data[index]["count"] / (3600.0 / 60.0)}] in [
-                attrs for time, attrs in results["rpm()"]["data"]
+                attrs for time, attrs in results["epm()"]["data"]
             ]
 
             assert [{"count": self.event_data[index]["count"]}] in [

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1246,6 +1246,42 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert data[1]["transaction"] == event2.transaction
         assert data[1]["rpm"] == 0.5
 
+    def test_epm_function(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+
+        data = load_data("transaction")
+        data["transaction"] = "/aggregates/1"
+        data["timestamp"] = iso_format(before_now(minutes=1))
+        data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
+        event1 = self.store_event(data, project_id=project.id)
+
+        data = load_data("transaction")
+        data["transaction"] = "/aggregates/2"
+        data["timestamp"] = iso_format(before_now(minutes=1))
+        data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=3))
+        event2 = self.store_event(data, project_id=project.id)
+
+        with self.feature("organizations:discover-basic"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "field": ["transaction", "epm()"],
+                    "query": "event.type:transaction",
+                    "orderby": ["transaction"],
+                    "statsPeriod": "2m",
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 2
+        data = response.data["data"]
+        assert data[0]["transaction"] == event1.transaction
+        assert data[0]["epm"] == 0.5
+        assert data[1]["transaction"] == event2.transaction
+        assert data[1]["epm"] == 0.5
+
     def test_nonexistent_fields(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
Change from rpm/rps (requests per ...) to epm/eps (events per ...) to better
match what is actually displayed. Since Sentry is actually tracking events,
not requests, change the terminology to match.