### PR TITLE
fix(metric_alerts): Fix bug when creating a metric alert for the transaction dataset.

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -390,7 +390,12 @@ def _prepare_query_params(query_params):
             query_params.filter_keys, is_grouprelease=query_params.is_grouprelease
         )
 
-    if query_params.dataset in [Dataset.Events, Dataset.Discover, Dataset.Sessions]:
+    if query_params.dataset in [
+        Dataset.Events,
+        Dataset.Discover,
+        Dataset.Sessions,
+        Dataset.Transactions,
+    ]:
         (organization_id, params_to_update) = get_query_params_to_update_for_projects(
             query_params, with_org=query_params.dataset == Dataset.Sessions
         )

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -58,6 +58,14 @@ class TestAlertRuleSerializer(TestCase):
         }
 
     @fixture
+    def valid_transaction_params(self):
+        params = self.valid_params.copy()
+        params["dataset"] = QueryDatasets.TRANSACTIONS.value
+        params["aggregate"] = "count()"
+        params.pop("aggregation")
+        return params
+
+    @fixture
     def access(self):
         return from_user(self.user, self.organization)
 
@@ -169,6 +177,13 @@ class TestAlertRuleSerializer(TestCase):
         assert serializer.is_valid(), serializer.errors
         alert_rule = serializer.save()
         assert alert_rule.snuba_query.aggregate == aggregate
+
+    def test_transaction_dataset(self):
+        serializer = AlertRuleSerializer(context=self.context, data=self.valid_transaction_params)
+        assert serializer.is_valid(), serializer.errors
+        alert_rule = serializer.save()
+        assert alert_rule.snuba_query.dataset == QueryDatasets.TRANSACTIONS.value
+        assert alert_rule.snuba_query.aggregate == "count()"
 
     def test_simple_below_threshold(self):
         payload = {


### PR DESCRIPTION
We missed adding a test here, and so a bug got through that prevents us from creating metric alerts
on transactions.