### PR TITLE
fix(metric_alerts): Remove aggregation and aggregations from metric alerts code

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -7,7 +7,6 @@ import six
 from sentry.api.serializers import register, serialize, Serializer
 from sentry.incidents.models import AlertRule, AlertRuleExcludedProjects, AlertRuleTrigger
 from sentry.models import Rule
-from sentry.snuba.subscriptions import aggregate_to_query_aggregation
 from sentry.utils.compat import zip
 from sentry.utils.db import attach_foreignkey
 
@@ -31,9 +30,6 @@ class AlertRuleSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         env = obj.snuba_query.environment
-        aggregation = aggregate_to_query_aggregation.get(obj.snuba_query.aggregate, None)
-        if aggregation:
-            aggregation = aggregation.value
         return {
             "id": six.text_type(obj.id),
             "name": obj.name,
@@ -42,10 +38,6 @@ class AlertRuleSerializer(Serializer):
             "dataset": obj.snuba_query.dataset,
             "query": obj.snuba_query.query,
             "aggregate": obj.snuba_query.aggregate,
-            # These fields are deprecated. Once we've moved over to using aggregate
-            # entirely we can remove
-            "aggregation": aggregation,
-            "aggregations": [aggregation] if aggregation else [],
             # TODO: Start having the frontend expect seconds
             "timeWindow": obj.snuba_query.time_window / 60,
             "environment": env.name if env else None,

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -36,8 +36,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import QueryAggregations, QueryDatasets
-from sentry.snuba.subscriptions import aggregation_function_translations
+from sentry.snuba.models import QueryDatasets
 from sentry.snuba.tasks import build_snuba_filter
 from sentry.utils.snuba import raw_query
 from sentry.utils.compat import zip
@@ -288,8 +287,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         required=True, min_value=1, max_value=int(timedelta(days=1).total_seconds() / 60)
     )
     threshold_period = serializers.IntegerField(default=1, min_value=1, max_value=20)
-    aggregate = serializers.CharField(required=False, min_length=1)
-    aggregation = serializers.IntegerField(required=False)
+    aggregate = serializers.CharField(required=True, min_length=1)
 
     class Meta:
         model = AlertRule
@@ -301,7 +299,6 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             "environment",
             "threshold_period",
             "aggregate",
-            "aggregation",
             "projects",
             "include_all_projects",
             "excluded_projects",
@@ -311,15 +308,6 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             "name": {"min_length": 1, "max_length": 64},
             "include_all_projects": {"default": False},
         }
-
-    def validate_aggregation(self, aggregation):
-        try:
-            return QueryAggregations(aggregation)
-        except ValueError:
-            raise serializers.ValidationError(
-                "Invalid aggregation, valid values are %s"
-                % [item.value for item in QueryAggregations]
-            )
 
     def validate_dataset(self, dataset):
         try:
@@ -335,62 +323,50 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         The critical trigger should both alert and resolve 'after' the warning trigger (whether that means > or < the value depends on threshold type).
         """
         data.setdefault("dataset", QueryDatasets.EVENTS)
-        if "aggregate" in data and "aggregation" in data:
-            # `aggregate` takes precedence over `aggregation`, so just drop `aggregation`
-            # if both are present.
-            data.pop("aggregation")
-        if "aggregation" in data:
-            data["aggregate"] = aggregation_function_translations[data.pop("aggregation")]
-        if "aggregate" in data:
-            project_id = data.get("projects")
-            if not project_id:
-                # We just need a valid project id from the org so that we can verify
-                # the query. We don't use the returned data anywhere, so it doesn't
-                # matter which.
-                project_id = list(self.context["organization"].project_set.all()[:1])
-            try:
-                snuba_filter = build_snuba_filter(
-                    data["dataset"],
-                    data["query"],
-                    data["aggregate"],
-                    data.get("environment"),
-                    params={
-                        "project_id": [p.id for p in project_id],
-                        "start": timezone.now() - timedelta(minutes=10),
-                        "end": timezone.now(),
-                    },
-                )
-            except (InvalidSearchQuery, ValueError) as e:
-                raise serializers.ValidationError(
-                    "Invalid Query or Aggregate: {}".format(e.message)
-                )
-            else:
-                if not snuba_filter.aggregations:
-                    raise serializers.ValidationError(
-                        "Invalid Aggregate: Please pass a valid function for aggregation"
-                    )
-
-                try:
-                    raw_query(
-                        aggregations=snuba_filter.aggregations,
-                        start=snuba_filter.start,
-                        end=snuba_filter.end,
-                        conditions=snuba_filter.conditions,
-                        filter_keys=snuba_filter.filter_keys,
-                        having=snuba_filter.having,
-                        dataset=Dataset(data["dataset"].value),
-                        limit=1,
-                        referrer="alertruleserializer.test_query",
-                    )
-                except Exception:
-                    logger.exception("Error while validating snuba alert rule query")
-                    raise serializers.ValidationError(
-                        "Invalid Query or Aggregate: An error occurred while attempting "
-                        "to run the query"
-                    )
-
+        project_id = data.get("projects")
+        if not project_id:
+            # We just need a valid project id from the org so that we can verify
+            # the query. We don't use the returned data anywhere, so it doesn't
+            # matter which.
+            project_id = list(self.context["organization"].project_set.all()[:1])
+        try:
+            snuba_filter = build_snuba_filter(
+                data["dataset"],
+                data["query"],
+                data["aggregate"],
+                data.get("environment"),
+                params={
+                    "project_id": [p.id for p in project_id],
+                    "start": timezone.now() - timedelta(minutes=10),
+                    "end": timezone.now(),
+                },
+            )
+        except (InvalidSearchQuery, ValueError) as e:
+            raise serializers.ValidationError("Invalid Query or Aggregate: {}".format(e.message))
         else:
-            raise serializers.ValidationError("Must pass `aggregation` or `aggregate`")
+            if not snuba_filter.aggregations:
+                raise serializers.ValidationError(
+                    "Invalid Aggregate: Please pass a valid function for aggregation"
+                )
+
+            try:
+                raw_query(
+                    aggregations=snuba_filter.aggregations,
+                    start=snuba_filter.start,
+                    end=snuba_filter.end,
+                    conditions=snuba_filter.conditions,
+                    filter_keys=snuba_filter.filter_keys,
+                    having=snuba_filter.having,
+                    dataset=Dataset(data["dataset"].value),
+                    limit=1,
+                    referrer="alertruleserializer.test_query",
+                )
+            except Exception:
+                logger.exception("Error while validating snuba alert rule query")
+                raise serializers.ValidationError(
+                    "Invalid Query or Aggregate: An error occurred while attempting "
+                    "to run the query"
+                )
 
         triggers = data.get("triggers", [])
         if not triggers:

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -643,8 +643,6 @@ def update_alert_rule(
             snuba_query = alert_rule.snuba_query
             updated_query_fields.setdefault("dataset", QueryDatasets(snuba_query.dataset))
             updated_query_fields.setdefault("query", snuba_query.query)
-            # XXX: We use the alert rule aggregation here since currently we're
-            # expecting the enum value to be passed.
             updated_query_fields.setdefault("aggregate", snuba_query.aggregate)
             updated_query_fields.setdefault(
                 "time_window", timedelta(seconds=snuba_query.time_window)

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -4,7 +4,7 @@ import logging
 
 from django.db import transaction
 
-from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription, SnubaQuery
+from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery
 from sentry.snuba.tasks import (
     create_subscription_in_snuba,
     delete_subscription_from_snuba,
@@ -12,14 +12,6 @@ from sentry.snuba.tasks import (
 )
 
 logger = logging.getLogger(__name__)
-
-aggregation_function_translations = {
-    QueryAggregations.TOTAL: "count()",
-    QueryAggregations.UNIQUE_USERS: "count_unique(tags[sentry:user])",
-}
-aggregate_to_query_aggregation = {
-    val: key for key, val in aggregation_function_translations.items()
-}
 
 
 def create_snuba_query(dataset, query, aggregate, time_window, resolution, environment):
@@ -29,7 +21,7 @@ def create_snuba_query(dataset, query, aggregate, time_window, resolution, envir
     :param dataset: The snuba dataset to query and aggregate over
     :param query: An event search query that we can parse and convert into a
     set of Snuba conditions
-    :param aggregation: An aggregation to calculate over the time window
+    :param aggregate: An aggregate to calculate over the time window
     :param time_window: The time window to aggregate over
     :param resolution: How often to receive updates/bucket size
     :param environment: An optional environment to filter by

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -12,23 +12,17 @@ from sentry.api.serializers.models.alert_rule import (
 from sentry.models import Rule
 from sentry.incidents.logic import create_alert_rule, create_alert_rule_trigger
 from sentry.incidents.models import AlertRuleThresholdType
-from sentry.snuba.subscriptions import aggregate_to_query_aggregation
 from sentry.testutils import TestCase, APITestCase
 
 
 class BaseAlertRuleSerializerTest(object):
     def assert_alert_rule_serialized(self, alert_rule, result, skip_dates=False):
-        aggregation = aggregate_to_query_aggregation.get(alert_rule.snuba_query.aggregate, None)
-        if aggregation:
-            aggregation = aggregation.value
-
         assert result["id"] == six.text_type(alert_rule.id)
         assert result["organizationId"] == six.text_type(alert_rule.organization_id)
         assert result["name"] == alert_rule.name
         assert result["dataset"] == alert_rule.snuba_query.dataset
         assert result["query"] == alert_rule.snuba_query.query
         assert result["aggregate"] == alert_rule.snuba_query.aggregate
-        assert result["aggregation"] == aggregation
         assert result["timeWindow"] == alert_rule.snuba_query.time_window / 60
         assert result["resolution"] == alert_rule.snuba_query.resolution / 60
         assert result["thresholdPeriod"] == alert_rule.threshold_period

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -33,8 +33,7 @@ class AlertRuleDetailsBase(object):
     @fixture
     def alert_rule_dict(self):
         return {
-            "aggregation": 0,
-            "aggregations": [0],
+            "aggregate": "count()",
             "query": "",
             "timeWindow": "300",
             "projects": [self.project.slug],
@@ -179,7 +178,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
         # Alert rule should be exactly the same
         assert resp.data == serialize(self.alert_rule)
-        # If the aggregation changed we'd have a new subscription, validate that
+        # If the aggregate changed we'd have a new subscription, validate that
         # it hasn't changed explicitly
         updated_sub = AlertRule.objects.get(id=self.alert_rule.id).snuba_query.subscriptions.first()
         assert updated_sub.subscription_id == existing_sub.subscription_id

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -66,8 +66,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         )
         self.login_as(self.user)
         valid_alert_rule = {
-            "aggregation": 0,
-            "aggregations": [0],
+            "aggregate": "count()",
             "query": "",
             "timeWindow": "300",
             "triggers": [
@@ -108,8 +107,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         )
         self.login_as(self.user)
         rule_one_trigger_no_label = {
-            "aggregation": 0,
-            "aggregations": [0],
+            "aggregate": "count()",
             "query": "",
             "timeWindow": "300",
             "projects": [self.project.slug],
@@ -137,8 +135,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         )
         self.login_as(self.user)
         rule_one_trigger_only_critical = {
-            "aggregation": 0,
-            "aggregations": [0],
+            "aggregate": "count()",
             "query": "",
             "timeWindow": "300",
             "projects": [self.project.slug],
@@ -170,8 +167,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         self.login_as(self.user)
 
         rule_no_triggers = {
-            "aggregation": 0,
-            "aggregations": [0],
+            "aggregate": "count()",
             "query": "",
             "timeWindow": "300",
             "projects": [self.project.slug],
@@ -191,8 +187,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         self.login_as(self.user)
 
         rule_one_trigger_only_warning = {
-            "aggregation": 0,
-            "aggregations": [0],
+            "aggregate": "count()",
             "query": "",
             "timeWindow": "300",
             "projects": [self.project.slug],
@@ -223,8 +218,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         self.login_as(self.user)
 
         rule_one_trigger_only_critical_no_action = {
-            "aggregation": 0,
-            "aggregations": [0],
+            "aggregate": "count()",
             "query": "",
             "timeWindow": "300",
             "projects": [self.project.slug],
@@ -261,7 +255,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
                 name="an alert",
                 thresholdType=1,
                 query="hi",
-                aggregation=0,
+                aggregate="count()",
                 timeWindow=10,
                 alertThreshold=1000,
                 resolveThreshold=100,

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -20,7 +20,7 @@ class AlertRuleDetailsBase(object):
             "threshold_type": 0,
             "resolve_threshold": 1,
             "alert_threshold": 0,
-            "aggregation": 0,
+            "aggregate": "count()",
             "threshold_period": 1,
             "projects": [self.project.slug],
             "triggers": [
@@ -156,7 +156,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
         # Alert rule should be exactly the same
         assert resp.data == serialize(self.alert_rule)
-        # If the aggregation changed we'd have a new subscription, validate that
+        # If the aggregate changed we'd have a new subscription, validate that
         # it hasn't changed explicitly
         updated_sub = AlertRule.objects.get(id=self.alert_rule.id).snuba_query.subscriptions.first()
         assert updated_sub.subscription_id == existing_sub.subscription_id

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -76,8 +76,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         )
         self.login_as(self.user)
         valid_alert_rule = {
-            "aggregation": 0,
-            "aggregations": [0],
+            "aggregate": "count()",
             "query": "",
             "timeWindow": "300",
             "triggers": [


### PR DESCRIPTION
This fixes a bug where the frontend passes a null `aggregation` value to the frontend, which causes
it to be passed to the backend when updating an alert rule, which then causes a validation error.

We also just get to remove all the deprecated `aggregation` related code, which is a nice cleanup.