### PR TITLE
feat(alerts): Register incidents-performance rollout option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -225,6 +225,10 @@ register("discover2.rollout-rate", default=0, flags=FLAG_PRIORITIZE_DISK)
 # Alerts / Workflow incremental rollout rate. Tied to feature handlers in getsentry
 register("workflow.rollout-rate", default=0, flags=FLAG_PRIORITIZE_DISK)
 
+# Performance metric alerts incremental rollout rate. Tied to feature handlers
+# in getsentry
+register("incidents-performance.rollout-rate", default=0, flags=FLAG_PRIORITIZE_DISK)
+
 # Max number of tags to combine in a single query in Discover2 tags facet.
 register("discover2.max_tags_to_combine", default=3, flags=FLAG_PRIORITIZE_DISK)
 


### PR DESCRIPTION
This was missing.