### PR TITLE
ref(ui) Consolidate common dropdown pattern

### DIFF
--- a/docs-ui/components/dropdownControl.stories.js
+++ b/docs-ui/components/dropdownControl.stories.js
@@ -51,7 +51,18 @@ storiesOf('UI|Dropdowns/DropdownControl', module)
     'element label',
     withInfo('Element labels replace the button contents')(() => (
       <div className="clearfix">
-        <DropdownControl label={<em>Slanty</em>}>
+        <DropdownControl label={<em>Created Date</em>}>
+          <MenuItem href="">Item</MenuItem>
+          <MenuItem href="">Item</MenuItem>
+        </DropdownControl>
+      </div>
+    ))
+  )
+  .add(
+    'prefixed label',
+    withInfo('Element labels replace the button contents')(() => (
+      <div className="clearfix">
+        <DropdownControl buttonProps={{prefix: 'Sort By'}} label={<em>Created At</em>}>
           <MenuItem href="">Item</MenuItem>
           <MenuItem href="">Item</MenuItem>
         </DropdownControl>

--- a/src/sentry/static/sentry/app/components/dropdownButton.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownButton.tsx
@@ -5,7 +5,17 @@ import Button from 'app/components/button';
 import InlineSvg from 'app/components/inlineSvg';
 
 type Props = React.ComponentProps<typeof Button> & {
+  /**
+   * The fixed prefix text to show in the button eg: 'Sort By'
+   */
+  prefix?: React.ReactNode;
+  /**
+   * Whether or not the button should render as open
+   */
   isOpen?: boolean;
+  /**
+   * Should a chevron icon be shown?
+   */
   showChevron?: boolean;
   forwardedRef?: React.Ref<typeof Button>;
 };
@@ -14,10 +24,12 @@ const DropdownButton = ({
   isOpen,
   children,
   forwardedRef,
+  prefix,
   showChevron = false,
   ...props
 }: Props) => (
   <StyledButton type="button" isOpen={isOpen} ref={forwardedRef} {...props}>
+    {prefix && <LabelText>{prefix}: &nbsp;</LabelText>}
     {children}
     {showChevron && <StyledChevronDown />}
   </StyledButton>
@@ -46,6 +58,11 @@ const StyledButton = styled(Button)<Pick<Props, 'isOpen' | 'disabled'>>`
   &:hover {
     border-bottom-color: ${p => (p.isOpen ? 'transparent' : p.theme.borderDark)};
   }
+`;
+
+const LabelText = styled('em')`
+  font-style: normal;
+  color: ${p => p.theme.gray2};
 `;
 
 export default React.forwardRef<typeof Button, Props>((props, ref) => (

--- a/src/sentry/static/sentry/app/components/dropdownButton.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownButton.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import Button from 'app/components/button';
 import InlineSvg from 'app/components/inlineSvg';
+import space from 'app/styles/space';
 
 type Props = React.ComponentProps<typeof Button> & {
   /**
@@ -29,7 +30,7 @@ const DropdownButton = ({
   ...props
 }: Props) => (
   <StyledButton type="button" isOpen={isOpen} ref={forwardedRef} {...props}>
-    {prefix && <LabelText>{prefix}: &nbsp;</LabelText>}
+    {prefix && <LabelText>{prefix}:</LabelText>}
     {children}
     {showChevron && <StyledChevronDown />}
   </StyledButton>
@@ -63,6 +64,7 @@ const StyledButton = styled(Button)<Pick<Props, 'isOpen' | 'disabled'>>`
 const LabelText = styled('em')`
   font-style: normal;
   color: ${p => p.theme.gray2};
+  padding-right: ${space(0.75)};
 `;
 
 export default React.forwardRef<typeof Button, Props>((props, ref) => (

--- a/src/sentry/static/sentry/app/views/issueList/sortOptions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/sortOptions.jsx
@@ -62,12 +62,8 @@ class IssueListSortOptions extends React.PureComponent {
     return (
       <Container>
         <DropdownControl
-          label={
-            <React.Fragment>
-              <LabelText>{t('Sort by')}: &nbsp; </LabelText>
-              {this.getSortLabel(this.state.sortKey)}
-            </React.Fragment>
-          }
+          buttonProps={{prefix: t('Sort by')}}
+          label={this.getSortLabel(this.state.sortKey)}
         >
           {this.getMenuItem('priority')}
           {this.getMenuItem('date')}
@@ -82,11 +78,6 @@ class IssueListSortOptions extends React.PureComponent {
 
 const Container = styled('div')`
   margin-right: ${space(0.5)};
-`;
-
-const LabelText = styled('em')`
-  font-style: normal;
-  color: ${p => p.theme.gray2};
 `;
 
 export default IssueListSortOptions;

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -126,15 +126,6 @@ class Issues extends React.Component<Props, State> {
     this.setState({issuesType});
   };
 
-  renderFilterLabel(label: string | undefined) {
-    return (
-      <React.Fragment>
-        <LabelText>{t('Filter')}: &nbsp; </LabelText>
-        {label}
-      </React.Fragment>
-    );
-  }
-
   renderEmptyMessage = () => {
     const {selection} = this.props;
     const {issuesType} = this.state;
@@ -179,10 +170,8 @@ class Issues extends React.Component<Props, State> {
         <ControlsWrapper>
           <DropdownControl
             button={({getActorProps}) => (
-              <FilterButton {...getActorProps()} isOpen={false}>
-                {this.renderFilterLabel(
-                  issuesTypes.find(i => i.value === issuesType)?.label
-                )}
+              <FilterButton prefix={t('Filter')} {...getActorProps()} isOpen={false}>
+                {issuesTypes.find(i => i.value === issuesType)?.label}
               </FilterButton>
             )}
           >
@@ -254,11 +243,6 @@ const TableWrapper = styled('div')`
     /* smaller space between table and pagination */
     margin-bottom: -${space(1)};
   }
-`;
-
-const LabelText = styled('em')`
-  font-style: normal;
-  color: ${p => p.theme.gray2};
 `;
 
 export default Issues;

--- a/src/sentry/static/sentry/app/views/releasesV2/list/releaseListDropdown.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/releaseListDropdown.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 
@@ -16,15 +15,10 @@ type Props = {
 };
 
 const ReleaseListDropdown = ({label, options, selected, onSelect}: Props) => {
-  const labelNode = (
-    <React.Fragment>
-      <LabelText>{label}: &nbsp; </LabelText>
-      {options.find(option => option.key === selected)?.label}
-    </React.Fragment>
-  );
+  const selectedOption = options.find(option => option.key === selected)?.label;
 
   return (
-    <DropdownControl label={labelNode}>
+    <DropdownControl buttonProps={{prefix: label}} label={selectedOption}>
       {options.map(option => (
         <DropdownItem
           key={option.key}
@@ -38,10 +32,5 @@ const ReleaseListDropdown = ({label, options, selected, onSelect}: Props) => {
     </DropdownControl>
   );
 };
-
-const LabelText = styled('em')`
-  font-style: normal;
-  color: ${p => p.theme.gray2};
-`;
 
 export default ReleaseListDropdown;


### PR DESCRIPTION
We have a few dropdown control elements that include a prefix string that is rendered the same. By moving this into the DropdownButton component we can re-use it more easily and keep it consistent.