### PR TITLE
ref(ui) Convert comment icons to the new icon

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
+import {IconChat} from 'app/icons';
 import {tct} from 'app/locale';
 import EventAnnotation from 'app/components/events/eventAnnotation';
-import InlineSvg from 'app/components/inlineSvg';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
 import SentryTypes from 'app/sentryTypes';
 import ShortId from 'app/components/shortId';
@@ -62,10 +62,12 @@ class EventOrGroupExtraDetails extends React.Component {
         <StyledTimes lastSeen={lastSeen} firstSeen={firstSeen} />
         {numComments > 0 && (
           <CommentsLink to={`${issuesPath}${id}/activity/`} className="comments">
-            <GroupExtraIcon
-              src="icon-comment-sm"
-              mentioned={
+            <IconChat
+              size="xs"
+              color={
                 subscriptionDetails && subscriptionDetails.reason === 'mentioned'
+                  ? 'green400'
+                  : 'currentColor'
               }
             />
             <span>{numComments}</span>
@@ -124,6 +126,10 @@ const StyledTimes = styled(Times)`
 `;
 
 const CommentsLink = styled(Link)`
+  display: inline-grid;
+  grid-gap: ${space(0.5)};
+  align-items: center;
+  grid-auto-flow: column;
   color: ${p => p.theme.gray700};
 `;
 
@@ -131,12 +137,6 @@ const GroupShortId = styled(ShortId)`
   flex-shrink: 0;
   font-size: 12px;
   color: ${p => p.theme.gray600};
-`;
-
-const GroupExtraIcon = styled(InlineSvg)`
-  color: ${p => (p.isMentioned ? p.theme.green400 : null)};
-  font-size: 11px;
-  margin-right: 4px;
 `;
 
 const AnnotationNoMargin = styled(EventAnnotation)`

--- a/src/sentry/static/sentry/app/components/issues/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/issues/compactIssue.jsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 
 import {PanelItem} from 'app/components/panels';
 import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
+import {IconChat} from 'app/icons';
 import {t} from 'app/locale';
 import DropdownLink from 'app/components/dropdownLink';
 import ErrorLevel from 'app/components/events/errorLevel';
@@ -69,17 +70,16 @@ class CompactIssueHeader extends React.Component {
   render() {
     const {data, organization, projectId, eventId} = this.props;
 
-    let styles = {};
-
     const basePath = `/organizations/${organization.slug}/issues/`;
 
     const issueLink = eventId
       ? `/organizations/${organization.slug}/projects/${projectId}/events/${eventId}/`
       : `${basePath}${data.id}/`;
 
-    if (data.subscriptionDetails && data.subscriptionDetails.reason === 'mentioned') {
-      styles = {color: '#57be8c'};
-    }
+    const commentColor =
+      data.subscriptionDetails && data.subscriptionDetails.reason === 'mentioned'
+        ? 'green400'
+        : 'currentColor';
 
     return (
       <React.Fragment>
@@ -99,10 +99,10 @@ class CompactIssueHeader extends React.Component {
           </span>
           {data.numComments !== 0 && (
             <span>
-              <Link to={`${basePath}${data.id}/activity/`} className="comments">
-                <span className="icon icon-comments" style={styles} />
+              <ChatLink to={`${basePath}${data.id}/activity/`} className="comments">
+                <IconChat size="xs" color={commentColor} />
                 <span className="tag-count">{data.numComments}</span>
-              </Link>
+              </ChatLink>
             </span>
           )}
           <span className="culprit">{this.getMessage()}</span>
@@ -280,4 +280,10 @@ const IssueHeaderMetaWrapper = styled('div')`
 const StyledErrorLevel = styled(ErrorLevel)`
   display: block;
   margin-right: ${space(1)};
+`;
+
+const ChatLink = styled(Link)`
+  & > svg {
+    margin-right: ${space(0.5)};
+  }
 `;

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -1582,7 +1582,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                   </StyledTimes>
                                   <LoggerAnnotation>
                                     <span
-                                      className="css-ixgywj-EventAnnotation-AnnotationNoMargin-LoggerAnnotation eec9orn6"
+                                      className="css-ixgywj-EventAnnotation-AnnotationNoMargin-LoggerAnnotation eec9orn5"
                                     >
                                       <Link
                                         onlyActiveOnIndex={false}


### PR DESCRIPTION
Update the comment icon usage. I also fixed the broken highlighting caused by prop mismatches.

![Screen Shot 2020-06-08 at 5 50 04 PM](https://user-images.githubusercontent.com/24086/84084202-01a33480-a9b1-11ea-95fb-3f67a682826b.png) 


![Screen Shot 2020-06-08 at 5 10 35 PM](https://user-images.githubusercontent.com/24086/84084201-010a9e00-a9b1-11ea-97d4-d9ee4c5ceb31.png)
