### PR TITLE
feat(ui): Add source maps settings

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -802,6 +802,8 @@ SENTRY_FEATURES = {
     "organizations:android-mappings": False,
     # Enable obtaining and using API keys.
     "organizations:api-keys": False,
+    # Move release artifacts to settings.
+    "organizations:artifacts-in-settings": False,
     # Enable explicit use of AND and OR in search.
     "organizations:boolean-search": False,
     # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -55,6 +55,7 @@ default_manager.add("organizations:create")
 # Organization scoped features
 default_manager.add("organizations:advanced-search", OrganizationFeature)  # NOQA
 default_manager.add("organizations:android-mappings", OrganizationFeature)  # NOQA
+default_manager.add("organizations:artifacts-in-settings", OrganizationFeature)  # NOQA
 default_manager.add("organizations:boolean-search", OrganizationFeature)  # NOQA
 default_manager.add("organizations:api-keys", OrganizationFeature)  # NOQA
 default_manager.add("organizations:data-export", OrganizationFeature)  # NOQA

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -425,6 +425,16 @@ function routes() {
         component={errorHandler(LazyLoad)}
       />
       <Route
+        path="source-maps/"
+        name={t('Source Maps')}
+        componentPromise={() =>
+          import(
+            /* webpackChunkName: "ProjectSourceMaps" */ 'app/views/settings/projectSourceMaps'
+          )
+        }
+        component={errorHandler(LazyLoad)}
+      />
+      <Route
         path="processing-issues/"
         name="Processing Issues"
         componentPromise={() =>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
@@ -9,6 +9,7 @@ import {formatVersion} from 'app/utils/formatters';
 import withOrganization from 'app/utils/withOrganization';
 import {Organization} from 'app/types';
 import AlertLink from 'app/components/alertLink';
+import Feature from 'app/components/acl/feature';
 
 import {ReleaseContext} from '..';
 
@@ -39,14 +40,16 @@ class ReleaseArtifacts extends AsyncView<Props> {
 
     return (
       <React.Fragment>
-        <AlertLink
-          to={`/settings/${organization.slug}/projects/${project.slug}/source-maps/`}
-          priority="info"
-        >
-          {tct('Artifacts were moved to [sourceMaps] in Settings.', {
-            sourceMaps: <u>{t('Source Maps')}</u>,
-          })}
-        </AlertLink>
+        <Feature features={['artifacts-in-settings']}>
+          <AlertLink
+            to={`/settings/${organization.slug}/projects/${project.slug}/source-maps/`}
+            priority="info"
+          >
+            {tct('Artifacts were moved to [sourceMaps] in Settings.', {
+              sourceMaps: <u>{t('Source Maps')}</u>,
+            })}
+          </AlertLink>
+        </Feature>
 
         <ReleaseArtifactsV1
           params={params}

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import {RouteComponentProps} from 'react-router/lib/Router';
 
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import ReleaseArtifactsV1 from 'app/views/releases/detail/releaseArtifacts';
 import AsyncView from 'app/views/asyncView';
 import routeTitleGen from 'app/utils/routeTitle';
 import {formatVersion} from 'app/utils/formatters';
 import withOrganization from 'app/utils/withOrganization';
 import {Organization} from 'app/types';
+import AlertLink from 'app/components/alertLink';
 
 import {ReleaseContext} from '..';
 
@@ -34,15 +35,26 @@ class ReleaseArtifacts extends AsyncView<Props> {
 
   renderBody() {
     const {project} = this.context;
-    const {params, location} = this.props;
+    const {params, location, organization} = this.props;
 
     return (
-      <ReleaseArtifactsV1
-        params={params}
-        location={location}
-        projectId={project.slug}
-        smallEmptyMessage
-      />
+      <React.Fragment>
+        <AlertLink
+          to={`/settings/${organization.slug}/projects/${project.slug}/source-maps/`}
+          priority="info"
+        >
+          {tct('Artifacts were moved to [sourceMaps] in Settings.', {
+            sourceMaps: <u>{t('Source Maps')}</u>,
+          })}
+        </AlertLink>
+
+        <ReleaseArtifactsV1
+          params={params}
+          location={location}
+          projectId={project.slug}
+          smallEmptyMessage
+        />
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -120,7 +120,12 @@ class ReleaseOverview extends AsyncView<Props> {
                     />
                   </Main>
                   <Sidebar>
-                    <ProjectReleaseDetails release={release} />
+                    <ProjectReleaseDetails
+                      release={release}
+                      releaseMeta={releaseMeta}
+                      orgSlug={organization.slug}
+                      projectSlug={project.slug}
+                    />
                     {commitCount > 0 && (
                       <CommitAuthorBreakdown
                         version={version}

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/projectReleaseDetails.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/projectReleaseDetails.tsx
@@ -1,20 +1,25 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {t} from 'app/locale';
+import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
-import {ReleaseWithHealth} from 'app/types';
+import {ReleaseWithHealth, ReleaseMeta} from 'app/types';
 import Version from 'app/components/version';
 import TimeSince from 'app/components/timeSince';
 import DateTime from 'app/components/dateTime';
+import Link from 'app/components/links/link';
+import Count from 'app/components/count';
 
 import {SectionHeading, Wrapper} from './styles';
 
 type Props = {
   release: ReleaseWithHealth;
+  releaseMeta: ReleaseMeta;
+  orgSlug: string;
+  projectSlug: string;
 };
 
-const ProjectReleaseDetails = ({release}: Props) => {
+const ProjectReleaseDetails = ({release, releaseMeta, orgSlug, projectSlug}: Props) => {
   const {version, dateCreated, firstEvent, lastEvent} = release;
 
   return (
@@ -44,6 +49,16 @@ const ProjectReleaseDetails = ({release}: Props) => {
           <StyledTr>
             <TagKey>{t('Last Event')}</TagKey>
             <TagValue>{lastEvent ? <TimeSince date={lastEvent} /> : '-'}</TagValue>
+          </StyledTr>
+
+          <StyledTr>
+            <TagKey>{t('Source Maps')}</TagKey>
+            <TagValue>
+              <Link to={`/settings/${orgSlug}/projects/${projectSlug}/source-maps/`}>
+                <Count value={releaseMeta.releaseFileCount} />{' '}
+                {tn('file uploaded', 'files uploaded', releaseMeta.releaseFileCount)}
+              </Link>
+            </TagValue>
           </StyledTr>
         </tbody>
       </StyledTable>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/projectReleaseDetails.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/projectReleaseDetails.tsx
@@ -9,6 +9,7 @@ import TimeSince from 'app/components/timeSince';
 import DateTime from 'app/components/dateTime';
 import Link from 'app/components/links/link';
 import Count from 'app/components/count';
+import Feature from 'app/components/acl/feature';
 
 import {SectionHeading, Wrapper} from './styles';
 
@@ -51,15 +52,17 @@ const ProjectReleaseDetails = ({release, releaseMeta, orgSlug, projectSlug}: Pro
             <TagValue>{lastEvent ? <TimeSince date={lastEvent} /> : '-'}</TagValue>
           </StyledTr>
 
-          <StyledTr>
-            <TagKey>{t('Source Maps')}</TagKey>
-            <TagValue>
-              <Link to={`/settings/${orgSlug}/projects/${projectSlug}/source-maps/`}>
-                <Count value={releaseMeta.releaseFileCount} />{' '}
-                {tn('file uploaded', 'files uploaded', releaseMeta.releaseFileCount)}
-              </Link>
-            </TagValue>
-          </StyledTr>
+          <Feature features={['artifacts-in-settings']}>
+            <StyledTr>
+              <TagKey>{t('Source Maps')}</TagKey>
+              <TagValue>
+                <Link to={`/settings/${orgSlug}/projects/${projectSlug}/source-maps/`}>
+                  <Count value={releaseMeta.releaseFileCount} />{' '}
+                  {tn('file uploaded', 'files uploaded', releaseMeta.releaseFileCount)}
+                </Link>
+              </TagValue>
+            </StyledTr>
+          </Feature>
         </tbody>
       </StyledTable>
     </Wrapper>

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
@@ -63,6 +63,11 @@ export default function getConfiguration({
           title: t('Debug Files'),
         },
         {
+          path: `${pathPrefix}/source-maps/`,
+          title: t('Source Maps'),
+          show: () => organization.features?.includes('artifacts-in-settings'),
+        },
+        {
           path: `${pathPrefix}/android-mappings/`,
           title: t('Android Mappings'),
           show: () => organization.features?.includes('android-mappings'),

--- a/src/sentry/static/sentry/app/views/settings/projectSourceMaps/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSourceMaps/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import {t} from 'app/locale';
+import {PageContent} from 'app/styles/organization';
+import Feature from 'app/components/acl/feature';
+import Alert from 'app/components/alert';
+import withOrganization from 'app/utils/withOrganization';
+
+import ProjectSourceMaps from './projectSourceMaps';
+
+class ProjectSourceMapsContainer extends React.Component<ProjectSourceMaps['props']> {
+  renderNoAccess() {
+    return (
+      <PageContent>
+        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+      </PageContent>
+    );
+  }
+
+  render() {
+    const {organization} = this.props;
+
+    return (
+      <Feature
+        features={['artifacts-in-settings']}
+        organization={organization}
+        renderDisabled={this.renderNoAccess}
+      >
+        <ProjectSourceMaps {...this.props} />
+      </Feature>
+    );
+  }
+}
+
+export default withOrganization(ProjectSourceMapsContainer);

--- a/src/sentry/static/sentry/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSourceMaps/projectSourceMaps.tsx
@@ -1,0 +1,52 @@
+import {RouteComponentProps} from 'react-router/lib/Router';
+import React from 'react';
+
+import {t} from 'app/locale';
+import AsyncView from 'app/views/asyncView';
+import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+import {Organization, Project} from 'app/types';
+import routeTitleGen from 'app/utils/routeTitle';
+
+type Props = RouteComponentProps<{orgId: string; projectId: string}, {}> & {
+  organization: Organization;
+  project: Project;
+};
+
+type State = AsyncView['state'] & {
+  //
+};
+
+class ProjectSourceMaps extends AsyncView<Props, State> {
+  getTitle() {
+    const {projectId} = this.props.params;
+
+    return routeTitleGen(t('Source Maps'), projectId, false);
+  }
+
+  getDefaultState(): State {
+    return {
+      ...super.getDefaultState(),
+      //
+    };
+  }
+
+  getEndpoints() {
+    const endpoints: ReturnType<AsyncView['getEndpoints']> = [];
+
+    return endpoints;
+  }
+
+  renderLoading() {
+    return this.renderBody();
+  }
+
+  renderBody() {
+    return (
+      <React.Fragment>
+        <SettingsPageHeader title={t('Source Maps')} />
+      </React.Fragment>
+    );
+  }
+}
+
+export default ProjectSourceMaps;


### PR DESCRIPTION
This PR adds a new project settings page called "Source Maps".
We will be moving Release Artifacts here in multiple other PRs.

This is work in progress behind `artifacts-in-settings` feature flag.

![image](https://user-images.githubusercontent.com/9060071/83262671-b1142600-a1bd-11ea-8e81-f9960b04fe8f.png)

![image](https://user-images.githubusercontent.com/9060071/83262604-95a91b00-a1bd-11ea-9c48-602442cf1106.png)

![image](https://user-images.githubusercontent.com/9060071/83262636-9fcb1980-a1bd-11ea-9290-b70b7820d1e3.png)

