### PR TITLE
ref(api): Capture all query parameters in current_release span

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -289,6 +289,15 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             if environments:
                 with sentry_sdk.start_span(op="GroupDetailsEndpoint.get.current_release") as span:
                     span.set_data("Environment Count", len(environments))
+                    span.set_data(
+                        "Raw Parameters",
+                        {
+                            "group.id": group.id,
+                            "group.project_id": group.project_id,
+                            "group.project.organization_id": group.project.organization_id,
+                            "environments": [{"id": e.id, "name": e.name} for e in environments],
+                        },
+                    )
 
                     try:
                         current_release = GroupRelease.objects.filter(


### PR DESCRIPTION
These will suffice to rebuild individual SQL queries by hand, so that we
can investigate whether slow responses are consistent and whether they
correlate with the size of intermediate result sets.