### PR TITLE
fix(ui): Move `/auth/login/` outside of `views/app` route

### DIFF
--- a/src/sentry/static/sentry/app/main.tsx
+++ b/src/sentry/static/sentry/app/main.tsx
@@ -1,9 +1,12 @@
 import {CacheProvider} from '@emotion/core'; // This is needed to set "speedy" = false (for percy)
+import {ThemeProvider} from 'emotion-theming';
 import {cache} from 'emotion'; // eslint-disable-line emotion/no-vanilla
 import React from 'react';
 import {Router, browserHistory} from 'react-router';
 
+import GlobalStyles from 'app/styles/global';
 import routes from 'app/routes';
+import theme from 'app/utils/theme';
 import {loadPreferencesState} from 'app/actionCreators/preferences';
 
 class Main extends React.Component {
@@ -14,7 +17,10 @@ class Main extends React.Component {
   render() {
     return (
       <CacheProvider value={cache}>
-        <Router history={browserHistory}>{routes()}</Router>
+        <ThemeProvider theme={theme}>
+          <GlobalStyles theme={theme} />
+          <Router history={browserHistory}>{routes()}</Router>
+        </ThemeProvider>
       </CacheProvider>
     );
   }

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -929,54 +929,7 @@ function routes() {
   );
 
   return (
-    <Route path="/" component={errorHandler(App)}>
-      <Route
-        path="/accept/:memberId/:token/"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "AcceptOrganizationInvite" */ 'app/views/acceptOrganizationInvite'
-          )
-        }
-        component={errorHandler(LazyLoad)}
-      />
-      <Route
-        path="/accept-transfer/"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "AcceptProjectTransfer" */ 'app/views/acceptProjectTransfer'
-          )
-        }
-        component={errorHandler(LazyLoad)}
-      />
-      <Route
-        path="/extensions/external-install/:providerId/:installationId"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ExtensionsIntegrationInstallation" */ 'app/views/integrationInstallation'
-          )
-        }
-        component={errorHandler(LazyLoad)}
-      />
-
-      <Route
-        path="/extensions/vsts/link/"
-        getComponent={(_loc, cb) =>
-          import(
-            /* webpackChunkName: "VSTSOrganizationLink" */ 'app/views/vstsOrganizationLink'
-          ).then(lazyLoad(cb))
-        }
-      />
-
-      <Route
-        path="/sentry-apps/:sentryAppSlug/external-install/"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "SentryAppExternalInstallation" */ 'app/views/sentryAppExternalInstallation'
-          )
-        }
-        component={errorHandler(LazyLoad)}
-      />
-
+    <Route>
       {EXPERIMENTAL_SPA && (
         <Route path="/auth/login/" component={errorHandler(AuthLayout)}>
           <IndexRoute
@@ -988,385 +941,415 @@ function routes() {
         </Route>
       )}
 
-      <Redirect from="/account/" to="/settings/account/details/" />
-
-      <Redirect from="/share/group/:shareId/" to="/share/issue/:shareId/" />
-      <Route
-        path="/share/issue/:shareId/"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "SharedGroupDetails" */ 'app/views/sharedGroupDetails/sharedGroupDetails'
-          )
-        }
-        component={errorHandler(LazyLoad)}
-      />
-
-      <Route
-        path="/organizations/new/"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationCreate" */ 'app/views/organizationCreate'
-          )
-        }
-        component={errorHandler(LazyLoad)}
-      />
-
-      <Route
-        path="/organizations/:orgId/data-export/:dataExportId"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "DataDownloadView" */ 'app/views/dataExport/dataDownload'
-          )
-        }
-        component={errorHandler(LazyLoad)}
-      />
-
-      <Route
-        path="/join-request/:orgId/"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationJoinRequest" */ 'app/views/organizationJoinRequest'
-          )
-        }
-        component={errorHandler(LazyLoad)}
-      />
-
-      <Route path="/onboarding/:orgId/" component={errorHandler(OrganizationContext)}>
-        <IndexRedirect to="welcome/" />
+      <Route path="/" component={errorHandler(App)}>
         <Route
-          path=":step/"
+          path="/accept/:memberId/:token/"
           componentPromise={() =>
-            import(/* webpackChunkName: "Onboarding" */ 'app/views/onboarding/onboarding')
+            import(
+              /* webpackChunkName: "AcceptOrganizationInvite" */ 'app/views/acceptOrganizationInvite'
+            )
           }
           component={errorHandler(LazyLoad)}
         />
-      </Route>
+        <Route
+          path="/accept-transfer/"
+          componentPromise={() =>
+            import(
+              /* webpackChunkName: "AcceptProjectTransfer" */ 'app/views/acceptProjectTransfer'
+            )
+          }
+          component={errorHandler(LazyLoad)}
+        />
+        <Route
+          path="/extensions/external-install/:providerId/:installationId"
+          componentPromise={() =>
+            import(
+              /* webpackChunkName: "ExtensionsIntegrationInstallation" */ 'app/views/integrationInstallation'
+            )
+          }
+          component={errorHandler(LazyLoad)}
+        />
 
-      {/* Settings routes */}
-      <Route component={errorHandler(OrganizationDetails)}>
-        <Route path="/settings/" name="Settings" component={SettingsWrapper}>
-          <IndexRoute
-            getComponent={(_loc, cb) =>
-              import(
-                /* webpackChunkName: "SettingsIndex" */ 'app/views/settings/settingsIndex'
-              ).then(lazyLoad(cb))
-            }
-          />
+        <Route
+          path="/extensions/vsts/link/"
+          getComponent={(_loc, cb) =>
+            import(
+              /* webpackChunkName: "VSTSOrganizationLink" */ 'app/views/vstsOrganizationLink'
+            ).then(lazyLoad(cb))
+          }
+        />
 
+        <Route
+          path="/sentry-apps/:sentryAppSlug/external-install/"
+          componentPromise={() =>
+            import(
+              /* webpackChunkName: "SentryAppExternalInstallation" */ 'app/views/sentryAppExternalInstallation'
+            )
+          }
+          component={errorHandler(LazyLoad)}
+        />
+
+        <Redirect from="/account/" to="/settings/account/details/" />
+
+        <Redirect from="/share/group/:shareId/" to="/share/issue/:shareId/" />
+        <Route
+          path="/share/issue/:shareId/"
+          componentPromise={() =>
+            import(
+              /* webpackChunkName: "SharedGroupDetails" */ 'app/views/sharedGroupDetails/sharedGroupDetails'
+            )
+          }
+          component={errorHandler(LazyLoad)}
+        />
+
+        <Route
+          path="/organizations/new/"
+          componentPromise={() =>
+            import(
+              /* webpackChunkName: "OrganizationCreate" */ 'app/views/organizationCreate'
+            )
+          }
+          component={errorHandler(LazyLoad)}
+        />
+
+        <Route
+          path="/organizations/:orgId/data-export/:dataExportId"
+          componentPromise={() =>
+            import(
+              /* webpackChunkName: "DataDownloadView" */ 'app/views/dataExport/dataDownload'
+            )
+          }
+          component={errorHandler(LazyLoad)}
+        />
+
+        <Route
+          path="/join-request/:orgId/"
+          componentPromise={() =>
+            import(
+              /* webpackChunkName: "OrganizationJoinRequest" */ 'app/views/organizationJoinRequest'
+            )
+          }
+          component={errorHandler(LazyLoad)}
+        />
+
+        <Route path="/onboarding/:orgId/" component={errorHandler(OrganizationContext)}>
+          <IndexRedirect to="welcome/" />
           <Route
-            path="account/"
-            name="Account"
-            getComponent={(_loc, cb) =>
+            path=":step/"
+            componentPromise={() =>
               import(
-                /* webpackChunkName: "AccountSettingsLayout" */ 'app/views/settings/account/accountSettingsLayout'
-              ).then(lazyLoad(cb))
+                /* webpackChunkName: "Onboarding" */ 'app/views/onboarding/onboarding'
+              )
             }
-          >
-            {accountSettingsRoutes}
-          </Route>
+            component={errorHandler(LazyLoad)}
+          />
+        </Route>
 
-          <Route name="Organization" path=":orgId/">
-            <Route
+        {/* Settings routes */}
+        <Route component={errorHandler(OrganizationDetails)}>
+          <Route path="/settings/" name="Settings" component={SettingsWrapper}>
+            <IndexRoute
               getComponent={(_loc, cb) =>
                 import(
-                  /* webpackChunkName: "OrganizationSettingsLayout" */ 'app/views/settings/organization/organizationSettingsLayout'
+                  /* webpackChunkName: "SettingsIndex" */ 'app/views/settings/settingsIndex'
+                ).then(lazyLoad(cb))
+              }
+            />
+
+            <Route
+              path="account/"
+              name="Account"
+              getComponent={(_loc, cb) =>
+                import(
+                  /* webpackChunkName: "AccountSettingsLayout" */ 'app/views/settings/account/accountSettingsLayout'
                 ).then(lazyLoad(cb))
               }
             >
-              {hook('routes:organization')}
-              {orgSettingsRoutes}
+              {accountSettingsRoutes}
             </Route>
 
-            <Route
-              name="Project"
-              path="projects/:projectId/"
-              getComponent={(_loc, cb) =>
-                import(
-                  /* webpackChunkName: "ProjectSettingsLayout" */ 'app/views/settings/project/projectSettingsLayout'
-                ).then(lazyLoad(cb))
-              }
-            >
-              <Route component={errorHandler(SettingsProjectProvider)}>
-                {projectSettingsRoutes}
+            <Route name="Organization" path=":orgId/">
+              <Route
+                getComponent={(_loc, cb) =>
+                  import(
+                    /* webpackChunkName: "OrganizationSettingsLayout" */ 'app/views/settings/organization/organizationSettingsLayout'
+                  ).then(lazyLoad(cb))
+                }
+              >
+                {hook('routes:organization')}
+                {orgSettingsRoutes}
               </Route>
-            </Route>
 
-            <Redirect from=":projectId/" to="projects/:projectId/" />
-            <Redirect from=":projectId/alerts/" to="projects/:projectId/alerts/" />
-            <Redirect
-              from=":projectId/alerts/rules/"
-              to="projects/:projectId/alerts/rules/"
-            />
-            <Redirect
-              from=":projectId/alerts/rules/:ruleId/"
-              to="projects/:projectId/alerts/rules/:ruleId/"
-            />
+              <Route
+                name="Project"
+                path="projects/:projectId/"
+                getComponent={(_loc, cb) =>
+                  import(
+                    /* webpackChunkName: "ProjectSettingsLayout" */ 'app/views/settings/project/projectSettingsLayout'
+                  ).then(lazyLoad(cb))
+                }
+              >
+                <Route component={errorHandler(SettingsProjectProvider)}>
+                  {projectSettingsRoutes}
+                </Route>
+              </Route>
+
+              <Redirect from=":projectId/" to="projects/:projectId/" />
+              <Redirect from=":projectId/alerts/" to="projects/:projectId/alerts/" />
+              <Redirect
+                from=":projectId/alerts/rules/"
+                to="projects/:projectId/alerts/rules/"
+              />
+              <Redirect
+                from=":projectId/alerts/rules/:ruleId/"
+                to="projects/:projectId/alerts/rules/:ruleId/"
+              />
+            </Route>
           </Route>
         </Route>
-      </Route>
 
-      {/* A route tree for lightweight organizational detail views. We place
+        {/* A route tree for lightweight organizational detail views. We place
       this above the heavyweight organization detail views because there
       exist some redirects from deprecated routes which should not take
       precedence over these lightweight routes*/}
-      <Route component={errorHandler(LightWeightOrganizationDetails)}>
-        <Route
-          path="/organizations/:orgId/projects/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        />
-
-        <Route
-          path="/organizations/:orgId/dashboards/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "DashboardsContainer" */ 'app/views/dashboards')
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
+        <Route component={errorHandler(LightWeightOrganizationDetails)}>
+          <Route
+            path="/organizations/:orgId/projects/"
             componentPromise={() =>
               import(
-                /* webpackChunkName: "OverviewDashboard" */ 'app/views/dashboards/overviewDashboard'
+                /* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard'
               )
             }
             component={errorHandler(LazyLoad)}
           />
-        </Route>
 
-        <Route
-          path="/organizations/:orgId/user-feedback/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "UserFeedback" */ 'app/views/userFeedback')
-          }
-          component={errorHandler(LazyLoad)}
-        />
+          <Route
+            path="/organizations/:orgId/dashboards/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "DashboardsContainer" */ 'app/views/dashboards')
+            }
+            component={errorHandler(LazyLoad)}
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "OverviewDashboard" */ 'app/views/dashboards/overviewDashboard'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
 
-        <Route
-          path="/organizations/:orgId/issues/"
-          component={errorHandler(IssueListContainer)}
-        >
-          <Redirect from="/organizations/:orgId/" to="/organizations/:orgId/issues/" />
-          <IndexRoute component={errorHandler(IssueListOverview)} />
-          <Route path="searches/:searchId/" component={errorHandler(IssueListOverview)} />
-        </Route>
+          <Route
+            path="/organizations/:orgId/user-feedback/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "UserFeedback" */ 'app/views/userFeedback')
+            }
+            component={errorHandler(LazyLoad)}
+          />
 
-        {/* Once org issues is complete, these routes can be nested under
+          <Route
+            path="/organizations/:orgId/issues/"
+            component={errorHandler(IssueListContainer)}
+          >
+            <Redirect from="/organizations/:orgId/" to="/organizations/:orgId/issues/" />
+            <IndexRoute component={errorHandler(IssueListOverview)} />
+            <Route
+              path="searches/:searchId/"
+              component={errorHandler(IssueListOverview)}
+            />
+          </Route>
+
+          {/* Once org issues is complete, these routes can be nested under
           /organizations/:orgId/issues */}
-        <Route
-          path="/organizations/:orgId/issues/:groupId/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "OrganizationGroupDetails" */ 'app/views/organizationGroupDetails'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationGroupEventDetails" */ 'app/views/organizationGroupDetails/groupEventDetails'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
           <Route
-            path="/organizations/:orgId/issues/:groupId/activity/"
+            path="/organizations/:orgId/issues/:groupId/"
             componentPromise={() =>
               import(
-                /* webpackChunkName: "GroupActivity" */ 'app/views/organizationGroupDetails/groupActivity'
+                /* webpackChunkName: "OrganizationGroupDetails" */ 'app/views/organizationGroupDetails'
               )
             }
             component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="/organizations/:orgId/issues/:groupId/events/:eventId/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationGroupEventDetails" */ 'app/views/organizationGroupDetails/groupEventDetails'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="/organizations/:orgId/issues/:groupId/events/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationGroupEvents" */ 'app/views/organizationGroupDetails/groupEvents'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="/organizations/:orgId/issues/:groupId/tags/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationGroupTags" */ 'app/views/organizationGroupDetails/groupTags'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="/organizations/:orgId/issues/:groupId/tags/:tagKey/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationGroupTagsValues" */ 'app/views/organizationGroupDetails/groupTagValues'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="/organizations/:orgId/issues/:groupId/feedback/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationGroupUserFeedback" */ 'app/views/organizationGroupDetails/groupUserFeedback'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="/organizations/:orgId/issues/:groupId/attachments/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "GroupEventAttachments" */ 'app/views/organizationGroupDetails/groupEventAttachments'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="/organizations/:orgId/issues/:groupId/similar/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "GroupSimilarView" */ 'app/views/organizationGroupDetails/groupSimilar'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="/organizations/:orgId/issues/:groupId/merged/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "GroupSimilarView" */ 'app/views/organizationGroupDetails/groupMerged'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-        </Route>
-
-        <Route
-          path="/organizations/:orgId/alerts/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "AlertsContainer" */ 'app/views/alerts')
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(/* webpackChunkName: "AlertsList" */ 'app/views/alerts/list')
-            }
-            component={errorHandler(LazyLoad)}
-          />
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "OrganizationGroupEventDetails" */ 'app/views/organizationGroupDetails/groupEventDetails'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/issues/:groupId/activity/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "GroupActivity" */ 'app/views/organizationGroupDetails/groupActivity'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/issues/:groupId/events/:eventId/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "OrganizationGroupEventDetails" */ 'app/views/organizationGroupDetails/groupEventDetails'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/issues/:groupId/events/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "OrganizationGroupEvents" */ 'app/views/organizationGroupDetails/groupEvents'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/issues/:groupId/tags/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "OrganizationGroupTags" */ 'app/views/organizationGroupDetails/groupTags'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/issues/:groupId/tags/:tagKey/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "OrganizationGroupTagsValues" */ 'app/views/organizationGroupDetails/groupTagValues'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/issues/:groupId/feedback/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "OrganizationGroupUserFeedback" */ 'app/views/organizationGroupDetails/groupUserFeedback'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/issues/:groupId/attachments/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "GroupEventAttachments" */ 'app/views/organizationGroupDetails/groupEventAttachments'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/issues/:groupId/similar/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "GroupSimilarView" */ 'app/views/organizationGroupDetails/groupSimilar'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/issues/:groupId/merged/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "GroupSimilarView" */ 'app/views/organizationGroupDetails/groupMerged'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
 
           <Route
-            path=":alertId/"
+            path="/organizations/:orgId/alerts/"
             componentPromise={() =>
-              import(/* webpackChunkName: "AlertsDetails" */ 'app/views/alerts/details')
+              import(/* webpackChunkName: "AlertsContainer" */ 'app/views/alerts')
             }
             component={errorHandler(LazyLoad)}
-          />
-        </Route>
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(/* webpackChunkName: "AlertsList" */ 'app/views/alerts/list')
+              }
+              component={errorHandler(LazyLoad)}
+            />
 
-        <Route
-          path="/organizations/:orgId/events/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "EventsContainer" */ 'app/views/events')
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(/* webpackChunkName: "Events" */ 'app/views/events/events')
-            }
-            component={errorHandler(LazyLoad)}
-          />
-        </Route>
+            <Route
+              path=":alertId/"
+              componentPromise={() =>
+                import(/* webpackChunkName: "AlertsDetails" */ 'app/views/alerts/details')
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
 
-        <Route
-          path="/organizations/:orgId/monitors/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "MonitorsContainer" */ 'app/views/monitors')
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(/* webpackChunkName: "Monitors" */ 'app/views/monitors/monitors')
-            }
-            component={errorHandler(LazyLoad)}
-          />
           <Route
-            path="/organizations/:orgId/monitors/create/"
+            path="/organizations/:orgId/events/"
             componentPromise={() =>
-              import(/* webpackChunkName: "MonitorCreate" */ 'app/views/monitors/create')
+              import(/* webpackChunkName: "EventsContainer" */ 'app/views/events')
             }
             component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="/organizations/:orgId/monitors/:monitorId/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "MonitorDetails" */ 'app/views/monitors/details'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="/organizations/:orgId/monitors/:monitorId/edit/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "MonitorEdit" */ 'app/views/monitors/edit')
-            }
-            component={errorHandler(LazyLoad)}
-          />
-        </Route>
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(/* webpackChunkName: "Events" */ 'app/views/events/events')
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
 
-        <Route
-          path="/organizations/:orgId/releases/"
-          componentPromise={() =>
-            decideReleasesVersion(v2 =>
-              v2
-                ? import(
-                    /* webpackChunkName: "ReleasesV2Container" */ 'app/views/releasesV2'
-                  )
-                : import(/* webpackChunkName: "ReleasesContainer" */ 'app/views/releases')
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
+          <Route
+            path="/organizations/:orgId/monitors/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "MonitorsContainer" */ 'app/views/monitors')
+            }
+            component={errorHandler(LazyLoad)}
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(/* webpackChunkName: "Monitors" */ 'app/views/monitors/monitors')
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/monitors/create/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "MonitorCreate" */ 'app/views/monitors/create'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/monitors/:monitorId/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "MonitorDetails" */ 'app/views/monitors/details'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="/organizations/:orgId/monitors/:monitorId/edit/"
+              componentPromise={() =>
+                import(/* webpackChunkName: "MonitorEdit" */ 'app/views/monitors/edit')
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
+
+          <Route
+            path="/organizations/:orgId/releases/"
             componentPromise={() =>
               decideReleasesVersion(v2 =>
                 v2
                   ? import(
-                      /* webpackChunkName: "ReleasesV2List" */ 'app/views/releasesV2/list'
-                    )
-                  : import(/* webpackChunkName: "Releases" */ 'app/views/releases/list')
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path=":release/"
-            componentPromise={() =>
-              decideReleasesVersion(v2 =>
-                v2
-                  ? import(
-                      /* webpackChunkName: "ReleasesV2Detail" */ 'app/views/releasesV2/detail'
+                      /* webpackChunkName: "ReleasesV2Container" */ 'app/views/releasesV2'
                     )
                   : import(
-                      /* webpackChunkName: "ReleaseDetail" */ 'app/views/releases/detail'
+                      /* webpackChunkName: "ReleasesContainer" */ 'app/views/releases'
                     )
               )
             }
@@ -1377,362 +1360,507 @@ function routes() {
                 decideReleasesVersion(v2 =>
                   v2
                     ? import(
-                        /* webpackChunkName: "ReleasesV2DetailOverview" */ 'app/views/releasesV2/detail/overview'
+                        /* webpackChunkName: "ReleasesV2List" */ 'app/views/releasesV2/list'
                       )
-                    : import(
-                        /* webpackChunkName: "ReleaseOverview" */ 'app/views/releases/detail/releaseOverview'
-                      )
+                    : import(/* webpackChunkName: "Releases" */ 'app/views/releases/list')
                 )
               }
               component={errorHandler(LazyLoad)}
             />
             <Route
-              path="commits/"
+              path=":release/"
               componentPromise={() =>
                 decideReleasesVersion(v2 =>
                   v2
                     ? import(
-                        /* webpackChunkName: "ReleasesV2DetailCommits" */ 'app/views/releasesV2/detail/commits'
+                        /* webpackChunkName: "ReleasesV2Detail" */ 'app/views/releasesV2/detail'
                       )
                     : import(
-                        /* webpackChunkName: "ReleaseCommits" */ 'app/views/releases/detail/releaseCommits'
+                        /* webpackChunkName: "ReleaseDetail" */ 'app/views/releases/detail'
                       )
                 )
               }
               component={errorHandler(LazyLoad)}
-            />
-            <Route
-              path="artifacts/"
-              componentPromise={() =>
-                decideReleasesVersion(v2 =>
-                  v2
-                    ? import(
-                        /* webpackChunkName: "ReleasesV2DetailArtifacts" */ 'app/views/releasesV2/detail/artifacts'
-                      )
-                    : import(
-                        /* webpackChunkName: "ReleaseArtifacts" */ 'app/views/releases/detail/releaseArtifacts'
-                      )
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-            <Route
-              path="files-changed/"
-              componentPromise={() =>
-                decideReleasesVersion(v2 =>
-                  v2
-                    ? import(
-                        /* webpackChunkName: "ReleasesV2DetailFilesChanged" */ 'app/views/releasesV2/detail/filesChanged'
-                      )
-                    : Promise.resolve(({router, params}) => (
-                        <RedirectTo
-                          router={router}
-                          to={`/organizations/${
-                            params.orgId
-                          }/releases/${encodeURIComponent(params.release)}/`}
-                        />
-                      ))
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-            <Route
-              path="new-events/"
-              componentPromise={() =>
-                decideReleasesVersion(v2 =>
-                  v2
-                    ? Promise.resolve(({router, params}) => (
-                        <RedirectTo
-                          router={router}
-                          to={`/organizations/${
-                            params.orgId
-                          }/releases/${encodeURIComponent(params.release)}/`}
-                        />
-                      ))
-                    : import(
-                        /* webpackChunkName: "ReleaseNewEvents" */ 'app/views/releases/detail/releaseNewEvents'
-                      )
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
-            <Route
-              path="all-events/"
-              componentPromise={() =>
-                decideReleasesVersion(v2 =>
-                  v2
-                    ? Promise.resolve(({router, params}) => (
-                        <RedirectTo
-                          router={router}
-                          to={`/organizations/${
-                            params.orgId
-                          }/releases/${encodeURIComponent(params.release)}/`}
-                        />
-                      ))
-                    : import(
-                        /* webpackChunkName: "ReleaseAllEvents" */ 'app/views/releases/detail/releaseAllEvents'
-                      )
-                )
-              }
-              component={errorHandler(LazyLoad)}
-            />
+            >
+              <IndexRoute
+                componentPromise={() =>
+                  decideReleasesVersion(v2 =>
+                    v2
+                      ? import(
+                          /* webpackChunkName: "ReleasesV2DetailOverview" */ 'app/views/releasesV2/detail/overview'
+                        )
+                      : import(
+                          /* webpackChunkName: "ReleaseOverview" */ 'app/views/releases/detail/releaseOverview'
+                        )
+                  )
+                }
+                component={errorHandler(LazyLoad)}
+              />
+              <Route
+                path="commits/"
+                componentPromise={() =>
+                  decideReleasesVersion(v2 =>
+                    v2
+                      ? import(
+                          /* webpackChunkName: "ReleasesV2DetailCommits" */ 'app/views/releasesV2/detail/commits'
+                        )
+                      : import(
+                          /* webpackChunkName: "ReleaseCommits" */ 'app/views/releases/detail/releaseCommits'
+                        )
+                  )
+                }
+                component={errorHandler(LazyLoad)}
+              />
+              <Route
+                path="artifacts/"
+                componentPromise={() =>
+                  decideReleasesVersion(v2 =>
+                    v2
+                      ? import(
+                          /* webpackChunkName: "ReleasesV2DetailArtifacts" */ 'app/views/releasesV2/detail/artifacts'
+                        )
+                      : import(
+                          /* webpackChunkName: "ReleaseArtifacts" */ 'app/views/releases/detail/releaseArtifacts'
+                        )
+                  )
+                }
+                component={errorHandler(LazyLoad)}
+              />
+              <Route
+                path="files-changed/"
+                componentPromise={() =>
+                  decideReleasesVersion(v2 =>
+                    v2
+                      ? import(
+                          /* webpackChunkName: "ReleasesV2DetailFilesChanged" */ 'app/views/releasesV2/detail/filesChanged'
+                        )
+                      : Promise.resolve(({router, params}) => (
+                          <RedirectTo
+                            router={router}
+                            to={`/organizations/${
+                              params.orgId
+                            }/releases/${encodeURIComponent(params.release)}/`}
+                          />
+                        ))
+                  )
+                }
+                component={errorHandler(LazyLoad)}
+              />
+              <Route
+                path="new-events/"
+                componentPromise={() =>
+                  decideReleasesVersion(v2 =>
+                    v2
+                      ? Promise.resolve(({router, params}) => (
+                          <RedirectTo
+                            router={router}
+                            to={`/organizations/${
+                              params.orgId
+                            }/releases/${encodeURIComponent(params.release)}/`}
+                          />
+                        ))
+                      : import(
+                          /* webpackChunkName: "ReleaseNewEvents" */ 'app/views/releases/detail/releaseNewEvents'
+                        )
+                  )
+                }
+                component={errorHandler(LazyLoad)}
+              />
+              <Route
+                path="all-events/"
+                componentPromise={() =>
+                  decideReleasesVersion(v2 =>
+                    v2
+                      ? Promise.resolve(({router, params}) => (
+                          <RedirectTo
+                            router={router}
+                            to={`/organizations/${
+                              params.orgId
+                            }/releases/${encodeURIComponent(params.release)}/`}
+                          />
+                        ))
+                      : import(
+                          /* webpackChunkName: "ReleaseAllEvents" */ 'app/views/releases/detail/releaseAllEvents'
+                        )
+                  )
+                }
+                component={errorHandler(LazyLoad)}
+              />
+            </Route>
           </Route>
-        </Route>
 
-        <Route
-          path="/organizations/:orgId/activity/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "OrganizationActivity" */ 'app/views/organizationActivity'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        />
+          <Route
+            path="/organizations/:orgId/activity/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "OrganizationActivity" */ 'app/views/organizationActivity'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          />
 
-        <Route
-          path="/organizations/:orgId/projects/:projectId/events/:eventId/"
-          component={errorHandler(ProjectEventRedirect)}
-        />
+          <Route
+            path="/organizations/:orgId/projects/:projectId/events/:eventId/"
+            component={errorHandler(ProjectEventRedirect)}
+          />
 
-        {/*
+          {/*
         TODO(mark) Long term this /queries route should go away and /discover should be the
         canoncial route for discover2. Also the duplication in route wrapping
         here should go away.
         */}
-        <Route
-          path="/organizations/:orgId/discover/queries/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "DiscoverV2Landing" */ 'app/views/eventsV2/landing'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-        </Route>
-        <Route
-          path="/organizations/:orgId/discover/results/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "DiscoverV2Results" */ 'app/views/eventsV2/results'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-        </Route>
-        <Route
-          path="/organizations/:orgId/discover/:eventSlug/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "DiscoverV2Details" */ 'app/views/eventsV2/eventDetails'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-        </Route>
-        <Route
-          path="/organizations/:orgId/performance/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "PerformanceContainer" */ 'app/views/performance')
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "PerformanceLanding" */ 'app/views/performance/landing'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-        </Route>
-        <Route
-          path="/organizations/:orgId/performance/summary/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "PerformanceContainer" */ 'app/views/performance')
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "PerformanceTransactionSummary" */ 'app/views/performance/transactionSummary'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-        </Route>
-
-        {/* Admin/manage routes */}
-        <Route
-          path="/manage/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "AdminLayout" */ 'app/views/admin/adminLayout')
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "AdminOverview" */ 'app/views/admin/adminOverview'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
           <Route
-            path="buffer/"
+            path="/organizations/:orgId/discover/queries/"
             componentPromise={() =>
-              import(/* webpackChunkName: "AdminBuffer" */ 'app/views/admin/adminBuffer')
+              import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
             }
             component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="relays/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "AdminRelays" */ 'app/views/admin/adminRelays')
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="organizations/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "AdminOrganizations" */ 'app/views/admin/adminOrganizations'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="projects/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "AdminProjects" */ 'app/views/admin/adminProjects'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="queue/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "AdminQueue" */ 'app/views/admin/adminQueue')
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="quotas/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "AdminQuotas" */ 'app/views/admin/adminQuotas')
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="settings/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "AdminSettings" */ 'app/views/admin/adminSettings'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route path="users/">
+          >
             <IndexRoute
               componentPromise={() =>
-                import(/* webpackChunkName: "AdminUsers" */ 'app/views/admin/adminUsers')
-              }
-              component={errorHandler(LazyLoad)}
-            />
-            <Route
-              path=":id"
-              componentPromise={() =>
                 import(
-                  /* webpackChunkName: "AdminUserEdit" */ 'app/views/admin/adminUserEdit'
+                  /* webpackChunkName: "DiscoverV2Landing" */ 'app/views/eventsV2/landing'
                 )
               }
               component={errorHandler(LazyLoad)}
             />
           </Route>
           <Route
-            path="status/mail/"
+            path="/organizations/:orgId/discover/results/"
             componentPromise={() =>
-              import(/* webpackChunkName: "AdminMail" */ 'app/views/admin/adminMail')
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="status/environment/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "AdminEnvironment" */ 'app/views/admin/adminEnvironment'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="status/packages/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "AdminPackages" */ 'app/views/admin/adminPackages'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path="status/warnings/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "AdminWarnings" */ 'app/views/admin/adminWarnings'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          {hook('routes:admin')}
-        </Route>
-      </Route>
-
-      {/* The heavyweight organization detail views */}
-      <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
-        <Route component={errorHandler(OrganizationRoot)}>
-          {hook('routes:organization-root')}
-          <Route
-            path="/organizations/:orgId/stats/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationStats" */ 'app/views/organizationStats'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-
-          <Route
-            path="/organizations/:orgId/discover/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "DiscoverContainer" */ 'app/views/discover')
+              import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
             }
             component={errorHandler(LazyLoad)}
           >
-            <Redirect path="saved/" to="/organizations/:orgId/discover/" />
-            <Route path="saved/:savedQueryId/" />
+            <IndexRoute
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "DiscoverV2Results" */ 'app/views/eventsV2/results'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
+          <Route
+            path="/organizations/:orgId/discover/:eventSlug/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
+            }
+            component={errorHandler(LazyLoad)}
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "DiscoverV2Details" */ 'app/views/eventsV2/eventDetails'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
+          <Route
+            path="/organizations/:orgId/performance/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "PerformanceLanding" */ 'app/views/performance/landing'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
+          <Route
+            path="/organizations/:orgId/performance/summary/"
+            componentPromise={() =>
+              import(
+                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
+              )
+            }
+            component={errorHandler(LazyLoad)}
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "PerformanceTransactionSummary" */ 'app/views/performance/transactionSummary'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
           </Route>
 
+          {/* Admin/manage routes */}
           <Route
-            path="/organizations/:orgId/projects/:projectId/getting-started/"
+            path="/manage/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "AdminLayout" */ 'app/views/admin/adminLayout')
+            }
+            component={errorHandler(LazyLoad)}
+          >
+            <IndexRoute
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminOverview" */ 'app/views/admin/adminOverview'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="buffer/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminBuffer" */ 'app/views/admin/adminBuffer'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="relays/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminRelays" */ 'app/views/admin/adminRelays'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="organizations/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminOrganizations" */ 'app/views/admin/adminOrganizations'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="projects/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminProjects" */ 'app/views/admin/adminProjects'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="queue/"
+              componentPromise={() =>
+                import(/* webpackChunkName: "AdminQueue" */ 'app/views/admin/adminQueue')
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="quotas/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminQuotas" */ 'app/views/admin/adminQuotas'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="settings/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminSettings" */ 'app/views/admin/adminSettings'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route path="users/">
+              <IndexRoute
+                componentPromise={() =>
+                  import(
+                    /* webpackChunkName: "AdminUsers" */ 'app/views/admin/adminUsers'
+                  )
+                }
+                component={errorHandler(LazyLoad)}
+              />
+              <Route
+                path=":id"
+                componentPromise={() =>
+                  import(
+                    /* webpackChunkName: "AdminUserEdit" */ 'app/views/admin/adminUserEdit'
+                  )
+                }
+                component={errorHandler(LazyLoad)}
+              />
+            </Route>
+            <Route
+              path="status/mail/"
+              componentPromise={() =>
+                import(/* webpackChunkName: "AdminMail" */ 'app/views/admin/adminMail')
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="status/environment/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminEnvironment" */ 'app/views/admin/adminEnvironment'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="status/packages/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminPackages" */ 'app/views/admin/adminPackages'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            <Route
+              path="status/warnings/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "AdminWarnings" */ 'app/views/admin/adminWarnings'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+            {hook('routes:admin')}
+          </Route>
+        </Route>
+
+        {/* The heavyweight organization detail views */}
+        <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
+          <Route component={errorHandler(OrganizationRoot)}>
+            {hook('routes:organization-root')}
+            <Route
+              path="/organizations/:orgId/stats/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "OrganizationStats" */ 'app/views/organizationStats'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+
+            <Route
+              path="/organizations/:orgId/discover/"
+              componentPromise={() =>
+                import(/* webpackChunkName: "DiscoverContainer" */ 'app/views/discover')
+              }
+              component={errorHandler(LazyLoad)}
+            >
+              <Redirect path="saved/" to="/organizations/:orgId/discover/" />
+              <Route path="saved/:savedQueryId/" />
+            </Route>
+
+            <Route
+              path="/organizations/:orgId/projects/:projectId/getting-started/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "ProjectGettingStarted" */ 'app/views/projectInstall/gettingStarted'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            >
+              <IndexRoute
+                componentPromise={() =>
+                  import(
+                    /* webpackChunkName: "ProjectInstallOverview" */ 'app/views/projectInstall/overview'
+                  )
+                }
+                component={errorHandler(LazyLoad)}
+              />
+              <Route
+                path=":platform/"
+                componentPromise={() =>
+                  import(
+                    /* webpackChunkName: "ProjectInstallPlatform" */ 'app/views/projectInstall/platform'
+                  )
+                }
+                component={errorHandler(LazyLoad)}
+              />
+            </Route>
+
+            <Route
+              path="/organizations/:orgId/teams/new/"
+              componentPromise={() =>
+                import(/* webpackChunkName: "TeamCreate" */ 'app/views/teamCreate')
+              }
+              component={errorHandler(LazyLoad)}
+            />
+
+            <Route path="/organizations/:orgId/">
+              {hook('routes:organization')}
+              <Redirect
+                path="/organizations/:orgId/teams/"
+                to="/settings/:orgId/teams/"
+              />
+              <Redirect
+                path="/organizations/:orgId/teams/your-teams/"
+                to="/settings/:orgId/teams/"
+              />
+              <Redirect
+                path="/organizations/:orgId/teams/all-teams/"
+                to="/settings/:orgId/teams/"
+              />
+              <Redirect
+                path="/organizations/:orgId/teams/:teamId/"
+                to="/settings/:orgId/teams/:teamId/"
+              />
+              <Redirect
+                path="/organizations/:orgId/teams/:teamId/members/"
+                to="/settings/:orgId/teams/:teamId/members/"
+              />
+              <Redirect
+                path="/organizations/:orgId/teams/:teamId/projects/"
+                to="/settings/:orgId/teams/:teamId/projects/"
+              />
+              <Redirect
+                path="/organizations/:orgId/teams/:teamId/settings/"
+                to="/settings/:orgId/teams/:teamId/settings/"
+              />
+              <Redirect path="/organizations/:orgId/settings/" to="/settings/:orgId/" />
+              <Redirect
+                path="/organizations/:orgId/api-keys/"
+                to="/settings/:orgId/api-keys/"
+              />
+              <Redirect
+                path="/organizations/:orgId/api-keys/:apiKey/"
+                to="/settings/:orgId/api-keys/:apiKey/"
+              />
+              <Redirect
+                path="/organizations/:orgId/members/"
+                to="/settings/:orgId/members/"
+              />
+              <Redirect
+                path="/organizations/:orgId/members/new/"
+                to="/settings/:orgId/members/new/"
+              />
+              <Redirect
+                path="/organizations/:orgId/members/:memberId/"
+                to="/settings/:orgId/members/:memberId/"
+              />
+              <Redirect
+                path="/organizations/:orgId/rate-limits/"
+                to="/settings/:orgId/rate-limits/"
+              />
+              <Redirect
+                path="/organizations/:orgId/repos/"
+                to="/settings/:orgId/repos/"
+              />
+            </Route>
+            <Route
+              path="/organizations/:orgId/projects/new/"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "NewProject" */ 'app/views/projectInstall/newProject'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
+          </Route>
+          <Route
+            path=":projectId/getting-started/"
             componentPromise={() =>
               import(
                 /* webpackChunkName: "ProjectGettingStarted" */ 'app/views/projectInstall/gettingStarted'
@@ -1758,346 +1886,256 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
           </Route>
-
-          <Route
-            path="/organizations/:orgId/teams/new/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "TeamCreate" */ 'app/views/teamCreate')
-            }
-            component={errorHandler(LazyLoad)}
-          />
-
-          <Route path="/organizations/:orgId/">
-            {hook('routes:organization')}
-            <Redirect path="/organizations/:orgId/teams/" to="/settings/:orgId/teams/" />
-            <Redirect
-              path="/organizations/:orgId/teams/your-teams/"
-              to="/settings/:orgId/teams/"
-            />
-            <Redirect
-              path="/organizations/:orgId/teams/all-teams/"
-              to="/settings/:orgId/teams/"
-            />
-            <Redirect
-              path="/organizations/:orgId/teams/:teamId/"
-              to="/settings/:orgId/teams/:teamId/"
-            />
-            <Redirect
-              path="/organizations/:orgId/teams/:teamId/members/"
-              to="/settings/:orgId/teams/:teamId/members/"
-            />
-            <Redirect
-              path="/organizations/:orgId/teams/:teamId/projects/"
-              to="/settings/:orgId/teams/:teamId/projects/"
-            />
-            <Redirect
-              path="/organizations/:orgId/teams/:teamId/settings/"
-              to="/settings/:orgId/teams/:teamId/settings/"
-            />
-            <Redirect path="/organizations/:orgId/settings/" to="/settings/:orgId/" />
-            <Redirect
-              path="/organizations/:orgId/api-keys/"
-              to="/settings/:orgId/api-keys/"
-            />
-            <Redirect
-              path="/organizations/:orgId/api-keys/:apiKey/"
-              to="/settings/:orgId/api-keys/:apiKey/"
-            />
-            <Redirect
-              path="/organizations/:orgId/members/"
-              to="/settings/:orgId/members/"
-            />
-            <Redirect
-              path="/organizations/:orgId/members/new/"
-              to="/settings/:orgId/members/new/"
-            />
-            <Redirect
-              path="/organizations/:orgId/members/:memberId/"
-              to="/settings/:orgId/members/:memberId/"
-            />
-            <Redirect
-              path="/organizations/:orgId/rate-limits/"
-              to="/settings/:orgId/rate-limits/"
-            />
-            <Redirect path="/organizations/:orgId/repos/" to="/settings/:orgId/repos/" />
-          </Route>
-          <Route
-            path="/organizations/:orgId/projects/new/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "NewProject" */ 'app/views/projectInstall/newProject'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
         </Route>
-        <Route
-          path=":projectId/getting-started/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectGettingStarted" */ 'app/views/projectInstall/gettingStarted'
-            )
-          }
-          component={errorHandler(LazyLoad)}
-        >
-          <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "ProjectInstallOverview" */ 'app/views/projectInstall/overview'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
-            path=":platform/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "ProjectInstallPlatform" */ 'app/views/projectInstall/platform'
-              )
-            }
-            component={errorHandler(LazyLoad)}
-          />
-        </Route>
-      </Route>
 
-      {/* A route tree for lightweight organizational detail views.
+        {/* A route tree for lightweight organizational detail views.
           This is strictly for deprecated URLs that we need to maintain */}
-      <Route component={errorHandler(LightWeightOrganizationDetails)}>
-        <Route name="Organization" path="/:orgId/">
-          <Route path=":projectId/">
-            {/* Support for deprecated URLs (pre-Sentry 10). We just redirect users to new canonical URLs. */}
-            <IndexRoute
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId}) =>
-                    `/organizations/${orgId}/issues/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="issues/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId}) =>
-                    `/organizations/${orgId}/issues/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="dashboard/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId}) =>
-                    `/organizations/${orgId}/dashboards/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="user-feedback/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId}) =>
-                    `/organizations/${orgId}/user-feedback/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="releases/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId}) =>
-                    `/organizations/${orgId}/releases/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="releases/:version/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId, router}) =>
-                    `/organizations/${orgId}/releases/${router.params.version}/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="releases/:version/new-events/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId, router}) =>
-                    `/organizations/${orgId}/releases/${router.params.version}/new-events/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="releases/:version/all-events/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId, router}) =>
-                    `/organizations/${orgId}/releases/${router.params.version}/all-events/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="releases/:version/artifacts/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId, router}) =>
-                    `/organizations/${orgId}/releases/${router.params.version}/artifacts/?project=${projectId}`
-                )
-              )}
-            />
-            <Route
-              path="releases/:version/commits/"
-              component={errorHandler(
-                redirectDeprecatedProjectRoute(
-                  ({orgId, projectId, router}) =>
-                    `/organizations/${orgId}/releases/${router.params.version}/commits/?project=${projectId}`
-                )
-              )}
-            />
+        <Route component={errorHandler(LightWeightOrganizationDetails)}>
+          <Route name="Organization" path="/:orgId/">
+            <Route path=":projectId/">
+              {/* Support for deprecated URLs (pre-Sentry 10). We just redirect users to new canonical URLs. */}
+              <IndexRoute
+                component={errorHandler(
+                  redirectDeprecatedProjectRoute(
+                    ({orgId, projectId}) =>
+                      `/organizations/${orgId}/issues/?project=${projectId}`
+                  )
+                )}
+              />
+              <Route
+                path="issues/"
+                component={errorHandler(
+                  redirectDeprecatedProjectRoute(
+                    ({orgId, projectId}) =>
+                      `/organizations/${orgId}/issues/?project=${projectId}`
+                  )
+                )}
+              />
+              <Route
+                path="dashboard/"
+                component={errorHandler(
+                  redirectDeprecatedProjectRoute(
+                    ({orgId, projectId}) =>
+                      `/organizations/${orgId}/dashboards/?project=${projectId}`
+                  )
+                )}
+              />
+              <Route
+                path="user-feedback/"
+                component={errorHandler(
+                  redirectDeprecatedProjectRoute(
+                    ({orgId, projectId}) =>
+                      `/organizations/${orgId}/user-feedback/?project=${projectId}`
+                  )
+                )}
+              />
+              <Route
+                path="releases/"
+                component={errorHandler(
+                  redirectDeprecatedProjectRoute(
+                    ({orgId, projectId}) =>
+                      `/organizations/${orgId}/releases/?project=${projectId}`
+                  )
+                )}
+              />
+              <Route
+                path="releases/:version/"
+                component={errorHandler(
+                  redirectDeprecatedProjectRoute(
+                    ({orgId, projectId, router}) =>
+                      `/organizations/${orgId}/releases/${router.params.version}/?project=${projectId}`
+                  )
+                )}
+              />
+              <Route
+                path="releases/:version/new-events/"
+                component={errorHandler(
+                  redirectDeprecatedProjectRoute(
+                    ({orgId, projectId, router}) =>
+                      `/organizations/${orgId}/releases/${router.params.version}/new-events/?project=${projectId}`
+                  )
+                )}
+              />
+              <Route
+                path="releases/:version/all-events/"
+                component={errorHandler(
+                  redirectDeprecatedProjectRoute(
+                    ({orgId, projectId, router}) =>
+                      `/organizations/${orgId}/releases/${router.params.version}/all-events/?project=${projectId}`
+                  )
+                )}
+              />
+              <Route
+                path="releases/:version/artifacts/"
+                component={errorHandler(
+                  redirectDeprecatedProjectRoute(
+                    ({orgId, projectId, router}) =>
+                      `/organizations/${orgId}/releases/${router.params.version}/artifacts/?project=${projectId}`
+                  )
+                )}
+              />
+              <Route
+                path="releases/:version/commits/"
+                component={errorHandler(
+                  redirectDeprecatedProjectRoute(
+                    ({orgId, projectId, router}) =>
+                      `/organizations/${orgId}/releases/${router.params.version}/commits/?project=${projectId}`
+                  )
+                )}
+              />
+            </Route>
           </Route>
         </Route>
-      </Route>
 
-      <Route path="/:orgId/">
-        <Route path=":projectId/settings/">
-          <Redirect from="teams/" to="/settings/:orgId/projects/:projectId/teams/" />
-          <Redirect from="alerts/" to="/settings/:orgId/projects/:projectId/alerts/" />
+        <Route path="/:orgId/">
+          <Route path=":projectId/settings/">
+            <Redirect from="teams/" to="/settings/:orgId/projects/:projectId/teams/" />
+            <Redirect from="alerts/" to="/settings/:orgId/projects/:projectId/alerts/" />
+            <Redirect
+              from="alerts/rules/"
+              to="/settings/:orgId/projects/:projectId/alerts/rules/"
+            />
+            <Redirect
+              from="alerts/rules/new/"
+              to="/settings/:orgId/projects/:projectId/alerts/rules/new/"
+            />
+            <Redirect
+              from="alerts/rules/:ruleId/"
+              to="/settings/:orgId/projects/:projectId/alerts/rules/:ruleId/"
+            />
+            <Redirect
+              from="environments/"
+              to="/settings/:orgId/projects/:projectId/environments/"
+            />
+            <Redirect
+              from="environments/hidden/"
+              to="/settings/:orgId/projects/:projectId/environments/hidden/"
+            />
+            <Redirect
+              from="tags/"
+              to="/settings/projects/:orgId/projects/:projectId/tags/"
+            />
+            <Redirect
+              from="issue-tracking/"
+              to="/settings/:orgId/projects/:projectId/issue-tracking/"
+            />
+            <Redirect
+              from="release-tracking/"
+              to="/settings/:orgId/projects/:projectId/release-tracking/"
+            />
+            <Redirect
+              from="ownership/"
+              to="/settings/:orgId/projects/:projectId/ownership/"
+            />
+            <Redirect
+              from="data-forwarding/"
+              to="/settings/:orgId/projects/:projectId/data-forwarding/"
+            />
+            <Redirect
+              from="debug-symbols/"
+              to="/settings/:orgId/projects/:projectId/debug-symbols/"
+            />
+            <Redirect
+              from="processing-issues/"
+              to="/settings/:orgId/projects/:projectId/processing-issues/"
+            />
+            <Redirect
+              from="filters/"
+              to="/settings/:orgId/projects/:projectId/filters/"
+            />
+            <Redirect from="hooks/" to="/settings/:orgId/projects/:projectId/hooks/" />
+            <Redirect from="keys/" to="/settings/:orgId/projects/:projectId/keys/" />
+            <Redirect
+              from="keys/:keyId/"
+              to="/settings/:orgId/projects/:projectId/keys/:keyId/"
+            />
+            <Redirect
+              from="user-feedback/"
+              to="/settings/:orgId/projects/:projectId/user-feedback/"
+            />
+            <Redirect
+              from="security-headers/"
+              to="/settings/:orgId/projects/:projectId/security-headers/"
+            />
+            <Redirect
+              from="security-headers/csp/"
+              to="/settings/:orgId/projects/:projectId/security-headers/csp/"
+            />
+            <Redirect
+              from="security-headers/expect-ct/"
+              to="/settings/:orgId/projects/:projectId/security-headers/expect-ct/"
+            />
+            <Redirect
+              from="security-headers/hpkp/"
+              to="/settings/:orgId/projects/:projectId/security-headers/hpkp/"
+            />
+            <Redirect
+              from="plugins/"
+              to="/settings/:orgId/projects/:projectId/plugins/"
+            />
+            <Redirect
+              from="plugins/:pluginId/"
+              to="/settings/:orgId/projects/:projectId/plugins/:pluginId/"
+            />
+            <Redirect
+              from="integrations/:providerKey/"
+              to="/settings/:orgId/projects/:projectId/integrations/:providerKey/"
+            />
+            <Redirect
+              from="install/"
+              to="/settings/:orgId/projects/:projectId/install/"
+            />
+            <Redirect
+              from="install/:platform'"
+              to="/settings/:orgId/projects/:projectId/install/:platform/"
+            />
+          </Route>
+          <Redirect from=":projectId/group/:groupId/" to="issues/:groupId/" />
           <Redirect
-            from="alerts/rules/"
-            to="/settings/:orgId/projects/:projectId/alerts/rules/"
+            from=":projectId/issues/:groupId/"
+            to="/organizations/:orgId/issues/:groupId/"
           />
           <Redirect
-            from="alerts/rules/new/"
-            to="/settings/:orgId/projects/:projectId/alerts/rules/new/"
+            from=":projectId/issues/:groupId/events/"
+            to="/organizations/:orgId/issues/:groupId/events/"
           />
           <Redirect
-            from="alerts/rules/:ruleId/"
-            to="/settings/:orgId/projects/:projectId/alerts/rules/:ruleId/"
+            from=":projectId/issues/:groupId/events/:eventId/"
+            to="/organizations/:orgId/issues/:groupId/events/:eventId/"
           />
           <Redirect
-            from="environments/"
-            to="/settings/:orgId/projects/:projectId/environments/"
+            from=":projectId/issues/:groupId/tags/"
+            to="/organizations/:orgId/issues/:groupId/tags/"
           />
           <Redirect
-            from="environments/hidden/"
-            to="/settings/:orgId/projects/:projectId/environments/hidden/"
+            from=":projectId/issues/:groupId/tags/:tagKey/"
+            to="/organizations/:orgId/issues/:groupId/tags/:tagKey/"
           />
           <Redirect
-            from="tags/"
-            to="/settings/projects/:orgId/projects/:projectId/tags/"
+            from=":projectId/issues/:groupId/feedback/"
+            to="/organizations/:orgId/issues/:groupId/feedback/"
           />
           <Redirect
-            from="issue-tracking/"
-            to="/settings/:orgId/projects/:projectId/issue-tracking/"
+            from=":projectId/issues/:groupId/similar/"
+            to="/organizations/:orgId/issues/:groupId/similar/"
           />
           <Redirect
-            from="release-tracking/"
-            to="/settings/:orgId/projects/:projectId/release-tracking/"
+            from=":projectId/issues/:groupId/merged/"
+            to="/organizations/:orgId/issues/:groupId/merged/"
           />
-          <Redirect
-            from="ownership/"
-            to="/settings/:orgId/projects/:projectId/ownership/"
-          />
-          <Redirect
-            from="data-forwarding/"
-            to="/settings/:orgId/projects/:projectId/data-forwarding/"
-          />
-          <Redirect
-            from="debug-symbols/"
-            to="/settings/:orgId/projects/:projectId/debug-symbols/"
-          />
-          <Redirect
-            from="processing-issues/"
-            to="/settings/:orgId/projects/:projectId/processing-issues/"
-          />
-          <Redirect from="filters/" to="/settings/:orgId/projects/:projectId/filters/" />
-          <Redirect from="hooks/" to="/settings/:orgId/projects/:projectId/hooks/" />
-          <Redirect from="keys/" to="/settings/:orgId/projects/:projectId/keys/" />
-          <Redirect
-            from="keys/:keyId/"
-            to="/settings/:orgId/projects/:projectId/keys/:keyId/"
-          />
-          <Redirect
-            from="user-feedback/"
-            to="/settings/:orgId/projects/:projectId/user-feedback/"
-          />
-          <Redirect
-            from="security-headers/"
-            to="/settings/:orgId/projects/:projectId/security-headers/"
-          />
-          <Redirect
-            from="security-headers/csp/"
-            to="/settings/:orgId/projects/:projectId/security-headers/csp/"
-          />
-          <Redirect
-            from="security-headers/expect-ct/"
-            to="/settings/:orgId/projects/:projectId/security-headers/expect-ct/"
-          />
-          <Redirect
-            from="security-headers/hpkp/"
-            to="/settings/:orgId/projects/:projectId/security-headers/hpkp/"
-          />
-          <Redirect from="plugins/" to="/settings/:orgId/projects/:projectId/plugins/" />
-          <Redirect
-            from="plugins/:pluginId/"
-            to="/settings/:orgId/projects/:projectId/plugins/:pluginId/"
-          />
-          <Redirect
-            from="integrations/:providerKey/"
-            to="/settings/:orgId/projects/:projectId/integrations/:providerKey/"
-          />
-          <Redirect from="install/" to="/settings/:orgId/projects/:projectId/install/" />
-          <Redirect
-            from="install/:platform'"
-            to="/settings/:orgId/projects/:projectId/install/:platform/"
+          <Route
+            path=":projectId/events/:eventId/"
+            component={errorHandler(ProjectEventRedirect)}
           />
         </Route>
-        <Redirect from=":projectId/group/:groupId/" to="issues/:groupId/" />
-        <Redirect
-          from=":projectId/issues/:groupId/"
-          to="/organizations/:orgId/issues/:groupId/"
-        />
-        <Redirect
-          from=":projectId/issues/:groupId/events/"
-          to="/organizations/:orgId/issues/:groupId/events/"
-        />
-        <Redirect
-          from=":projectId/issues/:groupId/events/:eventId/"
-          to="/organizations/:orgId/issues/:groupId/events/:eventId/"
-        />
-        <Redirect
-          from=":projectId/issues/:groupId/tags/"
-          to="/organizations/:orgId/issues/:groupId/tags/"
-        />
-        <Redirect
-          from=":projectId/issues/:groupId/tags/:tagKey/"
-          to="/organizations/:orgId/issues/:groupId/tags/:tagKey/"
-        />
-        <Redirect
-          from=":projectId/issues/:groupId/feedback/"
-          to="/organizations/:orgId/issues/:groupId/feedback/"
-        />
-        <Redirect
-          from=":projectId/issues/:groupId/similar/"
-          to="/organizations/:orgId/issues/:groupId/similar/"
-        />
-        <Redirect
-          from=":projectId/issues/:groupId/merged/"
-          to="/organizations/:orgId/issues/:groupId/merged/"
-        />
+
+        {hook('routes')}
         <Route
-          path=":projectId/events/:eventId/"
-          component={errorHandler(ProjectEventRedirect)}
+          path="*"
+          component={errorHandler(RouteNotFound)}
+          onEnter={appendTrailingSlash}
         />
       </Route>
-
-      {hook('routes')}
-      <Route
-        path="*"
-        component={errorHandler(RouteNotFound)}
-        onEnter={appendTrailingSlash}
-      />
     </Route>
   );
 }

--- a/src/sentry/static/sentry/app/views/app/index.tsx
+++ b/src/sentry/static/sentry/app/views/app/index.tsx
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import {RouteComponentProps} from 'react-router/lib/Router';
-import {ThemeProvider} from 'emotion-theming';
 import {browserHistory} from 'react-router';
 import Cookies from 'js-cookie';
 import PropTypes from 'prop-types';
@@ -20,14 +19,12 @@ import AlertActions from 'app/actions/alertActions';
 import ConfigStore from 'app/stores/configStore';
 import ErrorBoundary from 'app/components/errorBoundary';
 import GlobalModal from 'app/components/globalModal';
-import GlobalStyles from 'app/styles/global';
 import HookStore from 'app/stores/hookStore';
 import Indicators from 'app/components/indicators';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import NewsletterConsent from 'app/views/newsletterConsent';
 import OrganizationsStore from 'app/stores/organizationsStore';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
-import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 import withConfig from 'app/utils/withConfig';
 
@@ -259,15 +256,12 @@ class App extends React.Component<Props, State> {
     }
 
     return (
-      <ThemeProvider theme={theme}>
-        <GlobalStyles theme={theme} />
-        <div className="main-container" tabIndex={-1} ref={this.mainContainerRef}>
-          <GlobalModal onClose={this.handleGlobalModalClose} />
-          <SystemAlerts className="messages-container" />
-          <Indicators className="indicators-container" />
-          <ErrorBoundary>{this.renderBody()}</ErrorBoundary>
-        </div>
-      </ThemeProvider>
+      <div className="main-container" tabIndex={-1} ref={this.mainContainerRef}>
+        <GlobalModal onClose={this.handleGlobalModalClose} />
+        <SystemAlerts className="messages-container" />
+        <Indicators className="indicators-container" />
+        <ErrorBoundary>{this.renderBody()}</ErrorBoundary>
+      </div>
     );
   }
 }

--- a/tests/js/spec/components/modals/sudoModal.spec.jsx
+++ b/tests/js/spec/components/modals/sudoModal.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {Client} from 'app/api';
 import App from 'app/views/app';
@@ -47,7 +47,7 @@ describe('Sudo Modal', function() {
       ...ConfigStore.get('user'),
       hasPasswordAuth: true,
     });
-    const wrapper = mount(<App>{<div>placeholder content</div>}</App>);
+    const wrapper = mountWithTheme(<App>{<div>placeholder content</div>}</App>);
 
     const api = new Client();
     const successCb = jest.fn();
@@ -131,7 +131,7 @@ describe('Sudo Modal', function() {
       ...ConfigStore.get('user'),
       hasPasswordAuth: false,
     });
-    const wrapper = mount(<App>{<div>placeholder content</div>}</App>);
+    const wrapper = mountWithTheme(<App>{<div>placeholder content</div>}</App>);
 
     const api = new Client();
     const successCb = jest.fn();


### PR DESCRIPTION
This moves our experimental `/auth/login/` route outside of `views/app`. `views/app` expects the user to already be logged in. This fixes an issue where when you login via experimental SPA, you do not have a list of organizations to choose from since the request was made when you were logged out in the login screen.