### PR TITLE
fix(discover): Don't groupby when project is only aggregate

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1493,7 +1493,8 @@ def resolve_field_list(fields, snuba_filter, auto_fields=True):
 
     # If aggregations are present all columns
     # need to be added to the group by so that the query is valid.
-    if aggregations:
+    # But ignore the project transform aggregation
+    if aggregations and not (len(aggregations) == 1 and project_key):
         for column in columns:
             if isinstance(column, (list, tuple)):
                 groupby.append(column[2])

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1342,7 +1342,7 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["aggregations"] == [
             ["transform(project_id, array(), array(), '')", None, "project.name"]
         ]
-        assert result["groupby"] == ["event.type", "message", "id", "project.id"]
+        assert result["groupby"] == []
 
     def test_field_alias_duration_expansion_with_brackets(self):
         fields = [
@@ -1654,7 +1654,7 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["aggregations"] == [
             ["transform(project_id, array(), array(), '')", None, "project.name"]
         ]
-        assert result["groupby"] == ["message", "id", "project.id"]
+        assert result["groupby"] == []
 
     def test_orderby_field_aggregate(self):
         fields = ["count(id)", "count_unique(user)"]
@@ -1677,7 +1677,7 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["aggregations"] == [
             ["transform(project_id, array(), array(), '')", None, "project.name"]
         ]
-        assert result["groupby"] == ["issue.id", "id", "project.id"]
+        assert result["groupby"] == []
 
     def test_orderby_project_alias(self):
         fields = ["project"]
@@ -1686,4 +1686,15 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["aggregations"] == [
             ["transform(project_id, array(), array(), '')", None, "project"]
         ]
-        assert result["groupby"] == ["project.id", "id"]
+        assert result["groupby"] == []
+
+    def test_groupby_project_and_aggregate(self):
+        fields = ["project", "count(id)"]
+        result = resolve_field_list(fields, eventstore.Filter(orderby="-project"))
+        assert result["orderby"] == ["-project"]
+        assert result["aggregations"] == [
+            ["count", None, "count_id"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
+            ["transform(project_id, array(), array(), '')", None, "project"],
+        ]
+        assert result["groupby"] == ["project.id"]

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -212,11 +212,11 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         assert data[0]["release"] == "first-release"
 
         assert len(result["meta"]) == 5
-        assert result["meta"][0] == {"name": "user.email", "type": "Nullable(String)"}
-        assert result["meta"][1] == {"name": "release", "type": "Nullable(String)"}
-        assert result["meta"][2] == {"name": "id", "type": "FixedString(32)"}
-        assert result["meta"][3] == {"name": "project.id", "type": "UInt64"}
-        assert result["meta"][4] == {"name": "project.name", "type": "String"}
+        assert result["meta"][0] == {"name": "project.name", "type": "String"}
+        assert result["meta"][1] == {"name": "user.email", "type": "Nullable(String)"}
+        assert result["meta"][2] == {"name": "release", "type": "Nullable(String)"}
+        assert result["meta"][3] == {"name": "id", "type": "FixedString(32)"}
+        assert result["meta"][4] == {"name": "project.id", "type": "UInt64"}
 
     def test_auto_fields_aggregates(self):
         result = discover.query(
@@ -402,7 +402,7 @@ class QueryTransformTest(TestCase):
             end=None,
             start=None,
             conditions=[],
-            groupby=["email", "username", "ip_address", "user_id", "project_id"],
+            groupby=[],
             having=[],
             orderby=None,
             limit=50,
@@ -438,7 +438,7 @@ class QueryTransformTest(TestCase):
             end=None,
             start=None,
             conditions=[["project_id", "=", project2.id]],
-            groupby=["title", "project_id"],
+            groupby=[],
             having=[],
             orderby=None,
             limit=50,


### PR DESCRIPTION
- Since project is passed as an aggregate to transform ids to slugs
  we're grouping by all the columns for `All Events` unnecessarily.
- This changes the check so when there's only one aggregate if its the
  project transform aggregate to not group by everything