### PR TITLE
ref(api): Add instrumentation to OrganizationUsersEndpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
+import sentry_sdk
+
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -32,21 +34,29 @@ class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
         :auth: required
         """
         projects = self.get_projects(request, organization)
-        qs = (
-            OrganizationMember.objects.filter(
-                user__is_active=True,
-                organization=organization,
-                teams__projectteam__project__in=projects,
+
+        with sentry_sdk.start_span(op="OrganizationUsersEndpoint.get_members") as span:
+            qs = (
+                OrganizationMember.objects.filter(
+                    user__is_active=True,
+                    organization=organization,
+                    teams__projectteam__project__in=projects,
+                )
+                .select_related("user")
+                .prefetch_related(
+                    "teams", "teams__projectteam_set", "teams__projectteam_set__project"
+                )
+                .order_by("user__email")
+                .distinct()
             )
-            .select_related("user")
-            .prefetch_related("teams", "teams__projectteam_set", "teams__projectteam_set__project")
-            .order_by("user__email")
-            .distinct()
-        )
+            organization_members = list(qs)
+
+            span.set_data("Project Count", len(projects))
+            span.set_data("Member Count", len(organization_members))
 
         return Response(
             serialize(
-                list(qs),
+                organization_members,
                 request.user,
                 serializer=OrganizationMemberWithProjectsSerializer(
                     project_ids=[p.id for p in projects]


### PR DESCRIPTION
The primary motivation is to capture the full time cost of unpacking the
OrganizationMember query set; current traces show relatively cheap
queries with long spans between them (possibly attributable to Django's
prefetch logic). Capturing the counts of projects and organization
members is a secondary benefit.