### PR TITLE
ref(api): Set access_token as GitHubClient attribute

### DIFF
--- a/src/sentry/auth/providers/github/client.py
+++ b/src/sentry/auth/providers/github/client.py
@@ -15,11 +15,12 @@ class GitHubApiError(Exception):
 
 
 class GitHubClient(object):
-    def __init__(self):
+    def __init__(self, access_token):
         self.http = http.build_session()
+        self.access_token = access_token
 
-    def _request(self, path, access_token):
-        headers = {"Authorization": "token {0}".format(access_token)}
+    def _request(self, path):
+        headers = {"Authorization": "token {0}".format(self.access_token)}
 
         try:
             req = self.http.get(
@@ -31,17 +32,17 @@ class GitHubClient(object):
             raise GitHubApiError(req.content, status=req.status_code)
         return json.loads(req.content)
 
-    def get_org_list(self, access_token):
-        return self._request("/user/orgs", access_token)
+    def get_org_list(self):
+        return self._request("/user/orgs", self.access_token)
 
-    def get_user(self, access_token):
-        return self._request("/user", access_token)
+    def get_user(self):
+        return self._request("/user", self.access_token)
 
-    def get_user_emails(self, access_token):
-        return self._request("/user/emails", access_token)
+    def get_user_emails(self):
+        return self._request("/user/emails", self.access_token)
 
-    def is_org_member(self, access_token, org_id):
-        org_list = self.get_org_list(access_token)
+    def is_org_member(self, org_id):
+        org_list = self.get_org_list(self.ccess_token)
         org_id = six.text_type(org_id)
         for o in org_list:
             if six.text_type((o["id"])) == org_id:

--- a/src/sentry/auth/providers/github/client.py
+++ b/src/sentry/auth/providers/github/client.py
@@ -33,18 +33,17 @@ class GitHubClient(object):
         return json.loads(req.content)
 
     def get_org_list(self):
-        return self._request("/user/orgs", self.access_token)
+        return self._request("/user/orgs")
 
     def get_user(self):
-        return self._request("/user", self.access_token)
+        return self._request("/user")
 
     def get_user_emails(self):
-        return self._request("/user/emails", self.access_token)
+        return self._request("/user/emails")
 
     def is_org_member(self, org_id):
-        org_list = self.get_org_list(self.ccess_token)
         org_id = six.text_type(org_id)
-        for o in org_list:
+        for o in self.get_org_list():
             if six.text_type((o["id"])) == org_id:
                 return True
         return False

--- a/src/sentry/auth/providers/github/provider.py
+++ b/src/sentry/auth/providers/github/provider.py
@@ -56,11 +56,10 @@ class GitHubOAuth2Provider(OAuth2Provider):
         }
 
     def refresh_identity(self, auth_identity):
-        client = GitHubClient()
-        access_token = auth_identity.data["access_token"]
+        client = GitHubClient(auth_identity.data["access_token"])
 
         try:
-            if not client.is_org_member(access_token, self.org["id"]):
+            if not client.is_org_member(self.org["id"]):
                 raise IdentityNotValid
         except GitHubApiError as e:
             raise IdentityNotValid(e)

--- a/src/sentry/auth/providers/github/views.py
+++ b/src/sentry/auth/providers/github/views.py
@@ -28,20 +28,19 @@ def _get_name_from_email(email):
 class FetchUser(AuthView):
     def __init__(self, org=None, *args, **kwargs):
         self.org = org
-        self.client = GitHubClient()
         super(FetchUser, self).__init__(*args, **kwargs)
 
     def handle(self, request, helper):
-        access_token = helper.fetch_state("data")["access_token"]
+        client = GitHubClient(helper.fetch_state("data")["access_token"])
 
         if self.org is not None:
-            if not self.client.is_org_member(access_token, self.org["id"]):
+            if not client.is_org_member(self.org["id"]):
                 return helper.error(ERR_NO_ORG_ACCESS)
 
-        user = self.client.get_user(access_token)
+        user = client.get_user()
 
         if not user.get("email"):
-            emails = self.client.get_user_emails(access_token)
+            emails = client.get_user_emails()
             email = [
                 e["email"]
                 for e in emails
@@ -115,12 +114,11 @@ class SelectOrganizationForm(forms.Form):
 
 class SelectOrganization(AuthView):
     def __init__(self, *args, **kwargs):
-        self.client = GitHubClient()
         super(SelectOrganization, self).__init__(*args, **kwargs)
 
     def handle(self, request, helper):
-        access_token = helper.fetch_state("data")["access_token"]
-        org_list = self.client.get_org_list(access_token)
+        client = GitHubClient(helper.fetch_state("data")["access_token"])
+        org_list = client.get_org_list()
 
         form = SelectOrganizationForm(org_list, request.POST or None)
         if form.is_valid():

--- a/tests/sentry/auth/providers/github/test_client.py
+++ b/tests/sentry/auth/providers/github/test_client.py
@@ -15,8 +15,8 @@ class GitHubClientTest(TestCase):
             responses.GET, "https://{0}/".format(API_DOMAIN), json={"status": "SUCCESS"}, status=200
         )
 
-        client = GitHubClient()
-        client._request("/", "accessToken")
+        client = GitHubClient("accessToken")
+        client._request("/")
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.headers["Authorization"] == "token accessToken"

--- a/tests/sentry/auth/providers/github/test_client.py
+++ b/tests/sentry/auth/providers/github/test_client.py
@@ -1,22 +1,48 @@
 from __future__ import absolute_import
 
+import pytest
 import responses
-
-from sentry.testutils import TestCase
 
 from sentry.auth.providers.github.client import GitHubClient
 from sentry.auth.providers.github.constants import API_DOMAIN
+from sentry.utils.compat import mock
 
 
-class GitHubClientTest(TestCase):
-    @responses.activate
-    def test_request_sends_client_id_and_secret(self):
-        responses.add(
-            responses.GET, "https://{0}/".format(API_DOMAIN), json={"status": "SUCCESS"}, status=200
-        )
+@pytest.fixture
+def client():
+    return GitHubClient("accessToken")
 
-        client = GitHubClient("accessToken")
-        client._request("/")
 
-        assert len(responses.calls) == 1
-        assert responses.calls[0].request.headers["Authorization"] == "token accessToken"
+@responses.activate
+def test_request_sends_access_token(client):
+    responses.add(
+        responses.GET, "https://{0}/".format(API_DOMAIN), json={"status": "SUCCESS"}, status=200
+    )
+    client._request("/")
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.headers["Authorization"] == "token accessToken"
+
+
+@mock.patch.object(GitHubClient, "_request")
+def test_get_org_list(mock_request, client):
+    client.get_org_list()
+    mock_request.assert_called_once_with("/user/orgs")
+
+
+@mock.patch.object(GitHubClient, "_request")
+def test_get_user(mock_request, client):
+    client.get_user()
+    mock_request.assert_called_once_with("/user")
+
+
+@mock.patch.object(GitHubClient, "_request")
+def test_get_user_emails(mock_request, client):
+    client.get_user_emails()
+    mock_request.assert_called_once_with("/user/emails")
+
+
+@mock.patch.object(GitHubClient, "_request", return_value=[{"id": 1396951}])
+def test_is_org_member(mock_request, client):
+    got = client.is_org_member(1396951)
+    assert got is True


### PR DESCRIPTION
 Instead of passing the access_token in to every method call for GitHubClient, pass it into the constructor and store it as an object attribute.