### PR TITLE
perf(models): Optimize src.sentry.models.group.Group.get_absolute_url

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -9,13 +9,10 @@ from enum import Enum
 from datetime import timedelta
 
 import six
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
-from django.utils.http import urlencode
+from django.utils.http import urlencode, urlquote
 from django.utils.translation import ugettext_lazy as _
-
-import sentry_sdk
 
 from sentry import eventstore, eventtypes, tagstore
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
@@ -320,16 +317,14 @@ class Group(Model):
         super(Group, self).save(*args, **kwargs)
 
     def get_absolute_url(self, params=None):
-        url_args = [self.organization.slug, self.id]
-        with sentry_sdk.start_span(op="models.group.absolute_url.reverse") as span:
-            span.set_data("url_args", url_args)
-            url = reverse("sentry-organization-issue", args=url_args)
-        if params:
-            with sentry_sdk.start_span(op="models.group.absolute_url.params") as span:
-                span.set_data("params", params)
-                url = url + "?" + urlencode(params)
-        with sentry_sdk.start_span(op="models.group.absolute_url.format", description=url):
-            return absolute_uri(url)
+        # Built manually in preference to django.core.urlresolvers.reverse,
+        # because reverse has a measured performance impact.
+        url = u"organizations/{org}/issues/{id}/{params}".format(
+            org=urlquote(self.organization.slug),
+            id=self.id,
+            params="?" + urlencode(params) if params else "",
+        )
+        return absolute_uri(url)
 
     @property
     def qualified_short_id(self):

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -7,8 +7,6 @@ from django.conf import settings
 from six.moves.urllib.parse import parse_qs, quote, urlencode, urljoin, urlparse
 from functools import partial
 
-import sentry_sdk
-
 from sentry import options
 from sentry.utils import json
 from sentry.utils.compat import map
@@ -18,11 +16,9 @@ ParsedUriMatch = namedtuple("ParsedUriMatch", ["scheme", "domain", "path"])
 
 
 def absolute_uri(url=None):
-    with sentry_sdk.start_span(op="http.absolute_uri.options"):
-        url_prefix = options.get("system.url-prefix")
     if not url:
-        return url_prefix
-    return urljoin(url_prefix.rstrip("/") + "/", url.lstrip("/"))
+        return options.get("system.url-prefix")
+    return urljoin(options.get("system.url-prefix").rstrip("/") + "/", url.lstrip("/"))
 
 
 def origin_from_url(url):

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -475,6 +475,7 @@ urlpatterns += [
                     name="sentry-organization-issue-list",
                 ),
                 url(
+                    # See src.sentry.models.group.Group.get_absolute_url if this changes
                     r"^(?P<organization_slug>[\w_-]+)/issues/(?P<group_id>\d+)/$",
                     react_page_view,
                     name="sentry-organization-issue",

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -213,13 +213,23 @@ class GroupTest(TestCase, SnubaTestCase):
         assert group.get_email_subject() == "%s - %s" % (group.qualified_short_id, group.title)
 
     def test_get_absolute_url(self):
-        project = self.create_project(name="pumped-quagga")
-        group = self.create_group(project=project)
-
-        result = group.get_absolute_url({"environment": u"d\u00E9v"})
-        assert (
-            result
-            == u"http://testserver/organizations/baz/issues/{}/?environment=d%C3%A9v".format(
-                group.id
-            )
-        )
+        for (org_slug, group_id, params, expected) in [
+            ("org1", 23, None, "http://testserver/organizations/org1/issues/23/"),
+            (
+                "org2",
+                42,
+                {"environment": "dev"},
+                "http://testserver/organizations/org2/issues/42/?environment=dev",
+            ),
+            (
+                u"\u00F6rg3",
+                86,
+                {u"env\u00EDronment": u"d\u00E9v"},
+                "http://testserver/organizations/%C3%B6rg3/issues/86/?env%C3%ADronment=d%C3%A9v",
+            ),
+        ]:
+            org = self.create_organization(slug=org_slug)
+            project = self.create_project(organization=org)
+            group = self.create_group(id=group_id, project=project)
+            actual = group.get_absolute_url(params)
+            assert actual == expected


### PR DESCRIPTION
Because there was a measured performance impact to using
django.core.urlresolvers.reverse, resort to manually building a Group's
absolute URL with the path (as defined by urls.py) hard-coded.

Remove unneeded instrumentation related to the reverse bottleneck.
Beef up unit test to ensure that the new code encodes URL characters
correctly. Add a comment to urls.py indicating the linkage.