### PR TITLE
chore(react): Bump fast-refresh packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx-source": "^7.2.0",
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.2.0",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.3.1",
     "@sentry/node": "^5.16.0-beta.3",
     "@storybook/addon-a11y": "^5.3.3",
     "@storybook/addon-actions": "^5.3.3",
@@ -159,7 +159,7 @@
     "mockdate": "2.0.5",
     "object.fromentries": "^2.0.0",
     "prettier": "1.19.1",
-    "react-refresh": "^0.8.0",
+    "react-refresh": "^0.8.2",
     "react-test-renderer": "16.12.0",
     "source-map-loader": "^0.2.4",
     "speed-measure-webpack-plugin": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,16 +1784,17 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@pmmmwh/react-refresh-webpack-plugin@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.2.0.tgz#e2a684d430f74ad6465680d9a5869f52f307ec1e"
-  integrity sha512-rjdNzcWroULJeD/Y0+eETy9LhM7c5tbPF+wqT5G680rwDkh3iothIPEqGAuEE2WJlXEaAq293aO6ySzsIU518Q==
+"@pmmmwh/react-refresh-webpack-plugin@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.3.1.tgz#b2e0fa57949e72f27cdfef3b0f4554edd4776240"
+  integrity sha512-JlbMOHNtoaLV5LR/GWpfDZht5qQqMr2E6Fcto2GcGCiVSDWN9C9wac+WNhGWaAfKh9pLOlz3EX4DkWl4Tb7sCg==
   dependencies:
     ansi-html "^0.0.7"
-    error-stack-parser "^2.0.4"
+    error-stack-parser "^2.0.6"
     html-entities "^1.2.1"
     lodash.debounce "^4.0.8"
-    react-dev-utils "^9.1.0"
+    native-url "^0.2.6"
+    schema-utils "^2.6.5"
 
 "@popmotion/easing@^1.0.1":
   version "1.0.2"
@@ -6552,7 +6553,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-error-stack-parser@^2.0.4:
+error-stack-parser@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.6.tgz#5a99a707bd7a4c58a797902d48d82803ede6aad8"
   integrity sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==
@@ -10715,6 +10716,13 @@ nanomatch@^1.2.1, nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+native-url@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.2.6.tgz#ca1258f5ace169c716ff44eccbddb674e10399ae"
+  integrity sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==
+  dependencies:
+    querystring "^0.2.0"
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -12700,7 +12708,7 @@ react-date-range@^1.0.0-beta:
     prop-types "^15.5.10"
     react-list "^0.8.8"
 
-react-dev-utils@^9.0.0, react-dev-utils@^9.1.0:
+react-dev-utils@^9.0.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-9.1.0.tgz#3ad2bb8848a32319d760d0a84c56c14bdaae5e81"
   integrity sha512-X2KYF/lIGyGwP/F/oXgGDF24nxDA2KC4b7AFto+eqzc/t838gpSGiaU8trTqHXOohuLxxc5qi1eDzsl9ucPDpg==
@@ -12937,10 +12945,10 @@ react-redux@^7.0.2:
     prop-types "^15.7.2"
     react-is "^16.9.0"
 
-react-refresh@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.0.tgz#89225eef8891e108049c8c57a95cf536638369ed"
-  integrity sha512-tX+7Uazk22H5KJmi32uHA45Og1VyBAXlwYotd49oWkhMZ6oXKmdzMJiCMKmxgkLy4elfuEHysDlEf1o8ORBX2A==
+react-refresh@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.2.tgz#24bb0858eac92b0d7b0dd561747f0c9fd6c60327"
+  integrity sha512-n8GXxo3DwM2KtFEL69DAVhGc4A1THn2qjmfvSo3nze0NLCoPbywazeJPqdp0RdSGLmyhQzeyA+XPXOobbYlkzg==
 
 react-router@3.2.0:
   version "3.2.0"


### PR DESCRIPTION
This is primarily to get rid of this warning 

> Error: The plugin is unable to detect transformed code from
> react-refresh. Did you forget to include "react-refresh/babel" in your
> list of Babel plugins? Note: you can disable this check by setting
> "disableRefreshCheck: true".

See: https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/11

https://github.com/pmmmwh/react-refresh-webpack-plugin/releases/tag/v0.3.0