### PR TITLE
event_manager: Move short id generation out of transaction

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1074,8 +1074,9 @@ def _save_aggregate(event, hashes, release, **kwargs):
         # make sure it still exists
         first_release = kwargs.pop("first_release", None)
 
+        short_id = project.next_short_id()
+
         with transaction.atomic():
-            short_id = project.next_short_id()
             group, group_is_new = (
                 Group.objects.create(
                     project=project,


### PR DESCRIPTION
This has a tradeoff of not guaranteeing gapless ids, but should reduce
row lock contension for high volumes of groups within a project.