### PR TITLE
feat(workflow): Removing title from discover link

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -60,7 +60,7 @@ export default class DetailsBody extends React.Component<Props> {
     const discoverQuery: NewQuery = {
       id: undefined,
       name: (incident && incident.title) || '',
-      fields: ['issue', 'title', 'count(id)', 'count_unique(user.id)'],
+      fields: ['issue', 'count(id)', 'count_unique(user.id)'],
       orderby:
         incident.alertRule.aggregation === AlertRuleAggregations.UNIQUE_USERS
           ? '-count_unique_user_id'


### PR DESCRIPTION
We've opted to remove the title from the link again.

Addresses: https://app.asana.com/0/1143846759074121/1176346088294177