### PR TITLE
feat(ecosystem): check installation status for Sentry apps

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -11,7 +11,7 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.coreapi import APIError
 from sentry.mediators import sentry_app_components
-from sentry.models import Project, SentryAppComponent
+from sentry.models import Project, SentryAppComponent, SentryAppInstallation
 
 
 class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
@@ -36,7 +36,7 @@ class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
 
         components = []
 
-        for install in organization.sentry_app_installations.all():
+        for install in SentryAppInstallation.get_installed_for_org(organization.id):
             _components = SentryAppComponent.objects.filter(sentry_app_id=install.sentry_app_id)
 
             if "filter" in request.GET:

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -107,3 +107,9 @@ class SentryAppInstallation(ParanoidModel):
     def save(self, *args, **kwargs):
         self.date_updated = timezone.now()
         return super(SentryAppInstallation, self).save(*args, **kwargs)
+
+    @classmethod
+    def get_installed_for_org(cls, organization_id):
+        return cls.objects.filter(
+            organization_id=organization_id, status=SentryAppInstallationStatus.INSTALLED
+        )

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from sentry.models import GroupAssignee
+from sentry.models import GroupAssignee, SentryAppInstallation
 from sentry.signals import issue_ignored, issue_assigned, issue_resolved
 from sentry.tasks.sentry_apps import workflow_notification
 
@@ -54,6 +54,8 @@ def send_workflow_webhooks(organization, issue, user, event, data=None):
 
 
 def installations_to_notify(organization, event):
-    installations = organization.sentry_app_installations.select_related("sentry_app")
+    installations = SentryAppInstallation.get_installed_for_org(organization.id).select_related(
+        "sentry_app"
+    )
 
     return [i for i in installations if event in i.sentry_app.events]

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -12,6 +12,7 @@ from sentry.models import SentryApp
 from sentry.utils.safe import safe_execute
 from sentry.utils import metrics
 from sentry.tasks.sentry_apps import notify_sentry_app
+from sentry.constants import SentryAppInstallationStatus
 
 
 class NotifyEventServiceForm(forms.Form):
@@ -88,7 +89,9 @@ class NotifyEventServiceAction(EventAction):
 
     def get_sentry_app_services(self):
         apps = SentryApp.objects.filter(
-            installations__organization_id=self.project.organization_id, is_alertable=True
+            installations__organization_id=self.project.organization_id,
+            is_alertable=True,
+            installations__status=SentryAppInstallationStatus.INSTALLED,
         ).distinct()
         results = [SentryAppService(app) for app in apps]
         return results

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -196,9 +196,8 @@ def installation_webhook(installation_id, user_id, *args, **kwargs):
     extra = {"installation_id": installation_id, "user_id": user_id}
 
     try:
-        install = SentryAppInstallation.objects.get(
-            id=installation_id, status=SentryAppInstallationStatus.INSTALLED
-        )
+        # we should send the webhook for pending installations on the install event in case that's part of the workflow
+        install = SentryAppInstallation.objects.get(id=installation_id)
     except SentryAppInstallation.DoesNotExist:
         logger.info("installation_webhook.missing_installation", extra=extra)
         return

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -25,6 +25,7 @@ from sentry.models import (
 )
 from sentry.models.sentryapp import VALID_EVENTS, track_response_code
 from sentry.utils.compat import filter
+from sentry.constants import SentryAppInstallationStatus
 
 logger = logging.getLogger("sentry.tasks.sentry_apps")
 
@@ -90,7 +91,9 @@ def send_alert_event(event, rule, sentry_app_id):
 
     try:
         install = SentryAppInstallation.objects.get(
-            organization=organization.id, sentry_app=sentry_app
+            organization=organization.id,
+            sentry_app=sentry_app,
+            status=SentryAppInstallationStatus.INSTALLED,
         )
     except SentryAppInstallation.DoesNotExist:
         logger.info("event_alert_webhook.missing_installation", extra=extra)
@@ -158,7 +161,7 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
 
     installations = filter(
         lambda i: event in i.sentry_app.events,
-        org.sentry_app_installations.select_related("sentry_app"),
+        SentryAppInstallation.get_installed_for_org(org.id).select_related("sentry_app"),
     )
 
     for installation in installations:
@@ -193,7 +196,9 @@ def installation_webhook(installation_id, user_id, *args, **kwargs):
     extra = {"installation_id": installation_id, "user_id": user_id}
 
     try:
-        install = SentryAppInstallation.objects.get(id=installation_id)
+        install = SentryAppInstallation.objects.get(
+            id=installation_id, status=SentryAppInstallationStatus.INSTALLED
+        )
     except SentryAppInstallation.DoesNotExist:
         logger.info("installation_webhook.missing_installation", extra=extra)
         return
@@ -213,7 +218,9 @@ def workflow_notification(installation_id, issue_id, type, user_id, *args, **kwa
     extra = {"installation_id": installation_id, "issue_id": issue_id}
 
     try:
-        install = SentryAppInstallation.objects.get(id=installation_id)
+        install = SentryAppInstallation.objects.get(
+            id=installation_id, status=SentryAppInstallationStatus.INSTALLED
+        )
     except SentryAppInstallation.DoesNotExist:
         logger.info("workflow_notification.missing_installation", extra=extra)
         return

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -20,7 +20,7 @@ from django.utils import timezone
 from django.utils.text import slugify
 
 from sentry.event_manager import EventManager
-from sentry.constants import SentryAppStatus
+from sentry.constants import SentryAppStatus, SentryAppInstallationStatus
 from sentry.incidents.logic import (
     create_alert_rule,
     create_alert_rule_trigger,
@@ -659,17 +659,20 @@ class Factories(object):
         return _kwargs
 
     @staticmethod
-    def create_sentry_app_installation(organization=None, slug=None, user=None):
+    def create_sentry_app_installation(organization=None, slug=None, user=None, status=None):
         if not organization:
             organization = Factories.create_organization()
 
         Factories.create_project(organization=organization)
 
-        return sentry_app_installations.Creator.run(
+        install = sentry_app_installations.Creator.run(
             slug=(slug or Factories.create_sentry_app().slug),
             organization=organization,
             user=(user or Factories.create_user()),
         )
+        install.status = SentryAppInstallationStatus.INSTALLED if status is None else status
+        install.save()
+        return install
 
     @staticmethod
     def create_issue_link_schema():

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -6,6 +6,7 @@ from sentry.utils.compat.mock import patch
 from sentry.testutils import APITestCase
 import responses
 from sentry.mediators.token_exchange import GrantExchanger
+from sentry.constants import SentryAppInstallationStatus
 
 
 class SentryAppInstallationDetailsTest(APITestCase):
@@ -23,13 +24,19 @@ class SentryAppInstallationDetailsTest(APITestCase):
         )
 
         self.installation = self.create_sentry_app_installation(
-            slug=self.published_app.slug, organization=self.super_org, user=self.superuser
+            slug=self.published_app.slug,
+            organization=self.super_org,
+            user=self.superuser,
+            status=SentryAppInstallationStatus.PENDING,
         )
 
         self.unpublished_app = self.create_sentry_app(name="Testin", organization=self.org)
 
         self.installation2 = self.create_sentry_app_installation(
-            slug=self.unpublished_app.slug, organization=self.org, user=self.user
+            slug=self.unpublished_app.slug,
+            organization=self.org,
+            user=self.user,
+            status=SentryAppInstallationStatus.PENDING,
         )
 
         self.url = reverse(

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -43,7 +43,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
                 "organization": {"slug": self.org.slug},
                 "uuid": self.installation2.uuid,
                 "code": self.installation2.api_grant.code,
-                "status": "pending",
+                "status": "installed",
             }
         ]
 
@@ -58,7 +58,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
                 "organization": {"slug": self.super_org.slug},
                 "uuid": self.installation.uuid,
                 "code": self.installation.api_grant.code,
-                "status": "pending",
+                "status": "installed",
             }
         ]
 
@@ -73,7 +73,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
                 "organization": {"slug": self.org.slug},
                 "uuid": self.installation2.uuid,
                 "code": self.installation2.api_grant.code,
-                "status": "pending",
+                "status": "installed",
             }
         ]
 

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -7,6 +7,7 @@ from sentry.utils.compat.mock import patch, call
 
 from sentry.coreapi import APIError
 from sentry.testutils import APITestCase
+from sentry.constants import SentryAppInstallationStatus
 
 
 class SentryAppComponentsTest(APITestCase):
@@ -68,6 +69,12 @@ class OrganizationSentryAppComponentsTest(APITestCase):
 
         self.install2 = self.create_sentry_app_installation(
             slug=self.sentry_app2.slug, organization=self.org
+        )
+
+        self.install3 = self.create_sentry_app_installation(
+            slug=self.sentry_app3.slug,
+            organization=self.org,
+            status=SentryAppInstallationStatus.PENDING,
         )
 
         self.component1 = self.sentry_app1.components.first()

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -60,7 +60,7 @@ class TestInstallationNotifier(TestCase):
                         "organization": {"slug": self.org.slug},
                         "uuid": self.install.uuid,
                         "code": self.install.api_grant.code,
-                        "status": "pending",
+                        "status": "installed",
                     }
                 },
                 "actor": {"id": self.user.id, "name": self.user.name, "type": "user"},
@@ -94,7 +94,7 @@ class TestInstallationNotifier(TestCase):
                         "organization": {"slug": self.org.slug},
                         "uuid": self.install.uuid,
                         "code": self.install.api_grant.code,
-                        "status": "pending",
+                        "status": "installed",
                     }
                 },
                 "actor": {"id": self.user.id, "name": self.user.name, "type": "user"},

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -5,6 +5,7 @@ from sentry.utils.compat.mock import patch
 from sentry.models import Commit, GroupAssignee, GroupLink, Repository, Release
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.faux import faux
+from sentry.constants import SentryAppInstallationStatus
 
 
 # This testcase needs to be an APITestCase because all of the logic to resolve
@@ -144,6 +145,13 @@ class TestIssueWorkflowNotifications(APITestCase):
             user_id=self.user.id,
             data={},
         )
+
+    def test_notify_pending_installation(self, delay):
+        self.install.status = SentryAppInstallationStatus.PENDING
+        self.install.save()
+
+        self.update_issue()
+        assert not delay.called
 
 
 @patch("sentry.tasks.sentry_apps.workflow_notification.delay")


### PR DESCRIPTION
This PR adds a check to see if the Sentry App installation is actually `INSTALLED` instead of `PENDING`. I added this check in the following places:

- Loading UI components
- Alert rules
- Webhooks

Note that in pretty much all of these places, we aren't using an index on the query. This is not ideal but we weren't using an index before since this is a paranoid model and every query checks `date_deleted`. However, there are only like 4k rows in the installation table so the table scan isn't so bad. In the future, we might want to add indices to support the queries we use.