### PR TITLE
fix(asyc-csv): Pass batch size to snuba query

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -85,7 +85,7 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     "dataexport.enqueue", tags={"query_type": data["query_type"]}, sample_rate=1.0
                 )
                 assemble_download.delay(
-                    data_export_id=data_export.id, limit=limit, environment_id=environment_id
+                    data_export_id=data_export.id, export_limit=limit, environment_id=environment_id
                 )
                 status = 201
         except ValidationError as e:

--- a/src/sentry/data_export/processors/issues_by_tag.py
+++ b/src/sentry/data_export/processors/issues_by_tag.py
@@ -94,7 +94,7 @@ class IssuesByTagProcessor(object):
             result["ip_address"] = euser.ip_address if euser else ""
         return result
 
-    def get_raw_data(self, offset=0):
+    def get_raw_data(self, limit=1000, offset=0):
         """
         Returns list of GroupTagValues
         """
@@ -104,12 +104,13 @@ class IssuesByTagProcessor(object):
             environment_ids=[self.environment_id],
             key=self.lookup_key,
             callbacks=self.callbacks,
+            limit=limit,
             offset=offset,
         )
 
-    def get_serialized_data(self, offset=0):
+    def get_serialized_data(self, limit=1000, offset=0):
         """
         Returns list of serialized GroupTagValue dictionaries
         """
-        raw_data = self.get_raw_data(offset)
+        raw_data = self.get_raw_data(limit=limit, offset=offset)
         return [self.serialize_row(item, self.key) for item in raw_data]

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 
 
 @instrumented_task(name="sentry.data_export.tasks.assemble_download", queue="data_export")
-def assemble_download(data_export_id, limit=1000000, environment_id=None):
+def assemble_download(
+    data_export_id, limit=1000000, batch_size=SNUBA_MAX_RESULTS, environment_id=None
+):
     # Get the ExportedData object
     try:
         logger.info("dataexport.start", extra={"data_export_id": data_export_id})
@@ -39,7 +41,11 @@ def assemble_download(data_export_id, limit=1000000, environment_id=None):
             # Process the query based on its type
             if data_export.query_type == ExportQueryType.ISSUES_BY_TAG:
                 process_issues_by_tag(
-                    data_export=data_export, file=tf, limit=limit, environment_id=environment_id
+                    data_export=data_export,
+                    file=tf,
+                    limit=limit,
+                    batch_size=batch_size,
+                    environment_id=environment_id,
                 )
             elif data_export.query_type == ExportQueryType.DISCOVER:
                 process_discover(
@@ -80,7 +86,7 @@ def assemble_download(data_export_id, limit=1000000, environment_id=None):
         return data_export.email_failure(message="Internal processing failure")
 
 
-def process_issues_by_tag(data_export, file, limit, environment_id):
+def process_issues_by_tag(data_export, file, limit, batch_size, environment_id):
     """
     Convert the tag query to a CSV, writing it to the provided file.
     """
@@ -103,16 +109,16 @@ def process_issues_by_tag(data_export, file, limit, environment_id):
     with snuba_error_handler(logger=logger):
         is_completed = False
         while not is_completed:
-            offset = SNUBA_MAX_RESULTS * iteration
-            next_offset = SNUBA_MAX_RESULTS * (iteration + 1)
+            offset = batch_size * iteration
+            next_offset = batch_size * (iteration + 1)
             is_exceeding_limit = limit and limit < next_offset
-            gtv_list_unicode = processor.get_serialized_data(offset=offset)
+            gtv_list_unicode = processor.get_serialized_data(limit=batch_size, offset=offset)
             # TODO(python3): Remove next line once the 'csv' module has been updated to Python 3
             # See associated comment in './utils.py'
             gtv_list = convert_to_utf8(gtv_list_unicode)
             if is_exceeding_limit:
                 # Since the next offset will pass the limit, just write the remainder
-                writer.writerows(gtv_list[: limit % SNUBA_MAX_RESULTS])
+                writer.writerows(gtv_list[: limit % batch_size])
             else:
                 writer.writerows(gtv_list)
                 iteration += 1
@@ -120,7 +126,7 @@ def process_issues_by_tag(data_export, file, limit, environment_id):
             is_completed = len(gtv_list) == 0 or is_exceeding_limit
 
 
-def process_discover(data_export, file, limit, environment_id):
+def process_discover(data_export, file, limit, batch_size, environment_id):
     """
     Convert the discovery query to a CSV, writing it to the provided file.
     """
@@ -139,17 +145,17 @@ def process_discover(data_export, file, limit, environment_id):
     with snuba_error_handler(logger=logger):
         is_completed = False
         while not is_completed:
-            offset = SNUBA_MAX_RESULTS * iteration
-            next_offset = SNUBA_MAX_RESULTS * (iteration + 1)
+            offset = batch_size * iteration
+            next_offset = batch_size * (iteration + 1)
             is_exceeding_limit = limit and limit < next_offset
-            raw_data_unicode = processor.data_fn(offset=offset, limit=SNUBA_MAX_RESULTS)["data"]
+            raw_data_unicode = processor.data_fn(offset=offset, limit=batch_size)["data"]
             # TODO(python3): Remove next line once the 'csv' module has been updated to Python 3
             # See associated comment in './utils.py'
             raw_data = convert_to_utf8(raw_data_unicode)
             raw_data = processor.handle_fields(raw_data)
             if is_exceeding_limit:
                 # Since the next offset will pass the limit, just write the remainder
-                writer.writerows(raw_data[: limit % SNUBA_MAX_RESULTS])
+                writer.writerows(raw_data[: limit % batch_size])
             else:
                 writer.writerows(raw_data)
                 iteration += 1

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 @instrumented_task(name="sentry.data_export.tasks.assemble_download", queue="data_export")
 def assemble_download(
-    data_export_id, limit=1000000, batch_size=SNUBA_MAX_RESULTS, environment_id=None
+    data_export_id, export_limit=1000000, batch_size=SNUBA_MAX_RESULTS, environment_id=None
 ):
     # Get the ExportedData object
     try:
@@ -43,7 +43,7 @@ def assemble_download(
                 process_issues_by_tag(
                     data_export=data_export,
                     file=tf,
-                    limit=limit,
+                    export_limit=export_limit,
                     batch_size=batch_size,
                     environment_id=environment_id,
                 )
@@ -51,7 +51,7 @@ def assemble_download(
                 process_discover(
                     data_export=data_export,
                     file=tf,
-                    limit=limit,
+                    export_limit=export_limit,
                     batch_size=batch_size,
                     environment_id=environment_id,
                 )
@@ -90,7 +90,7 @@ def assemble_download(
         return data_export.email_failure(message="Internal processing failure")
 
 
-def process_issues_by_tag(data_export, file, limit, batch_size, environment_id):
+def process_issues_by_tag(data_export, file, export_limit, batch_size, environment_id):
     """
     Convert the tag query to a CSV, writing it to the provided file.
     """
@@ -115,22 +115,22 @@ def process_issues_by_tag(data_export, file, limit, batch_size, environment_id):
         while not is_completed:
             offset = batch_size * iteration
             next_offset = batch_size * (iteration + 1)
-            is_exceeding_limit = limit and limit < next_offset
+            is_exceeding_limit = export_limit and export_limit < next_offset
             gtv_list_unicode = processor.get_serialized_data(limit=batch_size, offset=offset)
             # TODO(python3): Remove next line once the 'csv' module has been updated to Python 3
             # See associated comment in './utils.py'
             gtv_list = convert_to_utf8(gtv_list_unicode)
             if is_exceeding_limit:
-                # Since the next offset will pass the limit, just write the remainder
-                writer.writerows(gtv_list[: limit % batch_size])
+                # Since the next offset will pass the export_limit, just write the remainder
+                writer.writerows(gtv_list[: export_limit % batch_size])
             else:
                 writer.writerows(gtv_list)
                 iteration += 1
-            # If there are no returned results, or we've passed the limit, stop iterating
+            # If there are no returned results, or we've passed the export_limit, stop iterating
             is_completed = len(gtv_list) == 0 or is_exceeding_limit
 
 
-def process_discover(data_export, file, limit, batch_size, environment_id):
+def process_discover(data_export, file, export_limit, batch_size, environment_id):
     """
     Convert the discovery query to a CSV, writing it to the provided file.
     """
@@ -151,19 +151,19 @@ def process_discover(data_export, file, limit, batch_size, environment_id):
         while not is_completed:
             offset = batch_size * iteration
             next_offset = batch_size * (iteration + 1)
-            is_exceeding_limit = limit and limit < next_offset
+            is_exceeding_limit = export_limit and export_limit < next_offset
             raw_data_unicode = processor.data_fn(offset=offset, limit=batch_size)["data"]
             # TODO(python3): Remove next line once the 'csv' module has been updated to Python 3
             # See associated comment in './utils.py'
             raw_data = convert_to_utf8(raw_data_unicode)
             raw_data = processor.handle_fields(raw_data)
             if is_exceeding_limit:
-                # Since the next offset will pass the limit, just write the remainder
-                writer.writerows(raw_data[: limit % batch_size])
+                # Since the next offset will pass the export_limit, just write the remainder
+                writer.writerows(raw_data[: export_limit % batch_size])
             else:
                 writer.writerows(raw_data)
                 iteration += 1
-            # If there are no returned results, or we've passed the limit, stop iterating
+            # If there are no returned results, or we've passed the export_limit, stop iterating
             is_completed = len(raw_data) == 0 or is_exceeding_limit
 
 

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -49,7 +49,11 @@ def assemble_download(
                 )
             elif data_export.query_type == ExportQueryType.DISCOVER:
                 process_discover(
-                    data_export=data_export, file=tf, limit=limit, environment_id=environment_id
+                    data_export=data_export,
+                    file=tf,
+                    limit=limit,
+                    batch_size=batch_size,
+                    environment_id=environment_id,
                 )
             # Create a new File object and attach it to the ExportedData
             tf.seek(0)

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -23,7 +23,11 @@ logger = logging.getLogger(__name__)
 
 @instrumented_task(name="sentry.data_export.tasks.assemble_download", queue="data_export")
 def assemble_download(
-    data_export_id, export_limit=1000000, batch_size=SNUBA_MAX_RESULTS, environment_id=None
+    data_export_id,
+    export_limit=1000000,
+    batch_size=SNUBA_MAX_RESULTS,
+    environment_id=None,
+    **kwargs
 ):
     # Get the ExportedData object
     try:

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from sentry.data_export.base import ExportQueryType
 from sentry.data_export.models import ExportedData
 from sentry.data_export.tasks import assemble_download
 from sentry.models import File
@@ -30,11 +31,11 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
         de = ExportedData.objects.create(
             user=self.user,
             organization=self.org,
-            query_type=0,
+            query_type=ExportQueryType.ISSUES_BY_TAG,
             query_info={"project": [self.project.id], "group": self.event.group_id, "key": "foo"},
         )
         with self.tasks():
-            assemble_download(de.id)
+            assemble_download(de.id, batch_size=1)
         de = ExportedData.objects.get(id=de.id)
         assert de.date_finished is not None
         assert de.date_expired is not None
@@ -54,7 +55,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
         de1 = ExportedData.objects.create(
             user=self.user,
             organization=self.org,
-            query_type=0,
+            query_type=ExportQueryType.ISSUES_BY_TAG,
             query_info={"project": [-1], "group": self.event.group_id, "key": "user"},
         )
         with self.tasks():


### PR DESCRIPTION
Pass the correct batch size to the snuba query to ensure the number of results returned is as expected. The current query does not have an explicit limit on the result size so it is using the default 1000 while the logic makes use of SNUBA_MAX_RESULTS which is set to 10000. This inconsistency led to the export to include results from index 0-999, then 10000-10999 and so on.