### PR TITLE
fix(plugins): change help text for github legacy integration

### DIFF
--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -240,10 +240,10 @@ class GitHubPlugin(GitHubMixin, IssuePlugin2):
                 "type": "text",
                 "placeholder": "e.g. getsentry/sentry",
                 "help": (
-                    "Enter your repository name, including the owner. "
-                    "<p><b>Looking to integrate commit data with releases?</b> You'll need to configure this through our"
-                    '<a href="/organizations/{}/repos/" '
-                    "> repos page</a>.</p>"
+                    "If you want to add a repository to integrate commit data with releases, please install the "
+                    'new <a href="/settings/{}/integrations/github/">'
+                    "Github global integration</a>.  "
+                    "You cannot add repositories to the legacy Github integration."
                 ).format(project.organization.slug),
                 "required": True,
             }


### PR DESCRIPTION
We removed the ability to add repositories for the Github legacy plugin a long time ago, this just explains it to the user.

![Screen Shot 2020-06-03 at 9 48 20 AM](https://user-images.githubusercontent.com/8533851/83665748-b1773d00-a580-11ea-8aca-e3f32cf09738.png)
