### PR TITLE
ref(ts): Convert `<SearchBar>` to typescript

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -26,7 +26,7 @@ import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import {Client} from 'app/api';
-import {SavedSearch, LightWeightOrganization} from 'app/types';
+import {LightWeightOrganization, SavedSearch, Tag} from 'app/types';
 import {
   fetchRecentSearches,
   pinSearch,
@@ -41,7 +41,7 @@ import {
 } from 'app/constants';
 
 import SearchDropdown from './searchDropdown';
-import {SearchItem, SearchType, SearchGroup, Tag, ItemType} from './types';
+import {SearchItem, SearchType, SearchGroup, ItemType} from './types';
 import {
   addSpace,
   removeSpace,
@@ -213,7 +213,7 @@ type Props = {
    * is because we don't want to treat environment as a tag in some places
    * such as the stream view where it is a top level concept
    */
-  excludeEnvironment: boolean;
+  excludeEnvironment?: boolean;
 };
 
 type State = {
@@ -621,7 +621,7 @@ class SmartSearchBar extends React.Component<Props, State> {
    * with results
    */
   getPredefinedTagValues = (tag: Tag, query: string): SearchItem[] =>
-    tag.values
+    (tag.values ?? [])
       .filter(value => value.indexOf(query) > -1)
       .map(value => ({
         value,

--- a/src/sentry/static/sentry/app/stores/tagStore.tsx
+++ b/src/sentry/static/sentry/app/stores/tagStore.tsx
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 import reduce from 'lodash/reduce';
 
-import {Tag} from 'app/types';
+import {Tag, TagCollection} from 'app/types';
 import TagActions from 'app/actions/tagActions';
 
 // This list is only used on issues. Events/discover
@@ -49,8 +49,6 @@ const BUILTIN_TAGS = [
   acc[tag] = {key: tag, name: tag};
   return acc;
 }, {});
-
-type TagCollection = {[key: string]: Tag};
 
 type TagStoreInterface = {
   state: TagCollection;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1135,6 +1135,8 @@ export type Tag = {
   predefined?: boolean;
 };
 
+export type TagCollection = {[key: string]: Tag};
+
 export type TagValue = {
   count: number;
   name: string;

--- a/src/sentry/static/sentry/app/utils/withIssueTags.tsx
+++ b/src/sentry/static/sentry/app/utils/withIssueTags.tsx
@@ -6,9 +6,7 @@ import assign from 'lodash/assign';
 import getDisplayName from 'app/utils/getDisplayName';
 import MemberListStore from 'app/stores/memberListStore';
 import TagStore from 'app/stores/tagStore';
-import {User, Tag} from 'app/types';
-
-type TagCollection = {[key: string]: Tag};
+import {User, TagCollection} from 'app/types';
 
 type InjectedTagsProps = {
   tags: TagCollection;

--- a/src/sentry/static/sentry/app/utils/withTags.tsx
+++ b/src/sentry/static/sentry/app/utils/withTags.tsx
@@ -4,9 +4,7 @@ import createReactClass from 'create-react-class';
 
 import getDisplayName from 'app/utils/getDisplayName';
 import TagStore from 'app/stores/tagStore';
-import {Tag} from 'app/types';
-
-type TagCollection = {[key: string]: Tag};
+import {TagCollection} from 'app/types';
 
 type InjectedTagsProps = {
   tags: TagCollection;

--- a/src/sentry/static/sentry/app/views/events/searchBar.tsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.tsx
@@ -47,17 +47,13 @@ class SearchBar extends React.PureComponent<SearchBarProps> {
 
   componentDidMount() {
     // Clear memoized data on mount to make tests more consistent.
-    if (this.getEventFieldValues.cache.clear) {
-      this.getEventFieldValues.cache.clear();
-    }
+    this.getEventFieldValues.cache.clear?.();
   }
 
   componentDidUpdate(prevProps) {
     if (!isEqual(this.props.projectIds, prevProps.projectIds)) {
       // Clear memoized data when projects change.
-      if (this.getEventFieldValues.cache.clear) {
-        this.getEventFieldValues.cache.clear();
-      }
+      this.getEventFieldValues.cache.clear?.();
     }
   }
 

--- a/src/sentry/static/sentry/app/views/events/searchBar.tsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import {NEGATION_OPERATOR, SEARCH_WILDCARD} from 'app/constants';
 import {defined} from 'app/utils';
 import {fetchTagValues} from 'app/actionCreators/tags';
+import SentryTypes from 'app/sentryTypes';
 import SmartSearchBar, {SearchType} from 'app/components/smartSearchBar';
 import {Field, FIELDS, TRACING_FIELDS} from 'app/utils/discover/fields';
 import withApi from 'app/utils/withApi';
@@ -38,8 +39,8 @@ type SearchBarProps = Omit<React.ComponentProps<typeof SmartSearchBar>, 'tags'> 
 class SearchBar extends React.PureComponent<SearchBarProps> {
   static propTypes: any = {
     api: PropTypes.object,
-    organization: PropTypes.object,
-    tags: PropTypes.object,
+    organization: SentryTypes.Organization,
+    tags: PropTypes.objectOf(SentryTypes.Tag),
     omitTags: PropTypes.arrayOf(PropTypes.string.isRequired),
     projectIds: PropTypes.arrayOf(PropTypes.number.isRequired),
     fields: PropTypes.arrayOf(PropTypes.object.isRequired) as any,

--- a/src/sentry/static/sentry/app/views/events/searchBar.tsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.tsx
@@ -15,7 +15,7 @@ import {Field, FIELDS, TRACING_FIELDS} from 'app/utils/discover/fields';
 import withApi from 'app/utils/withApi';
 import withTags from 'app/utils/withTags';
 import {Client} from 'app/api';
-import {Organization, Tag} from 'app/types';
+import {Organization, TagCollection} from 'app/types';
 
 const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   `^${NEGATION_OPERATOR}|\\${SEARCH_WILDCARD}`,
@@ -29,7 +29,7 @@ const FIELD_TAGS = Object.fromEntries(
 type SearchBarProps = Omit<React.ComponentProps<typeof SmartSearchBar>, 'tags'> & {
   api: Client;
   organization: Organization;
-  tags: {[key: string]: Tag};
+  tags: TagCollection;
   omitTags?: string[];
   projectIds?: number[] | Readonly<number[]>;
   fields?: Readonly<Field[]>;

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -26,6 +26,7 @@ import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import {ContentBox, Main, Side} from 'app/utils/discover/styles';
 import {generateQueryWithTag} from 'app/utils';
 import localStorage from 'app/utils/localStorage';
+import {decodeScalar} from 'app/utils/queryString';
 
 import {DEFAULT_EVENT_VIEW} from './data';
 import Table from './table';
@@ -255,7 +256,7 @@ class Results extends React.Component<Props, State> {
   render() {
     const {organization, location, router, api} = this.props;
     const {eventView, error, errorCode, totalValues, showTags} = this.state;
-    const query = location.query.query || '';
+    const query = decodeScalar(location.query.query) || '';
     const title = this.getDocumentTitle();
 
     return (

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -243,7 +243,6 @@ class PerformanceLanding extends React.Component<Props, State> {
                   <StyledSearchBar
                     organization={organization}
                     projectIds={eventView.project}
-                    location={location}
                     query={filterString}
                     fields={eventView.fields}
                     onSearch={this.handleSearch}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -13,6 +13,7 @@ import EventView from 'app/utils/discover/eventView';
 import {ContentBox, HeaderBox, Main, Side} from 'app/utils/discover/styles';
 import Tags from 'app/views/eventsV2/tags';
 import SearchBar from 'app/views/events/searchBar';
+import {decodeScalar} from 'app/utils/queryString';
 
 import TransactionList from './transactionList';
 import Breadcrumb from './breadcrumb';
@@ -72,7 +73,7 @@ class SummaryContent extends React.Component<Props> {
 
   render() {
     const {transactionName, location, eventView, organization, totalValues} = this.props;
-    const query = location.query.query || '';
+    const query = decodeScalar(location.query.query) || '';
 
     return (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -138,7 +138,6 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                     </SearchEventTypeNote>
                   </Tooltip>
                 }
-                help={t('Choose which metric to trigger on')}
                 omitTags={['event.type']}
                 disabled={disabled}
                 useFormWrapper={false}

--- a/tests/js/spec/views/events/searchBar.spec.jsx
+++ b/tests/js/spec/views/events/searchBar.spec.jsx
@@ -78,7 +78,7 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {project: [1, 2], statsPeriod: '14d'}})
+      expect.objectContaining({query: {project: ['1', '2'], statsPeriod: '14d'}})
     );
 
     await tick();
@@ -113,7 +113,7 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {project: [1, 2], statsPeriod: '14d'}})
+      expect.objectContaining({query: {project: ['1', '2'], statsPeriod: '14d'}})
     );
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('');
@@ -194,7 +194,7 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {project: [1, 2], statsPeriod: '14d'}})
+      expect.objectContaining({query: {project: ['1', '2'], statsPeriod: '14d'}})
     );
     selectFirstAutocompleteItem(wrapper);
     expect(wrapper.find('input').prop('value')).toBe('!gpu:*"Nvidia 1080ti" ');

--- a/tests/js/spec/views/performance/landing.spec.jsx
+++ b/tests/js/spec/views/performance/landing.spec.jsx
@@ -144,10 +144,10 @@ describe('Performance > Landing', function() {
 
   it('does not render onboarding for "my projects"', async function() {
     const projects = [
-      TestStubs.Project({id: 1, firstTransactionEvent: false}),
-      TestStubs.Project({id: 2, firstTransactionEvent: true}),
+      TestStubs.Project({id: '1', firstTransactionEvent: false}),
+      TestStubs.Project({id: '2', firstTransactionEvent: true}),
     ];
-    const data = initializeData(projects, {project: [-1]});
+    const data = initializeData(projects, {project: ['-1']});
 
     const wrapper = mountWithTheme(
       <PerformanceLanding


### PR DESCRIPTION
Converts events SearchBar to typescript. Used 'any' for Field to get around propType to typescript issues. Also pull a null guard for calling clear on cache instead of modifying memoize.