### PR TITLE
fix(github): Prevent archived repos from showing in dropdown

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -40,7 +40,8 @@ class GitHubClientMixin(ApiClient):
 
     def get_repositories(self):
         repositories = self.get("/installation/repositories", params={"per_page": 100})
-        return repositories["repositories"]
+        repos = repositories["repositories"]
+        return [repo for repo in repos if not repo.get("archived")]
 
     def search_repositories(self, query):
         return self.get("/search/repositories", params={"q": query})

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -178,7 +178,12 @@ class GitHubIssueBasicTest(TestCase):
         responses.add(
             responses.GET,
             "https://api.github.com/installation/repositories",
-            json={"repositories": [{"full_name": "getsentry/sentry", "name": "sentry"}]},
+            json={
+                "repositories": [
+                    {"full_name": "getsentry/sentry", "name": "sentry"},
+                    {"full_name": "getsentry/other", "name": "other", "archived": True},
+                ]
+            },
         )
 
         resp = self.integration.get_create_issue_config(group=event.group)


### PR DESCRIPTION
Keep archived repositories from appearing in the dropdown menu when configuring a Github integration. Tested manually and with a unit test modification.

Fixes ISSUE-659