### PR TITLE
chore: Remove local screenshots

### DIFF
--- a/tests/acceptance/test_create_team.py
+++ b/tests/acceptance/test_create_team.py
@@ -26,7 +26,6 @@ class CreateTeamTest(AcceptanceTestCase):
         self.browser.click('.modal-dialog button[aria-label="Create Team"]')
 
         # Wait for modal to go away.
-        self.browser.save_screenshot("create-team.png")
         self.browser.wait_until_not(".modal-header")
 
         # New team should be in dom

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -184,4 +184,3 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.page.ignore_issue()
 
         self.browser.snapshot("issue details ignored")
-        self.browser.save_screenshot("test.png")


### PR DESCRIPTION
These methods save screenshots locally. While useful for debugging they shouldn't be part of CI long term.