### PR TITLE
feat(ui): Limit release files and commits

### DIFF
--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -21,6 +21,7 @@ class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
         :pparam string organization_slug: the slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
+        :qparam int limit: how many files should be returned at maximum
         :auth: required
         """
         try:
@@ -31,12 +32,17 @@ class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
+        try:
+            limit = int(request.GET.get("limit"))
+        except ValueError:
+            limit = None
+
         queryset = list(
             CommitFileChange.objects.filter(
                 commit_id__in=ReleaseCommit.objects.filter(release=release).values_list(
                     "commit_id", flat=True
                 )
-            )
+            )[:limit]
         )
 
         context = serialize(queryset, request.user)

--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -32,8 +32,9 @@ class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
+        limit_param = request.GET.get("limit")
         try:
-            limit = int(request.GET.get("limit"))
+            limit = int(limit_param) if limit_param is not None else None
         except ValueError:
             limit = None
 

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/commits/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/commits/index.tsx
@@ -15,6 +15,7 @@ import AsyncView from 'app/views/asyncView';
 import routeTitleGen from 'app/utils/routeTitle';
 import {formatVersion} from 'app/utils/formatters';
 import withOrganization from 'app/utils/withOrganization';
+import Pagination from 'app/components/pagination';
 
 import {getCommitsByRepository, CommitsByRepository} from '../utils';
 import ReleaseNoCommitData from '../releaseNoCommitData';
@@ -121,7 +122,7 @@ class ReleaseCommits extends AsyncView<Props, State> {
 
   renderBody() {
     const {orgId} = this.props.params;
-    const {commits, repos, activeRepo} = this.state;
+    const {commits, commitsPageLinks, repos, activeRepo} = this.state;
 
     const commitsByRepository = getCommitsByRepository(commits);
     const reposToRender =
@@ -152,6 +153,8 @@ class ReleaseCommits extends AsyncView<Props, State> {
         {reposToRender.map(repoName =>
           this.renderCommitsForRepo(repoName, commitsByRepository)
         )}
+
+        <Pagination pageLinks={commitsPageLinks} />
       </React.Fragment>
     );
   }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
@@ -83,11 +83,11 @@ class FilesChanged extends AsyncView<Props, State> {
       <ContentBox>
         {fileList.length ? (
           <React.Fragment>
-            {Object.keys(filesByRepository).map(repository => (
+            {Object.entries(filesByRepository).map(([repository, file]) => (
               <RepositoryFileSummary
                 key={repository}
                 repository={repository}
-                fileChangeSummary={filesByRepository[repository]}
+                fileChangeSummary={file}
                 collapsable={false}
               />
             ))}

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/filesChanged/index.tsx
@@ -13,9 +13,14 @@ import withOrganization from 'app/utils/withOrganization';
 import routeTitleGen from 'app/utils/routeTitle';
 import {formatVersion} from 'app/utils/formatters';
 import {Panel, PanelBody} from 'app/components/panels';
+import Button from 'app/components/button';
 
 import {getFilesByRepository} from '../utils';
 import ReleaseNoCommitData from '../releaseNoCommitData';
+
+import {ReleaseContext} from '..';
+
+const FILES_LIMIT = 200;
 
 type RouteParams = {
   orgId: string;
@@ -48,13 +53,25 @@ class FilesChanged extends AsyncView<Props, State> {
       [
         'fileList',
         `/organizations/${orgId}/releases/${encodeURIComponent(release)}/commitfiles/`,
+        {
+          query: {
+            limit: this.shouldFetchAll() ? null : FILES_LIMIT,
+          },
+        },
       ],
       ['repos', `/organizations/${orgId}/repos/`],
     ];
   }
 
+  shouldFetchAll() {
+    const {location} = this.props;
+
+    return location.query.full === '1';
+  }
+
   renderBody() {
-    const {orgId} = this.props.params;
+    const {params, location} = this.props;
+    const {orgId} = params;
     const {fileList, repos} = this.state;
     const filesByRepository = getFilesByRepository(fileList);
 
@@ -65,14 +82,35 @@ class FilesChanged extends AsyncView<Props, State> {
     return (
       <ContentBox>
         {fileList.length ? (
-          Object.keys(filesByRepository).map(repository => (
-            <RepositoryFileSummary
-              key={repository}
-              repository={repository}
-              fileChangeSummary={filesByRepository[repository]}
-              collapsable={false}
-            />
-          ))
+          <React.Fragment>
+            {Object.keys(filesByRepository).map(repository => (
+              <RepositoryFileSummary
+                key={repository}
+                repository={repository}
+                fileChangeSummary={filesByRepository[repository]}
+                collapsable={false}
+              />
+            ))}
+
+            <ReleaseContext.Consumer>
+              {({releaseMeta}) =>
+                !this.shouldFetchAll() && releaseMeta.commitFilesChanged > FILES_LIMIT ? (
+                  <ShowAllWrapper>
+                    <Button
+                      priority="primary"
+                      size="small"
+                      to={{
+                        pathname: location.pathname,
+                        query: {...location.query, full: 1},
+                      }}
+                    >
+                      {t('Show all')}
+                    </Button>
+                  </ShowAllWrapper>
+                ) : null
+              }
+            </ReleaseContext.Consumer>
+          </React.Fragment>
         ) : (
           <Panel>
             <PanelBody>
@@ -93,6 +131,10 @@ const ContentBox = styled('div')`
     font-size: ${p => p.theme.fontSizeMedium};
     margin-bottom: ${space(1.5)};
   }
+`;
+
+const ShowAllWrapper = styled('div')`
+  text-align: center;
 `;
 
 export default withOrganization(FilesChanged);

--- a/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/list/index.tsx
@@ -182,7 +182,7 @@ class ReleasesList extends AsyncView<Props, State> {
       return <LoadingIndicator />;
     }
 
-    if (!releases.length) {
+    if (!releases?.length) {
       return this.renderEmptyMessage();
     }
 


### PR DESCRIPTION
This PR adds pagination to release `Commits` and limits the number of returned `Files Changed` (we don't want to have pagination there).

#sync-getsentry