### PR TITLE
feat(vercel): creates MVP of project mapping ui

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -10,18 +10,28 @@ class VercelClient(ApiClient):
 
     TEAMS_URL = "/v1/teams/%s"
     USER_URL = "/www/user"
+    PROJECTS_URL = "/v4/projects/"
 
-    def __init__(self, access_token):
-        # TODO(Steve): we might need a constructor arg to denote if this is a team installation when we do API calls
+    def __init__(self, access_token, team_id=None):
         super(VercelClient, self).__init__()
         self.access_token = access_token
+        self.team_id = team_id
 
     def request(self, method, path, data=None, params=None):
+        if self.team_id:
+            # always need to use the team_id as a param for requests
+            params = params or {}
+            params["teamId"] = self.team_id
         headers = {"Authorization": u"Bearer {}".format(self.access_token)}
-        return self._request(method, path, headers=headers, data=data, params=params,)
+        return self._request(method, path, headers=headers, data=data, params=params)
 
-    def get_team(self, team_id):
-        return self.get_cached(self.TEAMS_URL % team_id, params={"teamId": team_id})
+    def get_team(self):
+        assert self.team_id
+        return self.get_cached(self.TEAMS_URL % self.team_id)
 
     def get_user(self):
         return self.get_cached(self.USER_URL)["user"]
+
+    def get_projects(self):
+        # TODO: we will need pagination since we are limited to 20
+        return self.get(self.PROJECTS_URL)["projects"]

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -54,7 +54,7 @@ class VercelIntegration(IntegrationInstallation):
 
         proj_fields = ["id", "platform", "name", "slug"]
         sentry_projects = map(
-            lambda proj: {key: getattr(proj, key) for key in proj_fields},
+            lambda proj: {key: proj[key] for key in proj_fields},
             (
                 Project.objects.filter(organization_id=self.organization_id)
                 .order_by("slug")

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -13,6 +13,7 @@ from sentry.integrations import (
 from sentry.pipeline import NestedPipelineView
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.utils.http import absolute_uri
+from sentry.models import Project
 
 from .client import VercelClient
 
@@ -23,9 +24,9 @@ VERCEL DESC
 FEATURES = [
     FeatureDescription(
         """
-        COMMIT DESCRIPTION
+        DEPLOYMENT DESCRIPTION
         """,
-        IntegrationFeatures.COMMITS,
+        IntegrationFeatures.DEPLOYMENT,
     ),
 ]
 
@@ -42,7 +43,29 @@ metadata = IntegrationMetadata(
 
 
 class VercelIntegration(IntegrationInstallation):
-    pass
+    def get_organization_config(self):
+        metadata = self.model.metadata
+        vercel_client = VercelClient(metadata["access_token"], metadata.get("team_id"))
+        vercel_projects = [
+            {"value": p["id"], "label": p["name"]} for p in vercel_client.get_projects()
+        ]
+
+        sentry_projects = (
+            Project.objects.filter(organization_id=self.organization_id)
+            .order_by("slug")
+            .values("id", "platform", "name", "slug")
+        )
+
+        fields = [
+            {
+                "name": "project_mappings",
+                "type": "project_mapper",
+                "mappedDropdown": {"items": vercel_projects},
+                "sentryProjects": sentry_projects,
+            }
+        ]
+
+        return fields
 
 
 class VercelIntegrationProvider(IntegrationProvider):
@@ -51,7 +74,7 @@ class VercelIntegrationProvider(IntegrationProvider):
     requires_feature_flag = True
     metadata = metadata
     integration_cls = VercelIntegration
-    features = frozenset([IntegrationFeatures.COMMITS])
+    features = frozenset([IntegrationFeatures.DEPLOYMENT])
     oauth_redirect_url = "/extensions/vercel/configure/"
 
     def get_pipeline_views(self):
@@ -69,12 +92,13 @@ class VercelIntegrationProvider(IntegrationProvider):
     def build_integration(self, state):
         data = state["identity"]["data"]
         access_token = data["access_token"]
-        client = VercelClient(access_token)
+        team_id = data.get("team_id")
+        client = VercelClient(access_token, team_id)
 
-        if data.get("team_id"):
-            external_id = data["team_id"]
+        if team_id:
+            external_id = team_id
             installation_type = "team"
-            team = client.get_team(external_id)
+            team = client.get_team()
             name = team["name"]
         else:
             external_id = data["user_id"]

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -60,7 +60,10 @@ class VercelIntegration(IntegrationInstallation):
             {
                 "name": "project_mappings",
                 "type": "project_mapper",
-                "mappedDropdown": {"items": vercel_projects},
+                "mappedDropdown": {
+                    "items": vercel_projects,
+                    "placeholder": _('Select a Vercel Project')
+                    },
                 "sentryProjects": sentry_projects,
             }
         ]

--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
@@ -17,6 +17,7 @@ import InputField from './inputField';
 import ChoiceMapperField from './choiceMapperField';
 import RichListField from './richListField';
 import FieldSeparator from './fieldSeparator';
+import ProjectMapperField from './projectMapperField';
 import {Field} from './type';
 
 type Props = {
@@ -55,6 +56,7 @@ export default class FieldFromConfig extends React.Component<Props> {
         'textarea',
         'url',
         'table',
+        'project_mapper',
       ]),
       required: PropTypes.bool,
       multiline: PropTypes.bool,
@@ -135,6 +137,8 @@ export default class FieldFromConfig extends React.Component<Props> {
         return <RichListField {...props} />;
       case 'table':
         return <TableField {...props} />;
+      case 'project_mapper':
+        return <ProjectMapperField {...props} />;
       case 'custom':
         return field.Component(props);
       default:

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -44,7 +44,9 @@ export default class ProjectMapperField extends React.Component<Props> {
     const handleAdd = () => {
       const {value: sentryProjectId} = this.sentryProjectRef.current.state.value;
       const {value: mappedValue} = this.mappedRef.current.state.value;
+      //add the new value to the list of exsiting values
       const projectMappings = [...existingValues, [sentryProjectId, mappedValue]];
+      //trigger events so we save the value and show the check mark
       onChange?.(projectMappings, []);
       onBlur?.(projectMappings, []);
     };
@@ -62,6 +64,7 @@ export default class ProjectMapperField extends React.Component<Props> {
 
     const customValueContainer = containerProps => {
       const valueList = containerProps.getValue();
+      //if no value set, we want to return the default component that is rendered
       if (valueList.length === 0) {
         return <components.ValueContainer {...containerProps} />;
       }
@@ -83,7 +86,7 @@ export default class ProjectMapperField extends React.Component<Props> {
     };
 
     const customOptionProject = projectProps => {
-      const project = sentryProjects.find(({id}) => projectProps.value === id);
+      const project = sentryProjectsById[projectProps.value];
       if (!project) {
         return null;
       }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -13,15 +13,20 @@ import {t} from 'app/locale';
 type Props = InputField['props'];
 type RenderProps = Props & ProjectMapperType;
 
-export default class ProjectMapperField extends React.Component<Props> {
+export class RenderField extends React.Component<RenderProps> {
   private sentryProjectRef = React.createRef<typeof SelectControl>();
   private mappedRef = React.createRef<typeof SelectControl>();
 
-  renderField = (props: RenderProps) => {
-    const {onChange, onBlur, value, mappedDropdown} = props;
+  render() {
+    const {
+      onChange,
+      onBlur,
+      value,
+      mappedDropdown,
+      sentryProjects,
+      mappedDropdown: {items: mappedDropdownItems},
+    } = this.props;
     const existingValues: Array<[number, string | number]> = value || [];
-    const sentryProjects = props.sentryProjects || [];
-    const mappedDropdownItems = mappedDropdown?.items || [];
 
     // create maps by the project id for constant time lookups
     const sentryProjectsById = Object.fromEntries(
@@ -121,7 +126,7 @@ export default class ProjectMapperField extends React.Component<Props> {
             ref={this.sentryProjectRef}
           />
           <StyledSelectControl
-            placeholder={mappedDropdown?.placeholder}
+            placeholder={mappedDropdown.placeholder}
             name="mappedDropwdown"
             openMenuOnFocus
             options={mappedItemsToShow}
@@ -131,12 +136,17 @@ export default class ProjectMapperField extends React.Component<Props> {
         </SelectContainer>
       </Wrapper>
     );
-  };
-
-  render() {
-    return <InputField {...this.props} field={this.renderField} />;
   }
 }
+
+const ProjectMapperField = (props: Props) => (
+  <InputField
+    {...props}
+    field={(renderProps: RenderProps) => <RenderField {...renderProps} />}
+  />
+);
+
+export default ProjectMapperField;
 
 const StyledSelectControl = styled(SelectControl)`
   width: 50%;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -17,10 +17,10 @@ export default class ProjectMapperField extends React.Component<Props> {
   private mappedRef = React.createRef<typeof SelectControl>();
 
   renderField = (props: Props) => {
-    const {onChange, onBlur, value} = props;
+    const {onChange, onBlur, value, mappedDropdown} = props;
     const existingValues: Array<[number, string | number]> = value || [];
     const sentryProjects = props.sentryProjects || [];
-    const mappedDropdownItems = props.mappedDropdown?.items || [];
+    const mappedDropdownItems = mappedDropdown?.items || [];
 
     const sentryProjectsById = Object.fromEntries(
       sentryProjects.map(project => [project.id, project])
@@ -115,7 +115,7 @@ export default class ProjectMapperField extends React.Component<Props> {
             ref={this.sentryProjectRef}
           />
           <StyledSelectControl
-            placeholder={t('Select a Vercel Project')}
+            placeholder={mappedDropdown?.placeholder}
             name="mappedDropwdown"
             openMenuOnFocus
             options={mappedItemsToShow}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {components} from 'react-select';
+
+import InputField from 'app/views/settings/components/forms/inputField';
+import {ProjectMapperType} from 'app/views/settings/components/forms/type';
+import SelectControl from 'app/components/forms/selectControl';
+import IdBadge from 'app/components/idBadge';
+import Button from 'app/components/button';
+import {IconAdd} from 'app/icons';
+import {t} from 'app/locale';
+
+type Props = InputField['props'] & Omit<ProjectMapperType, 'type'>;
+
+export default class ProjectMapperField extends React.Component<Props> {
+  private sentryProjectRef = React.createRef<typeof SelectControl>();
+  private mappedRef = React.createRef<typeof SelectControl>();
+
+  renderField = (props: Props) => {
+    const {onChange, onBlur, value} = props;
+    const existingValues: Array<[number, string | number]> = value || [];
+    const sentryProjects = props.sentryProjects || [];
+    const mappedDropdownItems = props.mappedDropdown?.items || [];
+
+    const sentryProjectsById = Object.fromEntries(
+      sentryProjects.map(project => [project.id, project])
+    );
+
+    const mappedItemsByValue = Object.fromEntries(
+      mappedDropdownItems.map(item => [item.value, item])
+    );
+
+    const projectIdsUsed = new Set(existingValues.map(tuple => tuple[0]));
+    const mappedValuesUsed = new Set(existingValues.map(tuple => tuple[1]));
+
+    const projectOptions = sentryProjects
+      .filter(project => !projectIdsUsed.has(project.id))
+      .map(({slug, id}) => ({label: slug, value: id}));
+
+    const mappedItemsToShow = mappedDropdownItems.filter(
+      item => !mappedValuesUsed.has(item.value)
+    );
+
+    const handleAdd = () => {
+      const {value: sentryProjectId} = this.sentryProjectRef.current.state.value;
+      const {value: mappedValue} = this.mappedRef.current.state.value;
+      const projectMappings = [...existingValues, [sentryProjectId, mappedValue]];
+      onChange?.(projectMappings, []);
+      onBlur?.(projectMappings, []);
+    };
+
+    const renderItem = (itemTuple: [number, any]) => {
+      const [projectId, mappedValue] = itemTuple;
+      const {slug} = sentryProjectsById[projectId];
+      const {label: itemLabel} = mappedItemsByValue[mappedValue];
+      return (
+        <Item key={projectId}>
+          <ItemValue>{slug}</ItemValue> <ItemValue>{itemLabel}</ItemValue>
+        </Item>
+      );
+    };
+
+    const customValueContainer = containerProps => {
+      const valueList = containerProps.getValue();
+      if (valueList.length === 0) {
+        return <components.ValueContainer {...containerProps} />;
+      }
+      const projectId = valueList[0].value;
+      const project = sentryProjectsById[projectId];
+      if (!project) {
+        return <components.ValueContainer {...containerProps} />;
+      }
+      return (
+        <components.ValueContainer {...containerProps}>
+          <IdBadge
+            project={project}
+            avatarSize={20}
+            displayName={project.slug}
+            avatarProps={{consistentWidth: true}}
+          />
+        </components.ValueContainer>
+      );
+    };
+
+    const customOptionProject = projectProps => {
+      const project = sentryProjects.find(({id}) => projectProps.value === id);
+      if (!project) {
+        return null;
+      }
+      return (
+        <components.Option {...projectProps}>
+          <IdBadge
+            project={project}
+            avatarSize={20}
+            displayName={project.slug}
+            avatarProps={{consistentWidth: true}}
+          />
+        </components.Option>
+      );
+    };
+
+    return (
+      <Wrapper>
+        {existingValues.map(renderItem)}
+        <SelectContainer>
+          <StyledSelectControl
+            placeholder={t('Select a Project')}
+            name="project"
+            openMenuOnFocus
+            options={projectOptions}
+            components={{
+              Option: customOptionProject,
+              ValueContainer: customValueContainer,
+            }}
+            ref={this.sentryProjectRef}
+          />
+          <StyledSelectControl
+            placeholder={t('Select a Vercel Project')}
+            name="mappedDropwdown"
+            openMenuOnFocus
+            options={mappedItemsToShow}
+            ref={this.mappedRef}
+          />
+          <Button size="small" label={t('Add')} icon={<IconAdd />} onClick={handleAdd} />
+        </SelectContainer>
+      </Wrapper>
+    );
+  };
+
+  render() {
+    return <InputField {...this.props} field={this.renderField} />;
+  }
+}
+
+const StyledSelectControl = styled(SelectControl)`
+  width: 50%;
+`;
+
+const SelectContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+`;
+
+const Wrapper = styled('div')``;
+
+const Item = styled('div')`
+  padding: 5px;
+`;
+
+const ItemValue = styled('span')`
+  padding: 5px;
+`;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -10,18 +10,20 @@ import Button from 'app/components/button';
 import {IconAdd} from 'app/icons';
 import {t} from 'app/locale';
 
-type Props = InputField['props'] & Omit<ProjectMapperType, 'type'>;
+type Props = InputField['props'];
+type RenderProps = Props & ProjectMapperType;
 
 export default class ProjectMapperField extends React.Component<Props> {
   private sentryProjectRef = React.createRef<typeof SelectControl>();
   private mappedRef = React.createRef<typeof SelectControl>();
 
-  renderField = (props: Props) => {
+  renderField = (props: RenderProps) => {
     const {onChange, onBlur, value, mappedDropdown} = props;
     const existingValues: Array<[number, string | number]> = value || [];
     const sentryProjects = props.sentryProjects || [];
     const mappedDropdownItems = mappedDropdown?.items || [];
 
+    // create maps by the project id for constant time lookups
     const sentryProjectsById = Object.fromEntries(
       sentryProjects.map(project => [project.id, project])
     );
@@ -30,6 +32,7 @@ export default class ProjectMapperField extends React.Component<Props> {
       mappedDropdownItems.map(item => [item.value, item])
     );
 
+    //build sets of values used so we don't let the user select them twice
     const projectIdsUsed = new Set(existingValues.map(tuple => tuple[0]));
     const mappedValuesUsed = new Set(existingValues.map(tuple => tuple[1]));
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -14,8 +14,8 @@ type Props = InputField['props'];
 type RenderProps = Props & ProjectMapperType;
 
 export class RenderField extends React.Component<RenderProps> {
-  private sentryProjectRef = React.createRef<typeof SelectControl>();
-  private mappedRef = React.createRef<typeof SelectControl>();
+  sentryProjectRef = React.createRef<typeof SelectControl>();
+  mappedRef = React.createRef<typeof SelectControl>();
 
   render() {
     const {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -47,7 +47,7 @@ export default class ProjectMapperField extends React.Component<Props> {
     const handleAdd = () => {
       const {value: sentryProjectId} = this.sentryProjectRef.current.state.value;
       const {value: mappedValue} = this.mappedRef.current.state.value;
-      //add the new value to the list of exsiting values
+      //add the new value to the list of existing values
       const projectMappings = [...existingValues, [sentryProjectId, mappedValue]];
       //trigger events so we save the value and show the check mark
       onChange?.(projectMappings, []);
@@ -144,7 +144,6 @@ const StyledSelectControl = styled(SelectControl)`
 
 const SelectContainer = styled('div')`
   display: flex;
-  flex-direction: row;
 `;
 
 const Wrapper = styled('div')``;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
@@ -27,16 +27,15 @@ const defaultProps = {
 };
 
 type DefaultProps = Readonly<typeof defaultProps>;
-
-//Maybe not the best way of getting the props from TableType but it works
-type Props = DefaultProps & InputField['props'] & Omit<TableType, 'type'>;
+type Props = InputField['props'];
+type RenderProps = Props & DefaultProps & TableType;
 
 export default class TableField extends React.Component<Props> {
   static defaultProps = defaultProps;
 
   hasValue = value => defined(value) && !objectIsEmpty(value);
 
-  renderField = (props: Props) => {
+  renderField = (props: RenderProps) => {
     const {
       onChange,
       onBlur,

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -115,12 +115,12 @@ export type TableType = {
   /**
    * An object with of column labels (headers) for the table.
    */
-  columnLabels?: object;
+  columnLabels: object;
   /**
    * A list of column keys for the table, in the order that you want
    * the columns to appear - order doesn't matter in columnLabels
    */
-  columnKeys?: string[];
+  columnKeys: string[];
   /**
    * The confirmation message before a a row is deleted
    */
@@ -130,11 +130,11 @@ export type TableType = {
 
 export type ProjectMapperType = {
   type: 'project_mapper';
-  mappedDropdown?: {
+  mappedDropdown: {
     items: Array<{value: string | number; label: string}>;
     placeholder: string;
   };
-  sentryProjects?: Array<AvatarProject & {id: number; name: string}>;
+  sentryProjects: Array<AvatarProject & {id: number; name: string}>;
 };
 
 export type Field = (

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -132,6 +132,7 @@ export type ProjectMapperType = {
   type: 'project_mapper';
   mappedDropdown?: {
     items: Array<{value: string | number; label: string}>;
+    placeholder: string;
   };
   sentryProjects?: Array<AvatarProject & {id: number; name: string}>;
 };

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
 import Alert from 'app/components/alert';
+import {AvatarProject} from 'app/types';
 
 export const FieldType = [
   'array',
@@ -20,6 +21,7 @@ export const FieldType = [
   'text',
   'url',
   'table',
+  'project_mapper',
 ] as const;
 
 export type FieldValue = any;
@@ -126,6 +128,14 @@ export type TableType = {
   //TODO(TS): Should we have addButtonText and allowEmpty here as well?
 };
 
+export type ProjectMapperType = {
+  type: 'project_mapper';
+  mappedDropdown?: {
+    items: Array<{value: string | number; label: string}>;
+  };
+  sentryProjects?: Array<AvatarProject & {id: number; name: string}>;
+};
+
 export type Field = (
   | CustomType
   | SelectControlType
@@ -134,6 +144,7 @@ export type Field = (
   | RangeType
   | {type: typeof FieldType[number]}
   | TableType
+  | ProjectMapperType
 ) &
   BaseField;
 

--- a/tests/js/spec/components/forms/projectMapperField.spec.jsx
+++ b/tests/js/spec/components/forms/projectMapperField.spec.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {RenderField} from 'app/views/settings/components/forms/projectMapperField';
+
+describe('ProjectMapperField', () => {
+  let wrapper;
+  const mappedDropdown = {
+    placholder: 'hi',
+    items: [
+      {value: '1', label: 'label 1'},
+      {value: '2', label: 'label 2'},
+      {value: '3', label: 'label 3'},
+    ],
+  };
+
+  const sentryProjects = [
+    {id: 23, slug: 'cool', platform: 'javascript', name: 'Cool'},
+    {id: 24, slug: 'beans', platform: 'python', name: 'Beans'},
+  ];
+  const existingValues = [[23, '2']];
+  let onBlur, onChange;
+
+  beforeEach(() => {
+    onBlur = jest.fn();
+    onChange = jest.fn();
+    const props = {
+      mappedDropdown,
+      sentryProjects,
+      value: existingValues,
+      onChange,
+      onBlur,
+    };
+    wrapper = mountWithTheme(<RenderField {...props} />, {disableLifecycleMethods: true});
+  });
+
+  it('clicking add updates values with current dropdown values', () => {
+    wrapper.instance().sentryProjectRef.current = {state: {value: {value: 24}}};
+    wrapper.instance().mappedRef.current = {state: {value: {value: '1'}}};
+    wrapper.find('button').simulate('click');
+    expect(onBlur).toHaveBeenCalledWith(
+      [
+        [23, '2'],
+        [24, '1'],
+      ],
+      []
+    );
+    expect(onChange).toHaveBeenCalledWith(
+      [
+        [23, '2'],
+        [24, '1'],
+      ],
+      []
+    );
+  });
+});

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -25,13 +25,15 @@ class VercelIntegrationTest(IntegrationTestCase):
         }
 
         if is_team:
+            team_query = "?teamId=my_team_id"
             access_json["team_id"] = "my_team_id"
             responses.add(
                 responses.GET,
-                "https://api.vercel.com/v1/teams/my_team_id?teamId=my_team_id",
+                "https://api.vercel.com/v1/teams/my_team_id%s" % team_query,
                 json={"name": "my_team_name"},
             )
         else:
+            team_query = ""
             responses.add(
                 responses.GET,
                 "https://api.vercel.com/www/user",
@@ -40,6 +42,12 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.POST, "https://api.vercel.com/v2/oauth/access_token", json=access_json
+        )
+
+        responses.add(
+            responses.GET,
+            "https://api.vercel.com/v4/projects/%s" % team_query,
+            json={"projects": []},
         )
 
         resp = self.client.get(u"{}?{}".format(self.setup_path, urlencode({"code": "oauth-code"}),))


### PR DESCRIPTION
This PR creates an MVP of the project mapper that we will use with the future Vercel integration. It introduces a new form field type called `project_mapper` which is used to map Sentry projects to arbitrary items in a dropdown. For Vercel, we map it to a Vercel project. Note that this UI not going to be visible to customers right now.

Note the UI is pretty ugly right now. When we get a design for it, I'll make it look nice. I will add unit tests for the new component when I implement the design changes as well.

![Screen Shot 2020-06-12 at 9 38 38 AM](https://user-images.githubusercontent.com/8533851/84525534-a6af5d00-ac90-11ea-9d53-b04203db78db.png)

