### PR TITLE
ref: Bump django-picklefield to 1.1.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -7,7 +7,7 @@ confluent-kafka==0.11.5
 croniter>=0.3.26,<0.4.0
 datadog>=0.15.0,<0.31.0
 django-crispy-forms==1.7.2
-django-picklefield>=0.3.0,<1.1.0
+django-picklefield>=1.1.0,<1.2.0
 django-sudo>=3.0.0,<4.0.0
 Django>=1.11,<1.12
 djangorestframework==3.6.4


### PR DESCRIPTION
We have a strong suspicion that our double-pickling bug in production is
caused by a bug in django-picklefield 1.0.0 that has been accidentally
fixed in 1.1.0

We are encountering a bug where we read double-pickled values for
project options. We suspect that during a deploy, django-picklefield
catches a SystemExit or KeyboardInterrupt here:
https://github.com/gintas/django-picklefield/blob/v1.0.0/src/picklefield/fields.py#L124

All `except:` has been changed to `except Exception` in 1.1.0.