### PR TITLE
fix(apm): Display span status and any unknown keys within the span

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -21,7 +21,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 
-import {ProcessedSpanType, RawSpanType, ParsedTraceType} from './types';
+import {ProcessedSpanType, RawSpanType, ParsedTraceType, rawSpanKeys} from './types';
 import {isGapSpan, isOrphanSpan, getTraceDateTimeRange} from './utils';
 
 type TransactionResult = {
@@ -313,6 +313,10 @@ class SpanDetail extends React.Component<Props, State> {
       return null;
     }
 
+    const unknownKeys = Object.keys(span).filter(key => {
+      return !rawSpanKeys.has(key as any);
+    });
+
     return (
       <SpanDetailContainer
         data-component="span-detail"
@@ -365,6 +369,11 @@ class SpanDetail extends React.Component<Props, State> {
               {map(span?.data ?? {}, (value, key) => (
                 <Row title={key} key={key}>
                   {JSON.stringify(value, null, 4) || ''}
+                </Row>
+              ))}
+              {unknownKeys.map(key => (
+                <Row title={key} key={key}>
+                  {JSON.stringify(span[key], null, 4) || ''}
                 </Row>
               ))}
             </tbody>

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -338,6 +338,7 @@ class SpanDetail extends React.Component<Props, State> {
               </Row>
               <Row title="Parent Span ID">{span.parent_span_id || ''}</Row>
               <Row title="Description">{span?.description ?? ''}</Row>
+              <Row title="Status">{span.status || ''}</Row>
               <Row title="Start Date">
                 {getDynamicText({
                   fixed: 'Mar 16, 2020 9:10:12 AM UTC',

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -15,9 +15,24 @@ export type RawSpanType = {
   same_process_as_parent?: boolean;
   op?: string;
   description?: string;
+  status?: string;
   data: Object;
   tags?: {[key: string]: string};
 };
+
+export const rawSpanKeys: Set<keyof RawSpanType> = new Set([
+  'trace_id',
+  'parent_span_id',
+  'span_id',
+  'start_timestamp',
+  'timestamp',
+  'same_process_as_parent',
+  'op',
+  'description',
+  'status',
+  'data',
+  'tags',
+]);
 
 export type OrphanSpanType = {
   type: 'orphan';


### PR DESCRIPTION
- Display span `status` since this is one of the exposed attributes: https://develop.sentry.dev/sdk/event-payloads/span/#attributes

- Also expose any unknown keys within the span due to changes in spec that may be in flux.