### PR TITLE
feat(ui): Add row-level error handling to Alerts list

### DIFF
--- a/src/sentry/static/sentry/app/components/placeholder.tsx
+++ b/src/sentry/static/sentry/app/components/placeholder.tsx
@@ -16,13 +16,14 @@ type DefaultProps = Readonly<typeof defaultProps>;
 type Props = {
   className?: string;
   children?: React.ReactNode;
+  error?: React.ReactNode;
 } & Partial<DefaultProps>;
 
 const Placeholder = styled((props: Props) => {
-  const {className, children} = props;
+  const {className, children, error} = props;
   return (
     <div data-test-id="loading-placeholder" className={className}>
-      {children}
+      {error || children}
     </div>
   );
 })<Props>`
@@ -31,7 +32,8 @@ const Placeholder = styled((props: Props) => {
   flex-shrink: 0;
   justify-content: center;
 
-  background-color: ${p => p.theme.placeholderBackground};
+  background-color: ${p => (p.error ? p.theme.red100 : p.theme.placeholderBackground)};
+${p => p.error && `color: ${p.theme.red300};`}
   width: ${p => p.width};
   height: ${p => p.height};
   ${p => (p.shape === 'circle' ? 'border-radius: 100%;' : '')}

--- a/src/sentry/static/sentry/app/views/alerts/list/sparkLine.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/sparkLine.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import {IncidentStats} from 'app/views/alerts/types';
 import Placeholder from 'app/components/placeholder';
 import theme from 'app/utils/theme';
-import {IncidentStats} from 'app/views/alerts/types';
 
 // Height of sparkline
 const SPARKLINE_HEIGHT = 38;
@@ -11,6 +11,7 @@ const SPARKLINE_HEIGHT = 38;
 type Props = {
   className?: string;
   eventStats: IncidentStats['eventStats'];
+  error?: React.ReactNode;
 };
 
 const Sparklines = React.lazy(() =>
@@ -22,7 +23,11 @@ const SparklinesLine = React.lazy(() =>
 
 class SparkLine extends React.Component<Props> {
   render() {
-    const {className, eventStats} = this.props;
+    const {className, error, eventStats} = this.props;
+
+    if (error) {
+      return <SparklineError error={error} />;
+    }
 
     if (!eventStats) {
       return <SparkLinePlaceholder />;
@@ -54,6 +59,11 @@ const StyledSparkLine = styled(SparkLine)`
 
 const SparkLinePlaceholder = styled(Placeholder)`
   height: ${SPARKLINE_HEIGHT}px;
+`;
+
+const SparklineError = styled(SparkLinePlaceholder)`
+  align-items: center;
+  line-height: 1;
 `;
 
 export default StyledSparkLine;


### PR DESCRIPTION
This adds error boxes to specific portions of alert list rows (e.g. if `events-stats` fails to load). Also adds an `<ErrorBoundary>` for the row.

![image](https://user-images.githubusercontent.com/79684/83707763-9e3f8e00-a5cf-11ea-8ca0-b872beddbb21.png)

Fixes https://app.asana.com/0/1143846759074121/1177024340313985/f