### PR TITLE
ref(cache): Introduce configurable temp store for events

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1074,6 +1074,10 @@ SENTRY_CACHE_OPTIONS = {}
 SENTRY_ATTACHMENTS = "sentry.attachments.default.DefaultAttachmentCache"
 SENTRY_ATTACHMENTS_OPTIONS = {}
 
+# Events blobs processing backend
+SENTRY_EVENT_PROCESSING_STORE = "sentry.eventstore.processing.default.DefaultEventProcessingStore"
+SENTRY_EVENT_PROCESSING_STORE_OPTIONS = {}
+
 # The internal Django cache is still used in many places
 # TODO(dcramer): convert uses over to Sentry's backend
 CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}

--- a/src/sentry/eventstore/processing/__init__.py
+++ b/src/sentry/eventstore/processing/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+from sentry.utils.imports import import_string
+from django.conf import settings
+
+
+event_processing_store = import_string(settings.SENTRY_EVENT_PROCESSING_STORE)(
+    **settings.SENTRY_EVENT_PROCESSING_STORE_OPTIONS
+)
+
+
+__all__ = ["event_processing_store"]

--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+from sentry.utils.cache import cache_key_for_event
+
+DEFAULT_TIMEOUT = 3600
+
+
+class BaseEventProcessingStore(object):
+    """
+    Store for event blobs during processing
+
+    Ingest processing pipeline tasks are passing event payload through this
+    backend instead of the message broker. Tasks are submitted with a key so
+    the payload can be retrieved and in case of change saved back to the
+    processing store.
+
+    Separating processing store from the cache allows use of different
+    implementations.
+    """
+
+    def __init__(self, inner, timeout=DEFAULT_TIMEOUT):
+        self.inner = inner
+        self.timeout = timeout
+
+    def _key_for_event(self, event):
+        return cache_key_for_event(event)
+
+    def store(self, event):
+        key = self._key_for_event(event)
+        self.inner.set(key, event, self.timeout)
+        return key
+
+    def get(self, key):
+        return self.inner.get(key)
+
+    def delete_by_key(self, key):
+        return self.inner.delete(key)
+
+    def delete(self, event):
+        return self.inner.delete(self._key_for_event(event))

--- a/src/sentry/eventstore/processing/default.py
+++ b/src/sentry/eventstore/processing/default.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+from sentry.cache import default_cache
+
+from .base import BaseEventProcessingStore
+
+
+class DefaultEventProcessingStore(BaseEventProcessingStore):
+    """
+    Default implementation of processing store which uses the `default_cache`
+    as backend.
+    """
+
+    def __init__(self, **options):
+        super(DefaultEventProcessingStore, self).__init__(inner=default_cache, **options)

--- a/src/sentry/eventstore/processing/redis.py
+++ b/src/sentry/eventstore/processing/redis.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+import logging
+
+from .base import BaseEventProcessingStore
+from sentry.cache.redis import RedisClusterCache
+
+logger = logging.getLogger(__name__)
+
+
+class RedisClusterEventProcessingStore(BaseEventProcessingStore):
+    """
+    Processing store implementation using the redis cluster cache as a backend.
+    """
+
+    def __init__(self, **options):
+        super(RedisClusterEventProcessingStore, self).__init__(inner=RedisClusterCache(**options))


### PR DESCRIPTION
Temp event store acts by default just as facade to default_cache but
allow to be configured to use different redis cache or any other
compatible backend class.

#sync-getsentry