### PR TITLE
chore(eslint): Update eslint config to 1.37.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "enzyme-adapter-react-16": "1.15.1",
     "enzyme-to-json": "3.4.3",
     "eslint": "5.11.1",
-    "eslint-config-sentry-app": "1.36.0",
+    "eslint-config-sentry-app": "1.37.0",
     "jest": "24.9.0",
     "jest-canvas-mock": "^2.2.0",
     "jest-junit": "^9.0.0",

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {t} from 'app/locale';
 import minified from 'sentry-dreamy-components/dist/minified.svg';
 import emails from 'sentry-dreamy-components/dist/emails.svg';
 import issues from 'sentry-dreamy-components/dist/issues.svg';
 import suggestedAssignees from 'sentry-dreamy-components/dist/suggested-assignees.svg';
 import contributors from 'sentry-dreamy-components/dist/contributors.svg';
+
+import {t} from 'app/locale';
 import {Project, Organization} from 'app/types';
 import {analytics} from 'app/utils/analytics';
 import withOrganization from 'app/utils/withOrganization';

--- a/src/sentry/static/sentry/app/views/userFeedback/userFeedbackEmpty.tsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/userFeedbackEmpty.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import * as Sentry from '@sentry/browser';
 
+import userFeedback from 'sentry-dreamy-components/dist/user-feedback.svg';
+
 import {Organization, Project} from 'app/types';
 import {t} from 'app/locale';
 import {trackAnalyticsEvent, trackAdhocEvent} from 'app/utils/analytics';
@@ -10,7 +12,6 @@ import Button from 'app/components/button';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
-import userFeedback from 'sentry-dreamy-components/dist/user-feedback.svg';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
 

--- a/tests/js/spec/components/acl/access.spec.jsx
+++ b/tests/js/spec/components/acl/access.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import Access from 'app/components/acl/access';
 import ConfigStore from 'app/stores/configStore';
 

--- a/tests/js/spec/components/acl/feature.spec.jsx
+++ b/tests/js/spec/components/acl/feature.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount, mountWithTheme} from 'sentry-test/enzyme';
+
 import Feature from 'app/components/acl/feature';
 import ConfigStore from 'app/stores/configStore';
 import HookStore from 'app/stores/hookStore';

--- a/tests/js/spec/components/acl/featureDisabled.spec.jsx
+++ b/tests/js/spec/components/acl/featureDisabled.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {PanelAlert} from 'app/components/panels';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {PanelAlert} from 'app/components/panels';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
 
 describe('FeatureDisabled', function() {

--- a/tests/js/spec/components/actions/ignore.spec.jsx
+++ b/tests/js/spec/components/actions/ignore.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import $ from 'jquery';
 
 import {mount, mountWithTheme} from 'sentry-test/enzyme';
+
 import IgnoreActions from 'app/components/actions/ignore';
 
 describe('IgnoreActions', function() {

--- a/tests/js/spec/components/actions/resolve.spec.jsx
+++ b/tests/js/spec/components/actions/resolve.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import $ from 'jquery';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ResolveActions from 'app/components/actions/resolve';
 
 describe('ResolveActions', function() {

--- a/tests/js/spec/components/activity/note/input.spec.jsx
+++ b/tests/js/spec/components/activity/note/input.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import changeReactMentionsInput from 'sentry-test/changeReactMentionsInput';
+
 import NoteInput from 'app/components/activity/note/input';
 
 describe('NoteInput', function() {

--- a/tests/js/spec/components/activity/note/inputWithStorage.spec.jsx
+++ b/tests/js/spec/components/activity/note/inputWithStorage.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import changeReactMentionsInput from 'sentry-test/changeReactMentionsInput';
+
 import NoteInputWithStorage from 'app/components/activity/note/inputWithStorage';
 import localStorage from 'app/utils/localStorage';
 

--- a/tests/js/spec/components/alertLink.spec.jsx
+++ b/tests/js/spec/components/alertLink.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import AlertLink from 'app/components/alertLink';
 import {IconMail} from 'app/icons';
 

--- a/tests/js/spec/components/assigneeSelector.spec.jsx
+++ b/tests/js/spec/components/assigneeSelector.spec.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
+import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {
   AssigneeSelectorComponent,
   putSessionUserFirst,
 } from 'app/components/assigneeSelector';
 import {Client} from 'app/api';
-import {mountWithTheme} from 'sentry-test/enzyme';
 import ConfigStore from 'app/stores/configStore';
 import GroupStore from 'app/stores/groupStore';
 import MemberListStore from 'app/stores/memberListStore';

--- a/tests/js/spec/components/assistant/guideAnchor.spec.jsx
+++ b/tests/js/spec/components/assistant/guideAnchor.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import GuideAnchor from 'app/components/assistant/guideAnchor';
 import GuideActions from 'app/actions/guideActions';
 import ConfigStore from 'app/stores/configStore';

--- a/tests/js/spec/components/asyncComponent.spec.jsx
+++ b/tests/js/spec/components/asyncComponent.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import AsyncComponent from 'app/components/asyncComponent';
 

--- a/tests/js/spec/components/autoComplete.spec.jsx
+++ b/tests/js/spec/components/autoComplete.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import AutoComplete from 'app/components/autoComplete';
 
 const items = [

--- a/tests/js/spec/components/avatar.spec.jsx
+++ b/tests/js/spec/components/avatar.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Avatar from 'app/components/avatar';
 
 jest.mock('app/stores/configStore', () => ({

--- a/tests/js/spec/components/avatar/actorAvatar.spec.jsx
+++ b/tests/js/spec/components/avatar/actorAvatar.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mount} from 'sentry-test/enzyme';
+
 import ActorAvatar from 'app/components/avatar/actorAvatar';
 import MemberListStore from 'app/stores/memberListStore';
 import TeamStore from 'app/stores/teamStore';

--- a/tests/js/spec/components/avatar/avatarList.spec.jsx
+++ b/tests/js/spec/components/avatar/avatarList.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import AvatarList from 'app/components/avatar/avatarList';
 
 describe('AvatarList', function() {

--- a/tests/js/spec/components/avatarCropper.spec.jsx
+++ b/tests/js/spec/components/avatarCropper.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import AvatarCropper from 'app/components/avatarCropper';
 
 describe('AvatarCropper', function() {

--- a/tests/js/spec/components/breadcrumbs.spec.jsx
+++ b/tests/js/spec/components/breadcrumbs.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import Breadcrumbs from 'app/components/breadcrumbs';
 
 describe('Breadcrumbs', () => {

--- a/tests/js/spec/components/button.spec.jsx
+++ b/tests/js/spec/components/button.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Button from 'app/components/button';
 
 describe('Button', function() {

--- a/tests/js/spec/components/buttonBar.spec.jsx
+++ b/tests/js/spec/components/buttonBar.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 

--- a/tests/js/spec/components/charts/percentageTableChart.spec.jsx
+++ b/tests/js/spec/components/charts/percentageTableChart.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import PercentageTableChart from 'app/components/charts/percentageTableChart';
 
 describe('PercentageTableChart', function() {

--- a/tests/js/spec/components/charts/releaseSeries.spec.jsx
+++ b/tests/js/spec/components/charts/releaseSeries.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import ReleaseSeries from 'app/components/charts/releaseSeries';
 
 describe('ReleaseSeries', function() {

--- a/tests/js/spec/components/charts/tableChart/index.spec.jsx
+++ b/tests/js/spec/components/charts/tableChart/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import TableChart from 'app/components/charts/tableChart';
 
 describe('TableChart', function() {

--- a/tests/js/spec/components/checkbox.spec.jsx
+++ b/tests/js/spec/components/checkbox.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import Checkbox from 'app/components/checkbox';
 
 describe('Checkbox', function() {

--- a/tests/js/spec/components/checkboxFancy.spec.tsx
+++ b/tests/js/spec/components/checkboxFancy.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import CheckboxFancy from 'app/components/checkboxFancy/checkboxFancy';
 
 describe('CheckboxFancy', function() {

--- a/tests/js/spec/components/circleIndicator.spec.jsx
+++ b/tests/js/spec/components/circleIndicator.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import CircleIndicator from 'app/components/circleIndicator';
 
 describe('CircleIndicator', function() {

--- a/tests/js/spec/components/confirm.spec.jsx
+++ b/tests/js/spec/components/confirm.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import Confirm from 'app/components/confirm';
 
 describe('Confirm', function() {

--- a/tests/js/spec/components/confirmDelete.spec.jsx
+++ b/tests/js/spec/components/confirmDelete.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ConfirmDelete from 'app/components/confirmDelete';
 
 describe('ConfirmDelete', function() {

--- a/tests/js/spec/components/contextData.spec.jsx
+++ b/tests/js/spec/components/contextData.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ContextData from 'app/components/contextData';
 
 describe('ContextData', function() {

--- a/tests/js/spec/components/contextPickerModal.spec.jsx
+++ b/tests/js/spec/components/contextPickerModal.spec.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {selectByValue} from 'sentry-test/select-new';
+
 import ContextPickerModal from 'app/components/contextPickerModal';
 import OrganizationStore from 'app/stores/organizationStore';
 import OrganizationsStore from 'app/stores/organizationsStore';
 import ProjectsStore from 'app/stores/projectsStore';
-import {selectByValue} from 'sentry-test/select-new';
 
 jest.mock('jquery');
 

--- a/tests/js/spec/components/createSampleEventButton.spec.jsx
+++ b/tests/js/spec/components/createSampleEventButton.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import CreateSampleEventButton from 'app/views/onboarding/createSampleEventButton';
 
 jest.useFakeTimers();

--- a/tests/js/spec/components/customResolutionModal.spec.jsx
+++ b/tests/js/spec/components/customResolutionModal.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import CustomResolutionModal from 'app/components/customResolutionModal';
 
 describe('CustomResolutionModal', function() {

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Button from 'app/components/button';
 import WrappedDataExport, {DataExport} from 'app/components/dataExport';
 

--- a/tests/js/spec/components/deployBadge.spec.jsx
+++ b/tests/js/spec/components/deployBadge.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import DeployBadge from 'app/components/deployBadge';
 
 const deploy = {

--- a/tests/js/spec/components/detailedError.spec.jsx
+++ b/tests/js/spec/components/detailedError.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import DetailedError from 'app/components/errors/detailedError';
 
 describe('DetailedError', function() {

--- a/tests/js/spec/components/dropdownAutoComplete.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoComplete.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 
 describe('DropdownAutoComplete', function() {

--- a/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownAutoCompleteMenu.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import DropdownAutoCompleteMenu from 'app/components/dropdownAutoCompleteMenu';
 
 describe('DropdownAutoCompleteMenu', function() {

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import DropdownLink from 'app/components/dropdownLink';
 import {MENU_CLOSE_DELAY} from 'app/constants';
 

--- a/tests/js/spec/components/dropdownMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownMenu.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import DropdownMenu from 'app/components/dropdownMenu';
 
 jest.useFakeTimers();

--- a/tests/js/spec/components/errorRobot.spec.jsx
+++ b/tests/js/spec/components/errorRobot.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import {ErrorRobot} from 'app/components/errorRobot';
 

--- a/tests/js/spec/components/eventOrGroupExtraDetails.spec.jsx
+++ b/tests/js/spec/components/eventOrGroupExtraDetails.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import EventOrGroupExtraDetails from 'app/components/eventOrGroupExtraDetails';
 
 describe('EventOrGroupExtraDetails', function() {

--- a/tests/js/spec/components/eventOrGroupHeader.spec.jsx
+++ b/tests/js/spec/components/eventOrGroupHeader.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import EventOrGroupHeader from 'app/components/eventOrGroupHeader';
 
 const data = {

--- a/tests/js/spec/components/eventOrGroupTitle.spec.jsx
+++ b/tests/js/spec/components/eventOrGroupTitle.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import EventOrGroupTitle from 'app/components/eventOrGroupTitle';
 
 describe('EventOrGroupTitle', function() {

--- a/tests/js/spec/components/events/contextSummary.spec.jsx
+++ b/tests/js/spec/components/events/contextSummary.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mount} from 'sentry-test/enzyme';
+
 import ContextSummary from 'app/components/events/contextSummary/contextSummary';
 import {FILTER_MASK} from 'app/constants';
 import ContextSummaryUser from 'app/components/events/contextSummary/contextSummaryUser';

--- a/tests/js/spec/components/events/crashContent.spec.jsx
+++ b/tests/js/spec/components/events/crashContent.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import CrashContent from 'app/components/events/interfaces/crashContent';
 import {withMeta} from 'app/components/events/meta/metaProxy';
 

--- a/tests/js/spec/components/events/eventCause.spec.jsx
+++ b/tests/js/spec/components/events/eventCause.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import EventCause from 'app/components/events/eventCause';
 

--- a/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
+++ b/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import EventCauseEmpty from 'app/components/events/eventCauseEmpty';
 import {trackAdhocEvent, trackAnalyticsEvent} from 'app/utils/analytics';
 

--- a/tests/js/spec/components/events/interfaces/breadcrumbComponents/breadcrumbs.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/breadcrumbComponents/breadcrumbs.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import BreadcrumbsInterface from 'app/components/events/interfaces/breadcrumbs/breadcrumbs';
 
 describe('BreadcrumbsInterface', function() {

--- a/tests/js/spec/components/events/interfaces/breadcrumbComponents/httpRenderer.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/breadcrumbComponents/httpRenderer.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import HttpRenderer from 'app/components/events/interfaces/breadcrumbs/httpRenderer';
 
 describe('HttpRenderer', function() {

--- a/tests/js/spec/components/events/interfaces/contexts.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/contexts.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import User from 'app/components/events/contexts/user/user';
 import {FILTER_MASK} from 'app/constants';
 

--- a/tests/js/spec/components/events/interfaces/exceptionMechanism.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/exceptionMechanism.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ExceptionMechanism from 'app/components/events/interfaces/exceptionMechanism';
 
 describe('ExceptionMechanism', () => {

--- a/tests/js/spec/components/events/interfaces/exceptionStacktraceContent.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/exceptionStacktraceContent.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ExceptionStacktraceContent from 'app/components/events/interfaces/exceptionStacktraceContent';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 

--- a/tests/js/spec/components/events/interfaces/frame.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frame.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import Frame from 'app/components/events/interfaces/frame/frame';
 
 describe('Frame', function() {

--- a/tests/js/spec/components/events/interfaces/frameRegisters.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frameRegisters.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import FrameRegisters from 'app/components/events/interfaces/frameRegisters/frameRegisters';
 import FrameRegistersValue from 'app/components/events/interfaces/frameRegisters/frameRegistersValue';
 

--- a/tests/js/spec/components/events/interfaces/keyValueList.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/keyValueList.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import KeyValueList from 'app/components/events/interfaces/keyValueList/keyValueList';
 
 describe('KeyValueList', function() {

--- a/tests/js/spec/components/events/interfaces/openInContextLine.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/openInContextLine.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
 import {OpenInContextLine} from 'app/components/events/interfaces/openInContextLine';
 

--- a/tests/js/spec/components/events/interfaces/richHttpContent.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/richHttpContent.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount, shallow} from 'sentry-test/enzyme';
+
 import RichHttpContent from 'app/components/events/interfaces/richHttpContent/richHttpContent';
 
 describe('RichHttpContent', function() {

--- a/tests/js/spec/components/events/meta/annotated.spec.jsx
+++ b/tests/js/spec/components/events/meta/annotated.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import Annotated from 'app/components/events/meta/annotated';
 import {withMeta} from 'app/components/events/meta/metaProxy';
 

--- a/tests/js/spec/components/events/meta/metaData.spec.jsx
+++ b/tests/js/spec/components/events/meta/metaData.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {withMeta} from 'app/components/events/meta/metaProxy';
 import MetaData from 'app/components/events/meta/metaData';
 

--- a/tests/js/spec/components/events/sdkUpdates.spec.jsx
+++ b/tests/js/spec/components/events/sdkUpdates.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import EventSdkUpdates from 'app/components/events/sdkUpdates';
 
 describe('EventSdkUpdates', function() {

--- a/tests/js/spec/components/eventsTable/eventsTable.spec.jsx
+++ b/tests/js/spec/components/eventsTable/eventsTable.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import EventsTable from 'app/components/eventsTable/eventsTable';
 
 describe('EventsTable', function() {

--- a/tests/js/spec/components/eventsTable/eventsTableRow.spec.jsx
+++ b/tests/js/spec/components/eventsTable/eventsTableRow.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {EventsTableRow} from 'app/components/eventsTable/eventsTableRow';
 
 describe('EventsTableRow', function() {

--- a/tests/js/spec/components/externalLink.spec.jsx
+++ b/tests/js/spec/components/externalLink.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ExternalLink from 'app/components/links/externalLink';
 
 describe('ExternalLink', function() {

--- a/tests/js/spec/components/forms/booleanField.spec.jsx
+++ b/tests/js/spec/components/forms/booleanField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {BooleanField} from 'app/components/forms';
 
 describe('BooleanField', function() {

--- a/tests/js/spec/components/forms/emailField.spec.jsx
+++ b/tests/js/spec/components/forms/emailField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {EmailField} from 'app/components/forms';
 
 describe('EmailField', function() {

--- a/tests/js/spec/components/forms/form.spec.jsx
+++ b/tests/js/spec/components/forms/form.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {Form} from 'app/components/forms';
 
 describe('Form', function() {

--- a/tests/js/spec/components/forms/formField.spec.jsx
+++ b/tests/js/spec/components/forms/formField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import TextField from 'app/views/settings/components/forms/textField';
 import Form from 'app/views/settings/components/forms/form';
 import FormModel from 'app/views/settings/components/forms/model';

--- a/tests/js/spec/components/forms/genericField.spec.jsx
+++ b/tests/js/spec/components/forms/genericField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {GenericField, FormState} from 'app/components/forms';
 
 describe('GenericField', function() {

--- a/tests/js/spec/components/forms/multiSelectField.spec.jsx
+++ b/tests/js/spec/components/forms/multiSelectField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {MultiSelectField} from 'app/components/forms';
 
 describe('MultiSelectField', function() {

--- a/tests/js/spec/components/forms/multipleCheckboxField.spec.jsx
+++ b/tests/js/spec/components/forms/multipleCheckboxField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {MultipleCheckboxField} from 'app/components/forms';
 
 describe('MultipleCheckboxField', function() {

--- a/tests/js/spec/components/forms/numberField.spec.jsx
+++ b/tests/js/spec/components/forms/numberField.spec.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
+import {shallow, mount} from 'sentry-test/enzyme';
+
 import {NumberField} from 'app/components/forms';
 import Form from 'app/components/forms/form';
-import {shallow, mount} from 'sentry-test/enzyme';
 
 jest.mock('jquery');
 

--- a/tests/js/spec/components/forms/passwordField.spec.jsx
+++ b/tests/js/spec/components/forms/passwordField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {PasswordField} from 'app/components/forms';
 
 describe('PasswordField', function() {

--- a/tests/js/spec/components/forms/radioBooleanField.spec.jsx
+++ b/tests/js/spec/components/forms/radioBooleanField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mount} from 'sentry-test/enzyme';
+
 import {RadioBooleanField} from 'app/components/forms';
 import NewRadioBooleanField from 'app/views/settings/components/forms/radioBooleanField';
 

--- a/tests/js/spec/components/forms/radioGroup.spec.jsx
+++ b/tests/js/spec/components/forms/radioGroup.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount, shallow} from 'sentry-test/enzyme';
+
 import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
 
 describe('RadioGroup', function() {

--- a/tests/js/spec/components/forms/rangeField.spec.jsx
+++ b/tests/js/spec/components/forms/rangeField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {RangeField} from 'app/components/forms';
 
 describe('RangeField', function() {

--- a/tests/js/spec/components/forms/selectAsyncField.spec.jsx
+++ b/tests/js/spec/components/forms/selectAsyncField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Form, SelectAsyncField} from 'app/components/forms';
 
 describe('SelectAsyncField', function() {

--- a/tests/js/spec/components/forms/selectControlLegacy.spec.jsx
+++ b/tests/js/spec/components/forms/selectControlLegacy.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select';
+
 import {Form, SelectField} from 'app/components/forms';
 
 describe('SelectField', function() {

--- a/tests/js/spec/components/forms/selectCreatableField.spec.jsx
+++ b/tests/js/spec/components/forms/selectCreatableField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Form, SelectCreatableField} from 'app/components/forms';
 
 describe('SelectCreatableField', function() {

--- a/tests/js/spec/components/forms/selectField.spec.jsx
+++ b/tests/js/spec/components/forms/selectField.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select';
+
 import {Form, SelectField} from 'app/components/forms';
 
 describe('SelectField', function() {

--- a/tests/js/spec/components/forms/tableField.spec.jsx
+++ b/tests/js/spec/components/forms/tableField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Form from 'app/views/settings/components/forms/form';
 import FormModel from 'app/views/settings/components/forms/model';
 import TableField from 'app/views/settings/components/forms/tableField';

--- a/tests/js/spec/components/forms/textField.spec.jsx
+++ b/tests/js/spec/components/forms/textField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {TextField} from 'app/components/forms';
 
 describe('TextField', function() {

--- a/tests/js/spec/components/globalModal.spec.jsx
+++ b/tests/js/spec/components/globalModal.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mount} from 'sentry-test/enzyme';
+
 import GlobalModal from 'app/components/globalModal';
 import {openModal, closeModal} from 'app/actionCreators/modal';
 

--- a/tests/js/spec/components/globalSelectionLink.spec.jsx
+++ b/tests/js/spec/components/globalSelectionLink.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
 
 const path = 'http://some.url/';

--- a/tests/js/spec/components/group/externalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueActions.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ExternalIssueActions from 'app/components/group/externalIssueActions';
 
 describe('ExternalIssueActions', function() {

--- a/tests/js/spec/components/group/externalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueForm.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ExternalIssueForm from 'app/components/group/externalIssueForm';
 
 jest.mock('lodash/debounce', () => {

--- a/tests/js/spec/components/group/releaseStats.spec.jsx
+++ b/tests/js/spec/components/group/releaseStats.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import ConfigStore from 'app/stores/configStore';
 import GroupReleaseStats from 'app/components/group/releaseStats';
 

--- a/tests/js/spec/components/group/sentryAppExternalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/sentryAppExternalIssueActions.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select';
+
 import SentryAppExternalIssueActions from 'app/components/group/sentryAppExternalIssueActions';
 
 describe('SentryAppExternalIssueActions', () => {

--- a/tests/js/spec/components/group/sentryAppExternalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/sentryAppExternalIssueForm.spec.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {selectByValue} from 'sentry-test/select';
+
 import {Client} from 'app/api';
 import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
 import SentryAppExternalIssueForm from 'app/components/group/sentryAppExternalIssueForm';
-import {selectByValue} from 'sentry-test/select';
 
 const optionLabelSelector = label => `[aria-label="${label}"]`;
 

--- a/tests/js/spec/components/group/sidebar.spec.jsx
+++ b/tests/js/spec/components/group/sidebar.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import GroupSidebar from 'app/components/group/sidebar';
 
 describe('GroupSidebar', function() {

--- a/tests/js/spec/components/group/suggestedOwners.spec.jsx
+++ b/tests/js/spec/components/group/suggestedOwners.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import SuggestedOwners from 'app/components/group/suggestedOwners';
 import MemberListStore from 'app/stores/memberListStore';
 import {Client} from 'app/api';

--- a/tests/js/spec/components/group/tagDistributionMeter.spec.jsx
+++ b/tests/js/spec/components/group/tagDistributionMeter.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import GroupTagDistributionMeter from 'app/components/group/tagDistributionMeter';
 
 describe('TagDistributionMeter', function() {

--- a/tests/js/spec/components/highlight.spec.jsx
+++ b/tests/js/spec/components/highlight.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {HighlightComponent} from 'app/components/highlight';
 
 describe('Highlight', function() {

--- a/tests/js/spec/components/hook.spec.jsx
+++ b/tests/js/spec/components/hook.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import Hook from 'app/components/hook';
 import HookStore from 'app/stores/hookStore';
 

--- a/tests/js/spec/components/idBadge/baseBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/baseBadge.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import BaseBadge from 'app/components/idBadge/baseBadge';
 
 describe('BadgeBadge', function() {

--- a/tests/js/spec/components/idBadge/index.spec.jsx
+++ b/tests/js/spec/components/idBadge/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import IdBadge from 'app/components/idBadge';
 
 describe('IdBadge', function() {

--- a/tests/js/spec/components/idBadge/memberBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/memberBadge.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount, shallow} from 'sentry-test/enzyme';
+
 import MemberBadge from 'app/components/idBadge/memberBadge';
 
 describe('MemberBadge', function() {

--- a/tests/js/spec/components/idBadge/organizationBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/organizationBadge.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OrganizationBadge from 'app/components/idBadge/organizationBadge';
 
 describe('OrganizationBadge', function() {

--- a/tests/js/spec/components/idBadge/projectBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/projectBadge.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectBadge from 'app/components/idBadge/projectBadge';
 
 describe('ProjectBadge', function() {

--- a/tests/js/spec/components/idBadge/teamBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/teamBadge.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import TeamBadge from 'app/components/idBadge/teamBadge';
 
 describe('TeamBadge', function() {

--- a/tests/js/spec/components/idBadge/userBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/userBadge.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount, shallow} from 'sentry-test/enzyme';
+
 import UserBadge from 'app/components/idBadge/userBadge';
 
 describe('UserBadge', function() {

--- a/tests/js/spec/components/inactivePlugins.spec.jsx
+++ b/tests/js/spec/components/inactivePlugins.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount, shallow} from 'sentry-test/enzyme';
+
 import InactivePlugins from 'app/components/inactivePlugins';
 
 describe('InactivePlugins', function() {

--- a/tests/js/spec/components/indicators.spec.jsx
+++ b/tests/js/spec/components/indicators.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import Indicators from 'app/components/indicators';
 import IndicatorStore from 'app/stores/indicatorStore';
 import {

--- a/tests/js/spec/components/issueDiff.spec.jsx
+++ b/tests/js/spec/components/issueDiff.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import {IssueDiff} from 'app/components/issueDiff';
 
 jest.mock('app/api');

--- a/tests/js/spec/components/issueSyncListElement.spec.jsx
+++ b/tests/js/spec/components/issueSyncListElement.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mount} from 'sentry-test/enzyme';
+
 import IssueSyncListElement from 'app/components/issueSyncListElement';
 
 describe('AlertLink', function() {

--- a/tests/js/spec/components/issues/snoozeAction.spec.jsx
+++ b/tests/js/spec/components/issues/snoozeAction.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import SnoozeAction from 'app/components/issues/snoozeAction';
 
 describe('SnoozeAction', function() {

--- a/tests/js/spec/components/lazyLoad.spec.jsx
+++ b/tests/js/spec/components/lazyLoad.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import LazyLoad from 'app/components/lazyLoad';
 
 describe('LazyLoad', function() {

--- a/tests/js/spec/components/letterAvatar.spec.jsx
+++ b/tests/js/spec/components/letterAvatar.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import LetterAvatar from 'app/components/letterAvatar';
 
 describe('LetterAvatar', function() {

--- a/tests/js/spec/components/loading/loadingContainer.spec.jsx
+++ b/tests/js/spec/components/loading/loadingContainer.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import LoadingContainer from 'app/components/loading/loadingContainer';
 
 describe('LoadingContainer', function() {

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {openCommandPalette} from 'app/actionCreators/modal';
 import App from 'app/views/app';
 import FormSearchStore from 'app/stores/formSearchStore';

--- a/tests/js/spec/components/modals/createTeamModal.spec.jsx
+++ b/tests/js/spec/components/modals/createTeamModal.spec.jsx
@@ -1,8 +1,9 @@
 import {Modal} from 'react-bootstrap';
 import React from 'react';
 
-import {createTeam} from 'app/actionCreators/teams';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {createTeam} from 'app/actionCreators/teams';
 import CreateTeamModal from 'app/components/modals/createTeamModal';
 
 jest.mock('app/actionCreators/teams', () => ({

--- a/tests/js/spec/components/modals/diffModal.spec.jsx
+++ b/tests/js/spec/components/modals/diffModal.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import DiffModal from 'app/components/modals/diffModal';
 
 describe('DiffModal', function() {

--- a/tests/js/spec/components/modals/helpSearchModal.spec.jsx
+++ b/tests/js/spec/components/modals/helpSearchModal.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {openHelpSearchModal} from 'app/actionCreators/modal';
 import App from 'app/views/app';
 

--- a/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
+++ b/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
@@ -2,6 +2,7 @@ import {Modal} from 'react-bootstrap';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import InviteMembersModal from 'app/components/modals/inviteMembersModal';
 import TeamStore from 'app/stores/teamStore';
 

--- a/tests/js/spec/components/modals/recoveryOptionsModal.spec.jsx
+++ b/tests/js/spec/components/modals/recoveryOptionsModal.spec.jsx
@@ -2,6 +2,7 @@ import {Modal} from 'react-bootstrap';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import RecoveryOptionsModal from 'app/components/modals/recoveryOptionsModal';
 
 describe('RecoveryOptionsModal', function() {

--- a/tests/js/spec/components/modals/redirectToProject.spec.jsx
+++ b/tests/js/spec/components/modals/redirectToProject.spec.jsx
@@ -2,6 +2,7 @@ import {Modal} from 'react-bootstrap';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {RedirectToProjectModal} from 'app/components/modals/redirectToProject';
 
 jest.unmock('app/utils/recreateRoute');

--- a/tests/js/spec/components/modals/sentryAppDetailsModal.spec.jsx
+++ b/tests/js/spec/components/modals/sentryAppDetailsModal.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import SentryAppDetailsModal from 'app/components/modals/sentryAppDetailsModal';
 
 describe('SentryAppDetailsModal', function() {

--- a/tests/js/spec/components/modals/sudoModal.spec.jsx
+++ b/tests/js/spec/components/modals/sudoModal.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import App from 'app/views/app';
 import ConfigStore from 'app/stores/configStore';

--- a/tests/js/spec/components/modals/teamAccessRequestModal.spec.jsx
+++ b/tests/js/spec/components/modals/teamAccessRequestModal.spec.jsx
@@ -2,6 +2,7 @@ import {Modal} from 'react-bootstrap';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import TeamAccessRequestModal from 'app/components/modals/teamAccessRequestModal';
 
 describe('TeamAccessRequestModal', function() {

--- a/tests/js/spec/components/multipleCheckbox.spec.js
+++ b/tests/js/spec/components/multipleCheckbox.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mount} from 'sentry-test/enzyme';
+
 import MultipleCheckbox from 'app/views/settings/components/forms/controls/multipleCheckbox';
 
 describe('MultipleCheckbox', function() {

--- a/tests/js/spec/components/mutedBox.spec.jsx
+++ b/tests/js/spec/components/mutedBox.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import MutedBox from 'app/components/mutedBox';
 
 describe('MutedBox', function() {

--- a/tests/js/spec/components/narrowLayout.spec.jsx
+++ b/tests/js/spec/components/narrowLayout.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import NarrowLayout from 'app/components/narrowLayout';
 
 describe('NarrowLayout', function() {

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';

--- a/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import MultipleEnvironmentSelector from 'app/components/organizations/multipleEnvironmentSelector';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 

--- a/tests/js/spec/components/organizations/projectSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/projectSelector.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectSelector from 'app/components/organizations/projectSelector';
 
 describe('ProjectSelector', function() {

--- a/tests/js/spec/components/organizations/timeRangeSelector/dateRange.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/dateRange.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import MockDate from 'mockdate';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import DateRange from 'app/components/organizations/timeRangeSelector/dateRange';
 

--- a/tests/js/spec/components/organizations/timeRangeSelector/dateSummary.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/dateSummary.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import DateSummary from 'app/components/organizations/timeRangeSelector/dateSummary';
 
 const start = new Date('2017-10-14T02:38:00.000Z');

--- a/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 

--- a/tests/js/spec/components/pageHeader.spec.jsx
+++ b/tests/js/spec/components/pageHeader.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import PageHeading from 'app/components/pageHeading';
 
 describe('PageHeading', function() {

--- a/tests/js/spec/components/panels/panelTable.spec.jsx
+++ b/tests/js/spec/components/panels/panelTable.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import PanelTable from 'app/components/panels/panelTable';
 
 describe('PanelTable', function() {

--- a/tests/js/spec/components/platformList.spec.jsx
+++ b/tests/js/spec/components/platformList.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import PlatformList from 'app/components/platformList';
 
 describe('PlatformList', function() {

--- a/tests/js/spec/components/platformPicker.spec.jsx
+++ b/tests/js/spec/components/platformPicker.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import PlatformPicker from 'app/components/platformPicker';
 

--- a/tests/js/spec/components/pluginIcon.spec.jsx
+++ b/tests/js/spec/components/pluginIcon.spec.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import PluginIcon from 'app/plugins/components/pluginIcon';
 
 // For some reason jest only respects the last mocked, so we can't test

--- a/tests/js/spec/components/projects/bookmarkStar.spec.jsx
+++ b/tests/js/spec/components/projects/bookmarkStar.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import BookmarkStar from 'app/components/projects/bookmarkStar';
 
 describe('BookmarkStar', function() {

--- a/tests/js/spec/components/pullRequestLink.spec.jsx
+++ b/tests/js/spec/components/pullRequestLink.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import PullRequestLink from 'app/components/pullRequestLink';
 
 describe('PullRequestLink', function() {

--- a/tests/js/spec/components/qrcode.spec.jsx
+++ b/tests/js/spec/components/qrcode.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import Qrcode from 'app/components/qrcode';
 
 describe('Qrcode', function() {

--- a/tests/js/spec/components/queryCount.spec.js
+++ b/tests/js/spec/components/queryCount.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import QueryCount from 'app/components/queryCount';
 
 describe('QueryCount', function() {

--- a/tests/js/spec/components/rangeSlider.spec.jsx
+++ b/tests/js/spec/components/rangeSlider.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount, shallow} from 'sentry-test/enzyme';
+
 import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
 
 describe('RangeSlider', function() {

--- a/tests/js/spec/components/repositoryRow.spec.jsx
+++ b/tests/js/spec/components/repositoryRow.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {Client} from 'app/api';
 import RepositoryRow from 'app/components/repositoryRow';
 
 describe('RepositoryRow', function() {

--- a/tests/js/spec/components/resolutionBox.spec.jsx
+++ b/tests/js/spec/components/resolutionBox.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ResolutionBox from 'app/components/resolutionBox';
 
 describe('ResolutionBox', function() {

--- a/tests/js/spec/components/returnButton.spec.jsx
+++ b/tests/js/spec/components/returnButton.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ReturnButton from 'app/views/settings/components/forms/returnButton';
 
 describe('returnButton', function() {

--- a/tests/js/spec/components/scoreBar.spec.jsx
+++ b/tests/js/spec/components/scoreBar.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ScoreBar from 'app/components/scoreBar';
 
 describe('ScoreBar', function() {

--- a/tests/js/spec/components/search/sources/apiSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/apiSource.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {ApiSource} from 'app/components/search/sources/apiSource';
 
 describe('ApiSource', function() {

--- a/tests/js/spec/components/search/sources/formSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/formSource.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import FormSource from 'app/components/search/sources/formSource';
 import FormSearchActions from 'app/actions/formSearchActions';
 import * as ActionCreators from 'app/actionCreators/formSearch';

--- a/tests/js/spec/components/search/sources/routeSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/routeSource.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {RouteSource} from 'app/components/search/sources/routeSource';
 
 describe('RouteSource', function() {

--- a/tests/js/spec/components/seenByList.spec.jsx
+++ b/tests/js/spec/components/seenByList.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import SeenByList from 'app/components/seenByList';
 

--- a/tests/js/spec/components/settingsBreadcrumbDropdown.spec.jsx
+++ b/tests/js/spec/components/settingsBreadcrumbDropdown.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import BreadcrumbDropdown from 'app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown';
 
 jest.useFakeTimers();

--- a/tests/js/spec/components/settingsLayout.spec.jsx
+++ b/tests/js/spec/components/settingsLayout.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import SettingsLayout from 'app/views/settings/components/settingsLayout';
 

--- a/tests/js/spec/components/shareIssue.spec.jsx
+++ b/tests/js/spec/components/shareIssue.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ShareIssue from 'app/components/shareIssue';
 
 describe('ShareIssue', function() {

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import SidebarContainer, {Sidebar} from 'app/components/sidebar';
 import * as incidentActions from 'app/actionCreators/serviceIncidents';

--- a/tests/js/spec/components/sidebar/switchOrganization.spec.jsx
+++ b/tests/js/spec/components/sidebar/switchOrganization.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {SwitchOrganization} from 'app/components/sidebar/sidebarDropdown/switchOrganization';
 
 describe('SwitchOrganization', function() {

--- a/tests/js/spec/components/similarScoreCard.spec.jsx
+++ b/tests/js/spec/components/similarScoreCard.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import SimilarScoreCard from 'app/components/similarScoreCard';
 
 describe('SimilarScoreCard', function() {

--- a/tests/js/spec/components/similarSpectrum.spec.jsx
+++ b/tests/js/spec/components/similarSpectrum.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import SimilarSpectrum from 'app/components/similarSpectrum';
 
 describe('SimilarSpectrum', function() {

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import {SmartSearchBar} from 'app/components/smartSearchBar';
 import {addSpace, removeSpace} from 'app/components/smartSearchBar/utils';

--- a/tests/js/spec/components/splitDiff.spec.jsx
+++ b/tests/js/spec/components/splitDiff.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import SplitDiff from 'app/components/splitDiff';
 
 describe('SplitDiff', function() {

--- a/tests/js/spec/components/spreadLayout.spec.jsx
+++ b/tests/js/spec/components/spreadLayout.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import SpreadLayout from 'app/components/spreadLayout';
 
 describe('SpreadLayout', function() {

--- a/tests/js/spec/components/stackedBarChart.spec.jsx
+++ b/tests/js/spec/components/stackedBarChart.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import StackedBarChart from 'app/components/stackedBarChart';
 import ConfigStore from 'app/stores/configStore';
 

--- a/tests/js/spec/components/stream/processingIssueHint.spec.jsx
+++ b/tests/js/spec/components/stream/processingIssueHint.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ProcessingIssueHint from 'app/components/stream/processingIssueHint';
 
 describe('ProcessingIssueHint', function() {

--- a/tests/js/spec/components/stream/processingIssueList.spec.jsx
+++ b/tests/js/spec/components/stream/processingIssueList.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ProcessingIssueList from 'app/components/stream/processingIssueList';
 
 describe('ProcessingIssueList', function() {

--- a/tests/js/spec/components/streamGroup.spec.jsx
+++ b/tests/js/spec/components/streamGroup.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import GroupStore from 'app/stores/groupStore';
 import StreamGroup from 'app/components/stream/group';
 

--- a/tests/js/spec/components/tag.spec.jsx
+++ b/tests/js/spec/components/tag.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Tag from 'app/views/settings/components/tag';
 
 describe('Tag', function() {

--- a/tests/js/spec/components/textCopyInput.spec.jsx
+++ b/tests/js/spec/components/textCopyInput.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 
 describe('TextCopyInput', function() {

--- a/tests/js/spec/components/toggleRawEventData.spec.jsx
+++ b/tests/js/spec/components/toggleRawEventData.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import EventDataSection from 'app/components/events/eventDataSection';
 import KeyValueList from 'app/components/events/interfaces/keyValueList/keyValueList';
 

--- a/tests/js/spec/components/toolbar.spec.jsx
+++ b/tests/js/spec/components/toolbar.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import Toolbar from 'app/components/toolbar';
 
 describe('Toolbar', function() {

--- a/tests/js/spec/components/toolbarHeader.spec.jsx
+++ b/tests/js/spec/components/toolbarHeader.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ToolbarHeader from 'app/components/toolbarHeader';
 
 describe('ToolbarHeader', function() {

--- a/tests/js/spec/components/tooltip.spec.jsx
+++ b/tests/js/spec/components/tooltip.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount, mountWithTheme} from 'sentry-test/enzyme';
+
 import Tooltip from 'app/components/tooltip';
 
 describe('Tooltip', function() {

--- a/tests/js/spec/components/version.spec.jsx
+++ b/tests/js/spec/components/version.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import Version from 'app/components/version';
 
 const VERSION = 'foo.bar.Baz@1.0.0+20200101';

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -1,6 +1,7 @@
-import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 import {mount, mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 
 describe('getFieldRenderer', function() {
   let location, context, project, organization, data;

--- a/tests/js/spec/utils/eventWaiter.spec.jsx
+++ b/tests/js/spec/utils/eventWaiter.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import EventWaiter from 'app/utils/eventWaiter';
 
 jest.useFakeTimers();

--- a/tests/js/spec/utils/projects.spec.jsx
+++ b/tests/js/spec/utils/projects.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import Projects from 'app/utils/projects';
 import ProjectsStore from 'app/stores/projectsStore';
 import ProjectActions from 'app/actions/projectActions';

--- a/tests/js/spec/utils/withApi.spec.jsx
+++ b/tests/js/spec/utils/withApi.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import withApi from 'app/utils/withApi';
 
 describe('withApi', function() {

--- a/tests/js/spec/utils/withConfig.spec.jsx
+++ b/tests/js/spec/utils/withConfig.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import withConfig from 'app/utils/withConfig';
 

--- a/tests/js/spec/utils/withExperiment.spec.jsx
+++ b/tests/js/spec/utils/withExperiment.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import withExperiment from 'app/utils/withExperiment';
 import ConfigStore from 'app/stores/configStore';
 import {logExperiment} from 'app/utils/analytics';

--- a/tests/js/spec/utils/withGlobalSelection.spec.jsx
+++ b/tests/js/spec/utils/withGlobalSelection.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 

--- a/tests/js/spec/utils/withIssueTags.spec.jsx
+++ b/tests/js/spec/utils/withIssueTags.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import TagStore from 'app/stores/tagStore';
 import MemberListStore from 'app/stores/memberListStore';
 import withIssueTags from 'app/utils/withIssueTags';

--- a/tests/js/spec/utils/withProjects.spec.jsx
+++ b/tests/js/spec/utils/withProjects.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ProjectsStore from 'app/stores/projectsStore';
 import withProjects from 'app/utils/withProjects';
 

--- a/tests/js/spec/utils/withSentryAppComponents.spec.jsx
+++ b/tests/js/spec/utils/withSentryAppComponents.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import SentryAppComponentsStore from 'app/stores/sentryAppComponentsStore';
 import withSentryAppComponents from 'app/utils/withSentryAppComponents';
 

--- a/tests/js/spec/utils/withTags.spec.jsx
+++ b/tests/js/spec/utils/withTags.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import TagStore from 'app/stores/tagStore';
 import withTags from 'app/utils/withTags';
 

--- a/tests/js/spec/utils/withTeamsForUser.spec.jsx
+++ b/tests/js/spec/utils/withTeamsForUser.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import TeamActions from 'app/actions/teamActions';
 import ProjectActions from 'app/actions/projectActions';
 import withTeamsForUser from 'app/utils/withTeamsForUser';

--- a/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
+++ b/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {logout} from 'app/actionCreators/account';
 import AcceptOrganizationInvite from 'app/views/acceptOrganizationInvite';
 

--- a/tests/js/spec/views/acceptProjectTransfer.spec.jsx
+++ b/tests/js/spec/views/acceptProjectTransfer.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import AcceptProjectTransfer from 'app/views/acceptProjectTransfer';
 
 jest.mock('jquery');

--- a/tests/js/spec/views/accountAuthorization.spec.jsx
+++ b/tests/js/spec/views/accountAuthorization.spec.jsx
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {Client} from 'app/api';
 import {shallow} from 'sentry-test/enzyme';
+
+import {Client} from 'app/api';
 import AccountAuthorizations from 'app/views/settings/account/accountAuthorizations';
 
 describe('AccountAuthorizations', function() {

--- a/tests/js/spec/views/accountClose.spec.jsx
+++ b/tests/js/spec/views/accountClose.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import AccountClose from 'app/views/settings/account/accountClose';
 
 describe('AccountClose', function() {

--- a/tests/js/spec/views/accountDetail.spec.jsx
+++ b/tests/js/spec/views/accountDetail.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import AccountDetails from 'app/views/settings/account/accountDetails';
 
 jest.mock('jquery');

--- a/tests/js/spec/views/accountEmails.spec.jsx
+++ b/tests/js/spec/views/accountEmails.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import AccountEmails from 'app/views/settings/account/accountEmails';
 

--- a/tests/js/spec/views/accountIdentities.spec.jsx
+++ b/tests/js/spec/views/accountIdentities.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import AccountIdentities from 'app/views/settings/account/accountIdentities';
 

--- a/tests/js/spec/views/accountNotifications.spec.jsx
+++ b/tests/js/spec/views/accountNotifications.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import AccountNotifications from 'app/views/settings/account/accountNotifications';
 
 describe('AccountNotifications', function() {

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import AccountSecurity from 'app/views/settings/account/accountSecurity';
 import AccountSecurityWrapper from 'app/views/settings/account/accountSecurity/accountSecurityWrapper';

--- a/tests/js/spec/views/accountSecurityDetails.spec.jsx
+++ b/tests/js/spec/views/accountSecurityDetails.spec.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {Client} from 'app/api';
 import AccountSecurityDetails from 'app/views/settings/account/accountSecurity/accountSecurityDetails';
 import AccountSecurityWrapper from 'app/views/settings/account/accountSecurity/accountSecurityWrapper';
 

--- a/tests/js/spec/views/accountSecurityEnroll.spec.jsx
+++ b/tests/js/spec/views/accountSecurityEnroll.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import AccountSecurityEnroll from 'app/views/settings/account/accountSecurity/accountSecurityEnroll';
 

--- a/tests/js/spec/views/accountSecuritySessionHistory.spec.jsx
+++ b/tests/js/spec/views/accountSecuritySessionHistory.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import AccountSecuritySessionHistory from 'app/views/settings/account/accountSecurity/accountSecuritySessionHistory';
 

--- a/tests/js/spec/views/accountSubscriptions.spec.jsx
+++ b/tests/js/spec/views/accountSubscriptions.spec.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import AccountSubscriptions from 'app/views/settings/account/accountSubscriptions';
 

--- a/tests/js/spec/views/admin/adminBuffer.spec.jsx
+++ b/tests/js/spec/views/admin/adminBuffer.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import AdminBuffer from 'app/views/admin/adminBuffer';
 
 // TODO(dcramer): this doesnt really test anything as we need to

--- a/tests/js/spec/views/admin/adminQueue.spec.jsx
+++ b/tests/js/spec/views/admin/adminQueue.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import AdminQueue from 'app/views/admin/adminQueue';
 

--- a/tests/js/spec/views/admin/adminQuotas.spec.jsx
+++ b/tests/js/spec/views/admin/adminQuotas.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import AdminQuotas from 'app/views/admin/adminQuotas';
 

--- a/tests/js/spec/views/admin/adminSettings.spec.jsx
+++ b/tests/js/spec/views/admin/adminSettings.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import AdminSettings from 'app/views/admin/adminSettings';
 

--- a/tests/js/spec/views/alerts/details/activity.spec.jsx
+++ b/tests/js/spec/views/alerts/details/activity.spec.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import IncidentActivity from 'app/views/alerts/details/activity';
 import changeReactMentionsInput from 'sentry-test/changeReactMentionsInput';
+
+import IncidentActivity from 'app/views/alerts/details/activity';
 
 describe('IncidentDetails -> Activity', function() {
   const incident = TestStubs.Incident();

--- a/tests/js/spec/views/alerts/details/index.spec.jsx
+++ b/tests/js/spec/views/alerts/details/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import IncidentDetails from 'app/views/alerts/details';
 import ProjectsStore from 'app/stores/projectsStore';
 

--- a/tests/js/spec/views/alerts/index.spec.jsx
+++ b/tests/js/spec/views/alerts/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import IncidentsContainer from 'app/views/alerts';
 
 describe('IncidentsContainer', function() {

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import IncidentsList from 'app/views/alerts/list';
 import ProjectsStore from 'app/stores/projectsStore';
 

--- a/tests/js/spec/views/apiNewToken.spec.jsx
+++ b/tests/js/spec/views/apiNewToken.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ApiNewToken from 'app/views/settings/account/apiNewToken';
 
 describe('ApiNewToken', function() {

--- a/tests/js/spec/views/apiTokenRow.spec.jsx
+++ b/tests/js/spec/views/apiTokenRow.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import ApiTokenRow from 'app/views/settings/account/apiTokenRow';
 
 describe('ApiTokenRow', function() {

--- a/tests/js/spec/views/apiTokens.spec.jsx
+++ b/tests/js/spec/views/apiTokens.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import {ApiTokens} from 'app/views/settings/account/apiTokens';
 

--- a/tests/js/spec/views/app.spec.jsx
+++ b/tests/js/spec/views/app.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import App from 'app/views/app';
 import ConfigStore from 'app/stores/configStore';
 

--- a/tests/js/spec/views/auth/login.spec.jsx
+++ b/tests/js/spec/views/auth/login.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Login from 'app/views/auth/login';
 
 describe('Login', function() {

--- a/tests/js/spec/views/auth/loginForm.spec.jsx
+++ b/tests/js/spec/views/auth/loginForm.spec.jsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import LoginForm from 'app/views/auth/loginForm';
 

--- a/tests/js/spec/views/auth/registerForm.spec.jsx
+++ b/tests/js/spec/views/auth/registerForm.spec.jsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import RegisterForm from 'app/views/auth/registerForm';
 

--- a/tests/js/spec/views/auth/ssoForm.spec.jsx
+++ b/tests/js/spec/views/auth/ssoForm.spec.jsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import SsoForm from 'app/views/auth/ssoForm';
 
 function doSso(wrapper, apiRequest) {

--- a/tests/js/spec/views/dashboards/dashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/dashboard.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Dashboard from 'app/views/dashboards/dashboard';
 import OrganizationDashboardContainer from 'app/views/dashboards';
 import ProjectsStore from 'app/stores/projectsStore';

--- a/tests/js/spec/views/dashboards/discoverQuery.spec.jsx
+++ b/tests/js/spec/views/dashboards/discoverQuery.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {mount} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
+
 import DiscoverQuery from 'app/views/dashboards/discoverQuery';
 import ProjectsStore from 'app/stores/projectsStore';
 

--- a/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import DashboardsContainer from 'app/views/dashboards';
 import OverviewDashboard from 'app/views/dashboards/overviewDashboard';
 import ProjectsStore from 'app/stores/projectsStore';

--- a/tests/js/spec/views/dashboards/widgetChart.spec.jsx
+++ b/tests/js/spec/views/dashboards/widgetChart.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import WidgetChart from 'app/views/dashboards/widgetChart';
 
 describe('WidgetChart', function() {

--- a/tests/js/spec/views/dataExport/dataDownload.spec.jsx
+++ b/tests/js/spec/views/dataExport/dataDownload.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import {ExportQueryType} from 'app/components/dataExport';
 import DataDownload, {DownloadStatus} from 'app/views/dataExport/dataDownload';
 

--- a/tests/js/spec/views/discover/aggregations/aggregation.spec.jsx
+++ b/tests/js/spec/views/discover/aggregations/aggregation.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Aggregation from 'app/views/discover/aggregations/aggregation';
 
 describe('Aggregation', function() {

--- a/tests/js/spec/views/discover/aggregations/index.spec.jsx
+++ b/tests/js/spec/views/discover/aggregations/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Aggregations from 'app/views/discover/aggregations';
 
 describe('Aggregations', function() {

--- a/tests/js/spec/views/discover/conditions/condition.spec.jsx
+++ b/tests/js/spec/views/discover/conditions/condition.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Condition from 'app/views/discover/conditions/condition';
 
 describe('Condition', function() {

--- a/tests/js/spec/views/discover/conditions/index.spec.jsx
+++ b/tests/js/spec/views/discover/conditions/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Conditions from 'app/views/discover/conditions';
 
 describe('Conditions', function() {

--- a/tests/js/spec/views/discover/discover.spec.jsx
+++ b/tests/js/spec/views/discover/discover.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import Discover from 'app/views/discover/discover';
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';

--- a/tests/js/spec/views/discover/index.spec.jsx
+++ b/tests/js/spec/views/discover/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import DiscoverContainerWithStore, {DiscoverContainer} from 'app/views/discover';
 
 describe('DiscoverContainer', function() {

--- a/tests/js/spec/views/discover/result/index.spec.jsx
+++ b/tests/js/spec/views/discover/result/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import Result from 'app/views/discover/result';
 import createQueryBuilder from 'app/views/discover/queryBuilder';
 

--- a/tests/js/spec/views/discover/result/table.spec.jsx
+++ b/tests/js/spec/views/discover/result/table.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount, render} from 'sentry-test/enzyme';
+
 import {ResultTable} from 'app/views/discover/result/table';
 
 describe('ResultTable', function() {

--- a/tests/js/spec/views/discover/result/utils.spec.jsx
+++ b/tests/js/spec/views/discover/result/utils.spec.jsx
@@ -1,4 +1,5 @@
 import {mount} from 'sentry-test/enzyme';
+
 import {
   getChartData,
   getChartDataForWidget,

--- a/tests/js/spec/views/discover/sidebar/orderBy.spec.jsx
+++ b/tests/js/spec/views/discover/sidebar/orderBy.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Orderby from 'app/views/discover/sidebar/orderby';
 
 describe('orderBy', function() {

--- a/tests/js/spec/views/discover/sidebar/savedQueryList.spec.jsx
+++ b/tests/js/spec/views/discover/sidebar/savedQueryList.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import SavedQueryList from 'app/views/discover/sidebar/savedQueryList';
 
 describe('savedQueryList', function() {

--- a/tests/js/spec/views/events/events.spec.jsx
+++ b/tests/js/spec/views/events/events.spec.jsx
@@ -1,12 +1,13 @@
 import {withRouter, browserHistory} from 'react-router';
 import React from 'react';
 
-import Events, {parseRowFromLinks} from 'app/views/events/events';
 import {chart, doZoom} from 'sentry-test/charts';
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {getUtcToLocalDateObject} from 'app/utils/dates';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {getUtcToLocalDateObject} from 'app/utils/dates';
+import Events, {parseRowFromLinks} from 'app/views/events/events';
 import EventsContainer from 'app/views/events';
 import ProjectsStore from 'app/stores/projectsStore';
 

--- a/tests/js/spec/views/events/eventsAreaChart.spec.jsx
+++ b/tests/js/spec/views/events/eventsAreaChart.spec.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import {EventsChart} from 'app/views/events/eventsChart';
 import {mockZoomRange} from 'sentry-test/charts';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {EventsChart} from 'app/views/events/eventsChart';
 
 describe('EventsChart', function() {
   const {router, routerContext, org} = initializeOrg();

--- a/tests/js/spec/views/events/eventsChart.spec.jsx
+++ b/tests/js/spec/views/events/eventsChart.spec.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import {EventsChart} from 'app/views/events/eventsChart';
 import {chart, doZoom, mockZoomRange} from 'sentry-test/charts';
-import {getUtcToLocalDateObject} from 'app/utils/dates';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mount} from 'sentry-test/enzyme';
+
+import {getUtcToLocalDateObject} from 'app/utils/dates';
+import {EventsChart} from 'app/views/events/eventsChart';
 import * as globalSelection from 'app/actionCreators/globalSelection';
 
 jest.mock('app/views/events/utils/eventsRequest', () => jest.fn(() => null));

--- a/tests/js/spec/views/events/index.spec.jsx
+++ b/tests/js/spec/views/events/index.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {setActiveOrganization} from 'app/actionCreators/organizations';
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import EventsContainer from 'app/views/events';

--- a/tests/js/spec/views/events/searchBar.spec.jsx
+++ b/tests/js/spec/views/events/searchBar.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import SearchBar from 'app/views/events/searchBar';
 import TagStore from 'app/stores/tagStore';
 

--- a/tests/js/spec/views/events/utils/eventsRequest.spec.jsx
+++ b/tests/js/spec/views/events/utils/eventsRequest.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {doEventsRequest} from 'app/actionCreators/events';
 import EventsRequest from 'app/views/events/utils/eventsRequest';
 

--- a/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import EventDetails from 'app/views/eventsV2/eventDetails';
 import {ALL_VIEWS, DEFAULT_EVENT_VIEW} from 'app/views/eventsV2/data';
 import EventView from 'app/utils/discover/eventView';

--- a/tests/js/spec/views/eventsV2/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {DiscoverLanding} from 'app/views/eventsV2/landing';
 
 describe('EventsV2 > Landing', function() {

--- a/tests/js/spec/views/eventsV2/queryList.spec.jsx
+++ b/tests/js/spec/views/eventsV2/queryList.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import QueryList from 'app/views/eventsV2/queryList';
 
 function openContextMenu(card) {

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectsStore from 'app/stores/projectsStore';
 import Results from 'app/views/eventsV2/results';
 

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import SavedQueryButtonGroup from 'app/views/eventsV2/savedQuery';
 import {ALL_VIEWS} from 'app/views/eventsV2/data';
 import EventView from 'app/utils/discover/eventView';

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import CellAction from 'app/views/eventsV2/table/cellAction';
 import EventView from 'app/utils/discover/eventView';
 

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {selectByLabel, openMenu} from 'sentry-test/select-new';
+
 import ColumnEditModal from 'app/views/eventsV2/table/columnEditModal';
 
 const stubEl = props => <div>{props.children}</div>;

--- a/tests/js/spec/views/eventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/eventsV2/tags.spec.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import {Client} from 'app/api';
 import {Tags} from 'app/views/eventsV2/tags';
 import EventView from 'app/utils/discover/eventView';
-import {initializeOrg} from 'sentry-test/initializeOrg';
 
 describe('Tags', function() {
   const org = TestStubs.Organization();

--- a/tests/js/spec/views/installWizard.spec.jsx
+++ b/tests/js/spec/views/installWizard.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import InstallWizard from 'app/views/installWizard';
 

--- a/tests/js/spec/views/inviteMember/inviteMember.spec.jsx
+++ b/tests/js/spec/views/inviteMember/inviteMember.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import {InviteMember} from 'app/views/settings/organizationMembers/inviteMember';
 import ConfigStore from 'app/stores/configStore';
 

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import {IssueListActions} from 'app/views/issueList/actions';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
 import {selectByLabel} from 'sentry-test/select';
+
+import {IssueListActions} from 'app/views/issueList/actions';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 
 describe('IssueListActions', function() {

--- a/tests/js/spec/views/issueList/createSavedSearchButton.spec.jsx
+++ b/tests/js/spec/views/issueList/createSavedSearchButton.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import CreateSavedSearchButton from 'app/views/issueList/createSavedSearchButton';
 
 describe('CreateSavedSearchButton', function() {

--- a/tests/js/spec/views/issueList/noGroupsHandler/noUnresolvedIssues.spec.jsx
+++ b/tests/js/spec/views/issueList/noGroupsHandler/noUnresolvedIssues.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import NoUnresolvedIssues from 'app/views/issueList/noGroupsHandler/noUnresolvedIssues';
 import CongratsRobotsVideo from 'app/views/issueList/noGroupsHandler/congratsRobots';
 

--- a/tests/js/spec/views/issueList/organizationSavedSearchSelector.spec.jsx
+++ b/tests/js/spec/views/issueList/organizationSavedSearchSelector.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import IssueListSavedSearchSelector from 'app/views/issueList/savedSearchSelector';
 
 describe('IssueListSavedSearchSelector', function() {

--- a/tests/js/spec/views/issueList/overview.polling.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.polling.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import IssueList from 'app/views/issueList/overview';
 import StreamGroup from 'app/components/stream/group';
 import TagStore from 'app/stores/tagStore';

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import ErrorRobot from 'app/components/errorRobot';
 import GroupStore from 'app/stores/groupStore';
 import IssueListWithStores, {IssueListOverview} from 'app/views/issueList/overview';

--- a/tests/js/spec/views/issueList/searchBar.spec.jsx
+++ b/tests/js/spec/views/issueList/searchBar.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import IssueListSearchBar from 'app/views/issueList/searchBar';
 import TagStore from 'app/stores/tagStore';
 

--- a/tests/js/spec/views/issueList/tagFilter.spec.jsx
+++ b/tests/js/spec/views/issueList/tagFilter.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import IssueListTagFilter from 'app/views/issueList/tagFilter';
 
 describe('IssueListTagFilter', function() {

--- a/tests/js/spec/views/onboarding/onboarding.spec.jsx
+++ b/tests/js/spec/views/onboarding/onboarding.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Onboarding, {stepPropTypes} from 'app/views/onboarding/onboarding';
 import ProjectsStore from 'app/stores/projectsStore';
 

--- a/tests/js/spec/views/onboarding/platform.spec.jsx
+++ b/tests/js/spec/views/onboarding/platform.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {createProject} from 'app/actionCreators/projects';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {createProject} from 'app/actionCreators/projects';
 import OnboardingPlatform from 'app/views/onboarding/platform';
 import TeamStore from 'app/stores/teamStore';
 

--- a/tests/js/spec/views/onboarding/projectSetup/firstEventIndicator.spec.jsx
+++ b/tests/js/spec/views/onboarding/projectSetup/firstEventIndicator.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {Indicator} from 'app/views/onboarding/projectSetup/firstEventIndicator';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {Indicator} from 'app/views/onboarding/projectSetup/firstEventIndicator';
 
 describe('FirstEventIndicator', function() {
   it('renders waiting status', async function() {

--- a/tests/js/spec/views/onboarding/projectSetup/inviteMembers.spec.jsx
+++ b/tests/js/spec/views/onboarding/projectSetup/inviteMembers.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select';
+
 import ConfigStore from 'app/stores/configStore';
 import InviteMembers from 'app/views/onboarding/projectSetup/inviteMembers';
 

--- a/tests/js/spec/views/onboarding/welcome.spec.jsx
+++ b/tests/js/spec/views/onboarding/welcome.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OnboardingWelcome from 'app/views/onboarding/welcome';
 import ConfigStore from 'app/stores/configStore';
 

--- a/tests/js/spec/views/organizationActivity/index.spec.jsx
+++ b/tests/js/spec/views/organizationActivity/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import OrganizationActivity from 'app/views/organizationActivity';
 
 describe('OrganizationUserFeedback', function() {

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {openSudo} from 'app/actionCreators/modal';
 import * as OrganizationActionCreator from 'app/actionCreators/organization';
 import ConfigStore from 'app/stores/configStore';

--- a/tests/js/spec/views/organizationCreate.spec.jsx
+++ b/tests/js/spec/views/organizationCreate.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ConfigStore from 'app/stores/configStore';
 import OrganizationCreate from 'app/views/organizationCreate';
 

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OrganizationDetails, {
   LightWeightOrganizationDetails,
 } from 'app/views/organizationDetails';

--- a/tests/js/spec/views/organizationGroupDetails/actions.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/actions.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import GroupActions from 'app/views/organizationGroupDetails/actions';
 import ConfigStore from 'app/stores/configStore';
 

--- a/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import {GroupActivity} from 'app/views/organizationGroupDetails/groupActivity';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {GroupActivity} from 'app/views/organizationGroupDetails/groupActivity';
 import ConfigStore from 'app/stores/configStore';
 import GroupStore from 'app/stores/groupStore';
 import NoteInput from 'app/components/activity/note/input';

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import GroupDetails from 'app/views/organizationGroupDetails';
 import ProjectsStore from 'app/stores/projectsStore';

--- a/tests/js/spec/views/organizationGroupDetails/groupEventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventDetails.spec.jsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import GroupEventDetails from 'app/views/organizationGroupDetails/groupEventDetails/groupEventDetails';
 
 describe('groupEventDetails', () => {

--- a/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OrganizationEnvironmentsStore from 'app/stores/organizationEnvironmentsStore';
 import GroupEventDetailsContainer from 'app/views/organizationGroupDetails/groupEventDetails';
 

--- a/tests/js/spec/views/organizationGroupDetails/groupMergedView.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupMergedView.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {GroupMergedView} from 'app/views/organizationGroupDetails/groupMerged';
 import {Client} from 'app/api';
 

--- a/tests/js/spec/views/organizationGroupDetails/groupSimilar.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupSimilar.spec.jsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import GroupSimilar from 'app/views/organizationGroupDetails/groupSimilar';
 
 describe('Issues Similar View', function() {

--- a/tests/js/spec/views/organizationGroupDetails/groupTagValues.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupTagValues.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import GroupTagValues from 'app/views/organizationGroupDetails/groupTagValues';
 import DetailedError from 'app/components/errors/detailedError';
 

--- a/tests/js/spec/views/organizationGroupDetails/groupTags.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupTags.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import GroupTags from 'app/views/organizationGroupDetails/groupTags';
 
 describe('GroupTags', function() {

--- a/tests/js/spec/views/organizationGroupDetails/organizationGroupEvents.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/organizationGroupEvents.spec.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {browserHistory} from 'react-router';
 
 import {mount, shallow} from 'sentry-test/enzyme';
+
 import {GroupEvents} from 'app/views/organizationGroupDetails/groupEvents';
 
 const OrganizationGroupEvents = GroupEvents;

--- a/tests/js/spec/views/organizationIntegrations/integrationDetailedView.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationDetailedView.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {Client} from 'app/api';
 import IntegrationDetailedView from 'app/views/organizationIntegrations/integrationDetailedView';
 
 const mockResponse = mocks => {

--- a/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {Client} from 'app/api';
 import IntegrationListDirectory from 'app/views/organizationIntegrations/integrationListDirectory';
 
 const mockResponse = mocks => {

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {Client} from 'app/api';
 import IntegrationRepos from 'app/views/organizationIntegrations/integrationRepos';
 
 describe('IntegrationRepos', function() {

--- a/tests/js/spec/views/organizationIntegrations/integrationRow.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRow.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {Client} from 'app/api';
 import IntegrationRow from 'app/views/organizationIntegrations/integrationRow';
 
 describe('IntegrationRow', function() {

--- a/tests/js/spec/views/organizationIntegrations/pluginDetailedView.spec.js
+++ b/tests/js/spec/views/organizationIntegrations/pluginDetailedView.spec.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {Client} from 'app/api';
 import PluginDetailedView from 'app/views/organizationIntegrations/pluginDetailedView';
 import * as modal from 'app/actionCreators/modal';
 

--- a/tests/js/spec/views/organizationIntegrations/sentryAppDetailedView.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/sentryAppDetailedView.spec.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {Client} from 'app/api';
 import SentryAppDetailedView from 'app/views/organizationIntegrations/sentryAppDetailedView';
 
 const mockResponse = mocks => {

--- a/tests/js/spec/views/organizationJoinRequest.spec.jsx
+++ b/tests/js/spec/views/organizationJoinRequest.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {trackAdhocEvent} from 'app/utils/analytics';
 import OrganizationJoinRequest from 'app/views/organizationJoinRequest';

--- a/tests/js/spec/views/organizationRoot.spec.jsx
+++ b/tests/js/spec/views/organizationRoot.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {OrganizationRoot} from 'app/views/organizationRoot';
 import {setActiveProject} from 'app/actionCreators/projects';
 import {setLastRoute} from 'app/actionCreators/navigation';

--- a/tests/js/spec/views/organizationTeamProjects.spec.jsx
+++ b/tests/js/spec/views/organizationTeamProjects.spec.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import {Client} from 'app/api';
 import {TeamProjects as OrganizationTeamProjects} from 'app/views/settings/organizationTeams/teamProjects';
-import {initializeOrg} from 'sentry-test/initializeOrg';
 
 describe('OrganizationTeamProjects', function() {
   let team;

--- a/tests/js/spec/views/ownershipInput.spec.jsx
+++ b/tests/js/spec/views/ownershipInput.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OwnerInput from 'app/views/settings/project/projectOwnership/ownerInput';
 
 jest.mock('jquery');

--- a/tests/js/spec/views/passwordForm.spec.jsx
+++ b/tests/js/spec/views/passwordForm.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import PasswordForm from 'app/views/settings/account/passwordForm';
 

--- a/tests/js/spec/views/projectFilters.spec.jsx
+++ b/tests/js/spec/views/projectFilters.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectFilters from 'app/views/settings/project/projectFilters';
 
 describe('ProjectFilters', function() {

--- a/tests/js/spec/views/projectInstall/createProject.spec.jsx
+++ b/tests/js/spec/views/projectInstall/createProject.spec.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+import {MOCK_RESP_VERBOSE} from 'sentry-test/fixtures/ruleConditions';
+
 import {CreateProject} from 'app/views/projectInstall/createProject';
 import {openCreateTeamModal} from 'app/actionCreators/modal';
-import {MOCK_RESP_VERBOSE} from 'sentry-test/fixtures/ruleConditions';
 
 jest.mock('app/actionCreators/modal');
 

--- a/tests/js/spec/views/projectInstall/issueAlertOptions.spec.jsx
+++ b/tests/js/spec/views/projectInstall/issueAlertOptions.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
-import IssueAlertOptions from 'app/views/projectInstall/issueAlertOptions';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   MOCK_RESP_VERBOSE,
@@ -9,6 +8,8 @@ import {
   MOCK_RESP_INCONSISTENT_PLACEHOLDERS,
   MOCK_RESP_ONLY_IGNORED_CONDITIONS_INVALID,
 } from 'sentry-test/fixtures/ruleConditions';
+
+import IssueAlertOptions from 'app/views/projectInstall/issueAlertOptions';
 
 describe('IssueAlertOptions', function() {
   const {organization, routerContext} = initializeOrg();

--- a/tests/js/spec/views/projectInstall/newProject.spec.jsx
+++ b/tests/js/spec/views/projectInstall/newProject.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import NewProject from 'app/views/projectInstall/newProject';
 

--- a/tests/js/spec/views/projectInstall/platform.spec.jsx
+++ b/tests/js/spec/views/projectInstall/platform.spec.jsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import {ProjectInstallPlatform} from 'app/views/projectInstall/platform';
 
 describe('ProjectInstallPlatform', function() {

--- a/tests/js/spec/views/projectOwnership.spec.jsx
+++ b/tests/js/spec/views/projectOwnership.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import ProjectOwnership from 'app/views/settings/project/projectOwnership';
 

--- a/tests/js/spec/views/projectPluginDetails.spec.jsx
+++ b/tests/js/spec/views/projectPluginDetails.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectPluginDetailsContainer, {
   ProjectPluginDetails,
 } from 'app/views/settings/projectPlugins/details';

--- a/tests/js/spec/views/projectPlugins/index.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ProjectPlugins from 'app/views/settings/projectPlugins';
 import {fetchPlugins, enablePlugin, disablePlugin} from 'app/actionCreators/plugins';
 

--- a/tests/js/spec/views/projectPlugins/projectPlugins.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/projectPlugins.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectPlugins from 'app/views/settings/projectPlugins/projectPlugins';
 
 describe('ProjectPlugins', function() {

--- a/tests/js/spec/views/projectPlugins/projectPluginsRow.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/projectPluginsRow.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ProjectPluginRow from 'app/views/settings/projectPlugins/projectPluginRow';
 
 describe('ProjectPluginRow', function() {

--- a/tests/js/spec/views/projectSecurityHeaders/projectCspReports.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectCspReports.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+
 import ProjectCspReports from 'app/views/settings/projectSecurityHeaders/csp';
 
 describe('ProjectCspReports', function() {

--- a/tests/js/spec/views/projectSecurityHeaders/projectExpectCtReports.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectExpectCtReports.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ProjectExpectCtReports from 'app/views/settings/projectSecurityHeaders/expectCt';
 
 describe('ProjectExpectCtReports', function() {

--- a/tests/js/spec/views/projectSecurityHeaders/projectHpkpReports.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectHpkpReports.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ProjectHpkpReports from 'app/views/settings/projectSecurityHeaders/hpkp';
 
 describe('ProjectHpkpReports', function() {

--- a/tests/js/spec/views/projectSecurityHeaders/projectSecurityHeaders.spec.jsx
+++ b/tests/js/spec/views/projectSecurityHeaders/projectSecurityHeaders.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import ProjectSecurityHeaders from 'app/views/settings/projectSecurityHeaders';
 
 describe('ProjectSecurityHeaders', function() {

--- a/tests/js/spec/views/projectTags.spec.jsx
+++ b/tests/js/spec/views/projectTags.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import $ from 'jquery';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectTags from 'app/views/settings/projectTags';
 
 describe('ProjectTags', function() {

--- a/tests/js/spec/views/projectTeams.spec.jsx
+++ b/tests/js/spec/views/projectTeams.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import App from 'app/views/app';
 import ProjectTeams from 'app/views/settings/project/projectTeams';
 import * as modals from 'app/actionCreators/modal';

--- a/tests/js/spec/views/projects/projectContext.spec.jsx
+++ b/tests/js/spec/views/projects/projectContext.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {ProjectContext} from 'app/views/projects/projectContext';
 
 jest.unmock('app/utils/recreateRoute');

--- a/tests/js/spec/views/projectsDashboard/index.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Dashboard} from 'app/views/projectsDashboard';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
 import * as projectsActions from 'app/actionCreators/projects';

--- a/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import ProjectsStore from 'app/stores/projectsStore';
 

--- a/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import NoProjectMessage from 'app/components/noProjectMessage';
 
 describe('NoProjectMessage', function() {

--- a/tests/js/spec/views/projectsDashboard/projectCard.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/projectCard.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {ProjectCard} from 'app/views/projectsDashboard/projectCard';
 
 // NOTE: Unmocking debounce so that the actionCreator never fires

--- a/tests/js/spec/views/providerItem.spec.jsx
+++ b/tests/js/spec/views/providerItem.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {descopeFeatureName} from 'app/utils';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {descopeFeatureName} from 'app/utils';
 import ProviderItem from 'app/views/settings/organizationAuth/providerItem';
 
 describe('ProviderItem', function() {

--- a/tests/js/spec/views/releases/detail/releaseArtifacts.spec.jsx
+++ b/tests/js/spec/views/releases/detail/releaseArtifacts.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mount} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import {ReleaseArtifacts} from 'app/views/releases/detail/releaseArtifacts';
 

--- a/tests/js/spec/views/releases/detail/releaseCommits.spec.jsx
+++ b/tests/js/spec/views/releases/detail/releaseCommits.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import ReleaseCommits from 'app/views/releases/detail/releaseCommits';
 
 describe('ReleaseCommits', function() {

--- a/tests/js/spec/views/releases/detail/releaseDetails.spec.jsx
+++ b/tests/js/spec/views/releases/detail/releaseDetails.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ReleaseDetails from 'app/views/releases/detail/';
 import ProjectsStore from 'app/stores/projectsStore';
 

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectsStore from 'app/stores/projectsStore';
 import ReleaseList from 'app/views/releases/list/';
 

--- a/tests/js/spec/views/releases/list/projectList.spec.jsx
+++ b/tests/js/spec/views/releases/list/projectList.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectList from 'app/views/releases/list/projectList.tsx';
 
 const projects = [

--- a/tests/js/spec/views/releases/list/releaseProgress.spec.jsx
+++ b/tests/js/spec/views/releases/list/releaseProgress.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {ReleaseProgress} from 'app/views/releases/list/releaseProgress';
 
 describe('ReleaseProgress', function() {

--- a/tests/js/spec/views/releasesV2/index.spec.jsx
+++ b/tests/js/spec/views/releasesV2/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ReleasesV2Container from 'app/views/releasesV2';
 
 describe('ReleasesV2Container', function() {

--- a/tests/js/spec/views/releasesV2/list/index.spec.jsx
+++ b/tests/js/spec/views/releasesV2/list/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import ProjectsStore from 'app/stores/projectsStore';
 import ReleaseList from 'app/views/releasesV2/list/';
 

--- a/tests/js/spec/views/routeError.spec.jsx
+++ b/tests/js/spec/views/routeError.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as Sentry from '@sentry/browser';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {RouteError} from 'app/views/routeError';
 
 jest.mock('jquery');

--- a/tests/js/spec/views/ruleBuilder.spec.jsx
+++ b/tests/js/spec/views/ruleBuilder.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import MemberListStore from 'app/stores/memberListStore';
 import TeamStore from 'app/stores/teamStore';
 import ProjectsStore from 'app/stores/projectsStore';

--- a/tests/js/spec/views/sentryAppExternalInstallation.spec.jsx
+++ b/tests/js/spec/views/sentryAppExternalInstallation.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import pick from 'lodash/pick';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import SentryAppExternalInstallation from 'app/views/sentryAppExternalInstallation';
 
 describe('SentryAppExternalInstallation', () => {

--- a/tests/js/spec/views/settings/account/apiApplications.spec.jsx
+++ b/tests/js/spec/views/settings/account/apiApplications.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ApiApplications from 'app/views/settings/account/apiApplications';
 
 describe('ApiApplications', function() {

--- a/tests/js/spec/views/settings/accountSettingsLayout.spec.jsx
+++ b/tests/js/spec/views/settings/accountSettingsLayout.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import * as OrgActions from 'app/actionCreators/organizations';
 import AccountSettingsLayout from 'app/views/settings/account/accountSettingsLayout';
 

--- a/tests/js/spec/views/settings/auditLogView.spec.jsx
+++ b/tests/js/spec/views/settings/auditLogView.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import OrganizationAuditLog from 'app/views/settings/organizationAuditLog';
 

--- a/tests/js/spec/views/settings/components/dataPrivacyRulesPanel/source.tsx
+++ b/tests/js/spec/views/settings/components/dataPrivacyRulesPanel/source.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
+import {mountWithTheme} from 'sentry-test/enzyme';
+
 import Source from 'app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/source';
 import {
   binaryOperatorSuggestions,
   unaryOperatorSuggestions,
   defaultSuggestions,
 } from 'app/views/settings/components/dataPrivacyRules/dataPrivacyRulesForm/dataPrivacyRulesFormSourceSuggestions';
-import {mountWithTheme} from 'sentry-test/enzyme';
 
 function renderComponent({
   value = '$string',

--- a/tests/js/spec/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import BreadcrumbTitle from 'app/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import Crumb from 'app/views/settings/components/settingsBreadcrumb/crumb';
 import SettingsBreadcrumb from 'app/views/settings/components/settingsBreadcrumb';

--- a/tests/js/spec/views/settings/components/settingsBreadcrumb/organizationCrumb.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsBreadcrumb/organizationCrumb.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OrganizationCrumb from 'app/views/settings/components/settingsBreadcrumb/organizationCrumb';
 
 jest.unmock('app/utils/recreateRoute');

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {SettingsSearch} from 'app/views/settings/components/settingsSearch';
 import FormSearchStore from 'app/stores/formSearchStore';
 import {navigateTo} from 'app/actionCreators/navigation';

--- a/tests/js/spec/views/settings/incidentRules/create.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/create.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import IncidentRulesCreate from 'app/views/settings/incidentRules/create';
 
 describe('Incident Rules Create', function() {

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select-new';
+
 import GlobalModal from 'app/components/globalModal';
 import IncidentRulesDetails from 'app/views/settings/incidentRules/details';
 

--- a/tests/js/spec/views/settings/incidentRules/list.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/list.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import IncidentRulesList from 'app/views/settings/incidentRules/list';
 
 describe('Incident Rules List', function() {

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import RuleFormContainer from 'app/views/settings/incidentRules/ruleForm';
 
 describe('Incident Rules Form', function() {

--- a/tests/js/spec/views/settings/organizationApiKeyDetailsView.spec.jsx
+++ b/tests/js/spec/views/settings/organizationApiKeyDetailsView.spec.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import OrganizationApiKeyDetails from 'app/views/settings/organizationApiKeys/organizationApiKeyDetails';
 

--- a/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OrganizationApiKeysList from 'app/views/settings/organizationApiKeys/organizationApiKeysList';
 
 jest.unmock('app/utils/recreateRoute');

--- a/tests/js/spec/views/settings/organizationApiKeysView.spec.jsx
+++ b/tests/js/spec/views/settings/organizationApiKeysView.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import OrganizationApiKeys from 'app/views/settings/organizationApiKeys';
 

--- a/tests/js/spec/views/settings/organizationAuthList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationAuthList.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import OrganizationAuthList from 'app/views/settings/organizationAuth/organizationAuthList';
 
 jest.mock('jquery');

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {Client} from 'app/api';
 import OrganizationDeveloperSettings from 'app/views/settings/organizationDeveloperSettings/index';
 import App from 'app/views/app';
 

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/permissionSelection.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/permissionSelection.spec.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {selectByValue, openMenu} from 'sentry-test/select';
+
 import FormModel from 'app/views/settings/components/forms/model';
 import PermissionSelection from 'app/views/settings/organizationDeveloperSettings/permissionSelection';
-import {selectByValue, openMenu} from 'sentry-test/select';
 
 describe('PermissionSelection', () => {
   let wrapper;

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/permissionsObserver.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/permissionsObserver.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import FormModel from 'app/views/settings/components/forms/model';
 import PermissionsObserver from 'app/views/settings/organizationDeveloperSettings/permissionsObserver';
 

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import FormModel from 'app/views/settings/components/forms/model';
 import Subscriptions from 'app/views/settings/organizationDeveloperSettings/resourceSubscriptions';
 

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {Client} from 'app/api';
 import SentryApplicationDashboard from 'app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard';
 
 describe('Sentry Application Dashboard', function() {

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {selectByValue} from 'sentry-test/select';
+
+import {Client} from 'app/api';
 import SentryApplicationDetails from 'app/views/settings/organizationDeveloperSettings/sentryApplicationDetails';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import PermissionsObserver from 'app/views/settings/organizationDeveloperSettings/permissionsObserver';
-import {selectByValue} from 'sentry-test/select';
 
 describe('Sentry Application Details', function() {
   let org;

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import {SubscriptionBox} from 'app/views/settings/organizationDeveloperSettings/subscriptionBox';
 
 describe('SubscriptionBox', () => {

--- a/tests/js/spec/views/settings/organizationGeneralSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationGeneralSettings/index.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OrganizationGeneralSettings from 'app/views/settings/organizationGeneralSettings';
 
 jest.mock('jquery');

--- a/tests/js/spec/views/settings/organizationIntegrations/addIntegration.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/addIntegration.spec.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
+
 import AddIntegration from 'app/views/organizationIntegrations/addIntegration';
 
 describe('AddIntegration', function() {

--- a/tests/js/spec/views/settings/organizationIntegrations/addIntegrationButton.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/addIntegrationButton.spec.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import AddIntegrationButton from 'app/views/organizationIntegrations/addIntegrationButton';
 
 describe('AddIntegrationButton', function() {

--- a/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select';
+
 import InviteRequestRow from 'app/views/settings/organizationMembers/inviteRequestRow';
 
 const roles = [

--- a/tests/js/spec/views/settings/organizationMembers/organizationAccessRequests.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationAccessRequests.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OrganizationAccessRequests from 'app/views/settings/organizationMembers/organizationAccessRequests';
 
 describe('OrganizationAccessRequests', function() {

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {updateMember} from 'app/actionCreators/members';
 import OrganizationMemberDetail from 'app/views/settings/organizationMembers/organizationMemberDetail';
 

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberRow.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberRow.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import OrganizationMemberRow from 'app/views/settings/organizationMembers/organizationMemberRow';
 
 describe('OrganizationMemberRow', function() {

--- a/tests/js/spec/views/settings/organizationMembers/organizationMembersList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMembersList.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import ConfigStore from 'app/stores/configStore';
 import OrganizationMembersList from 'app/views/settings/organizationMembers/organizationMembersList';

--- a/tests/js/spec/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {openInviteMembersModal} from 'app/actionCreators/modal';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import OrganizationMembersList from 'app/views/settings/organizationMembers/organizationMembersList';

--- a/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select';
+
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import OrganizationRequestsView from 'app/views/settings/organizationMembers/organizationRequestsView';
 import OrganizationMembersWrapper from 'app/views/settings/organizationMembers/organizationMembersWrapper';

--- a/tests/js/spec/views/settings/organizationProjects.spec.jsx
+++ b/tests/js/spec/views/settings/organizationProjects.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import OrganizationProjectsContainer from 'app/views/settings/organizationProjects';
 

--- a/tests/js/spec/views/settings/organizationRateLimits.spec.jsx
+++ b/tests/js/spec/views/settings/organizationRateLimits.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import OrganizationRateLimits from 'app/views/settings/organizationRateLimits/organizationRateLimits';
 

--- a/tests/js/spec/views/settings/organizationRepositories.spec.jsx
+++ b/tests/js/spec/views/settings/organizationRepositories.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import OrganizationRepositories from 'app/views/settings/organizationRepositories/organizationRepositories';
 

--- a/tests/js/spec/views/settings/organizationRepositoriesContainer.spec.jsx
+++ b/tests/js/spec/views/settings/organizationRepositoriesContainer.spec.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import OrganizationRepositoriesContainer from 'app/views/settings/organizationRepositories';
 

--- a/tests/js/spec/views/settings/organizationSecurityAndPrivacy.spec.jsx
+++ b/tests/js/spec/views/settings/organizationSecurityAndPrivacy.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OrganizationSecurityAndPrivacy from 'app/views/settings/organizationSecurityAndPrivacy/organizationSecurityAndPrivacy';
 
 describe('OrganizationSecurityAndPrivacy', function() {

--- a/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
+++ b/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {saveOnBlurUndoMessage} from 'app/actionCreators/indicator';
 import OrganizationSettingsForm from 'app/views/settings/organizationGeneralSettings/organizationSettingsForm';
 

--- a/tests/js/spec/views/settings/organizationTeams.spec.jsx
+++ b/tests/js/spec/views/settings/organizationTeams.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {openCreateTeamModal} from 'app/actionCreators/modal';
 import OrganizationTeams from 'app/views/settings/organizationTeams/organizationTeams';
 import recreateRoute from 'app/utils/recreateRoute';

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select-new';
+
 import ProjectAlerts from 'app/views/settings/projectAlerts';
 import ProjectAlertsCreate from 'app/views/settings/projectAlerts/create';
 

--- a/tests/js/spec/views/settings/projectAlerts/issueEditor.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/issueEditor.spec.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select-new';
+
 import ProjectAlerts from 'app/views/settings/projectAlerts';
 import IssueEditor from 'app/views/settings/projectAlerts/issueEditor';
 import {updateOnboardingTask} from 'app/actionCreators/onboardingTasks';

--- a/tests/js/spec/views/settings/projectAlerts/list.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/list.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectAlerts from 'app/views/settings/projectAlerts';
 import ProjectAlertsList from 'app/views/settings/projectAlerts/list';
 

--- a/tests/js/spec/views/settings/projectAlerts/onboardingHovercard.spec.js
+++ b/tests/js/spec/views/settings/projectAlerts/onboardingHovercard.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import OnboardingHovercard from 'app/views/settings/projectAlerts/onboardingHovercard';
 import {updateOnboardingTask} from 'app/actionCreators/onboardingTasks';
 

--- a/tests/js/spec/views/settings/projectAlerts/settings.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/settings.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {Client} from 'app/api';
 import ProjectAlertSettings from 'app/views/settings/projectAlerts/settings';
 

--- a/tests/js/spec/views/settings/projectDebugFiles.spec.jsx
+++ b/tests/js/spec/views/settings/projectDebugFiles.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import ProjectDebugFiles from 'app/views/settings/projectDebugFiles';
 
 describe('ProjectDebugFiles', function() {

--- a/tests/js/spec/views/settings/projectEnvironments.spec.jsx
+++ b/tests/js/spec/views/settings/projectEnvironments.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectEnvironments from 'app/views/settings/project/projectEnvironments';
 import recreateRoute from 'app/utils/recreateRoute';
 import {ALL_ENVIRONMENTS_KEY} from 'app/constants';

--- a/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
@@ -2,10 +2,11 @@ import {browserHistory} from 'react-router';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {selectByValue} from 'sentry-test/select';
+
 import ProjectContext from 'app/views/projects/projectContext';
 import ProjectGeneralSettings from 'app/views/settings/projectGeneralSettings';
 import ProjectsStore from 'app/stores/projectsStore';
-import {selectByValue} from 'sentry-test/select';
 
 jest.mock('jquery');
 

--- a/tests/js/spec/views/settings/projectKeys/details/index.spec.jsx
+++ b/tests/js/spec/views/settings/projectKeys/details/index.spec.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectKeyDetails from 'app/views/settings/project/projectKeys/details';
 
 describe('ProjectKeyDetails', function() {

--- a/tests/js/spec/views/settings/projectKeys/list/index.spec.jsx
+++ b/tests/js/spec/views/settings/projectKeys/list/index.spec.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectKeys from 'app/views/settings/project/projectKeys/list';
 
 describe('ProjectKeys', function() {

--- a/tests/js/spec/views/settings/projectReleaseTracking.spec.jsx
+++ b/tests/js/spec/views/settings/projectReleaseTracking.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectReleaseTrackingContainer, {
   ProjectReleaseTracking,
 } from 'app/views/settings/project/projectReleaseTracking';

--- a/tests/js/spec/views/settings/projectUserFeedback.spec.jsx
+++ b/tests/js/spec/views/settings/projectUserFeedback.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectUserFeedback from 'app/views/settings/project/projectUserFeedback';
 
 describe('ProjectUserFeedback', function() {

--- a/tests/js/spec/views/settings/settingsIndex.spec.jsx
+++ b/tests/js/spec/views/settings/settingsIndex.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
+
 import * as OrgActions from 'app/actionCreators/organizations';
 import {SettingsIndex} from 'app/views/settings/settingsIndex';
 import ConfigStore from 'app/stores/configStore';

--- a/tests/js/spec/views/sharedGroupDetails/index.spec.jsx
+++ b/tests/js/spec/views/sharedGroupDetails/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import SharedGroupDetails from 'app/views/sharedGroupDetails/sharedGroupDetails';
 
 describe('SharedGroupDetails', function() {

--- a/tests/js/spec/views/teamCreate.spec.jsx
+++ b/tests/js/spec/views/teamCreate.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {shallow} from 'sentry-test/enzyme';
+
 import {TeamCreate} from 'app/views/teamCreate';
 
 describe('TeamCreate', function() {

--- a/tests/js/spec/views/teamMembers.spec.jsx
+++ b/tests/js/spec/views/teamMembers.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {Client} from 'app/api';
 import {
   openInviteMembersModal,
   openTeamAccessRequestModal,

--- a/tests/js/spec/views/teamSettings.spec.jsx
+++ b/tests/js/spec/views/teamSettings.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import TeamStore from 'app/stores/teamStore';
 import TeamSettings from 'app/views/settings/organizationTeams/teamSettings';
 

--- a/tests/js/spec/views/twoFactorRequired.spec.jsx
+++ b/tests/js/spec/views/twoFactorRequired.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Cookies from 'js-cookie';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import TwoFactorRequired from 'app/views/settings/account/accountSecurity/';
 import AccountSecurityWrapper from 'app/views/settings/account/accountSecurity/accountSecurityWrapper';
 

--- a/tests/js/spec/views/userFeedback/index.spec.jsx
+++ b/tests/js/spec/views/userFeedback/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectsStore from 'app/stores/projectsStore';
 import UserFeedback from 'app/views/userFeedback';
 

--- a/tests/js/spec/views/userFeedback/userFeedbackEmpty.spec.jsx
+++ b/tests/js/spec/views/userFeedback/userFeedbackEmpty.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import {UserFeedbackEmpty} from 'app/views/userFeedback/userFeedbackEmpty';
 
 describe('UserFeedbackEmpty', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6647,10 +6647,10 @@ eslint-config-prettier@6.3.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-sentry-app@1.36.0:
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.36.0.tgz#9dbbf892b94e22991909aca321cc8bd258face78"
-  integrity sha512-Zi988kDZ7UNsoeHAgIWM2MHQTY3uv830JeyXFNFp69v5OPqO1kqBMuim+MNtj189hYg/8EwUX3/HnSsSP7FtcA==
+eslint-config-sentry-app@1.37.0:
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.37.0.tgz#36bac360af442902938406bb9a91be1bcb3b525c"
+  integrity sha512-RlMoHklHbTdTzmLIz+JfVPWBcA2knRZhf+bBy8CTmLCG+v/gs2xV8ldC/81g0vNsteyegzU8yUZQjHBbYCf76w==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^2.23.0"
     "@typescript-eslint/parser" "^2.23.0"


### PR DESCRIPTION
This is a change mostly only used for getsentry, will group sentry/getsentry imports separately.

In `sentry`'s case, it affects tests by separating `sentry-test` and `app` imports.