### PR TITLE
feat(docs) Add storybook for tagsTable component

### DIFF
--- a/docs-ui/components/seenByList.stories.js
+++ b/docs-ui/components/seenByList.stories.js
@@ -1,8 +1,8 @@
 import React from 'react';
-
 import {number, string} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
+
 import SeenByList from 'app/components/seenByList';
 
 const USER = {
@@ -12,7 +12,7 @@ const USER = {
 };
 
 // eslint-disable-next-line
-storiesOf('UI|Other/SeenByList', module).add(
+storiesOf('UI|SeenByList', module).add(
   'default',
   withInfo('This displays a list of avatars but filters out the current user')(() => {
     const user = {...USER};

--- a/docs-ui/components/tagsTable.stories.js
+++ b/docs-ui/components/tagsTable.stories.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+import {text} from '@storybook/addon-knobs';
+
+import TagsTable from 'app/components/tagsTable';
+
+const event = {
+  id: 'deadbeef',
+  tags: [
+    {value: 'prod', key: 'environment', _meta: null},
+    {value: 'info', key: 'level', _meta: null},
+    {value: '1449204', key: 'project', _meta: null},
+    {value: '72ee409ef6df14396e6a608abbcd017aa374e497', key: 'release', _meta: null},
+    {value: 'CPython 2.7.16', key: 'runtime', _meta: null},
+    {value: 'CPython', key: 'runtime.name', _meta: null},
+    {value: 'worker-65881005', key: 'server_name', _meta: null},
+    {value: 'internal_error', key: 'status', _meta: null},
+    {value: 'sentry.tasks.store.save_event', key: 'task_name', _meta: null},
+    {value: '3c75bc89a4d4442b81af4cb41b6a1571', key: 'trace', _meta: null},
+    {
+      value: '3c75bc89a4d4442b81af4cb41b6a1571-8662ecdaef1bbbaf',
+      key: 'trace.ctx',
+    },
+    {value: '8662ecdaef1bbbaf', key: 'trace.span', _meta: null},
+    {value: 'sentry.tasks.store.save_event', key: 'transaction', _meta: null},
+  ],
+};
+
+storiesOf('UI|TagsTable', module).add(
+  'default',
+  withInfo(
+    'Display a table of tags with each value as a link, generally to another search result.'
+  )(() => {
+    return (
+      <TagsTable
+        title={text('title', 'Event Tags')}
+        query="event.type:error"
+        event={event}
+        generateUrl={tag => `/issues/search?key=${tag.key}&value=${tag.value}`}
+      />
+    );
+  })
+);


### PR DESCRIPTION
We use this in discover + performance and I thought it would be good to have in storybook in case we have another use for it in the future.