### PR TITLE
fix(alerts): Add back open in discover button

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -234,6 +234,7 @@ export default class DetailsBody extends React.Component<Props> {
                   <Placeholder height="200px" />
                 )}
               </PanelBody>
+              {this.renderChartActions()}
             </ChartPanel>
           </PageContent>
           <DetailWrapper>

--- a/tests/js/spec/views/alerts/details/index.spec.jsx
+++ b/tests/js/spec/views/alerts/details/index.spec.jsx
@@ -51,6 +51,10 @@ describe('IncidentDetails', function() {
     });
 
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/incidents/456/',
       statusCode: 404,
     });
@@ -103,6 +107,19 @@ describe('IncidentDetails', function() {
         .at(4)
         .text()
     ).toBe('2 weeks');
+  });
+
+  it('renders open in discover button', async function() {
+    const discoverOrg = {...organization, features: ['discover-basic', 'discover-query']};
+    const wrapper = createWrapper(
+      {},
+      {...routerContext, context: {...routerContext.context, organization: discoverOrg}}
+    );
+    await tick();
+    wrapper.update();
+
+    const chartActions = wrapper.find('ChartActions');
+    expect(chartActions.find('Button').text()).toBe('Open in Discover');
   });
 
   it('handles invalid incident', async function() {


### PR DESCRIPTION
Add back open in discover button to alert chart details, missed in a conflict resolution.

Adds some test coverage on rendering the open in discover button.