### PR TITLE
Fix oauth TypeError (int + string)

### DIFF
--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -153,7 +153,7 @@ class OAuth2Provider(Provider):
     def get_oauth_data(self, payload):
         data = {"access_token": payload["access_token"], "token_type": payload["token_type"]}
         if "expires_in" in payload:
-            data["expires"] = int(time()) + payload["expires_in"]
+            data["expires"] = int(time()) + int(payload["expires_in"])
         if "refresh_token" in payload:
             data["refresh_token"] = payload["refresh_token"]
         return data


### PR DESCRIPTION
Ensure that authorization `expires_in` token is an integer before adding it to another int

This is my first PR to sentry in and the contributing guidelines don't mention if I need to provide more information, stack errors etc. Let me know if you want them and I'll endeavor to add to future PRs