### PR TITLE
ref(integrations): Audit logs for install/uninstall

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -31,8 +31,8 @@ from sentry.shared_integrations.constants import (
     ERR_INTERNAL,
     ERR_UNSUPPORTED_RESPONSE_TYPE,
 )
-from sentry.models import Identity, OrganizationIntegration
-
+from sentry.models import AuditLogEntryEvent, Identity, OrganizationIntegration
+from sentry.utils.audit import create_audit_entry
 
 FeatureDescription = namedtuple(
     "FeatureDescription",
@@ -173,6 +173,21 @@ class IntegrationProvider(PipelineProvider):
 
     def post_install(self, integration, organization, extra=None):
         pass
+
+    def create_install_audit_log_entry(
+        self, integration, organization, request, action, extra=None
+    ):
+        """
+        Creates an audit log entry for the newly installed integration.
+        """
+        if action == "install":
+            create_audit_entry(
+                request=request,
+                organization=organization,
+                target_object=integration.id,
+                event=AuditLogEntryEvent.INTEGRATION_ADD,
+                data={"provider": integration.provider, "name": integration.name},
+            )
 
     def get_pipeline_views(self):
         """

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -174,9 +174,7 @@ class IntegrationProvider(PipelineProvider):
     def post_install(self, integration, organization, extra=None):
         pass
 
-    def create_install_audit_log_entry(
-        self, integration, organization, request, action, extra=None
-    ):
+    def create_audit_log_entry(self, integration, organization, request, action, extra=None):
         """
         Creates an audit log entry for the newly installed integration.
         """

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -53,8 +53,11 @@ class IntegrationPipeline(Pipeline):
         response = self._finish_pipeline(data)
 
         extra = data.get("post_install_data")
-
+        action = "upgrade" if extra else "install"
         # to Slack
+        self.provider.create_install_audit_log_entry(
+            self.integration, self.organization, self.request, action, extra=extra
+        )
         self.provider.post_install(self.integration, self.organization, extra=extra)
         self.clear_session()
         return response

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -55,7 +55,7 @@ class IntegrationPipeline(Pipeline):
         extra = data.get("post_install_data")
         action = "upgrade" if extra else "install"
         # to Slack
-        self.provider.create_install_audit_log_entry(
+        self.provider.create_audit_log_entry(
             self.integration, self.organization, self.request, action, extra=extra
         )
         self.provider.post_install(self.integration, self.organization, extra=extra)

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -191,6 +191,10 @@ class SlackIntegrationProvider(IntegrationProvider):
         return integration
 
     def create_audit_log_entry(self, integration, organization, request, action, extra=None):
+        super(SlackIntegrationProvider, self).create_audit_log_entry(
+            integration, organization, request, action
+        )
+
         if action == "upgrade":
             create_audit_entry(
                 request=request,
@@ -211,10 +215,6 @@ class SlackIntegrationProvider(IntegrationProvider):
                     )
 
             return
-
-        super(SlackIntegrationProvider, self).create_audit_log_entry(
-            integration, organization, request, action
-        )
 
     def post_install(self, integration, organization, extra=None):
         # normal installtions don't have extra, quit immediately

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -190,9 +190,7 @@ class SlackIntegrationProvider(IntegrationProvider):
 
         return integration
 
-    def create_install_audit_log_entry(
-        self, integration, organization, request, action, extra=None
-    ):
+    def create_audit_log_entry(self, integration, organization, request, action, extra=None):
         if action == "upgrade":
             create_audit_entry(
                 request=request,
@@ -206,7 +204,7 @@ class SlackIntegrationProvider(IntegrationProvider):
                 for org in Organization.objects.filter(slug__in=extra["extra_orgs"]):
                     create_audit_entry(
                         request=request,
-                        organization=organization,
+                        organization=org,
                         target_object=integration.id,
                         event=AuditLogEntryEvent.INTEGRATION_UPGRADE,
                         data={"provider": integration.provider, "name": integration.name},
@@ -214,7 +212,7 @@ class SlackIntegrationProvider(IntegrationProvider):
 
             return
 
-        super(IntegrationProvider, self).create_install_audit_log_entry(
+        super(SlackIntegrationProvider, self).create_audit_log_entry(
             integration, organization, request, action
         )
 

--- a/src/sentry/mediators/sentry_apps/internal_creator.py
+++ b/src/sentry/mediators/sentry_apps/internal_creator.py
@@ -64,6 +64,7 @@ class InternalCreator(Mediator):
                 organization=self.organization,
                 target_object=self.organization.id,
                 event=AuditLogEntryEvent.INTERNAL_INTEGRATION_ADD,
+                data={"name": self.sentry_app.name},
             )
 
     def record_analytics(self):

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -75,6 +75,7 @@ class AuditLogEntryEvent(object):
     SERVICEHOOK_ENABLE = 103
     SERVICEHOOK_DISABLE = 104
 
+    INTEGRATION_UPGRADE = 109
     INTEGRATION_ADD = 110
     INTEGRATION_EDIT = 111
     INTEGRATION_REMOVE = 112
@@ -160,6 +161,7 @@ class AuditLogEntry(Model):
             (AuditLogEntryEvent.SERVICEHOOK_REMOVE, "servicehook.remove"),
             (AuditLogEntryEvent.SERVICEHOOK_ENABLE, "servicehook.enable"),
             (AuditLogEntryEvent.SERVICEHOOK_DISABLE, "servicehook.disable"),
+            (AuditLogEntryEvent.INTEGRATION_UPGRADE, "integration.upgrade"),
             (AuditLogEntryEvent.INTEGRATION_ADD, "integration.add"),
             (AuditLogEntryEvent.INTEGRATION_EDIT, "integration.edit"),
             (AuditLogEntryEvent.INTEGRATION_REMOVE, "integration.remove"),
@@ -358,20 +360,42 @@ class AuditLogEntry(Model):
             return 'disabled the service hook for "%s"' % (truncatechars(self.data["url"], 64),)
 
         elif self.event == AuditLogEntryEvent.INTEGRATION_ADD:
-            return "enabled integration %s for project %s" % (
-                self.data["integration"],
-                self.data["project"],
-            )
+            if self.data.get("provider"):
+                return "installed %s for the %s integration" % (
+                    self.data["name"],
+                    self.data["provider"],
+                )
+            else:
+                return "enabled integration %s for project %s" % (
+                    self.data["integration"],
+                    self.data["project"],
+                )
         elif self.event == AuditLogEntryEvent.INTEGRATION_EDIT:
+            if self.data.get("provider"):
+                return "edited the %s for the %s integration" % (
+                    self.data["name"],
+                    self.data["provider"],
+                )
             return "edited integration %s for project %s" % (
                 self.data["integration"],
                 self.data["project"],
             )
         elif self.event == AuditLogEntryEvent.INTEGRATION_REMOVE:
+            if self.data.get("provider"):
+                return "uninstalled %s for the %s integration" % (
+                    self.data["name"],
+                    self.data["provider"],
+                )
             return "disabled integration %s from project %s" % (
                 self.data["integration"],
                 self.data["project"],
             )
+        elif self.event == AuditLogEntryEvent.INTEGRATION_UPGRADE:
+            if self.data.get("provider"):
+                return "upgraded %s for the %s integration" % (
+                    self.data["name"],
+                    self.data["provider"],
+                )
 
         elif self.event == AuditLogEntryEvent.SENTRY_APP_ADD:
             return "created sentry app %s" % (self.data["sentry_app"])
@@ -381,6 +405,8 @@ class AuditLogEntry(Model):
             return "installed sentry app %s" % (self.data["sentry_app"])
         elif self.event == AuditLogEntryEvent.SENTRY_APP_UNINSTALL:
             return "uninstalled sentry app %s" % (self.data["sentry_app"])
+        elif self.event == AuditLogEntryEvent.INTERNAL_INTEGRATION_ADD:
+            return "created internal integration %s" % (self.data.get("name", ""))
         elif self.event == AuditLogEntryEvent.INTERNAL_INTEGRATION_ADD_TOKEN:
             return "created a token for internal integration %s" % (self.data["sentry_app"])
         elif self.event == AuditLogEntryEvent.INTERNAL_INTEGRATION_REMOVE_TOKEN:

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -7,6 +7,8 @@ from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 
 from sentry.integrations.slack import SlackIntegrationProvider, SlackIntegration
 from sentry.models import (
+    AuditLogEntry,
+    AuditLogEntryEvent,
     Identity,
     IdentityProvider,
     IdentityStatus,
@@ -108,6 +110,9 @@ class SlackIntegrationTest(IntegrationTestCase):
         idp = IdentityProvider.objects.get(type="slack", external_id="TXXXXXXX1")
         identity = Identity.objects.get(idp=idp, user=self.user, external_id="UXXXXXXX1")
         assert identity.status == IdentityStatus.VALID
+
+        audit_entry = AuditLogEntry.objects.get(event=AuditLogEntryEvent.INTEGRATION_ADD)
+        assert audit_entry.get_note() == "installed Example for the slack integration"
 
     @responses.activate
     def test_multiple_integrations(self):


### PR DESCRIPTION
We don't currently have audit logs in place for our global integrations. However, we do have events in place already used by the plugins that we can use:
* `integration.add`
* `integration.edit`
* `integration.remove`

This PR only adds in the `integration.add` and `integration.remove` events. 

The former gets added through a method (`create_audit_log_entry`) on the IntegrationProvider since installing happens through the pipeline. 

The latter is just added through the `OrganizationIntegrationDetails` endpoint.

This PR also adds the `integration.upgrade` audit log event to be used by the Slack integration. We customize the audit log method to handle the upgrade flow and to make sure we create audit log entries for any of the organizations affected by an upgraded integration (same Slack workspace across multiple Sentry organizations)