### PR TITLE
feat(alerts): Add new metricField

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -23,6 +23,7 @@ import {
   ColumnType,
   isAggregateField,
   getAggregateAlias,
+  generateFieldAsString,
 } from './fields';
 import {getSortField} from './fieldRenderers';
 import {CHART_AXIS_OPTIONS, DisplayModes, DISPLAY_MODE_OPTIONS} from './types';
@@ -83,16 +84,6 @@ function getSortKeyFromField(field: Field, tableMeta?: MetaType): string | null 
 export function isFieldSortable(field: Field, tableMeta?: MetaType): boolean {
   return !!getSortKeyFromField(field, tableMeta);
 }
-
-const generateFieldAsString = (col: Column): string => {
-  if (col.kind === 'field') {
-    return col.field;
-  }
-
-  const aggregation = col.function[0];
-  const parameters = col.function.slice(1).filter(i => i);
-  return `${aggregation}(${parameters.join(',')})`;
-};
 
 const decodeFields = (location: Location): Array<Field> => {
   const {query} = location;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -13,10 +13,11 @@ import {t} from 'app/locale';
 import {SelectValue, OrganizationSummary} from 'app/types';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
-import {Column, AGGREGATIONS, FIELDS, TRACING_FIELDS} from 'app/utils/discover/fields';
+import {Column} from 'app/utils/discover/fields';
 
-import {FieldValue, FieldValueKind} from './types';
+import {FieldValue} from './types';
 import {QueryField} from './queryField';
+import {generateFieldOptions} from '../utils';
 
 type Props = {
   // Input columns
@@ -52,7 +53,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
     draggingTargetIndex: void 0,
     left: void 0,
     top: void 0,
-    fieldOptions: this.generateFieldOptions(),
+    fieldOptions: this.fieldOptions,
   };
 
   componentDidMount() {
@@ -87,71 +88,15 @@ class ColumnEditCollection extends React.Component<Props, State> {
   portal: HTMLElement | null = null;
   dragGhostRef = React.createRef<HTMLDivElement>();
 
-  generateFieldOptions() {
-    const {organization, tagKeys} = this.props;
-
-    let fields = Object.keys(FIELDS);
-    let functions = Object.keys(AGGREGATIONS);
-
-    // Strip tracing features if the org doesn't have access.
-    if (!organization.features.includes('transaction-events')) {
-      fields = fields.filter(item => !TRACING_FIELDS.includes(item));
-      functions = functions.filter(item => !TRACING_FIELDS.includes(item));
-    }
-    const fieldOptions: Record<string, SelectValue<FieldValue>> = {};
-
-    // Index items by prefixed keys as custom tags
-    // can overlap both fields and function names.
-    // Having a mapping makes finding the value objects easier
-    // later as well.
-    functions.forEach(func => {
-      const ellipsis = AGGREGATIONS[func].parameters.length ? '\u2026' : '';
-      fieldOptions[`function:${func}`] = {
-        label: `${func}(${ellipsis})`,
-        value: {
-          kind: FieldValueKind.FUNCTION,
-          meta: {
-            name: func,
-            parameters: AGGREGATIONS[func].parameters,
-          },
-        },
-      };
+  get fieldOptions() {
+    return generateFieldOptions({
+      organization: this.props.organization,
+      tagKeys: this.props.tagKeys,
     });
-
-    fields.forEach(field => {
-      fieldOptions[`field:${field}`] = {
-        label: field,
-        value: {
-          kind: FieldValueKind.FIELD,
-          meta: {
-            name: field,
-            dataType: FIELDS[field],
-          },
-        },
-      };
-    });
-
-    if (tagKeys !== null) {
-      tagKeys.forEach(tag => {
-        const tagValue =
-          FIELDS.hasOwnProperty(tag) || AGGREGATIONS.hasOwnProperty(tag)
-            ? `tags[${tag}]`
-            : tag;
-        fieldOptions[`tag:${tag}`] = {
-          label: tag,
-          value: {
-            kind: FieldValueKind.TAG,
-            meta: {name: tagValue, dataType: 'string'},
-          },
-        };
-      });
-    }
-
-    return fieldOptions;
   }
 
   syncFields() {
-    this.setState({fieldOptions: this.generateFieldOptions()});
+    this.setState({fieldOptions: this.fieldOptions});
   }
 
   keyForColumn(column: Column, isGhost: boolean): string {

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -4,7 +4,7 @@ import {browserHistory} from 'react-router';
 
 import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
 import {t} from 'app/locale';
-import {Event, Organization, OrganizationSummary} from 'app/types';
+import {Event, Organization, OrganizationSummary, SelectValue} from 'app/types';
 import {getTitle} from 'app/utils/events';
 import {getUtcDateString} from 'app/utils/dates';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
@@ -14,14 +14,17 @@ import EventView from 'app/utils/discover/eventView';
 import {
   Field,
   Column,
+  ColumnType,
   AGGREGATIONS,
   FIELDS,
   explodeFieldString,
   getAggregateAlias,
+  TRACING_FIELDS,
+  Aggregation,
 } from 'app/utils/discover/fields';
 
 import {ALL_VIEWS, TRANSACTION_VIEWS} from './data';
-import {TableColumn, TableDataRow} from './table/types';
+import {TableColumn, TableDataRow, FieldValue, FieldValueKind} from './table/types';
 
 export type QueryWithColumnState =
   | Query
@@ -159,7 +162,7 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
 }
 
 // A map between aggregate function names and its un-aggregated form
-const TRANSFORM_AGGREGATES: {[field: string]: string} = {
+const TRANSFORM_AGGREGATES = {
   p99: 'transaction.duration',
   p95: 'transaction.duration',
   p75: 'transaction.duration',
@@ -169,7 +172,7 @@ const TRANSFORM_AGGREGATES: {[field: string]: string} = {
   impact: '',
   user_misery: '',
   error_rate: '',
-};
+} as const;
 
 /**
  * Convert an aggregated query into one that does not have aggregates.
@@ -375,4 +378,76 @@ export function getDiscoverLandingUrl(organization: OrganizationSummary): string
     return `/organizations/${organization.slug}/discover/queries/`;
   }
   return `/organizations/${organization.slug}/discover/results/`;
+}
+
+type FieldGeneratorOpts = {
+  organization: OrganizationSummary;
+  tagKeys?: string[] | null;
+  aggregations?: Record<string, Aggregation>;
+  fields?: Record<string, ColumnType>;
+};
+
+export function generateFieldOptions({
+  organization,
+  tagKeys,
+  aggregations = AGGREGATIONS,
+  fields = FIELDS,
+}: FieldGeneratorOpts) {
+  let fieldKeys = Object.keys(fields);
+  let functions = Object.keys(aggregations);
+
+  // Strip tracing features if the org doesn't have access.
+  if (!organization.features.includes('transaction-events')) {
+    fieldKeys = fieldKeys.filter(item => !TRACING_FIELDS.includes(item));
+    functions = functions.filter(item => !TRACING_FIELDS.includes(item));
+  }
+  const fieldOptions: Record<string, SelectValue<FieldValue>> = {};
+
+  // Index items by prefixed keys as custom tags can overlap both fields and
+  // function names. Having a mapping makes finding the value objects easier
+  // later as well.
+  functions.forEach(func => {
+    const ellipsis = aggregations[func].parameters.length ? '\u2026' : '';
+    fieldOptions[`function:${func}`] = {
+      label: `${func}(${ellipsis})`,
+      value: {
+        kind: FieldValueKind.FUNCTION,
+        meta: {
+          name: func,
+          parameters: [...aggregations[func].parameters],
+        },
+      },
+    };
+  });
+
+  fieldKeys.forEach(field => {
+    fieldOptions[`field:${field}`] = {
+      label: field,
+      value: {
+        kind: FieldValueKind.FIELD,
+        meta: {
+          name: field,
+          dataType: fields[field],
+        },
+      },
+    };
+  });
+
+  if (tagKeys !== undefined && tagKeys !== null) {
+    tagKeys.forEach(tag => {
+      const tagValue =
+        fields.hasOwnProperty(tag) || AGGREGATIONS.hasOwnProperty(tag)
+          ? `tags[${tag}]`
+          : tag;
+      fieldOptions[`tag:${tag}`] = {
+        label: tag,
+        value: {
+          kind: FieldValueKind.TAG,
+          meta: {name: tagValue, dataType: 'string'},
+        },
+      };
+    });
+  }
+
+  return fieldOptions;
 }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {css} from '@emotion/core';
+
+import FormField from 'app/views/settings/components/forms/formField';
+import {t, tct} from 'app/locale';
+import {QueryField} from 'app/views/eventsV2/table/queryField';
+import {generateFieldOptions} from 'app/views/eventsV2/utils';
+import {FieldValueKind} from 'app/views/eventsV2/table/types';
+import {Organization} from 'app/types';
+import space from 'app/styles/space';
+import FormModel from 'app/views/settings/components/forms/model';
+import Button from 'app/components/button';
+import Tooltip from 'app/components/tooltip';
+import {
+  explodeFieldString,
+  generateFieldAsString,
+  AggregationKey,
+  FieldKey,
+  AGGREGATIONS,
+  FIELDS,
+} from 'app/utils/discover/fields';
+
+import {Dataset} from './types';
+
+type Props = Omit<FormField['props'], 'children' | 'help'> & {
+  organization: Organization;
+};
+
+const cannedAggregates = [
+  {
+    match: /^count\(\)/,
+    name: 'Number of errors',
+    validDataset: [Dataset.ERRORS],
+    default: 'count()',
+  },
+  {
+    match: /^count_unique\(user(\.id)?\)/,
+    name: 'Users affected',
+    validDataset: [Dataset.ERRORS],
+    default: 'count_unique(user)',
+  },
+  {
+    match: /^(p[0-9]{2,3}|percentile\(transaction\.duration,[^)]+\))/,
+    name: 'Latency',
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'percentile(transaction.duration, 0.95)',
+  },
+  {
+    match: /^apdex\([0-9.]+\)/,
+    name: 'Apdex',
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'apdex(300)',
+  },
+  {
+    match: /^count\(\)/,
+    name: 'Throughput',
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'count()',
+  },
+  {
+    match: /^error_rate\(\)/,
+    name: 'Error rate',
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'error_rate()',
+  },
+];
+
+type OptionConfig = {
+  aggregations: AggregationKey[];
+  fields: FieldKey[];
+};
+
+const errorFieldConfig: OptionConfig = {
+  aggregations: ['count', 'count_unique'],
+  fields: ['user'],
+};
+
+const transactionFieldConfig: OptionConfig = {
+  aggregations: [
+    'avg',
+    'percentile',
+    'error_rate',
+    'apdex',
+    'count',
+    'p50',
+    'p75',
+    'p95',
+    'p99',
+    'p100',
+  ],
+  fields: ['transaction.duration'],
+};
+
+const getFieldOptionConfig = (dataset: Dataset) => {
+  const config = dataset === Dataset.ERRORS ? errorFieldConfig : transactionFieldConfig;
+
+  const aggregations = Object.fromEntries(
+    config.aggregations.map(key => [key, AGGREGATIONS[key]])
+  );
+  const fields = Object.fromEntries(config.fields.map(key => [key, FIELDS[key]]));
+
+  return {aggregations, fields};
+};
+
+const help = ({name, model}: {name: string; model: FormModel}) => {
+  const aggregate = model.getValue(name) as string;
+
+  const presets = cannedAggregates
+    .filter(preset => preset.validDataset.includes(model.getValue('dataset') as Dataset))
+    .map(preset => ({...preset, selected: preset.match.test(aggregate)}))
+    .map((preset, i, list) => (
+      <React.Fragment key={preset.name}>
+        <Tooltip title={t('This preset is selected')} disabled={!preset.selected}>
+          <PresetLink
+            onClick={() => model.setValue(name, preset.default)}
+            isSelected={preset.selected}
+          >
+            {preset.name}
+          </PresetLink>
+        </Tooltip>
+        {i + 1 < list.length && ', '}
+      </React.Fragment>
+    ));
+
+  return tct(
+    'Choose an aggregate function. Not sure what to select, try a preset: [presets]',
+    {presets}
+  );
+};
+
+const MetricField = ({organization, ...props}: Props) => (
+  <FormField help={help} {...props}>
+    {({onChange, value, model}) => {
+      const dataset = model.getValue('dataset');
+
+      const fieldOptionsConfig = getFieldOptionConfig(dataset);
+      const fieldOptions = generateFieldOptions({organization, ...fieldOptionsConfig});
+      const fieldValue = explodeFieldString(value ?? '');
+
+      const fieldKey =
+        fieldValue?.kind === FieldValueKind.FUNCTION
+          ? `function:${fieldValue.function[0]}`
+          : '';
+
+      const selectedField = fieldOptions[fieldKey]?.value;
+      const numParameters =
+        selectedField &&
+        selectedField.kind === FieldValueKind.FUNCTION &&
+        selectedField.meta.parameters.length;
+
+      return (
+        <React.Fragment>
+          <AggregateHeader>
+            <div>{t('Function')}</div>
+            {numParameters > 0 && <div>{t('Parameter')}</div>}
+          </AggregateHeader>
+          <QueryField
+            filterPrimaryOptions={option => option.value.kind === FieldValueKind.FUNCTION}
+            fieldOptions={fieldOptions}
+            fieldValue={fieldValue}
+            onChange={v => onChange(generateFieldAsString(v), {})}
+          />
+        </React.Fragment>
+      );
+    }}
+  </FormField>
+);
+
+const AggregateHeader = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  grid-gap: ${space(1)};
+  text-transform: uppercase;
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.gray2};
+  font-weight: bold;
+  margin-bottom: ${space(1)};
+`;
+
+const PresetLink = styled(Button)<{isSelected: boolean}>`
+  ${p =>
+    p.isSelected &&
+    css`
+      color: ${p.theme.gray4};
+      &:hover,
+      &:focus {
+        color: ${p.theme.gray5};
+      }
+    `}
+`;
+
+PresetLink.defaultProps = {
+  priority: 'link',
+  borderless: true,
+};
+
+export default MetricField;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -13,6 +13,11 @@ export enum AlertRuleAggregations {
   UNIQUE_USERS,
 }
 
+export enum Dataset {
+  ERRORS,
+  TRANSACTIONS,
+}
+
 export type UnsavedTrigger = {
   // UnsavedTrigger can be apart of an Unsaved Alert Rule that does not have an
   // id yet

--- a/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import {openMenu, selectByLabel} from 'sentry-test/select-new';
-import Form from 'app/views/settings/components/forms/form';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import Form from 'app/views/settings/components/forms/form';
 import MetricField from 'app/views/settings/incidentRules/metricField';
 import {Dataset} from 'app/views/settings/incidentRules/types';
 

--- a/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+
+import {openMenu, selectByLabel} from 'sentry-test/select-new';
+import Form from 'app/views/settings/components/forms/form';
+import {mountWithTheme} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import MetricField from 'app/views/settings/incidentRules/metricField';
+import {Dataset} from 'app/views/settings/incidentRules/types';
+
+describe('MetricField', function() {
+  const {organization} = initializeOrg({
+    organization: {features: ['transaction-events']},
+  });
+
+  it('renders', function() {
+    mountWithTheme(
+      <Form initialData={{dataset: Dataset.ERRORS}}>
+        <MetricField name="metric" organization={organization} />
+      </Form>
+    );
+  });
+
+  it('has a select subset of error fields', function() {
+    const wrapper = mountWithTheme(
+      <Form initialData={{dataset: Dataset.ERRORS}}>
+        <MetricField name="metric" organization={organization} />
+      </Form>
+    );
+    openMenu(wrapper, {selector: 'QueryField'});
+
+    // two error aggregation configs
+    expect(wrapper.find('Option Option')).toHaveLength(2);
+
+    // Select count_unique and verify the tags
+    selectByLabel(wrapper, 'count_unique(…)', {selector: 'QueryField'});
+    openMenu(wrapper, {selector: 'QueryField', at: 1});
+
+    expect(
+      wrapper
+        .find('SelectControl')
+        .at(1)
+        .find('Option')
+    ).toHaveLength(1);
+  });
+
+  it('has a select subset of transaction fields', function() {
+    const wrapper = mountWithTheme(
+      <Form initialData={{dataset: Dataset.TRANSACTIONS}}>
+        <MetricField name="metric" organization={organization} />
+      </Form>
+    );
+    openMenu(wrapper, {selector: 'QueryField'});
+
+    // 10 error aggregate configs
+    expect(wrapper.find('Option Option')).toHaveLength(10);
+
+    selectByLabel(wrapper, 'avg(…)', {selector: 'QueryField'});
+    openMenu(wrapper, {selector: 'QueryField', at: 1});
+
+    expect(
+      wrapper
+        .find('SelectControl')
+        .at(1)
+        .find('Option')
+    ).toHaveLength(1);
+  });
+
+  it('maps field value to selected presets', function() {
+    const wrapper = mountWithTheme(
+      <Form initialData={{dataset: Dataset.TRANSACTIONS}}>
+        <MetricField name="metric" organization={organization} />
+      </Form>
+    );
+    selectByLabel(wrapper, 'error_rate()', {selector: 'QueryField'});
+
+    expect(wrapper.find('FieldHelp Button[isSelected=true]').text()).toEqual(
+      'Error rate'
+    );
+
+    selectByLabel(wrapper, 'p95()', {selector: 'QueryField'});
+
+    expect(wrapper.find('FieldHelp Button[isSelected=true]').text()).toEqual('Latency');
+  });
+
+  it('changes field values when selecting presets', function() {
+    const wrapper = mountWithTheme(
+      <Form initialData={{dataset: Dataset.TRANSACTIONS}}>
+        <MetricField name="metric" organization={organization} />
+      </Form>
+    );
+
+    wrapper.find('FieldHelp button[aria-label="Error rate"]').simulate('click');
+
+    expect(wrapper.find('QueryField SingleValue SingleValue').text()).toEqual(
+      'error_rate()'
+    );
+  });
+});


### PR DESCRIPTION
Looks something a little like this:

![image](https://user-images.githubusercontent.com/1421724/82396136-07d17100-9a02-11ea-9851-79e4f31cdbf3.png)

(Actually it looks exactly like that).

It's not currently used, there will be a follow up PR that removes aggregation and slots this in as aggregate.

Depends on https://github.com/getsentry/sentry/pull/18952