### PR TITLE
fix(integrations): changes permission for adding repos and fixes tooltips

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -96,15 +96,6 @@ class OrganizationIntegrationsPermission(OrganizationPermission):
     }
 
 
-class OrganizationRepositoryPermission(OrganizationPermission):
-    scope_map = {
-        "GET": ["org:read", "org:write", "org:admin", "org:integrations"],
-        "POST": ["org:write", "org:admin", "org:integrations"],
-        "PUT": ["org:write", "org:admin"],
-        "DELETE": ["org:admin"],
-    }
-
-
 class OrganizationAdminPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:admin"],

--- a/src/sentry/api/endpoints/organization_repositories.py
+++ b/src/sentry/api/endpoints/organization_repositories.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry.api.base import DocSection
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationRepositoryPermission
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
@@ -14,7 +14,7 @@ from sentry.utils.sdk import capture_exception
 
 class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
     doc_section = DocSection.ORGANIZATIONS
-    permission_classes = (OrganizationRepositoryPermission,)
+    permission_classes = (OrganizationIntegrationsPermission,)
 
     def get(self, request, organization):
         """

--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from django.db import transaction
 
 from sentry.api.base import DocSection
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationRepositoryPermission
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers import serialize
@@ -36,7 +36,7 @@ class RepositorySerializer(serializers.Serializer):
 
 class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
     doc_section = DocSection.ORGANIZATIONS
-    permission_classes = (OrganizationRepositoryPermission,)
+    permission_classes = (OrganizationIntegrationsPermission,)
 
     def put(self, request, organization, repo_id):
         if not request.user.is_authenticated():

--- a/src/sentry/static/sentry/app/components/repositoryRow.tsx
+++ b/src/sentry/static/sentry/app/components/repositoryRow.tsx
@@ -11,6 +11,7 @@ import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import {IconDelete} from 'app/icons';
 import space from 'app/styles/space';
+import Tooltip from 'app/components/tooltip';
 
 type DefaultProps = {
   showProvider?: boolean;
@@ -76,7 +77,7 @@ class RepositoryRow extends React.Component<Props> {
     const isActive = this.isActive;
 
     return (
-      <Access access={['org:admin']}>
+      <Access access={['org:integrations']}>
         {({hasAccess}) => (
           <StyledPanelItem status={repository.status}>
             <RepositoryTitleAndUrl>
@@ -105,23 +106,30 @@ class RepositoryRow extends React.Component<Props> {
               </div>
             </RepositoryTitleAndUrl>
 
-            <Confirm
-              disabled={
-                !hasAccess ||
-                (!isActive && repository.status !== RepositoryStatus.DISABLED)
-              }
-              onConfirm={this.deleteRepo}
-              message={t(
-                'Are you sure you want to remove this repository? All associated commit data will be removed in addition to the repository.'
+            <Tooltip
+              title={t(
+                'You must be an organization owner, manager or admin to remove a repository.'
               )}
+              disabled={hasAccess}
             >
-              <Button
-                size="xsmall"
-                icon={<IconDelete size="xs" />}
-                label={t('delete')}
-                disabled={!hasAccess}
-              />
-            </Confirm>
+              <Confirm
+                disabled={
+                  !hasAccess ||
+                  (!isActive && repository.status !== RepositoryStatus.DISABLED)
+                }
+                onConfirm={this.deleteRepo}
+                message={t(
+                  'Are you sure you want to remove this repository? All associated commit data will be removed in addition to the repository.'
+                )}
+              >
+                <Button
+                  size="xsmall"
+                  icon={<IconDelete size="xs" />}
+                  label={t('delete')}
+                  disabled={!hasAccess}
+                />
+              </Confirm>
+            </Tooltip>
           </StyledPanelItem>
         )}
       </Access>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.tsx
@@ -139,7 +139,9 @@ export default class IntegrationRepos extends AsyncComponent<Props, State> {
       return (
         <DropdownButton
           disabled
-          title={t('You do not have permission to add repositories')}
+          title={t(
+            'You must be an organization owner, manager or admin to add repositories'
+          )}
           isOpen={false}
           size="xsmall"
         >

--- a/tests/js/spec/components/repositoryRow.spec.jsx
+++ b/tests/js/spec/components/repositoryRow.spec.jsx
@@ -17,7 +17,7 @@ describe('RepositoryRow', function() {
 
   describe('rendering with access', function() {
     const organization = TestStubs.Organization({
-      access: ['org:admin'],
+      access: ['org:integrations'],
     });
     const routerContext = TestStubs.routerContext([{organization}]);
 
@@ -85,7 +85,7 @@ describe('RepositoryRow', function() {
 
   describe('deletion', function() {
     const organization = TestStubs.Organization({
-      access: ['org:admin'],
+      access: ['org:integrations'],
     });
     const routerContext = TestStubs.routerContext([{organization}]);
 
@@ -114,7 +114,7 @@ describe('RepositoryRow', function() {
 
   describe('cancel deletion', function() {
     const organization = TestStubs.Organization({
-      access: ['org:admin'],
+      access: ['org:integrations'],
     });
     const routerContext = TestStubs.routerContext([{organization}]);
 


### PR DESCRIPTION
This PR changes the permission requirements for adding/removing repositories to match other integrations with the `org:integrations` scope. I also updated some of the tooltips in the UI to match what we have in other places:
![Screen Shot 2020-05-22 at 10 48 16 AM](https://user-images.githubusercontent.com/8533851/82695737-899be700-9c1a-11ea-88d3-47005d843e04.png)
![Screen Shot 2020-05-22 at 10 48 26 AM](https://user-images.githubusercontent.com/8533851/82695739-8a347d80-9c1a-11ea-9ad7-8b19177c9c93.png)
