### PR TITLE
fix(plugins) change logic when to render data fowarding graph

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectDataForwarding.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataForwarding.jsx
@@ -38,13 +38,14 @@ class DataForwardingStats extends AsyncComponent {
   renderBody() {
     const {projectId} = this.props.params;
     const stats = this.state.stats.map(p => ({x: p[0], y: [p[1]]}));
+    const fowardedAny = stats.some(({y}) => y[0]);
 
     return (
       <Panel>
         <SentryDocumentTitle title={t('Data Forwarding')} objSlug={projectId} />
         <PanelHeader>{t('Forwarded events in the last 30 days (by day)')}</PanelHeader>
         <PanelBody>
-          {stats.length > 0 && stats[0][0] ? (
+          {fowardedAny ? (
             <StackedBarChart
               style={{
                 border: 'none',

--- a/src/sentry/static/sentry/app/views/settings/projectDataForwarding.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataForwarding.jsx
@@ -37,6 +37,7 @@ class DataForwardingStats extends AsyncComponent {
 
   renderBody() {
     const {projectId} = this.props.params;
+    //y is an array of size one which denotes how many events were forwarded in that period
     const stats = this.state.stats.map(p => ({x: p[0], y: [p[1]]}));
     const fowardedAny = stats.some(({y}) => y[0]);
 

--- a/src/sentry/static/sentry/app/views/settings/projectDataForwarding.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataForwarding.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t, tct} from 'app/locale';
@@ -14,11 +15,22 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import StackedBarChart from 'app/components/stackedBarChart';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import withOrganization from 'app/utils/withOrganization';
-import withProjects from 'app/utils/withProjects';
+import withProject from 'app/utils/withProject';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import {Organization, Plugin, Project} from 'app/types';
 
-class DataForwardingStats extends AsyncComponent {
-  getEndpoints() {
+type RouteParams = {projectId: string; orgId: string};
+
+type StatProps = {
+  params: RouteParams;
+};
+
+type StatState = AsyncComponent['state'] & {
+  stats: Array<{x: number; y: [number]}>;
+};
+
+class DataForwardingStats extends AsyncComponent<StatProps, StatState> {
+  getEndpoints(): [[string, string, object]] {
     const {orgId, projectId} = this.props.params;
     const until = Math.floor(new Date().getTime() / 1000);
     const since = until - 3600 * 24 * 30;
@@ -69,8 +81,17 @@ class DataForwardingStats extends AsyncComponent {
   }
 }
 
-class ProjectDataForwarding extends AsyncComponent {
-  getEndpoints() {
+type Props = RouteComponentProps<RouteParams, {}> & {
+  organization: Organization;
+  project: Project;
+};
+
+type State = AsyncComponent['state'] & {
+  plugins: Plugin[];
+};
+
+class ProjectDataForwarding extends AsyncComponent<Props, State> {
+  getEndpoints(): [[string, string]] {
     const {orgId, projectId} = this.props.params;
 
     return [['plugins', `/projects/${orgId}/${projectId}/plugins/`]];
@@ -82,7 +103,7 @@ class ProjectDataForwarding extends AsyncComponent {
     );
   }
 
-  updatePlugin(plugin, enabled) {
+  updatePlugin(plugin: Plugin, enabled: boolean) {
     const plugins = this.state.plugins.map(p => ({
       ...p,
       enabled: p.id === plugin.id ? enabled : p.enabled,
@@ -91,8 +112,8 @@ class ProjectDataForwarding extends AsyncComponent {
     this.setState({plugins});
   }
 
-  onEnablePlugin = plugin => this.updatePlugin(plugin, true);
-  onDisablePlugin = plugin => this.updatePlugin(plugin, false);
+  onEnablePlugin = (plugin: Plugin) => this.updatePlugin(plugin, true);
+  onDisablePlugin = (plugin: Plugin) => this.updatePlugin(plugin, false);
 
   renderBody() {
     const {params, organization, project} = this.props;
@@ -168,4 +189,4 @@ class ProjectDataForwarding extends AsyncComponent {
   }
 }
 
-export default withProjects(withOrganization(ProjectDataForwarding));
+export default withProject(withOrganization(ProjectDataForwarding));


### PR DESCRIPTION
This PR fixes the bug where the data forwarding graph never got rendered. This checks to make sure at least one period has a forwarded event to render the graph.

![Screen Shot 2020-06-02 at 9 55 54 AM](https://user-images.githubusercontent.com/8533851/83547798-98ef2000-a4b7-11ea-9b80-80e94005d327.png)
