### PR TITLE
feat(perf): Use the same y-axis when showing only percentile graphs

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -19,6 +19,11 @@ type Props = {
   loading: boolean;
 };
 
+function roundAxis(x) {
+  const exp10 = 10 ** Math.floor(Math.log10(x));
+  return Math.ceil(x / exp10) * exp10;
+}
+
 class Chart extends React.Component<Props> {
   render() {
     const {data, router, statsPeriod, utc, projects, environments, loading} = this.props;
@@ -28,12 +33,9 @@ class Chart extends React.Component<Props> {
     }
     const colors = theme.charts.getColorPalette(4);
 
-    let dataMax: string | number = 'dataMax';
-
-    if (data.every(value => PERCENTILE_NAMES.has(value.seriesName))) {
-      dataMax =
-        max(data.map(value => max(value.data.map(point => point.value)))) || 'dataMax';
-    }
+    const dataMax = data.every(value => PERCENTILE_NAMES.has(value.seriesName))
+      ? roundAxis(max(data.map(value => max(value.data.map(point => point.value)))))
+      : undefined;
 
     const areaChartProps = {
       seriesOptions: {

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -6,9 +6,8 @@ import min from 'lodash/min';
 import {Series} from 'app/types/echarts';
 import AreaChart from 'app/components/charts/areaChart';
 import ChartZoom from 'app/components/charts/chartZoom';
+import {aggregateOutputType} from 'app/utils/discover/fields';
 import theme from 'app/utils/theme';
-
-import {PERCENTILE_NAMES} from '../constants';
 
 type Props = {
   data: Series[];
@@ -57,9 +56,10 @@ class Chart extends React.Component<Props> {
     }
     const colors = theme.charts.getColorPalette(4);
 
-    const dataMax = data.every(value => PERCENTILE_NAMES.has(value.seriesName))
-      ? computeAxisMax(data)
-      : undefined;
+    const durationOnly = data.every(
+      value => aggregateOutputType(value.seriesName) === 'duration'
+    );
+    const dataMax = durationOnly ? computeAxisMax(data) : undefined;
 
     const areaChartProps = {
       seriesOptions: {

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import * as ReactRouter from 'react-router';
+import max from 'lodash/max';
 
 import {Series} from 'app/types/echarts';
 import AreaChart from 'app/components/charts/areaChart';
 import ChartZoom from 'app/components/charts/chartZoom';
 import theme from 'app/utils/theme';
+
+import {PERCENTILE_NAMES} from '../constants';
 
 type Props = {
   data: Series[];
@@ -24,6 +27,13 @@ class Chart extends React.Component<Props> {
       return null;
     }
     const colors = theme.charts.getColorPalette(4);
+
+    let dataMax: string | number = 'dataMax';
+
+    if (data.every(value => PERCENTILE_NAMES.has(value.seriesName))) {
+      dataMax =
+        max(data.map(value => max(value.data.map(point => point.value)))) || 'dataMax';
+    }
 
     const areaChartProps = {
       seriesOptions: {
@@ -61,10 +71,12 @@ class Chart extends React.Component<Props> {
         {
           gridIndex: 0,
           scale: true,
+          max: dataMax,
         },
         {
           gridIndex: 1,
           scale: true,
+          max: dataMax,
         },
       ],
       utc,

--- a/src/sentry/static/sentry/app/views/performance/constants.tsx
+++ b/src/sentry/static/sentry/app/views/performance/constants.tsx
@@ -70,3 +70,12 @@ export const AXIS_OPTIONS: TooltipOption[] = [
     label: t('p99 Duration'),
   },
 ];
+
+export const PERCENTILE_NAMES = new Set(
+  AXIS_OPTIONS.map(option => option.value).reduce((values: string[], value: string) => {
+    if (/^p[0-9]{2}\(\)$/.test(value)) {
+      values.push(value);
+    }
+    return values;
+  }, [])
+);

--- a/src/sentry/static/sentry/app/views/performance/constants.tsx
+++ b/src/sentry/static/sentry/app/views/performance/constants.tsx
@@ -70,12 +70,3 @@ export const AXIS_OPTIONS: TooltipOption[] = [
     label: t('p99 Duration'),
   },
 ];
-
-export const PERCENTILE_NAMES = new Set(
-  AXIS_OPTIONS.map(option => option.value).reduce((values: string[], value: string) => {
-    if (/^p[0-9]{2}\(\)$/.test(value)) {
-      values.push(value);
-    }
-    return values;
-  }, [])
-);


### PR DESCRIPTION
Currently, the graphs independently set their own y-axis which makes it difficult to compare magnitudes when they are both percentile graphs. This change ensures that when displaying two percentile graphs, the y-axes are the same making them comparable.