### PR TITLE
feat(workflow): Alias Query Fields

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -58,6 +58,8 @@ ReferenceEvent.__new__.__defaults__ = (None, None)
 PaginationResult = namedtuple("PaginationResult", ["next", "previous", "oldest", "latest"])
 FacetResult = namedtuple("FacetResult", ["key", "value", "count"])
 
+discover_column_resolver = resolve_column(Dataset.Discover)
+
 
 def is_real_column(col):
     """
@@ -80,9 +82,7 @@ def find_reference_event(reference_event):
         raise InvalidSearchQuery("Invalid reference event")
 
     column_names = [
-        resolve_column(Dataset.Discover)(col)
-        for col in reference_event.fields
-        if is_real_column(col)
+        discover_column_resolver(col) for col in reference_event.fields if is_real_column(col)
     ]
     # We don't need to run a query if there are no columns
     if not column_names:
@@ -137,7 +137,7 @@ def create_reference_event_conditions(reference_event):
     if event_data is None:
         return conditions
 
-    field_names = [resolve_column(Dataset.Discover)(col) for col in reference_event.fields]
+    field_names = [discover_column_resolver(col) for col in reference_event.fields]
     for (i, field) in enumerate(reference_event.fields):
         value = event_data.get(field_names[i], None)
         # If the value is a sequence use the first element as snuba
@@ -284,7 +284,7 @@ def resolve_discover_aliases(snuba_filter, function_translations=None):
     be renamed in the result set.
     """
     return resolve_snuba_aliases(
-        snuba_filter, resolve_column(Dataset.Discover), function_translations=function_translations
+        snuba_filter, discover_column_resolver, function_translations=function_translations
     )
 
 
@@ -826,7 +826,6 @@ def top_events_timeseries(
         )
 
         user_fields = FIELD_ALIASES["user"]["fields"]
-
         for field in selected_columns:
             # project is handled by filter_keys already
             if field in ["project", "project.id"]:
@@ -849,22 +848,18 @@ def top_events_timeseries(
                 elif field == "user":
                     snuba_filter.conditions.append(
                         [
-                            [resolve_column(Dataset.Discover)(user_field), "IN", values]
+                            [discover_column_resolver(user_field), "IN", values]
                             for user_field in user_fields
                         ]
                     )
                 elif None in values:
                     non_none_values = [value for value in values if value is not None]
-                    condition = [[["isNull", [resolve_column(Dataset.Discover)(field)]], "=", 1]]
+                    condition = [[["isNull", [discover_column_resolver(field)]], "=", 1]]
                     if non_none_values:
-                        condition.append(
-                            [resolve_column(Dataset.Discover)(field), "IN", non_none_values]
-                        )
+                        condition.append([discover_column_resolver(field), "IN", non_none_values])
                     snuba_filter.conditions.append(condition)
                 else:
-                    snuba_filter.conditions.append(
-                        [resolve_column(Dataset.Discover)(field), "IN", values]
-                    )
+                    snuba_filter.conditions.append([discover_column_resolver(field), "IN", values])
 
     with sentry_sdk.start_span(op="discover.discover", description="top_events.snuba_query"):
         result = raw_query(

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -272,7 +272,7 @@ def zerofill_histogram(results, column_meta, orderby, sentry_function_alias, snu
     return new_results
 
 
-def resolve_column(col, *args, **kwargs):
+def resolve_column(col):
     """
     Used as a column resolver in discover queries.
 

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -119,9 +119,7 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
 
 def build_snuba_filter(dataset, query, aggregate, environment, params=None):
     resolve_func = (
-        resolve_column(Dataset.Events)
-        if dataset == "events"
-        else resolve_column(Dataset.Transactions)
+        resolve_column(Dataset.Events) if dataset == "events" else resolve_column(Dataset.Discover)
     )
     snuba_filter = get_filter(query, params=params)
     snuba_filter.update_with(resolve_field_list([aggregate], snuba_filter, auto_fields=False))

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -119,7 +119,7 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
 
 def build_snuba_filter(dataset, query, aggregate, environment, params=None):
     def alerts_resolve_column(col):
-        return resolve_column(col, Dataset.Events)
+        return resolve_column(col, Dataset.Transactions)
 
     snuba_filter = get_filter(query, params=params)
     snuba_filter.update_with(resolve_field_list([aggregate], snuba_filter, auto_fields=False))

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -3,11 +3,16 @@ from __future__ import absolute_import
 import json
 
 from sentry.api.event_search import get_filter, resolve_field_list
-from sentry.snuba.discover import resolve_discover_aliases
 from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
-from sentry.utils.snuba import _snuba_pool, SnubaError
+from sentry.utils.snuba import (
+    _snuba_pool,
+    SnubaError,
+    resolve_column,
+    resolve_snuba_aliases,
+    Dataset,
+)
 
 
 # TODO: If we want to support security events here we'll need a way to
@@ -113,9 +118,12 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
 
 
 def build_snuba_filter(dataset, query, aggregate, environment, params=None):
+    def alerts_resolve_column(col):
+        return resolve_column(col, Dataset.Events)
+
     snuba_filter = get_filter(query, params=params)
     snuba_filter.update_with(resolve_field_list([aggregate], snuba_filter, auto_fields=False))
-    snuba_filter = resolve_discover_aliases(snuba_filter)[0]
+    snuba_filter = resolve_snuba_aliases(snuba_filter, alerts_resolve_column)[0]
     if environment:
         snuba_filter.conditions.append(["environment", "=", environment.name])
     snuba_filter.conditions = apply_dataset_conditions(dataset, snuba_filter.conditions)

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -118,12 +118,14 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
 
 
 def build_snuba_filter(dataset, query, aggregate, environment, params=None):
-    def alerts_resolve_column(col):
-        return resolve_column(col, Dataset.Transactions)
-
+    resolve_func = (
+        resolve_column(Dataset.Events)
+        if dataset == "events"
+        else resolve_column(Dataset.Transactions)
+    )
     snuba_filter = get_filter(query, params=params)
     snuba_filter.update_with(resolve_field_list([aggregate], snuba_filter, auto_fields=False))
-    snuba_filter = resolve_snuba_aliases(snuba_filter, alerts_resolve_column)[0]
+    snuba_filter = resolve_snuba_aliases(snuba_filter, resolve_func)[0]
     if environment:
         snuba_filter.conditions.append(["environment", "=", environment.name])
     snuba_filter.conditions = apply_dataset_conditions(dataset, snuba_filter.conditions)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -846,7 +846,7 @@ def resolve_complex_column(col, resolve_column):
 
     for i in range(len(args)):
         if isinstance(args[i], (list, tuple)):
-            resolve_complex_column(args[i])
+            resolve_complex_column(args[i], resolve_column)
         elif isinstance(args[i], six.string_types):
             args[i] = resolve_column(args[i])
 


### PR DESCRIPTION
When evaluating an alert, we need to alias the fields being used in the query/filter and aggregate. This was previously done in Snuba automatically when using the Discover dataset, but we are now using events/transactions explicitly and must do this ourselves (until, if ever, this logic is brought into Snuba).

We have been using Discover's function for resolving alias', which wasn't quite working for our purposes (it uses the Discover dataset alias' but we need to use transactions/events alias'). 

This PR is an attempt at abstracting that function out into something that can be used by Discover and Workflow. We can now pass a resolve_function argument, which, based on dataset, can return an aliased column - and Discover can keep using their custom version of resolve_column.