### PR TITLE
feat(breadcrumbsv2): Link transaction entries to Discover event details page

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbData.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbData.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {Event} from 'app/types';
+
 import BreadcrumbDataDefault from './breadcrumbDataDefault';
 import BreadcrumbDataException from './breadcrumbDataException';
 import BreadcrumbDataHttp from './breadcrumbDataHttp';
@@ -7,9 +9,11 @@ import {Breadcrumb, BreadcrumbType} from '../types';
 
 type Props = {
   breadcrumb: Breadcrumb;
+  event: Event;
+  orgId: string | null;
 };
 
-const BreadcrumbData = ({breadcrumb}: Props) => {
+const BreadcrumbData = ({breadcrumb, event, orgId}: Props) => {
   if (breadcrumb.type === BreadcrumbType.HTTP) {
     return <BreadcrumbDataHttp breadcrumb={breadcrumb} />;
   }
@@ -18,7 +22,9 @@ const BreadcrumbData = ({breadcrumb}: Props) => {
     breadcrumb.type === BreadcrumbType.WARNING ||
     breadcrumb.type === BreadcrumbType.ERROR
   ) {
-    return <BreadcrumbDataException breadcrumb={breadcrumb} />;
+    return (
+      <BreadcrumbDataException event={event} orgId={orgId} breadcrumb={breadcrumb} />
+    );
   }
 
   return <BreadcrumbDataDefault breadcrumb={breadcrumb} />;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbDataException.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbData/breadcrumbDataException.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import omit from 'lodash/omit';
 
+import {Event, Project} from 'app/types';
 import {getMeta} from 'app/components/events/meta/metaProxy';
 import {defined} from 'app/utils';
+import withProjects from 'app/utils/withProjects';
+import {generateEventSlug, eventDetailsRoute} from 'app/utils/discover/urls';
+import Link from 'app/components/links/link';
 
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
 import {BreadcrumbTypeDefault} from '../types';
@@ -10,9 +14,11 @@ import BreadcrumbDataSummary from './breadcrumbDataSummary';
 
 type Props = {
   breadcrumb: BreadcrumbTypeDefault;
+  event: Event;
+  orgId: string | null;
 };
 
-const BreadcrumbDataException = ({breadcrumb}: Props) => {
+const BreadcrumbDataException = ({breadcrumb, event, orgId}: Props) => {
   const {data} = breadcrumb;
   const dataValue = data?.value;
 
@@ -30,11 +36,61 @@ const BreadcrumbDataException = ({breadcrumb}: Props) => {
         })}
       {breadcrumb?.message &&
         getBreadcrumbCustomRendererValue({
-          value: breadcrumb.message,
+          value: (
+            <FormatMessage
+              event={event}
+              orgId={orgId}
+              breadcrumb={breadcrumb}
+              message={breadcrumb.message}
+            />
+          ),
           meta: getMeta(breadcrumb, 'message'),
         })}
     </BreadcrumbDataSummary>
   );
 };
+
+function isEventId(maybeEventId: string): boolean {
+  // maybeEventId is an event id if it's a hex string of 32 characters long
+  return /^[a-fA-F0-9]{32}$/.test(maybeEventId);
+}
+
+const FormatMessage = withProjects(function FormatMessageInner({
+  event,
+  message,
+  breadcrumb,
+  projects,
+  loadingProjects,
+  orgId,
+}: {
+  event: Event;
+  projects: Project[];
+  loadingProjects: boolean;
+  breadcrumb: BreadcrumbTypeDefault;
+  message: string;
+  orgId: string | null;
+}) {
+  if (
+    !loadingProjects &&
+    typeof orgId === 'string' &&
+    breadcrumb.category === 'sentry.transaction' &&
+    isEventId(message)
+  ) {
+    const maybeProject = projects.find(project => {
+      return project.id === event.projectID;
+    });
+
+    if (!maybeProject) {
+      return <React.Fragment>{message}</React.Fragment>;
+    }
+
+    const projectSlug = maybeProject.slug;
+    const eventSlug = generateEventSlug({project: projectSlug, id: message});
+
+    return <Link to={eventDetailsRoute({orgSlug: orgId, eventSlug})}>{message}</Link>;
+  }
+
+  return <React.Fragment>{message}</React.Fragment>;
+});
 
 export default BreadcrumbDataException;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbs.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbs.tsx
@@ -48,6 +48,7 @@ type State = {
 
 type Props = {
   event: Event;
+  orgId: string | null;
   type: string;
   data: {
     values: Array<Breadcrumb>;
@@ -297,7 +298,7 @@ class BreadcrumbsContainer extends React.Component<Props, State> {
   };
 
   render() {
-    const {type} = this.props;
+    const {type, event, orgId} = this.props;
     const {filterGroups, searchTerm} = this.state;
 
     const {
@@ -333,6 +334,8 @@ class BreadcrumbsContainer extends React.Component<Props, State> {
             <React.Fragment>
               <BreadcrumbsListHeader />
               <BreadcrumbsListBody
+                event={event}
+                orgId={orgId}
                 onToggleCollapse={this.handleToggleCollapse}
                 collapsedQuantity={collapsedQuantity}
                 breadcrumbs={filteredCollapsedBreadcrumbs}

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListBody.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/breadcrumbsListBody.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import {Event} from 'app/types';
 import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
 
@@ -19,6 +20,8 @@ type Props = {
   breadcrumbs: Breadcrumbs;
   collapsedQuantity: number;
   onToggleCollapse: () => void;
+  event: Event;
+  orgId: string | null;
 };
 
 type State = {
@@ -42,7 +45,7 @@ class BreadcrumbsListBody extends React.Component<Props, State> {
   };
 
   render() {
-    const {collapsedQuantity, onToggleCollapse, breadcrumbs} = this.props;
+    const {collapsedQuantity, onToggleCollapse, breadcrumbs, event, orgId} = this.props;
     const {breadCrumbListHeight} = this.state;
 
     return (
@@ -64,7 +67,11 @@ class BreadcrumbsListBody extends React.Component<Props, State> {
                 <BreadcrumbCategory category={crumb?.category} />
               </GridCellCategory>
               <GridCell hasError={hasError} isLastItem={isLastItem}>
-                <BreadcrumbData breadcrumb={crumb as Breadcrumb} />
+                <BreadcrumbData
+                  event={event}
+                  orgId={orgId}
+                  breadcrumb={crumb as Breadcrumb}
+                />
               </GridCell>
               <GridCell hasError={hasError} isLastItem={isLastItem}>
                 <BreadcrumbLevel level={crumb.level} />


### PR DESCRIPTION
Today, the JS SDK will add breadcrumbs for transaction events pushed to Sentry using the store endpoint. This is done via https://github.com/getsentry/sentry-javascript/blob/2efbc98e86a54b59336fd9c3998ff04955aa449f/packages/browser/src/integrations/breadcrumbs.ts#L310-L331

The breadcrumb message is the event id reference. We can convert them into links that lead to the Discover event details page.

I've made this change to breadcrumbs v2, rather than v1, since transactions are still in beta.

## TODO

- [ ] reorganize code


------

**Before:**

<img width="1293" alt="Screen Shot 2020-05-19 at 4 57 22 PM" src="https://user-images.githubusercontent.com/139499/82377713-1adc4500-99f2-11ea-87be-945639f087f7.png">

**After:**

<img width="1299" alt="Screen Shot 2020-05-19 at 4 57 15 PM" src="https://user-images.githubusercontent.com/139499/82377735-22035300-99f2-11ea-8138-2957dafdb7cd.png">
