### PR TITLE
fix(charts) Fix type error in chart tooltips

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.jsx
@@ -26,6 +26,9 @@ function defaultNameFormatter(value) {
 }
 
 function getSeriesValue(series, offset) {
+  if (!series.data) {
+    return undefined;
+  }
   if (Array.isArray(series.data)) {
     return series.data[offset];
   }


### PR DESCRIPTION
While this shouldn't happen, it has a few times in production.

Fixes JAVASCRIPT-21X9