### PR TITLE
fix(apm): For CTAs from within the span view, adjust project selection

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -160,6 +160,7 @@ class SpansInterface extends React.Component<Props, State> {
                     event={event}
                     searchQuery={this.state.searchQuery}
                     orgId={orgId}
+                    organization={organization}
                     eventView={eventView}
                     parsedTrace={parsedTrace}
                     spansWithErrors={spansWithErrors}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import 'intersection-observer'; // this is a polyfill
 
-import {Organization} from 'app/types';
+import {Organization, SentryTransactionEvent} from 'app/types';
 import {t} from 'app/locale';
 import {defined, OmitHtmlDivProps} from 'app/utils';
 import space from 'app/styles/space';
@@ -171,6 +171,7 @@ const getDurationDisplay = ({
 };
 
 type SpanBarProps = {
+  event: Readonly<SentryTransactionEvent>;
   orgId: string;
   organization: Organization;
   trace: Readonly<ParsedTraceType>;
@@ -238,6 +239,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       trace,
       totalNumberOfErrors,
       spanErrors,
+      event,
     } = this.props;
 
     return (
@@ -245,6 +247,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         span={span}
         orgId={orgId}
         organization={organization}
+        event={event}
         isRoot={!!isRoot}
         eventView={eventView}
         trace={trace}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import 'intersection-observer'; // this is a polyfill
 
+import {Organization} from 'app/types';
 import {t} from 'app/locale';
 import {defined, OmitHtmlDivProps} from 'app/utils';
 import space from 'app/styles/space';
@@ -171,6 +172,7 @@ const getDurationDisplay = ({
 
 type SpanBarProps = {
   orgId: string;
+  organization: Organization;
   trace: Readonly<ParsedTraceType>;
   span: Readonly<ProcessedSpanType>;
   spanBarColour?: string;
@@ -230,6 +232,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     const {
       span,
       orgId,
+      organization,
       isRoot,
       eventView,
       trace,
@@ -241,6 +244,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       <SpanDetail
         span={span}
         orgId={orgId}
+        organization={organization}
         isRoot={!!isRoot}
         eventView={eventView}
         trace={trace}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -179,7 +179,7 @@ class SpanDetail extends React.Component<Props, State> {
   }
 
   renderTraceButton() {
-    const {span, orgId, trace, eventView} = this.props;
+    const {span, orgId, organization, trace, event} = this.props;
 
     const {start, end} = getTraceDateTimeRange({
       start: trace.traceStartTimestamp,
@@ -189,6 +189,8 @@ class SpanDetail extends React.Component<Props, State> {
     if (isGapSpan(span)) {
       return null;
     }
+
+    const orgFeatures = new Set(organization.features);
 
     const traceEventView = EventView.fromSavedQuery({
       id: undefined,
@@ -202,7 +204,7 @@ class SpanDetail extends React.Component<Props, State> {
       ],
       orderby: '-timestamp',
       query: `event.type:transaction trace:${span.trace_id}`,
-      projects: eventView.project,
+      projects: orgFeatures.has('global-views') ? [] : [Number(event.projectID)],
       version: 2,
       start,
       end,

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -234,7 +234,15 @@ class SpanDetail extends React.Component<Props, State> {
   }
 
   renderSpanErrorMessage() {
-    const {orgId, spanErrors, totalNumberOfErrors, span, trace, eventView} = this.props;
+    const {
+      orgId,
+      spanErrors,
+      totalNumberOfErrors,
+      span,
+      trace,
+      organization,
+      event,
+    } = this.props;
 
     if (spanErrors.length === 0 || totalNumberOfErrors === 0 || isGapSpan(span)) {
       return null;
@@ -249,13 +257,15 @@ class SpanDetail extends React.Component<Props, State> {
       end: trace.traceEndTimestamp,
     });
 
+    const orgFeatures = new Set(organization.features);
+
     const errorsEventView = EventView.fromSavedQuery({
       id: undefined,
       name: `Error events associated with span ${span.span_id}`,
       fields: ['title', 'project', 'issue', 'timestamp'],
       orderby: '-timestamp',
       query: `event.type:error trace:${span.trace_id} trace.span:${span.span_id}`,
-      projects: eventView.project,
+      projects: orgFeatures.has('global-views') ? [] : [Number(event.projectID)],
       version: 2,
       start,
       end,

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import map from 'lodash/map';
 import styled from '@emotion/styled';
 
+import {Organization} from 'app/types';
 import {Client} from 'app/api';
 import {IconWarning} from 'app/icons';
 import {TableDataRow} from 'app/views/eventsV2/table/types';
@@ -33,6 +34,7 @@ type TransactionResult = {
 type Props = {
   api: Client;
   orgId: string;
+  organization: Organization;
   span: Readonly<ProcessedSpanType>;
   isRoot: boolean;
   eventView: EventView;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import map from 'lodash/map';
 import styled from '@emotion/styled';
 
-import {Organization} from 'app/types';
+import {Organization, SentryTransactionEvent} from 'app/types';
 import {Client} from 'app/api';
 import {IconWarning} from 'app/icons';
 import {TableDataRow} from 'app/views/eventsV2/table/types';
@@ -35,6 +35,7 @@ type Props = {
   api: Client;
   orgId: string;
   organization: Organization;
+  event: Readonly<SentryTransactionEvent>;
   span: Readonly<ProcessedSpanType>;
   isRoot: boolean;
   eventView: EventView;
@@ -119,7 +120,7 @@ class SpanDetail extends React.Component<Props, State> {
       );
     }
 
-    const {span, orgId, trace, eventView} = this.props;
+    const {span, orgId, trace, eventView, organization, event} = this.props;
 
     assert(!isGapSpan(span));
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -142,6 +142,8 @@ class SpanDetail extends React.Component<Props, State> {
       );
     }
 
+    const orgFeatures = new Set(organization.features);
+
     const {start, end} = getTraceDateTimeRange({
       start: trace.traceStartTimestamp,
       end: trace.traceEndTimestamp,
@@ -159,7 +161,7 @@ class SpanDetail extends React.Component<Props, State> {
       ],
       orderby: '-timestamp',
       query: `event.type:transaction trace:${span.trace_id} trace.parent_span:${span.span_id}`,
-      projects: eventView.project,
+      projects: orgFeatures.has('global-views') ? [] : [Number(event.projectID)],
       version: 2,
       start,
       end,

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Organization} from 'app/types';
+import {Organization, SentryTransactionEvent} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {TableData, TableDataRow} from 'app/views/eventsV2/table/types';
 
@@ -11,6 +11,7 @@ import SpanBar from './spanBar';
 type PropType = {
   orgId: string;
   organization: Organization;
+  event: Readonly<SentryTransactionEvent>;
   eventView: EventView;
   span: Readonly<ProcessedSpanType>;
   trace: Readonly<ParsedTraceType>;
@@ -94,6 +95,7 @@ class SpanGroup extends React.Component<PropType, State> {
       orgId,
       organization,
       eventView,
+      event,
     } = this.props;
 
     return (
@@ -101,6 +103,7 @@ class SpanGroup extends React.Component<PropType, State> {
         <SpanBar
           eventView={eventView}
           organization={organization}
+          event={event}
           orgId={orgId}
           spanBarColour={spanBarColour}
           spanBarHatch={spanBarHatch}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {Organization} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {TableData, TableDataRow} from 'app/views/eventsV2/table/types';
 
@@ -9,6 +10,7 @@ import SpanBar from './spanBar';
 
 type PropType = {
   orgId: string;
+  organization: Organization;
   eventView: EventView;
   span: Readonly<ProcessedSpanType>;
   trace: Readonly<ParsedTraceType>;
@@ -90,6 +92,7 @@ class SpanGroup extends React.Component<PropType, State> {
       spanNumber,
       isCurrentSpanFilteredOut,
       orgId,
+      organization,
       eventView,
     } = this.props;
 
@@ -97,6 +100,7 @@ class SpanGroup extends React.Component<PropType, State> {
       <React.Fragment>
         <SpanBar
           eventView={eventView}
+          organization={organization}
           orgId={orgId}
           spanBarColour={spanBarColour}
           spanBarHatch={spanBarHatch}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {SentryTransactionEvent} from 'app/types';
+import {SentryTransactionEvent, Organization} from 'app/types';
 import {t} from 'app/locale';
 import EventView from 'app/utils/discover/eventView';
 import {TableData} from 'app/views/eventsV2/table/types';
@@ -42,6 +42,7 @@ type RenderedSpanTree = {
 
 type PropType = {
   orgId: string;
+  organization: Organization;
   eventView: EventView;
   trace: ParsedTraceType;
   dragProps: DragManagerChildrenProps;
@@ -141,7 +142,7 @@ class SpanTree extends React.Component<PropType> {
     generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
     previousSiblingEndTimestamp: undefined | number;
   }): RenderedSpanTree => {
-    const {orgId, eventView, event, spansWithErrors} = this.props;
+    const {orgId, eventView, event, spansWithErrors, organization} = this.props;
 
     const spanBarColour: string = pickSpanBarColour(getSpanOperation(span));
     const spanChildren: Array<RawSpanType> = childSpans?.[getSpanID(span)] ?? [];
@@ -250,6 +251,7 @@ class SpanTree extends React.Component<PropType> {
         <SpanGroup
           eventView={eventView}
           orgId={orgId}
+          organization={organization}
           spanNumber={spanNumber}
           isLast={false}
           continuingTreeDepths={continuingTreeDepths}
@@ -277,6 +279,7 @@ class SpanTree extends React.Component<PropType> {
           <SpanGroup
             eventView={eventView}
             orgId={orgId}
+            organization={organization}
             spanNumber={spanGroupNumber}
             isLast={isLast}
             continuingTreeDepths={continuingTreeDepths}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -252,6 +252,7 @@ class SpanTree extends React.Component<PropType> {
           eventView={eventView}
           orgId={orgId}
           organization={organization}
+          event={event}
           spanNumber={spanNumber}
           isLast={false}
           continuingTreeDepths={continuingTreeDepths}
@@ -280,6 +281,7 @@ class SpanTree extends React.Component<PropType> {
             eventView={eventView}
             orgId={orgId}
             organization={organization}
+            event={event}
             spanNumber={spanGroupNumber}
             isLast={isLast}
             continuingTreeDepths={continuingTreeDepths}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -6,7 +6,7 @@ import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import EventView from 'app/utils/discover/eventView';
 import {TableData} from 'app/views/eventsV2/table/types';
-import {SentryTransactionEvent} from 'app/types';
+import {SentryTransactionEvent, Organization} from 'app/types';
 
 import DragManager, {DragManagerChildrenProps} from './dragManager';
 import SpanTree from './spanTree';
@@ -36,6 +36,7 @@ export type FilterSpans = {
 
 type Props = {
   orgId: string;
+  organization: Organization;
   event: Readonly<SentryTransactionEvent>;
   parsedTrace: ParsedTraceType;
   searchQuery: string | undefined;
@@ -184,7 +185,7 @@ class TraceView extends React.PureComponent<Props, State> {
       );
     }
 
-    const {orgId, eventView, spansWithErrors} = this.props;
+    const {orgId, organization, eventView, spansWithErrors} = this.props;
 
     return (
       <DragManager interactiveLayerRef={this.minimapInteractiveRef}>
@@ -202,6 +203,7 @@ class TraceView extends React.PureComponent<Props, State> {
               dragProps={dragProps}
               filterSpans={this.state.filterSpans}
               orgId={orgId}
+              organization={organization}
               spansWithErrors={spansWithErrors}
             />
           </CursorGuideHandler.Provider>


### PR DESCRIPTION
- Apply global views when searching for errors by trace id; otherwise apply the event's project id
- Apply global views when searching for transactions by trace id; otherwise apply the event's project id
- Apply global views when searching for span children; otherwise apply the event's project id	