### PR TITLE
ref(config): Rename config to SENTRY_TRUSTED_RELAY_PKS

### DIFF
--- a/src/sentry/api/endpoints/relay_index.py
+++ b/src/sentry/api/endpoints/relay_index.py
@@ -22,7 +22,7 @@ class RelayIndexEndpoint(Endpoint):
 
         :auth: required
         """
-        queryset = Relay.objects.filter(public_key__in=settings.SENTRY_RELAY_WHITELIST_PK)
+        queryset = Relay.objects.filter(public_key__in=settings.SENTRY_TRUSTED_RELAY_PKS)
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/relay_register.py
+++ b/src/sentry/api/endpoints/relay_register.py
@@ -45,7 +45,7 @@ def is_internal_relay(request, public_key):
     if (
         settings.DEBUG
         or request.META.get("REMOTE_ADDR", None) in settings.INTERNAL_IPS
-        or public_key in settings.SENTRY_RELAY_WHITELIST_PK
+        or public_key in settings.SENTRY_TRUSTED_RELAY_PKS
     ):
         return True
     return False

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1757,7 +1757,7 @@ SENTRY_BUILTIN_SOURCES = {
 # Relay
 # List of PKs whitelisted by Sentry.  All relays here are always
 # registered as internal relays.
-SENTRY_RELAY_WHITELIST_PK = [
+SENTRY_TRUSTED_RELAY_PKS = [
     # NOTE (RaduW) This is the relay key for the relay instance used by devservices.
     # This should NOT be part of any production environment.
     # This key should match the key in /sentry/config/relay/credentials.json

--- a/src/sentry/testutils/relay.py
+++ b/src/sentry/testutils/relay.py
@@ -59,7 +59,7 @@ def adjust_settings_for_relay_tests(settings):
             "message.max.bytes": 50000000,  # 50MB, default is 1MB
         }
     }
-    settings.SENTRY_RELAY_WHITELIST_PK = ["SMSesqan65THCV6M4qs4kBzPai60LzuDn-xNsvYpuP8"]
+    settings.SENTRY_TRUSTED_RELAY_PKS = ["SMSesqan65THCV6M4qs4kBzPai60LzuDn-xNsvYpuP8"]
 
 
 class SentryStoreHelper(object):

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -21,7 +21,7 @@ class RelayRegisterTest(APITestCase):
         self.key_pair = generate_key_pair()
 
         self.public_key = self.key_pair[1]
-        settings.SENTRY_RELAY_WHITELIST_PK.append(six.binary_type(self.public_key))
+        settings.SENTRY_TRUSTED_RELAY_PKS.append(six.binary_type(self.public_key))
 
         self.private_key = self.key_pair[0]
         self.relay_id = six.binary_type(six.text_type(uuid4()).encode("ascii"))
@@ -185,7 +185,7 @@ class RelayRegisterTest(APITestCase):
 
         keys = generate_key_pair()
 
-        settings.SENTRY_RELAY_WHITELIST_PK.append(six.binary_type(keys[1]))
+        settings.SENTRY_TRUSTED_RELAY_PKS.append(six.binary_type(keys[1]))
 
         data = {"public_key": six.binary_type(keys[1]), "relay_id": self.relay_id}
 


### PR DESCRIPTION
Renames the setting for trusted Relays to more sensitive language.

Requires https://github.com/getsentry/getsentry/pull/3988