### PR TITLE
feat(ui): Added heading component

### DIFF
--- a/src/sentry/static/sentry/app/components/group/suggestedOwners/ownershipRules.tsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners/ownershipRules.tsx
@@ -7,11 +7,12 @@ import {openCreateOwnershipRule} from 'app/actionCreators/modal';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
+import {Heading} from 'app/components/heading';
 import Hovercard from 'app/components/hovercard';
 import space from 'app/styles/space';
 import {Project, Organization} from 'app/types';
 
-import {Wrapper, Header, Heading} from './styles';
+import {Wrapper, Header} from './styles';
 
 type Props = {
   project: Project;
@@ -27,7 +28,7 @@ const OwnershipRules = ({project, organization, issueId}: Props) => {
   return (
     <Wrapper>
       <Header>
-        <Heading>{t('Ownership Rules')}</Heading>
+        <Heading is="h6">{t('Ownership Rules')}</Heading>
         <ClassNames>
           {({css}) => (
             <Hovercard

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners/styles.tsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners/styles.tsx
@@ -2,11 +2,6 @@ import styled from '@emotion/styled';
 
 import space from 'app/styles/space';
 
-const Heading = styled('h6')`
-  margin: 0 !important;
-  font-weight: 600;
-`;
-
 const Header = styled('div')`
   display: grid;
   align-items: center;
@@ -19,4 +14,4 @@ const Wrapper = styled('div')`
   margin-bottom: ${space(3)};
 `;
 
-export {Heading, Header, Wrapper};
+export {Header, Wrapper};

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners/suggestedAssignees.tsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners/suggestedAssignees.tsx
@@ -7,8 +7,9 @@ import ActorAvatar from 'app/components/avatar/actorAvatar';
 import SuggestedOwnerHovercard from 'app/components/group/suggestedOwnerHovercard';
 import {Actor, Commit} from 'app/types';
 import space from 'app/styles/space';
+import {Heading} from 'app/components/heading';
 
-import {Wrapper, Header, Heading} from './styles';
+import {Wrapper, Header} from './styles';
 
 type Owner = {
   actor: Actor;
@@ -24,7 +25,7 @@ type Props = {
 const SuggestedAssignees = ({owners, onAssign}: Props) => (
   <Wrapper>
     <Header>
-      <Heading>{t('Suggested Assignees')}</Heading>
+      <Heading is="h6">{t('Suggested Assignees')}</Heading>
       <StyledSmall>{t('Click to assign')}</StyledSmall>
     </Header>
     <Content>

--- a/src/sentry/static/sentry/app/components/heading.tsx
+++ b/src/sentry/static/sentry/app/components/heading.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {css} from '@emotion/core';
+
+const resetHeadingStyle = css`
+  margin-bottom: 0 !important;
+`;
+
+type HeadingComponent = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+type Props = {
+  is: HeadingComponent;
+  children: React.ReactNode;
+  className?: string;
+};
+
+const Heading = React.forwardRef<HTMLHeadingElement, Props>(function Heading(
+  {className, is, ...props},
+  ref
+) {
+  const Component = is;
+
+  return <Component className={className} css={resetHeadingStyle} ref={ref} {...props} />;
+});
+
+Heading.propTypes = {
+  // @ts-ignore type 'string' is not assignable to type 'HeadingComponent'.
+  is: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']).isRequired,
+};
+
+export {Heading};


### PR DESCRIPTION
As discussed in the TSC meeting (https://www.notion.so/sentry/321690a3061f43fe85f66df25435d883?v=daa97633c42242d4acc818b140afdd7f&p=3bd9286f3b0147e8936d8ba5288e481d), I am creating this draft to discuss more the new heading component. Please feel free to leave any feedback 😉

**Problem:**
Good content structure helps both people and technology—such as search engines, screen readers, and so on—interpret your site. Using appropriately ordered heading tags—H1, H2, H3, etc.—in your web pages makes it easier for people to understand them, especially for people with disabilities who rely on assistive technologies to browse the web. Similarly, search engines rely on these tags to interpret what your website is all about. — source: [https://www.mightybytes.com/blog/why-heading-tags-and-structure-matter/](https://www.mightybytes.com/blog/why-heading-tags-and-structure-matter/)

At Sentry, we often do not use an h * element when we should use it (including me) and, when we use it, the element possibly has different styles from the others.

**Solution:**
Add a "Heading" component in our design system

**Next Step:**
.Define variants such as:

```
small: {
...styles
},
normal: {
...styles
},
large: {
...styles
},
```
