### PR TITLE
fix(ui): Fix "organization not found error"

### DIFF
--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -50,8 +50,8 @@ const OrganizationStore = Reflux.createStore({
     this.organization = null;
     this.errorType = null;
 
-    switch (err.statusText) {
-      case 'NOT FOUND':
+    switch (err?.status) {
+      case 404:
         this.errorType = ORGANIZATION_FETCH_ERROR_TYPES.ORG_NOT_FOUND;
         break;
       default:

--- a/tests/js/spec/stores/organizationStore.spec.jsx
+++ b/tests/js/spec/stores/organizationStore.spec.jsx
@@ -59,7 +59,7 @@ describe('OrganizationStore', function() {
 
   it('errors correctly', async function() {
     const error = new Error('uh-oh');
-    error.statusText = 'NOT FOUND';
+    error.status = 404;
     OrganizationActions.fetchOrgError(error);
     await tick();
     expect(OrganizationStore.get()).toMatchObject({


### PR DESCRIPTION
Changed to compare against the status code instead of statusText as there
were some case sensitivity issues.