### PR TITLE
Revert "ref(org): Reorder props for withOrganization (#19077)"

### DIFF
--- a/src/sentry/static/sentry/app/utils/withOrganization.tsx
+++ b/src/sentry/static/sentry/app/utils/withOrganization.tsx
@@ -22,8 +22,8 @@ const withOrganization = <P extends InjectedOrganizationProps>(
     render() {
       return (
         <WrappedComponent
-          {...(this.props as P)}
           organization={this.context.organization as Organization}
+          {...(this.props as P)}
         />
       );
     }


### PR DESCRIPTION
This reverts commit 04d15b609b1209cad8ff844693dc659fdbc5280c.

This change broke the organization picker in settings.