### PR TITLE
build(webpack): Change condition when we record asset sizes

### DIFF
--- a/build-utils/sentry-instrumentation.js
+++ b/build-utils/sentry-instrumentation.js
@@ -5,9 +5,9 @@ const https = require('https');
 const os = require('os');
 
 const {
+  NODE_ENV,
   SENTRY_INSTRUMENTATION,
   SENTRY_WEBPACK_WEBHOOK_SECRET,
-  TEST_SUITE,
   TRAVIS_COMMIT,
   TRAVIS_BRANCH,
   TRAVIS_PULL_REQUEST,
@@ -26,7 +26,7 @@ const createSignature = function(secret, payload) {
 class SentryInstrumentation {
   constructor() {
     // Only run if SENTRY_INSTRUMENTATION` is set or when in travis, only in the javascript suite that runs webpack
-    if (!SENTRY_INSTRUMENTATION && TEST_SUITE !== 'js-build') {
+    if (!SENTRY_INSTRUMENTATION) {
       return;
     }
 
@@ -77,6 +77,7 @@ class SentryInstrumentation {
               commit: TRAVIS_COMMIT,
               pull_request_number: TRAVIS_PULL_REQUEST,
               environment: IS_CI ? 'ci' : '',
+              node_env: NODE_ENV,
             });
 
             const req = https.request({


### PR DESCRIPTION
Previously this would only work on sentry travis runs because of the env var we were inspecting, changed so that it runs whenever we have the webhook secret so that it will also run on getsentry builds.