### PR TITLE
fix(alerts): Change settings button text to "All Rules"

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -293,7 +293,7 @@ class IncidentsListContainer extends React.Component<Props> {
                   size="small"
                   icon={<IconSettings size="xs" />}
                 >
-                  {t('Settings')}
+                  {t('All Rules')}
                 </Button>
 
                 <ButtonBar merged active={status}>

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -293,7 +293,7 @@ class IncidentsListContainer extends React.Component<Props> {
                   size="small"
                   icon={<IconSettings size="xs" />}
                 >
-                  {t('All Rules')}
+                  {t('View Rules')}
                 </Button>
 
                 <ButtonBar merged active={status}>


### PR DESCRIPTION
This changes the text of a button causing confusion. In the long term, rules will be moved to its own tab.

Resolves: https://app.asana.com/0/1143846759074121/1180005054463729/f

OLD: 
![Screen Shot 2020-06-11 at 4 01 51 PM](https://user-images.githubusercontent.com/15015880/84448118-afefe980-abfe-11ea-9dd1-b671049b2753.png)

NEW: 
![Screen Shot 2020-06-11 at 4 01 31 PM](https://user-images.githubusercontent.com/15015880/84448120-b54d3400-abfe-11ea-88e6-bccd6c9ba5cf.png)

