### PR TITLE
(feat) Add link to integration platform if no results

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -520,16 +520,16 @@ export class IntegrationListDirectory extends AsyncComponent<
                   {tct('No Integrations found for "[searchTerm]".', {
                     searchTerm: searchInput,
                   })}
-                  <p style={{fontWeight: 'bold'}}>
+                  <EmptyResultsBodyBold>
                     {t("Not seeing what you're looking for?")}
-                  </p>
-                  <p>
+                  </EmptyResultsBodyBold>
+                  <EmptyResultsBody>
                     {tct('[link:Build it on the Sentry Integration Platform.]', {
                       link: (
                         <a href="https://docs.sentry.io/workflow/integrations/integration-platform/" />
                       ),
                     })}
-                  </p>
+                  </EmptyResultsBody>
                 </EmptyResultsBody>
               </EmptyResultsContainer>
             )}
@@ -556,6 +556,14 @@ const EmptyResultsContainer = styled('div')`
 
 const EmptyResultsBody = styled('div')`
   font-size: 16px;
+  line-height: 28px;
+  color: ${p => p.theme.gray500};
+  padding-bottom: ${space(2)};
+`;
+
+const EmptyResultsBodyBold = styled('div')`
+  font-size: 16px;
+  font-weight: bold;
   line-height: 28px;
   color: ${p => p.theme.gray500};
   padding-bottom: ${space(2)};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -520,16 +520,16 @@ export class IntegrationListDirectory extends AsyncComponent<
                   {tct('No Integrations found for "[searchTerm]".', {
                     searchTerm: searchInput,
                   })}
-                  <EmptyResultsBodyBold>
-                    {t("Not seeing what you're looking for?")}
-                  </EmptyResultsBodyBold>
-                  <EmptyResultsBody>
-                    {tct('[link:Build it on the Sentry Integration Platform.]', {
-                      link: (
-                        <a href="https://docs.sentry.io/workflow/integrations/integration-platform/" />
-                      ),
-                    })}
-                  </EmptyResultsBody>
+                </EmptyResultsBody>
+                <EmptyResultsBodyBold>
+                  {t("Not seeing what you're looking for?")}
+                </EmptyResultsBodyBold>
+                <EmptyResultsBody>
+                  {tct('[link:Build it on the Sentry Integration Platform.]', {
+                    link: (
+                      <a href="https://docs.sentry.io/workflow/integrations/integration-platform/" />
+                    ),
+                  })}
                 </EmptyResultsBody>
               </EmptyResultsContainer>
             )}
@@ -561,12 +561,8 @@ const EmptyResultsBody = styled('div')`
   padding-bottom: ${space(2)};
 `;
 
-const EmptyResultsBodyBold = styled('div')`
-  font-size: 16px;
+const EmptyResultsBodyBold = styled(EmptyResultsBody)`
   font-weight: bold;
-  line-height: 28px;
-  color: ${p => p.theme.gray500};
-  padding-bottom: ${space(2)};
 `;
 
 export default withOrganization(IntegrationListDirectory);

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -520,6 +520,16 @@ export class IntegrationListDirectory extends AsyncComponent<
                   {tct('No Integrations found for "[searchTerm]".', {
                     searchTerm: searchInput,
                   })}
+                  <p style={{fontWeight: 'bold'}}>
+                    {t("Not seeing what you're looking for?")}
+                  </p>
+                  <p>
+                    {tct('[link:Build it on the Sentry Integration Platform.]', {
+                      link: (
+                        <a href="https://docs.sentry.io/workflow/integrations/integration-platform/" />
+                      ),
+                    })}
+                  </p>
                 </EmptyResultsBody>
               </EmptyResultsContainer>
             )}


### PR DESCRIPTION
Draw attention to the Sentry Integration Platform if the query yields no results in the integration directory.

![Screen Shot 2020-06-01 at 3 09 34 PM](https://user-images.githubusercontent.com/29959063/83460047-5e837580-a41a-11ea-9d1f-5010046c3475.png)
