### PR TITLE
feat(discover): Per-cell enhancements 

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -63,7 +63,11 @@ const isSortEqualToField = (
   return sort.field === sortKey;
 };
 
-const fieldToSort = (field: Field, tableMeta: MetaType | undefined): Sort | undefined => {
+export const fieldToSort = (
+  field: Field,
+  tableMeta: MetaType | undefined,
+  kind?: 'desc' | 'asc'
+): Sort | undefined => {
   const sortKey = getSortKeyFromField(field, tableMeta);
 
   if (!sortKey) {
@@ -71,7 +75,7 @@ const fieldToSort = (field: Field, tableMeta: MetaType | undefined): Sort | unde
   }
 
   return {
-    kind: 'desc',
+    kind: kind || 'desc',
     field: sortKey,
   };
 };

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -563,7 +563,7 @@ class EventView {
 
   withSorts(sorts: Sort[]): EventView {
     const newEventView = this.clone();
-    const fields = newEventView.fields.map(field => field.field);
+    const fields = newEventView.fields.map(field => getAggregateAlias(field.field));
     newEventView.sorts = sorts.filter(sort => fields.includes(sort.field));
 
     return newEventView;

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -49,6 +49,11 @@ const EXTERNAL_QUERY_STRING_KEYS: Readonly<Array<keyof LocationQuery>> = [
   'cursor',
 ];
 
+const setSortOrder = (sort: Sort, kind: 'desc' | 'asc'): Sort => ({
+  kind,
+  field: sort.field,
+});
+
 const reverseSort = (sort: Sort): Sort => ({
   kind: sort.kind === 'desc' ? 'asc' : 'desc',
   field: sort.field,
@@ -63,7 +68,7 @@ const isSortEqualToField = (
   return sort.field === sortKey;
 };
 
-export const fieldToSort = (
+const fieldToSort = (
   field: Field,
   tableMeta: MetaType | undefined,
   kind?: 'desc' | 'asc'
@@ -926,7 +931,7 @@ class EventView {
     return this.sorts.find(sort => isSortEqualToField(sort, field, tableMeta));
   }
 
-  sortOnField(field: Field, tableMeta: MetaType): EventView {
+  sortOnField(field: Field, tableMeta: MetaType, kind?: 'desc' | 'asc'): EventView {
     // check if field can be sorted
     if (!isFieldSortable(field, tableMeta)) {
       return this;
@@ -942,7 +947,9 @@ class EventView {
       const currentSort = this.sorts[needleIndex];
 
       const sorts = [...newEventView.sorts];
-      sorts[needleIndex] = reverseSort(currentSort);
+      sorts[needleIndex] = kind
+        ? setSortOrder(currentSort, kind)
+        : reverseSort(currentSort);
 
       newEventView.sorts = sorts;
 
@@ -953,7 +960,7 @@ class EventView {
     const newEventView = this.clone();
 
     // invariant: this is not falsey, since sortKey exists
-    const sort = fieldToSort(field, tableMeta)!;
+    const sort = fieldToSort(field, tableMeta, kind)!;
 
     newEventView.sorts = [sort];
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -171,6 +171,10 @@ export default class CellAction extends React.Component<Props, State> {
       }
     }
 
+    if (actions.length === 0) {
+      return null;
+    }
+
     return (
       <MenuButtons
         onClick={event => {
@@ -185,6 +189,13 @@ export default class CellAction extends React.Component<Props, State> {
 
   renderMenu() {
     const {isOpen} = this.state;
+
+    const menuButtons = this.renderMenuButtons();
+
+    if (menuButtons === null) {
+      // do not render the menu if there are no per cell actions
+      return null;
+    }
 
     const modifiers: PopperJS.Modifiers = {
       hide: {
@@ -214,7 +225,7 @@ export default class CellAction extends React.Component<Props, State> {
                 data-placement={placement}
                 style={arrowProps.style}
               />
-              {this.renderMenuButtons()}
+              {menuButtons}
             </Menu>
           )}
         </Popper>,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -7,7 +7,7 @@ import {Manager, Reference, Popper} from 'react-popper';
 
 import {t} from 'app/locale';
 import {IconEllipsis} from 'app/icons';
-import EventView from 'app/utils/discover/eventView';
+import EventView, {MetaType, fieldToSort} from 'app/utils/discover/eventView';
 import space from 'app/styles/space';
 import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
 import {OrganizationSummary} from 'app/types';
@@ -28,6 +28,7 @@ type Props = {
   organization: OrganizationSummary;
   column: TableColumn<keyof TableDataRow>;
   dataRow: TableDataRow;
+  tableMeta: MetaType;
   children: React.ReactNode;
 };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -19,6 +19,8 @@ import {TableColumn, TableDataRow} from './types';
 enum Actions {
   ADD = 'add',
   EXCLUDE = 'exclude',
+  SHOW_GREATER_THAN = 'show_greater_than',
+  SHOW_LESS_THAN = 'show_less_than',
 }
 
 type Props = {
@@ -114,6 +116,16 @@ export default class CellAction extends React.Component<Props, State> {
         }
         query[negation].push(`${value}`);
         break;
+      case Actions.SHOW_GREATER_THAN:
+        // Remove query token if it already exists
+        delete query[`${column.name}`];
+        query[column.name] = [`>${value}`];
+        break;
+      case Actions.SHOW_LESS_THAN:
+        // Remove query token if it already exists
+        delete query[`${column.name}`];
+        query[column.name] = [`<${value}`];
+        break;
       default:
         throw new Error(`Unknown action type. ${action}`);
     }
@@ -156,19 +168,37 @@ export default class CellAction extends React.Component<Props, State> {
         </ActionItem>
       );
 
-      if (column.column.kind !== 'function') {
-        // we cannot add negation filters on functions
+      actions.push(
+        <ActionItem
+          key="exclude-from-filter"
+          data-test-id="exclude-from-filter"
+          onClick={() => this.handleCellAction(Actions.EXCLUDE, value)}
+        >
+          {t('Exclude from filter')}
+        </ActionItem>
+      );
+    }
 
-        actions.push(
-          <ActionItem
-            key="exclude-from-filter"
-            data-test-id="exclude-from-filter"
-            onClick={() => this.handleCellAction(Actions.EXCLUDE, value)}
-          >
-            {t('Exclude from filter')}
-          </ActionItem>
-        );
-      }
+    if (column.type !== 'string' && column.type !== 'boolean') {
+      actions.push(
+        <ActionItem
+          key="show-values-greater-than"
+          data-test-id="show-values-greater-than"
+          onClick={() => this.handleCellAction(Actions.SHOW_GREATER_THAN, value)}
+        >
+          {t('Show values greater than')}
+        </ActionItem>
+      );
+
+      actions.push(
+        <ActionItem
+          key="show-values-less-than"
+          data-test-id="show-values-less-than"
+          onClick={() => this.handleCellAction(Actions.SHOW_LESS_THAN, value)}
+        >
+          {t('Show values less than')}
+        </ActionItem>
+      );
     }
 
     if (actions.length === 0) {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -24,6 +24,7 @@ enum Actions {
   SHOW_GREATER_THAN = 'show_greater_than',
   SHOW_LESS_THAN = 'show_less_than',
   TRANSACTION = 'transaction',
+  RELEASE = 'release',
 }
 
 type Props = {
@@ -173,6 +174,20 @@ class CellAction extends React.Component<Props, State> {
         browserHistory.push(next);
         return;
       }
+      case Actions.RELEASE: {
+        const maybeProject = projects.find(project => {
+          return project.slug === dataRow.project;
+        });
+
+        browserHistory.push({
+          pathname: `/organizations/${organization.slug}/releases/${encodeURIComponent(
+            value
+          )}/`,
+          query: {project: maybeProject ? maybeProject.id : undefined},
+        });
+
+        return;
+      }
       default:
         throw new Error(`Unknown action type. ${action}`);
     }
@@ -246,6 +261,18 @@ class CellAction extends React.Component<Props, State> {
           onClick={() => this.handleCellAction(Actions.TRANSACTION, value)}
         >
           {t('Go to summary')}
+        </ActionItem>
+      );
+    }
+
+    if (column.column.kind === 'field' && column.column.field === 'release') {
+      actions.push(
+        <ActionItem
+          key="release"
+          data-test-id="release"
+          onClick={() => this.handleCellAction(Actions.RELEASE, value)}
+        >
+          {t('Go to release')}
         </ActionItem>
       );
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -95,7 +95,7 @@ export default class CellAction extends React.Component<Props, State> {
     });
   };
 
-  handleUpdateSearch = (action: Actions, value: React.ReactText) => {
+  handleCellAction = (action: Actions, value: React.ReactText) => {
     const {eventView, column, organization} = this.props;
     const query = tokenizeSearch(eventView.query);
     switch (action) {
@@ -150,7 +150,7 @@ export default class CellAction extends React.Component<Props, State> {
         <ActionItem
           key="add-to-filter"
           data-test-id="add-to-filter"
-          onClick={() => this.handleUpdateSearch(Actions.ADD, value)}
+          onClick={() => this.handleCellAction(Actions.ADD, value)}
         >
           {t('Add to filter')}
         </ActionItem>
@@ -163,7 +163,7 @@ export default class CellAction extends React.Component<Props, State> {
           <ActionItem
             key="exclude-from-filter"
             data-test-id="exclude-from-filter"
-            onClick={() => this.handleUpdateSearch(Actions.EXCLUDE, value)}
+            onClick={() => this.handleCellAction(Actions.EXCLUDE, value)}
           >
             {t('Exclude from filter')}
           </ActionItem>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -7,7 +7,7 @@ import {Manager, Reference, Popper} from 'react-popper';
 
 import {t} from 'app/locale';
 import {IconEllipsis} from 'app/icons';
-import EventView, {MetaType, fieldToSort} from 'app/utils/discover/eventView';
+import EventView, {MetaType} from 'app/utils/discover/eventView';
 import space from 'app/styles/space';
 import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
 import {OrganizationSummary, Project} from 'app/types';
@@ -140,7 +140,7 @@ class CellAction extends React.Component<Props, State> {
         const field = {field: column.name, width: column.width};
 
         // sort descending order
-        nextView = nextView.withSorts([fieldToSort(field, tableMeta, 'desc')!]);
+        nextView = nextView.sortOnField(field, tableMeta, 'desc');
 
         break;
       }
@@ -151,7 +151,7 @@ class CellAction extends React.Component<Props, State> {
         const field = {field: column.name, width: column.width};
 
         // sort ascending order
-        nextView = nextView.withSorts([fieldToSort(field, tableMeta, 'asc')!]);
+        nextView = nextView.sortOnField(field, tableMeta, 'asc');
 
         break;
       }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -134,13 +134,58 @@ export default class CellAction extends React.Component<Props, State> {
     this.setState({isOpen: !this.state.isOpen});
   };
 
-  renderMenu() {
+  renderMenuButtons() {
     const {dataRow, column} = this.props;
-    const {isOpen} = this.state;
 
-    const value = dataRow[column.name];
+    console.log('dataRow', dataRow);
+    console.log('column', column);
+
     const fieldAlias = getAggregateAlias(column.name);
     const value = dataRow[fieldAlias];
+
+    const actions: React.ReactNode[] = [];
+
+    if (column.type !== 'duration') {
+      actions.push(
+        <ActionItem
+          key="add-to-filter"
+          data-test-id="add-to-filter"
+          onClick={() => this.handleUpdateSearch(Actions.ADD, value)}
+        >
+          {t('Add to filter')}
+        </ActionItem>
+      );
+
+      if (column.column.kind !== 'function') {
+        // we cannot add negation filters on functions
+
+        actions.push(
+          <ActionItem
+            key="exclude-from-filter"
+            data-test-id="exclude-from-filter"
+            onClick={() => this.handleUpdateSearch(Actions.EXCLUDE, value)}
+          >
+            {t('Exclude from filter')}
+          </ActionItem>
+        );
+      }
+    }
+
+    return (
+      <MenuButtons
+        onClick={event => {
+          // prevent clicks from propagating further
+          event.stopPropagation();
+        }}
+      >
+        {actions}
+      </MenuButtons>
+    );
+  }
+
+  renderMenu() {
+    const {isOpen} = this.state;
+
     const modifiers: PopperJS.Modifiers = {
       hide: {
         enabled: false,
@@ -169,20 +214,7 @@ export default class CellAction extends React.Component<Props, State> {
                 data-placement={placement}
                 style={arrowProps.style}
               />
-              <MenuButtons>
-                <ActionItem
-                  data-test-id="add-to-filter"
-                  onClick={() => this.handleUpdateSearch(Actions.ADD, value)}
-                >
-                  {t('Add to filter')}
-                </ActionItem>
-                <ActionItem
-                  data-test-id="exclude-from-filter"
-                  onClick={() => this.handleUpdateSearch(Actions.EXCLUDE, value)}
-                >
-                  {t('Exclude from filter')}
-                </ActionItem>
-              </MenuButtons>
+              {this.renderMenuButtons()}
             </Menu>
           )}
         </Popper>,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -369,7 +369,7 @@ class CellAction extends React.Component<Props, State> {
       (column.column.function[0] === 'count' ||
         column.column.function[0] === 'count_unique');
 
-    if (value === null || shouldIgnoreColumn) {
+    if (value === null || value === undefined || shouldIgnoreColumn) {
       // per cell actions do not apply to values that are null
       return <React.Fragment>{children}</React.Fragment>;
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -168,7 +168,7 @@ class CellAction extends React.Component<Props, State> {
           orgSlug: organization.slug,
           transaction: String(value),
           projectID,
-          query: eventView.generateQueryStringObject(),
+          query: {},
         });
 
         browserHistory.push(next);

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -300,7 +300,13 @@ export default class CellAction extends React.Component<Props, State> {
     const fieldAlias = getAggregateAlias(column.name);
     const value = dataRow[fieldAlias];
 
-    if (value === null) {
+    // do not display per cell actions for count() and count_unique()
+    const shouldIgnoreColumn =
+      column.column.kind === 'function' &&
+      (column.column.function[0] === 'count' ||
+        column.column.function[0] === 'count_unique');
+
+    if (value === null || shouldIgnoreColumn) {
       // per cell actions do not apply to values that are null
       return <React.Fragment>{children}</React.Fragment>;
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -12,6 +12,7 @@ import space from 'app/styles/space';
 import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
 import {OrganizationSummary} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
+import {getAggregateAlias} from 'app/utils/discover/fields';
 
 import {TableColumn, TableDataRow} from './types';
 
@@ -138,6 +139,8 @@ export default class CellAction extends React.Component<Props, State> {
     const {isOpen} = this.state;
 
     const value = dataRow[column.name];
+    const fieldAlias = getAggregateAlias(column.name);
+    const value = dataRow[fieldAlias];
     const modifiers: PopperJS.Modifiers = {
       hide: {
         enabled: false,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -253,6 +253,15 @@ export default class CellAction extends React.Component<Props, State> {
     const {children} = this.props;
     const {isHovering} = this.state;
 
+    const {dataRow, column} = this.props;
+    const fieldAlias = getAggregateAlias(column.name);
+    const value = dataRow[fieldAlias];
+
+    if (value === null) {
+      // per cell actions do not apply to values that are null
+      return <React.Fragment>{children}</React.Fragment>;
+    }
+
     return (
       <Container
         onMouseEnter={this.handleMouseEnter}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -159,9 +159,7 @@ class CellAction extends React.Component<Props, State> {
       case Actions.TRANSACTION: {
         const maybeProject = projects.find(project => project.slug === dataRow.project);
 
-        const projectID = maybeProject
-          ? [maybeProject.id]
-          : eventView.project.map(id => String(id));
+        const projectID = maybeProject ? [maybeProject.id] : undefined;
 
         const next = transactionSummaryRouteWithQuery({
           orgSlug: organization.slug,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -125,7 +125,7 @@ class CellAction extends React.Component<Props, State> {
         break;
       case Actions.EXCLUDE:
         // Remove positive if it exists.
-        delete query[`${column.name}`];
+        delete query[column.name];
         // Negations should stack up.
         const negation = `!${column.name}`;
         if (!query.hasOwnProperty(negation)) {
@@ -135,7 +135,7 @@ class CellAction extends React.Component<Props, State> {
         break;
       case Actions.SHOW_GREATER_THAN: {
         // Remove query token if it already exists
-        delete query[`${column.name}`];
+        delete query[column.name];
         query[column.name] = [`>${value}`];
         const field = {field: column.name, width: column.width};
 
@@ -146,7 +146,7 @@ class CellAction extends React.Component<Props, State> {
       }
       case Actions.SHOW_LESS_THAN: {
         // Remove query token if it already exists
-        delete query[`${column.name}`];
+        delete query[column.name];
         query[column.name] = [`<${value}`];
         const field = {field: column.name, width: column.width};
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -368,7 +368,7 @@ class CellAction extends React.Component<Props, State> {
       (column.column.function[0] === 'count' ||
         column.column.function[0] === 'count_unique');
 
-    if (defined(value) || shouldIgnoreColumn) {
+    if (!defined(value) || shouldIgnoreColumn) {
       // per cell actions do not apply to values that are null
       return <React.Fragment>{children}</React.Fragment>;
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -182,7 +182,11 @@ class CellAction extends React.Component<Props, State> {
           pathname: `/organizations/${organization.slug}/releases/${encodeURIComponent(
             value
           )}/`,
-          query: {project: maybeProject ? maybeProject.id : undefined},
+          query: {
+            ...nextView.getGlobalSelection(),
+
+            project: maybeProject ? maybeProject.id : undefined,
+          },
         });
 
         return;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -156,9 +156,7 @@ class CellAction extends React.Component<Props, State> {
         break;
       }
       case Actions.TRANSACTION: {
-        const maybeProject = projects.find(project => {
-          return project.slug === dataRow.project;
-        });
+        const maybeProject = projects.find(project => project.slug === dataRow.project);
 
         const projectID = maybeProject
           ? [maybeProject.id]

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -6,6 +6,7 @@ import * as PopperJS from 'popper.js';
 import {Manager, Reference, Popper} from 'react-popper';
 
 import {t} from 'app/locale';
+import {defined} from 'app/utils';
 import {IconEllipsis} from 'app/icons';
 import EventView, {MetaType} from 'app/utils/discover/eventView';
 import space from 'app/styles/space';
@@ -367,7 +368,7 @@ class CellAction extends React.Component<Props, State> {
       (column.column.function[0] === 'count' ||
         column.column.function[0] === 'count_unique');
 
-    if (value === null || value === undefined || shouldIgnoreColumn) {
+    if (defined(value) || shouldIgnoreColumn) {
       // per cell actions do not apply to values that are null
       return <React.Fragment>{children}</React.Fragment>;
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -166,7 +166,14 @@ class TableView extends React.Component<TableViewProps> {
           location={location}
           tableMeta={tableData.meta}
         >
-          {fieldRenderer(dataRow, {organization, location})}
+          <CellAction
+            organization={organization}
+            eventView={eventView}
+            column={column}
+            dataRow={dataRow}
+          >
+            {fieldRenderer(dataRow, {organization, location})}
+          </CellAction>
         </ExpandAggregateRow>
       );
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -316,12 +316,7 @@ function ExpandAggregateRow(props: {
     );
   }
 
-  return (
-    <React.Fragment>
-      <div>{children}</div>
-      <div>per cell</div>
-    </React.Fragment>
-  );
+  return <React.Fragment>{children}</React.Fragment>;
 }
 
 const HeaderIcon = styled('span')`

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -171,6 +171,7 @@ class TableView extends React.Component<TableViewProps> {
             eventView={eventView}
             column={column}
             dataRow={dataRow}
+            tableMeta={tableData.meta}
           >
             {fieldRenderer(dataRow, {organization, location})}
           </CellAction>
@@ -185,6 +186,7 @@ class TableView extends React.Component<TableViewProps> {
         eventView={eventView}
         column={column}
         dataRow={dataRow}
+        tableMeta={tableData.meta}
       >
         {fieldRenderer(dataRow, {organization, location})}
       </CellAction>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -316,7 +316,12 @@ function ExpandAggregateRow(props: {
     );
   }
 
-  return <React.Fragment>{children}</React.Fragment>;
+  return (
+    <React.Fragment>
+      <div>{children}</div>
+      <div>per cell</div>
+    </React.Fragment>
+  );
 }
 
 const HeaderIcon = styled('span')`

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -1979,10 +1979,10 @@ describe('EventView.withSorts()', function() {
       fields: [{field: 'p50()'}],
     });
     const updated = eventView.withSorts([
-      {kind: 'desc', field: 'p50()'},
+      {kind: 'desc', field: 'p50'},
       {kind: 'asc', field: 'unknown'},
     ]);
-    expect(updated.sorts).toEqual([{kind: 'desc', field: 'p50()'}]);
+    expect(updated.sorts).toEqual([{kind: 'desc', field: 'p50'}]);
   });
 });
 

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -1930,6 +1930,25 @@ describe('EventView.sortOnField()', function() {
     expect(eventView2).toMatchObject(nextState);
   });
 
+  it('enforce sort order on sorted field', function() {
+    const eventView = new EventView(state);
+    expect(eventView).toMatchObject(state);
+
+    const field = state.fields[0];
+
+    const eventView2 = eventView.sortOnField(field, meta, 'asc');
+    expect(eventView2).toMatchObject({
+      ...state,
+      sorts: [{field: 'count', kind: 'asc'}],
+    });
+
+    const eventView3 = eventView.sortOnField(field, meta, 'desc');
+    expect(eventView3).toMatchObject({
+      ...state,
+      sorts: [{field: 'count', kind: 'desc'}],
+    });
+  });
+
   it('sort on new field', function() {
     const modifiedState = {
       ...state,
@@ -1951,6 +1970,24 @@ describe('EventView.sortOnField()', function() {
     };
 
     expect(eventView2).toMatchObject(nextState);
+
+    // enforce asc sort order
+
+    const eventView3 = eventView.sortOnField(field, meta, 'asc');
+
+    expect(eventView3).toMatchObject({
+      ...modifiedState,
+      sorts: [{field: 'title', kind: 'asc'}],
+    });
+
+    // enforce desc sort order
+
+    const eventView4 = eventView.sortOnField(field, meta, 'desc');
+
+    expect(eventView4).toMatchObject({
+      ...modifiedState,
+      sorts: [{field: 'title', kind: 'desc'}],
+    });
   });
 });
 

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -12,6 +12,7 @@ function makeWrapper(eventView, initial, columnIndex = 0) {
     transaction: 'best-transaction',
     count: 19,
     timestamp: '2020-06-09T01:46:25+00:00',
+    release: 'F2520C43515BD1F0E8A6BD46233324641A370BF6',
   };
   return mountWithTheme(
     <CellAction
@@ -29,8 +30,8 @@ describe('Discover -> CellAction', function() {
     query: {
       id: '42',
       name: 'best query',
-      field: ['transaction', 'count()', 'timestamp'],
-      widths: ['123', '456', '789'],
+      field: ['transaction', 'count()', 'timestamp', 'release'],
+      widths: ['437', '647', '416', '905'],
       sort: ['title'],
       query: 'event.type:transaction',
       project: [123],
@@ -134,6 +135,23 @@ describe('Discover -> CellAction', function() {
           query: undefined,
           project: ['123'],
           transaction: 'best-transaction',
+        }),
+      });
+    });
+
+    it('go to release button goes to release health page', function() {
+      wrapper = makeWrapper(view, initial, 3);
+      // Show button and menu.
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+
+      wrapper.find('button[data-test-id="release"]').simulate('click');
+
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname:
+          '/organizations/org-slug/releases/F2520C43515BD1F0E8A6BD46233324641A370BF6/',
+        query: expect.objectContaining({
+          project: undefined,
         }),
       });
     });

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -125,6 +125,19 @@ describe('Discover -> CellAction', function() {
       });
     });
 
+    it('go to summary button goes to transaction summary page', function() {
+      wrapper.find('button[data-test-id="transaction-summary"]').simulate('click');
+
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: '/organizations/org-slug/performance/summary/',
+        query: expect.objectContaining({
+          query: undefined,
+          project: ['123'],
+          transaction: 'best-transaction',
+        }),
+      });
+    });
+
     it('greater than button adds condition', function() {
       wrapper = makeWrapper(view, initial, 2);
       // Show button and menu.

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -133,7 +133,7 @@ describe('Discover -> CellAction', function() {
         pathname: '/organizations/org-slug/performance/summary/',
         query: expect.objectContaining({
           query: undefined,
-          project: ['123'],
+          project: undefined,
           transaction: 'best-transaction',
         }),
       });


### PR DESCRIPTION
- Add per-cell actions to aggregated columns as appropriate.
- Add "Show values greater than" action for cells that are neither boolean nor strings.
- Add "Show values less than" action for cells that are neither boolean nor strings.

<img width="248" alt="Screen Shot 2020-06-08 at 6 14 54 PM" src="https://user-images.githubusercontent.com/139499/84088578-d291c080-a9ba-11ea-8e94-5a6d5a9d051f.png">

- Add "Go to summary" action that'll redirect to the transaction summary page


<img width="679" alt="Screen Shot 2020-06-09 at 12 38 57 AM" src="https://user-images.githubusercontent.com/139499/84106670-c3763700-a9e9-11ea-8216-acbe1cbe5d60.png">

- Add "Go to release" action that'll redirect to the release health page


<img width="283" alt="Screen Shot 2020-06-09 at 12 59 57 AM" src="https://user-images.githubusercontent.com/139499/84107790-9d9e6180-a9ec-11ea-8cbd-abcec25d7b55.png">



## TODO

- [x] ~context menu is in the way of the drilldown link for `count()` and `count_unique()`~ EDIT: Spoke with @doralchan and @bowencai8 about this. Will just keep the context menu hidden for these functions in this PR.
- [x] Add "Go to release" action
- [x] Add "Go to [transaction] summary" action
- [x] apply sorting for "Show values greater/less than" actions