### PR TITLE
fix(alerts): Grow content to footer

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -289,6 +289,7 @@ export default class DetailsBody extends React.Component<Props> {
 const Main = styled('div')`
   background-color: ${p => p.theme.white};
   padding-top: ${space(3)};
+  flex-grow: 1;
 `;
 
 const DetailWrapper = styled('div')`


### PR DESCRIPTION
This was missing from the https://github.com/getsentry/sentry/pull/19046 refactor