### PR TITLE
fix(perf-view) Disable 'open in discover' based on features

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
@@ -7,6 +7,7 @@ import {Organization} from 'app/types';
 import space from 'app/styles/space';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
+import Feature from 'app/components/acl/feature';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import PanelTable from 'app/components/panels/panelTable';
 import Link from 'app/components/links/link';
@@ -91,14 +92,22 @@ class TransactionList extends React.PureComponent<WrapperProps> {
             ))}
           </DropdownControl>
           <HeaderButtonContainer>
-            <Button
-              onClick={this.handleDiscoverViewClick}
-              to={sortedEventView.getResultsViewUrlTarget(organization.slug)}
-              size="small"
-              data-test-id="discover-open"
+            <Feature
+              features={['organizations:discover-basic']}
+              organization={organization}
             >
-              {t('Open in Discover')}
-            </Button>
+              {({hasFeature}) => (
+                <Button
+                  onClick={this.handleDiscoverViewClick}
+                  to={sortedEventView.getResultsViewUrlTarget(organization.slug)}
+                  size="small"
+                  data-test-id="discover-open"
+                  disabled={!hasFeature}
+                >
+                  {t('Open in Discover')}
+                </Button>
+              )}
+            </Feature>
           </HeaderButtonContainer>
         </Header>
         <DiscoverQuery

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -8,7 +8,7 @@ import ProjectsStore from 'app/stores/projectsStore';
 import TransactionSummary from 'app/views/performance/transactionSummary';
 
 function initializeData() {
-  const features = ['transaction-event', 'performance-view'];
+  const features = ['discover-basic', 'performance-view'];
   const organization = TestStubs.Organization({
     features,
     projects: [TestStubs.Project()],


### PR DESCRIPTION
Disable the discover button when the discover feature flags are not available for the organization.