### PR TITLE
feat(apm): Add specialized Trace context interface UI component

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contexts.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts.jsx
@@ -14,6 +14,7 @@ const CONTEXT_TYPES = {
   runtime: require('app/components/events/contexts/runtime/runtime').default,
   user: require('app/components/events/contexts/user/user').default,
   gpu: require('app/components/events/contexts/gpu/gpu').default,
+  trace: require('app/components/events/contexts/trace/trace').default,
 };
 
 function getContextComponent(type) {
@@ -164,7 +165,7 @@ class ContextChunk extends React.Component {
         type={`context-${alias}`}
         title={this.renderSectionTitle()}
       >
-        <Component alias={alias} data={value} />
+        <Component alias={alias} event={evt} data={value} />
       </EventDataSection>
     );
   }

--- a/src/sentry/static/sentry/app/components/events/contexts.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts.jsx
@@ -119,6 +119,8 @@ class ContextChunk extends React.Component {
         return t('Graphics Processing Unit');
       case 'runtime':
         return t('Runtime');
+      case 'trace':
+        return t('Trace Details');
       case 'default':
         return toTitleCase(alias);
       default:

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownData.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownData.tsx
@@ -1,0 +1,39 @@
+import {Event, Organization} from 'app/types';
+import {defined} from 'app/utils';
+import {KeyValueListData} from 'app/components/events/interfaces/keyValueList/types';
+import {getMeta} from 'app/components/events/meta/metaProxy';
+
+import {TraceKnownData, TraceKnownDataType} from './types';
+import getUserKnownDataDetails from './getTraceKnownDataDetails';
+
+function getTraceKnownData(
+  data: TraceKnownData,
+  traceKnownDataValues: Array<TraceKnownDataType>,
+  event: Event,
+  organization: Organization
+): Array<KeyValueListData> {
+  const knownData: Array<KeyValueListData> = [];
+
+  const dataKeys = traceKnownDataValues.filter(
+    traceKnownDataValue => data[traceKnownDataValue]
+  );
+
+  for (const key of dataKeys) {
+    const knownDataDetails = getUserKnownDataDetails(data, key, event, organization);
+
+    if ((knownDataDetails && !defined(knownDataDetails.value)) || !knownDataDetails) {
+      continue;
+    }
+
+    knownData.push({
+      key,
+      ...knownDataDetails,
+      meta: getMeta(data, key),
+      subjectDataTestId: `trace-context-${key.toLowerCase()}-value`,
+    });
+  }
+
+  return knownData;
+}
+
+export default getTraceKnownData;

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownData.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownData.tsx
@@ -14,9 +14,15 @@ function getTraceKnownData(
 ): Array<KeyValueListData> {
   const knownData: Array<KeyValueListData> = [];
 
-  const dataKeys = traceKnownDataValues.filter(
-    traceKnownDataValue => data[traceKnownDataValue]
-  );
+  const dataKeys = traceKnownDataValues.filter(traceKnownDataValue => {
+    if (traceKnownDataValue === TraceKnownDataType.TRANSACTION_NAME) {
+      return event?.tags.find(tag => {
+        return tag.key === 'transaction';
+      });
+    }
+
+    return data[traceKnownDataValue];
+  });
 
   for (const key of dataKeys) {
     const knownDataDetails = getUserKnownDataDetails(data, key, event, organization);

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import moment from 'moment-timezone';
+
+import {Event, Organization} from 'app/types';
+import {t} from 'app/locale';
+import Button from 'app/components/button';
+import space from 'app/styles/space';
+import EventView from 'app/utils/discover/eventView';
+import {getTraceDateTimeRange} from 'app/components/events/interfaces/spans/utils';
+
+import {TraceKnownData, TraceKnownDataType} from './types';
+
+type Output = {
+  subject: string;
+  value: React.ReactNode | string | null;
+};
+
+function getUserKnownDataDetails(
+  data: TraceKnownData,
+  type: TraceKnownDataType,
+  event: Event,
+  organization: Organization
+): Output | undefined {
+  switch (type) {
+    case TraceKnownDataType.TRACE_ID: {
+      const traceId = data.trace_id || '';
+
+      if (!traceId) {
+        return undefined;
+      }
+
+      const dateCreated = moment(event.dateCreated).valueOf() / 1000;
+      const pointInTime = event?.dateReceived
+        ? moment(event.dateReceived).valueOf() / 1000
+        : dateCreated;
+
+      const {start, end} = getTraceDateTimeRange({start: pointInTime, end: pointInTime});
+
+      const orgFeatures = new Set(organization.features);
+
+      const traceEventView = EventView.fromSavedQuery({
+        id: undefined,
+        name: `Events with Trace ID ${traceId}`,
+        fields: ['title', 'event.type', 'project', 'trace.span', 'timestamp'],
+        orderby: '-timestamp',
+        query: `trace:${traceId}`,
+        projects: orgFeatures.has('global-views') ? [] : [Number(event.projectID)],
+        version: 2,
+        start,
+        end,
+      });
+      return {
+        subject: t('trace_id'),
+        value: (
+          <ButtonWrapper>
+            <pre className="val">
+              <span className="val-string">{traceId}</span>
+            </pre>
+            <StyledButton
+              size="xsmall"
+              to={traceEventView.getResultsViewUrlTarget(organization.slug)}
+            >
+              {t('Search by Trace')}
+            </StyledButton>
+          </ButtonWrapper>
+        ),
+      };
+    }
+
+    case TraceKnownDataType.SPAN_ID: {
+      return {
+        subject: t('span_id'),
+        value: data.span_id || '',
+      };
+    }
+
+    case TraceKnownDataType.PARENT_SPAN_ID: {
+      return {
+        subject: t('parent_span_id'),
+        value: data.parent_span_id || '',
+      };
+    }
+
+    case TraceKnownDataType.OP_NAME: {
+      return {
+        subject: t('op'),
+        value: data.op || '',
+      };
+    }
+
+    case TraceKnownDataType.STATUS: {
+      return {
+        subject: t('status'),
+        value: data.status || '',
+      };
+    }
+
+    default:
+      return undefined;
+  }
+}
+
+const ButtonWrapper = styled('div')`
+  position: relative;
+`;
+
+const StyledButton = styled(Button)`
+  position: absolute;
+  top: ${space(0.75)};
+  right: ${space(0.5)};
+`;
+
+export default getUserKnownDataDetails;

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -33,7 +33,7 @@ function getUserKnownDataDetails(
 
       if (!organization.features.includes('discover-basic')) {
         return {
-          subject: t('trace_id'),
+          subject: t('Trace ID'),
           value: traceId,
         };
       }
@@ -59,7 +59,7 @@ function getUserKnownDataDetails(
         end,
       });
       return {
-        subject: t('trace_id'),
+        subject: t('Trace ID'),
         value: (
           <ButtonWrapper>
             <pre className="val">
@@ -78,28 +78,28 @@ function getUserKnownDataDetails(
 
     case TraceKnownDataType.SPAN_ID: {
       return {
-        subject: t('span_id'),
+        subject: t('Span ID'),
         value: data.span_id || '',
       };
     }
 
     case TraceKnownDataType.PARENT_SPAN_ID: {
       return {
-        subject: t('parent_span_id'),
+        subject: t('Parent Span ID'),
         value: data.parent_span_id || '',
       };
     }
 
     case TraceKnownDataType.OP_NAME: {
       return {
-        subject: t('op'),
+        subject: t('Operation Name'),
         value: data.op || '',
       };
     }
 
     case TraceKnownDataType.STATUS: {
       return {
-        subject: t('status'),
+        subject: t('Status'),
         value: data.status || '',
       };
     }
@@ -123,13 +123,13 @@ function getUserKnownDataDetails(
 
       if (!organization.features.includes('performance-view')) {
         return {
-          subject: t('transaction'),
+          subject: t('Transaction'),
           value: transactionName,
         };
       }
 
       return {
-        subject: t('transaction'),
+        subject: t('Transaction'),
         value: (
           <ButtonWrapper>
             <pre className="val">

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -114,6 +114,13 @@ function getUserKnownDataDetails(
         query: {},
       });
 
+      if (!organization.features.includes('performance-view')) {
+        return {
+          subject: t('transaction'),
+          value: transactionName,
+        };
+      }
+
       return {
         subject: t('transaction'),
         value: (

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -14,7 +14,7 @@ import {TraceKnownData, TraceKnownDataType} from './types';
 
 type Output = {
   subject: string;
-  value: React.ReactNode | string | null;
+  value: React.ReactNode;
 };
 
 function getUserKnownDataDetails(

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -96,6 +96,21 @@ function getUserKnownDataDetails(
       };
     }
 
+    case TraceKnownDataType.TRANSACTION_NAME: {
+      const eventTag = event?.tags.find(tag => {
+        return tag.key === 'transaction';
+      });
+
+      if (!eventTag) {
+        return undefined;
+      }
+
+      return {
+        subject: t('transaction'),
+        value: eventTag.value || '',
+      };
+    }
+
     default:
       return undefined;
   }

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -8,6 +8,7 @@ import Button from 'app/components/button';
 import space from 'app/styles/space';
 import EventView from 'app/utils/discover/eventView';
 import {getTraceDateTimeRange} from 'app/components/events/interfaces/spans/utils';
+import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
 
 import {TraceKnownData, TraceKnownDataType} from './types';
 
@@ -105,9 +106,31 @@ function getUserKnownDataDetails(
         return undefined;
       }
 
+      const transactionName = eventTag.value || '';
+
+      if (!transactionName) {
+        return undefined;
+      }
+
+      const to = transactionSummaryRouteWithQuery({
+        orgSlug: organization.slug,
+        transaction: transactionName,
+        projectID: event.projectID,
+        query: {},
+      });
+
       return {
         subject: t('transaction'),
-        value: eventTag.value || '',
+        value: (
+          <ButtonWrapper>
+            <pre className="val">
+              <span className="val-string">{transactionName}</span>
+            </pre>
+            <StyledButton size="xsmall" to={to}>
+              {t('View Summary')}
+            </StyledButton>
+          </ButtonWrapper>
+        ),
       };
     }
 

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -31,6 +31,13 @@ function getUserKnownDataDetails(
         return undefined;
       }
 
+      if (!organization.features.includes('discover-basic')) {
+        return {
+          subject: t('trace_id'),
+          value: traceId,
+        };
+      }
+
       const dateCreated = moment(event.dateCreated).valueOf() / 1000;
       const pointInTime = event?.dateReceived
         ? moment(event.dateReceived).valueOf() / 1000

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -102,7 +102,7 @@ function getUserKnownDataDetails(
         return tag.key === 'transaction';
       });
 
-      if (!eventTag || !eventTag.value) {
+      if (!eventTag || typeof eventTag.value !== 'string') {
         return undefined;
       }
       const transactionName = eventTag.value;

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -102,15 +102,10 @@ function getUserKnownDataDetails(
         return tag.key === 'transaction';
       });
 
-      if (!eventTag) {
+      if (!eventTag || !eventTag.value) {
         return undefined;
       }
-
-      const transactionName = eventTag.value || '';
-
-      if (!transactionName) {
-        return undefined;
-      }
+      const transactionName = eventTag.value;
 
       const to = transactionSummaryRouteWithQuery({
         orgSlug: organization.slug,

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import {Event, Organization} from 'app/types';
+import {t} from 'app/locale';
+import withOrganization from 'app/utils/withOrganization';
+import ErrorBoundary from 'app/components/errorBoundary';
+import KeyValueList from 'app/components/events/interfaces/keyValueList/keyValueListV2';
+
+import {TraceKnownData, TraceKnownDataType} from './types';
+import getTraceKnownData from './getTraceKnownData';
+
+const traceKnownDataValues = [
+  TraceKnownDataType.TRACE_ID,
+  TraceKnownDataType.SPAN_ID,
+  TraceKnownDataType.PARENT_SPAN_ID,
+  TraceKnownDataType.OP_NAME,
+  TraceKnownDataType.STATUS,
+];
+
+type Props = {
+  organization: Organization;
+  event: Event;
+  data: TraceKnownData;
+};
+
+const InnerTrace = withOrganization(function({organization, event, data}: Props) {
+  return (
+    <ErrorBoundary mini>
+      <KeyValueList
+        data={getTraceKnownData(data, traceKnownDataValues, event, organization)}
+        raw={false}
+      />
+    </ErrorBoundary>
+  );
+});
+
+const Trace = (props: Props) => {
+  return <InnerTrace {...props} />;
+};
+
+Trace.getTitle = function() {
+  return t('Trace Details');
+};
+
+export default Trace;

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
@@ -28,6 +28,7 @@ const InnerTrace = withOrganization(function({organization, event, data}: Props)
     <ErrorBoundary mini>
       <KeyValueList
         data={getTraceKnownData(data, traceKnownDataValues, event, organization)}
+        isSorted={false}
         raw={false}
       />
     </ErrorBoundary>

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
@@ -14,6 +14,7 @@ const traceKnownDataValues = [
   TraceKnownDataType.TRACE_ID,
   TraceKnownDataType.SPAN_ID,
   TraceKnownDataType.PARENT_SPAN_ID,
+  TraceKnownDataType.TRANSACTION_NAME,
   TraceKnownDataType.OP_NAME,
 ];
 

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
@@ -10,11 +10,11 @@ import {TraceKnownData, TraceKnownDataType} from './types';
 import getTraceKnownData from './getTraceKnownData';
 
 const traceKnownDataValues = [
+  TraceKnownDataType.STATUS,
   TraceKnownDataType.TRACE_ID,
   TraceKnownDataType.SPAN_ID,
   TraceKnownDataType.PARENT_SPAN_ID,
   TraceKnownDataType.OP_NAME,
-  TraceKnownDataType.STATUS,
 ];
 
 type Props = {

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {Event, Organization} from 'app/types';
-import {t} from 'app/locale';
 import withOrganization from 'app/utils/withOrganization';
 import ErrorBoundary from 'app/components/errorBoundary';
 import KeyValueList from 'app/components/events/interfaces/keyValueList/keyValueListV2';

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/trace.tsx
@@ -40,8 +40,4 @@ const Trace = (props: Props) => {
   return <InnerTrace {...props} />;
 };
 
-Trace.getTitle = function() {
-  return t('Trace Details');
-};
-
 export default Trace;

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/types.tsx
@@ -1,0 +1,15 @@
+export enum TraceKnownDataType {
+  TRACE_ID = 'trace_id',
+  SPAN_ID = 'span_id',
+  PARENT_SPAN_ID = 'parent_span_id',
+  OP_NAME = 'op',
+  STATUS = 'status',
+}
+
+export type TraceKnownData = {
+  trace_id?: string;
+  span_id?: string;
+  parent_span_id?: string;
+  op?: string;
+  status?: string;
+};

--- a/src/sentry/static/sentry/app/components/events/contexts/trace/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/trace/types.tsx
@@ -4,6 +4,7 @@ export enum TraceKnownDataType {
   PARENT_SPAN_ID = 'parent_span_id',
   OP_NAME = 'op',
   STATUS = 'status',
+  TRANSACTION_NAME = 'transaction_name',
 }
 
 export type TraceKnownData = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/keyValueList/keyValueListV2.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/keyValueList/keyValueListV2.tsx
@@ -42,10 +42,14 @@ const KeyValueList = ({
       <tbody>
         {getData().map(
           ({key, subject, value = null, meta, subjectIcon, subjectDataTestId}) => {
-            const dataValue =
+            const dataValue: string | React.ReactNode | undefined =
               typeof value === 'object' && !React.isValidElement(value)
                 ? JSON.stringify(value, null, 2)
                 : value;
+
+            const valueIsReactRenderable: boolean =
+              typeof dataValue !== 'string' && React.isValidElement(dataValue);
+
             return (
               <tr key={key}>
                 <TableSubject className="key" wide={longKeys}>
@@ -60,6 +64,8 @@ const KeyValueList = ({
                     >
                       {subjectIcon}
                     </ContextData>
+                  ) : valueIsReactRenderable ? (
+                    dataValue
                   ) : (
                     <pre className="val-string">
                       <AnnotatedText value={dataValue} meta={meta} />

--- a/src/sentry/static/sentry/app/components/events/interfaces/keyValueList/keyValueListV2.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/keyValueList/keyValueListV2.tsx
@@ -42,10 +42,10 @@ const KeyValueList = ({
       <tbody>
         {getData().map(
           ({key, subject, value = null, meta, subjectIcon, subjectDataTestId}) => {
-            const dataValue: React.ReactNode;
-            typeof value === 'object' && !React.isValidElement(value)
-              ? JSON.stringify(value, null, 2)
-              : value;
+            const dataValue: React.ReactNode =
+              typeof value === 'object' && !React.isValidElement(value)
+                ? JSON.stringify(value, null, 2)
+                : value;
 
             const valueIsReactRenderable: boolean =
               typeof dataValue !== 'string' && React.isValidElement(dataValue);

--- a/src/sentry/static/sentry/app/components/events/interfaces/keyValueList/keyValueListV2.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/keyValueList/keyValueListV2.tsx
@@ -42,7 +42,7 @@ const KeyValueList = ({
       <tbody>
         {getData().map(
           ({key, subject, value = null, meta, subjectIcon, subjectDataTestId}) => {
-            const dataValue: string | React.ReactNode | undefined =
+            const dataValue: React.ReactNode
               typeof value === 'object' && !React.isValidElement(value)
                 ? JSON.stringify(value, null, 2)
                 : value;

--- a/src/sentry/static/sentry/app/components/events/interfaces/keyValueList/keyValueListV2.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/keyValueList/keyValueListV2.tsx
@@ -42,10 +42,10 @@ const KeyValueList = ({
       <tbody>
         {getData().map(
           ({key, subject, value = null, meta, subjectIcon, subjectDataTestId}) => {
-            const dataValue: React.ReactNode
-              typeof value === 'object' && !React.isValidElement(value)
-                ? JSON.stringify(value, null, 2)
-                : value;
+            const dataValue: React.ReactNode;
+            typeof value === 'object' && !React.isValidElement(value)
+              ? JSON.stringify(value, null, 2)
+              : value;
 
             const valueIsReactRenderable: boolean =
               typeof dataValue !== 'string' && React.isValidElement(dataValue);

--- a/src/sentry/static/sentry/app/components/events/interfaces/keyValueList/keyValueListV2.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/keyValueList/keyValueListV2.tsx
@@ -50,28 +50,34 @@ const KeyValueList = ({
             const valueIsReactRenderable: boolean =
               typeof dataValue !== 'string' && React.isValidElement(dataValue);
 
+            let contentComponent: React.ReactNode = (
+              <pre className="val-string">
+                <AnnotatedText value={dataValue} meta={meta} />
+                {subjectIcon}
+              </pre>
+            );
+
+            if (isContextData) {
+              contentComponent = (
+                <ContextData
+                  data={!raw ? value : JSON.stringify(value)}
+                  meta={meta}
+                  withAnnotatedText
+                >
+                  {subjectIcon}
+                </ContextData>
+              );
+            } else if (valueIsReactRenderable) {
+              contentComponent = dataValue;
+            }
+
             return (
               <tr key={key}>
                 <TableSubject className="key" wide={longKeys}>
                   {subject}
                 </TableSubject>
                 <td className="val" data-test-id={subjectDataTestId}>
-                  {isContextData ? (
-                    <ContextData
-                      data={!raw ? value : JSON.stringify(value)}
-                      meta={meta}
-                      withAnnotatedText
-                    >
-                      {subjectIcon}
-                    </ContextData>
-                  ) : valueIsReactRenderable ? (
-                    dataValue
-                  ) : (
-                    <pre className="val-string">
-                      <AnnotatedText value={dataValue} meta={meta} />
-                      {subjectIcon}
-                    </pre>
-                  )}
+                  {contentComponent}
                 </td>
               </tr>
             );

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -264,6 +264,7 @@ type SentryEventBase = {
   message: string;
   platform?: PlatformKey;
   dateCreated?: string;
+  dateReceived?: string;
   endTimestamp?: number;
   entries: EntryType[];
 

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -236,18 +236,9 @@ type RuntimeContext = {
   name?: string;
 };
 
-type TraceContext = {
-  type: 'trace';
-  op: string;
-  description: string;
-  parent_span_id: string;
-  span_id: string;
-  trace_id: string;
-};
-
 type EventContexts = {
   runtime?: RuntimeContext;
-  trace?: TraceContext;
+  trace?: TraceContextType;
 };
 
 type SentryEventBase = {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
@@ -14,7 +14,6 @@ import FileSize from 'app/components/fileSize';
 import SentryTypes from 'app/sentryTypes';
 import Tooltip from 'app/components/tooltip';
 import getDynamicText from 'app/utils/getDynamicText';
-import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
 
 const formatDateDelta = (reference, observed) => {
   const duration = moment.duration(Math.abs(+observed - +reference));
@@ -43,7 +42,6 @@ class GroupEventToolbar extends React.Component {
     group: SentryTypes.Group.isRequired,
     event: SentryTypes.Event.isRequired,
     location: PropTypes.object.isRequired,
-    organization: SentryTypes.Organization.isRequired,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -79,43 +77,6 @@ class GroupEventToolbar extends React.Component {
           </React.Fragment>
         )}
       </dl>
-    );
-  }
-
-  renderRelatedTransactionButton() {
-    const {organization, event, orgId, location} = this.props;
-
-    const orgFeatures = new Set(organization.features);
-
-    if (!orgFeatures.has('performance-view')) {
-      return null;
-    }
-
-    const transactionTag = event?.tags?.find(tag => {
-      return tag?.key === 'transaction';
-    });
-
-    if (!transactionTag) {
-      return null;
-    }
-
-    const transactionName = transactionTag?.value;
-
-    if (typeof transactionName !== 'string' || !transactionName) {
-      return null;
-    }
-
-    const to = transactionSummaryRouteWithQuery({
-      orgSlug: orgId,
-      transaction: transactionName,
-      projectID: event.projectID,
-      query: location.query,
-    });
-
-    return (
-      <Button key="related-transaction" to={to} size="small">
-        {t('Related Transaction')}
-      </Button>
     );
   }
 
@@ -182,7 +143,6 @@ class GroupEventToolbar extends React.Component {
     return (
       <div className="event-toolbar">
         <NavigationButtons gap={1}>
-          {this.renderRelatedTransactionButton()}
           <ButtonBar merged>{eventNavNodes}</ButtonBar>
         </NavigationButtons>
         <h4>

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1410,7 +1410,6 @@ span.val {
   color: darken(@purple, 10);
   border-radius: 3px;
   padding: 2px 4px;
-  margin: -2px -4px;
 }
 
 .val-string-multiline {


### PR DESCRIPTION
Proof of concept for a specialized UI to display any available trace context within the event payload.

## TODO

- [x] Delete "Related Transaction" button
- [x] Add "View Summary" button


------

On the event details in either Issues or Discover:

<img width="1317" alt="Screen Shot 2020-06-24 at 4 58 09 AM" src="https://user-images.githubusercontent.com/139499/85525706-5234a780-b5d7-11ea-8f84-70b74052d8e5.png">


-----

Clicking on the "Search by Trace" will lead to a Discover query for any events by trace id:

<img width="1307" alt="Screen Shot 2020-05-28 at 9 10 36 PM" src="https://user-images.githubusercontent.com/139499/83210055-df472680-a127-11ea-9fb1-165d9dabd4e8.png">
