### PR TITLE
feat(ui): Clarify "add a second platform" onboarding task

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -129,6 +129,7 @@ class OnboardingTasksSerializer(Serializer):
             "completionSeen": obj.completion_seen,
             "dateCompleted": obj.date_completed,
             "data": obj.data,
+            "project": obj.project_id,
         }
 
 

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -78,7 +78,7 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
       // to the new project.
       let location = task.location;
       if (task.task === OnboardingTaskKey.SECOND_PLATFORM && task.status === 'pending') {
-        // if there's no project id assiciated with the task, display project selector prompt.
+        // if there's no project id associated with the task, display project selector prompt.
         const projectSlug = task.project
           ? organization.projects.find(project => project.id === `${task.project}`)!.slug
           : ':projectId';

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -18,7 +18,7 @@ import Avatar from 'app/components/avatar';
 import LetterAvatar from 'app/components/letterAvatar';
 
 import SkipConfirm from './skipConfirm';
-import {isSecondPlatformPending} from './taskConfig';
+import {isSecondPlatformPending, sendEventPromptText} from './taskConfig';
 import {taskIsDone} from './utils';
 
 const recordAnalytics = (
@@ -128,18 +128,14 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
     </SkipConfirm>
   );
 
-  const sendEventPromptText =
-    'Complete this task by sending an event to your new project.';
-
   return (
     <Item interactive ref={forwardedRef} onClick={handleClick} data-test-id={task.task}>
       <Title>
         {IncompleteMarker}
         {task.title}
       </Title>
-      <Description>{`${task.description}. ${
-        task.detailedDescription ? task.detailedDescription : ''
-      }`}</Description>
+      <Description>{`${task.description}. ${task.detailedDescription ??
+        ''}`}</Description>
       {isSecondPlatformPending(task) && (
         <Description data-test-id="send-event-prompt">{sendEventPromptText}</Description>
       )}

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -17,8 +17,9 @@ import {IconLock, IconCheckmark, IconClose, IconEvent} from 'app/icons';
 import Avatar from 'app/components/avatar';
 import LetterAvatar from 'app/components/letterAvatar';
 
-import {taskIsDone} from './utils';
 import SkipConfirm from './skipConfirm';
+import {isSecondPlatformPending} from './taskConfig';
+import {taskIsDone} from './utils';
 
 const recordAnalytics = (
   task: OnboardingTask,
@@ -72,19 +73,7 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
     }
 
     if (task.actionType === 'app') {
-      // For the "second platform" task, it's confusing to continue linking to the "create new project"
-      // page after the user has created the new project -- instead, link to the install
-      // instructions for the corresponding project to prompt the user to send an event
-      // to the new project.
-      let location = task.location;
-      if (task.task === OnboardingTaskKey.SECOND_PLATFORM && task.status === 'pending') {
-        // if there's no project id associated with the task, display project selector prompt.
-        const projectSlug = task.project
-          ? organization.projects.find(project => project.id === `${task.project}`)!.slug
-          : ':projectId';
-        location = `/settings/${organization.slug}/projects/${projectSlug}/install/`;
-      }
-      navigateTo(`${location}?onboardingTask`, router);
+      navigateTo(`${task.location}?onboardingTask`, router);
     }
   };
 
@@ -151,7 +140,7 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
       <Description>{`${task.description}. ${
         task.detailedDescription ? task.detailedDescription : ''
       }`}</Description>
-      {task.task === OnboardingTaskKey.SECOND_PLATFORM && task.status === 'pending' && (
+      {isSecondPlatformPending(task) && (
         <Description data-test-id="send-event-prompt">{sendEventPromptText}</Description>
       )}
       {task.requisiteTasks.length === 0 && (

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -139,7 +139,7 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
     </SkipConfirm>
   );
 
-  const secondPlatformPendingText =
+  const sendEventPromptText =
     'Complete this task by sending an event to your new project.';
 
   return (
@@ -152,7 +152,7 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
         task.detailedDescription ? task.detailedDescription : ''
       }`}</Description>
       {task.task === OnboardingTaskKey.SECOND_PLATFORM && task.status === 'pending' && (
-        <Description>{secondPlatformPendingText}</Description>
+        <Description data-test-id="send-event-prompt">{sendEventPromptText}</Description>
       )}
       {task.requisiteTasks.length === 0 && (
         <ActionBar>

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -72,7 +72,19 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
     }
 
     if (task.actionType === 'app') {
-      navigateTo(`${task.location}?onboardingTask`, router);
+      // For the "second platform" task, it's confusing to continue linking to the "create new project"
+      // page after the user has created the new project -- instead, link to the install
+      // instructions for the corresponding project to prompt the user to send an event
+      // to the new project.
+      let location = task.location;
+      if (task.task === OnboardingTaskKey.SECOND_PLATFORM && task.status === 'pending') {
+        // if there's no project id assiciated with the task, display project selector prompt.
+        const projectSlug = task.project
+          ? organization.projects.find(project => project.id === `${task.project}`)!.slug
+          : ':projectId';
+        location = `/settings/${organization.slug}/projects/${projectSlug}/install/`;
+      }
+      navigateTo(`${location}?onboardingTask`, router);
     }
   };
 

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -133,7 +133,9 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
         {IncompleteMarker}
         {task.title}
       </Title>
-      <Description>{`${task.description}. ${task.detailedDescription}`}</Description>
+      <Description>{`${task.description}. ${
+        task.detailedDescription ? task.detailedDescription : ''
+      }`}</Description>
       {task.requisiteTasks.length === 0 && (
         <ActionBar>
           {task.status === 'pending' ? (

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -139,6 +139,9 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
     </SkipConfirm>
   );
 
+  const secondPlatformPendingText =
+    'Complete this task by sending an event to your new project.';
+
   return (
     <Item interactive ref={forwardedRef} onClick={handleClick} data-test-id={task.task}>
       <Title>
@@ -148,6 +151,9 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
       <Description>{`${task.description}. ${
         task.detailedDescription ? task.detailedDescription : ''
       }`}</Description>
+      {task.task === OnboardingTaskKey.SECOND_PLATFORM && task.status === 'pending' && (
+        <Description>{secondPlatformPendingText}</Description>
+      )}
       {task.requisiteTasks.length === 0 && (
         <ActionBar>
           {task.status === 'pending' ? (

--- a/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
@@ -197,6 +197,10 @@ export function getOnboardingTasks(
   ];
 }
 
+export const sendEventPromptText = t(
+  'Complete this task by sending an event to your new project.'
+);
+
 // Enable custom functionality for the "second platform" task when the task status
 // is pending.
 export const isSecondPlatformPending = (task: OnboardingTask) =>
@@ -219,6 +223,10 @@ export function getMergedTasks(organization: Organization) {
   // Change task.location for the "second platform" task when task status is pending.
   allTasks.map(task => {
     if (!isSecondPlatformPending(task)) return task;
+    if (
+      !('location' in task && 'getPendingLocation' in task && !!task.getPendingLocation)
+    )
+      return task;
     task.location = task.getPendingLocation(organization, task.project);
     return task;
   });

--- a/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
@@ -95,8 +95,9 @@ export function getOnboardingTasks(
     {
       task: OnboardingTaskKey.SECOND_PLATFORM,
       title: t('Add a second platform'),
-      description: t('Add Sentry to a second platform'),
-      detailedDescription: t('Capture errors from both your front and back ends.'),
+      description: t(
+        `Add a new project to capture errors from both your front and back ends for your other platforms`
+      ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
       actionType: 'app',

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1096,6 +1096,7 @@ export type OnboardingTaskDescriptor = {
   | {
       actionType: 'app' | 'external';
       location: string;
+      getPendingLocation?: (Organization, number?) => string;
     }
   | {
       actionType: 'action';

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1110,6 +1110,7 @@ export type OnboardingTaskStatus = {
   dateCompleted?: string;
   completionSeen?: string;
   data?: object;
+  project?: number;
 };
 
 export type OnboardingTask = OnboardingTaskStatus &

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -128,5 +128,6 @@ describe('Command Palette Modal', function() {
       .simulate('click');
 
     expect(navigateTo).toHaveBeenCalledWith('/billy-org/', expect.anything());
+    navigateTo.mockClear();
   });
 });

--- a/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
+++ b/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
@@ -3,20 +3,24 @@ import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 
 import Task from 'app/components/onboardingWizard/task';
-import {getOnboardingTasks} from 'app/components/onboardingWizard/taskConfig';
+import {getMergedTasks} from 'app/components/onboardingWizard/taskConfig';
 import {OnboardingTaskKey} from 'app/types';
 import {navigateTo} from 'app/actionCreators/navigation';
 
 jest.mock('app/actionCreators/navigation');
 
 describe('Task', () => {
-  const project = TestStubs.Project({id: '1', slug: 'angryGoose'});
-  const org = TestStubs.Organization({projects: [project], slug: 'GamesCorp'});
-  const tasks = getOnboardingTasks(org);
+  let org;
+  let project;
+  beforeEach(() => {
+    project = TestStubs.Project({id: '1', slug: 'angryGoose'});
+    org = TestStubs.Organization({projects: [project], slug: 'GamesCorp'});
+  });
 
   it('renders', () => {
-    const mockTask = Object.assign({}, tasks[0]);
-    mockTask.requisiteTasks = mockTask.requisites;
+    const tasks = getMergedTasks(org);
+    const mockTask = tasks[0];
+
     const wrapper = mountWithTheme(
       <Task organization={org} task={mockTask} />,
       TestStubs.routerContext()
@@ -26,17 +30,11 @@ describe('Task', () => {
   });
 
   describe('Add a Second Platform', () => {
-    let second_platform_task;
-
-    beforeEach(() => {
-      second_platform_task = Object.assign(
-        {},
-        tasks.find(t => t.task === OnboardingTaskKey.SECOND_PLATFORM)
-      );
-      second_platform_task.requisiteTasks = second_platform_task.requisites;
-    });
-
     it('renders without send event prompt initially', () => {
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
       const wrapper = mountWithTheme(
         <Task organization={org} task={second_platform_task} />,
         TestStubs.routerContext()
@@ -46,7 +44,16 @@ describe('Task', () => {
     });
 
     it('renders send event prompt when status is pending', () => {
-      second_platform_task.status = 'pending';
+      org.onboardingTasks = [
+        {
+          task: OnboardingTaskKey.SECOND_PLATFORM,
+          status: 'pending',
+        },
+      ];
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
 
       const wrapper = mountWithTheme(
         <Task organization={org} task={second_platform_task} />,
@@ -57,6 +64,10 @@ describe('Task', () => {
     });
 
     it('links to create new project page before task is started', () => {
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
       const wrapper = mountWithTheme(
         <Task organization={org} task={second_platform_task} />,
         TestStubs.routerContext()
@@ -74,8 +85,17 @@ describe('Task', () => {
     });
 
     it('links to project configuration page after project is created', () => {
-      second_platform_task.status = 'pending';
-      second_platform_task.project = 1;
+      org.onboardingTasks = [
+        {
+          task: OnboardingTaskKey.SECOND_PLATFORM,
+          status: 'pending',
+          project: 1,
+        },
+      ];
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
 
       const wrapper = mountWithTheme(
         <Task organization={org} task={second_platform_task} />,
@@ -94,7 +114,16 @@ describe('Task', () => {
     });
 
     it('passes :projectId to router when project id cannot be resolved', () => {
-      second_platform_task.status = 'pending';
+      org.onboardingTasks = [
+        {
+          task: OnboardingTaskKey.SECOND_PLATFORM,
+          status: 'pending',
+        },
+      ];
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
 
       const wrapper = mountWithTheme(
         <Task organization={org} task={second_platform_task} />,

--- a/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
+++ b/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
@@ -16,6 +16,9 @@ describe('Task', () => {
     project = TestStubs.Project({id: '1', slug: 'angryGoose'});
     org = TestStubs.Organization({projects: [project], slug: 'GamesCorp'});
   });
+  afterEach(() => {
+    navigateTo.mockClear();
+  });
 
   it('renders', () => {
     const tasks = getMergedTasks(org);
@@ -63,85 +66,79 @@ describe('Task', () => {
       expect(wrapper.find('[data-test-id="send-event-prompt"]').exists()).toBe(true);
     });
 
-    describe('with navigateTo mocks', () => {
-      afterEach(() => {
-        navigateTo.mockClear();
-      });
+    it('links to create new project page before task is started', () => {
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+      wrapper
+        .find('[data-test-id="setup_second_platform"]')
+        .first()
+        .simulate('click');
 
-      it('links to create new project page before task is started', () => {
-        const tasks = getMergedTasks(org);
-        const second_platform_task = tasks.find(
-          t => t.task === OnboardingTaskKey.SECOND_PLATFORM
-        );
-        const wrapper = mountWithTheme(
-          <Task organization={org} task={second_platform_task} />,
-          TestStubs.routerContext()
-        );
-        wrapper
-          .find('[data-test-id="setup_second_platform"]')
-          .first()
-          .simulate('click');
+      expect(navigateTo).toHaveBeenCalledWith(
+        `${second_platform_task.location}?onboardingTask`,
+        expect.anything()
+      );
+    });
 
-        expect(navigateTo).toHaveBeenCalledWith(
-          `${second_platform_task.location}?onboardingTask`,
-          expect.anything()
-        );
-      });
+    it('links to project configuration page after project is created', () => {
+      org.onboardingTasks = [
+        {
+          task: OnboardingTaskKey.SECOND_PLATFORM,
+          status: 'pending',
+          project: 1,
+        },
+      ];
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
 
-      it('links to project configuration page after project is created', () => {
-        org.onboardingTasks = [
-          {
-            task: OnboardingTaskKey.SECOND_PLATFORM,
-            status: 'pending',
-            project: 1,
-          },
-        ];
-        const tasks = getMergedTasks(org);
-        const second_platform_task = tasks.find(
-          t => t.task === OnboardingTaskKey.SECOND_PLATFORM
-        );
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+      wrapper
+        .find('[data-test-id="setup_second_platform"]')
+        .first()
+        .simulate('click');
 
-        const wrapper = mountWithTheme(
-          <Task organization={org} task={second_platform_task} />,
-          TestStubs.routerContext()
-        );
-        wrapper
-          .find('[data-test-id="setup_second_platform"]')
-          .first()
-          .simulate('click');
+      expect(navigateTo).toHaveBeenCalledWith(
+        `/settings/${org.slug}/projects/${project.slug}/install/?onboardingTask`,
+        expect.anything()
+      );
+    });
 
-        expect(navigateTo).toHaveBeenCalledWith(
-          `/settings/${org.slug}/projects/${project.slug}/install/?onboardingTask`,
-          expect.anything()
-        );
-      });
+    it('passes :projectId to router when project id cannot be resolved', () => {
+      org.onboardingTasks = [
+        {
+          task: OnboardingTaskKey.SECOND_PLATFORM,
+          status: 'pending',
+        },
+      ];
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
 
-      it('passes :projectId to router when project id cannot be resolved', () => {
-        org.onboardingTasks = [
-          {
-            task: OnboardingTaskKey.SECOND_PLATFORM,
-            status: 'pending',
-          },
-        ];
-        const tasks = getMergedTasks(org);
-        const second_platform_task = tasks.find(
-          t => t.task === OnboardingTaskKey.SECOND_PLATFORM
-        );
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+      wrapper
+        .find('[data-test-id="setup_second_platform"]')
+        .first()
+        .simulate('click');
 
-        const wrapper = mountWithTheme(
-          <Task organization={org} task={second_platform_task} />,
-          TestStubs.routerContext()
-        );
-        wrapper
-          .find('[data-test-id="setup_second_platform"]')
-          .first()
-          .simulate('click');
-
-        expect(navigateTo).toHaveBeenCalledWith(
-          `/settings/${org.slug}/projects/:projectId/install/?onboardingTask`,
-          expect.anything()
-        );
-      });
+      expect(navigateTo).toHaveBeenCalledWith(
+        `/settings/${org.slug}/projects/:projectId/install/?onboardingTask`,
+        expect.anything()
+      );
     });
   });
 });

--- a/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
+++ b/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
@@ -70,6 +70,7 @@ describe('Task', () => {
         `${second_platform_task.location}?onboardingTask`,
         expect.anything()
       );
+      navigateTo.mockClear();
     });
 
     it('links to project configuration page after project is created', () => {
@@ -89,6 +90,26 @@ describe('Task', () => {
         `/settings/${org.slug}/projects/${project.slug}/install/?onboardingTask`,
         expect.anything()
       );
+      navigateTo.mockClear();
+    });
+
+    it('passes :projectId to router when project id cannot be resolved', () => {
+      second_platform_task.status = 'pending';
+
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+      wrapper
+        .find('[data-test-id="setup_second_platform"]')
+        .first()
+        .simulate('click');
+
+      expect(navigateTo).toHaveBeenCalledWith(
+        `/settings/${org.slug}/projects/:projectId/install/?onboardingTask`,
+        expect.anything()
+      );
+      navigateTo.mockClear();
     });
   });
 });

--- a/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
+++ b/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
@@ -63,82 +63,85 @@ describe('Task', () => {
       expect(wrapper.find('[data-test-id="send-event-prompt"]').exists()).toBe(true);
     });
 
-    it('links to create new project page before task is started', () => {
-      const tasks = getMergedTasks(org);
-      const second_platform_task = tasks.find(
-        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
-      );
-      const wrapper = mountWithTheme(
-        <Task organization={org} task={second_platform_task} />,
-        TestStubs.routerContext()
-      );
-      wrapper
-        .find('[data-test-id="setup_second_platform"]')
-        .first()
-        .simulate('click');
+    describe('with navigateTo mocks', () => {
+      afterEach(() => {
+        navigateTo.mockClear();
+      });
 
-      expect(navigateTo).toHaveBeenCalledWith(
-        `${second_platform_task.location}?onboardingTask`,
-        expect.anything()
-      );
-      navigateTo.mockClear();
-    });
+      it('links to create new project page before task is started', () => {
+        const tasks = getMergedTasks(org);
+        const second_platform_task = tasks.find(
+          t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+        );
+        const wrapper = mountWithTheme(
+          <Task organization={org} task={second_platform_task} />,
+          TestStubs.routerContext()
+        );
+        wrapper
+          .find('[data-test-id="setup_second_platform"]')
+          .first()
+          .simulate('click');
 
-    it('links to project configuration page after project is created', () => {
-      org.onboardingTasks = [
-        {
-          task: OnboardingTaskKey.SECOND_PLATFORM,
-          status: 'pending',
-          project: 1,
-        },
-      ];
-      const tasks = getMergedTasks(org);
-      const second_platform_task = tasks.find(
-        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
-      );
+        expect(navigateTo).toHaveBeenCalledWith(
+          `${second_platform_task.location}?onboardingTask`,
+          expect.anything()
+        );
+      });
 
-      const wrapper = mountWithTheme(
-        <Task organization={org} task={second_platform_task} />,
-        TestStubs.routerContext()
-      );
-      wrapper
-        .find('[data-test-id="setup_second_platform"]')
-        .first()
-        .simulate('click');
+      it('links to project configuration page after project is created', () => {
+        org.onboardingTasks = [
+          {
+            task: OnboardingTaskKey.SECOND_PLATFORM,
+            status: 'pending',
+            project: 1,
+          },
+        ];
+        const tasks = getMergedTasks(org);
+        const second_platform_task = tasks.find(
+          t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+        );
 
-      expect(navigateTo).toHaveBeenCalledWith(
-        `/settings/${org.slug}/projects/${project.slug}/install/?onboardingTask`,
-        expect.anything()
-      );
-      navigateTo.mockClear();
-    });
+        const wrapper = mountWithTheme(
+          <Task organization={org} task={second_platform_task} />,
+          TestStubs.routerContext()
+        );
+        wrapper
+          .find('[data-test-id="setup_second_platform"]')
+          .first()
+          .simulate('click');
 
-    it('passes :projectId to router when project id cannot be resolved', () => {
-      org.onboardingTasks = [
-        {
-          task: OnboardingTaskKey.SECOND_PLATFORM,
-          status: 'pending',
-        },
-      ];
-      const tasks = getMergedTasks(org);
-      const second_platform_task = tasks.find(
-        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
-      );
+        expect(navigateTo).toHaveBeenCalledWith(
+          `/settings/${org.slug}/projects/${project.slug}/install/?onboardingTask`,
+          expect.anything()
+        );
+      });
 
-      const wrapper = mountWithTheme(
-        <Task organization={org} task={second_platform_task} />,
-        TestStubs.routerContext()
-      );
-      wrapper
-        .find('[data-test-id="setup_second_platform"]')
-        .first()
-        .simulate('click');
+      it('passes :projectId to router when project id cannot be resolved', () => {
+        org.onboardingTasks = [
+          {
+            task: OnboardingTaskKey.SECOND_PLATFORM,
+            status: 'pending',
+          },
+        ];
+        const tasks = getMergedTasks(org);
+        const second_platform_task = tasks.find(
+          t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+        );
 
-      expect(navigateTo).toHaveBeenCalledWith(
-        `/settings/${org.slug}/projects/:projectId/install/?onboardingTask`,
-        expect.anything()
-      );
-      navigateTo.mockClear();
+        const wrapper = mountWithTheme(
+          <Task organization={org} task={second_platform_task} />,
+          TestStubs.routerContext()
+        );
+        wrapper
+          .find('[data-test-id="setup_second_platform"]')
+          .first()
+          .simulate('click');
+
+        expect(navigateTo).toHaveBeenCalledWith(
+          `/settings/${org.slug}/projects/:projectId/install/?onboardingTask`,
+          expect.anything()
+        );
+      });
     });
   });
 });

--- a/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
+++ b/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import Task from 'app/components/onboardingWizard/task';
+import {getOnboardingTasks} from 'app/components/onboardingWizard/taskConfig';
+import {OnboardingTaskKey} from 'app/types';
+import {navigateTo} from 'app/actionCreators/navigation';
+
+jest.mock('app/actionCreators/navigation');
+
+describe('Task', () => {
+  const project = TestStubs.Project({id: '1', slug: 'angryGoose'});
+  const org = TestStubs.Organization({projects: [project], slug: 'GamesCorp'});
+  const tasks = getOnboardingTasks(org);
+
+  it('renders', () => {
+    const mockTask = Object.assign({}, tasks[0]);
+    mockTask.requisiteTasks = mockTask.requisites;
+    const wrapper = mountWithTheme(
+      <Task organization={org} task={mockTask} />,
+      TestStubs.routerContext()
+    );
+
+    expect(wrapper.find('Title').exists()).toBe(true);
+  });
+
+  describe('Add a Second Platform', () => {
+    let second_platform_task;
+
+    beforeEach(() => {
+      second_platform_task = Object.assign(
+        {},
+        tasks.find(t => t.task === OnboardingTaskKey.SECOND_PLATFORM)
+      );
+      second_platform_task.requisiteTasks = second_platform_task.requisites;
+    });
+
+    it('renders without send event prompt initially', () => {
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+
+      expect(wrapper.find('[data-test-id="send-event-prompt"]').exists()).toBe(false);
+    });
+
+    it('renders send event prompt when status is pending', () => {
+      second_platform_task.status = 'pending';
+
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+
+      expect(wrapper.find('[data-test-id="send-event-prompt"]').exists()).toBe(true);
+    });
+
+    it('links to create new project page before task is started', () => {
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+      wrapper
+        .find('[data-test-id="setup_second_platform"]')
+        .first()
+        .simulate('click');
+
+      expect(navigateTo).toHaveBeenCalledWith(
+        `${second_platform_task.location}?onboardingTask`,
+        expect.anything()
+      );
+    });
+
+    it('links to project configuration page after project is created', () => {
+      second_platform_task.status = 'pending';
+      second_platform_task.project = 1;
+
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+      wrapper
+        .find('[data-test-id="setup_second_platform"]')
+        .first()
+        .simulate('click');
+
+      expect(navigateTo).toHaveBeenCalledWith(
+        `/settings/${org.slug}/projects/${project.slug}/install/?onboardingTask`,
+        expect.anything()
+      );
+    });
+  });
+});

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1708,6 +1708,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                     "actionType": "app",
                     "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                     "display": true,
+                    "getPendingLocation": [Function],
                     "location": "/organizations/org-slug/projects/new/",
                     "requisiteTasks": Array [
                       Object {
@@ -4198,6 +4199,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                           "actionType": "app",
                           "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                           "display": true,
+                          "getPendingLocation": [Function],
                           "location": "/organizations/org-slug/projects/new/",
                           "requisiteTasks": Array [
                             Object {
@@ -4278,6 +4280,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             "actionType": "app",
                             "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                             "display": true,
+                            "getPendingLocation": [Function],
                             "location": "/organizations/org-slug/projects/new/",
                             "requisiteTasks": Array [
                               Object {
@@ -4326,6 +4329,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                               "actionType": "app",
                               "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                               "display": true,
+                              "getPendingLocation": [Function],
                               "location": "/organizations/org-slug/projects/new/",
                               "requisiteTasks": Array [
                                 Object {
@@ -4375,6 +4379,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                 "actionType": "app",
                                 "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                                 "display": true,
+                                "getPendingLocation": [Function],
                                 "location": "/organizations/org-slug/projects/new/",
                                 "requisiteTasks": Array [
                                   Object {
@@ -4453,6 +4458,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                   "actionType": "app",
                                   "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                                   "display": true,
+                                  "getPendingLocation": [Function],
                                   "location": "/organizations/org-slug/projects/new/",
                                   "requisiteTasks": Array [
                                     Object {
@@ -4830,6 +4836,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                     "actionType": "app",
                                     "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                                     "display": true,
+                                    "getPendingLocation": [Function],
                                     "location": "/organizations/org-slug/projects/new/",
                                     "requisiteTasks": Array [
                                       Object {

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1508,7 +1508,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                 <p
                   class="css-127nzq8-Description e9zebce2"
                 >
-                  Add Sentry to a second platform. Capture errors from both your front and back ends.
+                  Add a new project to capture errors from both your front and back ends for your other platforms. 
                 </p>
               </div>
               <div
@@ -1706,8 +1706,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                   },
                   Object {
                     "actionType": "app",
-                    "description": "Add Sentry to a second platform",
-                    "detailedDescription": "Capture errors from both your front and back ends.",
+                    "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                     "display": true,
                     "location": "/organizations/org-slug/projects/new/",
                     "requisiteTasks": Array [
@@ -4197,8 +4196,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                       task={
                         Object {
                           "actionType": "app",
-                          "description": "Add Sentry to a second platform",
-                          "detailedDescription": "Capture errors from both your front and back ends.",
+                          "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                           "display": true,
                           "location": "/organizations/org-slug/projects/new/",
                           "requisiteTasks": Array [
@@ -4278,8 +4276,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                         task={
                           Object {
                             "actionType": "app",
-                            "description": "Add Sentry to a second platform",
-                            "detailedDescription": "Capture errors from both your front and back ends.",
+                            "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                             "display": true,
                             "location": "/organizations/org-slug/projects/new/",
                             "requisiteTasks": Array [
@@ -4327,8 +4324,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                           task={
                             Object {
                               "actionType": "app",
-                              "description": "Add Sentry to a second platform",
-                              "detailedDescription": "Capture errors from both your front and back ends.",
+                              "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                               "display": true,
                               "location": "/organizations/org-slug/projects/new/",
                               "requisiteTasks": Array [
@@ -4377,8 +4373,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             task={
                               Object {
                                 "actionType": "app",
-                                "description": "Add Sentry to a second platform",
-                                "detailedDescription": "Capture errors from both your front and back ends.",
+                                "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                                 "display": true,
                                 "location": "/organizations/org-slug/projects/new/",
                                 "requisiteTasks": Array [
@@ -4456,8 +4451,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                               task={
                                 Object {
                                   "actionType": "app",
-                                  "description": "Add Sentry to a second platform",
-                                  "detailedDescription": "Capture errors from both your front and back ends.",
+                                  "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                                   "display": true,
                                   "location": "/organizations/org-slug/projects/new/",
                                   "requisiteTasks": Array [
@@ -4834,8 +4828,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                 task={
                                   Object {
                                     "actionType": "app",
-                                    "description": "Add Sentry to a second platform",
-                                    "detailedDescription": "Capture errors from both your front and back ends.",
+                                    "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                                     "display": true,
                                     "location": "/organizations/org-slug/projects/new/",
                                     "requisiteTasks": Array [
@@ -4965,7 +4958,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                       <p
                                         className="css-127nzq8-Description e9zebce2"
                                       >
-                                        Add Sentry to a second platform. Capture errors from both your front and back ends.
+                                        Add a new project to capture errors from both your front and back ends for your other platforms. 
                                       </p>
                                     </Description>
                                   </div>

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -152,5 +152,6 @@ describe('SettingsSearch', function() {
       .simulate('click');
 
     expect(navigateTo).toHaveBeenCalledWith('/billy-org/', expect.anything());
+    navigateTo.mockClear();
   });
 });

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -4,10 +4,17 @@ from __future__ import absolute_import
 
 import six
 
+from datetime import timedelta
 from django.conf import settings
+from django.utils import timezone
 
 from sentry.auth import access
-from sentry.api.serializers import serialize, DetailedOrganizationSerializer
+from sentry.api.serializers import (
+    serialize,
+    DetailedOrganizationSerializer,
+    OnboardingTasksSerializer,
+)
+from sentry.models import OnboardingTask, OnboardingTaskStatus, OrganizationOnboardingTask
 from sentry.testutils import TestCase
 
 
@@ -39,6 +46,33 @@ class OrganizationSerializerTest(TestCase):
                 "discover-query",
             ]
         )
+
+
+class OnboardingTasksSerializerTest(TestCase):
+    def test_serializer(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+        now = timezone.now()
+
+        want = OrganizationOnboardingTask(
+            organization_id=organization.id,
+            task=OnboardingTask.FIRST_PROJECT,
+            completion_seen=now,
+            date_completed=now - timedelta(minutes=5),
+            user=user,
+            status=OnboardingTaskStatus.COMPLETE,
+            project_id=100,
+        )
+
+        result = serialize(want, user, OnboardingTasksSerializer())
+
+        assert result["task"] == "create_project"
+        assert result["status"] == "complete"
+        assert result["user"]["id"] == six.text_type(user.id)
+        assert result["completionSeen"] == want.completion_seen
+        assert result["dateCompleted"] == want.date_completed
+        assert result["data"] == want.data
+        assert result["project"] == want.project_id
 
 
 class DetailedOrganizationSerializerTest(TestCase):


### PR DESCRIPTION
A user wrote in, confused that the "add a second platform" task in the onboarding sidebar seemed to be stuck in the "in progress" state. The task does get successfully marked as "complete" when the user creates a new project with a new platform (not a new platform in their first project), and sends an event to the new project, but the UI doesn't clearly communicate these requirements. This PR delivers a couple UI changes to clarify what is required for a task to go from "in progress" to complete:

* Updated task description text
* Conditionally display “Send an event to your new project” text, when the task is "in progress"
* Task links to project configuration page instead of new project creation page after the new project has been created

Addresses ENT-197.