### PR TITLE
fix(UI): fixes bug with navigateIfFinish called in an infinite loop

### DIFF
--- a/src/sentry/static/sentry/app/components/contextPickerModal.tsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.tsx
@@ -86,7 +86,7 @@ class ContextPickerModal extends React.Component<Props> {
   componentDidUpdate(prevProps: Props) {
     // Component may be mounted before projects is fetched, check if we can finish when
     // component is updated with projects
-    if (prevProps.projects !== this.props.projects) {
+    if (JSON.stringify(prevProps.projects) !== JSON.stringify(this.props.projects)) {
       this.navigateIfFinish(this.props.organizations, this.props.projects);
     }
   }


### PR DESCRIPTION
This fixes a bug where `componentDidUpdate` triggers a prop updates in an infinite loop when using the context modal picker when the user has exactly 1 project when pressing "Add to Project" for a plugin. For some reason, `props.projects` is a new array so the shallow equality check fails. This switches to using a deep equality check since the actual contents are the same. Note that props rarely update for this component so the performance hit of stringifying projects should be negligible.