### PR TITLE
feat(async-csv): Add content-length header

### DIFF
--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -50,5 +50,6 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
         response = StreamingHttpResponse(
             iter(lambda: raw_file.read(4096), b""), content_type="text/csv"
         )
+        response["Content-Length"] = file.size
         response["Content-Disposition"] = u'attachment; filename="{}"'.format(file.name)
         return response


### PR DESCRIPTION
Add the Content-Length header to the download response so the browser can
display the size of the download rather than just show unknown.