### PR TITLE
chore(mail_adapter): Add logging around mail adapter and digests

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -59,6 +59,8 @@ class MailAdapter(object):
             "event_id": event.event_id,
             "group_id": event.group_id,
             "is_from_mail_action_adapter": True,
+            "target_type": target_type.value,
+            "target_identifier": target_identifier,
         }
         log_event = "dispatched"
         for future in futures:
@@ -276,12 +278,19 @@ class MailAdapter(object):
     def notify(self, notification, target_type, target_identifier=None, **kwargs):
         metrics.incr("mail_adapter.notify")
         event = notification.event
-
         environment = event.get_tag("environment")
-
         group = event.group
         project = group.project
         org = group.organization
+        logger.info(
+            "mail.adapter.notify",
+            extra={
+                "target_type": target_type.value,
+                "target_identifier": target_identifier,
+                "group": group.id,
+                "project_id": project.id,
+            },
+        )
 
         subject = event.get_email_subject()
 
@@ -365,6 +374,17 @@ class MailAdapter(object):
             target_identifier=target_identifier,
             event=event,
         ):
+            logger.info(
+                "mail.adapter.notify.mail_user",
+                extra={
+                    "target_type": target_type,
+                    "target_identifier": target_identifier,
+                    "group": group.id,
+                    "project_id": project.id,
+                    "user_id": user_id,
+                },
+            )
+
             self.add_unsubscribe_link(context, user_id, project, "alert_email")
             self._send_mail(
                 subject=subject,
@@ -389,6 +409,15 @@ class MailAdapter(object):
     def notify_digest(self, project, digest, target_type, target_identifier=None):
         metrics.incr("mail_adapter.notify_digest")
         user_ids = self.get_send_to(project, target_type, target_identifier)
+        logger.info(
+            "mail.adapter.notify_digest",
+            extra={
+                "project_id": project.id,
+                "target_type": target_type.value,
+                "target_identifier": target_identifier,
+                "user_ids": user_ids,
+            },
+        )
         for user_id, digest in get_personalized_digests(project.id, digest, user_ids):
             start, end, counts = get_digest_metadata(digest)
 

--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -60,3 +60,12 @@ def deliver_digest(key, schedule_timestamp=None):
 
         if digest:
             mail_adapter.notify_digest(project, digest, target_type, target_identifier)
+        else:
+            logger.info(
+                "Skipped digest delivery due to empty digest",
+                extra={
+                    "project": project.id,
+                    "target_type": target_type.value,
+                    "target_identifier": target_identifier,
+                },
+            )


### PR DESCRIPTION
We're investigating an issue where a user isn't receiving alert emails for issue alerts. The rule
appears to be firing, but then an email isn't sent. Adding extra logging around this to figure out
what's happening.