### PR TITLE
chore: Remove transaction-events feature flag checks

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -121,7 +121,6 @@ default_manager.add("projects:plugins", ProjectPluginFeature)  # NOQA
 requires_snuba = (
     "organizations:discover",
     "organizations:events",
-    "organizations:transaction-events",
     "organizations:performance-view",
     "organizations:global-views",
     "organizations:incidents",

--- a/src/sentry/static/sentry/app/views/events/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.jsx
@@ -88,7 +88,7 @@ class SearchBar extends React.PureComponent {
         )
       : {};
 
-    const fieldTags = organization.features.includes('transaction-events')
+    const fieldTags = organization.features.includes('performance-view')
       ? assign(FIELD_TAGS, functionTags)
       : omit(FIELD_TAGS, TRACING_FIELDS);
 

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -122,7 +122,7 @@ export function generateTitle({eventView, event}: {eventView: EventView; event?:
 
 export function getPrebuiltQueries(organization: Organization) {
   let views = ALL_VIEWS;
-  if (organization.features.includes('transaction-events')) {
+  if (organization.features.includes('performance-view')) {
     // insert transactions queries at index 2
     const cloned = [...ALL_VIEWS];
     cloned.splice(2, 0, ...TRANSACTION_VIEWS);
@@ -437,7 +437,7 @@ export function generateFieldOptions({
   let functions = Object.keys(aggregations);
 
   // Strip tracing features if the org doesn't have access.
-  if (!organization.features.includes('transaction-events')) {
+  if (!organization.features.includes('performance-view')) {
     fieldKeys = fieldKeys.filter(item => !TRACING_FIELDS.includes(item));
     functions = functions.filter(item => !TRACING_FIELDS.includes(item));
   }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -107,7 +107,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
           <Feature
             requireAll
             features={[
-              'organizations:transaction-events',
+              'organizations:performance-view',
               'organizations:incidents-performance',
             ]}
           >

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -19,7 +19,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 FEATURE_NAMES = [
     "organizations:discover-basic",
     "organizations:discover-query",
-    "organizations:transaction-events",
+    "organizations:performance-view",
 ]
 
 

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -16,7 +16,6 @@ from .page_objects.base import BasePage
 
 FEATURE_NAMES = (
     "organizations:discover-basic",
-    "organizations:transaction-events",
     "organizations:performance-view",
 )
 

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -15,7 +15,6 @@ from .page_objects.transaction_summary import TransactionSummaryPage
 
 FEATURE_NAMES = (
     "organizations:discover-basic",
-    "organizations:transaction-events",
     "organizations:performance-view",
 )
 

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -26,7 +26,7 @@ function mountModal({tagKeys, columns, onApply}, initialData) {
 
 describe('EventsV2 -> ColumnEditModal', function() {
   const initialData = initializeOrg({
-    organization: {features: ['transaction-events']},
+    organization: {features: ['performance-view']},
   });
   const tagKeys = ['browser.name', 'custom-field'];
   const columns = [

--- a/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
@@ -10,7 +10,7 @@ import {Dataset} from 'app/views/settings/incidentRules/types';
 
 describe('MetricField', function() {
   const {organization} = initializeOrg({
-    organization: {features: ['transaction-events']},
+    organization: {features: ['performance-view']},
   });
 
   it('renders', function() {


### PR DESCRIPTION
Migrate the checks for this feature flag to performance-view as that is the feature that billing plans will provide. The transaction-events flag was an intermediate solution that we used before performance views were available.

All accounts that have access to transaction-events also have access to performance-view