### PR TITLE
feat: bump six to 1.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,15 +66,7 @@ setup-git: ensure-venv setup-git-config
 	@echo "--> Installing git hooks"
 	cd .git/hooks && ln -sf ../../config/hooks/* ./
 	@PYENV_VERSION=$(REQUIRED_PY3_VERSION) python3 -c '' || (echo 'Please run `make setup-pyenv` to install the required Python 3 version.'; exit 1)
-
-	@# XXX(joshuarli): virtualenv >= 20 doesn't work with the version of six we have pinned for sentry.
-	@# Since pre-commit is installed in the venv, it will install virtualenv in the venv as well.
-	@# We need to tell pre-commit to install an older virtualenv,
-	@# And we need to tell virtualenv to install an older six, so that sentry installation
-	@# won't complain about a newer six being present.
-	@# So, this six pin here needs to be synced with requirements-base.txt.
-	$(PIP) install "pre-commit==1.18.2" "virtualenv>=16.7,<20" "six>=1.10.0,<1.11.0"
-
+	$(PIP) install "pre-commit==1.18.2"
 	@PYENV_VERSION=$(REQUIRED_PY3_VERSION) pre-commit install --install-hooks
 	@echo ""
 

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -52,7 +52,7 @@ requests[security]>=2.20.0,<2.21.0
 sentry-relay>=0.5.10,<0.6.0
 sentry-sdk>=0.13.5
 simplejson>=3.2.0,<3.9.0
-six>=1.10.0,<1.11.0
+six>=1.11.0,<1.12.0
 sqlparse>=0.2.0,<0.3.0
 statsd>=3.1.0,<3.2.0
 structlog==16.1.0


### PR DESCRIPTION
I read this six diff: https://github.com/benjaminp/six/compare/1.10.0...1.11.0

Looks very innocuous. Most of the changelog is just adding some small stuff and the diff itself in six.py looks very safe.

This will enable removing the six and virtualenv pin introduced here as a workaround: https://github.com/getsentry/sentry/pull/17026/files#diff-b67911656ef5d18c4ae36cb6741b7965R60-R66
