### PR TITLE
ref(ui): Add generic to space function

### DIFF
--- a/src/sentry/static/sentry/app/styles/space.tsx
+++ b/src/sentry/static/sentry/app/styles/space.tsx
@@ -12,7 +12,7 @@ const SPACES = {
 
 export type ValidSize = keyof typeof SPACES;
 
-function space<Size extends ValidSize>(size: Size): typeof SPACES[Size] {
+function space<S extends ValidSize>(size: S): typeof SPACES[S] {
   return SPACES[size];
 }
 

--- a/src/sentry/static/sentry/app/styles/space.tsx
+++ b/src/sentry/static/sentry/app/styles/space.tsx
@@ -12,6 +12,8 @@ const SPACES = {
 
 export type ValidSize = keyof typeof SPACES;
 
-const space = (size: ValidSize): typeof SPACES[ValidSize] => SPACES[size];
+function space<Size extends ValidSize>(size: Size): typeof SPACES[Size] {
+  return SPACES[size];
+}
 
 export default space;


### PR DESCRIPTION
Allows the space function to statically know what the output will be. I'm not sure you can do this with lambda style syntax?

Before
![image](https://user-images.githubusercontent.com/1400464/82960366-250cbf00-9f6f-11ea-87fd-d1e9e8ab4c86.png)


After
![image](https://user-images.githubusercontent.com/1400464/82960345-16bea300-9f6f-11ea-95e4-2a3e0ce80ee2.png)
