### PR TITLE
fix(ui) Fix incorrectly aligned buttons on CSP section

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
@@ -122,6 +122,7 @@ const Permalink = styled('a')`
 const SectionHeader = styled('div')<{isCentered?: boolean}>`
   display: flex;
   justify-content: space-between;
+  align-items: center;
   position: relative;
   margin-bottom: ${space(3)};
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/csp.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/csp.jsx
@@ -50,31 +50,34 @@ export default class CspInterface extends React.Component {
     const {view, data} = this.state;
     const {event} = this.props;
 
-    const title = (
-      <div>
-        <ButtonBar merged active={view}>
-          <Button
-            barId="report"
-            size="xsmall"
-            onClick={this.toggleView.bind(this, 'report')}
-          >
-            {t('Report')}
-          </Button>
-          <Button barId="raw" size="xsmall" onClick={this.toggleView.bind(this, 'raw')}>
-            {t('Raw')}
-          </Button>
-          <Button barId="help" size="xsmall" onClick={this.toggleView.bind(this, 'help')}>
-            {t('Help')}
-          </Button>
-        </ButtonBar>
-        <h3>{t('CSP Report')}</h3>
-      </div>
+    const actions = (
+      <ButtonBar merged active={view}>
+        <Button
+          barId="report"
+          size="xsmall"
+          onClick={this.toggleView.bind(this, 'report')}
+        >
+          {t('Report')}
+        </Button>
+        <Button barId="raw" size="xsmall" onClick={this.toggleView.bind(this, 'raw')}>
+          {t('Raw')}
+        </Button>
+        <Button barId="help" size="xsmall" onClick={this.toggleView.bind(this, 'help')}>
+          {t('Help')}
+        </Button>
+      </ButtonBar>
     );
 
     const children = getView(view, data);
 
     return (
-      <EventDataSection event={event} type="csp" title={title} wrapTitle={false}>
+      <EventDataSection
+        event={event}
+        type="csp"
+        title={<h3>{t('CSP Report')}</h3>}
+        actions={actions}
+        wrapTitle={false}
+      >
         {children}
       </EventDataSection>
     );

--- a/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
@@ -586,7 +586,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                     isCentered={false}
                                   >
                                     <div
-                                      className="css-zang02-SectionHeader e1fbjd861"
+                                      className="css-1ccwfms-SectionHeader e1fbjd861"
                                       id="message"
                                     >
                                       <Permalink


### PR DESCRIPTION
Fix the alignment of buttons on the CSP interface section. I've also tweaked the alignment of buttons on event sections so that they are center aligned in the heading flexbox, as small buttons were previously top aligned to the box and not the text.