### PR TITLE
feat(apm): Add per-cell enhancements to the Performance page

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -1,21 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import styled from '@emotion/styled';
-import {browserHistory} from 'react-router';
 import * as PopperJS from 'popper.js';
 import {Manager, Reference, Popper} from 'react-popper';
 
 import {t} from 'app/locale';
 import {defined} from 'app/utils';
 import {IconEllipsis} from 'app/icons';
-import EventView, {MetaType} from 'app/utils/discover/eventView';
 import space from 'app/styles/space';
-import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
-import {OrganizationSummary, Project} from 'app/types';
-import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {getAggregateAlias} from 'app/utils/discover/fields';
-import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
-import withProjects from 'app/utils/withProjects';
 
 import {TableColumn, TableDataRow} from './types';
 
@@ -29,12 +22,8 @@ export enum Actions {
 }
 
 type Props = {
-  eventView: EventView;
-  organization: OrganizationSummary;
-  projects: Project[];
   column: TableColumn<keyof TableDataRow>;
   dataRow: TableDataRow;
-  tableMeta: MetaType;
   children: React.ReactNode;
   handleCellAction: (action: Actions, value: React.ReactText) => void;
 };
@@ -103,99 +92,6 @@ class CellAction extends React.Component<Props, State> {
       }
       return {...state, isHovering: false};
     });
-  };
-
-  handleCellAction = (action: Actions, value: React.ReactText) => {
-    const {eventView, column, organization, tableMeta, projects, dataRow} = this.props;
-
-    const query = tokenizeSearch(eventView.query);
-
-    let nextView = eventView.clone();
-
-    trackAnalyticsEvent({
-      eventKey: 'discover_v2.results.cellaction',
-      eventName: 'Discoverv2: Cell Action Clicked',
-      organization_id: parseInt(organization.id, 10),
-      action,
-    });
-
-    switch (action) {
-      case Actions.ADD:
-        // Remove exclusion if it exists.
-        delete query[`!${column.name}`];
-        query[column.name] = [`${value}`];
-        break;
-      case Actions.EXCLUDE:
-        // Remove positive if it exists.
-        delete query[column.name];
-        // Negations should stack up.
-        const negation = `!${column.name}`;
-        if (!query.hasOwnProperty(negation)) {
-          query[negation] = [];
-        }
-        query[negation].push(`${value}`);
-        break;
-      case Actions.SHOW_GREATER_THAN: {
-        // Remove query token if it already exists
-        delete query[column.name];
-        query[column.name] = [`>${value}`];
-        const field = {field: column.name, width: column.width};
-
-        // sort descending order
-        nextView = nextView.sortOnField(field, tableMeta, 'desc');
-
-        break;
-      }
-      case Actions.SHOW_LESS_THAN: {
-        // Remove query token if it already exists
-        delete query[column.name];
-        query[column.name] = [`<${value}`];
-        const field = {field: column.name, width: column.width};
-
-        // sort ascending order
-        nextView = nextView.sortOnField(field, tableMeta, 'asc');
-
-        break;
-      }
-      case Actions.TRANSACTION: {
-        const maybeProject = projects.find(project => project.slug === dataRow.project);
-
-        const projectID = maybeProject ? [maybeProject.id] : undefined;
-
-        const next = transactionSummaryRouteWithQuery({
-          orgSlug: organization.slug,
-          transaction: String(value),
-          projectID,
-          query: {},
-        });
-
-        browserHistory.push(next);
-        return;
-      }
-      case Actions.RELEASE: {
-        const maybeProject = projects.find(project => {
-          return project.slug === dataRow.project;
-        });
-
-        browserHistory.push({
-          pathname: `/organizations/${organization.slug}/releases/${encodeURIComponent(
-            value
-          )}/`,
-          query: {
-            ...nextView.getGlobalSelection(),
-
-            project: maybeProject ? maybeProject.id : undefined,
-          },
-        });
-
-        return;
-      }
-      default:
-        throw new Error(`Unknown action type. ${action}`);
-    }
-    nextView.query = stringifyQueryObject(query);
-
-    browserHistory.push(nextView.getResultsViewUrlTarget(organization.slug));
   };
 
   handleMenuToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -388,7 +284,7 @@ class CellAction extends React.Component<Props, State> {
   }
 }
 
-export default withProjects(CellAction);
+export default CellAction;
 
 const Container = styled('div')`
   position: relative;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -36,6 +36,7 @@ type Props = {
   dataRow: TableDataRow;
   tableMeta: MetaType;
   children: React.ReactNode;
+  handleCellAction: (action: Actions, value: React.ReactText) => void;
 };
 
 type State = {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -26,6 +26,9 @@ type Props = {
   dataRow: TableDataRow;
   children: React.ReactNode;
   handleCellAction: (action: Actions, value: React.ReactText) => void;
+
+  // allow list of actions to display on the context menu
+  allowActions?: Actions[];
 };
 
 type State = {
@@ -100,15 +103,25 @@ class CellAction extends React.Component<Props, State> {
   };
 
   renderMenuButtons() {
-    const {dataRow, column, handleCellAction} = this.props;
+    const {dataRow, column, handleCellAction, allowActions} = this.props;
 
     const fieldAlias = getAggregateAlias(column.name);
     const value = dataRow[fieldAlias];
 
     const actions: React.ReactNode[] = [];
 
+    function addMenuItem(action: Actions, menuItem: React.ReactNode) {
+      if (
+        (Array.isArray(allowActions) && allowActions.includes(action)) ||
+        !allowActions
+      ) {
+        actions.push(menuItem);
+      }
+    }
+
     if (column.type !== 'duration') {
-      actions.push(
+      addMenuItem(
+        Actions.ADD,
         <ActionItem
           key="add-to-filter"
           data-test-id="add-to-filter"
@@ -118,7 +131,8 @@ class CellAction extends React.Component<Props, State> {
         </ActionItem>
       );
 
-      actions.push(
+      addMenuItem(
+        Actions.EXCLUDE,
         <ActionItem
           key="exclude-from-filter"
           data-test-id="exclude-from-filter"
@@ -130,7 +144,8 @@ class CellAction extends React.Component<Props, State> {
     }
 
     if (column.type !== 'string' && column.type !== 'boolean') {
-      actions.push(
+      addMenuItem(
+        Actions.SHOW_GREATER_THAN,
         <ActionItem
           key="show-values-greater-than"
           data-test-id="show-values-greater-than"
@@ -140,7 +155,8 @@ class CellAction extends React.Component<Props, State> {
         </ActionItem>
       );
 
-      actions.push(
+      addMenuItem(
+        Actions.SHOW_LESS_THAN,
         <ActionItem
           key="show-values-less-than"
           data-test-id="show-values-less-than"
@@ -152,7 +168,8 @@ class CellAction extends React.Component<Props, State> {
     }
 
     if (column.column.kind === 'field' && column.column.field === 'transaction') {
-      actions.push(
+      addMenuItem(
+        Actions.TRANSACTION,
         <ActionItem
           key="transaction-summary"
           data-test-id="transaction-summary"
@@ -164,7 +181,8 @@ class CellAction extends React.Component<Props, State> {
     }
 
     if (column.column.kind === 'field' && column.column.field === 'release') {
-      actions.push(
+      addMenuItem(
+        Actions.RELEASE,
         <ActionItem
           key="release"
           data-test-id="release"

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -19,7 +19,7 @@ import withProjects from 'app/utils/withProjects';
 
 import {TableColumn, TableDataRow} from './types';
 
-enum Actions {
+export enum Actions {
   ADD = 'add',
   EXCLUDE = 'exclude',
   SHOW_GREATER_THAN = 'show_greater_than',

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -204,7 +204,7 @@ class CellAction extends React.Component<Props, State> {
   };
 
   renderMenuButtons() {
-    const {dataRow, column} = this.props;
+    const {dataRow, column, handleCellAction} = this.props;
 
     const fieldAlias = getAggregateAlias(column.name);
     const value = dataRow[fieldAlias];
@@ -216,7 +216,7 @@ class CellAction extends React.Component<Props, State> {
         <ActionItem
           key="add-to-filter"
           data-test-id="add-to-filter"
-          onClick={() => this.handleCellAction(Actions.ADD, value)}
+          onClick={() => handleCellAction(Actions.ADD, value)}
         >
           {t('Add to filter')}
         </ActionItem>
@@ -226,7 +226,7 @@ class CellAction extends React.Component<Props, State> {
         <ActionItem
           key="exclude-from-filter"
           data-test-id="exclude-from-filter"
-          onClick={() => this.handleCellAction(Actions.EXCLUDE, value)}
+          onClick={() => handleCellAction(Actions.EXCLUDE, value)}
         >
           {t('Exclude from filter')}
         </ActionItem>
@@ -238,7 +238,7 @@ class CellAction extends React.Component<Props, State> {
         <ActionItem
           key="show-values-greater-than"
           data-test-id="show-values-greater-than"
-          onClick={() => this.handleCellAction(Actions.SHOW_GREATER_THAN, value)}
+          onClick={() => handleCellAction(Actions.SHOW_GREATER_THAN, value)}
         >
           {t('Show values greater than')}
         </ActionItem>
@@ -248,7 +248,7 @@ class CellAction extends React.Component<Props, State> {
         <ActionItem
           key="show-values-less-than"
           data-test-id="show-values-less-than"
-          onClick={() => this.handleCellAction(Actions.SHOW_LESS_THAN, value)}
+          onClick={() => handleCellAction(Actions.SHOW_LESS_THAN, value)}
         >
           {t('Show values less than')}
         </ActionItem>
@@ -260,7 +260,7 @@ class CellAction extends React.Component<Props, State> {
         <ActionItem
           key="transaction-summary"
           data-test-id="transaction-summary"
-          onClick={() => this.handleCellAction(Actions.TRANSACTION, value)}
+          onClick={() => handleCellAction(Actions.TRANSACTION, value)}
         >
           {t('Go to summary')}
         </ActionItem>
@@ -272,7 +272,7 @@ class CellAction extends React.Component<Props, State> {
         <ActionItem
           key="release"
           data-test-id="release"
-          onClick={() => this.handleCellAction(Actions.RELEASE, value)}
+          onClick={() => handleCellAction(Actions.RELEASE, value)}
         >
           {t('Go to release')}
         </ActionItem>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -174,11 +174,8 @@ class TableView extends React.Component<TableViewProps> {
           tableMeta={tableData.meta}
         >
           <CellAction
-            organization={organization}
-            eventView={eventView}
             column={column}
             dataRow={dataRow}
-            tableMeta={tableData.meta}
             handleCellAction={this.handleCellAction(dataRow, column, tableData.meta)}
           >
             {fieldRenderer(dataRow, {organization, location})}
@@ -190,11 +187,8 @@ class TableView extends React.Component<TableViewProps> {
     // Scalar fields offer cell actions to build queries.
     return (
       <CellAction
-        organization={organization}
-        eventView={eventView}
         column={column}
         dataRow={dataRow}
-        tableMeta={tableData.meta}
         handleCellAction={this.handleCellAction(dataRow, column, tableData.meta)}
       >
         {fieldRenderer(dataRow, {organization, location})}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -25,7 +25,7 @@ import {getExpandedResults, pushEventViewToLocation} from '../utils';
 import ColumnEditModal, {modalCss} from './columnEditModal';
 import {TableColumn, TableData, TableDataRow} from './types';
 import HeaderCell from './headerCell';
-import CellAction from './cellAction';
+import CellAction, {Actions} from './cellAction';
 import TableActions from './tableActions';
 
 export type TableViewProps = {
@@ -175,6 +175,7 @@ class TableView extends React.Component<TableViewProps> {
             column={column}
             dataRow={dataRow}
             tableMeta={tableData.meta}
+            handleCellAction={this.handleCellAction(column)}
           >
             {fieldRenderer(dataRow, {organization, location})}
           </CellAction>
@@ -190,6 +191,7 @@ class TableView extends React.Component<TableViewProps> {
         column={column}
         dataRow={dataRow}
         tableMeta={tableData.meta}
+        handleCellAction={this.handleCellAction(column)}
       >
         {fieldRenderer(dataRow, {organization, location})}
       </CellAction>
@@ -211,6 +213,13 @@ class TableView extends React.Component<TableViewProps> {
       ),
       {modalCss}
     );
+  };
+
+  handleCellAction = (column: TableColumn<keyof TableDataRow>) => {
+    return (action: Actions, value: React.ReactText) => {
+      console.log(action, value, column);
+      // const {eventView, organization, tableMeta, projects, dataRow} = this.props;
+    };
   };
 
   handleUpdateColumns = (columns: Column[]): void => {

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -9,6 +9,7 @@ import {TableData, TableDataRow, TableColumn} from 'app/views/eventsV2/table/typ
 import GridEditable, {COL_WIDTH_UNDEFINED, GridColumn} from 'app/components/gridEditable';
 import SortLink from 'app/components/gridEditable/sortLink';
 import HeaderCell from 'app/views/eventsV2/table/headerCell';
+import CellAction from 'app/views/eventsV2/table/cellAction';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
@@ -84,13 +85,31 @@ class Table extends React.Component<Props, State> {
         });
 
         rendered = (
-          <Link to={target} onClick={this.handleSummaryClick}>
-            {rendered}
-          </Link>
+          <CellAction
+            organization={organization}
+            eventView={eventView}
+            column={column}
+            dataRow={dataRow}
+            tableMeta={tableData.meta}
+          >
+            <Link to={target} onClick={this.handleSummaryClick}>
+              {rendered}
+            </Link>
+          </CellAction>
         );
       }
 
-      return rendered;
+      return (
+        <CellAction
+          organization={organization}
+          eventView={eventView}
+          column={column}
+          dataRow={dataRow}
+          tableMeta={tableData.meta}
+        >
+          {rendered}
+        </CellAction>
+      );
     };
   };
 

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -235,6 +235,11 @@ class Table extends React.Component<Props, State> {
         );
       }
 
+      if (field.startsWith('user_misery')) {
+        // don't display per cell actions for user_misery
+        return rendered;
+      }
+
       return (
         <CellAction
           column={column}

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -55,16 +55,18 @@ class Table extends React.Component<Props, State> {
     widths: [],
   };
 
-  renderBodyCell = (tableMeta: TableData['meta']) => {
+  renderBodyCell = (tableData: TableData | null) => {
     const {eventView, organization, projects, location, summaryConditions} = this.props;
 
     return (
       column: TableColumn<keyof TableDataRow>,
       dataRow: TableDataRow
     ): React.ReactNode => {
-      if (!tableMeta) {
-        return null;
+      if (!tableData || !tableData.meta) {
+        return dataRow[column.key];
       }
+      const tableMeta = tableData.meta;
+
       const field = String(column.key);
       const fieldRenderer = getFieldRenderer(field, tableMeta);
       let rendered = fieldRenderer(dataRow, {organization, location});
@@ -180,7 +182,7 @@ class Table extends React.Component<Props, State> {
                 grid={{
                   onResizeColumn: this.handleResizeColumn,
                   renderHeadCell: this.renderHeadCell(tableData?.meta) as any,
-                  renderBodyCell: this.renderBodyCell(tableData?.meta) as any,
+                  renderBodyCell: this.renderBodyCell(tableData) as any,
                 }}
                 location={location}
               />

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -202,6 +202,13 @@ class Table extends React.Component<Props, State> {
       const fieldRenderer = getFieldRenderer(field, tableMeta);
       let rendered = fieldRenderer(dataRow, {organization, location});
 
+      const allowActions = [
+        Actions.ADD,
+        Actions.EXCLUDE,
+        Actions.SHOW_GREATER_THAN,
+        Actions.SHOW_LESS_THAN,
+      ];
+
       if (field === 'transaction') {
         const projectID = getProjectID(dataRow, projects);
         const summaryView = eventView.clone();
@@ -219,6 +226,7 @@ class Table extends React.Component<Props, State> {
             column={column}
             dataRow={dataRow}
             handleCellAction={this.handleCellAction(dataRow, column, tableData.meta)}
+            allowActions={allowActions}
           >
             <Link to={target} onClick={this.handleSummaryClick}>
               {rendered}
@@ -232,6 +240,7 @@ class Table extends React.Component<Props, State> {
           column={column}
           dataRow={dataRow}
           handleCellAction={this.handleCellAction(dataRow, column, tableData.meta)}
+          allowActions={allowActions}
         >
           {rendered}
         </CellAction>

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -9,7 +9,7 @@ import {TableData, TableDataRow, TableColumn} from 'app/views/eventsV2/table/typ
 import GridEditable, {COL_WIDTH_UNDEFINED, GridColumn} from 'app/components/gridEditable';
 import SortLink from 'app/components/gridEditable/sortLink';
 import HeaderCell from 'app/views/eventsV2/table/headerCell';
-import CellAction from 'app/views/eventsV2/table/cellAction';
+import CellAction, {Actions} from 'app/views/eventsV2/table/cellAction';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
@@ -56,6 +56,13 @@ class Table extends React.Component<Props, State> {
     widths: [],
   };
 
+  handleCellAction = (column: TableColumn<keyof TableDataRow>) => {
+    return (action: Actions, value: React.ReactText) => {
+      console.log(action, value, column);
+      // const {eventView, organization, tableMeta, projects, dataRow} = this.props;
+    };
+  };
+
   renderBodyCell = (tableData: TableData | null) => {
     const {eventView, organization, projects, location, summaryConditions} = this.props;
 
@@ -91,6 +98,7 @@ class Table extends React.Component<Props, State> {
             column={column}
             dataRow={dataRow}
             tableMeta={tableData.meta}
+            handleCellAction={this.handleCellAction(column)}
           >
             <Link to={target} onClick={this.handleSummaryClick}>
               {rendered}
@@ -106,6 +114,7 @@ class Table extends React.Component<Props, State> {
           column={column}
           dataRow={dataRow}
           tableMeta={tableData.meta}
+          handleCellAction={this.handleCellAction(column)}
         >
           {rendered}
         </CellAction>

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -62,13 +62,9 @@ class Table extends React.Component<Props, State> {
     widths: [],
   };
 
-  handleCellAction = (
-    dataRow: TableDataRow,
-    column: TableColumn<keyof TableDataRow>,
-    tableMeta: MetaType
-  ) => {
+  handleCellAction = (column: TableColumn<keyof TableDataRow>, tableMeta: MetaType) => {
     return (action: Actions, value: React.ReactText) => {
-      const {eventView, organization, projects, location} = this.props;
+      const {eventView, location} = this.props;
 
       let nextLocationQuery: Location['query'] = {};
       const searchConditions = tokenizeSearch(eventView.query);
@@ -138,39 +134,6 @@ class Table extends React.Component<Props, State> {
 
           break;
         }
-        case Actions.TRANSACTION: {
-          const maybeProject = projects.find(project => project.slug === dataRow.project);
-
-          const projectID = maybeProject ? [maybeProject.id] : undefined;
-
-          const next = transactionSummaryRouteWithQuery({
-            orgSlug: organization.slug,
-            transaction: String(value),
-            projectID,
-            query: {},
-          });
-
-          ReactRouter.browserHistory.push(next);
-          return;
-        }
-        case Actions.RELEASE: {
-          const maybeProject = projects.find(project => {
-            return project.slug === dataRow.project;
-          });
-
-          ReactRouter.browserHistory.push({
-            pathname: `/organizations/${organization.slug}/releases/${encodeURIComponent(
-              value
-            )}/`,
-            query: {
-              ...eventView.getGlobalSelection(),
-
-              project: maybeProject ? maybeProject.id : undefined,
-            },
-          });
-
-          return;
-        }
         default:
           throw new Error(`Unknown action type. ${action}`);
       }
@@ -225,7 +188,7 @@ class Table extends React.Component<Props, State> {
           <CellAction
             column={column}
             dataRow={dataRow}
-            handleCellAction={this.handleCellAction(dataRow, column, tableData.meta)}
+            handleCellAction={this.handleCellAction(column, tableData.meta)}
             allowActions={allowActions}
           >
             <Link to={target} onClick={this.handleSummaryClick}>
@@ -244,7 +207,7 @@ class Table extends React.Component<Props, State> {
         <CellAction
           column={column}
           dataRow={dataRow}
-          handleCellAction={this.handleCellAction(dataRow, column, tableData.meta)}
+          handleCellAction={this.handleCellAction(column, tableData.meta)}
           allowActions={allowActions}
         >
           {rendered}

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -200,7 +200,7 @@ class Table extends React.Component<Props, State> {
 
       const field = String(column.key);
       const fieldRenderer = getFieldRenderer(field, tableMeta);
-      let rendered = fieldRenderer(dataRow, {organization, location});
+      const rendered = fieldRenderer(dataRow, {organization, location});
 
       const allowActions = [
         Actions.ADD,
@@ -221,7 +221,7 @@ class Table extends React.Component<Props, State> {
           projectID,
         });
 
-        rendered = (
+        return (
           <CellAction
             column={column}
             dataRow={dataRow}

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -64,13 +64,20 @@ class Table extends React.Component<Props, State> {
 
   handleCellAction = (column: TableColumn<keyof TableDataRow>, tableMeta: MetaType) => {
     return (action: Actions, value: React.ReactText) => {
-      const {eventView, location} = this.props;
+      const {eventView, location, organization} = this.props;
 
       let nextLocationQuery: Location['query'] = {};
       const searchConditions = tokenizeSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
       delete searchConditions['event.type'];
+
+      trackAnalyticsEvent({
+        eventKey: 'performance_views.overview.cellaction',
+        eventName: 'Performance Views: Cell Action Clicked',
+        organization_id: parseInt(organization.id, 10),
+        action,
+      });
 
       switch (action) {
         case Actions.ADD: {

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
-import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import CellAction from 'app/views/eventsV2/table/cellAction';
 import EventView from 'app/utils/discover/eventView';
 
-function makeWrapper(eventView, initial, columnIndex = 0) {
+function makeWrapper(eventView, handleCellAction, columnIndex = 0) {
   const data = {
     transaction: 'best-transaction',
     count: 19,
@@ -16,10 +14,10 @@ function makeWrapper(eventView, initial, columnIndex = 0) {
   };
   return mountWithTheme(
     <CellAction
-      organization={initial.organization}
       dataRow={data}
       eventView={eventView}
       column={eventView.getColumns()[columnIndex]}
+      handleCellAction={handleCellAction}
     >
       <strong>some content</strong>
     </CellAction>
@@ -43,10 +41,9 @@ describe('Discover -> CellAction', function() {
     },
   };
   const view = EventView.fromLocation(location);
-  const initial = initializeOrg();
 
   describe('hover menu button', function() {
-    const wrapper = makeWrapper(view, initial);
+    const wrapper = makeWrapper(view);
 
     it('shows no menu by default', function() {
       expect(wrapper.find('MenuButton')).toHaveLength(0);
@@ -62,7 +59,7 @@ describe('Discover -> CellAction', function() {
   });
 
   describe('opening the menu', function() {
-    const wrapper = makeWrapper(view, initial);
+    const wrapper = makeWrapper(view);
     wrapper.find('Container').simulate('mouseEnter');
 
     it('toggles the menu on click', function() {
@@ -77,117 +74,86 @@ describe('Discover -> CellAction', function() {
 
   describe('per cell actions', function() {
     let wrapper;
+    let handleCellAction;
     beforeEach(function() {
-      wrapper = makeWrapper(view, initial);
+      handleCellAction = jest.fn();
+      wrapper = makeWrapper(view, handleCellAction);
       // Show button and menu.
       wrapper.find('Container').simulate('mouseEnter');
       wrapper.find('MenuButton').simulate('click');
-
-      browserHistory.push.mockReset();
     });
 
     it('add button appends condition', function() {
       wrapper.find('button[data-test-id="add-to-filter"]').simulate('click');
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/discover/results/',
-        query: expect.objectContaining({
-          query: 'event.type:transaction transaction:best-transaction',
-        }),
-      });
+      expect(handleCellAction).toHaveBeenCalledWith('add', 'best-transaction');
     });
 
     it('exclude button adds condition', function() {
       wrapper.find('button[data-test-id="exclude-from-filter"]').simulate('click');
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/discover/results/',
-        query: expect.objectContaining({
-          query: 'event.type:transaction !transaction:best-transaction',
-        }),
-      });
+      expect(handleCellAction).toHaveBeenCalledWith('exclude', 'best-transaction');
     });
 
     it('exclude button appends exclusions', function() {
       const excludeView = EventView.fromLocation({
         query: {...location.query, query: '!transaction:nope'},
       });
-      wrapper = makeWrapper(excludeView, initial);
+      wrapper = makeWrapper(excludeView, handleCellAction);
       // Show button and menu.
       wrapper.find('Container').simulate('mouseEnter');
       wrapper.find('MenuButton').simulate('click');
       wrapper.find('button[data-test-id="exclude-from-filter"]').simulate('click');
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/discover/results/',
-        query: expect.objectContaining({
-          query: '!transaction:nope !transaction:best-transaction',
-        }),
-      });
+      expect(handleCellAction).toHaveBeenCalledWith('exclude', 'best-transaction');
     });
 
     it('go to summary button goes to transaction summary page', function() {
       wrapper.find('button[data-test-id="transaction-summary"]').simulate('click');
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/performance/summary/',
-        query: expect.objectContaining({
-          query: undefined,
-          project: undefined,
-          transaction: 'best-transaction',
-        }),
-      });
+      expect(handleCellAction).toHaveBeenCalledWith('transaction', 'best-transaction');
     });
 
     it('go to release button goes to release health page', function() {
-      wrapper = makeWrapper(view, initial, 3);
+      wrapper = makeWrapper(view, handleCellAction, 3);
       // Show button and menu.
       wrapper.find('Container').simulate('mouseEnter');
       wrapper.find('MenuButton').simulate('click');
 
       wrapper.find('button[data-test-id="release"]').simulate('click');
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
-        pathname:
-          '/organizations/org-slug/releases/F2520C43515BD1F0E8A6BD46233324641A370BF6/',
-        query: expect.objectContaining({
-          project: undefined,
-        }),
-      });
+      expect(handleCellAction).toHaveBeenCalledWith(
+        'release',
+        'F2520C43515BD1F0E8A6BD46233324641A370BF6'
+      );
     });
 
     it('greater than button adds condition', function() {
-      wrapper = makeWrapper(view, initial, 2);
+      wrapper = makeWrapper(view, handleCellAction, 2);
       // Show button and menu.
       wrapper.find('Container').simulate('mouseEnter');
       wrapper.find('MenuButton').simulate('click');
 
       wrapper.find('button[data-test-id="show-values-greater-than"]').simulate('click');
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/discover/results/',
-        query: expect.objectContaining({
-          query: 'event.type:transaction timestamp:>2020-06-09T01:46:25+00:00',
-          sort: ['-timestamp'],
-        }),
-      });
+      expect(handleCellAction).toHaveBeenCalledWith(
+        'show_greater_than',
+        '2020-06-09T01:46:25+00:00'
+      );
     });
 
     it('less than button adds condition', function() {
-      wrapper = makeWrapper(view, initial, 2);
+      wrapper = makeWrapper(view, handleCellAction, 2);
       // Show button and menu.
       wrapper.find('Container').simulate('mouseEnter');
       wrapper.find('MenuButton').simulate('click');
 
       wrapper.find('button[data-test-id="show-values-less-than"]').simulate('click');
 
-      expect(browserHistory.push).toHaveBeenCalledWith({
-        pathname: '/organizations/org-slug/discover/results/',
-        query: expect.objectContaining({
-          query: 'event.type:transaction timestamp:<2020-06-09T01:46:25+00:00',
-          sort: ['timestamp'],
-        }),
-      });
+      expect(handleCellAction).toHaveBeenCalledWith(
+        'show_less_than',
+        '2020-06-09T01:46:25+00:00'
+      );
     });
   });
 });


### PR DESCRIPTION
<img width="1651" alt="Screen Shot 2020-06-09 at 7 33 42 PM" src="https://user-images.githubusercontent.com/139499/84210965-26b6a680-aa88-11ea-973d-592bcf793da3.png">

- Per-cell action analytics for the Performance page to be added in a follow up PR.

## TODO

- [x] user misery?
- [x] allow list for context menu items
- [x] add analytics
