### PR TITLE
fix(discover): sum() and avg() aggregation functions only work on fields of type duration

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -104,7 +104,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['integer', 'number', 'duration'],
+        columnTypes: ['duration'],
         required: true,
       },
     ],

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -116,7 +116,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['integer', 'number', 'duration'],
+        columnTypes: ['duration'],
         required: true,
       },
     ],


### PR DESCRIPTION

<img width="769" alt="Screen Shot 2020-06-08 at 6 29 22 PM" src="https://user-images.githubusercontent.com/139499/84089221-69ab4800-a9bc-11ea-8d0b-d0abcdc17c08.png">

-----

As per https://github.com/getsentry/sentry/blob/b0657e41f0a899d8b71a2505988d5c3a86841c24/src/sentry/api/event_search.py#L1232-L1243

