### PR TITLE
fix(breadcrumbsv2): Move transaction linkify from the exception breadcrumb to the default breadcrumb

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/data.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/data.tsx
@@ -22,10 +22,10 @@ const Data = ({breadcrumb, event, orgId}: Props) => {
     breadcrumb.type === BreadcrumbType.WARNING ||
     breadcrumb.type === BreadcrumbType.ERROR
   ) {
-    return <Exception event={event} orgId={orgId} breadcrumb={breadcrumb} />;
+    return <Exception breadcrumb={breadcrumb} />;
   }
 
-  return <Default breadcrumb={breadcrumb} />;
+  return <Default event={event} orgId={orgId} breadcrumb={breadcrumb} />;
 };
 
 export default Data;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/default.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/default.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
+import {Event, Project} from 'app/types';
 import {getMeta} from 'app/components/events/meta/metaProxy';
+import withProjects from 'app/utils/withProjects';
+import {generateEventSlug, eventDetailsRoute} from 'app/utils/discover/urls';
+import Link from 'app/components/links/link';
 
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
 import {BreadcrumbTypeDefault, BreadcrumbTypeNavigation} from '../types';
@@ -8,16 +12,68 @@ import Summary from './summary';
 
 type Props = {
   breadcrumb: BreadcrumbTypeDefault | BreadcrumbTypeNavigation;
+  event: Event;
+  orgId: string | null;
 };
 
-const Default = ({breadcrumb}: Props) => (
+const Default = ({breadcrumb, event, orgId}: Props) => (
   <Summary kvData={breadcrumb.data}>
     {breadcrumb?.message &&
       getBreadcrumbCustomRendererValue({
-        value: breadcrumb.message,
+        value: (
+          <FormatMessage
+            event={event}
+            orgId={orgId}
+            breadcrumb={breadcrumb}
+            message={breadcrumb.message}
+          />
+        ),
         meta: getMeta(breadcrumb, 'message'),
       })}
   </Summary>
 );
+
+function isEventId(maybeEventId: string): boolean {
+  // maybeEventId is an event id if it's a hex string of 32 characters long
+  return /^[a-fA-F0-9]{32}$/.test(maybeEventId);
+}
+
+const FormatMessage = withProjects(function FormatMessageInner({
+  event,
+  message,
+  breadcrumb,
+  projects,
+  loadingProjects,
+  orgId,
+}: {
+  event: Event;
+  projects: Project[];
+  loadingProjects: boolean;
+  breadcrumb: BreadcrumbTypeDefault | BreadcrumbTypeNavigation;
+  message: string;
+  orgId: string | null;
+}) {
+  if (
+    !loadingProjects &&
+    typeof orgId === 'string' &&
+    breadcrumb.category === 'sentry.transaction' &&
+    isEventId(message)
+  ) {
+    const maybeProject = projects.find(project => {
+      return project.id === event.projectID;
+    });
+
+    if (!maybeProject) {
+      return <React.Fragment>{message}</React.Fragment>;
+    }
+
+    const projectSlug = maybeProject.slug;
+    const eventSlug = generateEventSlug({project: projectSlug, id: message});
+
+    return <Link to={eventDetailsRoute({orgSlug: orgId, eventSlug})}>{message}</Link>;
+  }
+
+  return <React.Fragment>{message}</React.Fragment>;
+});
 
 export default Default;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/exception.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/exception.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import omit from 'lodash/omit';
 
-import {Event, Project} from 'app/types';
 import {getMeta} from 'app/components/events/meta/metaProxy';
 import {defined} from 'app/utils';
-import withProjects from 'app/utils/withProjects';
-import {generateEventSlug, eventDetailsRoute} from 'app/utils/discover/urls';
-import Link from 'app/components/links/link';
 
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
 import {BreadcrumbTypeDefault} from '../types';
@@ -14,11 +10,9 @@ import Summary from './summary';
 
 type Props = {
   breadcrumb: BreadcrumbTypeDefault;
-  event: Event;
-  orgId: string | null;
 };
 
-const Exception = ({breadcrumb, event, orgId}: Props) => {
+const Exception = ({breadcrumb}: Props) => {
   const {data} = breadcrumb;
   const dataValue = data?.value;
 
@@ -36,61 +30,11 @@ const Exception = ({breadcrumb, event, orgId}: Props) => {
         })}
       {breadcrumb?.message &&
         getBreadcrumbCustomRendererValue({
-          value: (
-            <FormatMessage
-              event={event}
-              orgId={orgId}
-              breadcrumb={breadcrumb}
-              message={breadcrumb.message}
-            />
-          ),
+          value: breadcrumb.message,
           meta: getMeta(breadcrumb, 'message'),
         })}
     </Summary>
   );
 };
-
-function isEventId(maybeEventId: string): boolean {
-  // maybeEventId is an event id if it's a hex string of 32 characters long
-  return /^[a-fA-F0-9]{32}$/.test(maybeEventId);
-}
-
-const FormatMessage = withProjects(function FormatMessageInner({
-  event,
-  message,
-  breadcrumb,
-  projects,
-  loadingProjects,
-  orgId,
-}: {
-  event: Event;
-  projects: Project[];
-  loadingProjects: boolean;
-  breadcrumb: BreadcrumbTypeDefault;
-  message: string;
-  orgId: string | null;
-}) {
-  if (
-    !loadingProjects &&
-    typeof orgId === 'string' &&
-    breadcrumb.category === 'sentry.transaction' &&
-    isEventId(message)
-  ) {
-    const maybeProject = projects.find(project => {
-      return project.id === event.projectID;
-    });
-
-    if (!maybeProject) {
-      return <React.Fragment>{message}</React.Fragment>;
-    }
-
-    const projectSlug = maybeProject.slug;
-    const eventSlug = generateEventSlug({project: projectSlug, id: message});
-
-    return <Link to={eventDetailsRoute({orgSlug: orgId, eventSlug})}>{message}</Link>;
-  }
-
-  return <React.Fragment>{message}</React.Fragment>;
-});
 
 export default Exception;


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/19062 