### PR TITLE
feat(perf-views) Add a onboarding override for getsentry to use

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -48,6 +48,7 @@ type Props = {
   router: ReactRouter.InjectedRouter;
   projects: Project[];
   loadingProjects: boolean;
+  demoMode?: boolean;
 };
 
 type State = {
@@ -178,8 +179,13 @@ class PerformanceLanding extends React.Component<Props, State> {
   }
 
   shouldShowOnboarding() {
-    const {projects} = this.props;
+    const {projects, demoMode} = this.props;
     const {eventView} = this.state;
+
+    // XXX used by getsentry to bypass onboarding for the upsell demo state.
+    if (demoMode) {
+      return false;
+    }
 
     if (projects.length === 0) {
       return false;


### PR DESCRIPTION
Currently performance overview uses withProjects() to get an account's project list. withProjects() populates the store and we use that project information to see if the current projects have sent any transactions.

However, when an account doesn't have access to performance views getsentry wants to show some fake data as 'demo' of the page. To do that we need to ignore the project list and render the page as normal using the fake data. We can't mutate the projects in the store as that could cause problems elsewhere.