### PR TITLE
fix(tests): Fix unstable alert_rule tests around fetching alert stats

### DIFF
--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -218,7 +218,7 @@ class BaseIncidentsTest(SnubaTestCase):
 
     @cached_property
     def now(self):
-        return timezone.now().replace(microsecond=0)
+        return timezone.now().replace(minute=0, second=0, microsecond=0)
 
 
 class BaseIncidentEventStatsTest(BaseIncidentsTest):
@@ -272,7 +272,7 @@ class BaseIncidentEventStatsTest(BaseIncidentsTest):
 class GetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
     @fixture
     def bucket_incident(self):
-        incident_start = self.now.replace(minute=0, second=0, microsecond=0) - timedelta(minutes=23)
+        incident_start = self.now - timedelta(minutes=23)
         self.create_event(incident_start + timedelta(seconds=1))
         self.create_event(incident_start + timedelta(minutes=2))
         self.create_event(incident_start + timedelta(minutes=6))
@@ -293,28 +293,32 @@ class GetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
         self.validate_result(incident, result, expected_results, start, end, windowed_stats)
 
     def test_project(self):
-        self.run_test(self.project_incident, [0, 2, 1])
-        self.run_test(self.project_incident, [0, 1], start=self.now - timedelta(minutes=1))
-        self.run_test(
-            self.project_incident, [0, 2], end=self.now - timedelta(minutes=1, seconds=59)
-        )
+        self.run_test(self.project_incident, [2, 1])
+        self.run_test(self.project_incident, [1], start=self.now - timedelta(minutes=1))
+        self.run_test(self.project_incident, [2], end=self.now - timedelta(minutes=1, seconds=59))
 
-        self.run_test(self.project_incident, [0, 2, 1], windowed_stats=True)
+        self.run_test(self.project_incident, [2, 1], windowed_stats=True)
         self.run_test(
             self.project_incident,
-            [0, 2, 1],
+            [2, 1],
             start=self.now - timedelta(minutes=1),
             windowed_stats=True,
         )
         self.run_test(
             self.project_incident,
-            [0, 2, 1],
+            [2, 1],
             end=self.now - timedelta(minutes=1, seconds=59),
             windowed_stats=True,
         )
 
     def test_start_bucket(self):
         self.run_test(self.bucket_incident, [2, 4, 2, 2])
+
+    def test_buckets_already_aligned(self):
+        self.bucket_incident.update(
+            date_started=self.now - timedelta(minutes=30), date_closed=self.now
+        )
+        self.run_test(self.bucket_incident, [2, 2, 2])
 
     def test_start_and_end_bucket(self):
         self.create_event(self.bucket_incident.date_started + timedelta(minutes=19))
@@ -341,7 +345,7 @@ class GetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
         event_data["transaction"] = "/foo_transaction/"
         self.store_event(data=event_data, project_id=self.project.id)
 
-        self.run_test(incident, [0, 2, 1])
+        self.run_test(incident, [2, 1])
 
 
 class BaseIncidentAggregatesTest(BaseIncidentsTest):
@@ -374,13 +378,13 @@ class CreateEventStatTest(TestCase, BaseIncidentsTest):
         snapshot = create_event_stat_snapshot(incident, windowed_stats=False)
         assert snapshot.start == incident.date_started - timedelta(minutes=1)
         assert snapshot.end == incident.current_end_date + timedelta(minutes=1)
-        assert [row[1] for row in snapshot.values] == [0, 2, 1]
+        assert [row[1] for row in snapshot.values] == [2, 1]
 
         snapshot = create_event_stat_snapshot(incident, windowed_stats=True)
         expected_start, expected_end = calculate_incident_time_range(incident, windowed_stats=True)
         assert snapshot.start == expected_start
         assert snapshot.end == expected_end
-        assert [row[1] for row in snapshot.values] == [0, 2, 1]
+        assert [row[1] for row in snapshot.values] == [2, 1]
 
 
 @freeze_time()


### PR DESCRIPTION
When I initially updated these tests adding the extra `0` bucket was incorrect. Since we weren't
freezing the time to be aligned to minutes, it meant that we always fetched the extra 0 bucket even
though it wasn't necessary. Very rarely we'd actually happen to run the query aligned to the minute
by chance, which would cause the tests to fail.

This aligns us to the minute, which means the queries will now run correctly and we won't have the
additional 0 bucket.