### PR TITLE
fix(subscriptions): Fix bug where query subscription consumer doesn't commit offsets for inactive partitions

### DIFF
--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -6,7 +6,7 @@ import jsonschema
 import pytz
 import sentry_sdk
 from sentry_sdk.tracing import Span
-from confluent_kafka import Consumer, KafkaException, TopicPartition
+from confluent_kafka import Consumer, KafkaException, OFFSET_INVALID, TopicPartition
 from dateutil.parser import parse as parse_date
 from django.conf import settings
 
@@ -80,11 +80,19 @@ class QuerySubscriptionConsumer(object):
             "default.topic.config": {"auto.offset.reset": self.initial_offset_reset},
         }
 
+        def on_assign(consumer, partitions):
+            for partition in partitions:
+                if partition.offset == OFFSET_INVALID:
+                    updated_offset = None
+                else:
+                    updated_offset = partition.offset
+                self.offsets[partition.partition] = updated_offset
+
         def on_revoke(consumer, partitions):
-            self.commit_offsets()
+            self.commit_offsets([partition.partition for partition in partitions])
 
         self.consumer = Consumer(conf)
-        self.consumer.subscribe([self.topic], on_revoke=on_revoke)
+        self.consumer.subscribe([self.topic], on_assign=on_assign, on_revoke=on_revoke)
 
         try:
             i = 0
@@ -119,14 +127,19 @@ class QuerySubscriptionConsumer(object):
 
         self.shutdown()
 
-    def commit_offsets(self):
+    def commit_offsets(self, partitions=None):
         if self.offsets and self.consumer:
-            to_commit = [
-                TopicPartition(self.topic, partition, offset)
-                for partition, offset in self.offsets.items()
-            ]
+            if partitions is None:
+                partitions = self.offsets.keys()
+            to_commit = []
+            for partition in partitions:
+                offset = self.offsets.pop(partition)
+                if offset is None:
+                    # Skip partitions that have no offset
+                    continue
+                to_commit.append(TopicPartition(self.topic, partition, offset))
+
             self.consumer.commit(offsets=to_commit)
-            self.offsets.clear()
 
     def shutdown(self):
         logger.debug("Committing offsets and closing consumer")


### PR DESCRIPTION
This fixes a problem where we only commit offsets for partitions we've received messages from,
rather than all partitions we're assigned. In practice this doesn't actually cause us issues, but it
does cause it to look like the consumer is extremely delayed, when everything is actually working
ok.

I manually tested this to confirm everything is working - not sure how to simulate partition
assignments and revocations properly, it might not really be worth doing.