### PR TITLE
fix(ui): locale template key error

### DIFF
--- a/src/sentry/static/sentry/app/locale.tsx
+++ b/src/sentry/static/sentry/app/locale.tsx
@@ -234,7 +234,7 @@ export function renderTemplate(template: ParsedTemplate, components: ComponentMa
       : React.cloneElement(element, {key: idx++}, children);
   }
 
-  return renderGroup('root');
+  return <React.Fragment>{renderGroup('root')}</React.Fragment>;
 }
 
 /**

--- a/tests/js/spec/components/events/__snapshots__/crashContent.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/crashContent.spec.jsx.snap
@@ -76,14 +76,16 @@ exports[`CrashContent renders with meta data 1`] = `
               containerDisplayMode="inline-block"
               position="top"
               title={
-                <span>
+                <React.Fragment>
                   <span>
-                    from 
+                    <span>
+                      from 
+                    </span>
+                    <span>
+                      exceptions
+                    </span>
                   </span>
-                  <span>
-                    exceptions
-                  </span>
-                </span>
+                </React.Fragment>
               }
             >
               <Manager>

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -4108,14 +4108,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           containerDisplayMode="block"
                                           position="top"
                                           title={
-                                            <span>
+                                            <React.Fragment>
                                               <span>
-                                                Create a project
+                                                <span>
+                                                  Create a project
+                                                </span>
+                                                <span>
+                                                   before completing this task
+                                                </span>
                                               </span>
-                                              <span>
-                                                 before completing this task
-                                              </span>
-                                            </span>
+                                            </React.Fragment>
                                           }
                                         >
                                           <Manager>
@@ -4895,14 +4897,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           containerDisplayMode="block"
                                           position="top"
                                           title={
-                                            <span>
+                                            <React.Fragment>
                                               <span>
-                                                Create a project
+                                                <span>
+                                                  Create a project
+                                                </span>
+                                                <span>
+                                                   before completing this task
+                                                </span>
                                               </span>
-                                              <span>
-                                                 before completing this task
-                                              </span>
-                                            </span>
+                                            </React.Fragment>
                                           }
                                         >
                                           <Manager>
@@ -5688,14 +5692,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           containerDisplayMode="block"
                                           position="top"
                                           title={
-                                            <span>
+                                            <React.Fragment>
                                               <span>
-                                                Create a project
+                                                <span>
+                                                  Create a project
+                                                </span>
+                                                <span>
+                                                   before completing this task
+                                                </span>
                                               </span>
-                                              <span>
-                                                 before completing this task
-                                              </span>
-                                            </span>
+                                            </React.Fragment>
                                           }
                                         >
                                           <Manager>
@@ -6482,14 +6488,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           containerDisplayMode="block"
                                           position="top"
                                           title={
-                                            <span>
+                                            <React.Fragment>
                                               <span>
-                                                Create a project
+                                                <span>
+                                                  Create a project
+                                                </span>
+                                                <span>
+                                                   before completing this task
+                                                </span>
                                               </span>
-                                              <span>
-                                                 before completing this task
-                                              </span>
-                                            </span>
+                                            </React.Fragment>
                                           }
                                         >
                                           <Manager>
@@ -7174,14 +7182,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           containerDisplayMode="block"
                                           position="top"
                                           title={
-                                            <span>
+                                            <React.Fragment>
                                               <span>
-                                                Create a project
+                                                <span>
+                                                  Create a project
+                                                </span>
+                                                <span>
+                                                   before completing this task
+                                                </span>
                                               </span>
-                                              <span>
-                                                 before completing this task
-                                              </span>
-                                            </span>
+                                            </React.Fragment>
                                           }
                                         >
                                           <Manager>

--- a/tests/js/spec/utils/locale.spec.jsx
+++ b/tests/js/spec/utils/locale.spec.jsx
@@ -5,7 +5,7 @@ import {mount} from 'sentry-test/enzyme';
 import {tct} from 'app/locale';
 
 describe('locale.gettextComponentTemplate', () => {
-  it('should render two component templates inside the same element', async () => {
+  it('should render two component templates inside the same parent', async () => {
     const wrapper = mount(
       <div>
         {tct('1st: [one]', {

--- a/tests/js/spec/utils/locale.spec.jsx
+++ b/tests/js/spec/utils/locale.spec.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import {mount} from 'sentry-test/enzyme';
+
+import {tct} from 'app/locale';
+
+describe('locale.gettextComponentTemplate', () => {
+  it('should render two component templates inside the same element', async () => {
+    const wrapper = mount(
+      <div>
+        {tct('1st: [one]', {
+          one: 'one',
+        })}
+        {tct('2nd: [two]', {
+          two: 'two',
+        })}
+      </div>
+    );
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.text()).toBe('1st: one2nd: two');
+  });
+});

--- a/tests/js/spec/views/__snapshots__/installWizard.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/installWizard.spec.jsx.snap
@@ -409,21 +409,23 @@ exports[`InstallWizard renders 1`] = `
                     disabled={false}
                     disabledReason={null}
                     help={
-                      <span>
+                      <React.Fragment>
                         <span>
-                          If enabled, any stats reported to sentry.io will exclude identifying information (such as your administrative email address). By anonymizing your installation the Sentry team will be unable to contact you about security updates. For more information on what data is sent to Sentry, see the 
-                        </span>
-                        <a
-                          href="https://docs.sentry.io/server/beacon/"
-                        >
                           <span>
-                            documentation
+                            If enabled, any stats reported to sentry.io will exclude identifying information (such as your administrative email address). By anonymizing your installation the Sentry team will be unable to contact you about security updates. For more information on what data is sent to Sentry, see the 
                           </span>
-                        </a>
-                        <span>
-                          .
+                          <a
+                            href="https://docs.sentry.io/server/beacon/"
+                          >
+                            <span>
+                              documentation
+                            </span>
+                          </a>
+                          <span>
+                            .
+                          </span>
                         </span>
-                      </span>
+                      </React.Fragment>
                     }
                     hideErrorMessage={false}
                     isSet={true}

--- a/tests/js/spec/views/__snapshots__/organizationCreate.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationCreate.spec.jsx.snap
@@ -46,28 +46,30 @@ exports[`OrganizationCreate render() renders with terms 1`] = `
         disabled={false}
         hideErrorMessage={false}
         label={
-          <span>
+          <React.Fragment>
             <span>
-              I agree to the 
-            </span>
-            <a
-              href="https://example.com/terms"
-            >
               <span>
-                Terms of Service
+                I agree to the 
               </span>
-            </a>
-            <span>
-               and the 
-            </span>
-            <a
-              href="https://example.com/privacy"
-            >
+              <a
+                href="https://example.com/terms"
+              >
+                <span>
+                  Terms of Service
+                </span>
+              </a>
               <span>
-                Privacy Policy
+                 and the 
               </span>
-            </a>
-          </span>
+              <a
+                href="https://example.com/privacy"
+              >
+                <span>
+                  Privacy Policy
+                </span>
+              </a>
+            </span>
+          </React.Fragment>
         }
         name="agreeTerms"
         required={true}

--- a/tests/js/spec/views/admin/__snapshots__/adminSettings.spec.jsx.snap
+++ b/tests/js/spec/views/admin/__snapshots__/adminSettings.spec.jsx.snap
@@ -184,21 +184,23 @@ exports[`AdminSettings render() renders 1`] = `
         component={[Function]}
         disabled={false}
         help={
-          <span>
+          <React.Fragment>
             <span>
-              If enabled, any stats reported to sentry.io will exclude identifying information (such as your administrative email address). By anonymizing your installation the Sentry team will be unable to contact you about security updates. For more information on what data is sent to Sentry, see the 
-            </span>
-            <a
-              href="https://docs.sentry.io/server/beacon/"
-            >
               <span>
-                documentation
+                If enabled, any stats reported to sentry.io will exclude identifying information (such as your administrative email address). By anonymizing your installation the Sentry team will be unable to contact you about security updates. For more information on what data is sent to Sentry, see the 
               </span>
-            </a>
-            <span>
-              .
+              <a
+                href="https://docs.sentry.io/server/beacon/"
+              >
+                <span>
+                  documentation
+                </span>
+              </a>
+              <span>
+                .
+              </span>
             </span>
-          </span>
+          </React.Fragment>
         }
         hideErrorMessage={false}
         key="beacon.anonymous"


### PR DESCRIPTION
If there are two calls to `tct` inside of the same parent that happen to have the same number of elements, react would spit out a key error.

```
Warning: Encountered two children with the same key, `5`. Keys should be unique so that components maintain their identity across updates.
```

Wrap the result from tct in a react fragment to prevent duplicate keys