### PR TITLE
feat(perf-view) Add filtering to transaction summary

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -458,6 +458,9 @@ class EventView {
     return newQuery;
   }
 
+  // TODO(mark) Refactor this to return the GlobalSelection type instead.
+  // We'll likely also need a function somewhere to convert GlobalSelection
+  // into query parameters, as that is how this method is currently used.
   getGlobalSelection(): {
     start: string | undefined;
     end: string | undefined;

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -12,6 +12,7 @@ import {Client} from 'app/api';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {fetchTotalCount} from 'app/actionCreators/events';
 import {loadOrganizationTags} from 'app/actionCreators/tags';
+import Alert from 'app/components/alert';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
@@ -23,7 +24,7 @@ import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import {ContentBox, Main, Side} from 'app/utils/discover/styles';
-import Alert from 'app/components/alert';
+import {generateQueryWithTag} from 'app/utils';
 
 import {DEFAULT_EVENT_VIEW} from './data';
 import Table from './table';
@@ -182,23 +183,34 @@ class Results extends React.Component<Props, State> {
     return generateTitle({eventView});
   }
 
-  renderTagsTable = () => {
+  renderTagsTable() {
     const {organization, location} = this.props;
     const {eventView, totalValues} = this.state;
 
-    // Move events-meta call out of Tags into this component
-    // so that we can push it into the chart footer.
     return (
       <Tags
+        generateUrl={this.generateTagUrl}
         totalValues={totalValues}
         eventView={eventView}
         organization={organization}
         location={location}
       />
     );
+  }
+
+  generateTagUrl = (key: string, value: string) => {
+    const {organization} = this.props;
+    const {eventView} = this.state;
+
+    const url = eventView.getResultsViewUrlTarget(organization.slug);
+    url.query = generateQueryWithTag(url.query, {
+      key,
+      value,
+    });
+    return url;
   };
 
-  renderError = error => {
+  renderError(error: string) {
     if (!error) {
       return null;
     }
@@ -207,9 +219,9 @@ class Results extends React.Component<Props, State> {
         {error}
       </Alert>
     );
-  };
+  }
 
-  setError = error => {
+  setError = (error: string) => {
     this.setState({error});
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -20,7 +20,7 @@ type TableProps = {
   eventView: EventView;
   organization: Organization;
   tags: {[key: string]: Tag};
-  setError: (msg: string | undefined) => void;
+  setError: (msg: string) => void;
   title: string;
 };
 
@@ -81,7 +81,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
     const url = `/organizations/${organization.slug}/eventsv2/`;
     const tableFetchID = Symbol('tableFetchID');
     const apiPayload = eventView.getEventsAPIPayload(location);
-    setError(undefined);
+    setError('');
 
     this.setState({isLoading: true, tableFetchID});
     metric.mark({name: `discover-events-start-${apiPayload.query}`});

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import {Location} from 'history';
+import {Location, LocationDescriptor} from 'history';
 import * as Sentry from '@sentry/browser';
 
 import {t} from 'app/locale';
@@ -17,7 +17,6 @@ import Placeholder from 'app/components/placeholder';
 import TagDistributionMeter from 'app/components/tagDistributionMeter';
 import withApi from 'app/utils/withApi';
 import {Organization} from 'app/types';
-import {generateQueryWithTag} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 
@@ -27,6 +26,7 @@ type Props = {
   eventView: EventView;
   location: Location;
   totalValues: null | number;
+  generateUrl: (key: string, value: string) => LocationDescriptor;
 };
 
 type State = {
@@ -85,7 +85,7 @@ class Tags extends React.Component<Props, State> {
     }
   };
 
-  onTagClick = (tag: string) => {
+  handleTagClick = (tag: string) => {
     const {organization} = this.props;
     // metrics
     trackAnalyticsEvent({
@@ -97,15 +97,10 @@ class Tags extends React.Component<Props, State> {
   };
 
   renderTag(tag: Tag) {
-    const {organization, eventView, totalValues} = this.props;
+    const {generateUrl, totalValues} = this.props;
 
     const segments: TagSegment[] = tag.topValues.map(segment => {
-      const url = eventView.getResultsViewUrlTarget(organization.slug);
-      url.query = generateQueryWithTag(url.query, {
-        key: tag.key,
-        value: segment.value,
-      });
-      segment.url = url;
+      segment.url = generateUrl(tag.key, segment.value);
 
       return segment;
     });
@@ -122,7 +117,7 @@ class Tags extends React.Component<Props, State> {
         segments={segments}
         totalValues={Number(maxTotalValues)}
         renderLoading={() => <StyledPlaceholder height="16px" />}
-        onTagClick={this.onTagClick}
+        onTagClick={this.handleTagClick}
         showReleasePackage
       />
     );

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -8,17 +8,19 @@ import * as Sentry from '@sentry/browser';
 import {Client} from 'app/api';
 import {t} from 'app/locale';
 import {fetchTotalCount} from 'app/actionCreators/events';
-import {Organization, Project} from 'app/types';
-import withOrganization from 'app/utils/withOrganization';
-import withProjects from 'app/utils/withProjects';
+import {loadOrganizationTags} from 'app/actionCreators/tags';
+import {Organization, Project, GlobalSelection} from 'app/types';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import {PageContent} from 'app/styles/organization';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import withApi from 'app/utils/withApi';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
+import withOrganization from 'app/utils/withOrganization';
+import withProjects from 'app/utils/withProjects';
 
 import SummaryContent from './content';
 
@@ -28,6 +30,7 @@ type Props = {
   params: Params;
   organization: Organization;
   projects: Project[];
+  selection: GlobalSelection;
   loadingProjects: boolean;
 };
 
@@ -56,7 +59,9 @@ class TransactionSummary extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    const {api, organization, selection} = this.props;
     this.fetchTotalCount();
+    loadOrganizationTags(api, organization.slug, selection);
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
@@ -158,11 +163,14 @@ function generateSummaryEventView(
   if (transactionName === undefined) {
     return undefined;
   }
-  const conditions = {
-    query: [],
+  // Use the user supplied query but overwrite any transaction or event type
+  // conditions they applied.
+  const query = decodeScalar(location.query.query) || '';
+  const conditions = Object.assign(tokenizeSearch(query), {
     'event.type': ['transaction'],
     transaction: [transactionName],
-  };
+  });
+
   // Handle duration filters from the latency chart
   if (location.query.startDuration || location.query.endDuration) {
     conditions['transaction.duration'] = [
@@ -187,4 +195,6 @@ function generateSummaryEventView(
   );
 }
 
-export default withApi(withProjects(withOrganization(TransactionSummary)));
+export default withApi(
+  withGlobalSelection(withProjects(withOrganization(TransactionSummary)))
+);

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -81,7 +81,7 @@ class RelatedIssues extends React.Component<Props> {
       <React.Fragment>
         <ControlsWrapper>
           <SectionHeading>{t('Related Issues')}</SectionHeading>
-          <Button size="small" to={issueSearch}>
+          <Button data-test-id="issues-open" size="small" to={issueSearch}>
             {t('Open in Issues')}
           </Button>
         </ControlsWrapper>

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/table.tsx
@@ -169,6 +169,7 @@ class SummaryContentTable extends React.Component<Props> {
               onClick={this.handleDiscoverViewClick}
               to={eventView.getResultsViewUrlTarget(organization.slug)}
               size="small"
+              data-test-id="discover-open"
             >
               {t('Open in Discover')}
             </Button>

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
-
 import ProjectsStore from 'app/stores/projectsStore';
 import Results from 'app/views/eventsV2/results';
 

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectsStore from 'app/stores/projectsStore';
 import Results from 'app/views/eventsV2/results';
 

--- a/tests/js/spec/views/eventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/eventsV2/tags.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import {Client} from 'app/api';
 import {Tags} from 'app/views/eventsV2/tags';
 import EventView from 'app/utils/discover/eventView';

--- a/tests/js/spec/views/eventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/eventsV2/tags.spec.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 
 import {mount} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
-
 import {Client} from 'app/api';
 import {Tags} from 'app/views/eventsV2/tags';
 import EventView from 'app/utils/discover/eventView';
 
 describe('Tags', function() {
+  function generateUrl(key, value) {
+    return `/endpoint/${key}/${value}`;
+  }
+
   const org = TestStubs.Organization();
   beforeEach(function() {
     Client.addMockResponse({
@@ -20,6 +23,10 @@ describe('Tags', function() {
         {
           key: 'environment',
           topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
+        },
+        {
+          key: 'color',
+          topValues: [{count: 2, value: 'red', name: 'red'}],
         },
       ],
     });
@@ -46,6 +53,7 @@ describe('Tags', function() {
         organization={org}
         selection={{projects: [], environments: [], datetime: {}}}
         location={{query: {}}}
+        generateUrl={generateUrl}
       />
     );
 
@@ -59,7 +67,7 @@ describe('Tags', function() {
     expect(wrapper.find('StyledPlaceholder')).toHaveLength(0);
   });
 
-  it('environment tag is a dedicated query string', async function() {
+  it('creates URLs with generateUrl', async function() {
     const api = new Client();
 
     const view = new EventView({
@@ -83,6 +91,7 @@ describe('Tags', function() {
         totalValues={2}
         selection={{projects: [], environments: [], datetime: {}}}
         location={initialData.router.location}
+        generateUrl={generateUrl}
       />,
       initialData.routerContext
     );
@@ -108,9 +117,6 @@ describe('Tags', function() {
     await tick();
     wrapper.update();
 
-    expect(initialData.router.push).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/discover/results/',
-      query: expect.objectContaining({environment: 'abcd123'}),
-    });
+    expect(initialData.router.push).toHaveBeenCalledWith('/endpoint/environment/abcd123');
   });
 });

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -1,0 +1,210 @@
+import {browserHistory} from 'react-router';
+import React from 'react';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountWithTheme} from 'sentry-test/enzyme';
+import ProjectsStore from 'app/stores/projectsStore';
+import TransactionSummary from 'app/views/performance/transactionSummary';
+
+function initializeData() {
+  const features = ['transaction-event', 'performance-view'];
+  const organization = TestStubs.Organization({
+    features,
+    projects: [TestStubs.Project()],
+  });
+  const initialData = initializeOrg({
+    organization,
+    router: {
+      location: {
+        query: {
+          transaction: '/performance',
+          project: 1,
+        },
+      },
+    },
+  });
+  ProjectsStore.loadInitialData(initialData.organization.projects);
+  return initialData;
+}
+
+describe('Performance > TransactionSummary', function() {
+  beforeEach(function() {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/user.email/values/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {data: [[123, []]]},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url:
+        '/organizations/org-slug/issues/?limit=5&project=1&query=is%3Aunresolved%20transaction%3A%2Fperformance&sort=new&statsPeriod=14d',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      method: 'POST',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/is-key-transactions/',
+      body: [],
+    });
+
+    // This mock is used for both the sidebar and table.
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {
+        meta: {
+          id: 'string',
+          user: 'string',
+          'transaction.duration': 'duration',
+          'project.id': 'integer',
+          timestamp: 'date',
+          apdex: 'number',
+          user_misery_300: 'number',
+        },
+        data: [
+          {
+            id: 'deadbeef',
+            user: 'uhoh@example.com',
+            'transaction.duration': 400,
+            'project.id': 1,
+            timestamp: '2020-05-21T15:31:18+00:00',
+            apdex: 0.6,
+            user_misery_300: 122,
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-meta/',
+      body: {
+        count: 2,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-facets/',
+      body: [
+        {
+          key: 'release',
+          topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
+        },
+        {
+          key: 'environment',
+          topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
+        },
+      ],
+    });
+  });
+
+  afterEach(function() {
+    MockApiClient.clearMockResponses();
+    ProjectsStore.reset();
+  });
+
+  it('renders basic UI elements', async function() {
+    const initialData = initializeData();
+    const wrapper = mountWithTheme(
+      <TransactionSummary
+        organization={initialData.organization}
+        location={initialData.router.location}
+      />,
+      initialData.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    // It shows a chart
+    expect(wrapper.find('TransactionSummaryCharts')).toHaveLength(1);
+
+    // It shows a searchbar
+    expect(wrapper.find('SearchBar')).toHaveLength(1);
+
+    // It shows a table
+    expect(wrapper.find('PanelTable')).toHaveLength(1);
+
+    // Ensure open in discover button exists.
+    expect(wrapper.find('a[data-test-id="discover-open"]')).toHaveLength(1);
+    // Ensure navigation is correct.
+
+    // Ensure open issues button exists.
+    expect(wrapper.find('a[data-test-id="issues-open"]')).toHaveLength(1);
+  });
+
+  it('triggers a navigation on search', async function() {
+    const initialData = initializeData();
+    const wrapper = mountWithTheme(
+      <TransactionSummary
+        organization={initialData.organization}
+        location={initialData.router.location}
+      />,
+      initialData.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    // Fill out the search box, and submit it.
+    const searchBar = wrapper.find('SearchBar input');
+    searchBar
+      .simulate('change', {target: {value: 'user.email:uhoh*'}})
+      .simulate('submit', {preventDefault() {}});
+    // Check the navigation.
+    expect(browserHistory.push).toHaveBeenCalledTimes(1);
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: undefined,
+      query: {
+        transaction: '/performance',
+        project: 1,
+        statsPeriod: '14d',
+        query: 'user.email:uhoh*',
+      },
+    });
+  });
+
+  it('can mark a transaction as key', async function() {
+    const initialData = initializeData();
+    const wrapper = mountWithTheme(
+      <TransactionSummary
+        organization={initialData.organization}
+        location={initialData.router.location}
+      />,
+      initialData.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    const mockUpdate = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/key-transactions/`,
+      method: 'POST',
+      body: {},
+    });
+
+    // Click the key transaction button
+    wrapper.find('KeyTransactionButton').simulate('click');
+
+    // Ensure request was made.
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+});

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
+
 import ProjectsStore from 'app/stores/projectsStore';
 import TransactionSummary from 'app/views/performance/transactionSummary';
 


### PR DESCRIPTION
Add the ability to filter transaction summary results with a discover query string. This lets users reduce the results shown on transaction summary to specific regions, users or tags.

I've added a few high level jest tests as this page is becoming more complex.

![Screen Shot 2020-05-21 at 8 53 41 PM](https://user-images.githubusercontent.com/24086/82675467-d7145600-9c12-11ea-991a-2ecedf813322.png)
