### PR TITLE
fix(discover) Fix negated issue conditions

### DIFF
--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1205,7 +1205,7 @@ class GetSnubaQueryArgsTest(TestCase):
         _filter = get_filter(
             "!issue:{}".format(group.qualified_short_id), {"organization_id": self.organization.id}
         )
-        assert _filter.conditions == [["issue.id", "!=", 2]]
+        assert _filter.conditions == [["issue.id", "!=", group.id]]
         assert _filter.filter_keys == {}
         assert _filter.group_ids == []
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1151,7 +1151,7 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_not_has_issue_id(self):
         has_issue_filter = get_filter("!has:issue.id")
         assert has_issue_filter.group_ids == []
-        assert has_issue_filter.conditions == [["issue.id", "=", 0]]
+        assert has_issue_filter.conditions == [[["isNull", ["issue.id"]], "=", 1]]
 
     def test_message_negative(self):
         assert get_filter('!message:"post_process.process_error HTTPError 403"').conditions == [

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1146,12 +1146,12 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_has_issue_id(self):
         has_issue_filter = get_filter("has:issue.id")
         assert has_issue_filter.group_ids == []
-        assert has_issue_filter.conditions == [[["isNull", ["issue.id"]], "!=", 1]]
+        assert has_issue_filter.conditions == [["issue.id", "!=", 0]]
 
     def test_not_has_issue_id(self):
         has_issue_filter = get_filter("!has:issue.id")
         assert has_issue_filter.group_ids == []
-        assert has_issue_filter.conditions == [[["isNull", ["issue.id"]], "=", 1]]
+        assert has_issue_filter.conditions == [["issue.id", "=", 0]]
 
     def test_message_negative(self):
         assert get_filter('!message:"post_process.process_error HTTPError 403"').conditions == [

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1185,11 +1185,29 @@ class GetSnubaQueryArgsTest(TestCase):
         assert _filter.filter_keys == {"group_id": [1]}
         assert _filter.group_ids == [1]
 
-    def test_issue_filter(self):
+    def test_issue_filter_invalid(self):
         with pytest.raises(InvalidSearchQuery) as err:
             get_filter("issue:1", {"organization_id": 1})
         assert "Invalid value '" in six.text_type(err)
         assert "' for 'issue:' filter" in six.text_type(err)
+
+    def test_issue_filter(self):
+        group = self.create_group(project=self.project)
+        _filter = get_filter(
+            "issue:{}".format(group.qualified_short_id), {"organization_id": self.organization.id}
+        )
+        assert _filter.conditions == [["issue.id", "=", group.id]]
+        assert _filter.filter_keys == {}
+        assert _filter.group_ids == []
+
+    def test_negated_issue_filter(self):
+        group = self.create_group(project=self.project)
+        _filter = get_filter(
+            "!issue:{}".format(group.qualified_short_id), {"organization_id": self.organization.id}
+        )
+        assert _filter.conditions == [["issue.id", "!=", 2]]
+        assert _filter.filter_keys == {}
+        assert _filter.group_ids == []
 
     def test_environment_param(self):
         params = {"environment": ["", "prod"]}

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1638,11 +1638,11 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             },
             project_id=project1.id,
         )
-        self.store_event(
+        event2 = self.store_event(
             data={
                 "event_id": "b" * 32,
                 "transaction": "/example",
-                "message": "how to make fast",
+                "message": "go really fast plz",
                 "timestamp": self.two_min_ago,
                 "fingerprint": ["group_2"],
             },
@@ -1656,7 +1656,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "field": ["title"],
+                    "field": ["title", "issue.id"],
                     "query": "!issue:{}".format(event1.group.qualified_short_id),
                 },
             )
@@ -1664,7 +1664,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             assert response.status_code == 200, response.content
             data = response.data["data"]
             assert len(data) == 1
-            assert data[0]["title"] == event1.title
+            assert data[0]["title"] == event2.title
+            assert data[0]["issue.id"] == event2.group_id
 
     def test_search_for_nonexistent_issue(self):
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1623,6 +1623,49 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 else:
                     assert data[0].get("issue", None) is None
 
+    def test_issue_negation(self):
+        self.login_as(user=self.user)
+
+        project1 = self.create_project()
+        project2 = self.create_project()
+        event1 = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "transaction": "/example",
+                "message": "how to make fast",
+                "timestamp": self.two_min_ago,
+                "fingerprint": ["group_1"],
+            },
+            project_id=project1.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "transaction": "/example",
+                "message": "how to make fast",
+                "timestamp": self.two_min_ago,
+                "fingerprint": ["group_2"],
+            },
+            project_id=project2.id,
+        )
+
+        with self.feature(
+            {"organizations:discover-basic": True, "organizations:global-views": True}
+        ):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "field": ["title"],
+                    "query": "!issue:{}".format(event1.group.qualified_short_id),
+                },
+            )
+
+            assert response.status_code == 200, response.content
+            data = response.data["data"]
+            assert len(data) == 1
+            assert data[0]["title"] == event1.title
+
     def test_search_for_nonexistent_issue(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
The issue condition should support negation like other conditions. I've changed the semantics a bit on how the issue filter works as it no longer goes into the `group_ids` filter key, but from what I saw snuba can still promote the new condition into a prewhere.