### PR TITLE
feat(performance) Convert EPM to TPM

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -21,6 +21,10 @@ function defaultValueFormatter(value) {
   return value;
 }
 
+function defaultNameFormatter(value) {
+  return value;
+}
+
 function getSeriesValue(series, offset) {
   if (Array.isArray(series.data)) {
     return series.data[offset];
@@ -40,6 +44,7 @@ function getFormatter({
   formatAxisLabel,
   utc,
   valueFormatter = defaultValueFormatter,
+  nameFormatter = defaultNameFormatter,
 }) {
   const getFilter = seriesParam => {
     // Series do not necessarily have `data` defined, e.g. releases don't have `data`, but rather
@@ -80,6 +85,7 @@ function getFormatter({
         seriesParamsOrParam.data.coord[1],
         seriesParamsOrParam.name
       );
+
       return [
         '<div class="tooltip-series">',
         `<div>
@@ -110,7 +116,9 @@ function getFormatter({
       seriesParams
         .filter(getFilter)
         .map(s => {
-          const formattedLabel = truncationFormatter(s.seriesName, truncate);
+          const formattedLabel = nameFormatter(
+            truncationFormatter(s.seriesName, truncate)
+          );
           const value = valueFormatter(getSeriesValue(s, 1), s.seriesName);
           return `<div><span class="tooltip-label">${s.marker} <strong>${formattedLabel}</strong></span> ${value}</div>`;
         })
@@ -131,6 +139,7 @@ export default function Tooltip({
   utc,
   formatAxisLabel,
   valueFormatter,
+  nameFormatter,
   ...props
 } = {}) {
   formatter =
@@ -143,6 +152,7 @@ export default function Tooltip({
       utc,
       formatAxisLabel,
       valueFormatter,
+      nameFormatter,
     });
 
   return {

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -71,6 +71,11 @@ class Chart extends React.Component<Props> {
       isGroupedByDate: true,
       showTimeInTooltip: true,
       colors: [colors[0], colors[0]],
+      tooltip: {
+        nameFormatter(value) {
+          return value === 'epm()' ? 'tpm()' : value;
+        },
+      },
     };
 
     if (loading) {

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -29,9 +29,9 @@ const YAXIS_OPTIONS = [
     tooltip: PERFORMANCE_TERMS.apdex,
   },
   {
-    label: 'Throughput',
+    label: 'Transactions per Minute',
     value: 'epm()',
-    tooltip: PERFORMANCE_TERMS.epm,
+    tooltip: PERFORMANCE_TERMS.tpm,
   },
 ];
 

--- a/src/sentry/static/sentry/app/views/performance/constants.tsx
+++ b/src/sentry/static/sentry/app/views/performance/constants.tsx
@@ -4,7 +4,7 @@ export const PERFORMANCE_TERMS: Record<string, string> = {
   apdex: t(
     'Apdex is the ratio of both satisfactory and tolerable response times to all response times.'
   ),
-  epm: t('Throughput is the number of recorded events per minute (epm).'),
+  tpm: t('TPM is the number of recorded transaction events per minute.'),
   errorRate: t(
     'Error rate is the percentage of recorded transactions that had a known and unsuccessful status.'
   ),

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -29,7 +29,7 @@ export const PERFORMANCE_EVENT_VIEW: Readonly<NewQuery> = {
 export const COLUMN_TITLES = [
   'transaction',
   'project',
-  'throughput',
+  'tpm',
   'p50',
   'p95',
   'error rate',


### PR DESCRIPTION
It's possible that users will be confused by "events per" in performance, since
the numbers will never include other event types. So instead change the naming
to TPM or "transactions per" to make it crystal clear what is being shown.