### PR TITLE
ref(icon refactor): replace icon return

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
-import InlineSvg from 'app/components/inlineSvg';
+import {IconReturn} from 'app/icons/iconReturn';
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -18,7 +18,7 @@ interface Props {
 
 const Assembly = ({name, version, culture, publicKeyToken, filePath}: Props) => (
   <AssemblyWrapper>
-    <Icon src="icon-return-key" />
+    <StyledIconReturn />
     <AssemblyInfo>
       <Caption>Assembly:</Caption>
       {name || '-'}
@@ -64,7 +64,7 @@ const AssemblyWrapper = styled('div')`
   padding: 0 ${space(3)} 0 50px;
 `;
 
-const Icon = styled(InlineSvg)`
+const StyledIconReturn = styled(IconReturn)`
   transform: scaleX(-1);
   position: absolute;
   top: 4px;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/returnButton.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/returnButton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
-import InlineSvg from 'app/components/inlineSvg';
+import {IconReturn} from 'app/icons/iconReturn';
 import Tooltip from 'app/components/tooltip';
 
 const SubmitButton = styled('div')`
@@ -38,7 +38,7 @@ const returnButton = props => (
   <ClickTargetStyled {...props}>
     <Tooltip title={t('Save')}>
       <SubmitButton>
-        <InlineSvg size="0.75em" src="icon-return-key" />
+        <IconReturn />
       </SubmitButton>
     </Tooltip>
   </ClickTargetStyled>

--- a/tests/js/spec/components/__snapshots__/returnButton.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/returnButton.spec.jsx.snap
@@ -8,10 +8,7 @@ exports[`returnButton renders 1`] = `
     title="Save"
   >
     <SubmitButton>
-      <InlineSvg
-        size="0.75em"
-        src="icon-return-key"
-      />
+      <ForwardRef />
     </SubmitButton>
   </Tooltip>
 </ClickTargetStyled>


### PR DESCRIPTION
**Twist:**
icon-return-key doesn't exist anywhere but is referenced.

![Screen Shot 2020-06-11 at 9 10 01 AM](https://user-images.githubusercontent.com/4830259/84411951-5f0ecf80-abc3-11ea-840a-84b720c6b27a.png)
