### PR TITLE
fix(metric_alerts): Fix alert start date being off by one bucket.

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -178,6 +178,16 @@ class SubscriptionProcessor(object):
             # Only create a new incident if we don't already have an active one
             if not self.active_incident:
                 detected_at = self.last_update
+                # Subscriptions label buckets by the end of the bucket, whereas discover
+                # labels them by the front. This causes us an off-by-one error with
+                # alert start dates, so to prevent this we subtract a bucket off of the
+                # start date.
+                # We also multiply by threshold_period so that we can show when the
+                # alert actually started happening, rather than when we detected it.
+                detected_at -= timedelta(
+                    seconds=self.alert_rule.snuba_query.time_window
+                    * self.alert_rule.threshold_period
+                )
                 self.active_incident = create_incident(
                     self.alert_rule.organization,
                     IncidentType.ALERT_TRIGGERED,

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -254,6 +254,9 @@ class ProcessUpdateTest(TestCase):
         processor = self.send_update(rule, trigger.alert_threshold + 1)
         self.assert_trigger_counts(processor, self.trigger, 0, 0)
         incident = self.assert_active_incident(rule)
+        assert incident.date_started == (
+            timezone.now().replace(microsecond=0) - timedelta(seconds=rule.snuba_query.time_window)
+        )
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
         self.assert_actions_fired_for_incident(incident, [self.action])
 


### PR DESCRIPTION
This fixes an issue caused by discover queries aligning to the start of a bucket, whereas
subscriptions align to the end. To fix this, we just subtract time_window from the subscription
start date.

I was going to fix the data in this pr, but it's tricky to make the migration idempotent, since we
don't have a great way to mark an incident as having been migrated, and we don't want to risk
accidentally moving the date too far forward. I might follow up in a new pr, or we could just wait
for old data to be irrelevant.