### PR TITLE
fix(ui): Make provider availibility sort stable

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/organizationAuthList.jsx
@@ -58,12 +58,10 @@ class OrganizationAuthList extends React.Component {
     const providerList = sortedByPopularity.sort((a, b) => {
       const aEnabled = features.includes(descopeFeatureName(a.requiredFeature));
       const bEnabled = features.includes(descopeFeatureName(b.requiredFeature));
-
-      if (aEnabled !== bEnabled) {
-        return aEnabled ? -1 : 1;
+      if (aEnabled === bEnabled) {
+        return 0;
       }
-
-      return a.requiredFeature.localeCompare(b.requiredFeature);
+      return aEnabled ? -1 : 1;
     });
 
     const warn2FADisable =


### PR DESCRIPTION
Fix for https://github.com/getsentry/sentry/pull/19185.

Adding a second sort before the provider availability sort caused the provider availability sort to break the provider popularity sort results. So for the final sorted provider list, the providers were grouped by availability correctly but not consistently sorted in order of popularity. This change fixes that by making the first (availability) sort stable.

See: https://medium.com/@fsufitch/is-javascript-array-sort-stable-46b90822543f

Related to ENT-12.