### PR TITLE
feat(workflow): Adding logging and syncing action update/create functionality

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -418,15 +418,22 @@ def get_channel_id_with_timeout(integration, name, timeout):
 
             item_id = {c["name"]: c["id"] for c in items[result_name]}.get(name)
             if item_id:
+                logger.info("rule.slack.%s_list_success" % list_type)
                 return (prefix, item_id, False)
 
             cursor = items.get("response_metadata", {}).get("next_cursor", None)
             if time.time() > time_to_quit:
+                logger.info(
+                    "rule.slack.%s_list_timeout" % list_type,
+                    extra={"diff": time.time() - time_to_quit},
+                )
                 return (prefix, None, True)
 
             if not cursor:
+                logger.info("rule.slack.%s_list_cursor" % list_type, extra={"name": name})
                 break
 
+    logger.info("rule.slack.name_not_found" % list_type)
     return (prefix, None, False)
 
 


### PR DESCRIPTION
There is an issue with some slack users returning an error when trying to create an alert - "Could not find channel XXX. Channel may not exist, or Sentry may not             "have been granted permission to access it". This was not happening on an update and it's because we were not checking the channel id.

This PR adds additional logging around our logic that fetches slack channel id's to better get to the bottom of this - and also syncs up our create/update logic. 

Additionally, it seems that notifications are NOT being sent to the users that are able to be saved. As a consistently reproducible example, @dan cannot be used to create an alert but @cfuller can.

Working towards addressing https://app.asana.com/0/1143846759074121/1176599231737881