### PR TITLE
feat(discover2): Revised navigation flow for Discover

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -396,6 +396,7 @@ class GridEditable<
 
 export default GridEditable;
 export {
+  COL_WIDTH_MINIMUM,
   COL_WIDTH_UNDEFINED,
   GridColumn,
   GridColumnHeader,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -75,11 +75,23 @@ class Table extends React.PureComponent<TableProps, TableState> {
   };
 
   fetchData = () => {
-    const {eventView, organization, location, setError} = this.props;
+    const {organization, location, setError} = this.props;
+    let {eventView} = this.props;
 
     if (!eventView.isValid()) {
       return;
     }
+
+    const hasAggregates = eventView.getAggregateFields().length > 0;
+    const hasEventIdColumn = eventView.getFields().includes('id');
+
+    if (!hasAggregates && !hasEventIdColumn) {
+      eventView = eventView.withNewColumn({
+        kind: 'field',
+        field: 'id',
+      });
+    }
+
     const url = `/organizations/${organization.slug}/eventsv2/`;
     const tableFetchID = Symbol('tableFetchID');
     const apiPayload = eventView.getEventsAPIPayload(location);

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -75,22 +75,14 @@ class Table extends React.PureComponent<TableProps, TableState> {
   };
 
   fetchData = () => {
-    const {organization, location, setError} = this.props;
-    let {eventView} = this.props;
+    const {eventView, organization, location, setError} = this.props;
 
     if (!eventView.isValid()) {
       return;
     }
 
-    const hasAggregates = eventView.getAggregateFields().length > 0;
-    const hasEventIdColumn = eventView.getFields().includes('id');
-
-    if (!hasAggregates && !hasEventIdColumn) {
-      eventView = eventView.withNewColumn({
-        kind: 'field',
-        field: 'id',
-      });
-    }
+    // note: If the eventView has no aggregates, the endpoint will automatically add the event id in
+    // the API payload response
 
     const url = `/organizations/${organization.slug}/eventsv2/`;
     const tableFetchID = Symbol('tableFetchID');

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -83,7 +83,7 @@ class TableView extends React.Component<TableViewProps> {
     dataRow?: any,
     rowIndex?: number
   ): React.ReactNode[] => {
-    const {organization, eventView} = this.props;
+    const {organization, eventView, tableData, location} = this.props;
     const hasAggregates = eventView.getAggregateFields().length > 0;
 
     if (isHeader) {
@@ -91,7 +91,7 @@ class TableView extends React.Component<TableViewProps> {
         return [
           <SortLink
             key="header-event-id"
-            align="right"
+            align="left"
             title={t('Event Id')}
             direction={undefined}
             canSort={false}
@@ -115,10 +115,27 @@ class TableView extends React.Component<TableViewProps> {
       eventView,
     });
 
+    if (!hasAggregates) {
+      let value = dataRow.id;
+
+      if (tableData && tableData.meta) {
+        const fieldRenderer = getFieldRenderer('id', tableData.meta);
+        value = fieldRenderer(dataRow, {organization, location});
+      }
+
+      return [
+        <Tooltip key={`eventlink${rowIndex}`} title={t('View Event')}>
+          <Link data-test-id="expand-count" to={target}>
+            {value}
+          </Link>
+        </Tooltip>,
+      ];
+    }
+
     return [
       <Tooltip key={`eventlink${rowIndex}`} title={t('View Details')}>
         <IconLink to={target} data-test-id="view-events">
-          {hasAggregates ? <IconStack size="sm" /> : <IconEvent size="sm" />}
+          <IconStack size="sm" />
         </IconLink>
       </Tooltip>,
     ];

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -5,7 +5,10 @@ import {Location, LocationDescriptorObject} from 'history';
 
 import {Organization, OrganizationSummary} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import GridEditable, {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  COL_WIDTH_MINIMUM,
+} from 'app/components/gridEditable';
 import SortLink from 'app/components/gridEditable/sortLink';
 import {IconEvent, IconStack} from 'app/icons';
 import {t} from 'app/locale';
@@ -275,6 +278,11 @@ class TableView extends React.Component<TableViewProps> {
     const columnOrder = eventView.getColumns();
     const columnSortBy = eventView.getSorts();
 
+    const hasAggregates = eventView.getAggregateFields().length > 0;
+    const prependColumnWidths = hasAggregates
+      ? ['40px']
+      : [`minmax(${COL_WIDTH_MINIMUM}px, auto)`];
+
     return (
       <GridEditable
         isLoading={isLoading}
@@ -288,7 +296,7 @@ class TableView extends React.Component<TableViewProps> {
           renderBodyCell: this._renderGridBodyCell as any,
           onResizeColumn: this._resizeColumn as any,
           renderPrependColumns: this._renderPrependColumns as any,
-          prependColumnWidths: ['40px'],
+          prependColumnWidths,
         }}
         headerButtons={this.renderHeaderButtons}
         location={location}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -304,7 +304,7 @@ class TableView extends React.Component<TableViewProps> {
     const hasAggregates = eventView.getAggregateFields().length > 0;
     const prependColumnWidths = hasAggregates
       ? ['40px']
-      : [`minmax(${COL_WIDTH_MINIMUM}px, auto)`];
+      : [`minmax(${COL_WIDTH_MINIMUM}px, max-content)`];
 
     return (
       <GridEditable

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -83,6 +83,21 @@ class TableView extends React.Component<TableViewProps> {
     const {organization, eventView} = this.props;
     const hasAggregates = eventView.getAggregateFields().length > 0;
     if (isHeader) {
+      const hasEventIdColumn = eventView.getFields().includes('id');
+
+      if (hasEventIdColumn && !hasAggregates) {
+        return [
+          <SortLink
+            key="header-event-id"
+            align="right"
+            title={t('Event Id')}
+            direction={undefined}
+            canSort={false}
+            generateSortLink={() => undefined}
+          />,
+        ];
+      }
+
       return [
         <HeaderIcon key="header-icon">
           {hasAggregates ? <IconStack size="sm" /> : <IconEvent size="sm" />}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -10,7 +10,7 @@ import GridEditable, {
   COL_WIDTH_MINIMUM,
 } from 'app/components/gridEditable';
 import SortLink from 'app/components/gridEditable/sortLink';
-import {IconEvent, IconStack} from 'app/icons';
+import {IconStack} from 'app/icons';
 import {t} from 'app/locale';
 import {openModal} from 'app/actionCreators/modal';
 import Link from 'app/components/links/link';
@@ -107,14 +107,6 @@ class TableView extends React.Component<TableViewProps> {
       ];
     }
 
-    const eventSlug = generateEventSlug(dataRow);
-
-    const target = eventDetailsRouteWithEventView({
-      orgSlug: organization.slug,
-      eventSlug,
-      eventView,
-    });
-
     if (!hasAggregates) {
       let value = dataRow.id;
 
@@ -122,6 +114,14 @@ class TableView extends React.Component<TableViewProps> {
         const fieldRenderer = getFieldRenderer('id', tableData.meta);
         value = fieldRenderer(dataRow, {organization, location});
       }
+
+      const eventSlug = generateEventSlug(dataRow);
+
+      const target = eventDetailsRouteWithEventView({
+        orgSlug: organization.slug,
+        eventSlug,
+        eventView,
+      });
 
       return [
         <Tooltip key={`eventlink${rowIndex}`} title={t('View Event')}>
@@ -132,8 +132,15 @@ class TableView extends React.Component<TableViewProps> {
       ];
     }
 
+    const nextView = getExpandedResults(eventView, {}, dataRow);
+
+    const target = {
+      pathname: location.pathname,
+      query: nextView.generateQueryStringObject(),
+    };
+
     return [
-      <Tooltip key={`eventlink${rowIndex}`} title={t('View Details')}>
+      <Tooltip key={`eventlink${rowIndex}`} title={t('Open Stack')}>
         <IconLink to={target} data-test-id="view-events">
           <IconStack size="sm" />
         </IconLink>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -85,10 +85,9 @@ class TableView extends React.Component<TableViewProps> {
   ): React.ReactNode[] => {
     const {organization, eventView} = this.props;
     const hasAggregates = eventView.getAggregateFields().length > 0;
-    if (isHeader) {
-      const hasEventIdColumn = eventView.getFields().includes('id');
 
-      if (hasEventIdColumn && !hasAggregates) {
+    if (isHeader) {
+      if (!hasAggregates) {
         return [
           <SortLink
             key="header-event-id"
@@ -103,7 +102,7 @@ class TableView extends React.Component<TableViewProps> {
 
       return [
         <HeaderIcon key="header-icon">
-          {hasAggregates ? <IconStack size="sm" /> : <IconEvent size="sm" />}
+          <IconStack size="sm" />
         </HeaderIcon>,
       ];
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -349,22 +349,6 @@ function ExpandAggregateRow(props: {
     });
   }
 
-  // count(column) drilldown
-  if (aggregation === 'count') {
-    const nextView = getExpandedResults(eventView, {}, dataRow);
-
-    const target = {
-      pathname: location.pathname,
-      query: nextView.generateQueryStringObject(),
-    };
-
-    return (
-      <Link data-test-id="expand-count" to={target} onClick={handleClick}>
-        {children}
-      </Link>
-    );
-  }
-
   // count_unique(column) drilldown
   if (aggregation === 'count_unique') {
     // Drilldown into each distinct value and get a count() for each value.

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -92,7 +92,7 @@ class TableView extends React.Component<TableViewProps> {
           <SortLink
             key="header-event-id"
             align="left"
-            title={t('Event Id')}
+            title={t('Id')}
             direction={undefined}
             canSort={false}
             generateSortLink={() => undefined}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -126,9 +126,9 @@ class TableView extends React.Component<TableViewProps> {
 
       return [
         <Tooltip key={`eventlink${rowIndex}`} title={t('View Event')}>
-          <Link data-test-id="view-event" to={target}>
+          <StyledLink data-test-id="view-event" to={target}>
             {value}
-          </Link>
+          </StyledLink>
         </Tooltip>,
       ];
     }
@@ -142,9 +142,9 @@ class TableView extends React.Component<TableViewProps> {
 
     return [
       <Tooltip key={`eventlink${rowIndex}`} title={t('Open Stack')}>
-        <IconLink to={target} data-test-id="open-stack">
-          <IconStack size="sm" />
-        </IconLink>
+        <Link to={target} data-test-id="open-stack">
+          <StyledIcon size="sm" />
+        </Link>
       </Tooltip>,
     ];
   };
@@ -375,16 +375,16 @@ function ExpandAggregateRow(props: {
 
 const PrependHeader = styled('span')`
   color: ${p => p.theme.gray600};
-  & > svg {
-    vertical-align: top;
+`;
+
+const StyledLink = styled(Link)`
+  > div {
+    display: inline;
   }
 `;
 
-// Fudge the icon down so it is center aligned with the table contents.
-const IconLink = styled(Link)`
-  position: relative;
-  display: inline-block;
-  top: 3px;
+const StyledIcon = styled(IconStack)`
+  vertical-align: middle;
 `;
 
 export default TableView;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -89,21 +89,22 @@ class TableView extends React.Component<TableViewProps> {
     if (isHeader) {
       if (!hasAggregates) {
         return [
-          <SortLink
-            key="header-event-id"
-            align="left"
-            title={t('Id')}
-            direction={undefined}
-            canSort={false}
-            generateSortLink={() => undefined}
-          />,
+          <PrependHeader key="header-event-id">
+            <SortLink
+              align="left"
+              title={t('Id')}
+              direction={undefined}
+              canSort={false}
+              generateSortLink={() => undefined}
+            />
+          </PrependHeader>,
         ];
       }
 
       return [
-        <HeaderIcon key="header-icon">
+        <PrependHeader key="header-icon">
           <IconStack size="sm" />
-        </HeaderIcon>,
+        </PrependHeader>,
       ];
     }
 
@@ -372,10 +373,10 @@ function ExpandAggregateRow(props: {
   return <React.Fragment>{children}</React.Fragment>;
 }
 
-const HeaderIcon = styled('span')`
+const PrependHeader = styled('span')`
+  color: ${p => p.theme.gray600};
   & > svg {
     vertical-align: top;
-    color: ${p => p.theme.gray600};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -142,7 +142,7 @@ class TableView extends React.Component<TableViewProps> {
 
     return [
       <Tooltip key={`eventlink${rowIndex}`} title={t('Open Stack')}>
-        <IconLink to={target} data-test-id="view-events">
+        <IconLink to={target} data-test-id="open-stack">
           <IconStack size="sm" />
         </IconLink>
       </Tooltip>,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -126,7 +126,7 @@ class TableView extends React.Component<TableViewProps> {
 
       return [
         <Tooltip key={`eventlink${rowIndex}`} title={t('View Event')}>
-          <Link data-test-id="expand-count" to={target}>
+          <Link data-test-id="view-event" to={target}>
             {value}
           </Link>
         </Tooltip>,

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -319,8 +319,8 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.get(self.result_path + "?" + all_events_query())
             self.wait_until_loaded()
 
-            # Click the event link to open the events detail view
-            self.browser.element('[data-test-id="view-events"]').click()
+            # Open the stack
+            self.browser.element('[data-test-id="open-stack"]').click()
             self.wait_until_loaded()
 
             header = self.browser.element('[data-test-id="event-header"] span')
@@ -353,8 +353,8 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.get(self.result_path + "?" + errors_query() + "&statsPeriod=24h")
             self.wait_until_loaded()
 
-            # Click the event link to open the event detail view
-            self.browser.element('[data-test-id="view-events"]').click()
+            # Open the stack
+            self.browser.element('[data-test-id="open-stack"]').click()
             self.wait_until_loaded()
 
             self.browser.snapshot("events-v2 - grouped error event detail view")
@@ -388,8 +388,8 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
             self.browser.save_screenshot("./index.png")
 
-            # Click the event link to open the event detail view
-            self.browser.find_elements_by_css_selector('[data-test-id="view-events"]')[0].click()
+            # Open the stack
+            self.browser.find_elements_by_css_selector('[data-test-id="open-stack"]')[0].click()
             self.wait_until_loaded()
             self.browser.save_screenshot("./details.png")
 

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -319,8 +319,8 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.get(self.result_path + "?" + all_events_query())
             self.wait_until_loaded()
 
-            # Open the stack
-            self.browser.element('[data-test-id="open-stack"]').click()
+            # View Event
+            self.browser.find_elements_by_css_selector('[data-test-id="view-event"]')[0].click()
             self.wait_until_loaded()
 
             header = self.browser.element('[data-test-id="event-header"] span')
@@ -357,15 +357,11 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.element('[data-test-id="open-stack"]').click()
             self.wait_until_loaded()
 
+            # View Event
+            self.browser.find_elements_by_css_selector('[data-test-id="view-event"]')[0].click()
+            self.wait_until_loaded()
+
             self.browser.snapshot("events-v2 - grouped error event detail view")
-
-            # Check that the newest event is loaded first and that pagination
-            # controls display
-            display_id = self.browser.element('[data-test-id="event-id"]')
-            assert event_ids[0] in display_id.text
-
-            assert self.browser.element_exists_by_test_id("older-event")
-            assert self.browser.element_exists_by_test_id("newer-event")
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_transactions_query(self, mock_now):
@@ -389,6 +385,10 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
             # Open the stack
             self.browser.find_elements_by_css_selector('[data-test-id="open-stack"]')[0].click()
+            self.wait_until_loaded()
+
+            # View Event
+            self.browser.find_elements_by_css_selector('[data-test-id="view-event"]')[0].click()
             self.wait_until_loaded()
 
             # Open a span detail so we can check the search by trace link.

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -386,17 +386,14 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             # Get the list page
             self.browser.get(self.result_path + "?" + transactions_query())
             self.wait_until_loaded()
-            self.browser.save_screenshot("./index.png")
 
             # Open the stack
             self.browser.find_elements_by_css_selector('[data-test-id="open-stack"]')[0].click()
             self.wait_until_loaded()
-            self.browser.save_screenshot("./details.png")
 
             # Open a span detail so we can check the search by trace link.
             # Click on the 6th one as a missing instrumentation span is inserted.
             self.browser.find_elements_by_css_selector('[data-test-id="span-row"]')[6].click()
-            self.browser.save_screenshot("./span.png")
 
             # Click on the child transaction.
             child_button = '[data-test-id="view-child-transaction"]'
@@ -459,7 +456,6 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             new_name = "Custom queryupdated!"
             new_card_selector = 'div[name="discover2-query-name"][value="{}"]'.format(new_name)
             self.browser.wait_until(new_card_selector)
-            self.browser.save_screenshot("./rename.png")
 
         # Assert the name was updated.
         assert DiscoverSavedQuery.objects.filter(name=new_name).exists()


### PR DESCRIPTION
Revise the Discover navigation flow to enforce the drilldown.

![Kapture 2020-06-11 at 22 12 56](https://user-images.githubusercontent.com/139499/84457644-3b826e00-ac31-11ea-86f7-d9ef87ed8295.gif)

Other changes include:

- On the Discover results page, an `id` field is added to the eventview object prior to generating the API payload only if the eventview has no aggregates and contains no `id` field. 

- `count(column)` aggregates no longer link to the drilldown CTA. However, `count_unique(column)` will still have the drilldown CTA.

<img width="1307" alt="Screen Shot 2020-06-11 at 10 15 09 PM" src="https://user-images.githubusercontent.com/139499/84457623-2c9bbb80-ac31-11ea-9fb3-6f196f0520c1.png">

<img width="1665" alt="Screen Shot 2020-06-11 at 10 09 38 PM" src="https://user-images.githubusercontent.com/139499/84457732-6a004900-ac31-11ea-898e-d8d918ab7de1.png">


## TODO

- [x] update acceptance tests
- [x] fix styling for preprend columns