### PR TITLE
fix(search-bar): When cursor is mid query autocomplete the tag

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -615,7 +615,7 @@ class SmartSearchBar extends React.Component<Props, State> {
           ? `"${value.replace('"', '\\"')}"`
           : value;
 
-        return {value: escapedValue, desc: escapedValue};
+        return {value: escapedValue, desc: escapedValue, type: 'tag-value' as ItemType};
       });
     },
     DEFAULT_DEBOUNCE_DURATION,
@@ -973,10 +973,9 @@ class SmartSearchBar extends React.Component<Props, State> {
     let newQuery: string;
 
     // If not postfixed with : (tag value), add trailing space
-    const lastChar = replaceText.charAt(replaceText.length - 1);
-    replaceText += lastChar === ':' || lastChar === '.' ? '' : ' ';
+    replaceText += item.type !== 'tag-value' || cursor < query.length ? '' : ' ';
 
-    const isNewTerm = query.charAt(query.length - 1) === ' ';
+    const isNewTerm = query.charAt(query.length - 1) === ' ' && item.type !== 'tag-value';
 
     if (!terms) {
       newQuery = replaceText;

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -564,6 +564,30 @@ describe('SmartSearchBar', function() {
       searchBar.onAutoComplete('myTag:', {type: 'tag'});
       expect(searchBar.state.query).toEqual('event.type:error myTag:');
     });
+
+    it('completes values if cursor is not at the end', function() {
+      const props = {
+        query: 'id: event.type:error ',
+        organization,
+        supportedTags,
+      };
+      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
+      searchBar.getCursorPosition = jest.fn().mockReturnValueOnce(3);
+      searchBar.onAutoComplete('12345', {type: 'tag-value'});
+      expect(searchBar.state.query).toEqual('id:12345 event.type:error ');
+    });
+
+    it('completes values if cursor is at the end', function() {
+      const props = {
+        query: 'event.type:error id:',
+        organization,
+        supportedTags,
+      };
+      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
+      searchBar.getCursorPosition = jest.fn().mockReturnValueOnce(20);
+      searchBar.onAutoComplete('12345', {type: 'tag-value'});
+      expect(searchBar.state.query).toEqual('event.type:error id:12345 ');
+    });
   });
 
   describe('onTogglePinnedSearch()', function() {


### PR DESCRIPTION
- This allows autocomplete to add tag values correctly when the cursor
  isn't at the end of the query
- Since the lastChar might not end in ` ` in these situations this would
  assume that it was a tag key and append it to the end