### PR TITLE
feat(ui): Display auth providers in order of popularity

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
@@ -49,7 +49,10 @@ class OrganizationAuthList extends React.Component {
       if (!(b.key in providerPopularity)) {
         return 1;
       }
-      return providerPopularity[a.key] > providerPopularity[b.key];
+      if (providerPopularity[a.key] === providerPopularity[b.key]) {
+        return 0;
+      }
+      return providerPopularity[a.key] > providerPopularity[b.key] ? 1 : -1;
     });
 
     const providerList = sortedByPopularity.sort((a, b) => {

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
@@ -14,16 +14,16 @@ import getCookie from 'app/utils/getCookie';
 
 import ProviderItem from './providerItem';
 
-const providerPopularity = [
-  'Google',
-  'github',
-  'okta',
-  'active directory',
-  'saml2',
-  'onelogin',
-  'rippling',
-  'auth0',
-];
+const providerPopularity = {
+  google: 0,
+  github: 1,
+  okta: 2,
+  'active-directory': 3,
+  saml2: 4,
+  onelogin: 5,
+  rippling: 6,
+  auth0: 7,
+};
 
 class OrganizationAuthList extends React.Component {
   static contextTypes = {
@@ -45,21 +45,38 @@ class OrganizationAuthList extends React.Component {
     // and second, sort feature-flagged integrations last.
 
     // arr.reduce(callback( accumulator, currentValue[, index[, array]] )[, initialValue])
+
     const reducer = (acc, cur, i, arr) => {
+      console.log('currently on: ', cur);
       const isEnabled = features.includes(descopeFeatureName(cur.requiredFeature));
       if (isEnabled) {
         acc.unavailable.push(cur);
       } else {
         acc.available.push(cur);
       }
+      return acc;
     };
 
     const initialValue = {
       available: [],
       unavailable: [],
+      unrecognized: [],
     };
 
     const sortedProviders = (this.props.providerList || []).reduce(reducer, initialValue);
+
+    const compareByPopularity = (a, b) => {
+      if (!(a in providerPopularity)) {
+        return -1;
+      }
+      if (!(b in providerPopularity)) {
+        return 1;
+      }
+      return providerPopularity[a] < providerPopularity[b];
+    };
+
+    sortedProviders.available.sort(compareByPopularity);
+    sortedProviders.unavailable.sort(compareByPopularity);
 
     const providerList = sortedProviders.available.concat(sortedProviders.unavailable);
 


### PR DESCRIPTION
On the Auth Settings page, displays the auth providers in order of how many users use them.

The list of auth providers is already sorted to display providers unavailable for the current plan last. The “displaying unavailable providers last” functionality is preserved, but within both the available and unavailable providers, providers are sorted by popularity.

The list of popularity order is hard-coded because neither the providers nor their relative popularity is expected to change frequently, and fetching it automatically would be a lot of effort and extra page load time for a relatively small UI tweak.

Part of ENT-12.