### PR TITLE
feat(api): Log session_expiration

### DIFF
--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -154,7 +154,7 @@ class SAML2ACSView(AuthView):
 
         helper.bind_state("auth_attributes", auth.get_attributes())
 
-        # 5/28/2020 Temporarily adding logging here to check if any IdPs send a SessionNotOnOrAfter
+        # XXX(slohmes): 5/28/2020 Temporarily adding logging here to check if any IdPs send a SessionNotOnOrAfter
         # value in their SAML response.
         if auth.get_session_expiration() is not None:
             logging.warning(

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function
 
+import logging
+
 from django.contrib import messages
 from django.contrib.auth import logout
 from django.core.urlresolvers import reverse
@@ -151,6 +153,14 @@ class SAML2ACSView(AuthView):
             return helper.error(ERR_SAML_FAILED.format(reason=auth.get_last_error_reason()))
 
         helper.bind_state("auth_attributes", auth.get_attributes())
+
+        # 5/28/2020 Temporarily adding logging here to check if any IdPs send a SessionNotOnOrAfter
+        # value in their SAML response.
+        if auth.get_session_expiration() is not None:
+            logging.warning(
+                "Received SessionNotOnOrAfter value in SAML response",
+                extra={"session_expiration": auth.get_session_expiration()},
+            )
 
         return helper.next_step()
 


### PR DESCRIPTION
The library we use to parse SAML responses, OneLogin, has a built-in method for fetching the SessionNotOnOrAfter attribute if it's sent in the SAML response. Okta doesn't send this attribute, but we don't know whether any other SAML identity provider sends this attribute. If anyone is sending this attribute, we need to fetch this value and set it as the session cookie's expiration. But if no one is sending it, that'd just be dead code and wasted effort.

This is a temporary change, that should be reverted in less than a week. 