### PR TITLE
fix(test) Stabilize issue details tests

### DIFF
--- a/src/sentry/static/sentry/app/components/events/groupingInfo/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/index.tsx
@@ -73,8 +73,9 @@ class EventGroupingInfo extends AsyncComponent<Props, State> {
       .join(', ');
 
     return (
-      <SummaryGroupedBy>{`(${t('grouped by')} ${groupedBy ||
-        t('nothing')})`}</SummaryGroupedBy>
+      <SummaryGroupedBy data-test-id="loaded-grouping-info">{`(${t(
+        'grouped by'
+      )} ${groupedBy || t('nothing')})`}</SummaryGroupedBy>
     );
   }
 

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -85,3 +85,4 @@ class IssueDetailsPage(BasePage):
         self.browser.wait_until_test_id("event-entries")
         self.browser.wait_until_test_id("linked-issues")
         self.browser.wait_until_test_id("loaded-device-name")
+        self.browser.wait_until_test_id("loaded-grouping-info")

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -85,4 +85,5 @@ class IssueDetailsPage(BasePage):
         self.browser.wait_until_test_id("event-entries")
         self.browser.wait_until_test_id("linked-issues")
         self.browser.wait_until_test_id("loaded-device-name")
-        self.browser.wait_until_test_id("loaded-grouping-info")
+        if self.browser.element_exists("#grouping-info"):
+            self.browser.wait_until_test_id("loaded-grouping-info")


### PR DESCRIPTION
The grouping info frequently diffs in percy as it hasn't loaded yet. Add more wait conditions so snapshots are more stable.