### PR TITLE
fix(settings): Handle Manager access to configure auth provider

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1318,6 +1318,7 @@ SENTRY_ROLES = (
                 "team:admin",
                 "org:read",
                 "org:write",
+                "org:admin",
                 "org:integrations",
             ]
         ),

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1318,7 +1318,6 @@ SENTRY_ROLES = (
                 "team:admin",
                 "org:read",
                 "org:write",
-                "org:admin",
                 "org:integrations",
             ]
         ),

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/index.jsx
@@ -16,7 +16,7 @@ class OrganizationAuth extends AsyncView {
   UNSAFE_componentWillUpdate(_nextProps, nextState) {
     const access = this.context.organization.access;
 
-    if (nextState.provider && access.includes('org:admin')) {
+    if (nextState.provider && access.includes('org:write')) {
       // If SSO provider is configured, keep showing loading while we redirect
       // to django configuration view
       window.location.assign(`/organizations/${this.props.params.orgId}/auth/configure/`);
@@ -95,7 +95,7 @@ class OrganizationAuth extends AsyncView {
     const {providerList, provider} = this.state;
     const access = this.context.organization.access;
 
-    if (access.includes('org:admin') && provider) {
+    if (access.includes('org:write') && provider) {
       // If SSO provider is configured, keep showing loading while we redirect
       // to django configuration view
       return this.renderLoading();

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
@@ -32,7 +32,7 @@ export default class ProviderItem extends React.PureComponent {
   renderDisabledLock = p => <LockedFeature provider={p.provider} features={p.features} />;
 
   renderInstallButton = ({provider, hasFeature}) => (
-    <Access access={['org:admin']}>
+    <Access access={['org:write']}>
       {({hasAccess}) => (
         <Button
           type="submit"

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
@@ -32,7 +32,7 @@ export default class ProviderItem extends React.PureComponent {
   renderDisabledLock = p => <LockedFeature provider={p.provider} features={p.features} />;
 
   renderInstallButton = ({provider, hasFeature}) => (
-    <Access access={['org:write']}>
+    <Access access={['org:admin']}>
       {({hasAccess}) => (
         <Button
           type="submit"

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -44,9 +44,9 @@ class AuthProviderSettingsForm(forms.Form):
 
 
 class OrganizationAuthSettingsView(OrganizationView):
-    # We restrict auth settings to org:admin as it allows a non-owner to
+    # We restrict auth settings to org:write as it allows a non-owner to
     # escalate members to own by disabling the default role.
-    required_scope = "org:admin"
+    required_scope = "org:write"
 
     def _disable_provider(self, request, organization, auth_provider):
         self.create_audit_entry(


### PR DESCRIPTION
Enable the configure button for Auth Providers for the Manager role and allow the Manager role to configure an auth provider. The Alert displays that Managers and Owners can edit these settings, but configure is disabled for Managers.

[Fixes ISSUE-854](https://getsentry.atlassian.net/browse/ISSUE-854)

**Before:**
- Alert displays that Managers or Owners can make edits to the Auth page (logged in as a Member in the screenshot)
<img width="973" alt="Screen Shot 2020-06-11 at 1 24 09 AM" src="https://user-images.githubusercontent.com/20312973/84428253-00ede680-abdb-11ea-9de2-65e224e8f42f.png">

- As a Manager, the configure button is still disabled (logged in as a Manager in the screenshot)
<img width="974" alt="Screen Shot 2020-06-11 at 1 22 35 AM" src="https://user-images.githubusercontent.com/20312973/84428311-16fba700-abdb-11ea-9f29-5e5cbcf0470b.png">

**After:**
- Enable the Configure button when the user role is Manager
<img width="972" alt="Screen Shot 2020-06-11 at 12 03 32 PM" src="https://user-images.githubusercontent.com/20312973/84428603-9c7f5700-abdb-11ea-92e0-555d6a7e5412.png">