### PR TITLE
fix(dev): pin pre-commit's virtualenv to 20.0.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ setup-git: ensure-venv setup-git-config
 	@echo "--> Installing git hooks"
 	cd .git/hooks && ln -sf ../../config/hooks/* ./
 	@PYENV_VERSION=$(REQUIRED_PY3_VERSION) python3 -c '' || (echo 'Please run `make setup-pyenv` to install the required Python 3 version.'; exit 1)
-	$(PIP) install "pre-commit==1.18.2"
+	$(PIP) install "pre-commit==1.18.2" "virtualenv==20.0.22"
 	@PYENV_VERSION=$(REQUIRED_PY3_VERSION) pre-commit install --install-hooks
 	@echo ""
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ setup-git: ensure-venv setup-git-config
 	@echo "--> Installing git hooks"
 	cd .git/hooks && ln -sf ../../config/hooks/* ./
 	@PYENV_VERSION=$(REQUIRED_PY3_VERSION) python3 -c '' || (echo 'Please run `make setup-pyenv` to install the required Python 3 version.'; exit 1)
-	$(PIP) install "pre-commit==1.18.2" "virtualenv==20.0.22"
+	$(PIP) install "pre-commit==1.18.2" "virtualenv==20.0.23"
 	@PYENV_VERSION=$(REQUIRED_PY3_VERSION) pre-commit install --install-hooks
 	@echo ""
 


### PR DESCRIPTION
Issue: https://github.com/pypa/virtualenv/pull/1851

Manifests fatally with our `make setup-git` on a fresh (not cached, hence why CI is not failing) venv.

Just gonna pin pre-commit's virtualenv to this future release (gonna merge when it gets cut) to try and prevent future breakage. We don't use virtualenv in any way in Sentry.
