### PR TITLE
ref(crumb's time): Replace time formatters with the getDuration method

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/time/time.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/time/time.tsx
@@ -5,7 +5,6 @@ import {defined} from 'app/utils';
 import Tooltip from 'app/components/tooltip';
 import getDynamicText from 'app/utils/getDynamicText';
 import TextOverflow from 'app/components/textOverflow';
-import space from 'app/styles/space';
 
 import {getFormattedTimestamp} from './utils';
 
@@ -27,7 +26,7 @@ const Time = React.memo(({timestamp, relativeTime, displayRelativeTime}: Props) 
   );
 
   return (
-    <Wrapper displayRelativeTime={displayRelativeTime}>
+    <Wrapper>
       <Tooltip
         title={
           <div>
@@ -50,8 +49,7 @@ const Time = React.memo(({timestamp, relativeTime, displayRelativeTime}: Props) 
 
 export default Time;
 
-const Wrapper = styled('div')<{displayRelativeTime?: boolean}>`
+const Wrapper = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.gray700};
-  ${p => p.displayRelativeTime && `padding-left: ${space(3)};`}
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/time/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/time/utils.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import {use24Hours} from 'app/utils/dates';
 import {defined} from 'app/utils';
 import {t} from 'app/locale';
-import {getAbbreviateRelativeTime} from 'app/utils/formatters';
+import {getDuration} from 'app/utils/formatters';
 
 const timeFormat = 'HH:mm:ss';
 const timeDateFormat = `ll ${timeFormat}`;
@@ -17,7 +17,11 @@ const getRelativeTime = (
   const formattedTime = moment(parsedTime.format(timeDateFormat));
   const formattedTimeToCompareWith = parsedTimeToCompareWith.format(timeDateFormat);
   const timeDiff = Math.abs(formattedTime.diff(formattedTimeToCompareWith));
-  const shortRelativeTime = getAbbreviateRelativeTime(timeDiff);
+
+  const shortRelativeTime = getDuration(Math.round(timeDiff / 1000), 0, true).replace(
+    /\s/g,
+    ''
+  );
 
   if (timeDiff !== 0) {
     return displayRelativeTime

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/time/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/time/utils.tsx
@@ -3,52 +3,10 @@ import moment from 'moment';
 import {use24Hours} from 'app/utils/dates';
 import {defined} from 'app/utils';
 import {t} from 'app/locale';
-
-enum TimeAbbreviation {
-  SECOND = 'second',
-  MINUTE = 'minute',
-  HOUR = 'hour',
-  DAY = 'day',
-  YEAR = 'year',
-}
+import {getAbbreviateRelativeTime} from 'app/utils/formatters';
 
 const timeFormat = 'HH:mm:ss';
 const timeDateFormat = `ll ${timeFormat}`;
-
-const getTimeShortString = (type: TimeAbbreviation, time: number) => {
-  switch (type) {
-    case TimeAbbreviation.SECOND:
-      return t('%s sec', time);
-    case TimeAbbreviation.MINUTE:
-      return t('%s min', time);
-    case TimeAbbreviation.HOUR:
-      return t('%s hr', time);
-    case TimeAbbreviation.DAY:
-      return t('%s d', time);
-    case TimeAbbreviation.YEAR:
-      return t('%s y', time);
-    default:
-      return '';
-  }
-};
-
-const getShortRelativeTime = (milliseconds: number) => {
-  const seconds = Math.round(milliseconds / 1000);
-  const minutes = Math.round(seconds / 60);
-  const hours = Math.round(minutes / 60);
-  const days = Math.round(hours / 24);
-  const years = Math.round(days / 365);
-
-  const args = ((seconds < 45 && [TimeAbbreviation.SECOND, seconds]) ||
-    (minutes < 45 && [TimeAbbreviation.MINUTE, minutes]) ||
-    (hours < 22 && [TimeAbbreviation.HOUR, hours]) ||
-    (days <= 300 && [TimeAbbreviation.DAY, days]) || [TimeAbbreviation.YEAR, years]) as [
-    TimeAbbreviation,
-    number
-  ];
-
-  return getTimeShortString(args[0], args[1]);
-};
 
 const getRelativeTime = (
   parsedTime: ReturnType<typeof moment>,
@@ -59,7 +17,7 @@ const getRelativeTime = (
   const formattedTime = moment(parsedTime.format(timeDateFormat));
   const formattedTimeToCompareWith = parsedTimeToCompareWith.format(timeDateFormat);
   const timeDiff = Math.abs(formattedTime.diff(formattedTimeToCompareWith));
-  const shortRelativeTime = getShortRelativeTime(timeDiff);
+  const shortRelativeTime = getAbbreviateRelativeTime(timeDiff);
 
   if (timeDiff !== 0) {
     return displayRelativeTime

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -46,11 +46,11 @@ function roundWithFixed(
 }
 
 // in milliseconds
-const MS_WEEK = 604800000;
-const MS_DAY = 86400000;
-const MS_HOUR = 3600000;
-const MS_MINUTE = 60000;
-const MS_SECOND = 1000;
+const WEEK = 604800000;
+const DAY = 86400000;
+const HOUR = 3600000;
+const MINUTE = 60000;
+const SECOND = 1000;
 
 export function getDuration(
   seconds: number,
@@ -59,24 +59,24 @@ export function getDuration(
 ): string {
   const value = Math.abs(seconds * 1000);
 
-  if (value >= MS_WEEK) {
-    const {label, result} = roundWithFixed(value / MS_WEEK, fixedDigits);
+  if (value >= WEEK) {
+    const {label, result} = roundWithFixed(value / WEEK, fixedDigits);
     return `${label} ${abbreviation ? t('wk') : tn('week', 'weeks', result)}`;
   }
   if (value >= 172800000) {
-    const {label, result} = roundWithFixed(value / MS_DAY, fixedDigits);
+    const {label, result} = roundWithFixed(value / DAY, fixedDigits);
     return `${label} ${abbreviation ? t('d') : tn('day', 'days', result)}`;
   }
   if (value >= 7200000) {
-    const {label, result} = roundWithFixed(value / MS_HOUR, fixedDigits);
+    const {label, result} = roundWithFixed(value / HOUR, fixedDigits);
     return `${label} ${abbreviation ? t('hr') : tn('hour', 'hours', result)}`;
   }
   if (value >= 120000) {
-    const {label, result} = roundWithFixed(value / MS_MINUTE, fixedDigits);
+    const {label, result} = roundWithFixed(value / MINUTE, fixedDigits);
     return `${label} ${abbreviation ? t('min') : tn('minute', 'minutes', result)}`;
   }
-  if (value >= MS_SECOND) {
-    const {label, result} = roundWithFixed(value / MS_SECOND, fixedDigits);
+  if (value >= SECOND) {
+    const {label, result} = roundWithFixed(value / SECOND, fixedDigits);
     return `${label} ${abbreviation ? t('s') : tn('second', 'seconds', result)}`;
   }
 
@@ -93,36 +93,36 @@ export function getExactDuration(seconds: number, abbreviation: boolean = false)
       return {quotient: Math.floor(value / time), remainder: value % time};
     };
 
-    if (value >= MS_WEEK) {
-      const {quotient, remainder} = divideBy(MS_WEEK);
+    if (value >= WEEK) {
+      const {quotient, remainder} = divideBy(WEEK);
 
       return `${quotient}${
         abbr ? t('wk') : ` ${tn('week', 'weeks', quotient)}`
       } ${convertDuration(remainder / 1000, abbr)}`;
     }
-    if (value >= MS_DAY) {
-      const {quotient, remainder} = divideBy(MS_DAY);
+    if (value >= DAY) {
+      const {quotient, remainder} = divideBy(DAY);
 
       return `${quotient}${
         abbr ? t('d') : ` ${tn('day', 'days', quotient)}`
       } ${convertDuration(remainder / 1000, abbr)}`;
     }
-    if (value >= MS_HOUR) {
-      const {quotient, remainder} = divideBy(MS_HOUR);
+    if (value >= HOUR) {
+      const {quotient, remainder} = divideBy(HOUR);
 
       return `${quotient}${
         abbr ? t('hr') : ` ${tn('hour', 'hours', quotient)}`
       } ${convertDuration(remainder / 1000, abbr)}`;
     }
-    if (value >= MS_MINUTE) {
-      const {quotient, remainder} = divideBy(MS_MINUTE);
+    if (value >= MINUTE) {
+      const {quotient, remainder} = divideBy(MINUTE);
 
       return `${quotient}${
         abbr ? t('min') : ` ${tn('minute', 'minutes', quotient)}`
       } ${convertDuration(remainder / 1000, abbr)}`;
     }
-    if (value >= MS_SECOND) {
-      const {quotient, remainder} = divideBy(MS_SECOND);
+    if (value >= SECOND) {
+      const {quotient, remainder} = divideBy(SECOND);
 
       return `${quotient}${
         abbr ? t('s') : ` ${tn('second', 'seconds', quotient)}`
@@ -187,49 +187,4 @@ export function formatAbbreviatedNumber(number: number | string) {
   }
 
   return number.toLocaleString();
-}
-
-export enum Time {
-  SECOND = 'second',
-  MINUTE = 'minute',
-  HOUR = 'hour',
-  DAY = 'day',
-  WEEK = 'week',
-  YEAR = 'year',
-}
-
-export const getAbbreviatedTime = (type: Time, time: number) => {
-  switch (type) {
-    case Time.SECOND:
-      return t('%s sec', time);
-    case Time.MINUTE:
-      return t('%s min', time);
-    case Time.HOUR:
-      return t('%s hr', time);
-    case Time.DAY:
-      return t('%s d', time);
-    case Time.WEEK:
-      return t('%s wk', time);
-    case Time.YEAR:
-      return t('%s y', time);
-    default:
-      return '';
-  }
-};
-
-export function getAbbreviateRelativeTime(milliseconds: number) {
-  const seconds = Math.round(milliseconds / 1000);
-  const minutes = Math.round(seconds / 60);
-  const hours = Math.round(minutes / 60);
-  const days = Math.round(hours / 24);
-  const weeks = Math.round(days / 7);
-  const years = Math.round(weeks / 52);
-
-  const args = ((seconds < 45 && [Time.SECOND, seconds]) ||
-    (minutes < 45 && [Time.MINUTE, minutes]) ||
-    (hours < 22 && [Time.HOUR, hours]) ||
-    (days <= 300 && [Time.DAY, days]) ||
-    (weeks <= 52 && [Time.WEEK, weeks]) || [Time.YEAR, years]) as [Time, number];
-
-  return getAbbreviatedTime(args[0], args[1]);
 }

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -46,11 +46,11 @@ function roundWithFixed(
 }
 
 // in milliseconds
-const WEEK = 604800000;
-const DAY = 86400000;
-const HOUR = 3600000;
-const MINUTE = 60000;
-const SECOND = 1000;
+const MS_WEEK = 604800000;
+const MS_DAY = 86400000;
+const MS_HOUR = 3600000;
+const MS_MINUTE = 60000;
+const MS_SECOND = 1000;
 
 export function getDuration(
   seconds: number,
@@ -59,24 +59,24 @@ export function getDuration(
 ): string {
   const value = Math.abs(seconds * 1000);
 
-  if (value >= WEEK) {
-    const {label, result} = roundWithFixed(value / WEEK, fixedDigits);
+  if (value >= MS_WEEK) {
+    const {label, result} = roundWithFixed(value / MS_WEEK, fixedDigits);
     return `${label} ${abbreviation ? t('wk') : tn('week', 'weeks', result)}`;
   }
   if (value >= 172800000) {
-    const {label, result} = roundWithFixed(value / DAY, fixedDigits);
+    const {label, result} = roundWithFixed(value / MS_DAY, fixedDigits);
     return `${label} ${abbreviation ? t('d') : tn('day', 'days', result)}`;
   }
   if (value >= 7200000) {
-    const {label, result} = roundWithFixed(value / HOUR, fixedDigits);
+    const {label, result} = roundWithFixed(value / MS_HOUR, fixedDigits);
     return `${label} ${abbreviation ? t('hr') : tn('hour', 'hours', result)}`;
   }
   if (value >= 120000) {
-    const {label, result} = roundWithFixed(value / MINUTE, fixedDigits);
+    const {label, result} = roundWithFixed(value / MS_MINUTE, fixedDigits);
     return `${label} ${abbreviation ? t('min') : tn('minute', 'minutes', result)}`;
   }
-  if (value >= SECOND) {
-    const {label, result} = roundWithFixed(value / SECOND, fixedDigits);
+  if (value >= MS_SECOND) {
+    const {label, result} = roundWithFixed(value / MS_SECOND, fixedDigits);
     return `${label} ${abbreviation ? t('s') : tn('second', 'seconds', result)}`;
   }
 
@@ -187,4 +187,49 @@ export function formatAbbreviatedNumber(number: number | string) {
   }
 
   return number.toLocaleString();
+}
+
+export enum Time {
+  SECOND = 'second',
+  MINUTE = 'minute',
+  HOUR = 'hour',
+  DAY = 'day',
+  WEEK = 'week',
+  YEAR = 'year',
+}
+
+export const getAbbreviatedTime = (type: Time, time: number) => {
+  switch (type) {
+    case Time.SECOND:
+      return t('%s sec', time);
+    case Time.MINUTE:
+      return t('%s min', time);
+    case Time.HOUR:
+      return t('%s hr', time);
+    case Time.DAY:
+      return t('%s d', time);
+    case Time.WEEK:
+      return t('%s wk', time);
+    case Time.YEAR:
+      return t('%s y', time);
+    default:
+      return '';
+  }
+};
+
+export function getAbbreviateRelativeTime(milliseconds: number) {
+  const seconds = Math.round(milliseconds / 1000);
+  const minutes = Math.round(seconds / 60);
+  const hours = Math.round(minutes / 60);
+  const days = Math.round(hours / 24);
+  const weeks = Math.round(days / 7);
+  const years = Math.round(weeks / 52);
+
+  const args = ((seconds < 45 && [Time.SECOND, seconds]) ||
+    (minutes < 45 && [Time.MINUTE, minutes]) ||
+    (hours < 22 && [Time.HOUR, hours]) ||
+    (days <= 300 && [Time.DAY, days]) ||
+    (weeks <= 52 && [Time.WEEK, weeks]) || [Time.YEAR, years]) as [Time, number];
+
+  return getAbbreviatedTime(args[0], args[1]);
 }

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -93,36 +93,36 @@ export function getExactDuration(seconds: number, abbreviation: boolean = false)
       return {quotient: Math.floor(value / time), remainder: value % time};
     };
 
-    if (value >= WEEK) {
-      const {quotient, remainder} = divideBy(WEEK);
+    if (value >= MS_WEEK) {
+      const {quotient, remainder} = divideBy(MS_WEEK);
 
       return `${quotient}${
         abbr ? t('wk') : ` ${tn('week', 'weeks', quotient)}`
       } ${convertDuration(remainder / 1000, abbr)}`;
     }
-    if (value >= DAY) {
-      const {quotient, remainder} = divideBy(DAY);
+    if (value >= MS_DAY) {
+      const {quotient, remainder} = divideBy(MS_DAY);
 
       return `${quotient}${
         abbr ? t('d') : ` ${tn('day', 'days', quotient)}`
       } ${convertDuration(remainder / 1000, abbr)}`;
     }
-    if (value >= HOUR) {
-      const {quotient, remainder} = divideBy(HOUR);
+    if (value >= MS_HOUR) {
+      const {quotient, remainder} = divideBy(MS_HOUR);
 
       return `${quotient}${
         abbr ? t('hr') : ` ${tn('hour', 'hours', quotient)}`
       } ${convertDuration(remainder / 1000, abbr)}`;
     }
-    if (value >= MINUTE) {
-      const {quotient, remainder} = divideBy(MINUTE);
+    if (value >= MS_MINUTE) {
+      const {quotient, remainder} = divideBy(MS_MINUTE);
 
       return `${quotient}${
         abbr ? t('min') : ` ${tn('minute', 'minutes', quotient)}`
       } ${convertDuration(remainder / 1000, abbr)}`;
     }
-    if (value >= SECOND) {
-      const {quotient, remainder} = divideBy(SECOND);
+    if (value >= MS_SECOND) {
+      const {quotient, remainder} = divideBy(MS_SECOND);
 
       return `${quotient}${
         abbr ? t('s') : ` ${tn('second', 'seconds', quotient)}`


### PR DESCRIPTION
**Description:** Replaced the method `getShortRelativeTime` with the `getDuration` method from `utils/formatters`

![image](https://user-images.githubusercontent.com/29228205/84296660-a312bd80-ab4c-11ea-8cc1-61bc9552ebb0.png)
