### PR TITLE
fix(discover2): Fix withSorts() by matching fields to their aggregated aliases

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -563,7 +563,7 @@ class EventView {
 
   withSorts(sorts: Sort[]): EventView {
     const newEventView = this.clone();
-    const fields = newEventView.fields.map(field => field.field);
+    const fields = newEventView.fields.map(field => getAggregateAlias(field.field));
     newEventView.sorts = sorts.filter(sort => fields.includes(sort.field));
 
     return newEventView;

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -1979,10 +1979,10 @@ describe('EventView.withSorts()', function() {
       fields: [{field: 'p50()'}],
     });
     const updated = eventView.withSorts([
-      {kind: 'desc', field: 'p50()'},
+      {kind: 'desc', field: 'p50'},
       {kind: 'asc', field: 'unknown'},
     ]);
-    expect(updated.sorts).toEqual([{kind: 'desc', field: 'p50()'}]);
+    expect(updated.sorts).toEqual([{kind: 'desc', field: 'p50'}]);
   });
 });
 


### PR DESCRIPTION
`EventView.withSorts()` was added in https://github.com/getsentry/sentry/pull/19009

Needed for https://github.com/getsentry/sentry/pull/19230