### PR TITLE
feat(alert_rules): Allow `aggregate` to be passed to the alert rule create/update endpoints

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -7,7 +7,9 @@ import operator
 from rest_framework import serializers
 
 from django.db import transaction
+from django.utils import timezone
 
+from sentry.api.event_search import InvalidSearchQuery
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.serializers.rest_framework.environment import EnvironmentField
 from sentry.api.serializers.rest_framework.project import ProjectField
@@ -33,8 +35,11 @@ from sentry.incidents.models import (
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.models.user import User
-from sentry.snuba.models import QueryAggregations
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import QueryAggregations, QueryDatasets
 from sentry.snuba.subscriptions import aggregation_function_translations
+from sentry.snuba.tasks import build_snuba_filter
+from sentry.utils.snuba import raw_query
 from sentry.utils.compat import zip
 
 
@@ -280,7 +285,8 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         required=True, min_value=1, max_value=int(timedelta(days=1).total_seconds() / 60)
     )
     threshold_period = serializers.IntegerField(default=1, min_value=1, max_value=20)
-    aggregation = serializers.IntegerField(required=True)
+    aggregate = serializers.CharField(required=False, min_length=1)
+    aggregation = serializers.IntegerField(required=False)
 
     class Meta:
         model = AlertRule
@@ -290,6 +296,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             "time_window",
             "environment",
             "threshold_period",
+            "aggregate",
             "aggregation",
             "projects",
             "include_all_projects",
@@ -315,7 +322,61 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         This includes ensuring there is either 1 or 2 triggers, which each have actions, and have proper thresholds set.
         The critical trigger should both alert and resolve 'after' the warning trigger (whether that means > or < the value depends on threshold type).
         """
-        data["aggregate"] = aggregation_function_translations[data.pop("aggregation")]
+        if "aggregate" in data and "aggregation" in data:
+            # `aggregate` takes precedence over `aggregation`, so just drop `aggregation`
+            # if both are present.
+            data.pop("aggregation")
+        if "aggregation" in data:
+            data["aggregate"] = aggregation_function_translations[data.pop("aggregation")]
+        if "aggregate" in data:
+            project_id = data.get("projects")
+            if not project_id:
+                # We just need a valid project id from the org so that we can verify
+                # the query. We don't use the returned data anywhere, so it doesn't
+                # matter which.
+                project_id = list(self.context["organization"].project_set.all()[:1])
+            try:
+                snuba_filter = build_snuba_filter(
+                    # TODO: Stop hardcoding this once we support multiple datasets
+                    QueryDatasets.EVENTS,
+                    data["query"],
+                    data["aggregate"],
+                    data.get("environment"),
+                    params={
+                        "project_id": [p.id for p in project_id],
+                        "start": timezone.now() - timedelta(minutes=10),
+                        "end": timezone.now(),
+                    },
+                )
+            except (InvalidSearchQuery, ValueError) as e:
+                raise serializers.ValidationError(
+                    "Invalid Query or Aggregate: {}".format(e.message)
+                )
+            else:
+                if not snuba_filter.aggregations:
+                    raise serializers.ValidationError(
+                        "Invalid Aggregate: Please pass a valid function for aggregation"
+                    )
+
+                try:
+                    raw_query(
+                        aggregations=snuba_filter.aggregations,
+                        start=snuba_filter.start,
+                        end=snuba_filter.end,
+                        conditions=snuba_filter.conditions,
+                        filter_keys=snuba_filter.filter_keys,
+                        having=snuba_filter.having,
+                        dataset=Dataset.Events,
+                        limit=1,
+                        referrer="alertruleserializer.test_query",
+                    )
+                except Exception as e:
+                    raise serializers.ValidationError(
+                        "Invalid Query or Aggregate: {}".format(e.message)
+                    )
+
+        else:
+            raise serializers.ValidationError("Must pass `aggregation` or `aggregate`")
 
         triggers = data.get("triggers", [])
         if not triggers:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -74,7 +74,7 @@ class AlertRuleDetailsBase(object):
             data=data,
         )
 
-        assert serializer.is_valid()
+        assert serializer.is_valid(), serializer.errors
         alert_rule = serializer.save()
         return alert_rule
 


### PR DESCRIPTION
This allows users to pass custom aggregates when creating alerts, using the function format
(`count()`, `count_unique(tags[sentry:user])`, etc). We still accept the old `aggregation` format
for backwards compatibility. If both are passed, `aggregate` takes precedence.

We'll still need to add validation here to restrict to only functions we support, but that can
happen after we're ready for alpha.