### PR TITLE
feat(discover): Limit the number of columns for discover queries to 20

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -132,6 +132,10 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
             )
             if not has_global_views and len(params.get("project_id", [])) > 1:
                 raise ParseError(detail="You cannot view events from multiple projects.")
+            if len(request.GET.getlist("field")) > 20:
+                raise ParseError(
+                    detail="You can view up to 20 fields at a time. Please delete some and try again."
+                )
 
         def data_fn(offset, limit):
             return discover.query(

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -132,6 +132,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
             )
             if not has_global_views and len(params.get("project_id", [])) > 1:
                 raise ParseError(detail="You cannot view events from multiple projects.")
+
             if len(request.GET.getlist("field")) > 20:
                 raise ParseError(
                     detail="You can view up to 20 fields at a time. Please delete some and try again."

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -321,7 +321,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
     const canAdd = columns.length < MAX_COL_COUNT;
     const title = canAdd
       ? undefined
-      : `Sorry, you reached the maximum number of columns. Delete a few columns to add more.`;
+      : `Sorry, you reached the maximum number of columns. Delete columns to add more.`;
 
     // Get the longest number of columns so we can layout the rows.
     // We always want at least 2 columns.

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -40,6 +40,7 @@ type State = {
 
 const DRAG_CLASS = 'draggable-item';
 const GRAB_HANDLE_FUDGE = 25;
+const MAX_COL_COUNT = 20;
 
 enum PlaceholderPosition {
   TOP,
@@ -317,6 +318,10 @@ class ColumnEditCollection extends React.Component<Props, State> {
   render() {
     const {columns} = this.props;
     const canDelete = columns.length > 1;
+    const canAdd = columns.length < MAX_COL_COUNT;
+    const title = canAdd
+      ? undefined
+      : `Sorry, you reached the maximum number of columns. Delete a few columns to add more.`;
 
     // Get the longest number of columns so we can layout the rows.
     // We always want at least 2 columns.
@@ -344,6 +349,8 @@ class ColumnEditCollection extends React.Component<Props, State> {
               size="small"
               label={t('Add a Column')}
               onClick={this.handleAddColumn}
+              title={title}
+              disabled={!canAdd}
               icon={<IconAdd isCircled size="xs" />}
             >
               {t('Add a Column')}

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -263,6 +263,26 @@ describe('EventsV2 -> ColumnEditModal', function() {
     });
   });
 
+  describe('adding rows', function() {
+    const wrapper = mountModal(
+      {
+        columns: [columns[0]],
+        onApply: () => void 0,
+        tagKeys,
+      },
+      initialData
+    );
+    it('allows rows to be added, but only up to 20', function() {
+      for (let i = 2; i <= 20; i++) {
+        wrapper.find('button[aria-label="Add a Column"]').simulate('click');
+        expect(wrapper.find('QueryField')).toHaveLength(i);
+      }
+      expect(
+        wrapper.find('button[aria-label="Add a Column"]').prop('aria-disabled')
+      ).toBe(true);
+    });
+  });
+
   describe('removing rows', function() {
     const wrapper = mountModal(
       {

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2588,3 +2588,18 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             )
 
             assert len(mock_quantize.mock_calls) == 2
+
+    def test_limit_number_of_fields(self):
+        self.login_as(user=self.user)
+        self.create_project()
+        with self.feature("organizations:discover-basic"):
+            for i in range(1, 40):
+                response = self.client.get(self.url, {"field": ["id"] * i})
+                if i <= 20:
+                    assert response.status_code == 200
+                else:
+                    assert response.status_code == 400
+                    assert (
+                        response.data["detail"]
+                        == "You can view up to 20 fields at a time. Please delete some and try again."
+                    )

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2593,7 +2593,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
         self.create_project()
         with self.feature("organizations:discover-basic"):
-            for i in range(1, 40):
+            for i in range(1, 25):
                 response = self.client.get(self.url, {"field": ["id"] * i})
                 if i <= 20:
                     assert response.status_code == 200


### PR DESCRIPTION
Currently, users can add as many columns as they want in a discover query, This allows them to
potentially make massive queries by adding 1000s of columns. This change limits the number of
columns they can query to 20 to limit the impact.