### PR TITLE
fix(pickle): Do not use bare-except when unpickling db value

### DIFF
--- a/src/sentry/db/models/fields/encrypted.py
+++ b/src/sentry/db/models/fields/encrypted.py
@@ -10,7 +10,7 @@ __all__ = (
 import six
 
 from django.db.models import CharField, TextField
-from picklefield.fields import PickledObjectField
+from picklefield.fields import PickledObjectField, dbsafe_decode, PickledObject, _ObjectWrapper
 from sentry.db.models.fields.jsonfield import JSONField
 from sentry.db.models.utils import Creator
 from sentry.utils.encryption import decrypt, encrypt
@@ -56,7 +56,24 @@ class EncryptedPickledObjectField(PickledObjectField):
     def to_python(self, value):
         if value is not None and isinstance(value, six.string_types):
             value = decrypt(value)
-        return super(EncryptedPickledObjectField, self).to_python(value)
+
+        # The following below is a copypaste of PickledObjectField.to_python of
+        # v1.0.0 with one change: We re-raise any baseexceptions such as
+        # signals. 1.0.0 has a bare `except:` which causes issues.
+
+        if value is not None:
+            try:
+                value = dbsafe_decode(value, self.compress)
+            except Exception:
+                # If the value is a definite pickle; and an error is raised in
+                # de-pickling it should be allowed to propogate.
+                if isinstance(value, PickledObject):
+                    raise
+            else:
+                if isinstance(value, _ObjectWrapper):
+                    return value._obj
+
+        return value
 
 
 class EncryptedTextField(TextField):


### PR DESCRIPTION
We are encountering a bug where we read double-pickled values for
project options. We suspect that during a deploy, django-picklefield
catches a SystemExit or KeyboardInterrupt here:
https://github.com/gintas/django-picklefield/blob/v1.0.0/src/picklefield/fields.py#L124