### PR TITLE
feat(perf-views) Enable discover endpoints to accept performance-view feature

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -25,6 +25,11 @@ from sentry.utils import snuba
 
 
 class OrganizationEventsEndpointBase(OrganizationEndpoint):
+    def has_feature(self, organization, request):
+        return features.has(
+            "organizations:discover-basic", organization, actor=request.user
+        ) or features.has("organizations:performance-view", organization, actor=request.user)
+
     def get_snuba_filter(self, request, organization, params=None):
         if params is None:
             params = self.get_filter_params(request, organization)

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
 from sentry.api.bases import OrganizationEventsEndpointBase, NoProjects
-from sentry import eventstore, features
+from sentry import eventstore
 from sentry.snuba import discover
 from sentry.models.project import Project, ProjectStatus
 from sentry.api.serializers import serialize
@@ -14,7 +14,7 @@ from sentry.api.serializers import serialize
 
 class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization, project_slug, event_id):
-        if not features.has("organizations:discover-basic", organization, actor=request.user):
+        if not self.has_feature(organization, request):
             return Response(status=404)
 
         try:

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -116,7 +116,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
         )
 
     def get(self, request, organization):
-        if not features.has("organizations:discover-basic", organization, actor=request.user):
+        if not self.has_feature(organization, request):
             return Response(status=404)
 
         with sentry_sdk.start_span(op="discover.endpoint", description="filter_params") as span:

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -17,7 +17,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
         with sentry_sdk.start_span(op="discover.endpoint", description="filter_params") as span:
             span.set_data("organization", organization)
-            if not features.has("organizations:discover-basic", organization, actor=request.user):
+            if not self.has_feature(organization, request):
                 return Response(status=404)
             try:
                 params = self.get_filter_params(request, organization)

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -6,7 +6,7 @@ import six
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
-from sentry import features, eventstore
+from sentry import eventstore
 from sentry.constants import MAX_TOP_EVENTS
 from sentry.api.bases import OrganizationEventsV2EndpointBase, NoProjects
 from sentry.api.event_search import resolve_field_list, InvalidSearchQuery
@@ -21,7 +21,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
     def get(self, request, organization):
         with sentry_sdk.start_span(op="discover.endpoint", description="filter_params") as span:
             span.set_data("organization", organization)
-            if not features.has("organizations:discover-basic", organization, actor=request.user):
+            if not self.has_feature(organization, request):
                 span.set_data("using_v1_results", True)
                 return self.get_v1_results(request, organization)
 

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -53,6 +53,21 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         )
         self.groups = list(Group.objects.all().order_by("id"))
 
+    def test_performance_flag(self):
+        url = reverse(
+            "sentry-api-0-organization-event-details",
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": "a" * 32,
+            },
+        )
+        with self.feature(
+            {"organizations:discover-basic": False, "organizations:performance-view": True}
+        ):
+            response = self.client.get(url, format="json")
+        assert response.status_code == 200, response.content
+
     def test_simple(self):
         url = reverse(
             "sentry-api-0-organization-event-details",

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -42,9 +42,9 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         with self.feature(
             {"organizations:discover-basic": False, "organizations:performance-view": True}
         ):
-            response = self.client.get(self.url, format="json")
+            response = self.client.get(self.url, data={"project": self.project.id}, format="json")
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.content
 
     def test_simple(self):
         self.store_event(

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -38,6 +38,14 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         assert "topValues" in actual
         assert sorted(expected) == sorted(actual["topValues"])
 
+    def test_performance_view_feature(self):
+        with self.feature(
+            {"organizations:discover-basic": False, "organizations:performance-view": True}
+        ):
+            response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 200
+
     def test_simple(self):
         self.store_event(
             data={

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -182,6 +182,23 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert [attrs for time, attrs in response.data["data"]] == [[{"count": 1}], [{"count": 2}]]
 
+    def test_performance_view_feature(self):
+        with self.feature(
+            {"organizations:performance-view": True, "organizations:discover-basic": False}
+        ):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "end": iso_format(before_now()),
+                    "start": iso_format(before_now(hours=2)),
+                    "query": "project_id:1",
+                    "interval": "30m",
+                    "yAxis": "count()",
+                },
+            )
+        assert response.status_code == 200
+
     def test_aggregate_function_count(self):
         with self.feature("organizations:discover-basic"):
             response = self.client.get(

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -55,6 +55,21 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 400
 
+    def test_performance_view_feature(self):
+        self.login_as(user=self.user)
+        self.store_event(
+            data={"event_id": "a" * 32, "timestamp": self.min_ago, "fingerprint": ["group1"]},
+            project_id=self.project.id,
+        )
+
+        query = {"field": ["id", "project.id"], "project": [self.project.id]}
+        with self.feature(
+            {"organizations:discover-basic": False, "organizations:performance-view": True}
+        ):
+            response = self.client.get(self.url, query, format="json")
+        assert response.status_code == 200
+        assert len(response.data["data"]) == 1
+
     def test_multi_project_feature_gate_rejection(self):
         self.login_as(user=self.user)
         team = self.create_team(organization=self.organization, members=[self.user])


### PR DESCRIPTION
We're planning on including performance-views but not discover on certain plans in the future. We need these endpoints to accept either feature flag so that performance views can be rendered.