### PR TITLE
fix(oauth2): ensure expires_in is an integer

### DIFF
--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -153,7 +153,8 @@ class OAuth2Provider(Provider):
     def get_oauth_data(self, payload):
         data = {"access_token": payload["access_token"], "token_type": payload["token_type"]}
         if "expires_in" in payload:
-            data["expires"] = int(time()) + payload["expires_in"]
+            expires_in = payload["expires_in"] if isinstance(payload["expires_in"], int) else int(payload["expires_in"])
+            data["expires"] = int(time()) + expires_in
         if "refresh_token" in payload:
             data["refresh_token"] = payload["refresh_token"]
         return data

--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -153,8 +153,7 @@ class OAuth2Provider(Provider):
     def get_oauth_data(self, payload):
         data = {"access_token": payload["access_token"], "token_type": payload["token_type"]}
         if "expires_in" in payload:
-            expires_in = payload["expires_in"] if isinstance(payload["expires_in"], int) else int(payload["expires_in"])
-            data["expires"] = int(time()) + expires_in
+            data["expires"] = int(time()) + int(payload["expires_in"])
         if "refresh_token" in payload:
             data["refresh_token"] = payload["refresh_token"]
         return data


### PR DESCRIPTION
Github SSO setup fails with the latest version of Sentry on-premise build because of the following error:

```
web_1                      | Traceback (most recent call last):
web_1                      |   File "/usr/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
web_1                      |     response = get_response(request)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
web_1                      |     response = self._get_response(request)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
web_1                      |     response = self.process_exception_by_middleware(e, request)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
web_1                      |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/django/views/generic/base.py", line 68, in view
web_1                      |     return self.dispatch(request, *args, **kwargs)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
web_1                      |     return view_func(*args, **kwargs)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/sentry/web/frontend/base.py", line 227, in dispatch
web_1                      |     return self.handle(request, *args, **kwargs)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/sentry/web/frontend/auth_provider_login.py", line 19, in handle
web_1                      |     return helper.current_step()
web_1                      |   File "/usr/local/lib/python2.7/site-packages/sentry/auth/helper.py", line 628, in current_step
web_1                      |     return self.pipeline[step_index].dispatch(request=self.request, helper=self)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
web_1                      |     return view_func(*args, **kwargs)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/sentry/web/frontend/base.py", line 227, in dispatch
web_1                      |     return self.handle(request, *args, **kwargs)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/sentry/auth/providers/github/views.py", line 130, in handle
web_1                      |     return helper.next_step()
web_1                      |   File "/usr/local/lib/python2.7/site-packages/sentry/auth/helper.py", line 635, in next_step
web_1                      |     return self.current_step()
web_1                      |   File "/usr/local/lib/python2.7/site-packages/sentry/auth/helper.py", line 626, in current_step
web_1                      |     return self.finish_pipeline()
web_1                      |   File "/usr/local/lib/python2.7/site-packages/sentry/auth/helper.py", line 646, in finish_pipeline
web_1                      |     identity = self.provider.build_identity(data)
web_1                      |   File "/usr/local/lib/python2.7/site-packages/sentry/auth/providers/github/provider.py", line 57, in build_identity
web_1                      |     "data": self.get_oauth_data(data),
web_1                      |   File "/usr/local/lib/python2.7/site-packages/sentry/auth/providers/oauth2.py", line 156, in get_oauth_data
web_1                      |     data["expires"] = int(time()) + payload["expires_in"]
web_1                      | TypeError: unsupported operand type(s) for +: 'int' and 'str'
```

This pull request fixes the error above that was caused because `payload["expires_in"]` could be string and the `get_oauth_data` tries to sum it with an integer value (current timestamp).

---

I'm not sure if sentry uses the API [documented here](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#response), as you can see Github response contains `expires_in` in string type.