### PR TITLE
fix(logging): Allow sentry_plugins info logs

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -741,6 +741,7 @@ LOGGING = {
     "loggers": {
         "celery": {"level": "WARNING"},
         "sentry": {"level": "INFO"},
+        "sentry_plugins": {"level": "INFO"},
         "sentry.files": {"level": "WARNING"},
         "sentry.minidumps": {"handlers": ["internal"], "propagate": False},
         "sentry.interfaces": {"handlers": ["internal"], "propagate": False},

--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -144,6 +144,7 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
                         "organization_id": event.project.organization_id,
                     },
                 )
+
                 metrics.incr(
                     metrics_name,
                     tags={

--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -144,13 +144,6 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
                         "organization_id": event.project.organization_id,
                     },
                 )
-                logger.info(
-                    metrics_name, extra={"organization_id": event.project.organization_id},
-                )
-                logger.info(
-                    metrics_name, extra={"project_id": event.project.id},
-                )
-                logger.info(metrics_name)
                 metrics.incr(
                     metrics_name,
                     tags={

--- a/tests/sentry_plugins/amazon_sqs/test_plugin.py
+++ b/tests/sentry_plugins/amazon_sqs/test_plugin.py
@@ -71,7 +71,7 @@ class AmazonSQSPluginTest(PluginTestCase):
             {"Error": {"Code": "AccessDenied", "Message": "Hello"}}, "SendMessage"
         )
         self.run_test()
-        assert len(logger.info.call_args_list) == 4
+        assert len(logger.info.call_args_list) == 1
         assert (
             logger.info.call_args_list[0][0][0] == "sentry_plugins.amazon_sqs.access_token_invalid"
         )


### PR DESCRIPTION
Undo extra logs from https://github.com/getsentry/sentry/pull/19195 and allow info level logs to be captured for `sentry_plugins`.