### PR TITLE
ref(pii): Update pii submit/convert methods logic

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/convertRelayPiiConfig.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/convertRelayPiiConfig.tsx
@@ -1,0 +1,59 @@
+import {RuleType, MethodType, Rule, PiiConfig, Applications} from './types';
+
+// Remap PII config format to something that is more usable in React. Ideally
+// we would stop doing this at some point and make some updates to how we
+// store this configuration on the server.
+//
+// For the time being the PII config format is documented at
+// https://getsentry.github.io/relay/pii-config/
+
+function convertRelayPiiConfig(relayPiiConfig?: string) {
+  const piiConfig = relayPiiConfig ? JSON.parse(relayPiiConfig) : {};
+  const rules: PiiConfig = piiConfig.rules || {};
+  const applications: Applications = piiConfig.applications || {};
+  const convertedRules: Array<Rule> = [];
+
+  for (const application in applications) {
+    for (const rule of applications[application]) {
+      const resolvedRule = rules[rule];
+      const id = convertedRules.length;
+
+      if (!resolvedRule) {
+        // Convert a "built-in" rule like "@anything:remove" to an object {
+        //   type: "anything",
+        //   method: "remove"
+        // }
+        if (rule[0] === '@') {
+          const [type, method] = rule.slice(1).split(':') as [RuleType, MethodType];
+          convertedRules.push({
+            id,
+            method,
+            type,
+            source: application,
+          });
+        }
+        continue;
+      }
+
+      const {type, redaction} = resolvedRule;
+      const method = redaction.method as MethodType;
+
+      if (resolvedRule.type === RuleType.PATTERN && resolvedRule?.pattern) {
+        convertedRules.push({
+          id,
+          method,
+          type: RuleType.PATTERN,
+          source: application,
+          customRegularExpression: resolvedRule.pattern,
+        });
+        continue;
+      }
+
+      convertedRules.push({id, method, type, source: application});
+    }
+  }
+
+  return convertedRules;
+}
+
+export default convertRelayPiiConfig;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/dataPrivacyRules.tsx
@@ -15,7 +15,9 @@ import DataPrivacyRulesModal from './dataPrivacyRulesModal';
 import DataPrivacyRulesPanelContent from './dataPrivacyRulesContent';
 import DataPrivacyRulesPanelForm from './dataPrivacyRulesForm/dataPrivacyRulesForm';
 import OrganizationRules from './organizationRules';
-import {Rule, RuleType, MethodType, EventIdStatus} from './types';
+import {Rule, EventIdStatus} from './types';
+import convertRelayPiiConfig from './convertRelayPiiConfig';
+import getRelayPiiConfig from './getRelayPiiConfig';
 
 const ADVANCED_DATASCRUBBING_LINK =
   'https://docs.sentry.io/data-management/advanced-datascrubbing/';
@@ -26,20 +28,6 @@ type DataPrivacyRulesPanelFormProps = React.ComponentProps<
 type ModalProps = React.ComponentProps<typeof DataPrivacyRulesModal>;
 type SourceSuggestions = ModalProps['sourceSuggestions'];
 type Errors = DataPrivacyRulesPanelFormProps['errors'];
-
-type PiiConfig = {
-  type: RuleType;
-  pattern: string;
-  redaction?: {
-    method?: MethodType;
-  };
-};
-
-type PiiConfigRule = {
-  [key: string]: PiiConfig;
-};
-
-type Applications = {[key: string]: Array<string>};
 
 type Props = {
   endpoint: string;
@@ -99,7 +87,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
 
     if (isProjectLevel) {
       try {
-        const convertedRules = this.convertRelayPiiConfig(organization.relayPiiConfig);
+        const convertedRules = convertRelayPiiConfig(organization.relayPiiConfig);
         this.setState({
           orgRules: convertedRules,
         });
@@ -111,7 +99,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
 
   loadRules() {
     try {
-      const convertedRules = this.convertRelayPiiConfig(this.state.relayPiiConfig);
+      const convertedRules = convertRelayPiiConfig(this.state.relayPiiConfig);
       this.setState({
         rules: convertedRules,
         savedRules: convertedRules,
@@ -120,55 +108,6 @@ class DataPrivacyRules extends React.Component<Props, State> {
       addErrorMessage(t('Unable to load project rules'));
     }
   }
-
-  // Remap PII config format to something that is more usable in React. Ideally
-  // we would stop doing this at some point and make some updates to how we
-  // store this configuration on the server.
-  //
-  // For the time being the PII config format is documented at
-  // https://getsentry.github.io/relay/pii-config/
-  convertRelayPiiConfig = (relayPiiConfig?: string) => {
-    const piiConfig = relayPiiConfig ? JSON.parse(relayPiiConfig) : {};
-    const rules: PiiConfigRule = piiConfig.rules || {};
-    const applications: Applications = piiConfig.applications || {};
-    const convertedRules: Array<Rule> = [];
-
-    for (const application in applications) {
-      for (const rule of applications[application]) {
-        if (!rules[rule]) {
-          // Convert a "built-in" rule like "@anything:remove" to an object {
-          //   type: "anything",
-          //   method: "remove"
-          // }
-          if (rule[0] === '@') {
-            const [type, method] = rule.slice(1).split(':');
-            convertedRules.push({
-              id: convertedRules.length,
-              type: type as RuleType,
-              method: method as MethodType,
-              source: application,
-            });
-          }
-          continue;
-        }
-
-        const resolvedRule = rules[rule];
-        if (resolvedRule.type === RuleType.PATTERN && resolvedRule.pattern) {
-          const method = resolvedRule?.redaction?.method;
-
-          convertedRules.push({
-            id: convertedRules.length,
-            type: RuleType.PATTERN,
-            method: method as MethodType,
-            source: application,
-            customRegularExpression: resolvedRule.pattern,
-          });
-        }
-      }
-    }
-
-    return convertedRules;
-  };
 
   loadSourceSuggestions = async () => {
     const {organization, projectId} = this.props;
@@ -237,41 +176,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
 
     const errors: Errors = {};
 
-    let customRulesCounter = 0;
-    const applications: Applications = {};
-    const customRules: PiiConfigRule = {};
-
-    for (const rule of rules) {
-      let ruleName = `@${rule.type}:${rule.method}`;
-      if (rule.type === RuleType.PATTERN && rule.customRegularExpression) {
-        ruleName = `customRule${customRulesCounter}`;
-
-        customRulesCounter += 1;
-
-        customRules[ruleName] = {
-          type: RuleType.PATTERN,
-          pattern: rule.customRegularExpression,
-          redaction: {
-            method: rule.method,
-          },
-        };
-      }
-
-      if (!applications[rule.source]) {
-        applications[rule.source] = [];
-      }
-
-      if (!applications[rule.source].includes(ruleName)) {
-        applications[rule.source].push(ruleName);
-      }
-    }
-
-    const piiConfig = {
-      rules: customRules,
-      applications,
-    };
-
-    const relayPiiConfig = JSON.stringify(piiConfig);
+    const relayPiiConfig = getRelayPiiConfig(rules);
 
     return await this.api
       .requestPromise(endpoint, {
@@ -280,19 +185,17 @@ class DataPrivacyRules extends React.Component<Props, State> {
       })
       .then(result => {
         onSubmitSuccess(result);
-        this.setState({
-          relayPiiConfig,
-        });
+        this.setState({relayPiiConfig});
       })
       .then(() => {
-        addSuccessMessage(t('Successfully saved data scrubbing rules'));
+        addSuccessMessage(t('Successfully saved data scrubbing rule'));
         return undefined;
       })
       .catch(error => {
         const errorMessage = error.responseJSON?.relayPiiConfig?.[0];
 
         if (!errorMessage) {
-          addErrorMessage(t('Unknown error occurred while saving data scrubbing rules'));
+          addErrorMessage(t('Unknown error occurred while saving data scrubbing rule'));
           return undefined;
         }
 
@@ -322,7 +225,7 @@ class DataPrivacyRules extends React.Component<Props, State> {
           };
         }
 
-        addErrorMessage(t('Unknown error occurred while saving data scrubbing rules'));
+        addErrorMessage(t('Unknown error occurred while saving data scrubbing rule'));
         return undefined;
       });
   };

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/getRelayPiiConfig.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/getRelayPiiConfig.tsx
@@ -1,0 +1,46 @@
+import {RuleType, PiiConfig, Rule} from './types';
+
+type Applications = Record<string, Array<string>>;
+
+function getCustomRule(rule: Rule): PiiConfig {
+  if (rule.type === RuleType.PATTERN) {
+    return {
+      type: rule.type,
+      pattern: rule?.customRegularExpression,
+      redaction: {
+        method: rule.method,
+      },
+    };
+  }
+  return {
+    type: rule.type,
+    redaction: {
+      method: rule.method,
+    },
+  };
+}
+
+function getRelayPiiConfig(rules: Array<Rule>) {
+  const applications: Applications = {};
+  const customRules: Record<string, PiiConfig> = {};
+
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+    const ruleId = String(i);
+    customRules[ruleId] = getCustomRule(rule);
+
+    if (!applications[rule.source]) {
+      applications[rule.source] = [];
+    }
+
+    if (!applications[rule.source].includes(ruleId)) {
+      applications[rule.source].push(ruleId);
+    }
+  }
+
+  const piiConfig = {rules: customRules, applications};
+
+  return JSON.stringify(piiConfig);
+}
+
+export default getRelayPiiConfig;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/types.tsx
@@ -63,4 +63,4 @@ export type PiiConfigRule = {
   [key: string]: PiiConfig;
 };
 
-export type Applications = {[key: string]: Array<string>};
+export type Applications = Record<string, Array<string>>;

--- a/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataPrivacyRules/types.tsx
@@ -50,3 +50,17 @@ export type Rule = {
   source: string;
   customRegularExpression?: string;
 };
+
+export type PiiConfig = {
+  type: RuleType;
+  pattern?: string;
+  redaction?: {
+    method?: MethodType;
+  };
+};
+
+export type PiiConfigRule = {
+  [key: string]: PiiConfig;
+};
+
+export type Applications = {[key: string]: Array<string>};


### PR DESCRIPTION
**Description:**

* Refactor the handleSubmit conversion logic to no longer emit rules like @creditcard:replace. Instead we should always emit a custom rule like we already do with regex rules: {"type": "creditcard", "redaction": {"method": "replace"}}

Part 1 of this task: https://app.asana.com/0/1158284503473033/1169336924425598