### PR TITLE
fix(ui): Clearing image filter search may crash the React app

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -319,6 +319,11 @@ class DebugMetaInterface extends React.PureComponent {
 
   filterImage(image) {
     const {showUnused, filter} = this.state;
+
+    if (typeof filter !== 'string') {
+      return true;
+    }
+
     if (!filter || filter.length < MIN_FILTER_LEN) {
       if (showUnused) {
         return true;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -320,10 +320,6 @@ class DebugMetaInterface extends React.PureComponent {
   filterImage(image) {
     const {showUnused, filter} = this.state;
 
-    if (typeof filter !== 'string') {
-      return true;
-    }
-
     if (!filter || filter.length < MIN_FILTER_LEN) {
       if (showUnused) {
         return true;

--- a/src/sentry/static/sentry/app/components/events/interfaces/imageForBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/imageForBar.tsx
@@ -9,20 +9,26 @@ import {t} from 'app/locale';
 
 type Props = {
   frame: Frame;
-  onShowAllImages: () => void;
+  onShowAllImages: (filter: string) => void;
 };
 
-const ImageForBar = ({frame, onShowAllImages}: Props) => (
-  <Wrapper>
-    <MatchedFunctionWrapper>
-      <MatchedFunctionCaption>{t('Image for: ')}</MatchedFunctionCaption>
-      <FrameFunctionName frame={frame} />
-    </MatchedFunctionWrapper>
-    <ResetAddressFilterCaption onClick={onShowAllImages}>
-      {t('Show all images')}
-    </ResetAddressFilterCaption>
-  </Wrapper>
-);
+const ImageForBar = ({frame, onShowAllImages}: Props) => {
+  const handleShowAllImages = () => {
+    onShowAllImages('');
+  };
+
+  return (
+    <Wrapper>
+      <MatchedFunctionWrapper>
+        <MatchedFunctionCaption>{t('Image for: ')}</MatchedFunctionCaption>
+        <FrameFunctionName frame={frame} />
+      </MatchedFunctionWrapper>
+      <ResetAddressFilterCaption onClick={handleShowAllImages}>
+        {t('Show all images')}
+      </ResetAddressFilterCaption>
+    </Wrapper>
+  );
+};
 
 ImageForBar.propTypes = {
   frame: PropTypes.object.isRequired,


### PR DESCRIPTION
Clicking on "Show All Images" after doing an image filter search will crash the app.

Step 1: Click on a stack frame to filter images:

<img width="1309" alt="Screen Shot 2020-05-22 at 4 25 37 AM" src="https://user-images.githubusercontent.com/139499/82647706-97367a00-9be4-11ea-915d-2506f74b353c.png">

which leads to an image filter search:

<img width="1322" alt="Screen Shot 2020-05-22 at 4 28 56 AM" src="https://user-images.githubusercontent.com/139499/82648008-0a3ff080-9be5-11ea-8f3d-f4efd6cf8bb8.png">

Step 2: Click on "Show All Images":

<img width="1322" alt="Screen Shot 2020-05-22 at 4 28 56 AM copy" src="https://user-images.githubusercontent.com/139499/82648093-2f346380-9be5-11ea-80f0-8d8e5fa73167.png">

which leads to an unrecoverable app crash:

![Screen Shot 2020-05-22 at 4 32 44 AM](https://user-images.githubusercontent.com/139499/82648231-60149880-9be5-11ea-9d4d-d42315cb5af5.png)



-------

https://sentry.io/organizations/sentry/issues/1637114320/

Fixes JAVASCRIPT-224R