### PR TITLE
fix(metric_alerts): Calculate correct resolve date for alerts based on alert rule values.

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -109,7 +109,12 @@ def create_incident(
 
 
 def update_incident_status(
-    incident, status, user=None, comment=None, status_method=IncidentStatusMethod.RULE_TRIGGERED
+    incident,
+    status,
+    user=None,
+    comment=None,
+    status_method=IncidentStatusMethod.RULE_TRIGGERED,
+    date_closed=None,
 ):
     """
     Updates the status of an Incident and write an IncidentActivity row to log
@@ -135,7 +140,7 @@ def update_incident_status(
 
         kwargs = {"status": status.value, "status_method": status_method.value}
         if status == IncidentStatus.CLOSED:
-            kwargs["date_closed"] = timezone.now()
+            kwargs["date_closed"] = date_closed if date_closed else timezone.now()
         elif status == IncidentStatus.OPEN:
             # If we're moving back out of closed status then unset the closed
             # date

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -163,6 +163,25 @@ class SubscriptionProcessor(object):
         # before the next one then we might alert twice.
         self.update_alert_rule_stats()
 
+    def calculate_event_date_from_update_date(self, update_date):
+        """
+        Calculates the date that an event actually happened based on the date that we
+        received the update. This takes into account time window and threshold period.
+        :return:
+        """
+        # Subscriptions label buckets by the end of the bucket, whereas discover
+        # labels them by the front. This causes us an off-by-one error with event dates,
+        # so to prevent this we subtract a bucket off of the date.
+        update_date -= timedelta(seconds=self.alert_rule.snuba_query.time_window)
+        # We want to also subtract `frequency * (threshold_period - 1)` from the date.
+        # This allows us to show the actual start of the event, rather than the date
+        # of the last update that we received.
+        return update_date - timedelta(
+            seconds=(
+                self.alert_rule.snuba_query.resolution * (self.alert_rule.threshold_period - 1)
+            )
+        )
+
     def trigger_alert_threshold(self, trigger, metric_value):
         """
         Called when a subscription update exceeds the value defined in the
@@ -177,21 +196,7 @@ class SubscriptionProcessor(object):
             metrics.incr("incidents.alert_rules.trigger", tags={"type": "fire"})
             # Only create a new incident if we don't already have an active one
             if not self.active_incident:
-                detected_at = self.last_update
-                # Subscriptions label buckets by the end of the bucket, whereas discover
-                # labels them by the front. This causes us an off-by-one error with
-                # alert start dates, so to prevent this we subtract a bucket off of the
-                # start date.
-                detected_at -= timedelta(seconds=self.alert_rule.snuba_query.time_window)
-                # We want to also subtract `frequency * (threshold_period - 1)` from the
-                # query. This allows us to show the actual start date of the alert,
-                # rather than the start of the last update that we received.
-                detected_at -= timedelta(
-                    seconds=(
-                        self.alert_rule.snuba_query.resolution
-                        * (self.alert_rule.threshold_period - 1)
-                    )
-                )
+                detected_at = self.calculate_event_date_from_update_date(self.last_update)
                 self.active_incident = create_incident(
                     self.alert_rule.organization,
                     IncidentType.ALERT_TRIGGERED,
@@ -261,6 +266,7 @@ class SubscriptionProcessor(object):
                     self.active_incident,
                     IncidentStatus.CLOSED,
                     status_method=IncidentStatusMethod.RULE_TRIGGERED,
+                    date_closed=self.calculate_event_date_from_update_date(self.last_update),
                 )
                 self.active_incident = None
                 self.incident_triggers.clear()


### PR DESCRIPTION
This is the same fix we applied to start date. Resolve date was even more incorrect here, since it
was just using the current time, and so could be an arbitrary number of buckets late.