### PR TITLE
fix(alerts): Avoid overflow in chart header

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -153,7 +153,7 @@ export default class DetailsBody extends React.Component<Props> {
               })}
           </ChartParameters>
         </div>
-        <ChartActions>
+        <div>
           <Feature features={['discover-basic']}>
             <Projects slugs={incident?.projects} orgId={params.orgId}>
               {({initiallyLoaded, fetching, projects}) => {
@@ -182,7 +182,7 @@ export default class DetailsBody extends React.Component<Props> {
               }}
             </Projects>
           </Feature>
-        </ChartActions>
+        </div>
       </ChartHeader>
     );
   }
@@ -353,9 +353,12 @@ const ChartHeader = styled('header')`
   margin-bottom: ${space(1)};
   display: grid;
   grid-template-columns: 1fr max-content;
-`;
+  grid-gap: ${space(2)};
 
-const ChartActions = styled('div')``;
+  > div:first-of-type {
+    overflow: hidden;
+  }
+`;
 
 const ChartParameters = styled('div')`
   color: ${p => p.theme.gray600};


### PR DESCRIPTION
Set overflow on the chart header (filter) to avoid the button being pushed out of the container
![image](https://user-images.githubusercontent.com/1421724/83687229-51908e80-a5a0-11ea-93f3-b796cc7463ca.png)
