### PR TITLE
fix(ui): Remove blocking behavior on `<SmartSearchBar>`

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -194,6 +194,12 @@ type Props = {
    * Called when the search is blurred
    */
   onBlur?: (value: string) => void;
+
+  /**
+   * Called on key down
+   */
+  onKeyDown?: (evt: React.KeyboardEvent<HTMLInputElement>) => void;
+
   /**
    * Called when a recent search is saved
    */
@@ -399,13 +405,10 @@ class SmartSearchBar extends React.Component<Props, State> {
    * Handle keyboard navigation
    */
   onKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
+    const {onKeyDown} = this.props;
     const {key} = evt;
 
-    // If tab or enter is pressed while the search bar is in a loading state then
-    // we should prevent any the form from submitting from this component
-    if ((key === 'Tab' || key === 'Enter') && this.state.loading) {
-      evt.preventDefault();
-    }
+    callIfFunction(onKeyDown, evt);
 
     if (!this.state.searchGroups.length) {
       return;
@@ -469,10 +472,6 @@ class SmartSearchBar extends React.Component<Props, State> {
     if ((key === 'Tab' || key === 'Enter') && isSelectingDropdownItems) {
       evt.preventDefault();
 
-      if (this.state.loading) {
-        return;
-      }
-
       const {activeSearchItem, searchGroups} = this.state;
       const [groupIndex, childrenIndex] = filterSearchGroupsByIndex(
         searchGroups,
@@ -490,11 +489,6 @@ class SmartSearchBar extends React.Component<Props, State> {
     }
 
     if (key === 'Enter') {
-      // If we are still loading dropdown, do nothing
-      if (this.state.loading) {
-        return;
-      }
-
       if (!useFormWrapper && !isSelectingDropdownItems) {
         // If enter is pressed, and we are not wrapping input in a `<form>`,
         // and we are not selecting an item from the dropdown, then we should

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -5,6 +5,7 @@ import {Client} from 'app/api';
 import {Environment, Organization} from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {addErrorMessage} from 'app/actionCreators/indicator';
+import {callIfFunction} from 'app/utils/callIfFunction';
 import {defined} from 'app/utils';
 import {getDisplayName} from 'app/utils/environment';
 import {t, tct} from 'app/locale';
@@ -118,7 +119,18 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                 useFormWrapper={false}
                 organization={organization}
                 onChange={onChange}
-                onKeyDown={onKeyDown}
+                onKeyDown={e => {
+                  /**
+                   * Do not allow enter key to submit the alerts form since it is unlikely
+                   * users will be ready to create the rule as this sits above required fields.
+                   */
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }
+
+                  callIfFunction(onKeyDown, e);
+                }}
                 onBlur={query => {
                   onFilterUpdate(query);
                   onBlur(query);

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -5,7 +5,6 @@ import {Client} from 'app/api';
 import {Environment, Organization} from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {addErrorMessage} from 'app/actionCreators/indicator';
-import {callIfFunction} from 'app/utils/callIfFunction';
 import {defined} from 'app/utils';
 import {getDisplayName} from 'app/utils/environment';
 import {t, tct} from 'app/locale';
@@ -129,7 +128,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                     e.stopPropagation();
                   }
 
-                  callIfFunction(onKeyDown, e);
+                  onKeyDown?.(e);
                 }}
                 onBlur={query => {
                   onFilterUpdate(query);

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -81,7 +81,7 @@ describe('SmartSearchBar', function() {
     MockApiClient.clearMockResponses();
   });
 
-  it('calls preventDefault when there are no search items and is loading and enter is pressed', async function() {
+  it('does not preventDefault when there are no search items and is loading and enter is pressed', async function() {
     jest.useRealTimers();
     const getTagValuesMock = jest.fn().mockImplementation(() => {
       return new Promise(() => {});
@@ -110,7 +110,7 @@ describe('SmartSearchBar', function() {
     const preventDefault = jest.fn();
     searchBar.find('input').simulate('keyDown', {key: 'Enter', preventDefault});
     expect(onSearch).not.toHaveBeenCalled();
-    expect(preventDefault).toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 
   it('calls preventDefault when there are existing search items and is loading and enter is pressed', async function() {
@@ -150,6 +150,7 @@ describe('SmartSearchBar', function() {
     const preventDefault = jest.fn();
     searchBar.find('input').simulate('keyDown', {key: 'Enter', preventDefault});
     expect(onSearch).not.toHaveBeenCalled();
+    // Prevent default since we need to select an item
     expect(preventDefault).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
This removes the behavior introduced in https://github.com/getsentry/sentry/pull/17799/files where it would block form submissions while dropdown is loading. Discover search bar can take a bit to load and it is not a good UX making the user wait until it is fully loaded before they can submit a search.

Also adds a `onKeyDown` callback to `<SmartSearchBar>`

