### PR TITLE
feat(async-csv): Disallow multiple exports back to back

### DIFF
--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -1,3 +1,4 @@
+import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 import React from 'react';
 
@@ -61,6 +62,8 @@ class DataExport extends React.Component<Props, State> {
       payload: {queryType, queryInfo},
     } = this.props;
 
+    this.setState({inProgress: true});
+
     api
       .requestPromise(`/organizations/${slug}/data-export/`, {
         includeAllArgs: true,
@@ -79,13 +82,14 @@ class DataExport extends React.Component<Props, State> {
               )
             : t("It looks like we're already working on it. Sit tight, we'll email you.")
         );
-        this.setState({inProgress: true, dataExportId});
+        this.setState({dataExportId});
       })
       .catch(err => {
         const message =
           err?.responseJSON?.detail ??
           "We tried our hardest, but we couldn't export your data. Give it another go.";
         addErrorMessage(t(message));
+        this.setState({inProgress: false});
       });
   };
 
@@ -107,7 +111,7 @@ class DataExport extends React.Component<Props, State> {
           </NewButton>
         ) : (
           <NewButton
-            onClick={this.startDataExport}
+            onClick={debounce(this.startDataExport, 500)}
             disabled={disabled || false}
             size="small"
             priority="default"

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -33,7 +33,6 @@ type Props = {
 
 type State = {
   inProgress: boolean;
-  dataExportId?: number;
 };
 
 class DataExport extends React.Component<Props, State> {
@@ -47,7 +46,6 @@ class DataExport extends React.Component<Props, State> {
   get initialState() {
     return {
       inProgress: false,
-      dataExportId: undefined,
     };
   }
 
@@ -73,8 +71,7 @@ class DataExport extends React.Component<Props, State> {
           query_info: queryInfo,
         },
       })
-      .then(([data, _, response]) => {
-        const {id: dataExportId} = data;
+      .then(([_data, _, response]) => {
         addSuccessMessage(
           response?.status === 201
             ? t(
@@ -82,7 +79,6 @@ class DataExport extends React.Component<Props, State> {
               )
             : t("It looks like we're already working on it. Sit tight, we'll email you.")
         );
-        this.setState({dataExportId});
       })
       .catch(err => {
         const message =
@@ -94,11 +90,11 @@ class DataExport extends React.Component<Props, State> {
   };
 
   render() {
-    const {inProgress, dataExportId} = this.state;
+    const {inProgress} = this.state;
     const {children, disabled, icon} = this.props;
     return (
       <Feature features={['organizations:data-export']}>
-        {inProgress && dataExportId ? (
+        {inProgress ? (
           <NewButton
             size="small"
             priority="default"

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -79,9 +79,12 @@ describe('DataExport', function() {
       <WrappedDataExport payload={mockPayload} />,
       mockRouterContext(mockAuthorizedOrg)
     );
-    wrapper.find('button').simulate('click');
     expect(wrapper.find(DataExport).state()).toEqual({
       inProgress: false,
+    });
+    wrapper.find('button').simulate('click');
+    expect(wrapper.find(DataExport).state()).toEqual({
+      inProgress: true,
     });
     expect(postDataExport).toHaveBeenCalledWith(url, {
       data: {
@@ -139,6 +142,9 @@ describe('DataExport', function() {
     expect(addErrorMessage).toHaveBeenCalledWith(
       "We tried our hardest, but we couldn't export your data. Give it another go."
     );
+    expect(wrapper.find(DataExport).state()).toEqual({
+      inProgress: false,
+    });
   });
 
   it('should display provided error message', async function() {

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -79,14 +79,10 @@ describe('DataExport', function() {
       <WrappedDataExport payload={mockPayload} />,
       mockRouterContext(mockAuthorizedOrg)
     );
-    expect(wrapper.find(Button).text()).toEqual(
-      expect.stringMatching(/^Export All to CSV/)
-    );
+    expect(wrapper.find(Button).prop('disabled')).toBe(false);
     wrapper.find('button').simulate('click');
     await tick();
-    expect(wrapper.find(Button).text()).toEqual(
-      expect.stringMatching(/^We're working on it.../)
-    );
+    expect(wrapper.find(Button).prop('disabled')).toBe(true);
     expect(postDataExport).toHaveBeenCalledWith(url, {
       data: {
         query_type: mockPayload.queryType,
@@ -98,11 +94,7 @@ describe('DataExport', function() {
     });
     await tick();
     wrapper.update();
-    expect(wrapper.text()).toContain("We're working on it...");
     expect(wrapper.find(Button).prop('disabled')).toBe(true);
-    expect(wrapper.find(Button).text()).toEqual(
-      expect.stringMatching(/^We're working on it.../)
-    );
   });
 
   it('should reset the state when receiving a new payload', async function() {
@@ -119,13 +111,10 @@ describe('DataExport', function() {
     wrapper.find('button').simulate('click');
     await tick();
     wrapper.update();
-    expect(wrapper.find(Button).text()).toEqual(
-      expect.stringMatching(/^We're working on it.../)
-    );
+    expect(wrapper.find(Button).prop('disabled')).toBe(true);
     wrapper.setProps({payload: {...mockPayload, queryType: 'Discover'}});
-    expect(wrapper.find(Button).text()).toEqual(
-      expect.stringMatching(/^Export All to CSV/)
-    );
+    wrapper.update();
+    expect(wrapper.find(Button).prop('disabled')).toBe(false);
   });
 
   it('should display default error message if non provided', async function() {
@@ -144,9 +133,8 @@ describe('DataExport', function() {
     expect(addErrorMessage).toHaveBeenCalledWith(
       "We tried our hardest, but we couldn't export your data. Give it another go."
     );
-    expect(wrapper.find(Button).text()).toEqual(
-      expect.stringMatching(/^Export All to CSV/)
-    );
+    wrapper.update();
+    expect(wrapper.find(Button).prop('disabled')).toBe(false);
   });
 
   it('should display provided error message', async function() {

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -4,7 +4,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import Button from 'app/components/button';
-import WrappedDataExport, {DataExport} from 'app/components/dataExport';
+import WrappedDataExport from 'app/components/dataExport';
 
 jest.mock('app/actionCreators/indicator');
 
@@ -79,13 +79,14 @@ describe('DataExport', function() {
       <WrappedDataExport payload={mockPayload} />,
       mockRouterContext(mockAuthorizedOrg)
     );
-    expect(wrapper.find(DataExport).state()).toEqual({
-      inProgress: false,
-    });
+    expect(wrapper.find(Button).text()).toEqual(
+      expect.stringMatching(/^Export All to CSV/)
+    );
     wrapper.find('button').simulate('click');
-    expect(wrapper.find(DataExport).state()).toEqual({
-      inProgress: true,
-    });
+    await tick();
+    expect(wrapper.find(Button).text()).toEqual(
+      expect.stringMatching(/^We're working on it.../)
+    );
     expect(postDataExport).toHaveBeenCalledWith(url, {
       data: {
         query_type: mockPayload.queryType,
@@ -99,10 +100,9 @@ describe('DataExport', function() {
     wrapper.update();
     expect(wrapper.text()).toContain("We're working on it...");
     expect(wrapper.find(Button).prop('disabled')).toBe(true);
-    expect(wrapper.find(DataExport).state()).toEqual({
-      inProgress: true,
-      dataExportId: 721,
-    });
+    expect(wrapper.find(Button).text()).toEqual(
+      expect.stringMatching(/^We're working on it.../)
+    );
   });
 
   it('should reset the state when receiving a new payload', async function() {
@@ -119,11 +119,13 @@ describe('DataExport', function() {
     wrapper.find('button').simulate('click');
     await tick();
     wrapper.update();
-    expect(wrapper.find(DataExport).state('inProgress')).toEqual(true);
-    expect(wrapper.find(DataExport).state('dataExportId')).toEqual(721);
+    expect(wrapper.find(Button).text()).toEqual(
+      expect.stringMatching(/^We're working on it.../)
+    );
     wrapper.setProps({payload: {...mockPayload, queryType: 'Discover'}});
-    expect(wrapper.find(DataExport).state('inProgress')).toEqual(false);
-    expect(wrapper.find(DataExport).state('dataExportId')).toBeUndefined();
+    expect(wrapper.find(Button).text()).toEqual(
+      expect.stringMatching(/^Export All to CSV/)
+    );
   });
 
   it('should display default error message if non provided', async function() {
@@ -142,9 +144,9 @@ describe('DataExport', function() {
     expect(addErrorMessage).toHaveBeenCalledWith(
       "We tried our hardest, but we couldn't export your data. Give it another go."
     );
-    expect(wrapper.find(DataExport).state()).toEqual({
-      inProgress: false,
-    });
+    expect(wrapper.find(Button).text()).toEqual(
+      expect.stringMatching(/^Export All to CSV/)
+    );
   });
 
   it('should display provided error message', async function() {


### PR DESCRIPTION
The export button only disables itself once a response comes back. This allows
the user to click the button multiple times before that happens triggering
multiple unnecessary exports. This change immediately disables the buttons as
well as debounce the start export function to minimize the chance of this
happening.