### PR TITLE
fix(api): Add support for sentry app install tokens

### DIFF
--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 
 from sentry.constants import SentryAppInstallationStatus
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, ParanoidModel, Model
+from sentry.models import Project
 
 
 def default_uuid():
@@ -35,6 +36,19 @@ class SentryAppInstallationToken(Model):
             return False
 
         return install_token.sentry_app_installation.organization_id == organization.id
+
+    @classmethod
+    def get_projects(cls, token):
+        try:
+            install_token = cls.objects.select_related("sentry_app_installation").get(
+                api_token=token
+            )
+        except cls.DoesNotExist:
+            return False
+
+        return Project.objects.filter(
+            organization_id=install_token.sentry_app_installation.organization_id
+        )
 
 
 class SentryAppInstallation(ParanoidModel):

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import six
 
-from sentry.models import Project, ProjectStatus
+from sentry.models import Project, ProjectStatus, SentryAppInstallationToken
 from sentry.testutils import APITestCase
 
 
@@ -138,3 +138,18 @@ class ProjectsListTest(APITestCase):
         response = self.client.get(u"{}?query=id:-1".format(self.path))
         assert response.status_code == 200
         assert len(response.data) == 0
+
+    def test_valid_with_internal_integration(self):
+        project = self.create_project(organization=self.organization, teams=[self.team])
+        self.create_internal_integration(
+            name="my_app",
+            organization=self.organization,
+            scopes=("project:read",),
+            webhook_url="http://example.com",
+        )
+        # there should only be one record created so just grab the first one
+        token = SentryAppInstallationToken.objects.first()
+        response = self.client.get(
+            u"{}".format(self.path), HTTP_AUTHORIZATION=u"Bearer {}".format(token.api_token.token)
+        )
+        assert project.name in response.content


### PR DESCRIPTION
**Context:**
Sentry apps use a proxy_user for an api token, and this proxy_user is linked to an organization through the token but not as an organization member. This causes problems in endpoints that previously worked with user auth tokens because the user tied to those tokens is indeed an organization member 

In the `project_index` endpoint, the specific problem is that for sentry apps, we return `[]` instead of the full list of projects

**Partial Solution:**
This PR fixes the problem for internal integrations. However, public integrations have the api_token stored on the `SentryAppInstallation` table instead of the join table (`SentryAppInstallationToken`). 

A follow up PR for this should have:
* Code for non-internal integrations to populate the join table 
* Data migration to backfill the other tokens to the join table