### PR TITLE
feat(onprem) Enable discover2 for on-prem

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -819,12 +819,10 @@ SENTRY_FEATURES = {
     "organizations:custom-symbol-sources": True,
     # Enable the events stream interface.
     "organizations:events": False,
-    # Enable events v2 instead of the events stream
-    "organizations:events-v2": False,
     # Enable discover 2 basic functions
-    "organizations:discover-basic": False,
+    "organizations:discover-basic": True,
     # Enable discover 2 custom queries and saved queries
-    "organizations:discover-query": False,
+    "organizations:discover-query": True,
     # Enable Performance view
     "organizations:performance-view": False,
     # Enable multi project selection

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -61,7 +61,6 @@ default_manager.add("organizations:data-export", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
 default_manager.add("organizations:enterprise-perf", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events", OrganizationFeature)  # NOQA
-default_manager.add("organizations:events-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:transaction-events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:performance-view", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover-basic", OrganizationFeature)  # NOQA
@@ -117,7 +116,6 @@ default_manager.add("projects:plugins", ProjectPluginFeature)  # NOQA
 requires_snuba = (
     "organizations:discover",
     "organizations:events",
-    "organizations:events-v2",
     "organizations:transaction-events",
     "organizations:performance-view",
     "organizations:global-views",

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -715,27 +715,19 @@ class AcceptanceTestCase(TransactionTestCase):
         # Forward session cookie to django client.
         self.client.cookies[settings.SESSION_COOKIE_NAME] = self.session.session_key
 
-    def dismiss_assistant(self):
-        res = self.client.put(
-            "/api/0/assistant/?v2",
-            content_type="application/json",
-            data=json.dumps({"guide": "discover_sidebar", "status": "viewed", "useful": True}),
-        )
-        assert res.status_code == 201
+    def dismiss_assistant(self, which=None):
+        if which is None:
+            which = ("discover_sidebar", "issue", "issue_stream")
+        if isinstance(which, six.string_types):
+            which = [which]
 
-        res = self.client.put(
-            "/api/0/assistant/?v2",
-            content_type="application/json",
-            data=json.dumps({"guide": "issue", "status": "viewed", "useful": True}),
-        )
-        assert res.status_code == 201
-
-        res = self.client.put(
-            "/api/0/assistant/?v2",
-            content_type="application/json",
-            data=json.dumps({"guide": "issue_stream", "status": "viewed", "useful": True}),
-        )
-        assert res.status_code == 201
+        for item in which:
+            res = self.client.put(
+                "/api/0/assistant/?v2",
+                content_type="application/json",
+                data=json.dumps({"guide": item, "status": "viewed", "useful": True}),
+            )
+            assert res.status_code == 201, res.content
 
 
 class IntegrationTestCase(TestCase):

--- a/tests/acceptance/test_dashboard.py
+++ b/tests/acceptance/test_dashboard.py
@@ -41,6 +41,7 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
         )
 
         self.login_as(self.user)
+        self.dismiss_assistant("discover_sidebar")
         self.path = u"/organizations/{}/projects/".format(self.organization.slug)
 
     def create_sample_event(self):
@@ -103,6 +104,7 @@ class EmptyDashboardTest(AcceptanceTestCase):
     def setUp(self):
         super(EmptyDashboardTest, self).setUp()
         self.login_as(self.user)
+        self.dismiss_assistant("discover_sidebar")
         self.path = u"/organizations/{}/projects/".format(self.organization.slug)
 
     def test_new_dashboard_empty(self):

--- a/tests/acceptance/test_organization_activity.py
+++ b/tests/acceptance/test_organization_activity.py
@@ -16,6 +16,7 @@ class OrganizationActivityTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.group = self.create_group(project=self.project)
         self.login_as(self.user)
+        self.dismiss_assistant("discover_sidebar")
         self.path = u"/organizations/{}/activity/".format(self.org.slug)
         self.project.update(first_event=timezone.now())
 

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -51,6 +51,7 @@ class OrganizationDiscoverTest(AcceptanceTestCase, SnubaTestCase):
             project_id=self.project.id,
         )
         self.path = u"/organizations/{}/discover/".format(self.org.slug)
+        self.dismiss_assistant("discover_sidebar")
 
     def test_no_access(self):
         self.browser.get(self.path)

--- a/tests/acceptance/test_organization_document_integration_detailed_view.py
+++ b/tests/acceptance/test_organization_document_integration_detailed_view.py
@@ -13,6 +13,7 @@ class OrganizationDocumentIntegrationDetailView(AcceptanceTestCase):
         self.login_as(self.user)
 
     def load_page(self, slug):
+        self.dismiss_assistant("discover_sidebar")
         url = u"/settings/{}/document-integrations/{}/".format(self.organization.slug, slug)
         self.browser.get(url)
         self.browser.wait_until_not(".loading-indicator")

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -150,7 +150,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         self.landing_path = u"/organizations/{}/discover/queries/".format(self.org.slug)
         self.result_path = u"/organizations/{}/discover/results/".format(self.org.slug)
 
-        self.dismiss_assistant()
+        self.dismiss_assistant("discover_sidebar")
 
     def wait_until_loaded(self):
         self.browser.wait_until_not(".loading-indicator")

--- a/tests/acceptance/test_organization_integration_detail_view.py
+++ b/tests/acceptance/test_organization_integration_detail_view.py
@@ -20,6 +20,7 @@ class OrganizationIntegrationDetailView(AcceptanceTestCase):
         self.login_as(self.user)
 
     def load_page(self, slug, configuration_tab=False):
+        self.dismiss_assistant("discover_sidebar")
         url = u"/settings/{}/integrations/{}/".format(self.organization.slug, slug)
         if configuration_tab:
             url += "?tab=configurations"

--- a/tests/acceptance/test_organization_integration_directory.py
+++ b/tests/acceptance/test_organization_integration_directory.py
@@ -7,6 +7,7 @@ class OrganizationIntegrationDirectoryTest(AcceptanceTestCase):
     def setUp(self):
         super(OrganizationIntegrationDirectoryTest, self).setUp()
         self.login_as(self.user)
+        self.dismiss_assistant("discover_sidebar")
 
     def test_all_integrations_list(self):
         path = u"/settings/{}/integrations/".format(self.organization.slug)

--- a/tests/acceptance/test_organization_plugin_detail_view.py
+++ b/tests/acceptance/test_organization_plugin_detail_view.py
@@ -20,6 +20,7 @@ class OrganizationPluginDetailedView(AcceptanceTestCase):
         self.project = self.create_project(organization=self.organization, name="Back end")
         self.create_project(organization=self.organization, name="Front End")
         self.login_as(self.user)
+        self.dismiss_assistant("discover_sidebar")
 
     def load_page(self, slug, configuration_tab=False):
         url = u"/settings/{}/plugins/{}/".format(self.organization.slug, slug)

--- a/tests/acceptance/test_organization_sentry_app_detailed_view.py
+++ b/tests/acceptance/test_organization_sentry_app_detailed_view.py
@@ -19,6 +19,7 @@ class OrganizationSentryAppDetailedView(AcceptanceTestCase):
             name="Super Awesome App",
         )
         self.login_as(self.user)
+        self.dismiss_assistant("discover_sidebar")
 
     def load_page(self, slug):
         url = u"/settings/{}/sentry-apps/{}/".format(self.organization.slug, slug)

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -47,7 +47,7 @@ class PerformanceOverviewTest(AcceptanceTestCase):
         self.path = u"/organizations/{}/performance/".format(self.org.slug)
 
         self.page = BasePage(self.browser)
-        self.dismiss_assistant()
+        self.dismiss_assistant("discover_sidebar")
 
     @patch("django.utils.timezone.now")
     def test_onboarding(self, mock_now):

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -50,7 +50,7 @@ class PerformanceSummaryTest(AcceptanceTestCase):
         )
 
         self.page = TransactionSummaryPage(self.browser)
-        self.dismiss_assistant()
+        self.dismiss_assistant("discover_sidebar")
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):

--- a/tests/acceptance/test_project_ownership.py
+++ b/tests/acceptance/test_project_ownership.py
@@ -7,6 +7,7 @@ class ProjectOwnershipTest(AcceptanceTestCase):
     def setUp(self):
         super(ProjectOwnershipTest, self).setUp()
         self.login_as(self.user)
+        self.dismiss_assistant("discover_sidebar")
         self.path = u"/settings/{}/projects/{}/ownership/".format(
             self.organization.slug, self.project.slug
         )

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -35,6 +35,8 @@ class OrganizationSerializerTest(TestCase):
                 "tweak-grouping-config",
                 "grouping-info",
                 "releases-v2",
+                "discover-basic",
+                "discover-query",
             ]
         )
 

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -170,17 +170,18 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["oldestEventID"] == format_project_event(self.project.slug, "a" * 32)
 
     def test_no_access_missing_feature(self):
-        url = reverse(
-            "sentry-api-0-organization-event-details",
-            kwargs={
-                "organization_slug": self.project.organization.slug,
-                "project_slug": self.project.slug,
-                "event_id": "a" * 32,
-            },
-        )
+        with self.feature({"organizations:discover-basic": False}):
+            url = reverse(
+                "sentry-api-0-organization-event-details",
+                kwargs={
+                    "organization_slug": self.project.organization.slug,
+                    "project_slug": self.project.slug,
+                    "event_id": "a" * 32,
+                },
+            )
 
-        response = self.client.get(url, format="json")
-        assert response.status_code == 404, response.content
+            response = self.client.get(url, format="json")
+            assert response.status_code == 404, response.content
 
     def test_access_non_member_project(self):
         # Add a new user to a project and then access events on project they are not part of.

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -109,9 +109,10 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
 
     def test_groupid_filter_invalid_value(self):
         url = "%s?group=not-a-number" % (self.url,)
-        response = self.client.get(url, format="json")
+        with self.feature({"organizations:discover-basic": False}):
+            response = self.client.get(url, format="json")
 
-        assert response.status_code == 400, response.content
+            assert response.status_code == 400, response.content
 
     def test_user_count(self):
         self.store_event(


### PR DESCRIPTION
Enable discover2 for on-prem usage as it has been mainlined in Saas for a while now. Remove the old events-v2 feature flag as it is unused and superseeded by the discover-query and discover-basic feature flags.

I tested that getsentry organizations continue to not get discover unless their billing plan provides it.
