### PR TITLE
fix(ui): Remove old color variables

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/category.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/category.jsx
@@ -57,7 +57,7 @@ const CrumbCategory = styled('span')`
   font-weight: bold;
   text-transform: none;
   padding-right: 10px;
-  color: ${p => p.theme.gray5};
+  color: ${p => p.theme.gray800};
 
   ${p => (p.ellipsisFromLeft ? overflowEllipsisLeft : overflowEllipsis)}
 `;

--- a/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
@@ -6,7 +6,7 @@ import omit from 'lodash/omit';
 const SearchResultWrapper = styled(props => <div {...omit(props, 'highlighted')} />)`
   cursor: pointer;
   display: block;
-  color: ${p => p.theme.gray5};
+  color: ${p => p.theme.gray800};
   padding: 10px;
 
   ${p =>

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -58,9 +58,6 @@ const colors = {
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Old Colors
-  gray5: '#302839',
-  gray6: '#AFA3BB', // form disabled
-
   blue: '#3B6ECC',
   blueLight: '#628BD6',
   blueLightest: '#F5FAFE',

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -58,17 +58,6 @@ const colors = {
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Old Colors
-  offWhite: '#FAF9FB',
-  offWhiteLight: '#F2F0F5',
-  offWhite2: '#E7E1EC',
-
-  whiteDark: '#fbfbfc',
-  foreground: '#493E54',
-
-  gray1: '#BDB4C7',
-  gray2: '#9585A3',
-  gray3: '#645574',
-  gray4: '#4A3E56',
   gray5: '#302839',
   gray6: '#AFA3BB', // form disabled
 

--- a/src/sentry/static/sentry/app/views/issueList/actions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.jsx
@@ -693,7 +693,7 @@ const GraphToggle = styled('a')`
   &:hover,
   &:focus,
   &:active {
-    color: ${p => (p.active ? p.theme.gray4 : p.theme.disabled)};
+    color: ${p => (p.active ? p.theme.gray700 : p.theme.disabled)};
   }
 `;
 


### PR DESCRIPTION
Removing the old gray color variables. I’ve quadruple checked getsentry for use of these colors too and everything seems a-okay to me. 