### PR TITLE
fix(perf-views): Ignore aggregates in transaction summary

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/breadcrumb.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/breadcrumb.tsx
@@ -24,8 +24,8 @@ class Breadcrumb extends React.Component<Props> {
     const performanceTarget = {
       pathname: getPerformanceLandingUrl(organization),
       query: {
-        ...location.query,
         ...eventView.generateBlankQueryStringObject(),
+        ...location.query,
         ...eventView.getGlobalSelection(),
         // clear out the transaction name
         transaction: undefined,

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -15,6 +15,7 @@ import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import {PageContent} from 'app/styles/organization';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
+import {isAggregateField} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
 import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
@@ -177,6 +178,10 @@ function generateSummaryEventView(
   const conditions = Object.assign(tokenizeSearch(query), {
     'event.type': ['transaction'],
     transaction: [transactionName],
+  });
+
+  Object.keys(conditions).forEach(field => {
+    if (isAggregateField(field)) delete conditions[field];
   });
 
   // Handle duration filters from the latency chart


### PR DESCRIPTION
- Since the columns in the transaction summary will always be the same
  and won't include the aggregates from the performance homepage, ignore
  them here instead
- Also fixes the `Performance` breadcrumb which was missing the query