### PR TITLE
feat(async-csv): Load up to 8Mb of data per batch

### DIFF
--- a/src/sentry/data_export/base.py
+++ b/src/sentry/data_export/base.py
@@ -4,6 +4,7 @@ import six
 from datetime import timedelta
 from enum import Enum
 
+MAX_BATCH_SIZE = 8 * 1024 * 1024
 EXPORTED_ROWS_LIMIT = 10000000
 SNUBA_MAX_RESULTS = 10000
 DEFAULT_EXPIRATION = timedelta(weeks=4)

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -131,7 +131,7 @@ def assemble_download(
         except MaxRetriesExceededError:
             return data_export.email_failure(message="Internal processing failure")
     else:
-        if rows and batch_offset >= batch_size and new_bytes_written and next_offset < export_limit:
+        if rows and len(rows) >= batch_size and new_bytes_written and next_offset < export_limit:
             assemble_download.delay(
                 data_export_id,
                 export_limit=export_limit,

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -88,21 +88,21 @@ def assemble_download(
             starting_pos = tf.tell()
 
             # the row offset relative to the start of the current task
-            # this offset tells you the number of rows written during this batch
-            batch_offset = 0
+            # this offset tells you the number of rows written during this batch fragment
+            fragment_offset = 0
 
             # the absolute row offset from the beginning of the export
-            next_offset = offset + batch_offset
+            next_offset = offset + fragment_offset
 
             while True:
-                # the number of rows to export in the next mini-batch
-                batch_row_count = min(batch_size, max(export_limit - next_offset, 1))
+                # the number of rows to export in the next batch fragment
+                fragment_row_count = min(batch_size, max(export_limit - next_offset, 1))
 
-                rows = process_rows(processor, data_export, batch_row_count, next_offset)
+                rows = process_rows(processor, data_export, fragment_row_count, next_offset)
                 writer.writerows(rows)
 
-                batch_offset += len(rows)
-                next_offset = offset + batch_offset
+                fragment_offset += len(rows)
+                next_offset = offset + fragment_offset
 
                 if (
                     not rows

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -126,7 +126,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
     @patch("sentry.tagstore.get_tag_key")
     @patch("sentry.utils.snuba.raw_query")
     @patch("sentry.data_export.models.ExportedData.email_failure")
-    def test_issues_by_tag_outside_retention(self, emailer, mock_query, mock_get_tag_key):
+    def test_issue_by_tag_outside_retention(self, emailer, mock_query, mock_get_tag_key):
         """
         When an issues by tag query goes outside the retention range, it returns 0 results.
         This gives us an empty CSV with just the headers.
@@ -194,6 +194,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
         error = emailer.call_args[1]["message"]
         assert error == "Requested project does not exist"
 
+    @patch("sentry.data_export.tasks.MAX_BATCH_SIZE", 35)
     @patch("sentry.data_export.tasks.MAX_FILE_SIZE", 55)
     @patch("sentry.data_export.models.ExportedData.email_success")
     def test_discover_export_file_too_large(self, emailer):

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -423,7 +423,7 @@ class AssembleDownloadLargeTest(TestCase, SnubaTestCase):
     def test_discover_large_batch(self, emailer):
         """
         Each row in this export requires exactly 13 bytes, with batch_size=3 and
-        MAX_BATCH_SIZE=200, this means that each batch can export 6 mini batches,
+        MAX_BATCH_SIZE=200, this means that each batch can export 6 batch fragments,
         each containing 3 rows for a total of 3 * 6 * 13 = 234 bytes per batch before
         it stops the current batch and starts another. This runs for 2 batches and
         during the 3rd batch, it will finish exporting all 50 rows.


### PR DESCRIPTION
It is quite likely that each batch of 10,000 rows is just over 1MB. This causes there to be a lot more file blobs than necessary to store the file as many of the blobs only contain ~100KB. This change allows each batch to download ~8MB of data before starting the next batch to

1. Reduce the number of file blobs needed to store the file.
2. Use each task more effectively by allowing it to run a little longer to minimize the overhead of starting tasks.

Sample export showing the every other file blob only contains ~100KB of data.

<img width="207" alt="Screen Shot 2020-06-10 at 11 00 47 AM" src="https://user-images.githubusercontent.com/10239353/84284037-b6506980-ab09-11ea-8c29-3e3d08e7a0ae.png">
