### PR TITLE
fix(metric_alerts): Fix bug where dataset isn't being applied when performing queries for alerts

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -31,6 +31,7 @@ from sentry.incidents.models import (
     TimeSeriesSnapshot,
 )
 from sentry.models import Integration, Project
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QueryDatasets
 from sentry.snuba.subscriptions import (
     bulk_create_snuba_subscriptions,
@@ -319,6 +320,7 @@ def build_incident_query_params(incident, start=None, end=None, windowed_stats=F
     )
 
     return {
+        "dataset": Dataset(snuba_query.dataset),
         "start": snuba_filter.start,
         "end": snuba_filter.end,
         "conditions": snuba_filter.conditions,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -72,6 +72,7 @@ from sentry.models import (
 )
 from sentry.models.integrationfeature import Feature, IntegrationFeature
 from sentry.signals import project_created
+from sentry.snuba.models import QueryDatasets
 from sentry.utils import loremipsum, json
 
 
@@ -858,6 +859,7 @@ class Factories(object):
         environment=None,
         excluded_projects=None,
         date_added=None,
+        dataset=QueryDatasets.EVENTS,
     ):
         if not name:
             name = petname.Generate(2, " ", letters=10).title()
@@ -870,6 +872,7 @@ class Factories(object):
             aggregate,
             time_window,
             threshold_period,
+            dataset=dataset,
             environment=environment,
             include_all_projects=include_all_projects,
             excluded_projects=excluded_projects,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -557,6 +557,18 @@ class GetIncidentStatsTest(TestCase, BaseIncidentsTest):
         )
         self.run_test(closed_incident)
 
+    def test_transaction(self):
+        alert_rule = self.create_alert_rule(
+            self.organization, dataset=QueryDatasets.TRANSACTIONS, aggregate="p75()"
+        )
+        open_incident = self.create_incident(
+            self.organization,
+            title="Open",
+            date_started=timezone.now() - timedelta(days=30),
+            alert_rule=alert_rule,
+        )
+        self.run_test(open_incident)
+
 
 class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
     def test(self):


### PR DESCRIPTION
Missed adding dataset to these queries, so calculating aggregates failed. Note that this didn't
affect the subscriptions in snuba themselves, just any queries related to the alert once it was
created.