### PR TITLE
fix(translations): Fix some problematic translations

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/ignore.tsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.tsx
@@ -196,7 +196,11 @@ export default class IgnoreActions extends React.Component<Props, State> {
                 {IGNORE_COUNTS.map(count => (
                   <li className="dropdown-submenu" key={count}>
                     <DropdownLink
-                      title={tn('one time\u2026', '%s times\u2026', count)}
+                      title={
+                        count === 1
+                          ? t('one time\u2026') // This is intentional as unbalanced string formatters are problematic
+                          : tn('%s time\u2026', '%s times\u2026', count)
+                      }
                       caret={false}
                       isNestedDropdown
                       alwaysRenderMenu

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -290,9 +290,17 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
 
   get inviteButtonLabel() {
     if (this.invites.length > 0) {
-      return this.willInvite
-        ? tn('Send invite', 'Send invites (%s)', this.invites.length)
-        : tn('Send invite request', 'Send invite requests (%s)', this.invites.length);
+      const numberInvites = this.invites.length;
+
+      // Note we use `t()` here because `tn()` expects the same # of string formatters
+      const inviteText =
+        numberInvites === 1 ? t('Send invite') : t('Send invites (%s)', numberInvites);
+      const requestText =
+        numberInvites === 1
+          ? t('Send invite request')
+          : t('Send invite requests (%s)', numberInvites);
+
+      return this.willInvite ? inviteText : requestText;
     }
 
     return this.willInvite ? t('Send invite') : t('Send invite request');


### PR DESCRIPTION
These translations strings are not good because the formatter expects a balanced amount of str placeholders