### PR TITLE
feat(apm): Add trace hovercard to the issue details page

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -179,6 +179,7 @@ class EventEntries extends React.Component {
 
     const features =
       organization && organization.features ? new Set(organization.features) : new Set();
+    const hasQueryFeature = features.has('discover-query');
 
     if (!event) {
       return (
@@ -218,6 +219,7 @@ class EventEntries extends React.Component {
             orgId={organization.slug}
             projectId={project.slug}
             location={location}
+            hasQueryFeature={hasQueryFeature}
           />
         )}
         {this.renderEntries()}

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTags.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTags.tsx
@@ -37,6 +37,7 @@ const EventTags = ({event: {tags}, orgId, projectId, location}: Props) => {
             tag={tag}
             projectId={projectId}
             orgId={orgId}
+            location={location}
             query={generateQueryWithTag(location.query, tag)}
             streamPath={streamPath}
             releasesPath={releasesPath}

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTags.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTags.tsx
@@ -18,9 +18,16 @@ type Props = {
   orgId: string;
   projectId: string;
   location: Location;
+  hasQueryFeature: boolean;
 };
 
-const EventTags = ({event: {tags}, orgId, projectId, location}: Props) => {
+const EventTags = ({
+  event: {tags},
+  orgId,
+  projectId,
+  location,
+  hasQueryFeature,
+}: Props) => {
   if (isEmpty(tags)) {
     return null;
   }
@@ -42,6 +49,7 @@ const EventTags = ({event: {tags}, orgId, projectId, location}: Props) => {
             streamPath={streamPath}
             releasesPath={releasesPath}
             meta={getMeta(tag, 'value')}
+            hasQueryFeature={hasQueryFeature}
           />
         ))}
       </Pills>

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
@@ -56,7 +56,7 @@ const EventTagsPill = ({
       </Link>
       {isUrl(tag.value) && (
         <a href={tag.value} className="external-icon">
-          <IconOpen size="xs" />
+          <StyledIconOpen size="xs" />
         </a>
       )}
       {isRelease && (
@@ -88,8 +88,7 @@ const EventTagsPill = ({
           {({to}) => {
             return (
               <Link to={to}>
-                <IconOpen size="xs" />
-                {/* <InlineSvg src="icon-circle-info" size="14px" /> */}
+                <StyledIconOpen size="xs" />
               </Link>
             );
           }}
@@ -100,6 +99,11 @@ const EventTagsPill = ({
 };
 
 const StyledIconInfo = styled(IconInfo)`
+  position: relative;
+  top: 1px;
+`;
+
+const StyledIconOpen = styled(IconOpen)`
   position: relative;
   top: 1px;
 `;

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
@@ -82,7 +82,6 @@ const EventTagsPill = ({
           containerClassName="pill-icon"
           traceId={tag.value}
           orgId={orgId}
-          projectId={projectId}
           location={location}
         >
           {({to}) => {

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {Link} from 'react-router';
 import * as queryString from 'query-string';
-import {Query} from 'history';
+import {Query, Location} from 'history';
 
 import {EventTag, Meta} from 'app/types';
 import AnnotatedText from 'app/components/events/meta/annotatedText';
@@ -10,6 +10,7 @@ import DeviceName from 'app/components/deviceName';
 import {isUrl} from 'app/utils';
 import Pill from 'app/components/pill';
 import VersionHoverCard from 'app/components/versionHoverCard';
+import TraceHoverCard from 'app/utils/discover/traceHoverCard';
 import Version from 'app/components/version';
 import {IconOpen, IconInfo} from 'app/icons';
 
@@ -18,6 +19,7 @@ type Props = {
   streamPath: string;
   releasesPath: string;
   query: Query;
+  location: Location;
   orgId: string;
   projectId: string;
   meta: Meta;
@@ -31,9 +33,11 @@ const EventTagsPill = ({
   streamPath,
   releasesPath,
   meta,
+  location,
 }: Props) => {
   const locationSearch = `?${queryString.stringify(query)}`;
   const isRelease = tag.key === 'release';
+  const isTrace = tag.key === 'trace';
   return (
     <Pill key={tag.key} name={tag.key} value={tag.value}>
       <Link
@@ -72,6 +76,24 @@ const EventTagsPill = ({
             </Link>
           </VersionHoverCard>
         </div>
+      )}
+      {isTrace && (
+        <TraceHoverCard
+          containerClassName="pill-icon"
+          traceId={tag.value}
+          orgId={orgId}
+          projectId={projectId}
+          location={location}
+        >
+          {({to}) => {
+            return (
+              <Link to={to}>
+                <IconOpen size="xs" />
+                {/* <InlineSvg src="icon-circle-info" size="14px" /> */}
+              </Link>
+            );
+          }}
+        </TraceHoverCard>
       )}
     </Pill>
   );

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
@@ -23,6 +23,7 @@ type Props = {
   orgId: string;
   projectId: string;
   meta: Meta;
+  hasQueryFeature: boolean;
 };
 
 const EventTagsPill = ({
@@ -34,6 +35,7 @@ const EventTagsPill = ({
   releasesPath,
   meta,
   location,
+  hasQueryFeature,
 }: Props) => {
   const locationSearch = `?${queryString.stringify(query)}`;
   const isRelease = tag.key === 'release';
@@ -77,7 +79,7 @@ const EventTagsPill = ({
           </VersionHoverCard>
         </div>
       )}
-      {isTrace && (
+      {isTrace && hasQueryFeature && (
         <TraceHoverCard
           containerClassName="pill-icon"
           traceId={tag.value}

--- a/src/sentry/static/sentry/app/utils/discover/traceHoverCard.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/traceHoverCard.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import {Location, LocationDescriptor} from 'history';
+import styled from '@emotion/styled';
+
+import {t} from 'app/locale';
+import withApi from 'app/utils/withApi';
+import {Client} from 'app/api';
+import Hovercard from 'app/components/hovercard';
+import Version from 'app/components/version';
+import space from 'app/styles/space';
+import Clipboard from 'app/components/clipboard';
+import {IconCopy} from 'app/icons';
+import {TableData} from 'app/views/eventsV2/table/types';
+import Button from 'app/components/button';
+import LoadingIndicator from 'app/components/loadingIndicator';
+import LoadingError from 'app/components/loadingError';
+
+import EventView from './eventView';
+import DiscoverQuery from './discoverQuery';
+
+type ChildrenProps = {to};
+
+type Props = {
+  api: Client;
+
+  orgId: string;
+  traceId: string;
+  projectId: string;
+
+  location: Location;
+
+  children: (props: ChildrenProps) => React.ReactNode;
+
+  // hover card props
+  containerClassName: string;
+};
+
+class TraceHoverCard extends React.Component<Props> {
+  renderHeader() {
+    const {traceId} = this.props;
+
+    return (
+      <HeaderWrapper>
+        <span>{t('Trace')}</span>
+        <TraceWrapper>
+          <StyledTrace version={traceId} truncate anchor={false} />
+          <Clipboard value={traceId}>
+            <ClipboardIconWrapper>
+              <IconCopy size="xs" />
+            </ClipboardIconWrapper>
+          </Clipboard>
+        </TraceWrapper>
+      </HeaderWrapper>
+    );
+  }
+
+  renderBody({
+    tableData,
+    isLoading,
+    error,
+    to,
+  }: {
+    tableData: TableData | null;
+    isLoading: boolean;
+    error: null | string;
+    to: LocationDescriptor;
+  }) {
+    if (isLoading) {
+      return (
+        <LoadingWrapper>
+          <LoadingIndicator mini />
+        </LoadingWrapper>
+      );
+    }
+
+    if (error) {
+      return <LoadingError />;
+    }
+
+    if (!tableData) {
+      return null;
+    }
+
+    const numOfTransactions = tableData?.data.length ?? 0;
+
+    return (
+      <div>
+        <div>
+          <h6>{t('Number of Transactions')}</h6>
+          <div className="count-since">{numOfTransactions}</div>
+        </div>
+        <div>
+          <StyledButton size="xsmall" to={to}>
+            {t('Search Transactions')}
+          </StyledButton>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    const {traceId, location, api, orgId} = this.props;
+
+    const traceEventView = EventView.fromSavedQuery({
+      id: undefined,
+      name: `Transactions with Trace ID ${traceId}`,
+      fields: [
+        'transaction',
+        'project',
+        'trace.span',
+        'transaction.duration',
+        'timestamp',
+      ],
+      orderby: '-timestamp',
+      query: `event.type:transaction trace:${traceId}`,
+      // TODO: fix
+      projects: [],
+      version: 2,
+
+      //   TODO: fix
+      range: '90d',
+      //   start,
+      //   end,
+    });
+
+    const to = traceEventView.getResultsViewUrlTarget(orgId);
+
+    return (
+      <DiscoverQuery
+        api={api}
+        location={location}
+        eventView={traceEventView}
+        orgSlug={orgId}
+      >
+        {({isLoading, error, tableData}) => {
+          return (
+            <Hovercard
+              {...this.props}
+              header={this.renderHeader()}
+              body={this.renderBody({isLoading, error, tableData, to})}
+            >
+              {this.props.children({to})}
+            </Hovercard>
+          );
+        }}
+      </DiscoverQuery>
+    );
+  }
+}
+
+const HeaderWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const TraceWrapper = styled('div')`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: flex-end;
+`;
+
+const StyledTrace = styled(Version)`
+  margin-right: ${space(0.5)};
+  max-width: 190px;
+`;
+
+const ClipboardIconWrapper = styled('span')`
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const StyledButton = styled(Button)`
+  margin-top: ${space(1)};
+`;
+
+const LoadingWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export default withApi(TraceHoverCard);

--- a/src/sentry/static/sentry/app/utils/discover/traceHoverCard.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/traceHoverCard.tsx
@@ -11,14 +11,13 @@ import space from 'app/styles/space';
 import Clipboard from 'app/components/clipboard';
 import {IconCopy} from 'app/icons';
 import {TableData} from 'app/views/eventsV2/table/types';
-import Button from 'app/components/button';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingError from 'app/components/loadingError';
 
 import EventView from './eventView';
 import DiscoverQuery from './discoverQuery';
 
-type ChildrenProps = {to};
+type ChildrenProps = {to: LocationDescriptor};
 
 type Props = {
   api: Client;
@@ -58,12 +57,10 @@ class TraceHoverCard extends React.Component<Props> {
     tableData,
     isLoading,
     error,
-    to,
   }: {
     tableData: TableData | null;
     isLoading: boolean;
     error: null | string;
-    to: LocationDescriptor;
   }) {
     if (isLoading) {
       return (
@@ -86,13 +83,8 @@ class TraceHoverCard extends React.Component<Props> {
     return (
       <div>
         <div>
-          <h6>{t('Number of Transactions')}</h6>
+          <h6>{t('Transactions')}</h6>
           <div className="count-since">{numOfTransactions}</div>
-        </div>
-        <div>
-          <StyledButton size="xsmall" to={to}>
-            {t('Search Transactions')}
-          </StyledButton>
         </div>
       </div>
     );
@@ -100,28 +92,24 @@ class TraceHoverCard extends React.Component<Props> {
 
   render() {
     const {traceId, location, api, orgId} = this.props;
-
-    const traceEventView = EventView.fromSavedQuery({
-      id: undefined,
-      name: `Transactions with Trace ID ${traceId}`,
-      fields: [
-        'transaction',
-        'project',
-        'trace.span',
-        'transaction.duration',
-        'timestamp',
-      ],
-      orderby: '-timestamp',
-      query: `event.type:transaction trace:${traceId}`,
-      // TODO: fix
-      projects: [],
-      version: 2,
-
-      //   TODO: fix
-      range: '90d',
-      //   start,
-      //   end,
-    });
+    const traceEventView = EventView.fromNewQueryWithLocation(
+      {
+        id: undefined,
+        name: `Transactions with Trace ID ${traceId}`,
+        fields: [
+          'transaction',
+          'project',
+          'trace.span',
+          'transaction.duration',
+          'timestamp',
+        ],
+        orderby: '-timestamp',
+        query: `event.type:transaction trace:${traceId}`,
+        projects: [],
+        version: 2,
+      },
+      location
+    );
 
     const to = traceEventView.getResultsViewUrlTarget(orgId);
 
@@ -137,7 +125,7 @@ class TraceHoverCard extends React.Component<Props> {
             <Hovercard
               {...this.props}
               header={this.renderHeader()}
-              body={this.renderBody({isLoading, error, tableData, to})}
+              body={this.renderBody({isLoading, error, tableData})}
             >
               {this.props.children({to})}
             </Hovercard>
@@ -170,10 +158,6 @@ const ClipboardIconWrapper = styled('span')`
   &:hover {
     cursor: pointer;
   }
-`;
-
-const StyledButton = styled(Button)`
-  margin-top: ${space(1)};
 `;
 
 const LoadingWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/utils/discover/traceHoverCard.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/traceHoverCard.tsx
@@ -24,7 +24,6 @@ type Props = {
 
   orgId: string;
   traceId: string;
-  projectId: string;
 
   location: Location;
 

--- a/src/sentry/static/sentry/app/utils/discover/traceHoverCard.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/traceHoverCard.tsx
@@ -77,7 +77,7 @@ class TraceHoverCard extends React.Component<Props> {
       return null;
     }
 
-    const numOfTransactions = tableData?.data.length ?? 0;
+    const numOfTransactions = tableData?.data[0]?.count ?? 0;
 
     return (
       <div>
@@ -91,6 +91,21 @@ class TraceHoverCard extends React.Component<Props> {
 
   render() {
     const {traceId, location, api, orgId} = this.props;
+
+    // used to fetch number of transactions to display in hovercard
+    const numTransactionsEventView = EventView.fromNewQueryWithLocation(
+      {
+        id: undefined,
+        name: `Transactions with Trace ID ${traceId}`,
+        fields: ['count()'],
+        query: `event.type:transaction trace:${traceId}`,
+        projects: [],
+        version: 2,
+      },
+      location
+    );
+
+    // used to create link to discover page with relevant query
     const traceEventView = EventView.fromNewQueryWithLocation(
       {
         id: undefined,
@@ -116,7 +131,7 @@ class TraceHoverCard extends React.Component<Props> {
       <DiscoverQuery
         api={api}
         location={location}
-        eventView={traceEventView}
+        eventView={numTransactionsEventView}
         orgSlug={orgId}
       >
         {({isLoading, error, tableData}) => {

--- a/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
@@ -513,6 +513,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                 "title": "ApiException",
                               }
                             }
+                            hasQueryFeature={false}
                             orgId="test-org"
                             projectId="project-slug"
                           />


### PR DESCRIPTION
Creates a trace hover card similar to the releases hover card in order to provide a convenient flow from the Sentry events in Issues to Transaction events in Discover. 

The hover card currently shows number of transactions and errors associated with the trace. Clicking the icon will lead the user to a discover query page showing events with that trace

![image](https://user-images.githubusercontent.com/9372512/88202323-b8ccd580-cc16-11ea-84fb-d055f68f6486.png)

Ref: WOR-71