### PR TITLE
fix(settings): Breadcrumb dropdown showed the same organization

### DIFF
--- a/src/sentry/static/sentry/app/components/idBadge/organizationBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/organizationBadge.tsx
@@ -6,7 +6,6 @@ import BadgeDisplayName from 'app/components/idBadge/badgeDisplayName';
 import SentryTypes from 'app/sentryTypes';
 import {Organization} from 'app/types';
 import OrganizationAvatar from 'app/components/avatar/organizationAvatar';
-import withOrganization from 'app/utils/withOrganization';
 
 type DefaultProps = {
   avatarSize: OrganizationAvatar['props']['size'];
@@ -54,4 +53,4 @@ class OrganizationBadge extends React.Component<Props> {
   }
 }
 
-export default withOrganization(OrganizationBadge);
+export default OrganizationBadge;


### PR DESCRIPTION
Found a long-term fix for #19098