### PR TITLE
ref: Rename Data Privacy to Scrubbing and align other related language

### DIFF
--- a/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
+++ b/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
@@ -27,7 +27,7 @@ class DataScrubbingSelectorSuggestionsEndpoint(OrganizationEndpoint):
         """
         Generate a list of data scrubbing selectors from existing event data.
 
-        This list is used to auto-complete settings in "Data Privacy" /
+        This list is used to auto-complete settings in "Data Anonymization" /
         "Security and Privacy" settings.
         """
 

--- a/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
+++ b/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
@@ -27,7 +27,7 @@ class DataScrubbingSelectorSuggestionsEndpoint(OrganizationEndpoint):
         """
         Generate a list of data scrubbing selectors from existing event data.
 
-        This list is used to auto-complete settings in "Data Anonymization" /
+        This list is used to auto-complete settings in "Data Scrubbing" /
         "Security and Privacy" settings.
         """
 

--- a/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacy.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacy.tsx
@@ -51,6 +51,61 @@ const organizationSecurityAndPrivacy: JsonFormObject[] = [
         },
       },
       {
+        name: 'scrapeJavaScript',
+        type: 'boolean',
+        confirm: {
+          false: t(
+            "Are you sure you want to disable sourcecode fetching for JavaScript events? This will affect Sentry's ability to aggregate issues if you're not already uploading sourcemaps as artifacts."
+          ),
+        },
+        label: t('Allow JavaScript Source Fetching'),
+        help: t('Allow Sentry to scrape missing JavaScript source context when possible'),
+      },
+      {
+        name: 'storeCrashReports',
+        type: 'range',
+        label: t('Store Native Crash Reports'),
+        help: t(
+          'Store native crash reports such as Minidumps for improved processing and download in issue details'
+        ),
+        visible: ({features}) => features.has('event-attachments'),
+        allowedValues: STORE_CRASH_REPORTS_VALUES,
+        formatLabel: formatStoreCrashReports,
+      },
+      {
+        name: 'trustedRelays',
+        type: 'string',
+        multiline: true,
+        autosize: true,
+        maxRows: 10,
+        placeholder: t('Paste the relay public keys here'),
+        label: t('Trusted Relays'),
+        help: t(
+          'The list of relay public keys that should be trusted. Any relay in this list will be permitted to access org and project configs. Separate multiple entries with a newline.'
+        ),
+        getValue: val => extractMultilineFields(val),
+        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+        visible: ({features}) => features.has('relay'),
+      },
+      {
+        name: 'allowJoinRequests',
+        type: 'boolean',
+
+        label: t('Allow Join Requests'),
+        help: t('Allow users to request to join your organization'),
+        confirm: {
+          true: t(
+            'Are you sure you want to allow users to request to join your organization?'
+          ),
+        },
+        visible: ({hasSsoEnabled}) => !hasSsoEnabled,
+      },
+    ],
+  },
+  {
+    title: t('Data Anonymization'),
+    fields: [
+      {
         name: 'dataScrubber',
         type: 'boolean',
         label: t('Require Data Scrubber'),
@@ -120,56 +175,6 @@ const organizationSecurityAndPrivacy: JsonFormObject[] = [
             'Disabling this can have privacy implications for ALL projects, are you sure you want to continue?'
           ),
         },
-      },
-      {
-        name: 'scrapeJavaScript',
-        type: 'boolean',
-        confirm: {
-          false: t(
-            "Are you sure you want to disable sourcecode fetching for JavaScript events? This will affect Sentry's ability to aggregate issues if you're not already uploading sourcemaps as artifacts."
-          ),
-        },
-        label: t('Allow JavaScript Source Fetching'),
-        help: t('Allow Sentry to scrape missing JavaScript source context when possible'),
-      },
-      {
-        name: 'storeCrashReports',
-        type: 'range',
-        label: t('Store Native Crash Reports'),
-        help: t(
-          'Store native crash reports such as Minidumps for improved processing and download in issue details'
-        ),
-        visible: ({features}) => features.has('event-attachments'),
-        allowedValues: STORE_CRASH_REPORTS_VALUES,
-        formatLabel: formatStoreCrashReports,
-      },
-      {
-        name: 'trustedRelays',
-        type: 'string',
-        multiline: true,
-        autosize: true,
-        maxRows: 10,
-        placeholder: t('Paste the relay public keys here'),
-        label: t('Trusted Relays'),
-        help: t(
-          'The list of relay public keys that should be trusted. Any relay in this list will be permitted to access org and project configs. Separate multiple entries with a newline.'
-        ),
-        getValue: val => extractMultilineFields(val),
-        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
-        visible: ({features}) => features.has('relay'),
-      },
-      {
-        name: 'allowJoinRequests',
-        type: 'boolean',
-
-        label: t('Allow Join Requests'),
-        help: t('Allow users to request to join your organization'),
-        confirm: {
-          true: t(
-            'Are you sure you want to allow users to request to join your organization?'
-          ),
-        },
-        visible: ({hasSsoEnabled}) => !hasSsoEnabled,
       },
     ],
   },

--- a/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacy.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacy.tsx
@@ -103,7 +103,7 @@ const organizationSecurityAndPrivacy: JsonFormObject[] = [
     ],
   },
   {
-    title: t('Data Anonymization'),
+    title: t('Data Scrubbing'),
     fields: [
       {
         name: 'dataScrubber',

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -395,8 +395,8 @@ function routes() {
         component={errorHandler(LazyLoad)}
       />
       <Route
-        name={t('Data Privacy')}
-        path="data-privacy/"
+        name={t('Security & Privacy')}
+        path="security-and-privacy/"
         component={errorHandler(LazyLoad)}
         componentPromise={() =>
           import(

--- a/src/sentry/static/sentry/app/utils/sanitizeQuerySelector.tsx
+++ b/src/sentry/static/sentry/app/utils/sanitizeQuerySelector.tsx
@@ -2,7 +2,7 @@
  * Sanitizes a string so that it can be used as a query selector
  *
  * e.g. `feedback:branding` --> `feedback-branding` or
- * 'Data Anonymization' --> 'Data-Anonymization'
+ * 'Data Scrubbing' --> 'Data-Scrubbing'
  *
  * @param str The string to sanitize
  * @return Returns a sanitized string (replace

--- a/src/sentry/static/sentry/app/utils/sanitizeQuerySelector.tsx
+++ b/src/sentry/static/sentry/app/utils/sanitizeQuerySelector.tsx
@@ -2,7 +2,7 @@
  * Sanitizes a string so that it can be used as a query selector
  *
  * e.g. `feedback:branding` --> `feedback-branding` or
- * 'Data Privacy' --> 'Data-Privacy'
+ * 'Data Anonymization' --> 'Data-Anonymization'
  *
  * @param str The string to sanitize
  * @return Returns a sanitized string (replace

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRules.tsx
@@ -292,9 +292,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
         const errorMessage = error.responseJSON?.relayPiiConfig?.[0];
 
         if (!errorMessage) {
-          addErrorMessage(
-            t('Unknown error occurred while saving data scrubbing rules')
-          );
+          addErrorMessage(t('Unknown error occurred while saving data scrubbing rules'));
           return undefined;
         }
 
@@ -324,9 +322,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
           };
         }
 
-        addErrorMessage(
-          t('Unknown error occurred while saving data scrubbing rules')
-        );
+        addErrorMessage(t('Unknown error occurred while saving data scrubbing rules'));
         return undefined;
       });
   };

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRules.tsx
@@ -292,7 +292,9 @@ class DataPrivacyRules extends React.Component<Props, State> {
         const errorMessage = error.responseJSON?.relayPiiConfig?.[0];
 
         if (!errorMessage) {
-          addErrorMessage(t('Unknown error occurred while saving data anonymization rules'));
+          addErrorMessage(
+            t('Unknown error occurred while saving data anonymization rules')
+          );
           return undefined;
         }
 
@@ -322,7 +324,9 @@ class DataPrivacyRules extends React.Component<Props, State> {
           };
         }
 
-        addErrorMessage(t('Unknown error occurred while saving data anonymization rules'));
+        addErrorMessage(
+          t('Unknown error occurred while saving data anonymization rules')
+        );
         return undefined;
       });
   };

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRules.tsx
@@ -285,14 +285,14 @@ class DataPrivacyRules extends React.Component<Props, State> {
         });
       })
       .then(() => {
-        addSuccessMessage(t('Successfully saved data privacy rules'));
+        addSuccessMessage(t('Successfully saved data anonymization rules'));
         return undefined;
       })
       .catch(error => {
         const errorMessage = error.responseJSON?.relayPiiConfig?.[0];
 
         if (!errorMessage) {
-          addErrorMessage(t('Unknown error occurred while saving data privacy rules'));
+          addErrorMessage(t('Unknown error occurred while saving data anonymization rules'));
           return undefined;
         }
 
@@ -322,7 +322,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
           };
         }
 
-        addErrorMessage(t('Unknown error occurred while saving data privacy rules'));
+        addErrorMessage(t('Unknown error occurred while saving data anonymization rules'));
         return undefined;
       });
   };
@@ -408,7 +408,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
       <React.Fragment>
         <Panel>
           <PanelHeader>
-            <div>{t('Data Privacy Rules')}</div>
+            <div>{t('Advanced Data Anonymization')}</div>
           </PanelHeader>
           <PanelAlert type="info">
             {additionalContext}{' '}
@@ -416,7 +416,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
             {tct('For more details, see [linkToDocs].', {
               linkToDocs: (
                 <ExternalLink href={ADVANCED_DATASCRUBBING_LINK}>
-                  {t('full documentation on data scrubbing')}
+                  {t('full documentation on data anonymization')}
                 </ExternalLink>
               ),
             })}

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRules.tsx
@@ -285,7 +285,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
         });
       })
       .then(() => {
-        addSuccessMessage(t('Successfully saved data anonymization rules'));
+        addSuccessMessage(t('Successfully saved data scrubbing rules'));
         return undefined;
       })
       .catch(error => {
@@ -293,7 +293,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
 
         if (!errorMessage) {
           addErrorMessage(
-            t('Unknown error occurred while saving data anonymization rules')
+            t('Unknown error occurred while saving data scrubbing rules')
           );
           return undefined;
         }
@@ -325,7 +325,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
         }
 
         addErrorMessage(
-          t('Unknown error occurred while saving data anonymization rules')
+          t('Unknown error occurred while saving data scrubbing rules')
         );
         return undefined;
       });
@@ -412,7 +412,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
       <React.Fragment>
         <Panel>
           <PanelHeader>
-            <div>{t('Advanced Data Anonymization')}</div>
+            <div>{t('Advanced Data Scrubbing')}</div>
           </PanelHeader>
           <PanelAlert type="info">
             {additionalContext}{' '}
@@ -420,7 +420,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
             {tct('For more details, see [linkToDocs].', {
               linkToDocs: (
                 <ExternalLink href={ADVANCED_DATASCRUBBING_LINK}>
-                  {t('full documentation on data anonymization')}
+                  {t('full documentation on data scrubbing')}
                 </ExternalLink>
               ),
             })}

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesContent.tsx
@@ -66,7 +66,7 @@ class DataPrivacyRulesContent extends React.Component<Props, State> {
       return (
         <EmptyMessage
           icon={<IconWarning size="xl" />}
-          description={t('You have no data privacy rules')}
+          description={t('You have no data anonymization rules')}
         />
       );
     }

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesContent.tsx
@@ -66,7 +66,7 @@ class DataPrivacyRulesContent extends React.Component<Props, State> {
       return (
         <EmptyMessage
           icon={<IconWarning size="xl" />}
-          description={t('You have no data anonymization rules')}
+          description={t('You have no data scrubbing rules')}
         />
       );
     }

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesModal.tsx
@@ -132,7 +132,9 @@ class DataPrivacyRulesModal extends React.Component<Props, State> {
     return (
       <StyledModal show animation={false} onHide={onClose}>
         <Modal.Header closeButton>
-          {rule?.id !== -1 ? t('Edit a data anonymization rule') : t('Add a data anonymization rule')}
+          {rule?.id !== -1
+            ? t('Edit a data anonymization rule')
+            : t('Add a data anonymization rule')}
         </Modal.Header>
         <Modal.Body>
           <DataPrivacyRulesPanelForm

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesModal.tsx
@@ -132,7 +132,7 @@ class DataPrivacyRulesModal extends React.Component<Props, State> {
     return (
       <StyledModal show animation={false} onHide={onClose}>
         <Modal.Header closeButton>
-          {rule?.id !== -1 ? t('Edit a data privacy rule') : t('Add a data privacy rule')}
+          {rule?.id !== -1 ? t('Edit a data anonymization rule') : t('Add a data anonymization rule')}
         </Modal.Header>
         <Modal.Body>
           <DataPrivacyRulesPanelForm

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRulesModal.tsx
@@ -133,8 +133,8 @@ class DataPrivacyRulesModal extends React.Component<Props, State> {
       <StyledModal show animation={false} onHide={onClose}>
         <Modal.Header closeButton>
           {rule?.id !== -1
-            ? t('Edit a data anonymization rule')
-            : t('Add a data anonymization rule')}
+            ? t('Edit a data scrubbing rule')
+            : t('Add a data scrubbing rule')}
         </Modal.Header>
         <Modal.Body>
           <DataPrivacyRulesPanelForm

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/organizationRules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/organizationRules.tsx
@@ -53,7 +53,7 @@ class OrganizationRules extends React.Component<Props, State> {
     if (rules.length === 0) {
       return (
         <Wrapper>
-          {t('There are no data anonymization rules at the organization level')}
+          {t('There are no data scrubbing rules at the organization level')}
         </Wrapper>
       );
     }

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/organizationRules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/organizationRules.tsx
@@ -53,7 +53,7 @@ class OrganizationRules extends React.Component<Props, State> {
     if (rules.length === 0) {
       return (
         <Wrapper>
-          {t('There are no data privacy rules at the organization level')}
+          {t('There are no data anonymization rules at the organization level')}
         </Wrapper>
       );
     }

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
@@ -23,7 +23,9 @@ const organizationNavigation: NavigationSection[] = [
       {
         path: `${pathPrefix}/security-and-privacy/`,
         title: t('Security & Privacy'),
-        description: t('Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing)'),
+        description: t(
+          'Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing)'
+        ),
         id: 'security-and-privacy',
         show: ({features}) => !!features?.has('datascrubbers-v2'),
         badge: () => 'new',

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
@@ -23,7 +23,7 @@ const organizationNavigation: NavigationSection[] = [
       {
         path: `${pathPrefix}/security-and-privacy/`,
         title: t('Security & Privacy'),
-        description: t('Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Anonymization)'),
+        description: t('Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing)'),
         id: 'security-and-privacy',
         show: ({features}) => !!features?.has('datascrubbers-v2'),
         badge: () => 'new',

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
@@ -23,9 +23,7 @@ const organizationNavigation: NavigationSection[] = [
       {
         path: `${pathPrefix}/security-and-privacy/`,
         title: t('Security & Privacy'),
-        description: t(
-          'View and manage the security and privacy settings of an organization'
-        ),
+        description: t('Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Anonymization)'),
         id: 'security-and-privacy',
         show: ({features}) => !!features?.has('datascrubbers-v2'),
         badge: () => 'new',

--- a/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/organizationSettingsForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/organizationSettingsForm.jsx
@@ -69,7 +69,7 @@ class OrganizationSettingsForm extends AsyncComponent {
               <Panel>
                 <PanelHeader>{t('Security & Privacy')}</PanelHeader>
                 <EmptyMessage
-                  title={t('Security & Privacy section now has its own tab')}
+                  title={t('Security & Privacy has moved')}
                   description={
                     <Link to={`/settings/${orgId}/security-and-privacy/`}>
                       {t('Go to Security & Privacy')}

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
@@ -75,7 +75,9 @@ export default function getConfiguration({
         {
           path: `${pathPrefix}/security-and-privacy/`,
           title: t('Security & Privacy'),
-          description: t('Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing)'),
+          description: t(
+            'Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing)'
+          ),
           show: () => organization.features?.includes('datascrubbers-v2'),
           badge: () => 'new',
         },

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
@@ -73,9 +73,9 @@ export default function getConfiguration({
           show: () => organization.features?.includes('android-mappings'),
         },
         {
-          path: `${pathPrefix}/data-privacy/`,
-          title: t('Data Privacy'),
-          description: t('Configure Datascrubbers for a project'),
+          path: `${pathPrefix}/security-and-privacy/`,
+          title: t('Security & Privacy'),
+          description: t('Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Anonymization)'),
           show: () => organization.features?.includes('datascrubbers-v2'),
           badge: () => 'new',
         },

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
@@ -75,7 +75,7 @@ export default function getConfiguration({
         {
           path: `${pathPrefix}/security-and-privacy/`,
           title: t('Security & Privacy'),
-          description: t('Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Anonymization)'),
+          description: t('Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing)'),
           show: () => organization.features?.includes('datascrubbers-v2'),
           badge: () => 'new',
         },

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacy.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacy.tsx
@@ -17,7 +17,7 @@ const ProjectDataPrivacy = ({organization, ...props}: Props) => (
       <FeatureDisabled
         alert={PanelAlert}
         features={organization.features}
-        featureName={t('Data Privacy - new')}
+        featureName={t('Security and Privacy - new')}
       />
     )}
   >

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
@@ -40,7 +40,7 @@ class ProjectDataPrivacyContent extends AsyncView<Props> {
 
     return (
       <React.Fragment>
-        <SettingsPageHeader title={t('Data Privacy')} />
+        <SettingsPageHeader title={t('Security & Privacy')} />
         <Form
           saveOnBlur
           allowUndo
@@ -50,7 +50,7 @@ class ProjectDataPrivacyContent extends AsyncView<Props> {
           onSubmitSuccess={this.handleUpdateProject}
         >
           <JsonForm
-            title={t('Data Privacy')}
+            title={t('Data Anonymization')}
             additionalFieldProps={{
               organization,
             }}

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
@@ -50,6 +50,17 @@ class ProjectDataPrivacyContent extends AsyncView<Props> {
           onSubmitSuccess={this.handleUpdateProject}
         >
           <JsonForm
+            title={t('Security & Privacy')}
+            additionalFieldProps={{
+              organization,
+            }}
+            features={features}
+            disabled={!access.has('project:write')}
+            fields={[
+              fields.storeCrashReports,
+            ]}
+          />
+          <JsonForm
             title={t('Data Anonymization')}
             additionalFieldProps={{
               organization,
@@ -62,7 +73,6 @@ class ProjectDataPrivacyContent extends AsyncView<Props> {
               fields.scrubIPAddresses,
               fields.sensitiveFields,
               fields.safeFields,
-              fields.storeCrashReports,
             ]}
           />
         </Form>

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
@@ -61,7 +61,7 @@ class ProjectDataPrivacyContent extends AsyncView<Props> {
             ]}
           />
           <JsonForm
-            title={t('Data Anonymization')}
+            title={t('Data Scrubbing')}
             additionalFieldProps={{
               organization,
             }}

--- a/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataPrivacy/projectDataPrivacyContent.tsx
@@ -56,9 +56,7 @@ class ProjectDataPrivacyContent extends AsyncView<Props> {
             }}
             features={features}
             disabled={!access.has('project:write')}
-            fields={[
-              fields.storeCrashReports,
-            ]}
+            fields={[fields.storeCrashReports]}
           />
           <JsonForm
             title={t('Data Scrubbing')}

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -482,7 +482,9 @@ class ProjectGeneralSettings extends AsyncView {
                   <EmptyMessage
                     title={t('Data Privacy has moved')}
                     description={
-                      <Link to={`/settings/${orgId}/projects/${projectId}/security-and-privacy/`}>
+                      <Link
+                        to={`/settings/${orgId}/projects/${projectId}/security-and-privacy/`}
+                      >
                         {t('Go to Security & Privacy')}
                       </Link>
                     }

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -480,10 +480,10 @@ class ProjectGeneralSettings extends AsyncView {
                 <Panel>
                   <PanelHeader>{t('Data Privacy')}</PanelHeader>
                   <EmptyMessage
-                    title={t('Data Privacy section now has its own tab')}
+                    title={t('Data Privacy has moved')}
                     description={
-                      <Link to={`/settings/${orgId}/projects/${projectId}/data-privacy/`}>
-                        {t('Go to Data Privacy')}
+                      <Link to={`/settings/${orgId}/projects/${projectId}/security-and-privacy/`}>
+                        {t('Go to Security & Privacy')}
                       </Link>
                     }
                   />
@@ -491,6 +491,8 @@ class ProjectGeneralSettings extends AsyncView {
               ) : (
                 <JsonForm
                   {...jsonFormProps}
+                  // Legacy use of the name Data Privacy... this codepath is
+                  // going to be gone if datascrubbersv2 goes GA
                   title={t('Data Privacy')}
                   fields={[
                     fields.dataScrubber,


### PR DESCRIPTION
We decided to get rid of our remaining uses of Data Privacy as it has been argued that data scrubbing does not really *only* cater to privacy aspects. We looked at what other terminology is in use and found ~anonymization to be the nicest of them all.~ scrubbing already widely in use.

* Mass-rename Data Privacy to Data ~Anonymization~ Scrubbing or Security & Privacy depending on context
* Split up org settings into multiple panes
* Retain Data Privacy phrasing in places where it would affect non-EA orgs (will go away with GA)

## Organization settings

![Screenshot_2020-06-09 Sentry(1)](https://user-images.githubusercontent.com/837573/84165199-b7cf5280-aa73-11ea-9386-a9bfabaa6cc3.png)

## Project settings

![Screenshot_2020-06-09 Sentry](https://user-images.githubusercontent.com/837573/84165209-b9007f80-aa73-11ea-8350-ddd18741053a.png)

