### PR TITLE
fix(discover) Retain chart interval on sort operations

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -35,6 +35,7 @@ type ChartProps = {
   previousTimeseriesData?: Series | null;
   previousSeriesName?: string;
   showDaily?: boolean;
+  interval?: string;
   yAxis: string;
 };
 
@@ -201,6 +202,10 @@ type Props = {
    */
   field?: string[];
   /**
+   * The interval resolution for a chart e.g. 1m, 5m, 1d
+   */
+  interval?: string;
+  /**
    * Order condition when showing topEvents
    */
   orderby?: string;
@@ -263,6 +268,7 @@ class EventsChart extends React.Component<Props> {
       currentSeriesName: currentName,
       previousSeriesName: previousName,
       field,
+      interval,
       showDaily,
       topEvents,
       orderby,
@@ -292,9 +298,7 @@ class EventsChart extends React.Component<Props> {
         }
       },
     };
-    const interval = showDaily
-      ? '1d'
-      : router?.location?.query?.interval || getInterval(this.props, true);
+    const intervalVal = showDaily ? '1d' : interval || getInterval(this.props, true);
 
     let chartImplementation = ({
       zoomRenderProps,
@@ -365,7 +369,7 @@ class EventsChart extends React.Component<Props> {
             environment={environments}
             start={start}
             end={end}
-            interval={interval}
+            interval={intervalVal}
             query={query}
             includePrevious={includePrevious}
             currentSeriesName={currentSeriesName}

--- a/src/sentry/static/sentry/app/utils/queryString.tsx
+++ b/src/sentry/static/sentry/app/utils/queryString.tsx
@@ -71,7 +71,17 @@ export function decodeScalar(
   return isString(unwrapped) ? unwrapped : undefined;
 }
 
+export function decodeList(
+  value: string[] | string | undefined | null
+): string[] | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return Array.isArray(value) ? value : isString(value) ? [value] : [];
+}
+
 export default {
+  decodeList,
   decodeScalar,
   formatQueryString,
   addQueryParamsToExistingUrl,

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -78,6 +78,7 @@ class ResultsChart extends React.Component<ResultsChartProps> {
               disablePrevious={eventView.display !== DisplayModes.PREVIOUS}
               disableReleases={eventView.display !== DisplayModes.RELEASES}
               field={isTopEvents ? apiPayload.field : undefined}
+              interval={eventView.interval}
               showDaily={isDaily}
               topEvents={isTopEvents ? 5 : undefined}
               orderby={isTopEvents ? decodeScalar(apiPayload.sort) : undefined}

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -561,6 +561,7 @@ describe('EventView.generateQueryStringObject()', function() {
       environment: ['staging'],
       yAxis: 'count()',
       display: 'releases',
+      interval: '1m',
     };
 
     const eventView = new EventView(state);
@@ -579,6 +580,7 @@ describe('EventView.generateQueryStringObject()', function() {
       environment: ['staging'],
       yAxis: 'count()',
       display: 'releases',
+      interval: '1m',
     };
 
     expect(eventView.generateQueryStringObject()).toEqual(expected);
@@ -1176,6 +1178,7 @@ describe('EventView.clone()', function() {
       end: '2019-10-02T00:00:00',
       statsPeriod: '14d',
       environment: ['staging'],
+      interval: '5m',
       display: 'releases',
     };
 

--- a/tests/js/spec/utils/queryString.spec.js
+++ b/tests/js/spec/utils/queryString.spec.js
@@ -86,3 +86,19 @@ describe('decodeScalar()', function() {
     expect(utils.decodeScalar('')).toBeUndefined();
   });
 });
+
+describe('decodeList()', function() {
+  it('wraps string values', function() {
+    expect(utils.decodeList('one')).toEqual(['one']);
+  });
+
+  it('handles arrays', function() {
+    expect(utils.decodeList(['one', 'two'])).toEqual(['one', 'two']);
+  });
+
+  it('handles falsey values', function() {
+    expect(utils.decodeList(undefined)).toBeUndefined();
+    expect(utils.decodeList(false)).toBeUndefined();
+    expect(utils.decodeList('')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Add interval to EventView so we can retain its value when using EventView to manipulate query strings. I've not added interval to the saved query model as that has not come up as something people want yet.