### PR TITLE
ref(ui): Rename Android Mappings to ProGuard

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -415,11 +415,11 @@ function routes() {
         component={errorHandler(LazyLoad)}
       />
       <Route
-        path="android-mappings/"
-        name={t('Android Mappings')}
+        path="proguard/"
+        name={t('ProGuard Mappings')}
         componentPromise={() =>
           import(
-            /* webpackChunkName: "ProjectAndroidMappings" */ 'app/views/settings/projectAndroidMappings'
+            /* webpackChunkName: "ProjectProguard" */ 'app/views/settings/projectProguard'
           )
         }
         component={errorHandler(LazyLoad)}

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
@@ -68,8 +68,8 @@ export default function getConfiguration({
           show: () => organization.features?.includes('artifacts-in-settings'),
         },
         {
-          path: `${pathPrefix}/android-mappings/`,
-          title: t('Android Mappings'),
+          path: `${pathPrefix}/proguard/`,
+          title: t('ProGuard'),
           show: () => organization.features?.includes('android-mappings'),
         },
         {

--- a/src/sentry/static/sentry/app/views/settings/projectProguard/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectProguard/index.tsx
@@ -7,11 +7,9 @@ import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import withOrganization from 'app/utils/withOrganization';
 
-import ProjectAndroidMappings from './projectAndroidMappings';
+import ProjectProguard from './projectProguard';
 
-class ProjectAndroidMappingsContainer extends React.Component<
-  ProjectAndroidMappings['props']
-> {
+class ProjectProguardContainer extends React.Component<ProjectProguard['props']> {
   static propTypes = {
     organization: SentryTypes.Organization.isRequired,
   };
@@ -33,10 +31,10 @@ class ProjectAndroidMappingsContainer extends React.Component<
         organization={organization}
         renderDisabled={this.renderNoAccess}
       >
-        <ProjectAndroidMappings {...this.props} />
+        <ProjectProguard {...this.props} />
       </Feature>
     );
   }
 }
 
-export default withOrganization(ProjectAndroidMappingsContainer);
+export default withOrganization(ProjectProguardContainer);

--- a/src/sentry/static/sentry/app/views/settings/projectProguard/projectProguard.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectProguard/projectProguard.tsx
@@ -27,11 +27,11 @@ type State = AsyncView['state'] & {
   showDetails: boolean;
 };
 
-class ProjectAndroidMappings extends AsyncView<Props, State> {
+class ProjectProguard extends AsyncView<Props, State> {
   getTitle() {
     const {projectId} = this.props.params;
 
-    return routeTitleGen(t('Android Mappings'), projectId, false);
+    return routeTitleGen(t('ProGuard Mappings'), projectId, false);
   }
 
   getDefaultState(): State {
@@ -130,11 +130,11 @@ class ProjectAndroidMappings extends AsyncView<Props, State> {
 
     return (
       <React.Fragment>
-        <SettingsPageHeader title={t('Android Mappings')} />
+        <SettingsPageHeader title={t('ProGuard Mappings')} />
 
         <TextBlock>
           {t(
-            `Android mapping files are used to convert minified classes, methods and field names into a human readable format.`
+            `ProGuard mapping files are used to convert minified classes, methods and field names into a human readable format.`
           )}
         </TextBlock>
 
@@ -220,4 +220,4 @@ const Label = styled('label')`
   }
 `;
 
-export default ProjectAndroidMappings;
+export default ProjectProguard;


### PR DESCRIPTION
We had a few requests to call proguard mappings android mappings but ultimately decided against it - this PR renames Android Mappings back to ProGuard Mappings.