### PR TITLE
ref(ts) Convert EventsChart to typescript

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -5,7 +5,12 @@ import {Client} from 'app/api';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {canIncludePreviousPeriod} from 'app/components/charts/utils';
 import {getPeriod} from 'app/utils/getPeriod';
-import {EventsStats, OrganizationSummary, MultiSeriesEventsStats} from 'app/types';
+import {
+  EventsStats,
+  DateString,
+  OrganizationSummary,
+  MultiSeriesEventsStats,
+} from 'app/types';
 
 function getBaseUrl(org: OrganizationSummary, keyTransactions: boolean | undefined) {
   if (keyTransactions) {
@@ -20,8 +25,8 @@ type Options = {
   project?: number[];
   environment?: string[];
   period?: string;
-  start?: Date;
-  end?: Date;
+  start?: DateString;
+  end?: DateString;
   interval?: string;
   includePrevious?: boolean;
   limit?: number;

--- a/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.jsx
@@ -218,6 +218,7 @@ class ChartZoom extends React.Component {
       return children(props);
     }
 
+    // TODO(mark) Update consumers of DataZoom when typing this.
     const renderProps = {
       // Zooming only works when grouped by date
       isGroupedByDate: true,

--- a/src/sentry/static/sentry/app/components/charts/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsRequest.tsx
@@ -4,10 +4,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {
-  OrganizationSummary,
+  DateString,
   EventsStats,
-  MultiSeriesEventsStats,
   EventsStatsData,
+  OrganizationSummary,
+  MultiSeriesEventsStats,
 } from 'app/types';
 import {Series, SeriesDataUnit} from 'app/types/echarts';
 import LoadingPanel from 'app/components/charts/loadingPanel';
@@ -51,15 +52,15 @@ type DefaultProps = {
    *
    * e.g. 24h, 7d, 30d
    */
-  period: any;
+  period?: string;
   /**
    * Absolute start date for query
    */
-  start: any;
+  start?: DateString;
   /**
    * Absolute end date for query
    */
-  end: any;
+  end?: DateString;
   /**
    * Interval to group results in
    *
@@ -201,7 +202,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
   };
 
   static defaultProps: DefaultProps = {
-    period: null,
+    period: undefined,
     start: null,
     end: null,
     interval: '1d',

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -447,12 +447,14 @@ export type DocumentIntegration = {
   resourceLinks: Array<{title: string; url: string}>;
 };
 
+export type DateString = Date | string | null;
+
 export type GlobalSelection = {
   projects: number[];
   environments: string[];
   datetime: {
-    start: Date | string | null;
-    end: Date | string | null;
+    start: DateString;
+    end: DateString;
     period: string;
     utc: boolean;
   };

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -13,6 +13,7 @@ import {Panel} from 'app/components/panels';
 import getDynamicText from 'app/utils/getDynamicText';
 import EventView from 'app/utils/discover/eventView';
 import {DisplayModes} from 'app/utils/discover/types';
+import {decodeScalar} from 'app/utils/queryString';
 
 import ChartFooter from './chartFooter';
 
@@ -44,11 +45,9 @@ class ResultsChart extends React.Component<ResultsChartProps> {
     const globalSelection = eventView.getGlobalSelection();
     const start = globalSelection.start
       ? getUtcToLocalDateObject(globalSelection.start)
-      : undefined;
+      : null;
 
-    const end = globalSelection.end
-      ? getUtcToLocalDateObject(globalSelection.end)
-      : undefined;
+    const end = globalSelection.end ? getUtcToLocalDateObject(globalSelection.end) : null;
 
     const {utc} = getParams(location.query);
     const apiPayload = eventView.getEventsAPIPayload(location);
@@ -81,7 +80,7 @@ class ResultsChart extends React.Component<ResultsChartProps> {
               field={isTopEvents ? apiPayload.field : undefined}
               showDaily={isDaily}
               topEvents={isTopEvents ? 5 : undefined}
-              orderby={isTopEvents ? apiPayload.sort : undefined}
+              orderby={isTopEvents ? decodeScalar(apiPayload.sort) : undefined}
               utc={utc === 'true'}
             />
           ),


### PR DESCRIPTION
There are still some related components that have not been converted. We also have a jumble of types for falsey values with null | undefined being used all over the place. I'd like to make another pass and remove the null values.