### PR TITLE
fix(metric_alerts): Ensure value shown in alert rule actions is always accurate.

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -27,11 +27,11 @@ class ActionHandler(object):
         self.project = project
 
     @abc.abstractmethod
-    def fire(self):
+    def fire(self, metric_value):
         pass
 
     @abc.abstractmethod
-    def resolve(self):
+    def resolve(self, metric_value):
         pass
 
 
@@ -68,10 +68,10 @@ class EmailActionHandler(ActionHandler):
         #     emails = [target]
         return targets
 
-    def fire(self):
+    def fire(self, metric_value):
         self.email_users(TriggerStatus.ACTIVE)
 
-    def resolve(self):
+    def resolve(self, metric_value):
         self.email_users(TriggerStatus.RESOLVED)
 
     def email_users(self, status):
@@ -148,17 +148,17 @@ class EmailActionHandler(ActionHandler):
     integration_provider="slack",
 )
 class SlackActionHandler(ActionHandler):
-    def fire(self):
-        self.send_alert()
+    def fire(self, metric_value):
+        self.send_alert(metric_value)
 
-    def resolve(self):
-        self.send_alert()
+    def resolve(self, metric_value):
+        self.send_alert(metric_value)
 
-    def send_alert(self):
+    def send_alert(self, metric_value):
         from sentry.integrations.slack.utils import send_incident_alert_notification
 
         # TODO: We should include more information about the trigger/severity etc.
-        send_incident_alert_notification(self.action, self.incident)
+        send_incident_alert_notification(self.action, self.incident, metric_value)
 
 
 def format_duration(minutes):

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -565,15 +565,15 @@ class AlertRuleTriggerAction(Model):
         else:
             metrics.incr("alert_rule_trigger.unhandled_type.{}".format(self.type))
 
-    def fire(self, incident, project):
+    def fire(self, incident, project, metric_value):
         handler = self.build_handler(incident, project)
         if handler:
-            return handler.fire()
+            return handler.fire(metric_value)
 
-    def resolve(self, incident, project):
+    def resolve(self, incident, project, metric_value):
         handler = self.build_handler(incident, project)
         if handler:
-            return handler.resolve()
+            return handler.resolve(metric_value)
 
     @classmethod
     def register_type(cls, slug, type, supported_target_types, integration_provider=None):

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -120,7 +120,7 @@ def handle_snuba_query_update(subscription_update, subscription):
     default_retry_delay=60,
     max_retries=5,
 )
-def handle_trigger_action(action_id, incident_id, project_id, method):
+def handle_trigger_action(action_id, incident_id, project_id, method, metric_value=None, **kwargs):
     try:
         action = AlertRuleTriggerAction.objects.select_related(
             "alert_rule_trigger", "alert_rule_trigger__alert_rule"
@@ -145,7 +145,7 @@ def handle_trigger_action(action_id, incident_id, project_id, method):
             AlertRuleTriggerAction.Type(action.type).name.lower(), method
         )
     )
-    getattr(action, method)(incident, project)
+    getattr(action, method)(incident, project, metric_value=metric_value)
 
 
 @instrumented_task(

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -295,7 +295,14 @@ def build_group_attachment(group, event=None, tags=None, identity=None, actions=
     }
 
 
-def build_incident_attachment(incident):
+def build_incident_attachment(incident, metric_value=None):
+    """
+    Builds an incident attachment for slack unfurling
+    :param incident: The `Incident` to build the attachment for
+    :param metric_value: The value of the metric that triggered this alert to fire. If
+    not provided we'll attempt to calculate this ourselves.
+    :return:
+    """
     logo_url = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
     alert_rule = incident.alert_rule
 
@@ -326,10 +333,13 @@ def build_incident_attachment(incident):
     agg_text = QUERY_AGGREGATION_DISPLAY.get(
         alert_rule.snuba_query.aggregate, alert_rule.snuba_query.aggregate
     )
-    agg_value = get_incident_aggregates(incident, start, end, use_alert_aggregate=True)["count"]
+    if metric_value is None:
+        metric_value = get_incident_aggregates(incident, start, end, use_alert_aggregate=True)[
+            "count"
+        ]
     time_window = alert_rule.snuba_query.time_window / 60
 
-    text = "{} {} in the last {} minutes".format(agg_value, agg_text, time_window)
+    text = "{} {} in the last {} minutes".format(metric_value, agg_text, time_window)
 
     if alert_rule.snuba_query.query != "":
         text = text + "\nFilter: {}".format(alert_rule.snuba_query.query)
@@ -438,10 +448,10 @@ def get_channel_id_with_timeout(integration, name, timeout):
     return (prefix, None, False)
 
 
-def send_incident_alert_notification(action, incident):
+def send_incident_alert_notification(action, incident, metric_value):
     channel = action.target_identifier
     integration = action.integration
-    attachment = build_incident_attachment(incident)
+    attachment = build_incident_attachment(incident, metric_value)
     payload = {
         "token": integration.metadata["access_token"],
         "channel": channel,

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -431,7 +431,7 @@ class AlertRuleTriggerActionActivateTest(object):
 
     def test_no_handler(self):
         trigger = AlertRuleTriggerAction(type=AlertRuleTriggerAction.Type.EMAIL.value)
-        assert trigger.fire(Mock(), Mock()) is None
+        assert trigger.fire(Mock(), Mock(), 123) is None
 
     def test_handler(self):
         mock_handler = Mock()
@@ -440,7 +440,7 @@ class AlertRuleTriggerActionActivateTest(object):
         type = AlertRuleTriggerAction.Type.EMAIL
         AlertRuleTriggerAction.register_type("something", type, [])(mock_handler)
         trigger = AlertRuleTriggerAction(type=type.value)
-        assert getattr(trigger, self.method)(Mock(), Mock()) == mock_method.return_value
+        assert getattr(trigger, self.method)(Mock(), Mock(), 123) == mock_method.return_value
 
 
 class AlertRuleTriggerActionFireTest(AlertRuleTriggerActionActivateTest, unittest.TestCase):

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -192,10 +192,13 @@ class HandleTriggerActionTest(TestCase):
                 mock_handler
             )
             incident = self.create_incident()
+            metric_value = 1234
             with self.tasks():
-                handle_trigger_action.delay(self.action.id, incident.id, self.project.id, "fire")
+                handle_trigger_action.delay(
+                    self.action.id, incident.id, self.project.id, "fire", metric_value=metric_value
+                )
             mock_handler.assert_called_once_with(self.action, incident, self.project)
-            mock_handler.return_value.fire.assert_called_once_with()
+            mock_handler.return_value.fire.assert_called_once_with(metric_value)
 
 
 class ProcessPendingIncidentSnapshots(TestCase):

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -105,6 +105,34 @@ class BuildIncidentAttachmentTest(TestCase):
             "actions": [],
         }
 
+    def test_metric_value(self):
+        logo_url = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
+        alert_rule = self.create_alert_rule()
+        incident = self.create_incident(alert_rule=alert_rule, status=2)
+        title = u"{}: {}".format("Resolved", alert_rule.name)
+        metric_value = 5000
+        assert build_incident_attachment(incident, metric_value=metric_value) == {
+            "fallback": title,
+            "title": title,
+            "title_link": absolute_uri(
+                reverse(
+                    "sentry-metric-alert",
+                    kwargs={
+                        "organization_slug": incident.organization.slug,
+                        "incident_id": incident.identifier,
+                    },
+                )
+            ),
+            "text": "{} events in the last 10 minutes\nFilter: level:error".format(metric_value),
+            "fields": [],
+            "mrkdwn_in": ["text"],
+            "footer_icon": logo_url,
+            "footer": "Sentry Incident",
+            "ts": to_timestamp(incident.date_started),
+            "color": RESOLVED_COLOR,
+            "actions": [],
+        }
+
     def test_build_group_attachment(self):
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)


### PR DESCRIPTION
In some cases we saw the value in a slack alert being incorrect. We already have the correct value
available from the subscription update, so just pass that through and use it directly. This also
saves an unnecessary query to snuba.

Also note: Since we added parameters to the task, we can't actually start passing them yet, since 
some celery workers won't be expecting the new param and will crash. I'll follow up with an 
additional pr to fix that piece.