### PR TITLE
fix(ecosystem): allow org token to be used to get project stats of project with no team

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -11,7 +11,7 @@ from sentry.api.helpers.environments import get_environments
 from sentry.api.exceptions import ResourceDoesNotExist, ProjectMoved
 from sentry.auth.superuser import is_active_superuser
 from sentry.auth.system import is_system_auth
-from sentry.models import OrganizationMember, Project, ProjectStatus, ProjectRedirect
+from sentry.models import OrganizationMember, Project, ProjectStatus, ProjectRedirect, SentryApp
 from sentry.utils.sdk import configure_scope, bind_organization_context
 
 from .organization import OrganizationPermission
@@ -47,6 +47,8 @@ class ProjectPermission(OrganizationPermission):
             # this is only for team-less projects
             if is_active_superuser(request):
                 return True
+            elif request.user.is_sentry_app:
+                return SentryApp.check_project_permission_for_sentry_app_user(request.user, project)
             try:
                 role = (
                     OrganizationMember.objects.filter(

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -132,6 +132,16 @@ class SentryApp(ParanoidModel, HasApiScopes):
 
         return cls.objects.filter(status=SentryAppStatus.PUBLISHED)
 
+    # this method checks if a user from a sentry app has permission to a specific project
+    # for now, only checks if app is installed on the org of the project
+    @classmethod
+    def check_project_permission_for_sentry_app_user(cls, user, project):
+        assert user.is_sentry_app
+        # if the user exists, so should the sentry_app
+        sentry_app = cls.objects.get(proxy_user=user)
+        org = project.organization
+        return sentry_app.is_installed_on(org)
+
     @property
     def is_published(self):
         return self.status == SentryAppStatus.PUBLISHED

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -139,8 +139,7 @@ class SentryApp(ParanoidModel, HasApiScopes):
         assert user.is_sentry_app
         # if the user exists, so should the sentry_app
         sentry_app = cls.objects.get(proxy_user=user)
-        org = project.organization
-        return sentry_app.is_installed_on(org)
+        return sentry_app.is_installed_on(project.organization)
 
     @property
     def is_published(self):

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -58,12 +58,12 @@ class SentryAppInstallation(ParanoidModel):
         related_name="sentry_app_installation",
     )
 
-    # Two scenarios for tokens:
-    # 1) An installation gets an access token once the Grant has been exchanged,
+    # Only use this token for public integrtions since each install has only token at a time
+    # An installation gets an access token once the Grant has been exchanged,
     # and is updated when the token gets refreshed.
     #
-    # 2) An installation is created for an internal SentryApp. This token will
-    # not need to be refreshed as it will live forever
+    # Do NOT Use this token for internal integrations since there could be multiple
+    # need to look at SentryAppInstallationToken which connects api_tokens to installations
     api_token = models.OneToOneField(
         "sentry.ApiToken",
         null=True,


### PR DESCRIPTION
This PR fixes a bug where an org token did not work on any endpoint that checked project permissions for a project with no teams. If a user is a sentry_app, we check to see if the sentry app is installed for that org and return true if it does.