### PR TITLE
ref(devservices): dynamic rm prompt text

### DIFF
--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -302,6 +302,8 @@ def down(project, service):
 
     prefix = project + "_"
 
+    # TODO: make more like devservices rm
+
     for container in client.containers.list(all=True):
         if container.name.startswith(prefix):
             if not service or container.name[len(prefix) :] in service:
@@ -311,8 +313,8 @@ def down(project, service):
 
 @devservices.command()
 @click.option("--project", default="sentry")
-@click.argument("service", nargs=-1)
-def rm(project, service):
+@click.argument("services", nargs=-1)
+def rm(project, services):
     """
     Shut down and delete all services and associated data.
     Useful if you'd like to start with a fresh slate.
@@ -322,21 +324,52 @@ def rm(project, service):
     """
     import docker
 
+    client = get_docker_client()
+
+    from sentry.runner import configure
+
+    configure()
+
+    containers = _prepare_containers(project, silent=True)
+
+    if services:
+        selected_containers = {}
+        for service in services:
+            # XXX: This isn't great, we assume a service has 1 container following naming schema
+            # PROJECT_SERVICE. Like sentry_redis.
+            # This code is also fairly duplicated in here at this point, so dedupe in the future.
+            if service not in containers:
+                click.secho(
+                    "Service `{}` is not known or not enabled.\n".format(service),
+                    err=True,
+                    fg="red",
+                )
+                click.secho(
+                    "Services that are available:\n" + "\n".join(containers.keys()) + "\n",
+                    err=True,
+                )
+                raise click.Abort()
+            selected_containers[service] = containers[service]
+        containers = selected_containers
+
     click.confirm(
-        "Are you sure you want to continue?\nThis will delete all of your Sentry related data!",
+        """
+This will delete these services and all of their data:
+
+%s
+
+Are you sure you want to continue?"""
+        % "\n".join(containers.keys()),
         abort=True,
     )
 
-    client = get_docker_client()
-
     prefix = project + "_"
 
-    for container in client.containers.list(all=True):
-        if container.name.startswith(prefix):
-            if not service or container.name[len(prefix) :] in service:
-                click.secho("> Removing '%s' container" % container.name, err=True, fg="red")
-                container.stop()
-                container.remove()
+    for container_name in containers:
+        click.secho("> Removing '%s' container" % (prefix + container_name), err=True, fg="red")
+        container = client.containers.get(prefix + container_name)
+        container.stop()
+        container.remove()
 
     for volume in client.volumes.list():
         if volume.name.startswith(prefix):

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -291,7 +291,13 @@ def _start_service(client, name, containers, project, fast=False, always_start=F
 @click.option("--project", default="sentry")
 @click.argument("service", nargs=-1)
 def down(project, service):
-    "Shut down all services."
+    """
+    Shut down services without deleting their underlying containers and data.
+    Useful if you want to temporarily relieve resources on your computer.
+
+    The default is everything, however you may pass positional arguments to specify
+    an explicit list of services to bring down.
+    """
     client = get_docker_client()
 
     prefix = project + "_"
@@ -307,8 +313,13 @@ def down(project, service):
 @click.option("--project", default="sentry")
 @click.argument("service", nargs=-1)
 def rm(project, service):
-    "Delete all services and associated data."
+    """
+    Shut down and delete all services and associated data.
+    Useful if you'd like to start with a fresh slate.
 
+    The default is everything, however you may pass positional arguments to specify
+    an explicit list of services to remove.
+    """
     import docker
 
     click.confirm(


### PR DESCRIPTION
Addresses https://github.com/getsentry/develop/pull/35#discussion_r428790609.

`devservices rm` takes nargs services, but the prompt text isn't generated accordingly.

This makes the experience similar to https://github.com/getsentry/sentry/pull/18514, read the PR description.

Also, this reminded me of this containers vs services wart that we assume a service has 1 container following naming schema: PROJECT_SERVICE. Notice how `selected_containers` is filtered from service names, and the resultant container names (w/o prefixes) are used in the prompt text as "services".

Ideally we should be able to take a service name and list all applicable containers, volumes, and networks.

So if anyone wants to block this by requesting a refactor for that, I could take a stab at it, but it might take a while.
