### PR TITLE
feat(discover) Update visualization of multi-series results

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -11,6 +11,7 @@ import {getInterval} from 'app/components/charts/utils';
 import ChartZoom from 'app/components/charts/chartZoom';
 import AreaChart from 'app/components/charts/areaChart';
 import BarChart from 'app/components/charts/barChart';
+import LineChart from 'app/components/charts/lineChart';
 import TransitionChart from 'app/components/charts/transitionChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
 import {IconWarning} from 'app/icons';
@@ -18,11 +19,9 @@ import theme from 'app/utils/theme';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import {getDuration, formatPercentage} from 'app/utils/formatters';
+import {aggregateOutputType, aggregateMultiPlotType} from 'app/utils/discover/fields';
 
 import EventsRequest from './eventsRequest';
-
-const DURATION_AGGREGATE_PATTERN = /^(p75|p95|p99|percentile)|transaction\.duration/;
-const PERCENTAGE_AGGREGATE_PATTERN = /^(error_rate)/;
 
 type ChartProps = {
   loading: boolean;
@@ -36,6 +35,7 @@ type ChartProps = {
   previousTimeseriesData?: Series | null;
   previousSeriesName?: string;
   showDaily?: boolean;
+  yAxis: string;
 };
 
 class Chart extends React.Component<ChartProps> {
@@ -50,6 +50,7 @@ class Chart extends React.Component<ChartProps> {
     currentSeriesName: PropTypes.string,
     previousSeriesName: PropTypes.string,
     showDaily: PropTypes.bool,
+    yAxis: PropTypes.string,
   };
 
   shouldComponentUpdate(nextProps: ChartProps) {
@@ -68,6 +69,24 @@ class Chart extends React.Component<ChartProps> {
     return true;
   }
 
+  getChartComponent() {
+    const {showDaily, timeseriesData, yAxis} = this.props;
+    if (showDaily) {
+      return BarChart;
+    }
+    if (timeseriesData.length > 1) {
+      switch (aggregateMultiPlotType(yAxis)) {
+        case 'line':
+          return LineChart;
+        case 'area':
+          return AreaChart;
+        default:
+          throw new Error(`Unknown multi plot type for ${yAxis}`);
+      }
+    }
+    return AreaChart;
+  }
+
   render() {
     const {
       loading: _loading,
@@ -79,7 +98,6 @@ class Chart extends React.Component<ChartProps> {
       showLegend,
       currentSeriesName,
       previousSeriesName,
-      showDaily,
       ...props
     } = this.props;
 
@@ -101,7 +119,7 @@ class Chart extends React.Component<ChartProps> {
     };
 
     const colors = theme.charts.getColorPalette(timeseriesData.length - 2);
-    const Component = showDaily ? BarChart : AreaChart;
+    const Component = this.getChartComponent();
     const series = Array.isArray(releaseSeries)
       ? [...timeseriesData, ...releaseSeries]
       : timeseriesData;
@@ -259,17 +277,18 @@ class EventsChart extends React.Component<Props> {
     const tooltip = {
       truncate: 80,
       valueFormatter(value: number) {
-        if (DURATION_AGGREGATE_PATTERN.test(yAxis)) {
-          return getDuration(value / 1000, 2);
+        switch (aggregateOutputType(yAxis)) {
+          case 'integer':
+            return value.toLocaleString();
+          case 'number':
+            return value.toLocaleString();
+          case 'percentage':
+            return formatPercentage(value, 2);
+          case 'duration':
+            return getDuration(value / 1000, 2);
+          default:
+            return value;
         }
-        if (PERCENTAGE_AGGREGATE_PATTERN.test(yAxis)) {
-          return formatPercentage(value, 2);
-        }
-        if (typeof value === 'number') {
-          return value.toLocaleString();
-        }
-
-        return value;
       },
     };
     const interval = showDaily
@@ -311,6 +330,7 @@ class EventsChart extends React.Component<Props> {
             currentSeriesName={currentSeriesName}
             previousSeriesName={previousSeriesName}
             stacked={typeof topEvents === 'number' && topEvents > 0}
+            yAxis={yAxis}
             showDaily={showDaily}
           />
         </TransitionChart>

--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -91,6 +91,7 @@ class Chart extends React.Component<ChartProps> {
     const {
       loading: _loading,
       reloading: _reloading,
+      yAxis: _yaxis,
       releaseSeries,
       zoomRenderProps,
       timeseriesData,

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -62,6 +62,7 @@ export const AGGREGATIONS = {
     parameters: [],
     outputType: 'number',
     isSortable: true,
+    multiPlotType: 'area',
   },
   count_unique: {
     parameters: [
@@ -73,6 +74,7 @@ export const AGGREGATIONS = {
     ],
     outputType: 'number',
     isSortable: true,
+    multiPlotType: 'line',
   },
   min: {
     parameters: [
@@ -84,6 +86,7 @@ export const AGGREGATIONS = {
     ],
     outputType: null,
     isSortable: true,
+    multiPlotType: 'line',
   },
   max: {
     parameters: [
@@ -95,6 +98,7 @@ export const AGGREGATIONS = {
     ],
     outputType: null,
     isSortable: true,
+    multiPlotType: 'line',
   },
   avg: {
     parameters: [
@@ -106,6 +110,7 @@ export const AGGREGATIONS = {
     ],
     outputType: null,
     isSortable: true,
+    multiPlotType: 'line',
   },
   sum: {
     parameters: [
@@ -117,11 +122,13 @@ export const AGGREGATIONS = {
     ],
     outputType: null,
     isSortable: true,
+    multiPlotType: 'area',
   },
   last_seen: {
     parameters: [],
     outputType: 'date',
     isSortable: true,
+    multiPlotType: 'area',
   },
 
   // Tracing functions.
@@ -129,27 +136,32 @@ export const AGGREGATIONS = {
     parameters: [],
     outputType: 'duration',
     isSortable: true,
+    multiPlotType: 'line',
   },
   p75: {
     parameters: [],
     outputType: 'duration',
     isSortable: true,
+    multiPlotType: 'line',
   },
   p95: {
     parameters: [],
     outputType: 'duration',
     type: [],
     isSortable: true,
+    multiPlotType: 'line',
   },
   p99: {
     parameters: [],
     outputType: 'duration',
     isSortable: true,
+    multiPlotType: 'line',
   },
   p100: {
     parameters: [],
     outputType: 'duration',
     isSortable: true,
+    multiPlotType: 'line',
   },
   percentile: {
     parameters: [
@@ -168,11 +180,13 @@ export const AGGREGATIONS = {
     ],
     outputType: null,
     isSortable: true,
+    multiPlotType: 'line',
   },
   error_rate: {
     parameters: [],
     outputType: 'percentage',
     isSortable: true,
+    multiPlotType: 'line',
   },
   apdex: {
     parameters: [
@@ -185,6 +199,7 @@ export const AGGREGATIONS = {
     ],
     outputType: 'percentage',
     isSortable: true,
+    multiPlotType: 'line',
   },
   impact: {
     parameters: [
@@ -197,6 +212,7 @@ export const AGGREGATIONS = {
     ],
     outputType: 'number',
     isSortable: true,
+    multiPlotType: 'line',
   },
   user_misery: {
     parameters: [
@@ -209,16 +225,19 @@ export const AGGREGATIONS = {
     ],
     outputType: 'number',
     isSortable: false,
+    multiPlotType: 'area',
   },
   eps: {
     parameters: [],
     outputType: 'number',
     isSortable: true,
+    multiPlotType: 'area',
   },
   epm: {
     parameters: [],
     outputType: 'number',
     isSortable: true,
+    multiPlotType: 'area',
   },
 } as const;
 
@@ -226,11 +245,19 @@ assert(AGGREGATIONS as Readonly<{[key in keyof typeof AGGREGATIONS]: Aggregation
 
 export type AggregationKey = keyof typeof AGGREGATIONS | '';
 
+export type AggregationOutputType = Extract<
+  ColumnType,
+  'number' | 'integer' | 'date' | 'duration' | 'percentage'
+>;
+
+export type PlotType = 'line' | 'area';
+
 export type Aggregation = {
   parameters: Readonly<AggregateParameter[]>;
   // null means to inherit from the column.
-  outputType: null | ColumnType;
+  outputType: AggregationOutputType | null;
   isSortable: boolean;
+  multiPlotType: PlotType;
 };
 
 /**
@@ -386,4 +413,43 @@ export function getAggregateAlias(field: string): string {
  */
 export function isAggregateField(field: string): boolean {
   return field.match(AGGREGATE_PATTERN) !== null;
+}
+
+/**
+ * Convert a function string into type it will output.
+ * This is useful when you need to format values in tooltips,
+ * or in series markers.
+ */
+export function aggregateOutputType(field: string): AggregationOutputType {
+  const matches = AGGREGATE_PATTERN.exec(field);
+  if (!matches) {
+    return 'number';
+  }
+  const funcName = matches[1];
+  const aggregate = AGGREGATIONS[funcName];
+  // Attempt to use the function's outputType. If the function
+  // is an inherit type it will have a field as the first parameter
+  // and we can use that to get the type.
+  if (aggregate && aggregate.outputType) {
+    return aggregate.outputType;
+  } else if (matches[2] && FIELDS.hasOwnProperty(matches[2])) {
+    return FIELDS[matches[2]];
+  }
+  return 'number';
+}
+
+/**
+ * Get the multi-series chart type for an aggregate function.
+ */
+export function aggregateMultiPlotType(field: string): PlotType {
+  const matches = AGGREGATE_PATTERN.exec(field);
+  // Handle invalid data.
+  if (!matches) {
+    return 'area';
+  }
+  const funcName = matches[1];
+  if (!AGGREGATIONS.hasOwnProperty(funcName)) {
+    return 'area';
+  }
+  return AGGREGATIONS[funcName].multiPlotType;
 }

--- a/tests/js/spec/utils/discover/fields.spec.jsx
+++ b/tests/js/spec/utils/discover/fields.spec.jsx
@@ -2,6 +2,8 @@ import {
   getAggregateAlias,
   isAggregateField,
   explodeField,
+  aggregateOutputType,
+  aggregateMultiPlotType,
 } from 'app/utils/discover/fields';
 
 describe('getAggregateAlias', function() {
@@ -85,5 +87,61 @@ describe('explodeField', function() {
       kind: 'function',
       function: ['count', 'foo.bar.is-Enterprise_42', undefined],
     });
+  });
+});
+
+describe('aggregateOutputType', function() {
+  it('handles unknown fields', function() {
+    expect(aggregateOutputType('')).toEqual('number');
+    expect(aggregateOutputType('blerg')).toEqual('number');
+  });
+
+  it('handles duration functions', function() {
+    expect(aggregateOutputType('p50()')).toEqual('duration');
+    expect(aggregateOutputType('p75()')).toEqual('duration');
+    expect(aggregateOutputType('p95()')).toEqual('duration');
+    expect(aggregateOutputType('p99()')).toEqual('duration');
+    expect(aggregateOutputType('p100()')).toEqual('duration');
+    expect(aggregateOutputType('percentile(transaction.duration, 0.51)')).toEqual(
+      'duration'
+    );
+    expect(aggregateOutputType('percentile(transaction.duration,0.99)')).toEqual(
+      'duration'
+    );
+  });
+
+  it('handles percentage functions', function() {
+    expect(aggregateOutputType('error_rate()')).toEqual('percentage');
+    expect(aggregateOutputType('apdex()')).toEqual('percentage');
+    expect(aggregateOutputType('apdex(500)')).toEqual('percentage');
+  });
+
+  it('handles number functions', function() {
+    expect(aggregateOutputType('user_misery(500)')).toEqual('number');
+    expect(aggregateOutputType('impact()')).toEqual('number');
+    expect(aggregateOutputType('eps()')).toEqual('number');
+    expect(aggregateOutputType('epm()')).toEqual('number');
+  });
+
+  it('handles inherit functions', function() {
+    expect(aggregateOutputType('sum(transaction.duration)')).toEqual('duration');
+    expect(aggregateOutputType('sum(stack.colno)')).toEqual('number');
+
+    expect(aggregateOutputType('min(stack.colno)')).toEqual('number');
+    expect(aggregateOutputType('min(timestamp)')).toEqual('date');
+
+    expect(aggregateOutputType('max(stack.colno)')).toEqual('number');
+    expect(aggregateOutputType('max(timestamp)')).toEqual('date');
+  });
+});
+
+describe('aggregateMultiPlotType', function() {
+  it('handles unknown functions', function() {
+    expect(aggregateMultiPlotType('blerg')).toBe('area');
+    expect(aggregateMultiPlotType('blerg(uhoh)')).toBe('area');
+  });
+  it('handles known functions', function() {
+    expect(aggregateMultiPlotType('sum(transaction.duration)')).toBe('area');
+    expect(aggregateMultiPlotType('p95()')).toBe('line');
   });
 });


### PR DESCRIPTION
Some of our metrics are not best visualized via stacked area graphs. Error rate is an example of something that fits poorly onto a stacked graph. Instead of using areas for everything we can use lines when areas don't make sense.

![Screen Shot 2020-06-02 at 5 07 25 PM](https://user-images.githubusercontent.com/24086/83570931-dfaf3b00-a4f4-11ea-911c-71d965667b9c.png)
