### PR TITLE
dev: unify make install-sentry-dev -> install-dev

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -57,7 +57,7 @@ It's recommended to use pyenv - please refer to https://docs.sentry.io/developme
 }
 
 advice_install_sentry () {
-    info "To install sentry, please type: make install-dev"
+    info "To install sentry, please type: make install-py-dev"
     return 1
 }
 
@@ -142,7 +142,7 @@ python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
 if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
     info "Your .venv is activated, but sentry doesn't seem to be installed."
     # XXX: if direnv fails, the venv won't be activated outside of direnv execution...
-    # So, it is critical that make install-dev is guarded by scripts/ensure-venv.
+    # So, it is critical that make install-py-dev is guarded by scripts/ensure-venv.
     advice_install_sentry
 fi
 

--- a/.envrc
+++ b/.envrc
@@ -67,7 +67,7 @@ advice_install_pre_commit () {
 }
 
 advice_install_yarn_pkgs () {
-    info "To install yarn packages, please type: make install-yarn-pkgs"
+    info "To install yarn packages, please type: make install-js-dev"
     return 1
 }
 

--- a/.envrc
+++ b/.envrc
@@ -57,7 +57,7 @@ It's recommended to use pyenv - please refer to https://docs.sentry.io/developme
 }
 
 advice_install_sentry () {
-    info "To install sentry, please type: make install-sentry-dev"
+    info "To install sentry, please type: make install-dev"
     return 1
 }
 
@@ -142,7 +142,7 @@ python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
 if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
     info "Your .venv is activated, but sentry doesn't seem to be installed."
     # XXX: if direnv fails, the venv won't be activated outside of direnv execution...
-    # So, it is critical that make install-sentry-dev is guarded by scripts/ensure-venv.
+    # So, it is critical that make install-dev is guarded by scripts/ensure-venv.
     advice_install_sentry
 fi
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ YARN := ./bin/yarn
 
 bootstrap: develop init-config run-dependent-services create-db apply-migrations
 
-develop: ensure-pinned-pip setup-git install-yarn-pkgs install-sentry-dev
+develop: ensure-pinned-pip setup-git install-yarn-pkgs install-dev
 
 clean:
 	@echo "--> Cleaning static cache"
@@ -83,7 +83,7 @@ install-yarn-pkgs: node-version-check
 	# Add an additional check against `node_modules`
 	$(YARN) check --verify-tree || $(YARN) install --check-files
 
-install-sentry-dev: ensure-pinned-pip
+install-dev: ensure-pinned-pip
 	@echo "--> Installing Sentry (for development)"
 	# SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
 	# Webpacked assets are only necessary for devserver (which does it lazily anyways)
@@ -226,7 +226,7 @@ lint-js:
 	@echo ""
 
 
-.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint-js
+.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint-js
 
 
 ############################

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ YARN := ./bin/yarn
 
 bootstrap: develop init-config run-dependent-services create-db apply-migrations
 
-develop: ensure-pinned-pip setup-git install-yarn-pkgs install-py-dev
+develop: ensure-pinned-pip setup-git install-js-dev install-py-dev
 
 clean:
 	@echo "--> Cleaning static cache"
@@ -73,7 +73,7 @@ setup-git: ensure-venv setup-git-config
 node-version-check:
 	@test "$$(node -v)" = v"$$(cat .nvmrc)" || (echo 'node version does not match .nvmrc. Recommended to use https://github.com/volta-cli/volta'; exit 1)
 
-install-yarn-pkgs: node-version-check
+install-js-dev: node-version-check
 	@echo "--> Installing Yarn packages (for development)"
 	# Use NODE_ENV=development so that yarn installs both dependencies + devDependencies
 	NODE_ENV=development $(YARN) install --frozen-lockfile
@@ -226,7 +226,7 @@ lint-js:
 	@echo ""
 
 
-.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-py-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint-js
+.PHONY: develop build reset-db clean setup-git node-version-check install-js-dev install-py-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint-js
 
 
 ############################

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ YARN := ./bin/yarn
 
 bootstrap: develop init-config run-dependent-services create-db apply-migrations
 
-develop: ensure-pinned-pip setup-git install-yarn-pkgs install-dev
+develop: ensure-pinned-pip setup-git install-yarn-pkgs install-py-dev
 
 clean:
 	@echo "--> Cleaning static cache"
@@ -83,7 +83,7 @@ install-yarn-pkgs: node-version-check
 	# Add an additional check against `node_modules`
 	$(YARN) check --verify-tree || $(YARN) install --check-files
 
-install-dev: ensure-pinned-pip
+install-py-dev: ensure-pinned-pip
 	@echo "--> Installing Sentry (for development)"
 	# SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
 	# Webpacked assets are only necessary for devserver (which does it lazily anyways)
@@ -226,7 +226,7 @@ lint-js:
 	@echo ""
 
 
-.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint-js
+.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-py-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint-js
 
 
 ############################

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -10,7 +10,7 @@ trap "rm -f ${files_changed_upstream}" EXIT
 git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD > "$files_changed_upstream"
 
 grep -E --quiet 'requirements.*\.txt' "$files_changed_upstream" && py="install-py-dev "
-grep -E --quiet 'yarn.lock' "$files_changed_upstream"           && js="install-yarn-pkgs "
+grep -E --quiet 'yarn.lock' "$files_changed_upstream"           && js="install-js-dev "
 grep -E --quiet 'migrations' "$files_changed_upstream"          && migrations="apply-migrations "
 
 [[ "$py" || "$js" || "$migrations" ]] && needs_update=1

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -9,7 +9,7 @@ trap "rm -f ${files_changed_upstream}" EXIT
 
 git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD > "$files_changed_upstream"
 
-grep -E --quiet 'requirements.*\.txt' "$files_changed_upstream" && py="install-dev "
+grep -E --quiet 'requirements.*\.txt' "$files_changed_upstream" && py="install-py-dev "
 grep -E --quiet 'yarn.lock' "$files_changed_upstream"           && js="install-yarn-pkgs "
 grep -E --quiet 'migrations' "$files_changed_upstream"          && migrations="apply-migrations "
 

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -9,7 +9,7 @@ trap "rm -f ${files_changed_upstream}" EXIT
 
 git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD > "$files_changed_upstream"
 
-grep -E --quiet 'requirements.*\.txt' "$files_changed_upstream" && py="install-sentry-dev "
+grep -E --quiet 'requirements.*\.txt' "$files_changed_upstream" && py="install-dev "
 grep -E --quiet 'yarn.lock' "$files_changed_upstream"           && js="install-yarn-pkgs "
 grep -E --quiet 'migrations' "$files_changed_upstream"          && migrations="apply-migrations "
 


### PR DESCRIPTION
See https://github.com/getsentry/develop/pull/36#discussion_r429463007.

There's no reason for this kind of inconsistency. Also, less stuff to type is nice.

getsentry: https://github.com/getsentry/getsentry/pull/3944