### PR TITLE
feat(pii): Added regex match help text

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesForm.tsx
@@ -103,6 +103,7 @@ const DataPrivacyRulesForm = ({
         onChange={(value: string) => {
           onChange('source', value);
         }}
+        isRegExMatchesSelected={type === RuleType.PATTERN}
         value={source}
         onBlur={onValidate('source')}
         suggestions={sourceSuggestions}

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/source.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/source.tsx
@@ -247,7 +247,7 @@ class Source extends React.Component<Props, State> {
     }
 
     const isPossiblyARegularExpression =
-      RegExp('^/').test(value) || RegExp('/g$').test(value);
+      RegExp('^/').test(value) || RegExp('/g$').test(value) || RegExp('/$').test(value);
 
     if (help) {
       if (!isPossiblyARegularExpression) {

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/source.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/source.tsx
@@ -246,8 +246,7 @@ class Source extends React.Component<Props, State> {
       return;
     }
 
-    const isPossiblyARegularExpression =
-      RegExp('^/.*/g?$').test(value);
+    const isPossiblyARegularExpression = RegExp('^/.*/g?$').test(value);
 
     if (help) {
       if (!isPossiblyARegularExpression) {

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/source.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/source.tsx
@@ -247,7 +247,7 @@ class Source extends React.Component<Props, State> {
     }
 
     const isPossiblyARegularExpression =
-      RegExp('^/').test(value) || RegExp('/g$').test(value) || RegExp('/$').test(value);
+      RegExp('^/.*/g?$').test(value);
 
     if (help) {
       if (!isPossiblyARegularExpression) {

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/source.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/source.tsx
@@ -18,6 +18,7 @@ type Props = {
   value: string;
   onChange: (value: string) => void;
   suggestions: Array<SourceSuggestion>;
+  isRegExMatchesSelected: boolean;
   error?: string;
   onBlur?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   disabled?: boolean;
@@ -29,6 +30,7 @@ type State = {
   activeSuggestion: number;
   showSuggestions: boolean;
   hideCaret: boolean;
+  help?: string;
 };
 
 class Source extends React.Component<Props, State> {
@@ -49,6 +51,13 @@ class Source extends React.Component<Props, State> {
     if (prevProps.suggestions !== this.props.suggestions) {
       this.loadFieldValues(this.props.value);
       this.hideSuggestions();
+    }
+
+    if (
+      prevProps.isRegExMatchesSelected !== this.props.isRegExMatchesSelected ||
+      prevProps.value !== this.props.value
+    ) {
+      this.checkPossiblyRegExMatchExpression(this.props.value);
     }
   }
 
@@ -226,6 +235,36 @@ class Source extends React.Component<Props, State> {
     });
   };
 
+  checkPossiblyRegExMatchExpression = (value: string) => {
+    const {isRegExMatchesSelected} = this.props;
+    const {help} = this.state;
+
+    if (isRegExMatchesSelected) {
+      if (help) {
+        this.setState({help: ''});
+      }
+      return;
+    }
+
+    const isPossiblyARegularExpression =
+      RegExp('^/').test(value) || RegExp('/g$').test(value);
+
+    if (help) {
+      if (!isPossiblyARegularExpression) {
+        this.setState({
+          help: '',
+        });
+      }
+      return;
+    }
+
+    if (isPossiblyARegularExpression) {
+      this.setState({
+        help: t("You might want to change Data Type's value to 'Regex matches'"),
+      });
+    }
+  };
+
   handleChange = (newValue: string) => {
     this.loadFieldValues(newValue);
     this.props.onChange(newValue);
@@ -352,7 +391,7 @@ class Source extends React.Component<Props, State> {
 
   render() {
     const {error, disabled, value, onBlur} = this.props;
-    const {showSuggestions, suggestions, activeSuggestion, hideCaret} = this.state;
+    const {showSuggestions, suggestions, activeSuggestion, hideCaret, help} = this.state;
 
     return (
       <Wrapper ref={this.selectorField} hideCaret={hideCaret}>
@@ -364,6 +403,7 @@ class Source extends React.Component<Props, State> {
           value={value}
           onKeyDown={this.handleKeyDown}
           error={error}
+          help={help}
           onBlur={onBlur}
           onFocus={this.handleFocus}
           disabled={disabled}

--- a/tests/js/spec/views/settings/components/dataPrivacyRulesPanel/source.tsx
+++ b/tests/js/spec/views/settings/components/dataPrivacyRulesPanel/source.tsx
@@ -15,6 +15,7 @@ function renderComponent({
 }: Partial<Source['props']>) {
   return mountWithTheme(
     <Source
+      isRegExMatchesSelected={false}
       suggestions={defaultSuggestions}
       onChange={onChange}
       value={value}


### PR DESCRIPTION
**Description:** 

When adding/editing a data scrubbing rule, if the user types for example /foo/ or /foo/g,  we would like to suggest to change the value of the data type selector to Regex matches.

![image](https://user-images.githubusercontent.com/29228205/82458765-66a4f200-9ab7-11ea-8f8f-cc75c69f21b2.png)

![image](https://user-images.githubusercontent.com/29228205/82458805-702e5a00-9ab7-11ea-984a-5d2a85c22add.png)

![image](https://user-images.githubusercontent.com/29228205/82458832-78869500-9ab7-11ea-9c16-6cd0f145557f.png)


closes: https://app.asana.com/0/1158284503473033/1170251627399075