### PR TITLE
feat(ui): Add an application root view

### DIFF
--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -5,6 +5,12 @@
 import {t} from 'app/locale';
 import {Scope} from 'app/types';
 
+// This is considered the "default" route/view that users should be taken
+// to when the application does not have any further context
+//
+// e.g. loading app root or switching organization
+export const DEFAULT_APP_ROUTE = '/organizations/:orgSlug/issues/';
+
 export const API_ACCESS_SCOPES = [
   'project:read',
   'project:write',

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -971,6 +971,13 @@ function routes() {
       )}
 
       <Route path="/" component={errorHandler(App)}>
+        <IndexRoute
+          componentPromise={() =>
+            import(/* webpackChunkName: "AppRoot" */ 'app/views/app/root')
+          }
+          component={errorHandler(LazyLoad)}
+        />
+
         <Route
           path="/accept/:memberId/:token/"
           componentPromise={() =>

--- a/src/sentry/static/sentry/app/views/app/root.tsx
+++ b/src/sentry/static/sentry/app/views/app/root.tsx
@@ -1,0 +1,41 @@
+import {RouteComponentProps} from 'react-router/lib/Router';
+import {browserHistory} from 'react-router';
+import React from 'react';
+
+import {Config} from 'app/types';
+import {DEFAULT_APP_ROUTE} from 'app/constants';
+import replaceRouterParams from 'app/utils/replaceRouterParams';
+import withConfig from 'app/utils/withConfig';
+
+type Props = {
+  config: Config;
+} & RouteComponentProps<{}, {}>;
+
+/**
+ * This view is used when a user lands on the route `/` which historically
+ * is a server-rendered route which redirects the user to their last selected organization
+ *
+ * However, this does not work when in the experimental SPA mode (e.g. developing against a remote API,
+ * or a deploy preview), so we must replicate the functionality and redirect
+ * the user to the proper organization.
+ *
+ * TODO: There might be an edge case where user does not have `lastOrganization` set,
+ * in which case we should load their list of organizations and make a decision
+ */
+class AppRoot extends React.Component<Props> {
+  componentDidMount() {
+    const {config} = this.props;
+
+    if (config.lastOrganization) {
+      browserHistory.replace(
+        replaceRouterParams(DEFAULT_APP_ROUTE, {orgSlug: config.lastOrganization})
+      );
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default withConfig(AppRoot);

--- a/tests/js/spec/stores/organizationStore.spec.jsx
+++ b/tests/js/spec/stores/organizationStore.spec.jsx
@@ -59,7 +59,7 @@ describe('OrganizationStore', function() {
 
   it('errors correctly', async function() {
     const error = new Error('uh-oh');
-    error.statusText = 'NOT FOUND';
+    error.status = 404;
     OrganizationActions.fetchOrgError(error);
     await tick();
     expect(OrganizationStore.get()).toMatchObject({

--- a/tests/js/spec/stores/organizationStore.spec.jsx
+++ b/tests/js/spec/stores/organizationStore.spec.jsx
@@ -59,7 +59,7 @@ describe('OrganizationStore', function() {
 
   it('errors correctly', async function() {
     const error = new Error('uh-oh');
-    error.status = 404;
+    error.statusText = 'NOT FOUND';
     OrganizationActions.fetchOrgError(error);
     await tick();
     expect(OrganizationStore.get()).toMatchObject({


### PR DESCRIPTION
This adds a frontend view for the root route (`/`). This is used for our "SPA Mode", e.g. deploy previews, and soon for local development. It currently uses the users last used organization and redirects them to the issues stream. Previously, it would just display a blank page since it was an unhandled route.