### PR TITLE
fix(apm): Adjust transaction name normalization

### DIFF
--- a/src/sentry/static/sentry/app/utils/apm.tsx
+++ b/src/sentry/static/sentry/app/utils/apm.tsx
@@ -58,6 +58,11 @@ export async function normalizeTransactionName(
         set(event, ['tags', 'transaction.rename.router-match'], 'success');
 
         const routePath = getRouteStringFromRoutes(renderProps.routes ?? []);
+
+        if (routePath.length === 0 || routePath === '/*') {
+          return resolve(window.location.pathname);
+        }
+
         return resolve(routePath);
       }
     );

--- a/src/sentry/static/sentry/app/utils/apm.tsx
+++ b/src/sentry/static/sentry/app/utils/apm.tsx
@@ -43,7 +43,7 @@ export async function normalizeTransactionName(
     prevTransactionName = window.location.pathname;
   }
 
-  const transactionName: string | undefined = await new Promise(function(resolve) {
+  const transactionName: string = await new Promise(function(resolve) {
     Router.match(
       {
         routes: appRoutes,
@@ -52,7 +52,7 @@ export async function normalizeTransactionName(
       (error, _redirectLocation, renderProps) => {
         if (error) {
           set(event, ['tags', 'transaction.rename.router-match'], 'error');
-          return resolve(undefined);
+          return resolve(window.location.pathname);
         }
 
         set(event, ['tags', 'transaction.rename.router-match'], 'success');
@@ -68,14 +68,12 @@ export async function normalizeTransactionName(
     );
   });
 
-  if (typeof transactionName === 'string' && transactionName.length) {
-    event.transaction = transactionName;
+  event.transaction = transactionName;
 
-    set(event, ['tags', 'transaction.rename.before'], prevTransactionName);
-    set(event, ['tags', 'transaction.rename.after'], transactionName);
+  set(event, ['tags', 'transaction.rename.before'], prevTransactionName);
+  set(event, ['tags', 'transaction.rename.after'], transactionName);
 
-    set(event, ['tags', 'ui.route'], transactionName);
-  }
+  set(event, ['tags', 'ui.route'], transactionName);
 
   return event;
 }

--- a/src/sentry/static/sentry/app/utils/apm.tsx
+++ b/src/sentry/static/sentry/app/utils/apm.tsx
@@ -31,7 +31,7 @@ export async function normalizeTransactionName(
 
   let prevTransactionName = event.transaction;
 
-  if (typeof prevTransactionName === 'string') {
+  if (typeof prevTransactionName === 'string' && prevTransactionName.length > 0) {
     if (prevTransactionName.startsWith('/')) {
       return event;
     }


### PR DESCRIPTION
A follow up change to https://github.com/getsentry/sentry/pull/18822

-----

Make some adjustments to the  transaction name normalization:

- If the transaction name is a blank string, then fallback to `window.location.pathname`
- If `getRouteStringFromRoutes()` function returns either a blank string or `/*`, then fallback to `window.location.pathname`
- If react-router's `match()` function returns an error (it likely shouldn't), then fallback to `window.location.pathname`