### PR TITLE
build(webpack): Save asset sizes somewhere more useful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -228,7 +228,7 @@ matrix:
 
     - python: 2.7
       name: 'Frontend [build]'
-      env: TEST_SUITE=js-build NODE_ENV=production
+      env: TEST_SUITE=js-build
       before_install:
         - *install_volta
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -228,7 +228,7 @@ matrix:
 
     - python: 2.7
       name: 'Frontend [build]'
-      env: TEST_SUITE=js-build
+      env: TEST_SUITE=js-build NODE_ENV=production
       before_install:
         - *install_volta
       install:

--- a/build-utils/sentry-instrumentation.js
+++ b/build-utils/sentry-instrumentation.js
@@ -137,20 +137,21 @@ class SentryInstrumentation {
     compiler.hooks.done.tapAsync(
       PLUGIN_NAME,
       async ({compilation, startTime, endTime}, done) => {
-        if (!this.Sentry) {
-          done();
-          return;
-        }
-        this.measureBuildTime(startTime / 1000, endTime / 1000);
-
+        // eslint-disable-next-line
+        console.log('webpack hook', IS_CI, this.initialBuild, TRAVIS_COMMIT);
         // Only record this once and only on Travis
         // Don't really care about asset sizes during local dev
         if (IS_CI && !this.initialBuild) {
           this.measureAssetSizes(compilation);
         }
 
+        if (this.Sentry) {
+          this.measureBuildTime(startTime / 1000, endTime / 1000);
+          await this.Sentry.flush();
+        }
+
         this.initialBuild = true;
-        await this.Sentry.flush();
+
         done();
       }
     );

--- a/build-utils/sentry-instrumentation.js
+++ b/build-utils/sentry-instrumentation.js
@@ -142,8 +142,7 @@ class SentryInstrumentation {
 
         // Only record this once and only on Travis
         // Don't really care about asset sizes during local dev
-        // if (!IS_TRAVIS && !this.initialBuild) {
-        if (!this.initialBuild) {
+        if (!IS_TRAVIS && !this.initialBuild) {
           this.measureAssetSizes(compilation);
         }
 

--- a/build-utils/sentry-instrumentation.js
+++ b/build-utils/sentry-instrumentation.js
@@ -13,7 +13,7 @@ const {
   TRAVIS_PULL_REQUEST,
   TRAVIS_PULL_REQUEST_BRANCH,
 } = process.env;
-const IS_TRAVIS = !!TRAVIS_COMMIT;
+const IS_CI = !!TRAVIS_COMMIT;
 
 const PLUGIN_NAME = 'SentryInstrumentation';
 const GB_BYTE = 1073741824;
@@ -36,11 +36,11 @@ class SentryInstrumentation {
 
     this.Sentry.init({
       dsn: 'https://3d282d186d924374800aa47006227ce9@sentry.io/2053674',
-      environment: IS_TRAVIS ? 'travis' : 'local',
+      environment: IS_CI ? 'ci' : 'local',
       tracesSampleRate: 1.0,
     });
 
-    if (IS_TRAVIS) {
+    if (IS_CI) {
       this.Sentry.setTag('branch', TRAVIS_PULL_REQUEST_BRANCH || TRAVIS_BRANCH);
       this.Sentry.setTag('pull_request', TRAVIS_PULL_REQUEST);
     }
@@ -76,7 +76,7 @@ class SentryInstrumentation {
               size,
               commit: TRAVIS_COMMIT,
               pull_request_number: TRAVIS_PULL_REQUEST,
-              environment: IS_TRAVIS ? 'ci' : '',
+              environment: IS_CI ? 'ci' : '',
             });
 
             const req = http.request({
@@ -142,7 +142,7 @@ class SentryInstrumentation {
 
         // Only record this once and only on Travis
         // Don't really care about asset sizes during local dev
-        if (!IS_TRAVIS && !this.initialBuild) {
+        if (!IS_CI && !this.initialBuild) {
           this.measureAssetSizes(compilation);
         }
 

--- a/build-utils/sentry-instrumentation.js
+++ b/build-utils/sentry-instrumentation.js
@@ -59,12 +59,8 @@ class SentryInstrumentation {
    */
   measureAssetSizes(compilation) {
     if (!SENTRY_WEBPACK_WEBHOOK_SECRET) {
-      // eslint-disable-next-line
-      console.log('no webhook secret');
       return;
     }
-    // eslint-disable-next-line
-    console.log('measureAssetSizes');
 
     [...compilation.entrypoints].forEach(([entrypointName, entry]) =>
       entry.chunks.forEach(chunk =>
@@ -137,8 +133,6 @@ class SentryInstrumentation {
     compiler.hooks.done.tapAsync(
       PLUGIN_NAME,
       async ({compilation, startTime, endTime}, done) => {
-        // eslint-disable-next-line
-        console.log('webpack hook', IS_CI, this.initialBuild, TRAVIS_COMMIT);
         // Only record this once and only on Travis
         // Don't really care about asset sizes during local dev
         if (IS_CI && !this.initialBuild) {

--- a/build-utils/sentry-instrumentation.js
+++ b/build-utils/sentry-instrumentation.js
@@ -1,7 +1,7 @@
 /*eslint-env node*/
 /*eslint import/no-nodejs-modules:0 */
 const crypto = require('crypto');
-const http = require('http');
+const https = require('https');
 const os = require('os');
 
 const {
@@ -79,10 +79,9 @@ class SentryInstrumentation {
               environment: IS_CI ? 'ci' : '',
             });
 
-            const req = http.request({
+            const req = https.request({
               host: 'product-eng-webhooks-vmrqv3f7nq-uw.a.run.app',
               path: '/metrics/webpack/webhook',
-              port: 80,
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',

--- a/build-utils/sentry-instrumentation.js
+++ b/build-utils/sentry-instrumentation.js
@@ -59,8 +59,12 @@ class SentryInstrumentation {
    */
   measureAssetSizes(compilation) {
     if (!SENTRY_WEBPACK_WEBHOOK_SECRET) {
+      // eslint-disable-next-line
+      console.log('no webhook secret');
       return;
     }
+    // eslint-disable-next-line
+    console.log('measureAssetSizes');
 
     [...compilation.entrypoints].forEach(([entrypointName, entry]) =>
       entry.chunks.forEach(chunk =>

--- a/build-utils/sentry-instrumentation.js
+++ b/build-utils/sentry-instrumentation.js
@@ -145,7 +145,7 @@ class SentryInstrumentation {
 
         // Only record this once and only on Travis
         // Don't really care about asset sizes during local dev
-        if (!IS_CI && !this.initialBuild) {
+        if (IS_CI && !this.initialBuild) {
           this.measureAssetSizes(compilation);
         }
 


### PR DESCRIPTION
Instead of using Sentry transactions to track webpack-built asset sizes, send to an existing project on GCP (https://github.com/getsentry/sentry-development-metrics) so that we can see how our asset sizes change over time.