### PR TITLE
feat(pii): Add custom placeholder field

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/dialog.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/dialog.tsx
@@ -92,7 +92,12 @@ class Dialog extends React.Component<Props, State> {
   ) => {
     const rule: Rule = {...this.state.rule, [stateProperty]: value};
 
+    if (rule.type === RuleType.PATTERN) {
+      rule.pattern = rule?.pattern || '';
+    }
+
     if (rule.type !== RuleType.PATTERN) {
+      // TODO(Priscila): Improve this logic
       // @ts-ignore
       delete rule?.pattern;
       this.clearError('pattern');

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/form/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/form/form.tsx
@@ -30,6 +30,7 @@ type Props<R extends Rule, K extends KeysOfUnion<R>> = {
   sourceSuggestions?: Array<SourceSuggestion>;
   eventId?: EventId;
 };
+
 const Form = ({
   rule,
   errors,
@@ -42,37 +43,51 @@ const Form = ({
   const {source, type, method} = rule;
   return (
     <Wrapper>
-      <WrapperSelectFields>
-        <FormField label={t('Method')} tooltipInfo={t('What to do')}>
-          <SelectField
-            placeholder={t('Select method')}
-            name="method"
-            options={sortBy(Object.values(MethodType)).map(value => ({
-              ...getMethodLabel(value),
-              value,
-            }))}
-            value={method}
-            onChange={({value}) => onChange('method', value)}
-          />
-        </FormField>
+      <FormField label={t('Method')} tooltipInfo={t('What to do')}>
+        <SelectField
+          placeholder={t('Select method')}
+          name="method"
+          options={sortBy(Object.values(MethodType)).map(value => ({
+            ...getMethodLabel(value),
+            value,
+          }))}
+          value={method}
+          onChange={({value}) => onChange('method', value)}
+        />
+      </FormField>
+      {rule.method === MethodType.REPLACE && (
         <FormField
-          label={t('Data Type')}
-          tooltipInfo={t(
-            'What to look for. Use an existing pattern or define your own using regular expressions.'
-          )}
+          label={t('Custom Placeholder (Optional)')}
+          tooltipInfo={t('It will replace the default placeholder [Filtered]')}
+          isFullWidth
         >
-          <SelectField
-            placeholder={t('Select type')}
-            name="type"
-            options={sortBy(Object.values(RuleType)).map(value => ({
-              label: getRuleLabel(value),
-              value,
-            }))}
-            value={type}
-            onChange={({value}) => onChange('type', value)}
+          <Placeholder
+            name="placeholder"
+            placeholder={`[${t('Filtered')}]`}
+            onChange={(value: string) => {
+              onChange('placeholder', value);
+            }}
+            value={rule.placeholder}
           />
         </FormField>
-      </WrapperSelectFields>
+      )}
+      <FormField
+        label={t('Data Type')}
+        tooltipInfo={t(
+          'What to look for. Use an existing pattern or define your own using regular expressions.'
+        )}
+      >
+        <SelectField
+          placeholder={t('Select type')}
+          name="type"
+          options={sortBy(Object.values(RuleType)).map(value => ({
+            label: getRuleLabel(value),
+            value,
+          }))}
+          value={type}
+          onChange={({value}) => onChange('type', value)}
+        />
+      </FormField>
       {rule.type === RuleType.PATTERN && (
         <FormField
           label={t('Regex matches')}
@@ -122,20 +137,20 @@ const Wrapper = styled('div')`
   grid-row-gap: ${space(2)};
 `;
 
-const WrapperSelectFields = styled('div')`
-  display: grid;
-  grid-gap: ${space(2)};
-  grid-template-columns: 1fr;
-  @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    grid-template-columns: auto auto;
-  }
-`;
-
-const RegularExpression = styled(TextField)`
-  font-size: ${p => p.theme.fontSizeSmall};
+const StyledTextField = styled(TextField)`
   height: 40px;
   input {
     height: 40px;
+  }
+`;
+
+const Placeholder = styled(StyledTextField)`
+  margin-bottom: 0;
+`;
+
+const RegularExpression = styled(StyledTextField)`
+  font-size: ${p => p.theme.fontSizeSmall};
+  input {
     font-family: ${p => p.theme.text.familyMono};
   }
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/form/sourceSuggestionExamples.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/form/sourceSuggestionExamples.tsx
@@ -16,9 +16,7 @@ type State = {
 };
 
 class SourceSuggestionExamples extends React.Component<Props, State> {
-  state: State = {
-    isOpen: false,
-  };
+  state: State = {isOpen: false};
 
   toggleModal = () => {
     this.setState({isOpen: !this.state.isOpen});

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/index.tsx
@@ -94,9 +94,8 @@ class DataScrubbing<T extends ProjectId = undefined> extends React.Component<
 
     if (isProjectLevel) {
       try {
-        const convertedRules = convertRelayPiiConfig(organization.relayPiiConfig);
         this.setState({
-          orgRules: convertedRules,
+          orgRules: convertRelayPiiConfig(organization.relayPiiConfig),
         });
       } catch {
         addErrorMessage(t('Unable to load organization rules'));
@@ -192,7 +191,7 @@ class DataScrubbing<T extends ProjectId = undefined> extends React.Component<
         this.setState(prevState => ({
           errors: {
             ...prevState.errors,
-            customRegex: error.message,
+            pattern: error.message,
           },
         }));
         break;

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/rulesList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/rulesList.tsx
@@ -8,13 +8,38 @@ import {IconDelete, IconEdit} from 'app/icons';
 import Button from 'app/components/button';
 
 import {getMethodLabel, getRuleLabel} from './utils';
-import {RuleType, Rule} from './types';
+import {RuleType, MethodType, Rule} from './types';
 
 type Props = {
   rules: Array<Rule>;
   onShowEditRuleModal?: (id: Rule['id']) => () => void;
   onDeleteRule?: (id: Rule['id']) => () => void;
   disabled?: boolean;
+};
+
+const getListItemDescription = (rule: Rule) => {
+  const {method, type, source} = rule;
+  const methodLabel = getMethodLabel(method);
+  const typeLabel = getRuleLabel(type);
+
+  const descriptionDetails: Array<string> = [];
+
+  descriptionDetails.push(`[${methodLabel.label}]`);
+
+  if (rule.method === MethodType.REPLACE && rule.placeholder) {
+    descriptionDetails.push(`with [${rule.placeholder}]`);
+  }
+
+  descriptionDetails.push(`[${typeLabel}]`);
+
+  if (rule.type === RuleType.PATTERN) {
+    descriptionDetails[descriptionDetails.length - 1] =
+      descriptionDetails.length === 3
+        ? `${t('using')} [${rule.pattern}]`
+        : `[${rule.pattern}]`;
+  }
+
+  return `${descriptionDetails.join(' ')} ${t('from')} [${source}]`;
 };
 
 const RulesList = React.forwardRef(function RulesList(
@@ -24,15 +49,10 @@ const RulesList = React.forwardRef(function RulesList(
   return (
     <List ref={ref} isDisabled={disabled}>
       {rules.map(rule => {
-        const {id, method, type, source} = rule;
-        const methodLabel = getMethodLabel(method);
-        const typeLabel = getRuleLabel(type);
-        const typeDescription = rule.type === RuleType.PATTERN ? rule.pattern : typeLabel;
+        const {id} = rule;
         return (
           <ListItem key={id}>
-            <TextOverflow>
-              {`[${methodLabel.label}] [${typeDescription}] ${t('from')} [${source}]`}
-            </TextOverflow>
+            <TextOverflow>{getListItemDescription(rule)}</TextOverflow>
             {onShowEditRuleModal && (
               <Button
                 label={t('Edit Rule')}

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/utils.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/utils.tsx
@@ -55,7 +55,7 @@ function getMethodLabel(type: MethodType) {
     case MethodType.REPLACE:
       return {
         label: t('Replace'),
-        description: t('Replace with [Filtered]'),
+        description: t('Replace with Placeholder'),
       };
     default:
       return {


### PR DESCRIPTION
**Description:** 

* Add a text field for replace to take a custom placeholder text other than [Filter]. The resulting JSON should look like this: {"type": "creditcard", "redaction": {"method": "replace", "text": "[Filter]"}}

This is the second step of this task: https://app.asana.com/0/1158284503473033/1169336924425598

**Preview:**

![image](https://user-images.githubusercontent.com/29228205/84491155-6528ad00-aca4-11ea-892b-7fbcbd89d5a6.png)

Next Steps:

- Make event ID input a button
- Replace Modals with the GlobalModal component