### PR TITLE
feat(discover) Add % to user misery tooltip

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -295,11 +295,14 @@ const SPECIAL_FUNCTIONS: SpecialFunctions = {
     const palette = new Array(10).fill(theme.purpleDarkest);
     const score = Math.floor((userMisery / Math.max(uniqueUsers, 1)) * palette.length);
     const miseryLimit = parseInt(userMiseryField.split('_').pop() || '', 10);
+    const miseryPercentage = ((100 * userMisery) / Math.max(uniqueUsers, 1)).toFixed(2);
+
     const title = tct(
-      '[affectedUsers] out of [totalUsers] unique users waited more than [duration]ms',
+      '[affectedUsers] out of [totalUsers] ([miseryPercentage]%) unique users waited more than [duration]ms',
       {
         affectedUsers: userMisery,
         totalUsers: uniqueUsers,
+        miseryPercentage,
         duration: 4 * miseryLimit,
       }
     );


### PR DESCRIPTION
### Summary
This adds a % to user misery tooltip to make it easier to understand the number of users involved at a glance.

### Screenshots
![Screen Shot 2020-06-10 at 10 24 59 AM](https://user-images.githubusercontent.com/6111995/84321008-5d8fc980-ab27-11ea-90c1-48676d86232b.png)
