### PR TITLE
fix(thread-selector): Fixed large space between selector item  in safari

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/option.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/option.tsx
@@ -26,6 +26,7 @@ type ThreadInfo = {
 const Option = ({id, details, name, crashed, crashedInfo}: Props) => {
   const {label = `<${t('unknown')}>`, filename = `<${t('unknown')}>`} = details;
   const optionName = name || `<${t('unknown')}>`;
+
   return (
     <Grid>
       <GridCell>
@@ -61,9 +62,9 @@ const Option = ({id, details, name, crashed, crashedInfo}: Props) => {
           {crashed ? (
             crashedInfo ? (
               <Tooltip
-                title={`${tct('errored with [crashedInfo]', {
+                title={tct('Errored with [crashedInfo]', {
                   crashedInfo: crashedInfo.values[0].type,
-                })}`}
+                })}
                 position="top"
               >
                 <IconFire color="red" />

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/styles.tsx
@@ -6,6 +6,7 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 const Grid = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   display: grid;
+  height: 100%;
   grid-gap: ${space(1)};
   align-items: center;
   grid-template-columns: 30px 2.5fr 4fr 0fr 40px;


### PR DESCRIPTION
Fixes ISSUE-883

**Description:** Thread menu has large spacing in Safari

Before:

![image](https://user-images.githubusercontent.com/29228205/84173383-852a5780-aa7d-11ea-8036-30260b2d3d36.png)

After:

![image](https://user-images.githubusercontent.com/29228205/84173347-7479e180-aa7d-11ea-9632-cb487d44250e.png)
