### PR TITLE
feat(ui): Grouping info improvements

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -249,7 +249,7 @@ class EventEntries extends React.Component {
           <EventGroupingInfo
             projectId={project.slug}
             event={event}
-            showSelector={features.has('set-grouping-config')}
+            showGroupingConfig={features.has('set-grouping-config')}
           />
         )}
         {!isShare && features.has('event-attachments') && (

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponent.tsx
@@ -48,9 +48,17 @@ const GroupingComponentList = styled('ul')<{isInline: boolean}>`
   }
 `;
 
-export const GroupingComponentListItem = styled('li')`
+export const GroupingComponentListItem = styled('li')<{isCollapsable?: boolean}>`
   padding: 0;
   margin: ${space(0.25)} 0 ${space(0.25)} ${space(1.5)};
+
+  ${p =>
+    p.isCollapsable &&
+    `
+    border-left: 1px solid ${p.theme.borderLight};
+    margin: 0 0 -${space(0.25)} ${space(1)};
+    padding-left: ${space(0.5)};
+  `}
 `;
 
 export const GroupingValue = styled('code')<{valueType: string}>`

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -1,6 +1,7 @@
-// TODO(matej): I would like to refactor this to reusable component
 import React from 'react';
+import styled from '@emotion/styled';
 
+import space from 'app/styles/space';
 import {tct} from 'app/locale';
 import Button from 'app/components/button';
 import {IconAdd, IconSubtract} from 'app/icons';
@@ -31,18 +32,23 @@ class GroupingComponentFrames extends React.Component<Props, State> {
   render() {
     const {items, maxVisibleItems} = this.props;
     const {collapsed} = this.state;
+    const isCollapsable = items.length > maxVisibleItems;
 
     return (
       <React.Fragment>
         {items.map((item, index) => {
           if (!collapsed || index < maxVisibleItems) {
-            return item;
+            return (
+              <GroupingComponentListItem isCollapsable={isCollapsable} key={index}>
+                {item}
+              </GroupingComponentListItem>
+            );
           }
 
           if (index === maxVisibleItems) {
             return (
-              <GroupingComponentListItem>
-                <Button
+              <GroupingComponentListItem key={index}>
+                <ToggleCollapse
                   size="small"
                   priority="link"
                   icon={<IconAdd size="8px" />}
@@ -51,7 +57,7 @@ class GroupingComponentFrames extends React.Component<Props, State> {
                   {tct('show [numberOfFrames] similiar', {
                     numberOfFrames: items.length - maxVisibleItems,
                   })}
-                </Button>
+                </ToggleCollapse>
               </GroupingComponentListItem>
             );
           }
@@ -61,7 +67,7 @@ class GroupingComponentFrames extends React.Component<Props, State> {
 
         {!collapsed && items.length > maxVisibleItems && (
           <GroupingComponentListItem>
-            <Button
+            <ToggleCollapse
               size="small"
               priority="link"
               icon={<IconSubtract size="8px" />}
@@ -70,12 +76,16 @@ class GroupingComponentFrames extends React.Component<Props, State> {
               {tct('collapse [numberOfFrames] similiar', {
                 numberOfFrames: items.length - maxVisibleItems,
               })}
-            </Button>
+            </ToggleCollapse>
           </GroupingComponentListItem>
         )}
       </React.Fragment>
     );
   }
 }
+
+const ToggleCollapse = styled(Button)`
+  margin: ${space(0.5)} 0;
+`;
 
 export default GroupingComponentFrames;

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {EventGroupComponent} from 'app/types';
 
-import GroupingComponent, {GroupingComponentListItem} from './groupingComponent';
+import GroupingComponent from './groupingComponent';
 import {groupingComponentFilter} from './utils';
 import GroupingComponentFrames from './groupingComponentFrames';
 
@@ -47,12 +47,11 @@ const GroupingComponentStacktrace = ({component, showNonContributing}: Props) =>
         <GroupingComponentFrames
           key={index}
           items={group.data.map((v, idx) => (
-            <GroupingComponentListItem key={idx}>
-              <GroupingComponent
-                component={v}
-                showNonContributing={showNonContributing}
-              />
-            </GroupingComponentListItem>
+            <GroupingComponent
+              key={idx}
+              component={v}
+              showNonContributing={showNonContributing}
+            />
           ))}
         />
       ))}

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingVariant.tsx
@@ -53,7 +53,7 @@ class GroupVariant extends React.Component<Props, State> {
           <QuestionTooltip
             size="xs"
             position="top"
-            title="Events with the same hash are grouped together"
+            title={t('Events with the same hash are grouped together')}
           />
         </TextWithQuestionTooltip>,
       ]);

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingVariant.tsx
@@ -11,12 +11,14 @@ import theme from 'app/utils/theme';
 import {IconCheckmark, IconClose} from 'app/icons';
 import space from 'app/styles/space';
 import Tooltip from 'app/components/tooltip';
+import QuestionTooltip from 'app/components/questionTooltip';
 
 import {hasNonContributingComponent} from './utils';
 import GroupingComponent from './groupingComponent';
 
 type Props = {
   variant: EventGroupVariant;
+  showGroupingConfig: boolean;
 };
 
 type State = {
@@ -39,12 +41,22 @@ class GroupVariant extends React.Component<Props, State> {
   };
 
   getVariantData(): [VariantData, EventGroupComponent | undefined] {
-    const {variant} = this.props;
-    const data: VariantData = [[t('Type'), variant.type]];
+    const {variant, showGroupingConfig} = this.props;
+    const data: VariantData = [];
     let component: EventGroupComponent | undefined;
 
     if (variant.hash !== null) {
-      data.push([t('Hash'), variant.hash]);
+      data.push([
+        t('Hash'),
+        <TextWithQuestionTooltip key="hash">
+          {variant.hash}
+          <QuestionTooltip
+            size="xs"
+            position="top"
+            title="Events with the same hash are grouped together"
+          />
+        </TextWithQuestionTooltip>,
+      ]);
     }
 
     if (variant.hashMismatch) {
@@ -57,21 +69,58 @@ class GroupVariant extends React.Component<Props, State> {
     switch (variant.type) {
       case EventGroupVariantType.COMPONENT:
         component = variant.component;
-        if (variant.config?.id) {
+        data.push([
+          t('Type'),
+          <TextWithQuestionTooltip key="type">
+            {variant.type}
+            <QuestionTooltip
+              size="xs"
+              position="top"
+              title={t(
+                'Uses a complex grouping algorithm taking event data into account'
+              )}
+            />
+          </TextWithQuestionTooltip>,
+        ]);
+        if (showGroupingConfig && variant.config?.id) {
           data.push([t('Grouping Config'), variant.config.id]);
         }
         break;
       case EventGroupVariantType.CUSTOM_FINGERPRINT:
+        data.push([
+          t('Type'),
+          <TextWithQuestionTooltip key="type">
+            {variant.type}
+            <QuestionTooltip
+              size="xs"
+              position="top"
+              title={t('Overrides the default grouping by a custom fingerprinting rule')}
+            />
+          </TextWithQuestionTooltip>,
+        ]);
         if (variant.values) {
           data.push([t('Fingerprint values'), variant.values]);
         }
         break;
       case EventGroupVariantType.SALTED_COMPONENT:
         component = variant.component;
+        data.push([
+          t('Type'),
+          <TextWithQuestionTooltip key="type">
+            {variant.type}
+            <QuestionTooltip
+              size="xs"
+              position="top"
+              title={t(
+                'Uses a complex grouping algorithm taking event data and a fingerprint into account'
+              )}
+            />
+          </TextWithQuestionTooltip>,
+        ]);
         if (variant.values) {
           data.push([t('Fingerprint values'), variant.values]);
         }
-        if (variant.config?.id) {
+        if (showGroupingConfig && variant.config?.id) {
           data.push([t('Grouping Config'), variant.config.id]);
         }
         break;
@@ -106,9 +155,9 @@ class GroupVariant extends React.Component<Props, State> {
           <ContributionIcon isContributing={isContributing} />
           {t('By')}{' '}
           {variant.description
-            .split(' ')
+            ?.split(' ')
             .map(i => capitalize(i))
-            .join(' ')}
+            .join(' ') ?? t('Nothing')}
         </VariantTitle>
       </Tooltip>
     );
@@ -175,6 +224,13 @@ const ContributionIcon = styled(({isContributing, ...p}) =>
 
 const GroupingTree = styled('div')`
   color: #2f2936;
+`;
+
+const TextWithQuestionTooltip = styled('div')`
+  display: grid;
+  align-items: center;
+  grid-template-columns: max-content min-content;
+  grid-gap: ${space(0.5)};
 `;
 
 export default GroupVariant;

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/index.tsx
@@ -67,9 +67,9 @@ class EventGroupingInfo extends AsyncComponent<Props, State> {
     }
 
     const groupedBy = Object.values(groupInfo)
-      .filter(variant => variant.hash !== null)
+      .filter(variant => variant.hash !== null && variant.description !== null)
       .map(variant => variant.description)
-      .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+      .sort((a, b) => a!.toLowerCase().localeCompare(b!.toLowerCase()))
       .join(', ');
 
     return <small>{`(${t('grouped by')} ${groupedBy || t('nothing')})`}</small>;
@@ -99,7 +99,9 @@ class EventGroupingInfo extends AsyncComponent<Props, State> {
     const variants = Object.values(groupInfo).sort((a, b) =>
       a.hash && !b.hash
         ? -1
-        : a.description.toLowerCase().localeCompare(b.description.toLowerCase())
+        : a.description
+            ?.toLowerCase()
+            .localeCompare(b.description?.toLowerCase() ?? '') ?? 1
     );
 
     return (

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/index.tsx
@@ -19,7 +19,7 @@ type Props = AsyncComponent['props'] & {
   organization: Organization;
   projectId: string;
   event: Event;
-  showSelector: boolean;
+  showGroupingConfig: boolean;
 };
 
 type State = AsyncComponent['state'] & {
@@ -94,7 +94,7 @@ class EventGroupingInfo extends AsyncComponent<Props, State> {
 
   renderGroupInfo() {
     const {groupInfo, loading} = this.state;
-    const {showSelector} = this.props;
+    const {showGroupingConfig} = this.props;
 
     const variants = Object.values(groupInfo).sort((a, b) =>
       a.hash && !b.hash
@@ -104,14 +104,14 @@ class EventGroupingInfo extends AsyncComponent<Props, State> {
 
     return (
       <React.Fragment>
-        {showSelector && this.renderGroupConfigSelect()}
+        {showGroupingConfig && this.renderGroupConfigSelect()}
 
         {loading ? (
           <LoadingIndicator />
         ) : (
           variants.map((variant, index) => (
             <React.Fragment key={variant.key}>
-              <GroupVariant variant={variant} />
+              <GroupVariant variant={variant} showGroupingConfig={showGroupingConfig} />
               {index < variants.length - 1 && <VariantDivider />}
             </React.Fragment>
           ))

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1251,7 +1251,7 @@ export enum EventGroupVariantType {
 }
 
 export type EventGroupVariant = {
-  description: string;
+  description: string | null;
   hash: string | null;
   hashMismatch: boolean;
   key: EventGroupVariantKey;


### PR DESCRIPTION
Before:
<img width="1574" alt="Screenshot 2020-05-20 at 17 47 01" src="https://user-images.githubusercontent.com/9060071/82467628-28610000-9ac2-11ea-9838-41e20d563b3e.png">

After:
<img width="1575" alt="Screenshot 2020-05-20 at 17 48 20" src="https://user-images.githubusercontent.com/9060071/82467655-30b93b00-9ac2-11ea-9530-cfaeb9b33398.png">


- grouping config field behind a feature flag
- border on collapsable frames
- question tooltips

Fixes JAVASCRIPT-22AF
Fixes JAVASCRIPT-22AE