### PR TITLE
ref(slack-migration): Remove 'upgrade now' after upgrading

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
@@ -24,7 +24,7 @@ export type Props = {
   integration: Integration;
   onRemove: (integration: Integration) => void;
   onDisable: (integration: Integration) => void;
-  onReinstallIntegration: (integration: Integration) => void;
+  onReAuthIntegration: (integration: Integration) => void;
   trackIntegrationEvent: (
     options: Pick<SingleIntegrationEvent, 'eventKey' | 'eventName'>
   ) => void; //analytics callback
@@ -49,11 +49,8 @@ export default class InstalledIntegration extends React.Component<Props> {
     );
   }
 
-  reinstallIntegration = () => {
-    const activeIntegration = Object.assign({}, this.props.integration, {
-      status: 'active',
-    });
-    this.props.onReinstallIntegration(activeIntegration);
+  reAuthIntegration = (integration: Integration) => {
+    this.props.onReAuthIntegration(integration);
   };
 
   handleUninstallClick = () => {
@@ -157,8 +154,7 @@ export default class InstalledIntegration extends React.Component<Props> {
                   <AddIntegrationButton
                     disabled={!hasAccess}
                     provider={provider}
-                    // TODO: actually pass in an onInstall function
-                    onAddIntegration={() => {}}
+                    onAddIntegration={this.reAuthIntegration}
                     integrationId={integration.id}
                     priority="primary"
                     size="small"

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
@@ -49,7 +49,7 @@ export default class InstalledIntegration extends React.Component<Props> {
     );
   }
 
-  reAuthIntegration = (integration: Integration) => {
+  handleReAuthIntegration = (integration: Integration) => {
     this.props.onReAuthIntegration(integration);
   };
 
@@ -154,7 +154,7 @@ export default class InstalledIntegration extends React.Component<Props> {
                   <AddIntegrationButton
                     disabled={!hasAccess}
                     provider={provider}
-                    onAddIntegration={this.reAuthIntegration}
+                    onAddIntegration={this.handleReAuthIntegration}
                     integrationId={integration.id}
                     priority="primary"
                     size="small"

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -226,7 +226,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
                     integration={integration}
                     onRemove={this.onRemove}
                     onDisable={this.onDisable}
-                    onReinstallIntegration={this.onInstall}
+                    onReAuthIntegration={this.onInstall}
                     data-test-id={integration.id}
                     trackIntegrationEvent={this.trackIntegrationEvent}
                     showReauthMessage={hasFeature && isSlackWorkspaceApp(integration)}


### PR DESCRIPTION
Make sure the frontend updates correctly when the Slack upgrade is successfully finished.

We don't use the reinstall methods anymore so I just renamed them since they do want we need. 