### PR TITLE
feat(discover) Move top5 display modes to higher plans

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
+++ b/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
@@ -43,6 +43,7 @@ function OptionSelector({options, onChange, selected, title, menuWidth = 'auto'}
             eventKey={opt.value}
             disabled={opt.disabled}
             isActive={selected === opt.value}
+            data-test-id={`option-${opt.value}`}
           >
             {opt.label}
           </DropdownItem>

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -129,6 +129,19 @@ class ResultsChartContainer extends React.Component<ContainerProps> {
     } = this.props;
 
     const yAxisValue = eventView.getYAxis();
+    const hasQueryFeature = organization.features.includes('discover-query');
+    const displayOptions = eventView.getDisplayOptions().filter(opt => {
+      // top5 modes are only available with larger packages in saas.
+      // We remove instead of disable here as showing tooltips in dropdown
+      // menus is clunky.
+      if (
+        [DisplayModes.TOP5, DisplayModes.DAILYTOP5].includes(opt.value as DisplayModes) &&
+        !hasQueryFeature
+      ) {
+        return false;
+      }
+      return true;
+    });
 
     return (
       <StyledPanel>
@@ -144,7 +157,7 @@ class ResultsChartContainer extends React.Component<ContainerProps> {
           yAxisValue={yAxisValue}
           yAxisOptions={eventView.getYAxisOptions()}
           onAxisChange={onAxisChange}
-          displayOptions={eventView.getDisplayOptions()}
+          displayOptions={displayOptions}
           displayMode={eventView.display || DisplayModes.DEFAULT}
           onDisplayChange={onDisplayChange}
         />

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -282,9 +282,9 @@ describe('EventsV2 > Results', function() {
     // Open the selector
     selector.find('StyledDropdownButton button').simulate('click');
 
-    // Click the 'none' option.
+    // Click the 'default' option.
     selector
-      .find('DropdownMenu MenuItem span')
+      .find('DropdownMenu MenuItem [data-test-id="option-default"]')
       .first()
       .simulate('click');
     wrapper.update();
@@ -292,5 +292,41 @@ describe('EventsV2 > Results', function() {
     const eventsRequest = wrapper.find('EventsChart').props();
     expect(eventsRequest.disableReleases).toEqual(true);
     expect(eventsRequest.disablePrevious).toEqual(true);
+  });
+
+  it('excludes top5 options when plan does not include discover-query', function() {
+    const organization = TestStubs.Organization({
+      features: ['discover-basic'],
+      projects: [TestStubs.Project()],
+    });
+
+    const initialData = initializeOrg({
+      organization,
+      router: {
+        location: {query: {...generateFields(), display: 'previoux'}},
+      },
+    });
+
+    const wrapper = mountWithTheme(
+      <Results
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+      />,
+      initialData.routerContext
+    );
+    // display selector is first.
+    const selector = wrapper.find('OptionSelector').first();
+
+    // Open the selector
+    selector.find('StyledDropdownButton button').simulate('click');
+
+    // Make sure the top5 option isn't present
+    const options = selector
+      .find('DropdownMenu MenuItem')
+      .map(item => item.prop('data-test-id'));
+    expect(options).not.toContain('option-top5');
+    expect(options).not.toContain('option-dailytop5');
+    expect(options).toContain('option-default');
   });
 });


### PR DESCRIPTION
The top5 modes will only be available on plans that include custom queries. I'm removing the option from the available list of options as showing a disabled tooltip/upsell flag inside the dropdown component is clunky.