### PR TITLE
build(lint): Put ESlint results under .artifacts

### DIFF
--- a/bin/eslint-travis-wrapper
+++ b/bin/eslint-travis-wrapper
@@ -27,7 +27,7 @@ console.log(consoleFormatter(report.results));
 if (otherFormatterType) {
   const otherFormatter = cli.getFormatter(otherFormatterType);
 
-  fs.writeFile('eslint.checkstyle.xml', otherFormatter(report.results), 'utf8', () => {
+  fs.writeFile('.artifacts/eslint.checkstyle.xml', otherFormatter(report.results), 'utf8', () => {
     process.exit(report.errorCount);
   });
 }

--- a/bin/eslint-travis-wrapper
+++ b/bin/eslint-travis-wrapper
@@ -27,7 +27,12 @@ console.log(consoleFormatter(report.results));
 if (otherFormatterType) {
   const otherFormatter = cli.getFormatter(otherFormatterType);
 
-  fs.writeFile('.artifacts/eslint.checkstyle.xml', otherFormatter(report.results), 'utf8', () => {
-    process.exit(report.errorCount);
-  });
+  fs.writeFile(
+    '.artifacts/eslint.checkstyle.xml',
+    otherFormatter(report.results),
+    'utf8',
+    () => {
+      process.exit(report.errorCount);
+    }
+  );
 }


### PR DESCRIPTION
We only upload artifacts to Zeus from .artifacts so place the ESLint file there.