### PR TITLE
fix(metric_alerts): Fix bug with including alert start/end buckets from stats endpoint.

### DIFF
--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -131,6 +131,9 @@ def zerofill(data, start, end, rollup):
     i = 0
     for key in six.moves.xrange(start, end, rollup):
         try:
+            while data[i][0] < key:
+                rv.append(data[i])
+                i += 1
             if data[i][0] == key:
                 rv.append(data[i])
                 i += 1

--- a/tests/sentry/api/serializers/test_snuba.py
+++ b/tests/sentry/api/serializers/test_snuba.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import
+
+import unittest
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.api.serializers.snuba import zerofill
+from sentry.utils.dates import to_timestamp
+
+
+class ZeroFillTest(unittest.TestCase):
+    def run_test(self, filled_buckets, irregular_buckets, start, end, rollup, zerofilled_buckets):
+        filled_buckets = [(start + (rollup * bucket), val) for bucket, val in filled_buckets]
+        buckets = [(to_timestamp(date), val) for date, val in filled_buckets + irregular_buckets]
+        sort_key = lambda row: row[0]
+        buckets.sort(key=sort_key)
+        zerofilled_buckets = [
+            (to_timestamp(start + (rollup * bucket)), []) for bucket in zerofilled_buckets
+        ]
+        expected = buckets + zerofilled_buckets
+        expected.sort(key=sort_key)
+
+        assert zerofill(buckets, start, end, int(rollup.total_seconds())) == expected
+
+    def test_missing_buckets(self):
+        start = timezone.now().replace(minute=0, second=0, microsecond=0)
+        rollup = timedelta(minutes=10)
+        self.run_test(
+            [(0, [0]), (1, [1])], [], start, start + timedelta(minutes=60), rollup, [2, 3, 4, 5, 6]
+        )
+        self.run_test(
+            [(0, [0]), (2, [1]), (4, [4])],
+            [],
+            start,
+            start + timedelta(minutes=60),
+            rollup,
+            [1, 3, 5, 6],
+        )
+
+    def test_non_rollup_buckets(self):
+        start = timezone.now().replace(minute=0, second=0, microsecond=0)
+        rollup = timedelta(minutes=10)
+        self.run_test(
+            filled_buckets=[(0, [0]), (1, [1])],
+            irregular_buckets=[
+                (start + timedelta(minutes=5), [5]),
+                (start + timedelta(minutes=32), [8]),
+            ],
+            start=start,
+            end=start + timedelta(minutes=60),
+            rollup=rollup,
+            zerofilled_buckets=[2, 3, 4, 5, 6],
+        )

--- a/tests/sentry/incidents/endpoints/test_organization_incident_stats.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_stats.py
@@ -1,18 +1,24 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
+from datetime import datetime, timedelta
+from uuid import uuid4
 
 from django.utils import timezone
+from django.utils.functional import cached_property
 from exam import fixture
 from freezegun import freeze_time
+from pytz import utc
 
-from sentry.testutils import APITestCase
+from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format
 
 
-class OrganizationIncidentDetailsTest(APITestCase):
+@freeze_time()
+class OrganizationIncidentDetailsTest(SnubaTestCase, APITestCase):
     endpoint = "sentry-api-0-organization-incident-stats"
 
     def setUp(self):
+        super(OrganizationIncidentDetailsTest, self).setUp()
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
 
@@ -28,6 +34,38 @@ class OrganizationIncidentDetailsTest(APITestCase):
     def user(self):
         return self.create_user()
 
+    def create_event(self, timestamp, fingerprint=None, user=None):
+        event_id = uuid4().hex
+        if fingerprint is None:
+            fingerprint = event_id
+
+        data = {
+            "event_id": event_id,
+            "fingerprint": [fingerprint],
+            "timestamp": iso_format(timestamp),
+            "type": "error",
+            "exception": [{"type": "Foo"}],
+        }
+        if user:
+            data["user"] = user
+        return self.store_event(data=data, project_id=self.project.id)
+
+    @cached_property
+    def now(self):
+        return datetime.utcnow().replace(minute=0, second=0, microsecond=0, tzinfo=utc)
+
+    @fixture
+    def bucket_incident(self):
+        incident_start = self.now - timedelta(minutes=23)
+        self.create_event(incident_start + timedelta(seconds=1))
+        self.create_event(incident_start + timedelta(minutes=2))
+        self.create_event(incident_start + timedelta(minutes=6))
+        self.create_event(incident_start + timedelta(minutes=9, seconds=59))
+        self.create_event(incident_start + timedelta(minutes=14))
+        self.create_event(incident_start + timedelta(minutes=16))
+        alert_rule = self.create_alert_rule(time_window=10)
+        return self.create_incident(date_started=incident_start, query="", alert_rule=alert_rule)
+
     def test_no_perms(self):
         incident = self.create_incident()
         self.login_as(self.create_user())
@@ -40,7 +78,6 @@ class OrganizationIncidentDetailsTest(APITestCase):
         resp = self.get_response(incident.organization.slug, incident.id)
         assert resp.status_code == 404
 
-    @freeze_time()
     def test_simple(self):
         incident = self.create_incident(date_started=timezone.now() - timedelta(minutes=5))
         with self.feature("organizations:incidents"):
@@ -48,4 +85,25 @@ class OrganizationIncidentDetailsTest(APITestCase):
 
         assert resp.data["totalEvents"] == 0
         assert resp.data["uniqueUsers"] == 0
-        assert [data[1] for data in resp.data["eventStats"]["data"]] == [[]] * 201
+        assert [data[1] for data in resp.data["eventStats"]["data"]] == [[]] * 196 + [
+            [{"count": 0}]
+        ] + [[]] * 5
+
+    def test_buckets(self):
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(
+                self.bucket_incident.organization.slug, self.bucket_incident.identifier
+            )
+
+        assert resp.data["totalEvents"] == 6
+        assert resp.data["uniqueUsers"] == 0
+        assert [data[1] for data in resp.data["eventStats"]["data"]] == [[]] * 194 + [
+            [{"count": 2}],
+            [{"count": 4}],
+            [{"count": 2}],
+            [{"count": 2}],
+            [],
+            [],
+            [],
+            [],
+        ]


### PR DESCRIPTION
This fixes a bug with https://github.com/getsentry/sentry/pull/19282. Due to the way zerofill
currently works, adding in a start/end bucket that isn't cleanly divisible by the rollup causes that
bucket and every subsequent bucket to be incorrectly zerofilled. This fixes zerofill to handle this
behaviour correctly, and adds missing tests to make sure things are working as expected.