### PR TITLE
feat(auth): Respect session expiration sent from SAML providers

### DIFF
--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, print_function
 
 import logging
+from datetime import datetime
+from django.utils import timezone
 
 from django.contrib import messages
 from django.contrib.auth import logout
@@ -107,7 +109,7 @@ class SAML2AcceptACSView(BaseView):
             sso_login = AuthProviderLoginView()
             return sso_login.handle(request)
 
-        # IdP initiated authentication. The organizatio_slug must be valid and
+        # IdP initiated authentication. The organization_slug must be valid and
         # an auth provider must exist for this organization to proceed with
         # IdP initiated SAML auth.
         try:
@@ -154,13 +156,22 @@ class SAML2ACSView(AuthView):
 
         helper.bind_state("auth_attributes", auth.get_attributes())
 
+        # Not all providers send a session expiration value, but if they do,
+        # we should respect it and set session cookies to expire at the given time.
         # XXX(slohmes): 5/28/2020 Temporarily adding logging here to check if any IdPs send a SessionNotOnOrAfter
         # value in their SAML response.
         if auth.get_session_expiration() is not None:
             logging.warning(
                 "Received SessionNotOnOrAfter value in SAML response",
-                extra={"session_expiration": auth.get_session_expiration()},
+                extra={
+                    "session_expiration": auth.get_session_expiration(),
+                    "provider": helper.auth_provider.provider,
+                },
             )
+            session_expiration = datetime.fromtimestamp(auth.get_session_expiration()).replace(
+                tzinfo=timezone.utc
+            )
+            request.session.set_expiry(session_expiration)
 
         return helper.next_step()
 

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -161,11 +161,15 @@ class SAML2ACSView(AuthView):
         # XXX(slohmes): 5/28/2020 Temporarily adding logging here to check if any IdPs send a SessionNotOnOrAfter
         # value in their SAML response.
         if auth.get_session_expiration() is not None:
+            try:
+                providerString = helper.auth_provider.provider
+            except AttributeError:
+                providerString = ""
             logging.warning(
                 "Received SessionNotOnOrAfter value in SAML response",
                 extra={
                     "session_expiration": auth.get_session_expiration(),
-                    "provider": helper.auth_provider.provider,
+                    "provider": providerString,
                 },
             )
             session_expiration = datetime.fromtimestamp(auth.get_session_expiration()).replace(

--- a/src/sentry/web/frontend/twofactor.py
+++ b/src/sentry/web/frontend/twofactor.py
@@ -36,7 +36,7 @@ class TwoFactorAuthView(BaseView):
         return rv
 
     def fail_signin(self, request, user, form):
-        # Ladies and gentlemen: he world's shittiest bruteforce
+        # Ladies and gentlemen: the world's shittiest bruteforce
         # prevention.
         time.sleep(2.0)
         form.errors["__all__"] = [_("Invalid confirmation code. Try again.")]

--- a/tests/sentry/auth/providers/test_saml2.py
+++ b/tests/sentry/auth/providers/test_saml2.py
@@ -1,13 +1,17 @@
 from __future__ import absolute_import, print_function
 
 import pytest
-from sentry.utils.compat import mock
+import types
 
-from sentry.auth.providers.saml2.provider import SAML2Provider, Attributes
+from datetime import datetime
+from django.utils import timezone
 
+from sentry.auth.helper import AuthHelper
+from sentry.auth.providers.saml2.provider import SAML2Provider, Attributes, SAML2ACSView
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.models import AuthProvider
 from sentry.testutils import TestCase
+from sentry.utils.compat import mock
 
 dummy_provider_config = {
     "attribute_mapping": {
@@ -70,3 +74,40 @@ class SAML2ProviderTest(TestCase):
         assert identity["id"] == "123"
         assert identity["email"] == "valid@example.com"
         assert identity["name"] == "Morty Smith"
+
+
+@mock.patch("sentry.auth.providers.saml2.provider.build_auth")
+class SAML2ACSViewTest(TestCase):
+    def test_set_session_expiration(self, mock_auth):
+        self.org = self.create_organization()
+        self.auth_provider = AuthProvider.objects.create(provider="saml2", organization=self.org)
+        self.provider = SAML2Provider(key=self.auth_provider.provider)
+        self.provider.config = dummy_provider_config
+        self.auth_provider.get_provider = mock.MagicMock(return_value=self.provider)
+        super(SAML2ACSViewTest, self).setUp()
+
+        request = self.make_request(user=None)
+        request.META = {
+            "PATH_INFO": "/",
+        }
+
+        test_view = SAML2ACSView()
+        helper = AuthHelper(
+            request, self.org, AuthHelper.FLOW_LOGIN, auth_provider=self.auth_provider
+        )
+
+        def mock_next_step(self):
+            return
+
+        helper.next_step = types.MethodType(mock_next_step, helper)
+
+        instance = mock_auth.return_value
+        instance.get_errors.return_value = None
+        instance.get_attributes.return_value = {}
+        instance.get_session_expiration = 1591044492
+
+        test_view.dispatch(request, helper)
+
+        assert request.session.get_expiry_date() == datetime.fromtimestamp(1591047400).replace(
+            tzinfo=timezone.utc
+        )

--- a/tests/sentry/auth/providers/test_saml2.py
+++ b/tests/sentry/auth/providers/test_saml2.py
@@ -104,10 +104,10 @@ class SAML2ACSViewTest(TestCase):
         instance = mock_auth.return_value
         instance.get_errors.return_value = None
         instance.get_attributes.return_value = {}
-        instance.get_session_expiration = 1591044492
+        instance.get_session_expiration.return_value = 1591044492
 
         test_view.dispatch(request, helper)
 
-        assert request.session.get_expiry_date() == datetime.fromtimestamp(1591047400).replace(
+        assert request.session.get_expiry_date() == datetime.fromtimestamp(1591044492).replace(
             tzinfo=timezone.utc
         )


### PR DESCRIPTION
When identity providers send a SessionNotOnOrAfter attribute in a SAML request, set the session cookie expiry to that value.

This commit also logs the provider name, so we know who is sending us that attribute.

Part of [ENT-132](https://getsentry.atlassian.net/browse/ENT-132).