### PR TITLE
feat(alerts): Add descriptive header to alerts

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {AlertRuleThresholdType, Trigger} from 'app/views/settings/incidentRules/types';
+import {PRESET_AGGREGATES} from 'app/views/settings/incidentRules/constants';
 import {NewQuery, Project} from 'app/types';
 import {PageContent} from 'app/styles/organization';
 import {defined} from 'app/utils';
 import {getUtcDateString} from 'app/utils/dates';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import Duration from 'app/components/duration';
 import EventView from 'app/utils/discover/eventView';
@@ -22,6 +23,7 @@ import {SectionHeading} from 'app/components/charts/styles';
 import Projects from 'app/utils/projects';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
+import {Panel} from 'app/components/panels';
 
 import {
   Incident,
@@ -94,6 +96,13 @@ export default class DetailsBody extends React.Component<Props> {
     return `${direction} ${trigger[key]}`;
   }
 
+  get friendlyIncidentType() {
+    const aggregate = this.props?.incident?.alertRule?.aggregate;
+    const preset = PRESET_AGGREGATES.find(p => p.match.test(aggregate ?? ''));
+
+    return preset?.name ?? t('Custom metric');
+  }
+
   renderRuleDetails() {
     const {incident} = this.props;
 
@@ -145,6 +154,36 @@ export default class DetailsBody extends React.Component<Props> {
     );
   }
 
+  renderChartHeader() {
+    const {incident} = this.props;
+    const alertRule = incident?.alertRule;
+
+    return (
+      <ChartHeader>
+        {this.friendlyIncidentType}
+
+        <ChartParameters>
+          {tct('Metric: [metric] over [window]', {
+            metric: <code>{alertRule?.aggregate ?? '...'}</code>,
+            window: (
+              <code>
+                {incident ? (
+                  <Duration seconds={incident.alertRule.timeWindow * 60} />
+                ) : (
+                  '...'
+                )}
+              </code>
+            ),
+          })}
+          {alertRule?.query &&
+            tct('Filter: [filter]', {
+              filter: <code>{alertRule.query}</code>,
+            })}
+        </ChartParameters>
+      </ChartHeader>
+    );
+  }
+
   render() {
     const {params, incident, stats} = this.props;
 
@@ -161,82 +200,86 @@ export default class DetailsBody extends React.Component<Props> {
               </Alert>
             </AlertWrapper>
           )}
-        <ChartWrapper>
-          {incident && stats ? (
-            <Chart
-              aggregate={incident.alertRule.aggregate}
-              data={stats.eventStats.data}
-              detected={incident.dateDetected}
-              closed={incident.dateClosed}
-            />
-          ) : (
-            <Placeholder height="200px" />
-          )}
-        </ChartWrapper>
-
         <Main>
-          <ActivityPageContent>
-            <StyledNavTabs underlined>
-              <li className="active">
-                <Link to="">{t('Activity')}</Link>
-              </li>
-
-              <SeenByTab>
-                {incident && (
-                  <StyledSeenByList
-                    iconPosition="right"
-                    seenBy={incident.seenBy}
-                    iconTooltip={t('People who have viewed this alert')}
-                  />
-                )}
-              </SeenByTab>
-            </StyledNavTabs>
-            <Activity
-              incident={incident}
-              params={params}
-              incidentStatus={!!incident ? incident.status : null}
-            />
-          </ActivityPageContent>
-          <Sidebar>
-            <SidebarHeading>
-              <span>{t('Alert Rule')}</span>
-              {incident?.alertRule?.status !== AlertRuleStatus.SNAPSHOT && (
-                <SideHeaderLink
-                  to={{
-                    pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule?.id}/`,
-                  }}
-                >
-                  {t('View Rule')}
-                  <IconLink size="xs" />
-                </SideHeaderLink>
+          <PageContent>
+            <ChartPanel>
+              {this.renderChartHeader()}
+              {incident && stats ? (
+                <Chart
+                  aggregate={incident.alertRule.aggregate}
+                  data={stats.eventStats.data}
+                  detected={incident.dateDetected}
+                  closed={incident.dateClosed}
+                />
+              ) : (
+                <Placeholder height="200px" />
               )}
-            </SidebarHeading>
-            {this.renderRuleDetails()}
+            </ChartPanel>
+          </PageContent>
+          <DetailWrapper>
+            <ActivityPageContent>
+              <StyledNavTabs underlined>
+                <li className="active">
+                  <Link to="">{t('Activity')}</Link>
+                </li>
 
-            <SidebarHeading>
-              <span>{t('Query')}</span>
-              <Feature features={['discover-basic']}>
-                <Projects slugs={incident?.projects} orgId={params.orgId}>
-                  {({initiallyLoaded, fetching, projects}) => (
-                    <SideHeaderLink
-                      disabled={!incident || fetching || !initiallyLoaded}
-                      to={this.getDiscoverUrl(
-                        ((initiallyLoaded && projects) as Project[]) || []
-                      )}
-                    >
-                      {t('View in Discover')}
-                      <IconTelescope size="xs" />
-                    </SideHeaderLink>
+                <SeenByTab>
+                  {incident && (
+                    <StyledSeenByList
+                      iconPosition="right"
+                      seenBy={incident.seenBy}
+                      iconTooltip={t('People who have viewed this alert')}
+                    />
                   )}
-                </Projects>
-              </Feature>
-            </SidebarHeading>
-            {incident ? (
-              <Query>{incident?.alertRule.query || '""'}</Query>
-            ) : (
-              <Placeholder height="30px" />
-            )}
-          </Sidebar>
+                </SeenByTab>
+              </StyledNavTabs>
+              <Activity
+                incident={incident}
+                params={params}
+                incidentStatus={!!incident ? incident.status : null}
+              />
+            </ActivityPageContent>
+            <Sidebar>
+              <SidebarHeading>
+                <span>{t('Alert Rule')}</span>
+                {incident?.alertRule?.status !== AlertRuleStatus.SNAPSHOT && (
+                  <SideHeaderLink
+                    to={{
+                      pathname: `/settings/${params.orgId}/projects/${incident?.projects[0]}/alerts/metric-rules/${incident?.alertRule?.id}/`,
+                    }}
+                  >
+                    {t('View Rule')}
+                    <IconLink size="xs" />
+                  </SideHeaderLink>
+                )}
+              </SidebarHeading>
+              {this.renderRuleDetails()}
+
+              <SidebarHeading>
+                <span>{t('Query')}</span>
+                <Feature features={['discover-basic']}>
+                  <Projects slugs={incident?.projects} orgId={params.orgId}>
+                    {({initiallyLoaded, fetching, projects}) => (
+                      <SideHeaderLink
+                        disabled={!incident || fetching || !initiallyLoaded}
+                        to={this.getDiscoverUrl(
+                          ((initiallyLoaded && projects) as Project[]) || []
+                        )}
+                      >
+                        {t('View in Discover')}
+                        <IconTelescope size="xs" />
+                      </SideHeaderLink>
+                    )}
+                  </Projects>
+                </Feature>
+              </SidebarHeading>
+              {incident ? (
+                <Query>{incident?.alertRule.query || '""'}</Query>
+              ) : (
+                <Placeholder height="30px" />
+              )}
+            </Sidebar>
+          </DetailWrapper>
         </Main>
       </StyledPageContent>
     );
@@ -244,10 +287,13 @@ export default class DetailsBody extends React.Component<Props> {
 }
 
 const Main = styled('div')`
+  background-color: ${p => p.theme.white};
+  padding-top: ${space(3)};
+`;
+
+const DetailWrapper = styled('div')`
   display: flex;
   flex: 1;
-  border-top: 1px solid ${p => p.theme.borderLight};
-  background-color: ${p => p.theme.white};
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     flex-direction: column-reverse;
@@ -292,8 +338,37 @@ const StyledPageContent = styled(PageContent)`
   flex-direction: column;
 `;
 
-const ChartWrapper = styled('div')`
+const ChartPanel = styled(Panel)`
   padding: ${space(2)};
+`;
+
+const ChartHeader = styled('div')`
+  margin-bottom: ${space(1)};
+`;
+
+const ChartParameters = styled('div')`
+  color: ${p => p.theme.gray3};
+  font-size: ${p => p.theme.fontSizeMedium};
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  grid-gap: ${space(4)};
+  align-items: center;
+
+  > * {
+    position: relative;
+  }
+
+  > *:not(:last-of-type):after {
+    content: '';
+    display: block;
+    height: 70%;
+    width: 1px;
+    background: ${p => p.theme.borderLight};
+    position: absolute;
+    right: -${space(2)};
+    top: 15%;
+  }
 `;
 
 const AlertWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 
 import {t} from 'app/locale';
+import space from 'app/styles/space';
 import LineChart from 'app/components/charts/lineChart';
 import MarkPoint from 'app/components/charts/components/markPoint';
 
@@ -69,77 +70,83 @@ type Props = {
   closed?: string;
 };
 
-export default class Chart extends React.PureComponent<Props> {
-  render() {
-    const {aggregate, data, detected, closed} = this.props;
-    const detectedTs = detected && moment.utc(detected).unix();
-    const closedTs = closed && moment.utc(closed).unix();
-    const chartData = data.map(([ts, val]) => [
-      ts * 1000,
-      val.length ? val.reduce((acc, {count} = {count: 0}) => acc + count, 0) : 0,
-    ]);
+const Chart = (props: Props) => {
+  const {aggregate, data, detected, closed} = props;
+  const detectedTs = detected && moment.utc(detected).unix();
+  const closedTs = closed && moment.utc(closed).unix();
+  const chartData = data.map(([ts, val]) => [
+    ts * 1000,
+    val.length ? val.reduce((acc, {count} = {count: 0}) => acc + count, 0) : 0,
+  ]);
 
-    let detectedCoordinate: number[] | undefined;
-    if (detectedTs) {
-      const nearbyDetectedTimestampIndex = getNearbyIndex(data, detectedTs);
-      const detectedYValue =
-        nearbyDetectedTimestampIndex &&
-        getAverageBetweenPoints(data, nearbyDetectedTimestampIndex);
-      detectedCoordinate = [detectedTs * 1000, detectedYValue];
-      chartData.splice(nearbyDetectedTimestampIndex + 1, 0, detectedCoordinate);
-    }
-
-    const showClosedMarker =
-      data && closedTs && data[data.length - 1] && data[data.length - 1][0] >= closedTs
-        ? true
-        : false;
-    let closedCoordinate: number[] | undefined;
-    if (closedTs && showClosedMarker) {
-      const nearbyClosedTimestampIndex = getNearbyIndex(data, closedTs);
-      const closedYValue =
-        nearbyClosedTimestampIndex &&
-        getAverageBetweenPoints(data, nearbyClosedTimestampIndex);
-      closedCoordinate = [closedTs * 1000, closedYValue];
-      chartData.splice(nearbyClosedTimestampIndex + 1, 0, closedCoordinate);
-    }
-
-    const seriesName = aggregate;
-
-    return (
-      <LineChart
-        isGroupedByDate
-        showTimeInTooltip
-        series={[
-          {
-            // e.g. Events or Users
-            seriesName,
-            dataArray: chartData,
-            markPoint: MarkPoint({
-              data: [
-                {
-                  labelForValue: seriesName,
-                  seriesName,
-                  symbol: `image://${detectedSymbol}`,
-                  name: t('Alert Triggered'),
-                  coord: detectedCoordinate,
-                },
-                ...(closedTs
-                  ? [
-                      {
-                        labelForValue: seriesName,
-                        seriesName,
-                        symbol: `image://${closedSymbol}`,
-                        symbolSize: 24,
-                        name: t('Alert Resolved'),
-                        coord: closedCoordinate,
-                      },
-                    ]
-                  : []),
-              ],
-            }),
-          },
-        ]}
-      />
-    );
+  let detectedCoordinate: number[] | undefined;
+  if (detectedTs) {
+    const nearbyDetectedTimestampIndex = getNearbyIndex(data, detectedTs);
+    const detectedYValue =
+      nearbyDetectedTimestampIndex &&
+      getAverageBetweenPoints(data, nearbyDetectedTimestampIndex);
+    detectedCoordinate = [detectedTs * 1000, detectedYValue];
+    chartData.splice(nearbyDetectedTimestampIndex + 1, 0, detectedCoordinate);
   }
-}
+
+  const showClosedMarker =
+    data && closedTs && data[data.length - 1] && data[data.length - 1][0] >= closedTs
+      ? true
+      : false;
+  let closedCoordinate: number[] | undefined;
+  if (closedTs && showClosedMarker) {
+    const nearbyClosedTimestampIndex = getNearbyIndex(data, closedTs);
+    const closedYValue =
+      nearbyClosedTimestampIndex &&
+      getAverageBetweenPoints(data, nearbyClosedTimestampIndex);
+    closedCoordinate = [closedTs * 1000, closedYValue];
+    chartData.splice(nearbyClosedTimestampIndex + 1, 0, closedCoordinate);
+  }
+
+  const seriesName = aggregate;
+
+  return (
+    <LineChart
+      isGroupedByDate
+      showTimeInTooltip
+      grid={{
+        left: 0,
+        right: 0,
+        top: space(2),
+        bottom: 0,
+      }}
+      series={[
+        {
+          // e.g. Events or Users
+          seriesName,
+          dataArray: chartData,
+          markPoint: MarkPoint({
+            data: [
+              {
+                labelForValue: seriesName,
+                seriesName,
+                symbol: `image://${detectedSymbol}`,
+                name: t('Alert Triggered'),
+                coord: detectedCoordinate,
+              },
+              ...(closedTs
+                ? [
+                    {
+                      labelForValue: seriesName,
+                      seriesName,
+                      symbol: `image://${closedSymbol}`,
+                      symbolSize: 24,
+                      name: t('Alert Resolved'),
+                      coord: closedCoordinate,
+                    },
+                  ]
+                : []),
+            ],
+          }),
+        },
+      ]}
+    />
+  );
+};
+
+export default Chart;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -7,6 +7,45 @@ import {
 
 export const DEFAULT_AGGREGATE = 'count()';
 
+export const PRESET_AGGREGATES = [
+  {
+    match: /^count\(\)/,
+    name: 'Number of errors',
+    validDataset: [Dataset.ERRORS],
+    default: 'count()',
+  },
+  {
+    match: /^count_unique\(tags\[sentry:user\]\)/,
+    name: 'Users affected',
+    validDataset: [Dataset.ERRORS],
+    default: 'count_unique(tags[sentry:user])',
+  },
+  {
+    match: /^(p[0-9]{2,3}|percentile\(transaction\.duration,[^)]+\))/,
+    name: 'Latency',
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'percentile(transaction.duration, 0.95)',
+  },
+  {
+    match: /^apdex\([0-9.]+\)/,
+    name: 'Apdex',
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'apdex(300)',
+  },
+  {
+    match: /^count\(\)/,
+    name: 'Throughput',
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'count()',
+  },
+  {
+    match: /^error_rate\(\)/,
+    name: 'Error rate',
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'error_rate()',
+  },
+];
+
 export const DATASET_EVENT_TYPE_FILTERS = {
   [Dataset.ERRORS]: 'event.type:error',
   [Dataset.TRANSACTIONS]: 'event.type:transaction',

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -22,49 +22,11 @@ import {
 } from 'app/utils/discover/fields';
 
 import {Dataset} from './types';
+import {PRESET_AGGREGATES} from './constants';
 
 type Props = Omit<FormField['props'], 'children' | 'help'> & {
   organization: Organization;
 };
-
-const cannedAggregates = [
-  {
-    match: /^count\(\)/,
-    name: 'Number of errors',
-    validDataset: [Dataset.ERRORS],
-    default: 'count()',
-  },
-  {
-    match: /^count_unique\(tags\[sentry:user\]\)/,
-    name: 'Users affected',
-    validDataset: [Dataset.ERRORS],
-    default: 'count_unique(tags[sentry:user])',
-  },
-  {
-    match: /^(p[0-9]{2,3}|percentile\(transaction\.duration,[^)]+\))/,
-    name: 'Latency',
-    validDataset: [Dataset.TRANSACTIONS],
-    default: 'percentile(transaction.duration, 0.95)',
-  },
-  {
-    match: /^apdex\([0-9.]+\)/,
-    name: 'Apdex',
-    validDataset: [Dataset.TRANSACTIONS],
-    default: 'apdex(300)',
-  },
-  {
-    match: /^count\(\)/,
-    name: 'Throughput',
-    validDataset: [Dataset.TRANSACTIONS],
-    default: 'count()',
-  },
-  {
-    match: /^error_rate\(\)/,
-    name: 'Error rate',
-    validDataset: [Dataset.TRANSACTIONS],
-    default: 'error_rate()',
-  },
-];
 
 type OptionConfig = {
   aggregations: AggregationKey[];
@@ -116,8 +78,9 @@ const getFieldOptionConfig = (dataset: Dataset) => {
 const help = ({name, model}: {name: string; model: FormModel}) => {
   const aggregate = model.getValue(name) as string;
 
-  const presets = cannedAggregates
-    .filter(preset => preset.validDataset.includes(model.getValue('dataset') as Dataset))
+  const presets = PRESET_AGGREGATES.filter(preset =>
+    preset.validDataset.includes(model.getValue('dataset') as Dataset)
+  )
     .map(preset => ({...preset, selected: preset.match.test(aggregate)}))
     .map((preset, i, list) => (
       <React.Fragment key={preset.name}>


### PR DESCRIPTION
Before ![image](https://user-images.githubusercontent.com/1421724/83063242-ac603e00-a014-11ea-95f3-b43499956b74.png)

After 
![image](https://user-images.githubusercontent.com/1421724/83063263-b1bd8880-a014-11ea-902e-29e147c85258.png)

I'm not 100% convinced we want to pull the chart into this frame though