### PR TITLE
fix(discover2): Fix drilldown behaviour

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -190,12 +190,7 @@ function transformAggregate(fieldName: string): string {
 }
 
 function isTransformAggregate(fieldName: string): boolean {
-  // test if a field name is a percentile field name. for example: p50
-  if (/^p\d+$/.test(fieldName)) {
-    return true;
-  }
-
-  return TRANSFORM_AGGREGATES.hasOwnProperty(fieldName);
+  return transformAggregate(fieldName) !== '';
 }
 
 /**

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -268,6 +268,13 @@ export function getExpandedResults(
       if (exploded.function[0] === 'count') {
         field = 'id';
       }
+
+      if (!field) {
+        // This is a function with no field alias. We delete this column as it'll add a blank column in the drilldown.
+        fieldsToDelete.push(indexToUpdate);
+        return;
+      }
+
       transformedFields.add(field);
 
       const updatedColumn: Column = {

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -172,9 +172,6 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
 
 // A map between aggregate function names and its un-aggregated form
 const TRANSFORM_AGGREGATES = {
-  p99: 'transaction.duration',
-  p95: 'transaction.duration',
-  p75: 'transaction.duration',
   last_seen: 'timestamp',
   latest_event: 'id',
   apdex: '',
@@ -182,6 +179,24 @@ const TRANSFORM_AGGREGATES = {
   user_misery: '',
   error_rate: '',
 } as const;
+
+function transformAggregate(fieldName: string): string {
+  // test if a field name is a percentile field name. for example: p50
+  if (/^p\d+$/.test(fieldName)) {
+    return 'transaction.duration';
+  }
+
+  return TRANSFORM_AGGREGATES[fieldName] || '';
+}
+
+function isTransformAggregate(fieldName: string): boolean {
+  // test if a field name is a percentile field name. for example: p50
+  if (/^p\d+$/.test(fieldName)) {
+    return true;
+  }
+
+  return TRANSFORM_AGGREGATES.hasOwnProperty(fieldName);
+}
 
 /**
  * Convert an aggregated query into one that does not have aggregates.
@@ -213,20 +228,14 @@ export function getExpandedResults(
     const exploded = explodeFieldString(currentField.field);
 
     let fieldNameAlias: string = '';
-    if (
-      exploded.kind === 'function' &&
-      TRANSFORM_AGGREGATES.hasOwnProperty(exploded.function[0])
-    ) {
+    if (exploded.kind === 'function' && isTransformAggregate(exploded.function[0])) {
       fieldNameAlias = exploded.function[0];
     } else if (exploded.kind === 'field') {
       fieldNameAlias = exploded.field;
     }
 
-    if (
-      fieldNameAlias !== undefined &&
-      TRANSFORM_AGGREGATES.hasOwnProperty(fieldNameAlias)
-    ) {
-      const nextFieldName = TRANSFORM_AGGREGATES[fieldNameAlias];
+    if (fieldNameAlias !== undefined && isTransformAggregate(fieldNameAlias)) {
+      const nextFieldName = transformAggregate(fieldNameAlias);
       if (!nextFieldName || transformedFields.has(nextFieldName)) {
         // this field is either duplicated in another column, or nextFieldName is undefined.
         // in either case, we remove this column

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -238,6 +238,7 @@ describe('getExpandedResults()', function() {
         {field: 'p99()'},
         {field: 'p100()'},
         {field: 'p9001()'}, // it's over 9000
+        {field: 'foobar()'}, // unknown function with no parameter
         {field: 'custom_tag'},
         {field: 'title'}, // not expected to be dropped
         {field: 'unique_count(id)'},

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -232,9 +232,12 @@ describe('getExpandedResults()', function() {
         {field: 'latest_event()'},
         {field: 'title'},
         {field: 'avg(transaction.duration)'}, // expect this to be dropped
+        {field: 'p50()'},
         {field: 'p75()'},
         {field: 'p95()'},
         {field: 'p99()'},
+        {field: 'p100()'},
+        {field: 'p9001()'}, // it's over 9000
         {field: 'custom_tag'},
         {field: 'title'}, // not expected to be dropped
         {field: 'unique_count(id)'},


### PR DESCRIPTION
- Percentile functions that have since been available weren't properly supported for the drilldown behaviour. I've updated it to support arbitrary percentile functions. 

- Also fixed this bug: Any parameterless functions with no field name aliases will become a blank column after a drilldown. This isn't useful, so we delete them. 