### PR TITLE
feat(async-csv): Display SHA1 checksum on download page

### DIFF
--- a/src/sentry/api/serializers/models/exporteddata.py
+++ b/src/sentry/api/serializers/models/exporteddata.py
@@ -33,4 +33,5 @@ class ExportedDataSerializer(Serializer):
             "dateExpired": obj.date_expired,
             "query": {"type": ExportQueryType.as_str(obj.query_type), "info": obj.query_info},
             "status": obj.status,
+            "checksum": obj.file.checksum,
         }

--- a/src/sentry/api/serializers/models/exporteddata.py
+++ b/src/sentry/api/serializers/models/exporteddata.py
@@ -25,6 +25,13 @@ class ExportedDataSerializer(Serializer):
         return attrs
 
     def serialize(self, obj, attrs, user, **kwargs):
+        if obj.file is None:
+            checksum = None
+            file_name = None
+        else:
+            checksum = obj.file.checksum
+            file_name = obj.file.name
+
         return {
             "id": obj.id,
             "user": attrs["user"],
@@ -33,5 +40,6 @@ class ExportedDataSerializer(Serializer):
             "dateExpired": obj.date_expired,
             "query": {"type": ExportQueryType.as_str(obj.query_type), "info": obj.query_info},
             "status": obj.status,
-            "checksum": obj.file.checksum,
+            "checksum": checksum,
+            "fileName": file_name,
         }

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -36,6 +36,7 @@ type Download = {
     info: object;
   };
   status: DownloadStatus;
+  checksum: string;
 };
 
 type Props = {} & RouteComponentProps<RouteParams, {}>;
@@ -108,6 +109,7 @@ class DataDownload extends AsyncView<Props, State> {
       </React.Fragment>
     );
   }
+
   renderExpired(): React.ReactNode {
     const {query} = this.state.download;
     const actionLink = this.getActionLink(query.type);
@@ -136,7 +138,7 @@ class DataDownload extends AsyncView<Props, State> {
   }
   renderValid(): React.ReactNode {
     const {
-      download: {dateExpired},
+      download: {dateExpired, checksum},
     } = this.state;
     const {orgId, dataExportId} = this.props.params;
     return (
@@ -158,6 +160,10 @@ class DataDownload extends AsyncView<Props, State> {
             <br />
             {this.renderDate(dateExpired)}
           </p>
+          <p>{t('Want to double check the download?')}</p>
+          <small>
+            <strong>{`SHA1: ${checksum}`}</strong>
+          </small>
         </Body>
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -8,7 +8,7 @@ import DateTime from 'app/components/dateTime';
 import AsyncView from 'app/views/asyncView';
 import Layout from 'app/views/auth/layout';
 import space from 'app/styles/space';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 
 export enum DownloadStatus {
   Early = 'EARLY',
@@ -164,14 +164,17 @@ class DataDownload extends AsyncView<Props, State> {
             <strong>SHA1:{checksum}</strong>
           </small>
           <p>
-            Need help verifying? Checkout our{' '}
-            <a
-              href="https://docs.sentry.io/performance/discover/query-builder/#verifying-the-download"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              docs
-            </a>
+            {tct('Need help verifying? [link].', {
+              link: (
+                <a
+                  href="https://docs.sentry.io/performance/discover/query-builder/#verifying-the-download"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t('Checkout our docs.')}
+                </a>
+              ),
+            })}
           </p>
         </Body>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -171,7 +171,7 @@ class DataDownload extends AsyncView<Props, State> {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  {t('Checkout our docs.')}
+                  {t('Check out our docs.')}
                 </a>
               ),
             })}

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -16,11 +16,6 @@ export enum DownloadStatus {
   Expired = 'EXPIRED',
 }
 
-const CodeBlock = styled('pre')`
-  word-break: break-all;
-  white-space: pre-wrap;
-`;
-
 type RouteParams = {
   orgId: string;
   dataExportId: string;
@@ -42,7 +37,6 @@ type Download = {
   };
   status: DownloadStatus;
   checksum: string;
-  fileName: string;
 };
 
 type Props = {} & RouteComponentProps<RouteParams, {}>;
@@ -144,7 +138,7 @@ class DataDownload extends AsyncView<Props, State> {
   }
   renderValid(): React.ReactNode {
     const {
-      download: {dateExpired, checksum, fileName},
+      download: {dateExpired, checksum},
     } = this.state;
     const {orgId, dataExportId} = this.props.params;
     return (
@@ -166,12 +160,19 @@ class DataDownload extends AsyncView<Props, State> {
             <br />
             {this.renderDate(dateExpired)}
           </p>
-          <p>{t('Want to double check the download?')}</p>
-          {checksum && fileName ? (
-            <CodeBlock>
-              echo "{checksum} {fileName}" | sha1sum -c -
-            </CodeBlock>
-          ) : null}
+          <small>
+            <strong>SHA1:{checksum}</strong>
+          </small>
+          <p>
+            Need help verifying? Checkout our{' '}
+            <a
+              href="https://docs.sentry.io/performance/discover/query-builder/#verifying-the-download"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              docs
+            </a>
+          </p>
         </Body>
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -16,6 +16,11 @@ export enum DownloadStatus {
   Expired = 'EXPIRED',
 }
 
+const CodeBlock = styled('pre')`
+  word-break: break-all;
+  white-space: pre-wrap;
+`;
+
 type RouteParams = {
   orgId: string;
   dataExportId: string;
@@ -37,6 +42,7 @@ type Download = {
   };
   status: DownloadStatus;
   checksum: string;
+  fileName: string;
 };
 
 type Props = {} & RouteComponentProps<RouteParams, {}>;
@@ -138,7 +144,7 @@ class DataDownload extends AsyncView<Props, State> {
   }
   renderValid(): React.ReactNode {
     const {
-      download: {dateExpired, checksum},
+      download: {dateExpired, checksum, fileName},
     } = this.state;
     const {orgId, dataExportId} = this.props.params;
     return (
@@ -161,9 +167,11 @@ class DataDownload extends AsyncView<Props, State> {
             {this.renderDate(dateExpired)}
           </p>
           <p>{t('Want to double check the download?')}</p>
-          <small>
-            <strong>{`SHA1: ${checksum}`}</strong>
-          </small>
+          {checksum && fileName ? (
+            <CodeBlock>
+              echo "{checksum} {fileName}" | sha1sum -c -
+            </CodeBlock>
+          ) : null}
         </Body>
       </React.Fragment>
     );

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -55,6 +55,8 @@ class DataExportTest(APITestCase):
             "dateExpired": None,
             "query": {"type": self.payload["query_type"], "info": self.payload["query_info"]},
             "status": ExportStatus.Early,
+            "checksum": None,
+            "fileName": None,
         }
 
     def test_progress_export(self):
@@ -82,6 +84,8 @@ class DataExportTest(APITestCase):
                 "info": data_export.query_info,
             },
             "status": data_export.status,
+            "checksum": None,
+            "fileName": None,
         }
 
     def test_export_too_many_fields(self):


### PR DESCRIPTION
Before
<img width="575" alt="Screen Shot 2020-06-10 at 6 00 03 PM" src="https://user-images.githubusercontent.com/10239353/84323123-37c4ed80-ab44-11ea-956c-acbab3425daa.png">

After:
<img width="568" alt="Screen Shot 2020-06-12 at 10 55 47 AM" src="https://user-images.githubusercontent.com/10239353/84516970-969d7a80-ac9c-11ea-94a3-f936ac4e8be9.png">

Docs:
<img width="751" alt="Screen Shot 2020-06-12 at 11 03 19 AM" src="https://user-images.githubusercontent.com/10239353/84517022-a87f1d80-ac9c-11ea-8fdd-164d4e0f9b74.png">

getsentry/sentry-docs#1747