### PR TITLE
feat(alerts): Add timestamp to comments in alert activity

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/activity/activity.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/activity.tsx
@@ -135,6 +135,7 @@ class Activity extends React.Component<Props> {
                             user={activity.user}
                             modelId={activity.id}
                             text={activity.comment}
+                            dateCreated={activity.dateCreated}
                             activity={activity}
                             authorName={authorName}
                             onDelete={this.handleDeleteNote}


### PR DESCRIPTION
This adds a timestamp to user comments on the alert page, similar to system comments. Timestamps are UTC+0.

Resolves: https://app.asana.com/0/1174156445846705/1172482041769997/f

OLD:
![Screen Shot 2020-06-08 at 10 38 10 AM](https://user-images.githubusercontent.com/15015880/84062508-4361ba00-a974-11ea-882c-028749c205b6.png)

NEW:
![Screen Shot 2020-06-08 at 10 38 47 AM](https://user-images.githubusercontent.com/15015880/84062537-4d83b880-a974-11ea-93bd-0e29a6ebe83c.png)
