### PR TITLE
fix(store): Do not set None tags in save_event

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -102,7 +102,8 @@ def pop_tag(data, key):
 
 def set_tag(data, key, value):
     pop_tag(data, key)
-    data["tags"].append((key, trim(value, MAX_TAG_VALUE_LENGTH)))
+    if value is not None:
+        data["tags"].append((key, trim(value, MAX_TAG_VALUE_LENGTH)))
 
 
 def get_tag(data, key):


### PR DESCRIPTION
In https://github.com/getsentry/relay/pull/585, we are potentially removing the default `level` on event. This would create a `None` tag value, which is not permitted. Skip such tags values.