### PR TITLE
feat(slack): Allow matching on Slack display name

### DIFF
--- a/src/sentry/shared_integrations/exceptions.py
+++ b/src/sentry/shared_integrations/exceptions.py
@@ -83,6 +83,10 @@ class IntegrationError(Exception):
     pass
 
 
+class DuplicateDisplayNameError(IntegrationError):
+    pass
+
+
 class IntegrationFormError(IntegrationError):
     def __init__(self, field_errors):
         super(IntegrationFormError, self).__init__("Invalid integration action")


### PR DESCRIPTION
When configuring an alert rule, allow users to select a user to send to by the user's display name. In the case that the display name isn't unique, this will error out and recommend giving the user's username instead (which, while deprecated, can still be found at \<workspace name\>.slack.com/account/settings). Tested manually and with unit tests.

![image](https://user-images.githubusercontent.com/32143113/83926509-d7e2d700-a73e-11ea-9333-4ebbb88e9f1f.png)

Fixes API-1024