### PR TITLE
feat(alerts): Add specialized 'open in discover' button

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -2,17 +2,12 @@ import {RouteComponentProps} from 'react-router/lib/Router';
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {AlertRuleThresholdType, Trigger} from 'app/views/settings/incidentRules/types';
-import {PRESET_AGGREGATES} from 'app/views/settings/incidentRules/constants';
-import {NewQuery, Project} from 'app/types';
+import {Project} from 'app/types';
 import {PageContent} from 'app/styles/organization';
 import {defined} from 'app/utils';
-import {getUtcDateString} from 'app/utils/dates';
 import {t, tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import Duration from 'app/components/duration';
-import EventView from 'app/utils/discover/eventView';
-import {getAggregateAlias} from 'app/utils/discover/fields';
 import Feature from 'app/components/acl/feature';
 import Link from 'app/components/links/link';
 import NavTabs from 'app/components/navTabs';
@@ -24,7 +19,19 @@ import Projects from 'app/utils/projects';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import {Panel} from 'app/components/panels';
+import Button from 'app/components/button';
+import {
+  AlertRuleThresholdType,
+  Trigger,
+  Dataset,
+} from 'app/views/settings/incidentRules/types';
+import {
+  PRESET_AGGREGATES,
+  makeDefaultCta,
+} from 'app/views/settings/incidentRules/presets';
 
+import Activity from './activity';
+import Chart from './chart';
 import {
   Incident,
   IncidentStats,
@@ -32,8 +39,7 @@ import {
   IncidentStatus,
   IncidentStatusMethod,
 } from '../types';
-import Activity from './activity';
-import Chart from './chart';
+import {getIncidentDiscoverUrl} from '../utils';
 
 type Props = {
   incident?: Incident;
@@ -41,41 +47,14 @@ type Props = {
 } & RouteComponentProps<{alertId: string; orgId: string}, {}>;
 
 export default class DetailsBody extends React.Component<Props> {
-  getDiscoverUrl(projects: Project[]) {
-    const {incident, params, stats} = this.props;
-    const {orgId} = params;
+  get metricPreset() {
+    const alertRule = this.props.incident?.alertRule;
+    const aggregate = alertRule?.aggregate;
+    const dataset = alertRule?.dataset ?? Dataset.ERRORS;
 
-    if (!projects || !projects.length || !incident || !stats) {
-      return '';
-    }
-
-    const timeWindowString = `${incident.alertRule.timeWindow}m`;
-    const start = getUtcDateString(stats.eventStats.data[0][0] * 1000);
-    const end = getUtcDateString(
-      stats.eventStats.data[stats.eventStats.data.length - 1][0] * 1000
+    return PRESET_AGGREGATES.find(
+      p => p.validDataset.includes(dataset) && p.match.test(aggregate ?? '')
     );
-
-    const discoverQuery: NewQuery = {
-      id: undefined,
-      name: (incident && incident.title) || '',
-      fields: ['issue', 'count(id)', 'count_unique(user.id)'],
-      orderby: `-${getAggregateAlias(incident.alertRule.aggregate)}`,
-      query: incident?.discoverQuery ?? '',
-      projects: projects
-        .filter(({slug}) => incident.projects.includes(slug))
-        .map(({id}) => Number(id)),
-      version: 2 as const,
-      start,
-      end,
-    };
-
-    const discoverView = EventView.fromSavedQuery(discoverQuery);
-    const {query, ...toObject} = discoverView.getResultsViewUrlTarget(orgId);
-
-    return {
-      query: {...query, interval: timeWindowString},
-      ...toObject,
-    };
   }
 
   /**
@@ -94,13 +73,6 @@ export default class DetailsBody extends React.Component<Props> {
     const direction = isAbove === isAlert ? '>' : '<';
 
     return `${direction} ${trigger[key]}`;
-  }
-
-  get friendlyIncidentType() {
-    const aggregate = this.props?.incident?.alertRule?.aggregate;
-    const preset = PRESET_AGGREGATES.find(p => p.match.test(aggregate ?? ''));
-
-    return preset?.name ?? t('Custom metric');
   }
 
   renderRuleDetails() {
@@ -155,31 +127,62 @@ export default class DetailsBody extends React.Component<Props> {
   }
 
   renderChartHeader() {
-    const {incident} = this.props;
+    const {incident, stats, params} = this.props;
     const alertRule = incident?.alertRule;
 
     return (
       <ChartHeader>
-        {this.friendlyIncidentType}
-
-        <ChartParameters>
-          {tct('Metric: [metric] over [window]', {
-            metric: <code>{alertRule?.aggregate ?? '...'}</code>,
-            window: (
-              <code>
-                {incident ? (
-                  <Duration seconds={incident.alertRule.timeWindow * 60} />
-                ) : (
-                  '...'
-                )}
-              </code>
-            ),
-          })}
-          {alertRule?.query &&
-            tct('Filter: [filter]', {
-              filter: <code>{alertRule.query}</code>,
+        <div>
+          {this.metricPreset?.name ?? t('Custom metric')}
+          <ChartParameters>
+            {tct('Metric: [metric] over [window]', {
+              metric: <code>{alertRule?.aggregate ?? '\u2026'}</code>,
+              window: (
+                <code>
+                  {incident ? (
+                    <Duration seconds={incident.alertRule.timeWindow * 60} />
+                  ) : (
+                    '\u2026'
+                  )}
+                </code>
+              ),
             })}
-        </ChartParameters>
+            {alertRule?.query &&
+              tct('Filter: [filter]', {
+                filter: <code>{alertRule.query}</code>,
+              })}
+          </ChartParameters>
+        </div>
+        <ChartActions>
+          <Feature features={['discover-basic']}>
+            <Projects slugs={incident?.projects} orgId={params.orgId}>
+              {({initiallyLoaded, fetching, projects}) => {
+                const preset = this.metricPreset;
+                const ctaOpts = {
+                  orgSlug: params.orgId,
+                  projects: (initiallyLoaded ? projects : []) as Project[],
+                  incident,
+                  stats,
+                };
+
+                const {buttonText, ...props} = preset
+                  ? preset.makeCtaParams(ctaOpts)
+                  : makeDefaultCta(ctaOpts);
+
+                return (
+                  <Button
+                    size="small"
+                    priority="primary"
+                    disabled={!incident || fetching || !initiallyLoaded}
+                    {...props}
+                  >
+                    {buttonText}
+                  </Button>
+                );
+              }}
+            </Projects>
+          </Feature>
+        </ChartActions>
       </ChartHeader>
     );
   }
@@ -255,24 +258,27 @@ export default class DetailsBody extends React.Component<Props> {
               </SidebarHeading>
               {this.renderRuleDetails()}
 
-              <SidebarHeading>
-                <span>{t('Query')}</span>
-                <Feature features={['discover-basic']}>
+              <Feature features={['discover-basic']}>
+                <SidebarHeading>
+                  <span>{t('Query')}</span>
                   <Projects slugs={incident?.projects} orgId={params.orgId}>
                     {({initiallyLoaded, fetching, projects}) => (
                       <SideHeaderLink
                         disabled={!incident || fetching || !initiallyLoaded}
-                        to={this.getDiscoverUrl(
-                          ((initiallyLoaded && projects) as Project[]) || []
-                        )}
+                        to={getIncidentDiscoverUrl({
+                          orgSlug: params.orgId,
+                          projects: (initiallyLoaded ? projects : []) as Project[],
+                          incident,
+                          stats,
+                        })}
                       >
                         {t('View in Discover')}
                         <IconTelescope size="xs" />
                       </SideHeaderLink>
                     )}
                   </Projects>
-                </Feature>
-              </SidebarHeading>
+                </SidebarHeading>
+              </Feature>
               {incident ? (
                 <Query>{incident?.alertRule.query || '""'}</Query>
               ) : (
@@ -343,9 +349,13 @@ const ChartPanel = styled(Panel)`
   padding: ${space(2)};
 `;
 
-const ChartHeader = styled('div')`
+const ChartHeader = styled('header')`
   margin-bottom: ${space(1)};
+  display: grid;
+  grid-template-columns: 1fr max-content;
 `;
+
+const ChartActions = styled('div')``;
 
 const ChartParameters = styled('div')`
   color: ${p => p.theme.gray600};

--- a/src/sentry/static/sentry/app/views/alerts/utils.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils.tsx
@@ -1,4 +1,9 @@
 import {Client} from 'app/api';
+import {Project, NewQuery} from 'app/types';
+import {getAggregateAlias} from 'app/utils/discover/fields';
+import {getUtcDateString} from 'app/utils/dates';
+import EventView from 'app/utils/discover/eventView';
+import {Dataset} from 'app/views/settings/incidentRules/types';
 
 import {Incident, IncidentStats, IncidentStatus} from './types';
 
@@ -61,4 +66,71 @@ export function isOpen(incident: Incident): boolean {
     default:
       return true;
   }
+}
+
+/**
+ * Gets start and end date query parameters from stats
+ */
+export function getStartEndFromStats(stats: IncidentStats) {
+  const start = getUtcDateString(stats.eventStats.data[0][0] * 1000);
+  const end = getUtcDateString(
+    stats.eventStats.data[stats.eventStats.data.length - 1][0] * 1000
+  );
+
+  return {start, end};
+}
+
+/**
+ * Gets the URL for a discover view of the incident with the following default
+ * parameters:
+ *
+ * - Ordered by the incident aggregate, descending
+ * - yAxis maps to the aggregate
+ * - The following fields are displayed:
+ *   - For Error dataset alerts: [issue, count(), count_unique(user)]
+ *   - For Transaction dataset alerts: [transaction, count()]
+ * - Start and end are scoped to the same period as the alert rule
+ */
+export function getIncidentDiscoverUrl(opts: {
+  orgSlug: string;
+  projects: Project[];
+  incident?: Incident;
+  stats?: IncidentStats;
+  extraQueryParams?: Partial<NewQuery>;
+}) {
+  const {orgSlug, projects, incident, stats, extraQueryParams} = opts;
+
+  if (!projects || !projects.length || !incident || !stats) {
+    return '';
+  }
+
+  const timeWindowString = `${incident.alertRule.timeWindow}m`;
+  const {start, end} = getStartEndFromStats(stats);
+
+  const discoverQuery: NewQuery = {
+    id: undefined,
+    name: (incident && incident.title) || '',
+    orderby: `-${getAggregateAlias(incident.alertRule.aggregate)}`,
+    yAxis: incident.alertRule.aggregate,
+    query: incident?.discoverQuery ?? '',
+    projects: projects
+      .filter(({slug}) => incident.projects.includes(slug))
+      .map(({id}) => Number(id)),
+    version: 2,
+    fields:
+      incident.alertRule.dataset === Dataset.ERRORS
+        ? ['issue', 'count()', 'count_unique(user)']
+        : ['transaction', incident.alertRule.aggregate],
+    start,
+    end,
+    ...extraQueryParams,
+  };
+
+  const discoverView = EventView.fromSavedQuery(discoverQuery);
+  const {query, ...toObject} = discoverView.getResultsViewUrlTarget(orgSlug);
+
+  return {
+    query: {...query, interval: timeWindowString},
+    ...toObject,
+  };
 }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/utils.tsx
@@ -12,7 +12,7 @@ export function transactionSummaryRouteWithQuery({
 }: {
   orgSlug: string;
   transaction: string;
-  projectID: string | string[] | undefined;
+  projectID?: string | string[];
   query: Query;
 }) {
   const pathname = generateTransactionSummaryRoute({

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -7,45 +7,6 @@ import {
 
 export const DEFAULT_AGGREGATE = 'count()';
 
-export const PRESET_AGGREGATES = [
-  {
-    match: /^count\(\)/,
-    name: 'Number of errors',
-    validDataset: [Dataset.ERRORS],
-    default: 'count()',
-  },
-  {
-    match: /^count_unique\(tags\[sentry:user\]\)/,
-    name: 'Users affected',
-    validDataset: [Dataset.ERRORS],
-    default: 'count_unique(tags[sentry:user])',
-  },
-  {
-    match: /^(p[0-9]{2,3}|percentile\(transaction\.duration,[^)]+\))/,
-    name: 'Latency',
-    validDataset: [Dataset.TRANSACTIONS],
-    default: 'percentile(transaction.duration, 0.95)',
-  },
-  {
-    match: /^apdex\([0-9.]+\)/,
-    name: 'Apdex',
-    validDataset: [Dataset.TRANSACTIONS],
-    default: 'apdex(300)',
-  },
-  {
-    match: /^count\(\)/,
-    name: 'Throughput',
-    validDataset: [Dataset.TRANSACTIONS],
-    default: 'count()',
-  },
-  {
-    match: /^error_rate\(\)/,
-    name: 'Error rate',
-    validDataset: [Dataset.TRANSACTIONS],
-    default: 'error_rate()',
-  },
-];
-
 export const DATASET_EVENT_TYPE_FILTERS = {
   [Dataset.ERRORS]: 'event.type:error',
   [Dataset.TRANSACTIONS]: 'event.type:transaction',

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -22,7 +22,7 @@ import {
 } from 'app/utils/discover/fields';
 
 import {Dataset} from './types';
-import {PRESET_AGGREGATES} from './constants';
+import {PRESET_AGGREGATES} from './presets';
 
 type Props = Omit<FormField['props'], 'children' | 'help'> & {
   organization: Organization;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
@@ -1,0 +1,254 @@
+import {t} from 'app/locale';
+import {Incident, IncidentStats} from 'app/views/alerts/types';
+import {Project} from 'app/types';
+import Link from 'app/components/links/link';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
+import {getIncidentDiscoverUrl, getStartEndFromStats} from 'app/views/alerts/utils';
+
+import {Dataset} from './types';
+
+type PresetCta = {
+  /**
+   * The location to direct to upon clicking the CTA.
+   */
+  to: React.ComponentProps<typeof Link>['to'];
+  /**
+   * The CTA text
+   */
+  buttonText: string;
+  /**
+   * The tooltip title for the CTA button, may be empty.
+   */
+  title?: string;
+};
+
+type PresetCtaOpts = {
+  orgSlug: string;
+  projects: Project[];
+  incident?: Incident;
+  stats?: IncidentStats;
+};
+
+type Preset = {
+  /**
+   * The regex used to match aggregates to this preset.
+   */
+  match: RegExp;
+  /**
+   * The name of the preset
+   */
+  name: string;
+  /**
+   * The dataset that this preset applys to.
+   */
+  validDataset: Dataset[];
+  /**
+   * The default aggregate to use when selecting this preset
+   */
+  default: string;
+  /**
+   * Generates the CTA component
+   */
+  makeCtaParams: (opts: PresetCtaOpts) => PresetCta;
+};
+
+export const PRESET_AGGREGATES: Preset[] = [
+  {
+    name: t('Error count'),
+    match: /^count\(\)/,
+    validDataset: [Dataset.ERRORS],
+    default: 'count()',
+    /**
+     * Simple "Open in Discover" button
+     */
+    makeCtaParams: makeDefaultCta,
+  },
+  {
+    name: t('Users affected'),
+    match: /^count_unique\(tags\[sentry:user\]\)/,
+    validDataset: [Dataset.ERRORS],
+    default: 'count_unique(tags[sentry:user])',
+    /**
+     * Simple "Open in Discover" button
+     */
+    makeCtaParams: makeDefaultCta,
+  },
+  {
+    name: t('Latency'),
+    match: /^(p[0-9]{2,3}|percentile\(transaction\.duration,[^)]+\))/,
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'percentile(transaction.duration, 0.95)',
+    /**
+     * see: makeGenericTransactionCta
+     */
+    makeCtaParams: opts =>
+      makeGenericTransactionCta({
+        opts,
+        tooltip: t('Latency by Transaction'),
+      }),
+  },
+  {
+    name: t('Apdex'),
+    match: /^apdex\([0-9.]+\)/,
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'apdex(300)',
+    /**
+     * see: makeGenericTransactionCta
+     */
+    makeCtaParams: opts =>
+      makeGenericTransactionCta({
+        opts,
+        tooltip: t('Apdex by Transaction'),
+      }),
+  },
+  {
+    name: t('Transaction Count'),
+    match: /^count\(\)/,
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'count()',
+    /**
+     * see: makeGenericTransactionCta
+     */
+    makeCtaParams: opts => makeGenericTransactionCta({opts}),
+  },
+  {
+    name: t('Failure rate'),
+    match: /^error_rate\(\)/,
+    validDataset: [Dataset.TRANSACTIONS],
+    default: 'error_rate()',
+    /**
+     * See makeFailureRateCta
+     */
+    makeCtaParams: makeFailureRateCta,
+  },
+];
+
+/**
+ * - CASE 1: If has a specific transaction filter
+ *   - CTA is: "View Transaction Summary"
+ *   - Tooltip is the transaction name
+ *   - the same period as the alert graph (i.e. with alert start time in the middle)
+ *
+ * - CASE 2: If transaction is NOT filtered, or has a * filter:
+ *   - "Open in Discover" button with optional tooltip which opens a discover view with...
+ *      - fields {transaction, count(), <metric>} sorted by count()
+ *      - top-5 activated
+ */
+function makeGenericTransactionCta(opts: {
+  opts: PresetCtaOpts;
+  tooltip?: string;
+}): PresetCta {
+  const {
+    opts: {orgSlug, projects, incident, stats},
+    tooltip,
+  } = opts;
+
+  if (!incident || !stats) {
+    return {to: '', buttonText: t('Incident details')};
+  }
+
+  const query = tokenizeSearch(incident.discoverQuery ?? '');
+  const transaction = query.transaction?.find(filter => !filter.includes('*'));
+
+  // CASE 1
+  if (transaction !== undefined) {
+    const period = getStartEndFromStats(stats);
+
+    const summaryUrl = transactionSummaryRouteWithQuery({
+      orgSlug,
+      transaction,
+      query: {...period},
+    });
+
+    return {
+      to: summaryUrl,
+      buttonText: t('View Transaction Summary'),
+      title: transaction,
+    };
+  }
+
+  // CASE 2
+  const extraQueryParams = {
+    fields: [...new Set(['transaction', 'count()', incident.alertRule.aggregate])],
+    orderby: '-count',
+    display: 'top5',
+  };
+
+  const discoverUrl = getIncidentDiscoverUrl({
+    orgSlug,
+    projects,
+    incident,
+    stats,
+    extraQueryParams,
+  });
+
+  return {
+    to: discoverUrl,
+    buttonText: t('Open in Discover'),
+    title: tooltip,
+  };
+}
+
+/**
+ * - CASE 1: Filtered to a specific transaction, "Open in Discover" with...
+ *   - fields [transaction.status, count()] sorted by count(),
+ *   - "Top 5 period" activated.
+ *
+ * - CASE 2: If filtered on multiple transactions, "Open in Discover" button
+ *   with tooltip "Failure rate by transaction" which opens a discover view
+ *   - fields [transaction, failure_rate()] sorted by failure_rate
+ *   - top 5 activated
+ */
+function makeFailureRateCta({orgSlug, incident, projects, stats}: PresetCtaOpts) {
+  if (!incident || !stats) {
+    return {to: '', buttonText: t('Incident details')};
+  }
+
+  const query = tokenizeSearch(incident.discoverQuery ?? '');
+  const transaction = query.transaction?.find(filter => !filter.includes('*'));
+
+  const extraQueryParams =
+    transaction !== undefined
+      ? // CASE 1
+        {
+          fields: ['transaction.status', 'count()'],
+          orderby: '-count',
+          display: 'top5',
+        }
+      : // Case 2
+        {
+          fields: ['transaction', 'failure_rate()'],
+          orderby: '-failure_rate',
+          display: 'top5',
+        };
+
+  const discoverUrl = getIncidentDiscoverUrl({
+    orgSlug,
+    projects,
+    incident,
+    stats,
+    extraQueryParams,
+  });
+
+  return {
+    to: discoverUrl,
+    buttonText: t('Open in Discover'),
+    title: transaction === undefined ? t('Failure rate by transaction') : undefined,
+  };
+}
+
+/**
+ * Get the CTA used for alerts that do not have a preset
+ */
+export function makeDefaultCta({
+  orgSlug,
+  projects,
+  incident,
+  stats,
+}: PresetCtaOpts): PresetCta {
+  return {
+    buttonText: t('Open in Discover'),
+    to: getIncidentDiscoverUrl({orgSlug, projects, incident, stats}),
+  };
+}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -227,7 +227,7 @@ const SearchEventTypeNote = styled('div')`
   font: ${p => p.theme.fontSizeExtraSmall} ${p => p.theme.text.familyMono};
   color: ${p => p.theme.gray600};
   background: ${p => p.theme.gray200};
-  border-radius: ${p => p.theme.borderRadius};
+  border-radius: 2px;
   padding: ${space(0.5)} ${space(0.75)};
   margin: 0 ${space(0.5)} 0 ${space(1)};
   user-select: none;

--- a/tests/js/spec/views/alerts/utils.spec.jsx
+++ b/tests/js/spec/views/alerts/utils.spec.jsx
@@ -1,0 +1,84 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {Dataset} from 'app/views/settings/incidentRules/types';
+import {getIncidentDiscoverUrl} from 'app/views/alerts/utils';
+
+describe('Alert utils', function() {
+  const {org, projects} = initializeOrg();
+
+  const mockStats = {
+    eventStats: {
+      data: [
+        [0, 10],
+        [120, 10],
+      ],
+    },
+  };
+
+  describe('getIncidentDiscoverUrl', function() {
+    it('creates a discover query url for errors', function() {
+      const incident = {
+        title: 'Test error alert',
+        discoverQuery: 'id:test',
+        projects,
+        alertRule: {
+          timeWindow: 1,
+          dataset: Dataset.ERRORS,
+          aggregate: 'count()',
+        },
+      };
+
+      const to = getIncidentDiscoverUrl({
+        orgSlug: org.slug,
+        projects,
+        incident,
+        stats: mockStats,
+      });
+
+      expect(to).toEqual({
+        query: expect.objectContaining({
+          name: 'Test error alert',
+          field: ['issue', 'count()', 'count_unique(user)'],
+          sort: ['-count'],
+          query: 'id:test',
+          yAxis: 'count()',
+          start: '1970-01-01T00:00:00.000',
+          end: '1970-01-01T00:02:00.000',
+          interval: '1m',
+        }),
+        pathname: '/organizations/org-slug/discover/results/',
+      });
+    });
+
+    it('creates a discover query url for transactions', function() {
+      const incident = {
+        title: 'Test transaction alert',
+        discoverQuery: 'id:test',
+        projects,
+        alertRule: {
+          timeWindow: 1,
+          dataset: Dataset.TRANSACTIONS,
+          aggregate: 'p90()',
+        },
+      };
+
+      const to = getIncidentDiscoverUrl({
+        orgSlug: org.slug,
+        projects,
+        incident,
+        stats: mockStats,
+      });
+
+      expect(to).toEqual({
+        query: expect.objectContaining({
+          name: 'Test transaction alert',
+          field: ['transaction', 'p90()'],
+          sort: ['-p90'],
+          query: 'id:test',
+          yAxis: 'p90()',
+        }),
+        pathname: '/organizations/org-slug/discover/results/',
+      });
+    });
+  });
+});

--- a/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
@@ -75,7 +75,7 @@ describe('MetricField', function() {
     selectByLabel(wrapper, 'error_rate()', {selector: 'QueryField'});
 
     expect(wrapper.find('FieldHelp Button[isSelected=true]').text()).toEqual(
-      'Error rate'
+      'Failure rate'
     );
 
     selectByLabel(wrapper, 'p95()', {selector: 'QueryField'});
@@ -90,7 +90,7 @@ describe('MetricField', function() {
       </Form>
     );
 
-    wrapper.find('FieldHelp button[aria-label="Error rate"]').simulate('click');
+    wrapper.find('FieldHelp button[aria-label="Failure rate"]').simulate('click');
 
     expect(wrapper.find('QueryField SingleValue SingleValue').text()).toEqual(
       'error_rate()'

--- a/tests/js/spec/views/settings/incidentRules/presets.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/presets.spec.jsx
@@ -1,0 +1,423 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {Dataset} from 'app/views/settings/incidentRules/types';
+import {PRESET_AGGREGATES} from 'app/views/settings/incidentRules/presets';
+import {getIncidentDiscoverUrl} from 'app/views/alerts/utils';
+import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
+
+jest.mock('app/views/performance/transactionSummary/utils', () => ({
+  transactionSummaryRouteWithQuery: jest.fn(),
+}));
+
+jest.mock('app/views/alerts/utils', () => {
+  const actual = jest.requireActual('app/views/alerts/utils');
+  return {
+    ...actual,
+    getIncidentDiscoverUrl: jest.fn(),
+  };
+});
+
+describe('Incident Presets', function() {
+  const {org, projects} = initializeOrg();
+
+  const mockStats = {
+    eventStats: {
+      data: [
+        [0, 10],
+        [120, 10],
+      ],
+    },
+  };
+
+  const findPresetByName = name => PRESET_AGGREGATES.find(p => p.name === name);
+
+  describe('CTAs', function() {
+    beforeEach(function() {
+      getIncidentDiscoverUrl.mockClear();
+    });
+
+    it('creates the CTA for error count', function() {
+      const preset = findPresetByName('Error count');
+
+      const incident = {
+        title: 'Test error alert',
+        discoverQuery: 'id:test',
+        projects,
+        alertRule: {
+          dataset: Dataset.ERRORS,
+          aggregate: 'count()',
+        },
+      };
+
+      const cta = preset.makeCtaParams({
+        orgSlug: org.slug,
+        projects,
+        incident,
+        stats: mockStats,
+      });
+
+      expect(getIncidentDiscoverUrl).toHaveBeenCalledWith({
+        orgSlug: org.slug,
+        projects,
+        incident,
+        stats: mockStats,
+      });
+
+      expect(cta).toEqual(
+        expect.objectContaining({
+          buttonText: 'Open in Discover',
+        })
+      );
+    });
+
+    it('creates the CTA for unique user count', function() {
+      const preset = findPresetByName('Users affected');
+
+      const incident = {
+        title: 'Test error alert',
+        discoverQuery: 'id:test',
+        projects,
+        alertRule: {
+          dataset: Dataset.ERRORS,
+          aggregate: 'count_unique(user)',
+        },
+      };
+
+      const cta = preset.makeCtaParams({
+        orgSlug: org.slug,
+        projects,
+        incident,
+        stats: mockStats,
+      });
+
+      expect(getIncidentDiscoverUrl).toHaveBeenCalledWith({
+        orgSlug: org.slug,
+        projects,
+        incident,
+        stats: mockStats,
+      });
+
+      expect(cta).toEqual(
+        expect.objectContaining({
+          buttonText: 'Open in Discover',
+        })
+      );
+    });
+
+    describe('Latency CTA', function() {
+      const preset = findPresetByName('Latency');
+
+      it('creates the CTA for multiple transaction latency', function() {
+        // Incident rule WITHOUT a specific transaction
+        const incident = {
+          title: 'Test error alert',
+          discoverQuery: 'id:test transaction:*',
+          projects,
+          alertRule: {
+            dataset: Dataset.ERRORS,
+            aggregate: 'p95()',
+          },
+        };
+
+        const allTransactionCta = preset.makeCtaParams({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+        });
+
+        expect(getIncidentDiscoverUrl).toHaveBeenCalledWith({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+          extraQueryParams: {
+            display: 'top5',
+            fields: ['transaction', 'count()', 'p95()'],
+            orderby: '-count',
+          },
+        });
+
+        expect(allTransactionCta).toEqual(
+          expect.objectContaining({
+            buttonText: 'Open in Discover',
+            title: 'Latency by Transaction',
+          })
+        );
+      });
+
+      it('creates the CTA for a specific transaction latency', function() {
+        // Incident rule WITH a specific transaction
+        const incident = {
+          title: 'Test error alert',
+          discoverQuery: 'id:test transaction:do_work',
+          projects,
+          alertRule: {
+            dataset: Dataset.ERRORS,
+            aggregate: 'p95()',
+          },
+        };
+
+        const specificTransactionCta = preset.makeCtaParams({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+        });
+
+        expect(transactionSummaryRouteWithQuery).toHaveBeenCalledWith({
+          orgSlug: org.slug,
+          transaction: 'do_work',
+          query: {
+            start: '1970-01-01T00:00:00',
+            end: '1970-01-01T00:02:00',
+          },
+        });
+
+        expect(specificTransactionCta).toEqual(
+          expect.objectContaining({
+            buttonText: 'View Transaction Summary',
+            title: 'do_work',
+          })
+        );
+      });
+    });
+
+    describe('Apdex CTA', function() {
+      const preset = findPresetByName('Apdex');
+
+      it('creates the CTA for multiple transaction apdex', function() {
+        // Incident rule WITHOUT a specific transaction
+        const incident = {
+          title: 'Test error alert',
+          discoverQuery: 'id:test transaction:*',
+          projects,
+          alertRule: {
+            dataset: Dataset.ERRORS,
+            aggregate: 'apdex(300)',
+          },
+        };
+
+        const allTransactionCta = preset.makeCtaParams({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+        });
+
+        expect(getIncidentDiscoverUrl).toHaveBeenCalledWith({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+          extraQueryParams: {
+            display: 'top5',
+            fields: ['transaction', 'count()', 'apdex(300)'],
+            orderby: '-count',
+          },
+        });
+
+        expect(allTransactionCta).toEqual(
+          expect.objectContaining({
+            buttonText: 'Open in Discover',
+            title: 'Apdex by Transaction',
+          })
+        );
+      });
+
+      it('creates the CTA for a specific transaction apdex', function() {
+        // Incident rule WITH a specific transaction
+        const incident = {
+          title: 'Test error alert',
+          discoverQuery: 'id:test transaction:do_work',
+          projects,
+          alertRule: {
+            dataset: Dataset.ERRORS,
+            aggregate: 'apdex(300)',
+          },
+        };
+
+        const specificTransactionCta = preset.makeCtaParams({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+        });
+
+        expect(transactionSummaryRouteWithQuery).toHaveBeenCalledWith({
+          orgSlug: org.slug,
+          transaction: 'do_work',
+          query: {
+            start: '1970-01-01T00:00:00',
+            end: '1970-01-01T00:02:00',
+          },
+        });
+
+        expect(specificTransactionCta).toEqual(
+          expect.objectContaining({
+            buttonText: 'View Transaction Summary',
+            title: 'do_work',
+          })
+        );
+      });
+    });
+
+    describe('Transaction count CTA', function() {
+      const preset = findPresetByName('Transaction Count');
+
+      it('creates the CTA for multiple transaction counts', function() {
+        // Incident rule WITHOUT a specific transaction
+        const incident = {
+          title: 'Test error alert',
+          discoverQuery: 'id:test transaction:*',
+          projects,
+          alertRule: {
+            dataset: Dataset.ERRORS,
+            aggregate: 'count()',
+          },
+        };
+
+        const allTransactionCta = preset.makeCtaParams({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+        });
+
+        expect(getIncidentDiscoverUrl).toHaveBeenCalledWith({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+          extraQueryParams: {
+            display: 'top5',
+            fields: ['transaction', 'count()'],
+            orderby: '-count',
+          },
+        });
+
+        expect(allTransactionCta).toEqual(
+          expect.objectContaining({
+            buttonText: 'Open in Discover',
+          })
+        );
+      });
+
+      it('creates the CTA for a specific transaction count', function() {
+        // Incident rule WITH a specific transaction
+        const incident = {
+          title: 'Test error alert',
+          discoverQuery: 'id:test transaction:do_work',
+          projects,
+          alertRule: {
+            dataset: Dataset.ERRORS,
+            aggregate: 'count()',
+          },
+        };
+
+        const specificTransactionCta = preset.makeCtaParams({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+        });
+
+        expect(transactionSummaryRouteWithQuery).toHaveBeenCalledWith({
+          orgSlug: org.slug,
+          transaction: 'do_work',
+          query: {
+            start: '1970-01-01T00:00:00',
+            end: '1970-01-01T00:02:00',
+          },
+        });
+
+        expect(specificTransactionCta).toEqual(
+          expect.objectContaining({
+            buttonText: 'View Transaction Summary',
+          })
+        );
+      });
+    });
+
+    describe('Failure rate CTA', function() {
+      const preset = findPresetByName('Failure rate');
+
+      it('creates the CTA for multiple transaction failure rates', function() {
+        // Incident rule WITHOUT a specific transaction
+        const incident = {
+          title: 'Test error alert',
+          discoverQuery: 'id:test transaction:*',
+          projects,
+          alertRule: {
+            dataset: Dataset.ERRORS,
+            aggregate: 'count()',
+          },
+        };
+
+        const allTransactionCta = preset.makeCtaParams({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+        });
+
+        expect(getIncidentDiscoverUrl).toHaveBeenCalledWith({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+          extraQueryParams: {
+            display: 'top5',
+            fields: ['transaction', 'failure_rate()'],
+            orderby: '-failure_rate',
+          },
+        });
+
+        expect(allTransactionCta).toEqual(
+          expect.objectContaining({
+            buttonText: 'Open in Discover',
+            title: 'Failure rate by transaction',
+          })
+        );
+      });
+
+      it('creates the CTA for a specific transaction count', function() {
+        // Incident rule WITH a specific transaction
+        const incident = {
+          title: 'Test error alert',
+          discoverQuery: 'id:test transaction:do_work',
+          projects,
+          alertRule: {
+            dataset: Dataset.ERRORS,
+            aggregate: 'count()',
+          },
+        };
+
+        const specificTransactionCta = preset.makeCtaParams({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+        });
+
+        expect(getIncidentDiscoverUrl).toHaveBeenCalledWith({
+          orgSlug: org.slug,
+          projects,
+          incident,
+          stats: mockStats,
+          extraQueryParams: {
+            display: 'top5',
+            fields: ['transaction.status', 'count()'],
+            orderby: '-count',
+          },
+        });
+
+        expect(specificTransactionCta).toEqual(
+          expect.objectContaining({
+            buttonText: 'Open in Discover',
+          })
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/83306033-b02bc600-a1b6-11ea-8a1f-dce688605755.png)

A "Open in Discover" button now lives in the top right of the chart.

It's smart in the sense that you will be placed on discover with different columns depending on the detected alert type.