### PR TITLE
ref(slack): Updated copy for Slack migration

### DIFF
--- a/src/sentry/integrations/slack/post_migration.py
+++ b/src/sentry/integrations/slack/post_migration.py
@@ -19,7 +19,7 @@ doc_link = "https://docs.sentry.io/workflow/integrations/global-integrations/#sl
 def build_migration_attachment():
     return {
         "title": "Action required",
-        "text": "Your Sentry Slack Integration has been upgraded. Mention `@sentry` to receive Sentry notifications in this channel. For more information, <%s|check out the documentation>."
+        "text": "Your Sentry Slack Integration is upgraded and nearly ready to report errors. Mention `@sentry` to get notifications in this channel. To learn more, <%s|see our documentation>."
         % (doc_link),
         "footer": "Sentry API",
         "footer_icon": "https://sentryio-assets.storage.googleapis.com/img/slack/integration-avatar.png",

--- a/src/sentry/templates/sentry/emails/slack-migration.html
+++ b/src/sentry/templates/sentry/emails/slack-migration.html
@@ -5,34 +5,34 @@
 {% load sentry_helpers %}
 
 {% block main %}
-  <h3>Slack Upgrade</h3>
-  Your Sentry Slack Integration for workspace <strong>{{integration.name}}</strong> has been updated on behalf of organization <strong>{{organization.name}}</strong>. For more information, <a href="{{ doc_link }}">check out the documentation.</a>
+  <h3>You're All Upgraded</h3>
+    Well, you're looking fresh. Your organization <strong>{{organization.name}}</strong>'s Sentry-Slack Integration for your workspace
+    <strong>{{integration.name}}</strong> is all up to date and ready to report errors. If you're confused, curious, or just looking
+    for some light reading, see <a href="{{ doc_link }}">our docs</a>.
   <br />
   <br />
-  {% if good_channels %}
+    {% if good_channels or failing_channels %}
+    <strong>Private Channels</strong>
     <div>
-        <strong>Working Private Channels</strong>
-        <p>Sentry was able to send messages to the following private channels with instructions on how to add Sentry to the channel:</p>
+        <p>Before you pack up and go home, take a look at the following private channel(s). We sent you a message with instructions to add Sentry to the channel(s).</p>
         {% for channel in good_channels %}
             <li class="channel-name">{{channel.name}} </li>
         {% endfor %}
-    </div>
-    {% endif %}
-    {% if failing_channels %}
+        {% if failing_channels %}
         <br />
-        <strong>Failing Private Channels</strong>
-        <p>Sentry was unable to send messages to the following private channels:</p>
+        <p>For some reason, we couldn't send a message to private channel(s) below:</p>
         {% for channel in failing_channels %}
             <li class="channel-name">{{channel.name}} </li>
         {% endfor %}
-        </div>
+        {% endif %}
+    </div>
     {% endif %}
     {% if missing_channels %}
         <br />
         <div>
             <strong>Missing or Unauthorized Channels</strong>
             <p class="section-info">
-                {% trans "These channels were found to be missing or unauthorized by the current Slack integration. If they are private channels, you'll have make sure to add the Sentry bot to the channels after migration. Otherwise you may want update your alert rules to use a different channel." %}
+                {% trans "These channels were found to be missing or unauthorized in your legacy Slack integration. If they were private channels, you'll have make sure to add the Sentry bot to these channels. Otherwise you may want update your alert rules accordingly." %}
             </p>
             {% for channel in missing_channels %}
                 <li class="channel-name">{{channel.name}} </li>
@@ -42,4 +42,13 @@
 
 {% endblock %}
 
-{% block footer %}{% endblock %}
+<div class="container">
+    <div class="footer">
+        {% block footer %}
+        <a href="{% absolute_uri %}" style="float:right">Home</a>
+        <span href="#">
+            Have questions? Emails us at <a href="mailto:partners@sentry.io?subject=Slack Upgrade"><strong>partners@sentry.io</strong></a>.
+        </span>
+        {% endblock %}
+    </div>
+</div>

--- a/src/sentry/templates/sentry/integrations/slack-reauth-details.html
+++ b/src/sentry/templates/sentry/integrations/slack-reauth-details.html
@@ -41,10 +41,10 @@
 
 
 {% block main %}
-    <h3>Time For An Upgrade</h3>
+    <h3>{% trans "Time For An Upgrade" %}</h3>
     {% if private %}
         <div class="private">
-            <strong>Well, look who has private channels with alert rules.</strong>
+            <strong>{% trans "Well, look who has private channels with alert rules." %}</strong>
             <p class="section-info">
                 {% blocktrans %}
                 So what does this mean for you and the future of your channels? Not much.
@@ -63,7 +63,7 @@
             </p>
         </div>
 
-        <strong>Next Steps</strong>
+        <strong>{% trans "Next Steps" %}</strong>
         <p class="section-info">
             {% blocktrans %}
             Click <strong>Upgrade</strong> to start the authentication flow for the new Slack app.
@@ -74,7 +74,7 @@
 
     <div>
         {% if not private %}
-            <h5>Next Steps</h5>
+            <h5>{% trans "Next Steps" %}</h5>
             <p>
                 {% blocktrans %}
                 See, that wasn't so bad. Just click <strong>Upgrade</strong> to start the authentication flow for the new Slack app.
@@ -85,8 +85,10 @@
 
     <div class="form-actions clearfix">
         <div>
-            <div class="footer-text">Have questions? Emails us at
-                <a href="mailto:partners@sentry.io?subject=Slack Upgrade"><strong>partners@sentry.io</strong></a>
+            <div class="footer-text">
+                {% blocktrans %}
+                Have questions? Emails us at <a href="mailto:partners@sentry.io?subject=Slack Upgrade"><strong>partners@sentry.io</strong></a>
+                {% endblocktrans %}
             </div>
             <div class="pull-right">
                 <a class="btn btn-primary" onclick="loading()" href="{{ next_url }}">{% trans "Upgrade" %}</a>

--- a/src/sentry/templates/sentry/integrations/slack-reauth-details.html
+++ b/src/sentry/templates/sentry/integrations/slack-reauth-details.html
@@ -25,11 +25,14 @@
         margin: 0px 5px;
     }
     .section-info {
-        font-size: 90%;
         margin-top: 5px;
     }
     .private :last-child {
         margin-top: 20px;
+    }
+    .footer-text {
+        display: inline-block;
+        font-size: 90%;
     }
   </style>
 
@@ -38,15 +41,15 @@
 
 
 {% block main %}
-    <h3>Authorize New Sentry Slack App</h3>
-    <div class="private">
-        {% if private %}
-            <strong>We've found some private channels being used in your alert rules:</strong>
+    <h3>Time For An Upgrade</h3>
+    {% if private %}
+        <div class="private">
+            <strong>Well, look who has private channels with alert rules.</strong>
             <p class="section-info">
                 {% blocktrans %}
-                    What does this mean? Am I doomed? No, you're not doomed. All this means is that once you're done
-                    authorizing the new Slack app, you'll need to add the Sentry bot to each of these channels to
-                    ensure that the bot has access to alert you about your Sentry errors!
+                So what does this mean for you and the future of your channels? Not much.
+                You'll just need to add the Sentry bot to each channel after you authorize the new Slack app.
+                Otherwise, you might miss out on some important error alerts.
                 {% endblocktrans %}
             </p>
             {% for channel in private %}
@@ -54,26 +57,40 @@
             {% endfor %}
             <p class="section-info">
                 {% blocktrans %}
-                    What if I forget what channels are used the moment I leave this screen? Don't worry, after the
-                    authentication step, we'll send your private channels one last message from the legacy app, reminding
-                    you to add the new Sentry bot.
+                We can't even remember the name of that show everyone's been recommending, so we couldn't possibly
+                expect you to remember these channel names. We'll send you another reminder in your private Slack channels.
                 {% endblocktrans %}
             </p>
-        {% endif %}
+        </div>
 
-    </div>
+        <strong>Next Steps</strong>
+        <p class="section-info">
+            {% blocktrans %}
+            Click <strong>Upgrade</strong> to start the authentication flow for the new Slack app.
+            {% endblocktrans %}
+        </p>
+    {% endif %}
 
 
     <div>
         {% if not private %}
-        <h6><strong>Next Steps</strong></h6>
-            <p class="section-info"> You are good to go! Click "Next" to start the re-authentication flow!</p>
+            <h5>Next Steps</h5>
+            <p>
+                {% blocktrans %}
+                See, that wasn't so bad. Just click <strong>Upgrade</strong> to start the authentication flow for the new Slack app.
+                {% endblocktrans %}
+            </p>
         {% endif %}
     </div>
 
     <div class="form-actions clearfix">
-        <div class="pull-right">
-            <a class="btn btn-primary" href="{{ next_url }}">{% trans "Start Authorization" %}</a>
+        <div>
+            <div class="footer-text">Have questions? Emails us at
+                <a href="mailto:partners@sentry.io?subject=Slack Upgrade"><strong>partners@sentry.io</strong></a>
+            </div>
+            <div class="pull-right">
+                <a class="btn btn-primary" onclick="loading()" href="{{ next_url }}">{% trans "Upgrade" %}</a>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/sentry/templates/sentry/integrations/slack-reauth-introduction.html
+++ b/src/sentry/templates/sentry/integrations/slack-reauth-introduction.html
@@ -37,6 +37,10 @@
         display: flex;
         flex-direction: column;
     }
+    .footer-text {
+        display: inline-block;
+        font-size: 90%;
+    }
     .loader, .loader:after {
         border-radius: 50%;
         width: 10em;
@@ -86,41 +90,38 @@
         document.getElementById("loader").setAttribute("class", "loader");
     };
 </script>
-    <h3>Authorize New Sentry Slack App</h3>
+    <h3>{% trans "Time For An Upgrade" %}</h3>
 
-    <h5>Moving Off Slack's Legacy Workspace Apps</h5>
-    <strong>Was it worth it? When we work(space)d it.</strong>
-    <strong>We put our code down, flip it and reverse it.</strong>
+    <h5>{% trans "Farewell to Slack's legacy workspace apps." %}</h5>
     <p>
-        {% blocktrans %}
-            Slack has deprecated their workspace apps which our integration
-            was previously built on. But not to worry, Sentry has built a new Slack app,
-            and a path for you to upgrade to this new app! In order to continue using
-            the Slack integration and your existing configuration, you will need to
-            authorize the new app in upcoming steps.
-        {% endblocktrans %}
+        {% trans "The time has come, Slack's deprecated its workspace apps. And with it, goes our legacy Slack integration." %}
     </p>
-    <p>{% trans "If you want more details about the move, please visit our docs" %}</p>
-
-    <h5>Existing Alert Rule Configurations</h5>
-    <strong>We (may) interrupt your regularly scheduled programming...</strong>
+    <p>
+        {% trans "But don't worry, we built you a whole new Sentry-Slack integration. Just authorize the app, and then you can get back to doing whatever it is you came here to do." %}
+    </p>
     <p>
         {% blocktrans %}
-            If you aren't using any private channels in your alert rules, authorizing
-            the new Slack app will be all you need to do. However, if you <strong>do</strong>
-            have any private channels in your rule configurations, you'll have one extra
-            step after authorizing the new Slack app.
+        Want to know more about the move? We wrote you some <a href="https://docs.sentry.io/workflow/integrations/global-integrations/#upgrading-slack">docs</a>.
         {% endblocktrans %}
     </p>
 
+    <h5>{% trans "Your existing alert rules may need some love." %}</h5>
+    <p>
+        {% trans "If you don't have private channels in your alert rules, just authorize our new Slack app and then you can get on with your life." %}
+    </p>
     <p>
         {% blocktrans %}
-            But how do I know what channels are being used? Good question! This next step will
-            audit your alert rules to see if there are any private channels that require
-            attention after authenticating. Please note that if you have a high number
-            of slack channels in your alert rules this could take a hot minute...
-         {% endblocktrans %}
-     </p>
+        If you <strong>do</strong> have private channels being used in your alert rules, bear with us. You've got an extra step to go.
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans %}
+        How do you know which channels are used in alert rules? We'll tell you. Our next step audits your configuration to identify
+        which channels need some post-authentication love. Bear in mind that if you've got a lot of Slack channels with alert rules,
+        this might take a hot minute.
+        {% endblocktrans %}
+    </p>
+
 
     {% if extra_orgs %}
     <p class="alert alert-block flex">
@@ -141,8 +142,13 @@
 
     <div id="loader"></div>
     <div class="form-actions clearfix">
-        <div class="pull-right">
-            <a class="btn btn-primary" onclick="loading()" href="{{ next_url }}">{% trans "Continue" %}</a>
+        <div>
+            <div class="footer-text">Have questions? Emails us at
+                <a href="mailto:partners@sentry.io?subject=Slack Upgrade"><strong>partners@sentry.io</strong></a>
+            </div>
+            <div class="pull-right">
+                <a class="btn btn-primary" onclick="loading()" href="{{ next_url }}">{% trans "Continue" %}</a>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/sentry/templates/sentry/integrations/slack-reauth-introduction.html
+++ b/src/sentry/templates/sentry/integrations/slack-reauth-introduction.html
@@ -143,8 +143,10 @@
     <div id="loader"></div>
     <div class="form-actions clearfix">
         <div>
-            <div class="footer-text">Have questions? Emails us at
-                <a href="mailto:partners@sentry.io?subject=Slack Upgrade"><strong>partners@sentry.io</strong></a>
+            <div class="footer-text">
+                {% blocktrans %}
+                Have questions? Emails us at <a href="mailto:partners@sentry.io?subject=Slack Upgrade"><strong>partners@sentry.io</strong></a>
+                {% endblocktrans %}
             </div>
             <div class="pull-right">
                 <a class="btn btn-primary" onclick="loading()" href="{{ next_url }}">{% trans "Continue" %}</a>


### PR DESCRIPTION
This PR updates the copy for:
* Upgrade flow in app 
* Slack messages posted to private channels
* Follow up email for private channels and/or missing and unauthorized emails 

All of the above sections will provide the `partners@sentry.io` email. This could change to be support in the future.