### PR TITLE
Revert "ref(devservices): Rename reverse_proxy to proxy"

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1513,7 +1513,6 @@ SENTRY_DEVSERVICES = {
         # started up, only pulled and made available for `devserver` which will start
         # it with `devservices attach --is-devserver reverse_proxy`.
         "with_devserver": True,
-        "devserver_alias": "proxy",
     },
     "relay": {
         "image": "us.gcr.io/sentryio/relay:latest",

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -227,12 +227,7 @@ def devserver(
 
     for name, container_options in _prepare_containers("sentry", silent=True).items():
         if container_options.get("with_devserver", False):
-            daemons += [
-                (
-                    container_options.get("devserver_alias", name),
-                    ["sentry", "devservices", "attach", "--fast", name],
-                )
-            ]
+            daemons += [(name, ["sentry", "devservices", "attach", "--fast", name])]
 
     # A better log-format for local dev when running through honcho,
     # but if there aren't any other daemons, we don't want to override.


### PR DESCRIPTION
Reverts getsentry/sentry#18948

This actually breaks the devserver with this error:

```
07:30:22 proxy   |   File "/Users/haza/Projects/sentry/.venv/lib/python2.7/site-packages/click/core.py", line 535, in invoke
07:30:22 proxy   |     return callback(*args, **kwargs)
07:30:22 proxy   |   File "/Users/haza/Projects/sentry/src/sentry/runner/commands/devservices.py", line 82, in attach
07:30:22 proxy   |     container = _start_service(client, service, containers, project, fast=fast, always_start=True)
07:30:22 proxy   |   File "/Users/haza/Projects/sentry/src/sentry/runner/commands/devservices.py", line 286, in _start_service
07:30:22 proxy   |     container = client.containers.create(**options)
07:30:22 proxy   |   File "/Users/haza/Projects/sentry/.venv/lib/python2.7/site-packages/docker/models/containers.py", line 842, in create
07:30:22 proxy   |     create_kwargs = _create_container_args(kwargs)
07:30:22 proxy   |   File "/Users/haza/Projects/sentry/.venv/lib/python2.7/site-packages/docker/models/containers.py", line 1056, in _create_container_args
07:30:22 proxy   |     raise create_unexpected_kwargs_error('run', kwargs)
07:30:22 proxy   | TypeError: run() got an unexpected keyword argument 'devserver_alias'
```

To get that error do:

```
sentry devservices rm reverse_proxy
sentry devserver --workers
```

@EvanPurkhiser why did we not just rename the dictionary key instead of adding this option? I thought we agreed on it