### PR TITLE
(fix) Invite Members Modal Copy

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -327,8 +327,8 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
           {this.willInvite
             ? t('Invite new members by email to join your organization.')
             : t(
-                `You don't have permission to directly invite users, but we’ll
-                 send a request on your behalf!`
+                `You don’t have permission to directly invite users, but we’ll
+                 send a request on your behalf.`
               )}
         </Subtext>
 


### PR DESCRIPTION
I showed this modal to the Creative team and they want me to remove the exclamation point and fix the apostrophe. 

![Screen Shot 2020-05-20 at 5 27 00 PM](https://user-images.githubusercontent.com/31750075/82962955-85532f00-9f76-11ea-96eb-04ea37ba5ec3.png)
