### PR TITLE
feat(alert_rules): Allow dataset to be passed to alert rule create/update endpoints

### DIFF
--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -23,6 +23,7 @@ query_aggregation_to_snuba = {
 
 class QueryDatasets(Enum):
     EVENTS = "events"
+    TRANSACTIONS = "transactions"
 
 
 class SnubaQuery(Model):

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -4,7 +4,7 @@ import logging
 
 from django.db import transaction
 
-from sentry.snuba.models import QueryAggregations, QuerySubscription, SnubaQuery
+from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription, SnubaQuery
 from sentry.snuba.tasks import (
     create_subscription_in_snuba,
     delete_subscription_from_snuba,
@@ -45,7 +45,9 @@ def create_snuba_query(dataset, query, aggregate, time_window, resolution, envir
     )
 
 
-def update_snuba_query(snuba_query, query, aggregate, time_window, resolution, environment):
+def update_snuba_query(
+    snuba_query, dataset, query, aggregate, time_window, resolution, environment
+):
     """
     Updates a SnubaQuery. Triggers updates to any related QuerySubscriptions.
 
@@ -59,16 +61,18 @@ def update_snuba_query(snuba_query, query, aggregate, time_window, resolution, e
     :param environment: An optional environment to filter by
     :return: A list of QuerySubscriptions
     """
+    old_dataset = QueryDatasets(snuba_query.dataset)
     with transaction.atomic():
         query_subscriptions = list(snuba_query.subscriptions.all())
         snuba_query.update(
+            dataset=dataset.value,
             query=query,
             aggregate=aggregate,
             time_window=int(time_window.total_seconds()),
             resolution=int(resolution.total_seconds()),
             environment=environment,
         )
-        bulk_update_snuba_subscriptions(query_subscriptions, snuba_query)
+        bulk_update_snuba_subscriptions(query_subscriptions, old_dataset)
 
 
 def bulk_create_snuba_subscriptions(projects, subscription_type, snuba_query):
@@ -111,7 +115,7 @@ def create_snuba_subscription(project, subscription_type, snuba_query):
     return subscription
 
 
-def bulk_update_snuba_subscriptions(subscriptions, snuba_query):
+def bulk_update_snuba_subscriptions(subscriptions, old_dataset):
     """
     Updates a list of query subscriptions.
 
@@ -122,26 +126,26 @@ def bulk_update_snuba_subscriptions(subscriptions, snuba_query):
     updated_subscriptions = []
     # TODO: Batch this up properly once we care about multi-project rules.
     for subscription in subscriptions:
-        updated_subscriptions.append(update_snuba_subscription(subscription, snuba_query))
+        updated_subscriptions.append(update_snuba_subscription(subscription, old_dataset))
     return subscriptions
 
 
-def update_snuba_subscription(subscription, snuba_query):
+def update_snuba_subscription(subscription, old_dataset):
     """
     Updates a subscription to a snuba query.
 
     :param query: An event search query that we can parse and convert into a
     set of Snuba conditions
-    :param snuba_query: A `SnubaQuery` instance to subscribe the project to.
-    :param aggregation: An aggregation to calculate over the time window. This will be
-    removed soon, once we're relying entirely on `snuba_query`.
+    :param old_dataset: The `QueryDataset` that this subscription was associated with
+    before the update.
     :return: The QuerySubscription representing the subscription
     """
     with transaction.atomic():
         subscription.update(status=QuerySubscription.Status.UPDATING.value)
 
         update_subscription_in_snuba.apply_async(
-            kwargs={"query_subscription_id": subscription.id}, countdown=5
+            kwargs={"query_subscription_id": subscription.id, "old_dataset": old_dataset.value},
+            countdown=5,
         )
 
     return subscription

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -57,7 +57,7 @@ def create_subscription_in_snuba(query_subscription_id, **kwargs):
     default_retry_delay=5,
     max_retries=5,
 )
-def update_subscription_in_snuba(query_subscription_id, **kwargs):
+def update_subscription_in_snuba(query_subscription_id, old_dataset=None, **kwargs):
     """
     Task to update a corresponding subscription in Snuba from a `QuerySubscription` in
     Sentry. Updating in Snuba means deleting the existing subscription, then creating a
@@ -74,9 +74,8 @@ def update_subscription_in_snuba(query_subscription_id, **kwargs):
         return
 
     if subscription.subscription_id is not None:
-        _delete_from_snuba(
-            QueryDatasets(subscription.snuba_query.dataset), subscription.subscription_id
-        )
+        dataset = old_dataset if old_dataset is not None else subscription.snuba_query.dataset
+        _delete_from_snuba(QueryDatasets(dataset), subscription.subscription_id)
 
     subscription_id = _create_in_snuba(subscription)
     subscription.update(

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -16,7 +16,7 @@ from sentry.incidents.endpoints.serializers import (
 from sentry.incidents.logic import create_alert_rule_trigger
 from sentry.incidents.models import AlertRule, AlertRuleThresholdType, AlertRuleTriggerAction
 from sentry.models import Integration, Environment
-from sentry.snuba.models import QueryAggregations
+from sentry.snuba.models import QueryAggregations, QueryDatasets
 from sentry.testutils import TestCase
 
 
@@ -26,6 +26,7 @@ class TestAlertRuleSerializer(TestCase):
         return {
             "name": "hello",
             "time_window": 10,
+            "dataset": QueryDatasets.EVENTS.value,
             "query": "level:error",
             "threshold_type": 0,
             "resolve_threshold": 1,
@@ -110,6 +111,12 @@ class TestAlertRuleSerializer(TestCase):
         self.run_fail_validation_test(
             {"timeWindow": 0}, {"timeWindow": ["Ensure this value is greater than or equal to 1."]}
         )
+
+    def test_dataset(self):
+        invalid_values = [
+            "Invalid dataset, valid values are %s" % [item.value for item in QueryDatasets]
+        ]
+        self.run_fail_validation_test({"dataset": "events_wrong"}, {"dataset": invalid_values})
 
     def test_aggregation(self):
         invalid_values = [

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -715,7 +715,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             10,
             1,
         )
-        update_alert_rule(alert_rule, [self.project])
+        update_alert_rule(alert_rule, projects=[self.project])
         assert self.alert_rule.snuba_query.subscriptions.get().project == self.project
 
     def test_new_updated_deleted_projects(self):
@@ -732,7 +732,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         new_project = self.create_project(fire_project_created=True)
         updated_projects = [self.project, new_project]
         with self.tasks():
-            update_alert_rule(alert_rule, updated_projects, query=query_update)
+            update_alert_rule(alert_rule, projects=updated_projects, query=query_update)
         updated_subscriptions = alert_rule.snuba_query.subscriptions.all()
         assert set([sub.project for sub in updated_subscriptions]) == set(updated_projects)
         for sub in updated_subscriptions:


### PR DESCRIPTION
This allows us to specify dataset when creating or updating an alert rule. Since dataset is part of
the primary key we use when talking to snuba, we also need to make sure that the old dataset is
passed along to the update task when we update in snuba so that we can correctly identify it.