### PR TITLE
ref(Sentry apps): Change error capturing and retry logic

### DIFF
--- a/src/sentry/mediators/sentry_app_installations/destroyer.py
+++ b/src/sentry/mediators/sentry_app_installations/destroyer.py
@@ -7,6 +7,7 @@ from sentry.mediators import Mediator, Param
 from sentry.mediators import service_hooks, sentry_app_installation_tokens
 from sentry.models import ApiToken, AuditLogEntryEvent, SentryAppInstallationToken, ServiceHook
 from sentry.mediators.sentry_app_installations.installation_notifier import InstallationNotifier
+from sentry.shared_integrations.exceptions import IgnorableSentryAppError
 from sentry.utils.audit import create_audit_entry
 
 
@@ -55,7 +56,7 @@ class Destroyer(Mediator):
             try:
                 InstallationNotifier.run(install=self.install, user=self.user, action="deleted")
             # if the error is from a request exception, log the error and continue
-            except RequestException as exc:
+            except (RequestException, IgnorableSentryAppError) as exc:
                 self.log(error=exc)
         self.install.delete()
 

--- a/src/sentry/mediators/sentry_app_installations/destroyer.py
+++ b/src/sentry/mediators/sentry_app_installations/destroyer.py
@@ -7,7 +7,6 @@ from sentry.mediators import Mediator, Param
 from sentry.mediators import service_hooks, sentry_app_installation_tokens
 from sentry.models import ApiToken, AuditLogEntryEvent, SentryAppInstallationToken, ServiceHook
 from sentry.mediators.sentry_app_installations.installation_notifier import InstallationNotifier
-from sentry.shared_integrations.exceptions import IgnorableSentryAppError
 from sentry.utils.audit import create_audit_entry
 
 
@@ -56,7 +55,7 @@ class Destroyer(Mediator):
             try:
                 InstallationNotifier.run(install=self.install, user=self.user, action="deleted")
             # if the error is from a request exception, log the error and continue
-            except (RequestException, IgnorableSentryAppError) as exc:
+            except RequestException as exc:
                 self.log(error=exc)
         self.install.delete()
 

--- a/src/sentry/shared_integrations/exceptions.py
+++ b/src/sentry/shared_integrations/exceptions.py
@@ -73,14 +73,6 @@ class ApiUnauthorized(ApiError):
     code = 401
 
 
-class ServiceUnavailable(ApiError):
-    code = 503
-
-
-class GatewayTimeout(ApiError):
-    code = 504
-
-
 class UnsupportedResponseType(ApiError):
     @property
     def content_type(self):

--- a/src/sentry/shared_integrations/exceptions.py
+++ b/src/sentry/shared_integrations/exceptions.py
@@ -73,6 +73,14 @@ class ApiUnauthorized(ApiError):
     code = 401
 
 
+class ServiceUnavailable(ApiError):
+    code = 503
+
+
+class GatewayTimeout(ApiError):
+    code = 504
+
+
 class UnsupportedResponseType(ApiError):
     @property
     def content_type(self):
@@ -91,3 +99,7 @@ class IntegrationFormError(IntegrationError):
     def __init__(self, field_errors):
         super(IntegrationFormError, self).__init__("Invalid integration action")
         self.field_errors = field_errors
+
+
+class IgnorableSentryAppError(IntegrationError):
+    pass

--- a/src/sentry/shared_integrations/exceptions.py
+++ b/src/sentry/shared_integrations/exceptions.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from bs4 import BeautifulSoup
 from collections import OrderedDict
+from requests.exceptions import RequestException
+
 from simplejson.decoder import JSONDecodeError
 from six.moves.urllib.parse import urlparse
 from sentry.utils import json
@@ -93,5 +95,5 @@ class IntegrationFormError(IntegrationError):
         self.field_errors = field_errors
 
 
-class IgnorableSentryAppError(IntegrationError):
+class IgnorableSentryAppError(RequestException):
     pass

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -54,7 +54,7 @@ def instrumented_task(name, stat_suffix=None, **kwargs):
     return wrapped
 
 
-def retry(func=None, on=(Exception,), exclude=()):
+def retry(func=None, on=(Exception,), exclude=(), ignore=None):
     """
     >>> @retry(on=(Exception,), exclude=(AnotherException,))
     >>> def my_task():
@@ -69,6 +69,8 @@ def retry(func=None, on=(Exception,), exclude=()):
         def wrapped(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
+            except ignore:
+                return
             except exclude:
                 raise
             except on as exc:

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -54,7 +54,7 @@ def instrumented_task(name, stat_suffix=None, **kwargs):
     return wrapped
 
 
-def retry(func=None, on=(Exception,), exclude=(), ignore=None):
+def retry(func=None, on=(Exception,), exclude=(), ignore=()):
     """
     >>> @retry(on=(Exception,), exclude=(AnotherException,))
     >>> def my_task():

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -56,7 +56,7 @@ def instrumented_task(name, stat_suffix=None, **kwargs):
 
 def retry(func=None, on=(Exception,), exclude=(), ignore=()):
     """
-    >>> @retry(on=(Exception,), exclude=(AnotherException,))
+    >>> @retry(on=(Exception,), exclude=(AnotherException,), ignore=(IgnorableException,))
     >>> def my_task():
     >>>     ...
     """

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -310,7 +310,7 @@ def send_webhooks(installation, event, **kwargs):
         )
 
 
-def check_app_status(func):
+def ignore_unpublished_app_errors(func):
     def wrapper(url, sentry_app, app_platform_event):
         try:
             return func(url, sentry_app, app_platform_event)
@@ -323,7 +323,7 @@ def check_app_status(func):
     return wrapper
 
 
-@check_app_status
+@ignore_unpublished_app_errors
 def send_and_save_webhook_request(url, sentry_app, app_platform_event):
     buffer = SentryAppWebhookRequestsBuffer(sentry_app)
 

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -143,7 +143,11 @@ class TestDestroyer(TestCase):
 
     @responses.activate
     def test_fail_on_other_error(self):
+        from sentry.constants import SentryAppStatus
+
         install = self.install
+        self.sentry_app.update(status=SentryAppStatus.PUBLISHED)
+        # we don't log errors for unpublished and internal apps
         try:
             responses.add(
                 responses.POST, "https://example.com/webhook", body=Exception("Other error")


### PR DESCRIPTION
Change the Sentry app task behavior to not retry unless the response is a 503 or a 504 status code (since these could be temporary). Additionally, this stops capturing exceptions for unpublished and internal Sentry apps. This also now captures ConnectionErrors.