### PR TITLE
feat(app): Show invites awaiting approval to inviters

### DIFF
--- a/src/sentry/api/endpoints/organization_invite_request_index.py
+++ b/src/sentry/api/endpoints/organization_invite_request_index.py
@@ -27,12 +27,25 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
     permission_classes = (InviteRequestPermissions,)
 
     def get(self, request, organization):
-        queryset = OrganizationMember.objects.filter(
-            Q(user__isnull=True),
-            Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
-            | Q(invite_status=InviteStatus.REQUESTED_TO_JOIN.value),
-            organization=organization,
-        ).order_by("invite_status", "email")
+        # Users with only member:read access can only see invites they've requested,
+        # and cannot see requests to join.
+        if request.access.has_scope("member:read") and not (
+            request.access.has_scope("member:write") or request.access.has_scope("member:admin")
+        ):
+            queryset = OrganizationMember.objects.filter(
+                Q(user__isnull=True),
+                Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value),
+                Q(inviter=request.user),
+                organization=organization,
+            ).order_by("invite_status", "email")
+
+        else:
+            queryset = OrganizationMember.objects.filter(
+                Q(user__isnull=True),
+                Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
+                | Q(invite_status=InviteStatus.REQUESTED_TO_JOIN.value),
+                organization=organization,
+            ).order_by("invite_status", "email")
 
         if organization.get_option("sentry:join_requests") is False:
             queryset = queryset.filter(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -189,7 +189,7 @@ const StyledPanelItem = styled(PanelItem)`
 
 const InviteStatus = styled('div')`
   display: block;
-  font-size: 14px;
+  font-size: ${p => p.theme.fontSizeMedium};
   padding: ${space(0.5)} ${space(0.5)};
   grid-column: max-content;
   justify-self: end;

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
@@ -54,27 +54,9 @@ class OrganizationMembersWrapper extends AsyncView<Props, State> {
     return organization.access.includes('member:write');
   }
 
-  get showInviteRequests() {
-    return this.hasWriteAccess;
-  }
-
-  get showNavTabs() {
-    const {requestList} = this.state;
-
-    // show the requests tab if there are pending team requests,
-    // or if the user has access to approve or deny invite requests
-    return (requestList && requestList.length > 0) || this.showInviteRequests;
-  }
-
   get requestCount() {
     const {requestList, inviteRequests} = this.state;
-    let count = requestList.length;
-
-    // if the user can't see the invite requests panel,
-    // exclude those requests from the total count
-    if (this.showInviteRequests) {
-      count += inviteRequests.length;
-    }
+    const count = requestList.length + inviteRequests.length;
     return count ? count.toString() : null;
   }
 
@@ -126,33 +108,30 @@ class OrganizationMembersWrapper extends AsyncView<Props, State> {
           </Button>
         </StyledPanel>
 
-        {this.showNavTabs && (
-          <NavTabs underlined>
-            <ListLink
-              to={`/settings/${orgId}/members/`}
-              isActive={() => !this.onRequestsTab}
-              data-test-id="members-tab"
-            >
-              {t('Members')}
-            </ListLink>
-            <ListLink
-              to={`/settings/${orgId}/members/requests/`}
-              isActive={() => this.onRequestsTab}
-              data-test-id="requests-tab"
-              onClick={() => {
-                this.showInviteRequests &&
-                  trackAnalyticsEvent({
-                    eventKey: 'invite_request.tab_clicked',
-                    eventName: 'Invite Request Tab Clicked',
-                    organization_id: organization.id,
-                  });
-              }}
-            >
-              {t('Requests')}
-            </ListLink>
-            {this.requestCount && <StyledBadge text={this.requestCount} />}
-          </NavTabs>
-        )}
+        <NavTabs underlined>
+          <ListLink
+            to={`/settings/${orgId}/members/`}
+            isActive={() => !this.onRequestsTab}
+            data-test-id="members-tab"
+          >
+            {t('Members')}
+          </ListLink>
+          <ListLink
+            to={`/settings/${orgId}/members/requests/`}
+            isActive={() => this.onRequestsTab}
+            data-test-id="requests-tab"
+            onClick={() =>
+              trackAnalyticsEvent({
+                eventKey: 'invite_request.tab_clicked',
+                eventName: 'Invite Request Tab Clicked',
+                organization_id: organization.id,
+              })
+            }
+          >
+            {t('Requests')}
+          </ListLink>
+          {this.requestCount && <StyledBadge text={this.requestCount} />}
+        </NavTabs>
 
         {children &&
           React.cloneElement(children, {
@@ -161,7 +140,7 @@ class OrganizationMembersWrapper extends AsyncView<Props, State> {
             onRemoveInviteRequest: this.removeInviteRequest,
             onUpdateInviteRequest: this.updateInviteRequest,
             onRemoveAccessRequest: this.removeAccessRequest,
-            showInviteRequests: this.showInviteRequests,
+            hasWriteAccess: this.hasWriteAccess,
           })}
       </React.Fragment>
     );

--- a/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
@@ -51,6 +51,7 @@ describe('InviteRequestRow', function() {
         inviteRequestBusy={inviteRequestBusy}
         allTeams={[]}
         allRoles={roles}
+        hasWriteAccess
       />
     );
 
@@ -71,11 +72,28 @@ describe('InviteRequestRow', function() {
         inviteRequestBusy={inviteRequestBusy}
         allTeams={[]}
         allRoles={roles}
+        hasWriteAccess
       />
     );
 
     expect(wrapper.find('UserName').text()).toBe(joinRequest.email);
     expect(wrapper.find('JoinRequestIndicator').exists()).toBe(true);
+  });
+
+  it('displays status when no write access', function() {
+    const wrapper = mountWithTheme(
+      <InviteRequestRow
+        orgId={orgId}
+        inviteRequest={inviteRequest}
+        inviteRequestBusy={inviteRequestBusy}
+        allTeams={[]}
+        allRoles={roles}
+      />
+    );
+
+    expect(wrapper.find('InviteStatus').exists()).toBe(true);
+    expect(wrapper.find('button[aria-label="Approve"]').exists()).toBe(false);
+    expect(wrapper.find('button[aria-label="Confirm"]').exists()).toBe(false);
   });
 
   it('can approve invite request', function() {
@@ -91,6 +109,7 @@ describe('InviteRequestRow', function() {
         onDeny={mockDeny}
         allTeams={[]}
         allRoles={roles}
+        hasWriteAccess
       />
     );
 
@@ -113,6 +132,7 @@ describe('InviteRequestRow', function() {
         onDeny={mockDeny}
         allTeams={[]}
         allRoles={roles}
+        hasWriteAccess
       />
     );
 
@@ -139,6 +159,7 @@ describe('InviteRequestRow', function() {
         allTeams={[{slug: 'one'}, {slug: 'two'}]}
         allRoles={roles}
         onUpdate={mockUpdate}
+        hasWriteAccess
       />
     );
 
@@ -167,6 +188,7 @@ describe('InviteRequestRow', function() {
         allTeams={[{slug: 'one'}, {slug: 'two'}]}
         allRoles={roles}
         onUpdate={mockUpdate}
+        hasWriteAccess
       />
     );
 

--- a/tests/js/spec/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
@@ -70,12 +70,17 @@ describe('OrganizationMembersWrapper', function() {
     });
   });
 
-  it('does not render requests tab without access', function() {
+  it('renders requests tab without join requests for users without write access', function() {
     const org = TestStubs.Organization({
       access: [],
       status: {
         id: 'active',
       },
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/invite-requests/',
+      method: 'GET',
+      body: [inviteRequest],
     });
 
     const wrapper = mountWithTheme(
@@ -83,11 +88,13 @@ describe('OrganizationMembersWrapper', function() {
       TestStubs.routerContext()
     );
 
-    expect(wrapper.find('NavTabs').exists()).toBe(false);
-    expect(trackAnalyticsEvent).not.toHaveBeenCalled();
+    expect(wrapper.find('NavTabs').exists()).toBe(true);
+    expect(wrapper.find('StyledBadge[text="1"]').exists()).toBe(true);
+    expect(wrapper.find('ListLink[data-test-id="members-tab"]').exists()).toBe(true);
+    expect(wrapper.find('ListLink[data-test-id="requests-tab"]').exists()).toBe(true);
   });
 
-  it('renders requests tab with access', function() {
+  it('renders requests tab for write-access users', function() {
     const org = TestStubs.Organization({
       access: ['member:admin', 'org:admin', 'member:write'],
       status: {
@@ -150,37 +157,6 @@ describe('OrganizationMembersWrapper', function() {
     );
 
     expect(wrapper.find('NavTabs').exists()).toBe(true);
-    expect(wrapper.find('ListLink[data-test-id="members-tab"]').exists()).toBe(true);
-    expect(wrapper.find('ListLink[data-test-id="requests-tab"]').exists()).toBe(true);
-
-    expect(trackAnalyticsEvent).not.toHaveBeenCalled();
-  });
-
-  it('renders requests tab with team requests and no access', function() {
-    const org = TestStubs.Organization({
-      access: [],
-      status: {
-        id: 'active',
-      },
-    });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/access-requests/',
-      method: 'GET',
-      body: [TestStubs.AccessRequest()],
-    });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/invite-requests/',
-      method: 'GET',
-      body: [inviteRequest, joinRequest],
-    });
-
-    const wrapper = mountWithTheme(
-      <OrganizationMembersWrapper organization={org} {...defaultProps} />,
-      TestStubs.routerContext()
-    );
-
-    expect(wrapper.find('NavTabs').exists()).toBe(true);
-    expect(wrapper.find('StyledBadge[text="1"]').exists()).toBe(true);
     expect(wrapper.find('ListLink[data-test-id="members-tab"]').exists()).toBe(true);
     expect(wrapper.find('ListLink[data-test-id="requests-tab"]').exists()).toBe(true);
 

--- a/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
@@ -136,7 +136,6 @@ describe('OrganizationRequestsView', function() {
     wrapper.update();
 
     expect(wrapper.find('[data-test-id="request-message"]').exists()).toBe(false);
-    expect(wrapper.find('NavTabs').exists()).toBe(false);
 
     expect(trackAnalyticsEvent).not.toHaveBeenCalled();
   });
@@ -177,12 +176,9 @@ describe('OrganizationRequestsView', function() {
     wrapper.update();
 
     expect(wrapper.find('[data-test-id="request-message"]').exists()).toBe(false);
-    expect(wrapper.find('NavTabs').exists()).toBe(false);
-
-    expect(trackAnalyticsEvent).not.toHaveBeenCalled();
   });
 
-  it('does not render invite requests without access', function() {
+  it('does not render invite request approve / deny buttons without access', function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/invite-requests/',
       method: 'GET',
@@ -191,7 +187,7 @@ describe('OrganizationRequestsView', function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/access-requests/',
       method: 'GET',
-      body: [accessRequest],
+      body: [],
     });
 
     const org = TestStubs.Organization({
@@ -209,8 +205,12 @@ describe('OrganizationRequestsView', function() {
     );
 
     expect(wrapper.find('NavTabs').exists()).toBe(true);
-    expect(wrapper.find('StyledBadge[text="1"]').exists()).toBe(true);
-    expect(wrapper.find('InviteRequestRow').exists()).toBe(false);
+
+    expect(wrapper.find('StyledBadge').text()).toBe('1');
+
+    expect(wrapper.find('InviteStatus').exists()).toBe(true);
+    expect(wrapper.find('button[aria-label="Approve"]').exists()).toBe(false);
+    expect(wrapper.find('button[aria-label="Confirm"]').exists()).toBe(false);
 
     expect(trackAnalyticsEvent).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Currently when users send a member invite, it's not clear that the request must be approved by an owner or manager before the invite will be sent to the invitee. This change makes the requests tab visible to all members (rather than just owners, managers, and team admins), and filters invite requests so non-owner/manager users can only view invites they've sent.

UI tweaks to make the "send an invite" modal clearer will be part of a future change.

Part of ENT-216.