### PR TITLE
fix(discover) Show 'n/a' when user field has no user data

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -67,6 +67,9 @@ type FieldFormatters = {
 export type FieldTypes = keyof FieldFormatters;
 
 const emptyValue = <span>{t('n/a')}</span>;
+const EmptyValueContainer = styled(Container)`
+  color: ${p => p.theme.gray500};
+`;
 
 /**
  * A mapping of field types to their rendering function.
@@ -252,11 +255,7 @@ const SPECIAL_FIELDS: SpecialFields = {
         return <Container>{badge}</Container>;
       }
 
-      const StyledContainer = styled('div')`
-        color: ${p => p.theme.gray500};
-      `;
-
-      return <StyledContainer>{t('n/a')}</StyledContainer>;
+      return <EmptyValueContainer>{emptyValue}</EmptyValueContainer>;
     },
   },
   release: {

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Location} from 'history';
 import partial from 'lodash/partial';
+import styled from '@emotion/styled';
 
 import {Organization} from 'app/types';
 import {t, tct} from 'app/locale';
@@ -246,9 +247,16 @@ const SPECIAL_FIELDS: SpecialFields = {
         ip_address: '',
       };
 
-      const badge = <UserBadge user={userObj} hideEmail avatarSize={16} />;
+      if (data.user) {
+        const badge = <UserBadge user={userObj} hideEmail avatarSize={16} />;
+        return <Container>{badge}</Container>;
+      }
 
-      return <Container>{badge}</Container>;
+      const StyledContainer = styled('div')`
+        color: ${p => p.theme.gray500};
+      `;
+
+      return <StyledContainer>{t('n/a')}</StyledContainer>;
     },
   },
   release: {

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -178,12 +178,31 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     def test_all_events_query(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
         min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
         self.store_event(
             data={
                 "event_id": "a" * 32,
                 "message": "oh no",
                 "timestamp": min_ago,
                 "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "this is bad.",
+                "timestamp": two_min_ago,
+                "fingerprint": ["group-2"],
+                "user": {
+                    "id": "123",
+                    "email": "someone@example.com",
+                    "username": "haveibeenpwned",
+                    "ip_address": "8.8.8.8",
+                    "name": "Someone",
+                },
             },
             project_id=self.project.id,
             assert_no_errors=False,

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -38,7 +38,6 @@ describe('getFieldRenderer', function() {
 
   it('can render string fields', function() {
     const renderer = getFieldRenderer('url', {url: 'string'});
-    expect(renderer).toBeInstanceOf(Function);
     const wrapper = mount(renderer(data, {location, organization}));
     const text = wrapper.find('Container');
     expect(text.text()).toEqual(data.url);
@@ -46,7 +45,6 @@ describe('getFieldRenderer', function() {
 
   it('can render boolean fields', function() {
     const renderer = getFieldRenderer('boolValue', {boolValue: 'boolean'});
-    expect(renderer).toBeInstanceOf(Function);
     const wrapper = mount(renderer(data, {location, organization}));
     const text = wrapper.find('Container');
     expect(text.text()).toEqual('yes');
@@ -54,7 +52,6 @@ describe('getFieldRenderer', function() {
 
   it('can render integer fields', function() {
     const renderer = getFieldRenderer('numeric', {numeric: 'integer'});
-    expect(renderer).toBeInstanceOf(Function);
     const wrapper = mount(renderer(data, {location, organization}));
 
     const value = wrapper.find('Count');
@@ -74,7 +71,6 @@ describe('getFieldRenderer', function() {
 
   it('can render null date fields', function() {
     const renderer = getFieldRenderer('nope', {nope: 'date'});
-    expect(renderer).toBeInstanceOf(Function);
     const wrapper = mount(renderer(data, {location, organization}));
 
     const value = wrapper.find('StyledDateTime');
@@ -84,7 +80,6 @@ describe('getFieldRenderer', function() {
 
   it('can render user fields with aliased user', function() {
     const renderer = getFieldRenderer('user', {user: 'string'});
-    expect(renderer).toBeInstanceOf(Function);
 
     const wrapper = mount(renderer(data, {location, organization}));
 
@@ -98,7 +93,6 @@ describe('getFieldRenderer', function() {
 
   it('can render null user fields', function() {
     const renderer = getFieldRenderer('user', {user: 'string'});
-    expect(renderer).toBeInstanceOf(Function);
 
     delete data.user;
     const wrapper = mount(renderer(data, {location, organization}));
@@ -113,7 +107,7 @@ describe('getFieldRenderer', function() {
 
   it('can render project as an avatar', function() {
     const renderer = getFieldRenderer('project', {project: 'string'});
-    expect(renderer).toBeInstanceOf(Function);
+
     const wrapper = mountWithTheme(
       renderer(data, {location, organization}),
       context.routerContext

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -106,7 +106,7 @@ describe('getFieldRenderer', function() {
     const badge = wrapper.find('UserBadge');
     expect(badge).toHaveLength(0);
 
-    const value = wrapper.find('StyledContainer');
+    const value = wrapper.find('EmptyValueContainer');
     expect(value).toHaveLength(1);
     expect(value.text()).toEqual('n/a');
   });


### PR DESCRIPTION
### Summary
When there is no title to display, the `user` field was showing an avatar with question mark inside. This change only shows user data if it exists and will show 'n/a' instead of rendering otherwise.

### Screenshots
#### Before
![Screen Shot 2020-06-09 at 5 34 25 PM](https://user-images.githubusercontent.com/6111995/84214172-7a6cc400-aa77-11ea-8af9-a537e95e3871.png)

#### After
![Screen Shot 2020-06-09 at 5 35 10 PM](https://user-images.githubusercontent.com/6111995/84214211-9cfedd00-aa77-11ea-9a86-8136ec48082c.png)