### PR TITLE
ref(devservices): Rename reverse_proxy to proxy

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1513,6 +1513,7 @@ SENTRY_DEVSERVICES = {
         # started up, only pulled and made available for `devserver` which will start
         # it with `devservices attach --is-devserver reverse_proxy`.
         "with_devserver": True,
+        "devserver_alias": "proxy",
     },
     "relay": {
         "image": "us.gcr.io/sentryio/relay:latest",

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -227,7 +227,12 @@ def devserver(
 
     for name, container_options in _prepare_containers("sentry", silent=True).items():
         if container_options.get("with_devserver", False):
-            daemons += [(name, ["sentry", "devservices", "attach", "--fast", name])]
+            daemons += [
+                (
+                    container_options.get("devserver_alias", name),
+                    ["sentry", "devservices", "attach", "--fast", name],
+                )
+            ]
 
     # A better log-format for local dev when running through honcho,
     # but if there aren't any other daemons, we don't want to override.


### PR DESCRIPTION
The only motivation is that all of the other devserver daemons (note, devserver daemons, NOT devservices, however because this is started with the devserver it becomes a devserver daemon) are nice and short, meaning the honcho prefix is short.

Because this one was so long, it caused the honcho prefix to pad left spaces on all other devserver daemons.