### PR TITLE
ref(endpoints): Get most recent previous release with commits

### DIFF
--- a/src/sentry/api/endpoints/organization_release_previous_commits.py
+++ b/src/sentry/api/endpoints/organization_release_previous_commits.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.models import Release
+from sentry.utils.commiters import get_previous_releases
+
+
+class OrganizationReleasePreviousCommitsEndpoint(OrganizationReleasesBaseEndpoint):
+    def get(self, request, organization, version):
+        """
+        Retrieve an Organization's Previous Release that has commits
+        ````````````````````````````````````````````````````````````
+
+        Return details on an individual release.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string version: the version identifier of the release.
+        :qparam array[string] project:    An optional list of project ids to filter
+        :auth: required
+        """
+
+        try:
+            release = Release.objects.get(organization_id=organization.id, version=version)
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        if not self.has_release_permission(request, organization, release):
+            raise ResourceDoesNotExist
+
+        # project_ids = set(map(int, request.GET.getlist("project")))
+        prev_release_with_commit = None
+        prev_releases = []
+        for project in release.projects:
+            prev_releases = get_previous_releases(project, version)
+
+        for prev_release in prev_releases:
+            if prev_release.last_commit_id:
+                prev_release_with_commit = prev_release
+                break
+
+        return Response(serialize(prev_release_with_commit, request.user,))

--- a/src/sentry/api/endpoints/organization_release_previous_commits.py
+++ b/src/sentry/api/endpoints/organization_release_previous_commits.py
@@ -6,21 +6,17 @@ from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.models import Release
-from sentry.utils.commiters import get_previous_releases
 
 
 class OrganizationReleasePreviousCommitsEndpoint(OrganizationReleasesBaseEndpoint):
     def get(self, request, organization, version):
         """
-        Retrieve an Organization's Previous Release that has commits
+        Retrieve an Organization's Most Recent Release with Commits
         ````````````````````````````````````````````````````````````
-
-        Return details on an individual release.
 
         :pparam string organization_slug: the slug of the organization the
                                           release belongs to.
         :pparam string version: the version identifier of the release.
-        :qparam array[string] project:    An optional list of project ids to filter
         :auth: required
         """
 
@@ -32,15 +28,23 @@ class OrganizationReleasePreviousCommitsEndpoint(OrganizationReleasesBaseEndpoin
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        # project_ids = set(map(int, request.GET.getlist("project")))
-        prev_release_with_commit = None
-        prev_releases = []
-        for project in release.projects:
-            prev_releases = get_previous_releases(project, version)
+        start_date = release.date_released or release.date_added
 
-        for prev_release in prev_releases:
-            if prev_release.last_commit_id:
-                prev_release_with_commit = prev_release
-                break
+        prev_release_with_commits = (
+            Release.objects.filter(
+                organization_id=organization.id,
+                projects__in=release.projects.all(),
+                last_commit_id__isnull=False,
+            )
+            .extra(
+                select={"date": "COALESCE(date_released, date_added)"},
+                where=["COALESCE(date_released, date_added) <= %s"],
+                params=[start_date],
+            )
+            .extra(order_by=["-date"])[:1]
+        )
 
-        return Response(serialize(prev_release_with_commit, request.user,))
+        if not prev_release_with_commits:
+            return Response({})
+
+        return Response(serialize(prev_release_with_commits[0], request.user,))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -130,6 +130,9 @@ from .endpoints.organization_projects import OrganizationProjectsEndpoint
 from .endpoints.organization_recent_searches import OrganizationRecentSearchesEndpoint
 from .endpoints.organization_release_assemble import OrganizationReleaseAssembleEndpoint
 from .endpoints.organization_release_commits import OrganizationReleaseCommitsEndpoint
+from .endpoints.organization_release_previous_commits import (
+    OrganizationReleasePreviousCommitsEndpoint,
+)
 from .endpoints.organization_release_details import OrganizationReleaseDetailsEndpoint
 from .endpoints.organization_release_meta import OrganizationReleaseMetaEndpoint
 from .endpoints.organization_release_file_details import OrganizationReleaseFileDetailsEndpoint
@@ -1012,6 +1015,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/commits/$",
                     OrganizationReleaseCommitsEndpoint.as_view(),
                     name="sentry-api-0-organization-release-commits",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/previous-with-commits/$",
+                    OrganizationReleasePreviousCommitsEndpoint.as_view(),
+                    name="sentry-api-0-organization-release-previous-with-commits",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/user-feedback/$",

--- a/tests/sentry/api/endpoints/test_organization_release_previous_commits.py
+++ b/tests/sentry/api/endpoints/test_organization_release_previous_commits.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import
+from django.core.urlresolvers import reverse
+
+from sentry.models import (
+    Commit,
+    Release,
+    ReleaseCommit,
+    Repository,
+)
+from sentry.testutils import APITestCase
+
+
+class ReleasePreviousCommitsTest(APITestCase):
+    def setUp(self):
+        self.user = self.create_user(is_staff=False, is_superuser=False)
+        # org = self.organization
+        # org.flags.allow_joinleave = False
+        # org.save()
+
+        # team1 = self.create_team(organization=org)
+        # team2 = self.create_team(organization=org)
+
+        project = self.create_project(organization=self.organization)
+        self.project2 = self.create_project(organization=self.organization)
+
+        repo = Repository.objects.create(organization_id=project.organization_id, name="some/repo")
+
+        # previous releases
+        release = Release.objects.create(organization_id=self.organization.id, version="abcabcabc")
+        release.add_project(project)
+        commit = Commit.objects.create(
+            organization_id=project.organization_id, repository_id=repo.id, key="12345678"
+        )
+        commit2 = Commit.objects.create(
+            organization_id=project.organization_id, repository_id=repo.id, key="b" * 40
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id, release=release, commit=commit, order=1
+        )
+        ReleaseCommit.objects.create(
+            organization_id=project.organization_id, release=release, commit=commit2, order=0
+        )
+
+        Release.objects.filter(version="abcabcabc").update(last_commit_id=commit2.id)
+
+        self.release_with_commit = release
+
+        release2 = Release.objects.create(organization_id=self.organization.id, version="12345678")
+        release2.add_project(self.project2)
+
+        new_release = Release.objects.create(
+            organization_id=self.organization.id, version="newnewnew"
+        )
+        new_release.add_project(project)
+        new_release.add_project(self.project2)
+        self.url = reverse(
+            "sentry-api-0-organization-release-previous-with-commits",
+            kwargs={"organization_slug": self.organization.slug, "version": new_release.version},
+        )
+
+    def test_previous_release_has_commits(self):
+        self.login_as(user=self.user)
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == 200, response.content
+        assert response.data["version"] == self.release_with_commit.version
+
+    def test_no_previous_release_with_commit(self):
+        self.login_as(user=self.user)
+        new_release = Release.objects.create(
+            organization_id=self.organization.id, version="123123123"
+        )
+        new_release.add_project(self.project2)
+        url = reverse(
+            "sentry-api-0-organization-release-previous-with-commits",
+            kwargs={"organization_slug": self.organization.slug, "version": new_release.version},
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200, response.content
+        assert response.content == "{}"
+
+    def test_wrong_release_version(self):
+        self.login_as(user=self.user)
+        release = Release.objects.create(organization_id=self.organization.id, version="456456456")
+
+        url = reverse(
+            "sentry-api-0-organization-release-previous-with-commits",
+            kwargs={"organization_slug": self.organization.slug, "version": release.version},
+        )
+
+        response = self.client.get(url)
+        assert response.status_code == 404, response.content

--- a/tests/sentry/api/endpoints/test_organization_release_previous_commits.py
+++ b/tests/sentry/api/endpoints/test_organization_release_previous_commits.py
@@ -10,15 +10,9 @@ from sentry.models import (
 from sentry.testutils import APITestCase
 
 
-class ReleasePreviousCommitsTest(APITestCase):
+class OrganizationReleasePreviousCommitsTest(APITestCase):
     def setUp(self):
         self.user = self.create_user(is_staff=False, is_superuser=False)
-        # org = self.organization
-        # org.flags.allow_joinleave = False
-        # org.save()
-
-        # team1 = self.create_team(organization=org)
-        # team2 = self.create_team(organization=org)
 
         project = self.create_project(organization=self.organization)
         self.project2 = self.create_project(organization=self.organization)


### PR DESCRIPTION
**Context:**
Work is being done in the sentry-cli to be able to support commits without the need for a repo provider (meaning they have the GH, Bitbucket, etc. integration set up). While users can already [use the API](https://docs.sentry.io/workflow/releases/?platform=javascript#alternatively-without-a-repository-integration) to do this, it requires a lot of manual steps. 

The sentry-cli needs to be able to know what the most recent commit was so that we can create the correct `patch_set` for the commits in the current release.

**Previous Release Scenarios:**
1. There is no previous release - the user has never set up releases before so in the sentry-cli we will take a handful of the latest commits as a starting point

2. No previous release have commits - the user may have been using releases but never sent commits, same result as scenario 1.

3. A previous release has a commit - returns that release, and the sentry-cli will use the `lastCommit` to be able to calculate which commits need to be in the current release

Releases can be associated with multiple projects so we want to make sure if there are multiple previous releases (with commits) that we return the release with the most recent `lastCommit`.