### PR TITLE
ref(apm): Rename tag key since it is too long

### DIFF
--- a/src/sentry/static/sentry/app/utils/apm.tsx
+++ b/src/sentry/static/sentry/app/utils/apm.tsx
@@ -51,11 +51,11 @@ export async function normalizeTransactionName(
       },
       (error, _redirectLocation, renderProps) => {
         if (error) {
-          set(event, ['tags', 'transaction.rename.react-router-match'], 'error');
+          set(event, ['tags', 'transaction.rename.router-match'], 'error');
           return resolve(undefined);
         }
 
-        set(event, ['tags', 'transaction.rename.react-router-match'], 'success');
+        set(event, ['tags', 'transaction.rename.router-match'], 'success');
 
         const routePath = getRouteStringFromRoutes(renderProps.routes ?? []);
         return resolve(routePath);


### PR DESCRIPTION
Tag key values can only be at most 32 characters long. Otherwise they're dropped in relay: https://github.com/getsentry/relay/blob/a80118dc43c7a69d44e2c50baa3d264df4fd286a/relay-general/src/processor/attrs.rs#L137