### PR TITLE
feat(workflow): Rendering errors and changing error message for name in use

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -476,7 +476,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 self._handle_triggers(alert_rule, triggers)
                 return alert_rule
         except AlertRuleNameAlreadyUsedError:
-            raise serializers.ValidationError("This name is already in use for this project")
+            raise serializers.ValidationError("This name is already in use for this organization")
 
     def update(self, instance, validated_data):
         triggers = validated_data.pop("triggers")
@@ -488,7 +488,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 self._handle_triggers(alert_rule, triggers)
                 return alert_rule
         except AlertRuleNameAlreadyUsedError:
-            raise serializers.ValidationError("This name is already in use for this project")
+            raise serializers.ValidationError("This name is already in use for this organization")
 
     def _handle_triggers(self, alert_rule, triggers):
         if triggers is not None:

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -325,14 +325,12 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         onSubmitSuccess(resp, model);
       }
     } catch (err) {
-      addErrorMessage(
-        t(
-          'Unable to save alert%s',
-          err?.responseJSON?.nonFieldErrors
-            ? `: ${err.responseJSON.nonFieldErrors.join(', ')}`
-            : ''
-        )
-      );
+      const apiErrors = Array.isArray(err?.responseJSON)
+        ? `: ${err.responseJSON.join(', ')}`
+        : err?.responseJSON?.nonFieldErrors
+        ? `: ${err.responseJSON.nonFieldErrors.join(', ')}`
+        : '';
+      addErrorMessage(t('Unable to save alert%s', apiErrors));
     }
   };
 


### PR DESCRIPTION
Error responses seem to come from the backend in two forms:
```
{"nonFieldErrors":["\"critical\" trigger must have an action."]}
```
which we've been rendering with no problems, and:
```
["Could not find channel @cfuller2. Channel may not exist, or Sentry may not have been granted permission to access it"]
```
which we have not been rendering. This PR makes a change to check if the top-level response is an array and renders that error.

This PR also changes the error response on a duplicate name to be per organization and not per project, since that is the check we're actually performing.