### PR TITLE
fix(metric_alerts): Fix incident start date when we have a `threshold_period` > 1.

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -182,11 +182,15 @@ class SubscriptionProcessor(object):
                 # labels them by the front. This causes us an off-by-one error with
                 # alert start dates, so to prevent this we subtract a bucket off of the
                 # start date.
-                # We also multiply by threshold_period so that we can show when the
-                # alert actually started happening, rather than when we detected it.
+                detected_at -= timedelta(seconds=self.alert_rule.snuba_query.time_window)
+                # We want to also subtract `frequency * (threshold_period - 1)` from the
+                # query. This allows us to show the actual start date of the alert,
+                # rather than the start of the last update that we received.
                 detected_at -= timedelta(
-                    seconds=self.alert_rule.snuba_query.time_window
-                    * self.alert_rule.threshold_period
+                    seconds=(
+                        self.alert_rule.snuba_query.resolution
+                        * (self.alert_rule.threshold_period - 1)
+                    )
                 )
                 self.active_incident = create_incident(
                     self.alert_rule.organization,


### PR DESCRIPTION


Previously we were calculating this by subtracting `time_window * threshold_period`. This works fine
when the `threshold_period` is 1, but will subtract too much for higher values.

The way subscriptions work is that it's a rolling window, so evaluation of a time window of say 5
minutes looks like
```
1 2 3 4 5 6 7 8 9 10
--------------------
[-------]
  [-------]
    [-------]
```

The way we were calculating was incorrect, and assumes we're calculating like
```
1 2 3 4 5 6 7 8 9 10
--------------------
[-------]
          [-------]
```

This pr fixes this so that we rely on `threshold_period` and `resolution` instead, so that we just
shift back by `threshold_period - 1` buckets of size `resolution` seconds.