### PR TITLE
perf(models): Instrument Group.get_absolute_url

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -11,6 +11,8 @@ from django.conf import settings
 from django.db.models import Min, Q
 from django.utils import timezone
 
+import sentry_sdk
+
 from sentry import tagstore, tsdb
 from sentry.app import env
 from sentry.api.serializers import Serializer, register, serialize
@@ -408,7 +410,8 @@ class GroupSerializerBase(Serializer):
             or is_valid_sentryapp
             or (user.is_authenticated() and user.get_orgs().filter(id=obj.organization.id).exists())
         ):
-            return obj.get_absolute_url()
+            with sentry_sdk.start_span(op="GroupSerializerBase.serialize.permalink.build"):
+                return obj.get_absolute_url()
         else:
             return None
 

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from six.moves.urllib.parse import parse_qs, quote, urlencode, urljoin, urlparse
 from functools import partial
 
+import sentry_sdk
+
 from sentry import options
 from sentry.utils import json
 from sentry.utils.compat import map
@@ -16,9 +18,11 @@ ParsedUriMatch = namedtuple("ParsedUriMatch", ["scheme", "domain", "path"])
 
 
 def absolute_uri(url=None):
+    with sentry_sdk.start_span(op="http.absolute_uri.options"):
+        url_prefix = options.get("system.url-prefix")
     if not url:
-        return options.get("system.url-prefix")
-    return urljoin(options.get("system.url-prefix").rstrip("/") + "/", url.lstrip("/"))
+        return url_prefix
+    return urljoin(url_prefix.rstrip("/") + "/", url.lstrip("/"))
 
 
 def origin_from_url(url):


### PR DESCRIPTION
Targets a performance bottleneck measured from
GroupSerializerBase._get_permalink.

Clean up spans in GroupSerializerBase that are no longer needed.