### PR TITLE
feat(discover): Adding aggregates to the autocomplete

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -525,7 +525,7 @@ def transform_deprecated_functions_in_query(query):
         if old_function + "()" in query:
             replacement = OLD_FUNCTIONS_TO_NEW[old_function]
             query = query.replace(old_function + "()", replacement)
-        elif old_function in query:
+        elif old_function + ":" in query:
             replacement = OLD_FUNCTIONS_TO_NEW[old_function]
             query = query.replace(old_function, replacement)
 

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -250,6 +250,7 @@ class Results extends React.Component<Props, State> {
                   organization={organization}
                   projectIds={eventView.project}
                   query={query}
+                  fields={eventView.fields}
                   onSearch={this.handleSearch}
                 />
                 <ResultsChart

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -239,6 +239,7 @@ class PerformanceLanding extends React.Component<Props, State> {
                     projectIds={eventView.project}
                     location={location}
                     query={filterString}
+                    fields={eventView.fields}
                     onSearch={this.handleSearch}
                   />
                   <Charts

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -96,6 +96,7 @@ class SummaryContent extends React.Component<Props> {
               organization={organization}
               projectIds={eventView.project}
               query={query}
+              fields={eventView.fields}
               onSearch={this.handleSearch}
             />
             <TransactionSummaryCharts

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2055,6 +2055,23 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             assert data[0]["avg_transaction_duration"] == 5000
             assert data[0]["sum_transaction_duration"] == 10000
 
+        with self.feature(
+            {"organizations:discover-basic": True, "organizations:global-views": True}
+        ):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "field": ["event.type", "apdex(400)"],
+                    "query": "event.type:transaction apdex(400):0",
+                },
+            )
+
+            assert response.status_code == 200, response.content
+            data = response.data["data"]
+            assert len(data) == 1
+            assert data[0]["apdex_400"] == 0
+
     def test_functions_in_orderby(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
- Including the default params to the autocomplete to make them easier
  to use. The idea being that `percentile(transaction.duration, 0.5):`
  is easier to update than simply `percentile():`
- This also fixes an issue where `apdex(400):0` would be interpreted
  `apdex(300)(400):0` instead, since the old function `apdex` would be
  found in the query and replaced
