### PR TITLE
feat(sentry-apps): Add link to schema docs for new integration

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
@@ -67,7 +67,14 @@ const getPublicFormFields = (): Field[] => [
     type: 'textarea',
     label: 'Schema',
     autosize: true,
-    help: 'Schema for your UI components',
+    help: tct(
+      'Schema for your UI components. Click [schema_docs:here] for documentation',
+      {
+        schema_docs: (
+          <a href="https://docs.sentry.io/workflow/integrations/integration-platform/ui-components/" />
+        ),
+      }
+    ),
     getValue: (val: string) => (val === '' ? {} : JSON.parse(val)),
     setValue: (val: string) => {
       const schema = JSON.stringify(val, null, 2);


### PR DESCRIPTION
When creating a new integration, add a link to the schema documentation after the schema description.

Fixes API-1008