### PR TITLE
fix(ui): Update repositories when changing project in debug files

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -154,6 +154,7 @@ export type Project = {
   // XXX: These are part of the DetailedProject serializer
   plugins: Plugin[];
   processingIssues: number;
+  builtinSymbolSources?: string[];
 } & AvatarProject;
 
 export type MinimalProject = Pick<Project, 'id' | 'slug'>;

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/index.tsx
@@ -17,6 +17,7 @@ import {Organization, Project} from 'app/types';
 import routeTitleGen from 'app/utils/routeTitle';
 import Checkbox from 'app/components/checkbox';
 import SearchBar from 'app/components/searchBar';
+import ProjectActions from 'app/actions/projectActions';
 
 import {DebugFile, BuiltinSymbolSource} from './types';
 import DebugFileRow from './debugFileRow';
@@ -175,6 +176,8 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
               initialData={project}
               apiMethod="PUT"
               apiEndpoint={`/projects/${orgId}/${projectId}/`}
+              onSubmitSuccess={ProjectActions.updateSuccess}
+              key={project.builtinSymbolSources?.join() || project.id}
             >
               <JsonForm
                 features={new Set(features)}


### PR DESCRIPTION
The Built-in Repositories section in the debug symbols project settings doesn’t properly update when switching projects and when going to other pages and back (without refresh).