### PR TITLE
ref(ts): Convert `utils/isTimeSeries` to typescript

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboards/utils/isTimeSeries.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/isTimeSeries.jsx
@@ -1,4 +1,0 @@
-// Consider a query a time series if
-export function isTimeSeries(query) {
-  return query.groupby.includes('time');
-}

--- a/src/sentry/static/sentry/app/views/dashboards/utils/isTimeSeries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/isTimeSeries.tsx
@@ -1,0 +1,8 @@
+type Query = {
+  groupby: string[];
+};
+
+// Consider a query a time series if
+export function isTimeSeries(query: Query) {
+  return query.groupby.includes('time');
+}


### PR DESCRIPTION
This converts `isTimeSeries` util to typescript. Added temporary restrictive query type to be replaced when the query object is converted to typescript as well.