### PR TITLE
fix(search): Fix search for `release:latest` returning incorrect results when no environments selected

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -234,7 +234,7 @@ def get_latest_release(projects, environments, organization_id=None):
 
     release_qs = Release.objects.filter(organization_id=organization_id, projects__in=projects)
 
-    if environments is not None:
+    if environments:
         release_qs = release_qs.filter(
             releaseprojectenvironment__environment__id__in=[
                 environment.id for environment in environments

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -532,6 +532,10 @@ class GetLatestReleaseTest(TestCase):
             == new.version
         )
 
+        # Verify that not passing an environment correctly gets the latest one
+        assert get_latest_release([self.project], None) == newest.version
+        assert get_latest_release([self.project], []) == newest.version
+
         with pytest.raises(Release.DoesNotExist):
             # environment with no releases
             environment = self.create_environment()


### PR DESCRIPTION
The search was incorrectly only returning results for issues with no release specified, rather than
the latest release across any environment. Looks to have been broken for over a year!