### PR TITLE
fix(sentry-apps): add better punctuation

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
@@ -68,7 +68,7 @@ const getPublicFormFields = (): Field[] => [
     label: 'Schema',
     autosize: true,
     help: tct(
-      'Schema for your UI components. Click [schema_docs:here] for documentation',
+      'Schema for your UI components. Click [schema_docs:here] for documentation.',
       {
         schema_docs: (
           <a href="https://docs.sentry.io/workflow/integrations/integration-platform/ui-components/" />


### PR DESCRIPTION
Add punctuation to the end of the sentence that links to schema documentation when creating a new integration. 