### PR TITLE
feat(ui): Add project icon to global header

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -204,11 +204,12 @@ export default class MultipleProjectSelector extends React.PureComponent {
       <StyledHeaderItem
         data-test-id="global-header-project-selector"
         icon={
-          <PlatformList
-            platforms={forceProject?.platform ? [forceProject.platform] : []}
-            max={1}
-            size={16}
-          />
+          forceProject && (
+            <PlatformList
+              platforms={forceProject.platform ? [forceProject.platform] : []}
+              max={1}
+            />
+          )
         }
         locked
         lockedMessage={this.getLockedMessage()}
@@ -272,7 +273,6 @@ export default class MultipleProjectSelector extends React.PureComponent {
                 <PlatformList
                   platforms={selectedProjects.map(p => p.platform ?? 'other').reverse()}
                   max={5}
-                  size={16}
                 />
               ) : (
                 <IconProject />

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -203,7 +203,13 @@ export default class MultipleProjectSelector extends React.PureComponent {
     return shouldForceProject ? (
       <StyledHeaderItem
         data-test-id="global-header-project-selector"
-        icon={<PlatformList platforms={[forceProject.platform]} max={1} size={20} />}
+        icon={
+          <PlatformList
+            platforms={forceProject?.platform ? [forceProject.platform] : []}
+            max={1}
+            size={20}
+          />
+        }
         locked
         lockedMessage={this.getLockedMessage()}
         settingsLink={
@@ -264,7 +270,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
                 : t('My Projects');
               const icon = hasSelected ? (
                 <PlatformList
-                  platforms={selectedProjects.map(p => p.platform).reverse()}
+                  platforms={selectedProjects.map(p => p.platform ?? 'other').reverse()}
                   max={5}
                   size={20}
                 />

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -10,12 +10,12 @@ import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import {t, tct} from 'app/locale';
 import Button from 'app/components/button';
-import InlineSvg from 'app/components/inlineSvg';
 import Tooltip from 'app/components/tooltip';
 import HeaderItem from 'app/components/organizations/headerItem';
 import {growIn} from 'app/styles/animations';
 import space from 'app/styles/space';
 import PlatformList from 'app/components/platformList';
+import {IconProject} from 'app/icons';
 
 import ProjectSelector from './projectSelector';
 
@@ -207,7 +207,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
           <PlatformList
             platforms={forceProject?.platform ? [forceProject.platform] : []}
             max={1}
-            size={20}
+            size={16}
           />
         }
         locked
@@ -223,7 +223,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     ) : !isGlobalSelectionReady ? (
       <StyledHeaderItem
         data-test-id="global-header-project-selector"
-        icon={<StyledInlineSvg src="icon-project" />}
+        icon={<IconProject />}
         loading
       >
         {t('Loading\u2026')}
@@ -272,10 +272,10 @@ export default class MultipleProjectSelector extends React.PureComponent {
                 <PlatformList
                   platforms={selectedProjects.map(p => p.platform ?? 'other').reverse()}
                   max={5}
-                  size={20}
+                  size={16}
                 />
               ) : (
-                <StyledInlineSvg src="icon-project" />
+                <IconProject />
               );
 
               return (
@@ -396,12 +396,6 @@ const StyledHeaderItem = styled(HeaderItem)`
   height: 100%;
   width: 100%;
   ${p => p.locked && 'cursor: default'};
-`;
-
-const StyledInlineSvg = styled(InlineSvg)`
-  height: 18px;
-  width: 18px;
-  transform: translateY(-2px);
 `;
 
 const StyledLink = styled(Link)`

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -15,6 +15,7 @@ import Tooltip from 'app/components/tooltip';
 import HeaderItem from 'app/components/organizations/headerItem';
 import {growIn} from 'app/styles/animations';
 import space from 'app/styles/space';
+import PlatformList from 'app/components/platformList';
 
 import ProjectSelector from './projectSelector';
 
@@ -202,7 +203,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     return shouldForceProject ? (
       <StyledHeaderItem
         data-test-id="global-header-project-selector"
-        icon={<StyledInlineSvg src="icon-project" />}
+        icon={<PlatformList platforms={[forceProject.platform]} max={1} size={20} />}
         locked
         lockedMessage={this.getLockedMessage()}
         settingsLink={
@@ -261,12 +262,21 @@ export default class MultipleProjectSelector extends React.PureComponent {
                 : selectedProjectIds.has(ALL_ACCESS_PROJECTS)
                 ? t('All Projects')
                 : t('My Projects');
+              const icon = hasSelected ? (
+                <PlatformList
+                  platforms={selectedProjects.map(p => p.platform).reverse()}
+                  max={5}
+                  size={20}
+                />
+              ) : (
+                <StyledInlineSvg src="icon-project" />
+              );
 
               return (
                 <StyledHeaderItem
                   data-test-id="global-header-project-selector"
                   active={hasSelected || isOpen}
-                  icon={<StyledInlineSvg src="icon-project" />}
+                  icon={icon}
                   hasSelected={hasSelected}
                   hasChanges={this.state.hasChanges}
                   isOpen={isOpen}

--- a/src/sentry/static/sentry/app/components/platformList.jsx
+++ b/src/sentry/static/sentry/app/components/platformList.jsx
@@ -31,9 +31,9 @@ class PlatformList extends React.Component {
     consistentWidth: false,
   };
 
-  getIcon = platform => {
+  getIcon = (platform, index) => {
     const {size} = this.props;
-    return <StyledPlatformIcon key={platform} platform={platform} size={size} />;
+    return <StyledPlatformIcon key={platform + index} platform={platform} size={size} />;
   };
 
   getIcons = platforms =>

--- a/tests/js/spec/views/projectsDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/projectsDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -416,7 +416,7 @@ exports[`ProjectCard renders 1`] = `
                                                 size={18}
                                               >
                                                 <StyledPlatformIcon
-                                                  key="javascript"
+                                                  key="javascript0"
                                                   platform="javascript"
                                                   size={18}
                                                 >


### PR DESCRIPTION
No project selected:
![image](https://user-images.githubusercontent.com/9060071/84892769-773c8e00-b09e-11ea-8ac7-e96e42d3cc53.png)

One project selected:
![image](https://user-images.githubusercontent.com/9060071/84892793-84f21380-b09e-11ea-8b55-2db2e8678370.png)

Multiple projects selected (no more than 5 icons will be shown):
![image](https://user-images.githubusercontent.com/9060071/84892914-b5d24880-b09e-11ea-8122-157427c9e44b.png)

I also refactored icon-project InlineSvg while I was in there.

#sync-getsentry