### PR TITLE
feat(store): Add store for Repositories

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/repositories.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/repositories.tsx
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/browser';
 
 import RepositoryActions from 'app/actions/repositoryActions';
 import {Client} from 'app/api';
+import RepositoryStore from 'app/stores/repositoryStore';
 import {Repository} from 'app/types';
 
 type ParamsGet = {
@@ -12,6 +13,12 @@ export function getRepositories(api: Client, params: ParamsGet) {
   const {orgSlug} = params;
   const path = `/organizations/${orgSlug}/repos/`;
 
+  // HACK(leedongwei): Actions fired by the ActionCreators are queued to
+  // the back of the event loop, allowing another getRepo for the same
+  // repo to be fired before the loading state is updated in store.
+  // This hack short-circuits that and update the state immediately.
+  RepositoryStore.state.repositoriesLoading = true;
+  RepositoryStore.state.orgSlug = orgSlug;
   RepositoryActions.loadRepositories(orgSlug);
 
   return api

--- a/src/sentry/static/sentry/app/actionCreators/repositories.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/repositories.tsx
@@ -18,7 +18,6 @@ export function getRepositories(api: Client, params: ParamsGet) {
   // repo to be fired before the loading state is updated in store.
   // This hack short-circuits that and update the state immediately.
   RepositoryStore.state.repositoriesLoading = true;
-  RepositoryStore.state.orgSlug = orgSlug;
   RepositoryActions.loadRepositories(orgSlug);
 
   return api
@@ -26,10 +25,10 @@ export function getRepositories(api: Client, params: ParamsGet) {
       method: 'GET',
     })
     .then((res: Repository[]) => {
-      RepositoryActions.loadRepositoriesSuccess(orgSlug, res);
+      RepositoryActions.loadRepositoriesSuccess(res);
     })
     .catch(err => {
-      RepositoryActions.loadRepositoriesError(orgSlug, err);
+      RepositoryActions.loadRepositoriesError(err);
       Sentry.withScope(scope => {
         scope.setLevel(Sentry.Severity.Warning);
         scope.setFingerprint(['getRepositories-action-creator']);

--- a/src/sentry/static/sentry/app/actionCreators/repositories.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/repositories.tsx
@@ -1,0 +1,32 @@
+import * as Sentry from '@sentry/browser';
+
+import RepositoryActions from 'app/actions/repositoryActions';
+import {Client} from 'app/api';
+import {Repository} from 'app/types';
+
+type ParamsGet = {
+  orgSlug: string;
+};
+
+export function getRepositories(api: Client, params: ParamsGet) {
+  const {orgSlug} = params;
+  const path = `/organizations/${orgSlug}/repos/`;
+
+  RepositoryActions.loadRepositories(orgSlug);
+
+  return api
+    .requestPromise(path, {
+      method: 'GET',
+    })
+    .then((res: Repository[]) => {
+      RepositoryActions.loadRepositoriesSuccess(orgSlug, res);
+    })
+    .catch(err => {
+      RepositoryActions.loadRepositoriesError(orgSlug, err);
+      Sentry.withScope(scope => {
+        scope.setLevel(Sentry.Severity.Warning);
+        scope.setFingerprint(['getRepositories-action-creator']);
+        Sentry.captureException(err);
+      });
+    });
+}

--- a/src/sentry/static/sentry/app/actions/repositoryActions.tsx
+++ b/src/sentry/static/sentry/app/actions/repositoryActions.tsx
@@ -1,0 +1,8 @@
+import Reflux from 'reflux';
+
+export default Reflux.createActions([
+  'resetRepositories',
+  'loadRepositories',
+  'loadRepositoriesError',
+  'loadRepositoriesSuccess',
+]);

--- a/src/sentry/static/sentry/app/stores/repositoryStore.tsx
+++ b/src/sentry/static/sentry/app/stores/repositoryStore.tsx
@@ -78,8 +78,8 @@ export const RepositoryStoreConfig: Reflux.StoreDefinition & RepositoryStoreInte
   },
 
   /**
-   * `organizationSlug` is optional. If present, method will run a check if data
-   * in the store originated from the same organization
+   * `orgSlug` is optional. If present, method will run a check if data in the
+   * store originated from the same organization
    */
   get(orgSlug?: string) {
     const {orgSlug: stateOrgSlug, ...data} = this.state;

--- a/src/sentry/static/sentry/app/stores/repositoryStore.tsx
+++ b/src/sentry/static/sentry/app/stores/repositoryStore.tsx
@@ -38,30 +38,42 @@ const RepositoryStoreConfig: Reflux.StoreDefinition & RepositoryStoreInterface =
   },
 
   resetRepositories() {
-    this.state.orgSlug = undefined;
-    this.state.repositories = undefined;
-    this.state.repositoriesLoading = undefined;
-    this.state.repositoriesError = undefined;
+    this.state = {
+      orgSlug: undefined,
+      repositories: undefined,
+      repositoriesLoading: undefined,
+      repositoriesError: undefined,
+    };
     this.trigger(this.state);
   },
 
   loadRepositories(orgSlug: string) {
-    this.state.orgSlug = orgSlug;
-    this.state.repositoriesLoading = true;
-    this.state.repositoriesError = undefined;
+    this.state = {
+      orgSlug,
+      repositories: orgSlug === this.state.orgSlug ? this.state.repositories : undefined,
+      repositoriesLoading: true,
+      repositoriesError: undefined,
+    };
     this.trigger(this.state);
   },
 
   loadRepositoriesError(err: Error) {
-    this.state.repositoriesLoading = false;
-    this.state.repositoriesError = err;
+    this.state = {
+      ...this.state,
+      repositories: undefined,
+      repositoriesLoading: false,
+      repositoriesError: err,
+    };
     this.trigger(this.state);
   },
 
   loadRepositoriesSuccess(data: Repository[]) {
-    this.state.repositories = data;
-    this.state.repositoriesLoading = false;
-    this.state.repositoriesError = undefined;
+    this.state = {
+      ...this.state,
+      repositories: data,
+      repositoriesLoading: false,
+      repositoriesError: undefined,
+    };
     this.trigger(this.state);
   },
 
@@ -71,6 +83,7 @@ const RepositoryStoreConfig: Reflux.StoreDefinition & RepositoryStoreInterface =
    */
   get(orgSlug?: string) {
     const {orgSlug: stateOrgSlug, ...data} = this.state;
+
     if (orgSlug !== undefined && orgSlug !== stateOrgSlug) {
       return {
         repositories: undefined,

--- a/src/sentry/static/sentry/app/stores/repositoryStore.tsx
+++ b/src/sentry/static/sentry/app/stores/repositoryStore.tsx
@@ -1,0 +1,87 @@
+import Reflux from 'reflux';
+
+import RepoActions from 'app/actions/repositoryActions';
+import {Repository} from 'app/types';
+
+type RepositoryStoreInterface = {
+  get(
+    orgSlug?: string
+  ): {
+    repositories?: Repository[];
+    repositoriesLoading?: boolean;
+    repositoriesError?: Error;
+  };
+
+  state: {
+    orgSlug?: string;
+    repositories?: Repository[];
+    repositoriesLoading?: boolean;
+    repositoriesError?: Error;
+  };
+
+  loadRepositories(orgSlug: string): void;
+  loadRepositoriesSuccess(data: Repository[]): void;
+  loadRepositoriesError(error: Error): void;
+};
+
+const RepositoryStoreConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
+  listenables: RepoActions,
+  state: {
+    orgSlug: undefined,
+    repositories: undefined,
+    repositoriesLoading: undefined,
+    repositoriesError: undefined,
+  },
+
+  init() {
+    this.resetRepositories();
+  },
+
+  resetRepositories() {
+    this.state.orgSlug = undefined;
+    this.state.repositories = undefined;
+    this.state.repositoriesLoading = undefined;
+    this.state.repositoriesError = undefined;
+    this.trigger(this.state);
+  },
+
+  loadRepositories(orgSlug: string) {
+    this.state.orgSlug = orgSlug;
+    this.state.repositoriesLoading = true;
+    this.state.repositoriesError = undefined;
+    this.trigger(this.state);
+  },
+
+  loadRepositoriesError(err: Error) {
+    this.state.repositoriesLoading = false;
+    this.state.repositoriesError = err;
+    this.trigger(this.state);
+  },
+
+  loadRepositoriesSuccess(data: Repository[]) {
+    this.state.repositories = data;
+    this.state.repositoriesLoading = false;
+    this.state.repositoriesError = undefined;
+    this.trigger(this.state);
+  },
+
+  /**
+   * `organizationSlug` is optional. If present, method will run a check if data
+   * in the store originated from the same organization
+   */
+  get(orgSlug?: string) {
+    const {orgSlug: stateOrgSlug, ...data} = this.state;
+    if (orgSlug !== undefined && orgSlug !== stateOrgSlug) {
+      return {
+        repositories: undefined,
+        repositoriesLoading: undefined,
+        repositoriesError: undefined,
+      };
+    }
+
+    return {...data};
+  },
+};
+
+type RepositoryStore = Reflux.Store & RepositoryStoreInterface;
+export default Reflux.createStore(RepositoryStoreConfig) as RepositoryStore;

--- a/src/sentry/static/sentry/app/stores/repositoryStore.tsx
+++ b/src/sentry/static/sentry/app/stores/repositoryStore.tsx
@@ -24,7 +24,7 @@ type RepositoryStoreInterface = {
   loadRepositoriesError(error: Error): void;
 };
 
-const RepositoryStoreConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
+export const RepositoryStoreConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   listenables: RepoActions,
   state: {
     orgSlug: undefined,

--- a/src/sentry/static/sentry/app/utils/withRepositories.tsx
+++ b/src/sentry/static/sentry/app/utils/withRepositories.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import Reflux from 'reflux';
+import createReactClass from 'create-react-class';
+
+import {Client} from 'app/api';
+import {Repository} from 'app/types';
+import getDisplayName from 'app/utils/getDisplayName';
+import RepositoryStore from 'app/stores/repositoryStore';
+import {getRepositories} from 'app/actionCreators/repositories';
+
+type DependentProps = {
+  api: Client;
+  orgSlug: string;
+  projectSlug: string;
+  releaseVersion: string;
+};
+
+type InjectedProps = {
+  repositories: Repository[] | undefined;
+  repositoriesLoading: boolean | undefined;
+  repositoriesError: Error | undefined;
+};
+
+const withRepositories = <P extends InjectedProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
+  createReactClass<
+    Omit<P, keyof InjectedProps> & Partial<InjectedProps> & DependentProps,
+    InjectedProps
+  >({
+    displayName: `withRepositories(${getDisplayName(WrappedComponent)})`,
+    mixins: [Reflux.listenTo(RepositoryStore, 'onStoreUpdate') as any],
+
+    getInitialState() {
+      const {orgSlug} = this.props as P & DependentProps;
+      const repoData = RepositoryStore.get(orgSlug);
+
+      return {
+        repositories: undefined,
+        repositoriesLoading: undefined,
+        repositoriesError: undefined,
+        ...repoData,
+      };
+    },
+
+    componentDidMount() {
+      this.fetchRepos();
+    },
+
+    fetchRepos() {
+      const {api, orgSlug} = this.props as P & DependentProps;
+      const repoData = RepositoryStore.get(orgSlug);
+
+      if (!repoData.repositories && !repoData.repositoriesLoading) {
+        // HACK(leedongwei): Actions fired by the ActionCreators are queued to
+        // the back of the event loop, allowing another getRepo for the same
+        // repo to be fired before the loading state is updated in store.
+        // This hack short-circuits that and update the state immediately.
+        RepositoryStore.state.repositoriesLoading = true;
+        RepositoryStore.state.orgSlug = orgSlug;
+
+        getRepositories(api, {orgSlug});
+      }
+    },
+
+    onStoreUpdate() {
+      const {orgSlug} = this.props as P & DependentProps;
+      const repoData = RepositoryStore.get(orgSlug);
+
+      this.setState({...repoData});
+    },
+
+    render() {
+      return <WrappedComponent {...(this.props as P & DependentProps)} {...this.state} />;
+    },
+  });
+
+export default withRepositories;

--- a/src/sentry/static/sentry/app/utils/withRepositories.tsx
+++ b/src/sentry/static/sentry/app/utils/withRepositories.tsx
@@ -52,13 +52,6 @@ const withRepositories = <P extends InjectedProps>(
       const repoData = RepositoryStore.get(orgSlug);
 
       if (!repoData.repositories && !repoData.repositoriesLoading) {
-        // HACK(leedongwei): Actions fired by the ActionCreators are queued to
-        // the back of the event loop, allowing another getRepo for the same
-        // repo to be fired before the loading state is updated in store.
-        // This hack short-circuits that and update the state immediately.
-        RepositoryStore.state.repositoriesLoading = true;
-        RepositoryStore.state.orgSlug = orgSlug;
-
         getRepositories(api, {orgSlug});
       }
     },

--- a/src/sentry/static/sentry/app/utils/withRepositories.tsx
+++ b/src/sentry/static/sentry/app/utils/withRepositories.tsx
@@ -11,8 +11,6 @@ import {getRepositories} from 'app/actionCreators/repositories';
 type DependentProps = {
   api: Client;
   orgSlug: string;
-  projectSlug: string;
-  releaseVersion: string;
 };
 
 type InjectedProps = {
@@ -44,10 +42,12 @@ const withRepositories = <P extends InjectedProps>(
     },
 
     componentDidMount() {
-      this.fetchRepos();
+      // XXX(leedongwei): Do not move this function call unless you modify the
+      // unit test named "prevents repeated calls"
+      this.fetchRepositories();
     },
 
-    fetchRepos() {
+    fetchRepositories() {
       const {api, orgSlug} = this.props as P & DependentProps;
       const repoData = RepositoryStore.get(orgSlug);
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {migrateRepository, addRepository} from 'app/actionCreators/integrations';
+import RepositoryActions from 'app/actions/repositoryActions';
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
@@ -77,6 +78,7 @@ export default class IntegrationRepos extends AsyncComponent<Props, State> {
       }
     });
     this.setState({itemList});
+    RepositoryActions.resetRepositories();
   };
 
   debouncedSearchRepositoriesRequest = debounce(
@@ -128,6 +130,7 @@ export default class IntegrationRepos extends AsyncComponent<Props, State> {
     promise.then(
       (repo: Repository) => {
         this.setState({adding: false, itemList: itemList.concat(repo)});
+        RepositoryActions.resetRepositories();
       },
       () => this.setState({adding: false})
     );

--- a/tests/js/spec/actionCreators/repositories.spec.jsx
+++ b/tests/js/spec/actionCreators/repositories.spec.jsx
@@ -1,0 +1,38 @@
+import {getRepositories} from 'app/actionCreators/repositories';
+import RepositoryActions from 'app/actions/repositoryActions';
+
+describe('RepositoryActionCreator', function() {
+  const api = new MockApiClient();
+  const orgSlug = 'myOrg';
+
+  const repoUrl = `/organizations/${orgSlug}/repos/`;
+  const mockData = {id: '1'};
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.spyOn(RepositoryActions, 'loadRepositories');
+    jest.spyOn(RepositoryActions, 'loadRepositoriesSuccess');
+  });
+
+  afterEach(function() {
+    jest.restoreAllMocks();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('fetch a Repository and emit an action', async () => {
+    const mockResponse = MockApiClient.addMockResponse({
+      url: repoUrl,
+      body: mockData,
+    });
+
+    getRepositories(api, {orgSlug});
+    await tick();
+
+    expect(mockResponse).toHaveBeenCalledWith(repoUrl, expect.anything());
+    expect(RepositoryActions.loadRepositories).toHaveBeenCalledWith(orgSlug);
+    expect(RepositoryActions.loadRepositoriesSuccess).toHaveBeenCalledWith(
+      orgSlug,
+      mockData
+    );
+  });
+});

--- a/tests/js/spec/actionCreators/repositories.spec.jsx
+++ b/tests/js/spec/actionCreators/repositories.spec.jsx
@@ -48,7 +48,6 @@ describe('RepositoryActionCreator', function() {
 
     expect(mockResponse).toHaveBeenCalledWith(repoUrl, expect.anything());
     expect(RepositoryActions.loadRepositoriesSuccess).toHaveBeenCalledWith(mockData);
-    // expect(RepositoryStore.loadRepositories).toHaveBeenCalled();
 
     expect(RepositoryStore.state.orgSlug).toEqual(orgSlug);
     expect(RepositoryStore.state.repositories).toEqual(mockData);

--- a/tests/js/spec/actionCreators/repositories.spec.jsx
+++ b/tests/js/spec/actionCreators/repositories.spec.jsx
@@ -1,38 +1,59 @@
 import {getRepositories} from 'app/actionCreators/repositories';
 import RepositoryActions from 'app/actions/repositoryActions';
+import RepositoryStore from 'app/stores/repositoryStore';
 
 describe('RepositoryActionCreator', function() {
-  const api = new MockApiClient();
   const orgSlug = 'myOrg';
-
   const repoUrl = `/organizations/${orgSlug}/repos/`;
-  const mockData = {id: '1'};
+
+  const api = new MockApiClient();
+  const mockData = [{id: '1'}];
+  let mockResponse;
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-    jest.spyOn(RepositoryActions, 'loadRepositories');
-    jest.spyOn(RepositoryActions, 'loadRepositoriesSuccess');
-  });
-
-  afterEach(function() {
-    jest.restoreAllMocks();
-    MockApiClient.clearMockResponses();
-  });
-
-  it('fetch a Repository and emit an action', async () => {
-    const mockResponse = MockApiClient.addMockResponse({
+    mockResponse = MockApiClient.addMockResponse({
       url: repoUrl,
       body: mockData,
     });
 
-    getRepositories(api, {orgSlug});
-    await tick();
+    jest.restoreAllMocks();
+    jest.spyOn(RepositoryActions, 'loadRepositories');
+    jest.spyOn(RepositoryActions, 'loadRepositoriesSuccess');
 
-    expect(mockResponse).toHaveBeenCalledWith(repoUrl, expect.anything());
+    RepositoryStore.init();
+  });
+
+  it('fetches a Repository and emits actions', async () => {
+    getRepositories(api, {orgSlug}); // Fire loadRepositories
     expect(RepositoryActions.loadRepositories).toHaveBeenCalledWith(orgSlug);
-    expect(RepositoryActions.loadRepositoriesSuccess).toHaveBeenCalledWith(
-      orgSlug,
-      mockData
-    );
+    expect(RepositoryActions.loadRepositoriesSuccess).not.toHaveBeenCalled();
+
+    await tick(); // Run loadRepositories and fire loadRepositoriesSuccess
+    expect(mockResponse).toHaveBeenCalledWith(repoUrl, expect.anything());
+    expect(RepositoryActions.loadRepositoriesSuccess).toHaveBeenCalledWith(mockData);
+    expect(RepositoryStore.state.orgSlug).toEqual(orgSlug);
+    expect(RepositoryStore.state.repositories).toEqual(undefined);
+    expect(RepositoryStore.state.repositoriesLoading).toEqual(true);
+
+    await tick(); // Run loadRepositoriesSuccess
+    expect(RepositoryStore.state.orgSlug).toEqual(orgSlug);
+    expect(RepositoryStore.state.repositories).toEqual(mockData);
+    expect(RepositoryStore.state.repositoriesLoading).toEqual(false);
+  });
+
+  it('short-circuits the JS event loop', async () => {
+    expect(RepositoryStore.state.repositoriesLoading).toEqual(undefined);
+
+    getRepositories(api, {orgSlug}); // Fire loadRepositories
+    expect(RepositoryActions.loadRepositories).toHaveBeenCalled();
+    expect(RepositoryStore.state.repositoriesLoading).toEqual(true); // Short-circuit
+
+    await tick(); // Run loadRepositories and fire loadRepositoriesSuccess
+    expect(RepositoryActions.loadRepositoriesSuccess).toHaveBeenCalled();
+    expect(RepositoryStore.state.repositoriesLoading).toEqual(true);
+
+    await tick(); // Run loadRepositoriesSuccess
+    expect(RepositoryStore.state.repositoriesLoading).toEqual(false);
   });
 });

--- a/tests/js/spec/actionCreators/repositories.spec.jsx
+++ b/tests/js/spec/actionCreators/repositories.spec.jsx
@@ -17,26 +17,39 @@ describe('RepositoryActionCreator', function() {
       body: mockData,
     });
 
+    RepositoryStore.resetRepositories();
+
     jest.restoreAllMocks();
     jest.spyOn(RepositoryActions, 'loadRepositories');
     jest.spyOn(RepositoryActions, 'loadRepositoriesSuccess');
 
-    RepositoryStore.init();
+    /**
+     * XXX(leedongwei): We would want to ensure that Store methods are not
+     * called to be 100% sure that the short-circuit is happening correctly.
+     *
+     * However, it seems like we cannot attach a listener to the method
+     * See: https://github.com/reflux/refluxjs/issues/139#issuecomment-64495623
+     */
+    // jest.spyOn(RepositoryStore, 'loadRepositories');
+    // jest.spyOn(RepositoryStore, 'loadRepositoriesSuccess');
   });
 
+  /**
+   * XXX(leedongwei): I wanted to separate the ticks and run tests to assert the
+   * state change at every tick but it is incredibly flakey.
+   */
   it('fetches a Repository and emits actions', async () => {
-    getRepositories(api, {orgSlug}); // Fire loadRepositories
+    getRepositories(api, {orgSlug}); // Fire Action.loadRepositories
     expect(RepositoryActions.loadRepositories).toHaveBeenCalledWith(orgSlug);
     expect(RepositoryActions.loadRepositoriesSuccess).not.toHaveBeenCalled();
 
-    await tick(); // Run loadRepositories and fire loadRepositoriesSuccess
+    await tick(); // Run Store.loadRepositories and fire Action.loadRepositoriesSuccess
+    await tick(); // Run Store.loadRepositoriesSuccess
+
     expect(mockResponse).toHaveBeenCalledWith(repoUrl, expect.anything());
     expect(RepositoryActions.loadRepositoriesSuccess).toHaveBeenCalledWith(mockData);
-    expect(RepositoryStore.state.orgSlug).toEqual(orgSlug);
-    expect(RepositoryStore.state.repositories).toEqual(undefined);
-    expect(RepositoryStore.state.repositoriesLoading).toEqual(true);
+    // expect(RepositoryStore.loadRepositories).toHaveBeenCalled();
 
-    await tick(); // Run loadRepositoriesSuccess
     expect(RepositoryStore.state.orgSlug).toEqual(orgSlug);
     expect(RepositoryStore.state.repositories).toEqual(mockData);
     expect(RepositoryStore.state.repositoriesLoading).toEqual(false);
@@ -45,15 +58,9 @@ describe('RepositoryActionCreator', function() {
   it('short-circuits the JS event loop', async () => {
     expect(RepositoryStore.state.repositoriesLoading).toEqual(undefined);
 
-    getRepositories(api, {orgSlug}); // Fire loadRepositories
+    getRepositories(api, {orgSlug}); // Fire Action.loadRepositories
     expect(RepositoryActions.loadRepositories).toHaveBeenCalled();
+    // expect(RepositoryStore.loadRepositories).not.toHaveBeenCalled();
     expect(RepositoryStore.state.repositoriesLoading).toEqual(true); // Short-circuit
-
-    await tick(); // Run loadRepositories and fire loadRepositoriesSuccess
-    expect(RepositoryActions.loadRepositoriesSuccess).toHaveBeenCalled();
-    expect(RepositoryStore.state.repositoriesLoading).toEqual(true);
-
-    await tick(); // Run loadRepositoriesSuccess
-    expect(RepositoryStore.state.repositoriesLoading).toEqual(false);
   });
 });

--- a/tests/js/spec/utils/withRepositories.spec.jsx
+++ b/tests/js/spec/utils/withRepositories.spec.jsx
@@ -6,10 +6,6 @@ import RepositoryStore from 'app/stores/repositoryStore';
 import withRepositories from 'app/utils/withRepositories';
 
 describe('withRepositories HoC', function() {
-  jest.mock('app/actionCreators/repositories', () => ({
-    ...jest.requireActual('app/actionCreators/repositories'),
-  }));
-
   const orgSlug = 'myOrg';
   const repoUrl = `/organizations/${orgSlug}/repos/`;
 
@@ -32,9 +28,9 @@ describe('withRepositories HoC', function() {
     const Container = withRepositories(Component);
     const wrapper = mount(<Container api={api} orgSlug={orgSlug} />);
 
-    await tick(); // Run loadRepositories
-    await tick(); // Run loadRepositoriesSuccess
-    wrapper.update(); // Re-render component
+    await tick(); // Run Store.loadRepositories
+    await tick(); // Run Store.loadRepositoriesSuccess
+    wrapper.update(); // Re-render component with Store data
 
     const mountedComponent = wrapper.find(Component);
     expect(mountedComponent.prop('repositories')).toEqual(mockData);
@@ -61,9 +57,7 @@ describe('withRepositories HoC', function() {
     // Mount and run duplicates
     mount(<Container api={api} orgSlug={orgSlug} />);
     await tick();
-    await tick();
     mount(<Container api={api} orgSlug={orgSlug} />);
-    await tick();
     await tick();
 
     expect(api.requestPromise).toHaveBeenCalledTimes(1);

--- a/tests/js/spec/utils/withRepositories.spec.jsx
+++ b/tests/js/spec/utils/withRepositories.spec.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import {mount} from 'sentry-test/enzyme';
+
+import RepositoryStore from 'app/stores/repositoryStore';
+import withRepositories from 'app/utils/withRepositories';
+
+describe('withRepositories HoC', function() {
+  jest.mock('app/actionCreators/repositories', () => ({
+    ...jest.requireActual('app/actionCreators/repositories'),
+  }));
+
+  const orgSlug = 'myOrg';
+  const repoUrl = `/organizations/${orgSlug}/repos/`;
+
+  const api = new MockApiClient();
+  const mockData = [{id: '1'}];
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: repoUrl,
+      body: mockData,
+    });
+
+    jest.restoreAllMocks();
+    RepositoryStore.init();
+  });
+
+  it('adds repositories prop', async () => {
+    const Component = () => null;
+    const Container = withRepositories(Component);
+    const wrapper = mount(<Container api={api} orgSlug={orgSlug} />);
+
+    await tick(); // Run loadRepositories
+    await tick(); // Run loadRepositoriesSuccess
+    wrapper.update(); // Re-render component
+
+    const mountedComponent = wrapper.find(Component);
+    expect(mountedComponent.prop('repositories')).toEqual(mockData);
+    expect(mountedComponent.prop('repositoriesLoading')).toEqual(false);
+    expect(mountedComponent.prop('repositoriesError')).toEqual(undefined);
+  });
+
+  it('prevents repeated calls', async () => {
+    const Component = () => null;
+    const Container = withRepositories(Component);
+
+    // XXX(leedongwei): We cannot spy on `fetchRepositories` as Jest can't
+    // replace the method in the prototype due to createReactClass.
+    // As such, I'm using `componentDidMount` as a proxy.
+    jest.spyOn(api, 'requestPromise');
+    jest.spyOn(Container.prototype, 'componentDidMount');
+    // jest.spyOn(Container.prototype, 'fetchRepositories');
+
+    // Mount and run component
+    mount(<Container api={api} orgSlug={orgSlug} />);
+    await tick();
+    await tick();
+
+    // Mount and run duplicates
+    mount(<Container api={api} orgSlug={orgSlug} />);
+    await tick();
+    await tick();
+    mount(<Container api={api} orgSlug={orgSlug} />);
+    await tick();
+    await tick();
+
+    expect(api.requestPromise).toHaveBeenCalledTimes(1);
+    expect(Container.prototype.componentDidMount).toHaveBeenCalledTimes(3);
+    // expect(Container.prototype.fetchRepositories).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -2,17 +2,23 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 
+import RepositoryActions from 'app/actions/repositoryActions';
 import {Client} from 'app/api';
 import IntegrationRepos from 'app/views/organizationIntegrations/integrationRepos';
 
 describe('IntegrationRepos', function() {
-  beforeEach(function() {
-    Client.clearMockResponses();
-  });
-
   const org = TestStubs.Organization();
   const integration = TestStubs.GitHubIntegration();
   const routerContext = TestStubs.routerContext();
+
+  beforeEach(() => {
+    Client.clearMockResponses();
+    jest.spyOn(RepositoryActions, 'resetRepositories');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   describe('Getting repositories', function() {
     it('handles broken integrations', function() {
@@ -81,6 +87,8 @@ describe('IntegrationRepos', function() {
         .first();
       expect(name).toHaveLength(1);
       expect(name.text()).toEqual('example/repo-name');
+
+      expect(RepositoryActions.resetRepositories).toHaveBeenCalled();
     });
 
     it('handles failure during save', async function() {
@@ -120,7 +128,7 @@ describe('IntegrationRepos', function() {
   });
 
   describe('migratable repo', function() {
-    it('associates repository with integration', () => {
+    it('associates repository with integration', async () => {
       Client.addMockResponse({
         url: `/organizations/${org.slug}/repos/`,
         body: [
@@ -151,12 +159,15 @@ describe('IntegrationRepos', function() {
 
       wrapper.find('DropdownButton').simulate('click');
       wrapper.find('StyledListElement').simulate('click');
+      await tick();
+
       expect(updateRepo).toHaveBeenCalledWith(
         `/organizations/${org.slug}/repos/4/`,
         expect.objectContaining({
           data: {integrationId: '1'},
         })
       );
+      expect(RepositoryActions.resetRepositories).toHaveBeenCalled();
     });
 
     it('uses externalSlug not name for comparison', () => {


### PR DESCRIPTION
There is an odd pattern here: we are tracking the `lastUpdated` for the store, so that we can reduced the frequency/quantity of API calls to the `/organization/.../repos/` endpoint.