### PR TITLE
ref(eslint): Fix strict eslint errors (namely `no-unused-vars`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "enzyme-adapter-react-16": "1.15.1",
     "enzyme-to-json": "3.4.3",
     "eslint": "5.11.1",
-    "eslint-config-sentry-app": "1.37.0",
+    "eslint-config-sentry-app": "1.39.0",
     "html-webpack-plugin": "^4.3.0",
     "jest": "24.9.0",
     "jest-canvas-mock": "^2.2.0",

--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -30,7 +30,9 @@ import routes from 'app/routes';
 import {normalizeTransactionName} from 'app/utils/apm';
 
 if (process.env.NODE_ENV === 'development') {
-  import(/* webpackMode: "eager" */ 'app/utils/silence-react-unsafe-warnings');
+  import(
+    /* webpackChunkName: "SilenceReactUnsafeWarnings" */ /* webpackMode: "eager" */ 'app/utils/silence-react-unsafe-warnings'
+  );
 }
 
 function getSentryIntegrations(hasReplays: boolean = false) {

--- a/src/sentry/static/sentry/app/components/charts/tableChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/tableChart.jsx
@@ -6,32 +6,6 @@ import {Panel, PanelHeader, PanelItem} from 'app/components/panels';
 
 export const TableChart = styled(
   class TableChartComponent extends React.Component {
-    static propTypes = {
-      data: PropTypes.arrayOf(PropTypes.any),
-      /**
-       * The column index where your data starts.
-       * This is used to calculate totals.
-       *
-       * Will not work if you have mixed string/number columns
-       */
-      dataStartIndex: PropTypes.number,
-      widths: PropTypes.arrayOf(PropTypes.number),
-      // Height of body
-      bodyHeight: PropTypes.string,
-      getValue: PropTypes.func,
-      renderTableHeader: PropTypes.func,
-      renderBody: PropTypes.func,
-      renderHeaderCell: PropTypes.func,
-      renderDataCell: PropTypes.func,
-      shadeRowPercentage: PropTypes.bool,
-      showRowTotal: PropTypes.bool,
-      showColumnTotal: PropTypes.bool,
-      rowTotalLabel: PropTypes.string,
-      columnTotalLabel: PropTypes.string,
-      // props to pass to PanelHeader
-      headerProps: PropTypes.object,
-    };
-
     static get defaultProps() {
       // Default renderer for Table Header
       const defaultRenderTableHeader = ({
@@ -219,6 +193,32 @@ export const TableChart = styled(
         rowTotalWidth: 120,
       };
     }
+
+    static propTypes = {
+      data: PropTypes.arrayOf(PropTypes.any),
+      /**
+       * The column index where your data starts.
+       * This is used to calculate totals.
+       *
+       * Will not work if you have mixed string/number columns
+       */
+      dataStartIndex: PropTypes.number,
+      widths: PropTypes.arrayOf(PropTypes.number),
+      // Height of body
+      bodyHeight: PropTypes.string,
+      getValue: PropTypes.func,
+      renderTableHeader: PropTypes.func,
+      renderBody: PropTypes.func,
+      renderHeaderCell: PropTypes.func,
+      renderDataCell: PropTypes.func,
+      shadeRowPercentage: PropTypes.bool,
+      showRowTotal: PropTypes.bool,
+      showColumnTotal: PropTypes.bool,
+      rowTotalLabel: PropTypes.string,
+      columnTotalLabel: PropTypes.string,
+      // props to pass to PanelHeader
+      headerProps: PropTypes.object,
+    };
 
     // TODO(billy): memoize?
     getTotals(rows) {

--- a/src/sentry/static/sentry/app/components/dateTime.tsx
+++ b/src/sentry/static/sentry/app/components/dateTime.tsx
@@ -63,11 +63,11 @@ class DateTime extends React.Component<Props> {
   render() {
     const {
       date,
-      seconds, // eslint-disable-line no-unused-vars
-      shortDate, // eslint-disable-line no-unused-vars
-      dateOnly, // eslint-disable-line no-unused-vars
       utc,
-      timeOnly: _timeOnly, // eslint-disable-line no-unused-vars
+      seconds: _seconds,
+      shortDate: _shortDate,
+      dateOnly: _dateOnly,
+      timeOnly: _timeOnly,
       ...carriedProps
     } = this.props;
     const user = ConfigStore.get('user');

--- a/src/sentry/static/sentry/app/components/deviceName.tsx
+++ b/src/sentry/static/sentry/app/components/deviceName.tsx
@@ -43,8 +43,6 @@ export default class DeviceName extends React.Component<Props, State> {
     };
   }
 
-  private _isMounted?: boolean;
-
   componentDidMount() {
     // This is to handle react's warning on calling setState for unmounted components
     // Since we can't cancel promises, we need to do this
@@ -64,6 +62,8 @@ export default class DeviceName extends React.Component<Props, State> {
   componentWillUnmount() {
     this._isMounted = false;
   }
+
+  private _isMounted?: boolean;
 
   render() {
     const {value, children} = this.props;

--- a/src/sentry/static/sentry/app/components/dropdownAutoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoComplete.jsx
@@ -25,11 +25,7 @@ class DropdownAutoComplete extends React.Component {
       <DropdownAutoCompleteMenu {...props}>
         {renderProps => {
           // Don't pass `onClick` from `getActorProps`
-          const {
-            //eslint-disable-next-line no-unused-vars
-            onClick,
-            ...actorProps
-          } = renderProps.getActorProps();
+          const {onClick: _onClick, ...actorProps} = renderProps.getActorProps();
 
           return (
             <Actor

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -55,6 +55,10 @@ export class Provider extends React.Component<PropType, StateType> {
     dividerPosition: DEFAULT_DIVIDER_POSITION,
   };
 
+  componentWillUnmount() {
+    this.cleanUpListeners();
+  }
+
   previousUserSelect: UserSelectValues | null = null;
   dividerHandlePosition: number = DEFAULT_DIVIDER_POSITION;
   isDragging: boolean = false;
@@ -187,10 +191,6 @@ export class Provider extends React.Component<PropType, StateType> {
       window.removeEventListener('mouseup', this.onDragEnd);
     }
   };
-
-  componentWillUnmount() {
-    this.cleanUpListeners();
-  }
 
   render() {
     const childrenProps = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/dragManager.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/dragManager.tsx
@@ -92,6 +92,10 @@ class DragManager extends React.Component<DragManagerProps, DragManagerState> {
     viewWindowEnd: 1,
   };
 
+  componentWillUnmount() {
+    this.cleanUpListeners();
+  }
+
   previousUserSelect: UserSelectValues | null = null;
 
   hasInteractiveLayer = (): boolean => !!this.props.interactiveLayerRef.current;
@@ -362,10 +366,6 @@ class DragManager extends React.Component<DragManagerProps, DragManagerState> {
       window.removeEventListener('mouseup', this.onWindowSelectionDragEnd);
     }
   };
-
-  componentWillUnmount() {
-    this.cleanUpListeners();
-  }
 
   render() {
     const childrenProps = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -49,8 +49,6 @@ type State = {
 };
 
 class TraceView extends React.PureComponent<Props, State> {
-  minimapInteractiveRef = React.createRef<HTMLDivElement>();
-
   constructor(props: Props) {
     super(props);
 
@@ -66,6 +64,8 @@ class TraceView extends React.PureComponent<Props, State> {
       this.filterOnSpans(this.props.searchQuery);
     }
   }
+
+  minimapInteractiveRef = React.createRef<HTMLDivElement>();
 
   async filterOnSpans(searchQuery: string | undefined) {
     if (!searchQuery) {

--- a/src/sentry/static/sentry/app/components/forms/rangeField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/rangeField.jsx
@@ -45,13 +45,15 @@ export default class RangeField extends InputField {
     if (this.props.disabled) {
       suffixClassNames += ' disabled';
     }
+
+    // eslint-disable-next-line react/no-find-dom-node
     $(ReactDOM.findDOMNode(this.refs.input))
-      .on('slider:ready', (e, data) => {
+      .on('slider:ready', (_e, data) => {
         const value = parseInt(data.value, 10);
         $value.appendTo(data.el);
         $value.html(this.props.formatLabel(value));
       })
-      .on('slider:changed', (e, data) => {
+      .on('slider:changed', (_e, data) => {
         const value = parseInt(data.value, 10);
         $value.html(this.props.formatLabel(value));
         this.setValue(value);

--- a/src/sentry/static/sentry/app/components/lazyLoad.jsx
+++ b/src/sentry/static/sentry/app/components/lazyLoad.jsx
@@ -116,8 +116,7 @@ class LazyLoad extends React.Component {
 
   render() {
     const {Component, error} = this.state;
-    // eslint-disable-next-line no-unused-vars
-    const {hideBusy, hideError, component, ...otherProps} = this.props;
+    const {hideBusy, hideError, component: _component, ...otherProps} = this.props;
 
     if (error && !hideError) {
       return (

--- a/src/sentry/static/sentry/app/components/letterAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/letterAvatar.tsx
@@ -65,7 +65,13 @@ type LetterAvatarProps = React.ComponentProps<'svg'> & Props;
  * the svg, etc) will also need to be changed there.
  */
 const LetterAvatar = styled(
-  ({identifier, displayName, round, forwardedRef, ...props}: LetterAvatarProps) => (
+  ({
+    identifier,
+    displayName,
+    round: _round,
+    forwardedRef,
+    ...props
+  }: LetterAvatarProps) => (
     <svg ref={forwardedRef} viewBox="0 0 120 120" {...props}>
       <rect
         x="0"

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/index.jsx
@@ -26,6 +26,11 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 
 class DateRange extends React.Component {
+  static getTimeStringFromDate = date =>
+    moment(date)
+      .local()
+      .format('HH:mm');
+
   static propTypes = {
     /**
      * Start date value for absolute date selector
@@ -74,20 +79,15 @@ class DateRange extends React.Component {
     organization: SentryTypes.Organization,
   };
 
+  static contextTypes = {
+    router: PropTypes.object,
+  };
+
   static defaultProps = {
     showAbsolute: true,
     showRelative: false,
     maxPickableDays: MAX_PICKABLE_DAYS,
   };
-
-  static contextTypes = {
-    router: PropTypes.object,
-  };
-
-  static getTimeStringFromDate = date =>
-    moment(date)
-      .local()
-      .format('HH:mm');
 
   handleSelectDateRange = ({selection}) => {
     const {onChange} = this.props;

--- a/src/sentry/static/sentry/app/components/shareIssue.jsx
+++ b/src/sentry/static/sentry/app/components/shareIssue.jsx
@@ -33,6 +33,7 @@ class ShareUrlContainer extends React.Component {
     if (!this.urlRef) {
       return;
     }
+    // eslint-disable-next-line react/no-find-dom-node
     selectText(ReactDOM.findDOMNode(this.urlRef));
   };
 
@@ -41,6 +42,7 @@ class ShareUrlContainer extends React.Component {
 
     if (this.urlRef) {
       // Always select url if it's available
+      // eslint-disable-next-line react/no-find-dom-node
       selectText(ReactDOM.findDOMNode(this.urlRef));
     }
   };
@@ -186,7 +188,7 @@ class ShareIssue extends React.Component {
   };
 
   // State of confirm modal so we can keep dropdown menu opn
-  handleConfirmCancel = e => (this.hasConfirmModal = false);
+  handleConfirmCancel = () => (this.hasConfirmModal = false);
   handleConfirmReshare = () => (this.hasConfirmModal = true);
 
   render() {

--- a/src/sentry/static/sentry/app/stores/pluginsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/pluginsStore.jsx
@@ -8,11 +8,7 @@ const PluginsStore = Reflux.createStore({
   },
 
   getState() {
-    const {
-      //eslint-disable-next-line no-unused-vars
-      plugins,
-      ...state
-    } = this.state;
+    const {plugins: _plugins, ...state} = this.state;
 
     return {
       ...state,

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getDiscoverUrlPathFromDiscoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getDiscoverUrlPathFromDiscoverQuery.jsx
@@ -4,20 +4,10 @@ import {getExternal, getInternal} from 'app/views/discover/aggregations/utils';
 import {getQueryStringFromQuery} from 'app/views/discover/utils';
 
 export function getDiscoverUrlPathFromDiscoverQuery({organization, selection, query}) {
-  const {
-    datetime,
-    environments, // eslint-disable-line no-unused-vars
-    ...restSelection
-  } = selection;
+  const {datetime, environments: _environments, ...restSelection} = selection;
 
   // Discover does not support importing these
-  const {
-    groupby, // eslint-disable-line no-unused-vars
-    rollup, // eslint-disable-line no-unused-vars
-    name, // eslint-disable-line no-unused-vars
-    orderby,
-    ...restQuery
-  } = query;
+  const {groupby: _groupby, rollup: _rollup, name: _name, orderby, ...restQuery} = query;
 
   const orderbyTimeIndex = orderby.indexOf('time');
   const visual = orderbyTimeIndex === -1 ? 'table' : 'line-by-day';

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getEventsUrlPathFromDiscoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getEventsUrlPathFromDiscoverQuery.jsx
@@ -6,12 +6,7 @@ import {getUtcDateString} from 'app/utils/dates';
 import {getDiscoverConditionsToSearchString} from './getDiscoverConditionsToSearchString';
 
 export function getEventsUrlPathFromDiscoverQuery({organization, selection, query}) {
-  const {
-    projects,
-    datetime,
-    environments, // eslint-disable-line no-unused-vars
-    ...restSelection
-  } = selection;
+  const {projects, datetime, environments: _environments, ...restSelection} = selection;
 
   return `/organizations/${organization.slug}/events/?${qs.stringify(
     pickBy({

--- a/src/sentry/static/sentry/app/views/discover/result/index.tsx
+++ b/src/sentry/static/sentry/app/views/discover/result/index.tsx
@@ -53,9 +53,6 @@ type ResultState = {
 };
 
 class Result extends React.Component<ResultProps, ResultState> {
-  // This is the ref of the table container component
-  private container: any;
-
   constructor(props: ResultProps) {
     super(props);
     this.state = {
@@ -89,6 +86,9 @@ class Result extends React.Component<ResultProps, ResultState> {
   componentWillUnmount() {
     window.removeEventListener('resize', this.throttledUpdateDimensions);
   }
+
+  // This is the ref of the table container component
+  private container: any;
 
   setDimensions = (ref: any) => {
     this.container = ref;

--- a/src/sentry/static/sentry/app/views/discover/utils.tsx
+++ b/src/sentry/static/sentry/app/views/discover/utils.tsx
@@ -127,8 +127,14 @@ export function queryHasChanged(prev: string, next: string): boolean {
  * our internal representation of queries.
  */
 export function parseSavedQuery(savedQuery: any): SavedQuery {
-  // eslint-disable-next-line no-unused-vars
-  const {id, name, dateCreated, dateUpdated, createdBy, ...query} = savedQuery;
+  const {
+    id: _id,
+    name: _name,
+    dateCreated: _dateCreated,
+    dateUpdated: _dateUpdated,
+    createdBy: _createdBy,
+    ...query
+  } = savedQuery;
   return query;
 }
 
@@ -138,7 +144,7 @@ export function fetchSavedQuery(organization: any, queryId: string): Promise<any
 
   return api.requestPromise(endpoint, {
     method: 'GET',
-  } as any); // TODO: Remove as any
+  } as any); // TODO(ts): Remove as any
 }
 
 export function fetchSavedQueries(organization: any): Promise<any> {
@@ -148,7 +154,7 @@ export function fetchSavedQueries(organization: any): Promise<any> {
   return api.requestPromise(endpoint, {
     method: 'GET',
     query: {all: 1, query: 'version:1', sortBy: '-dateUpdated'},
-  } as any); // TODO: Remove as any
+  } as any); // TODO(ts): Remove as any
 }
 
 export function createSavedQuery(organization: any, data: any): Promise<any> {
@@ -158,7 +164,7 @@ export function createSavedQuery(organization: any, data: any): Promise<any> {
   return api.requestPromise(endpoint, {
     data,
     method: 'POST',
-  } as any); // TODO: Remove as any
+  } as any); // TODO(ts): Remove as any
 }
 
 export function updateSavedQuery(organization: any, id: any, data: any): Promise<any> {
@@ -168,7 +174,7 @@ export function updateSavedQuery(organization: any, id: any, data: any): Promise
   return api.requestPromise(endpoint, {
     data,
     method: 'PUT',
-  } as any); // TODO: Remove as any
+  } as any); // TODO(ts): Remove as any
 }
 
 export function deleteSavedQuery(organization: any, id: any): Promise<any> {
@@ -177,7 +183,7 @@ export function deleteSavedQuery(organization: any, id: any): Promise<any> {
 
   return api.requestPromise(endpoint, {
     method: 'DELETE',
-  } as any); // TODO: Remove as any
+  } as any); // TODO(ts): Remove as any
 }
 
 /**

--- a/src/sentry/static/sentry/app/views/onboarding/createSampleEventButton.tsx
+++ b/src/sentry/static/sentry/app/views/onboarding/createSampleEventButton.tsx
@@ -126,8 +126,13 @@ class CreateSampleEventButton extends React.Component<Props, State> {
   };
 
   render() {
-    // eslint-disable-next-line no-unused-vars
-    const {api, organization, project, source, ...props} = this.props;
+    const {
+      api: _api,
+      organization: _organization,
+      project: _project,
+      source: _source,
+      ...props
+    } = this.props;
     const {creating} = this.state;
 
     return (

--- a/src/sentry/static/sentry/app/views/settings/components/forms/apiForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/apiForm.jsx
@@ -41,8 +41,12 @@ export default class ApiForm extends React.Component {
   };
 
   render() {
-    // eslint-disable-next-line no-unused-vars
-    const {onSubmit, apiMethod, apiEndpoint, ...otherProps} = this.props;
+    const {
+      onSubmit: _onSubmit,
+      apiMethod: _apiMethod,
+      apiEndpoint: _apiEndpoint,
+      ...otherProps
+    } = this.props;
 
     return <Form onSubmit={this.onSubmit} {...otherProps} />;
   }

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -89,23 +89,20 @@ type State = {
 };
 
 export default class PermissionSelection extends React.Component<Props, State> {
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-    form: PropTypes.object,
-  };
-
   static propTypes = {
     permissions: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     appPublished: PropTypes.bool,
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      permissions: this.props.permissions,
-    };
-  }
+  static contextTypes = {
+    router: PropTypes.object.isRequired,
+    form: PropTypes.object,
+  };
+
+  state = {
+    permissions: this.props.permissions,
+  };
 
   /**
    * Converts the "Permission" values held in `state` to a list of raw

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/onboardingHovercard.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/onboardingHovercard.tsx
@@ -57,7 +57,7 @@ class OnboardingHovercard extends React.Component<Props, State> {
   };
 
   render() {
-    const {children, organization, location, ...props} = this.props;
+    const {children, organization: _org, location: _location, ...props} = this.props;
 
     if (!this.shouldShowHovercard) {
       return children;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6640,35 +6640,35 @@ eslint-config-prettier@6.3.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-sentry-app@1.37.0:
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.37.0.tgz#36bac360af442902938406bb9a91be1bcb3b525c"
-  integrity sha512-RlMoHklHbTdTzmLIz+JfVPWBcA2knRZhf+bBy8CTmLCG+v/gs2xV8ldC/81g0vNsteyegzU8yUZQjHBbYCf76w==
+eslint-config-sentry-app@1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.39.0.tgz#1274eedbbf23a842719180608b7725815903886d"
+  integrity sha512-deXyIg0fm/dymV3iQJ6ByHHj2jBqcQq2OccEW+Gyhvt636b+z35XjHEL0gl5hPtJFmmlcTKMoJ3K93iWd1uYZA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^2.23.0"
     "@typescript-eslint/parser" "^2.23.0"
     eslint-config-prettier "6.3.0"
-    eslint-config-sentry "^1.34.0"
-    eslint-config-sentry-react "^1.35.0"
+    eslint-config-sentry "^1.39.0"
+    eslint-config-sentry-react "^1.39.0"
     eslint-import-resolver-webpack "0.12.1"
     eslint-plugin-emotion "^10.0.27"
     eslint-plugin-import "2.20.1"
     eslint-plugin-jest "22.17.0"
     eslint-plugin-prettier "3.1.1"
     eslint-plugin-react "7.15.1"
-    eslint-plugin-sentry "^1.35.0"
+    eslint-plugin-sentry "^1.39.0"
 
-eslint-config-sentry-react@^1.35.0:
-  version "1.35.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.35.0.tgz#0ec43c1b39204d3351695d2727fdbfcf989633e9"
-  integrity sha512-82n/KHoh/oX+808eXVoru+aDFR9pLcOmkimXm0amCNkPNi/Q5Bx8yqRcO0FajrGQ1n2LlFy7oOMEPfhm7uimMA==
+eslint-config-sentry-react@^1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.39.0.tgz#7bcfef2d997f6c63c97e12925de48477e0aa9403"
+  integrity sha512-O5ZFier9W2SS7x4dEzIMZgrZajykzdLyPhO5TNrwV2tDrG/UKoTO+mrh95KGK7YJXeQpGa42WHrfCfjwrHMP6Q==
   dependencies:
-    eslint-config-sentry "^1.34.0"
+    eslint-config-sentry "^1.39.0"
 
-eslint-config-sentry@^1.34.0:
-  version "1.34.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.34.0.tgz#6c0e8916aa9a0914385f537ff06ffa93f2643ca6"
-  integrity sha512-hioksXUrCurZ/D4J8QGGGuVZlthnj04EUpZlLjyl0SLojNvMDxUxJB2cvgPsEk7iOn9hU8tNnkepYthR0qyY3Q==
+eslint-config-sentry@^1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.39.0.tgz#0e1b191ddfc4928b28b6358e40236905022303cc"
+  integrity sha512-uJgnAKvJPar103msg4q408NfG77aWz6lLS5dXmGIwcaBqFKq5Ysn+UQqgk+QBU9F5QLLV3mfP0ipl1NnqbQ2uA==
 
 eslint-import-resolver-node@^0.3.2:
   version "0.3.3"
@@ -6754,10 +6754,10 @@ eslint-plugin-react@7.15.1:
     prop-types "^15.7.2"
     resolve "^1.12.0"
 
-eslint-plugin-sentry@^1.35.0:
-  version "1.35.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.35.0.tgz#ffef605286c07431138984d85c74cff56cb954f4"
-  integrity sha512-GK4eUQW+gntTmU+IVS+sJGCVkrlFuUjALz57RkAvCNHvtU7YEwinZpttjSTxKn+Kae1dW9vrs0gllMiHxbfXpQ==
+eslint-plugin-sentry@^1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.39.0.tgz#27912276dac833c91da281dd7046be03f0e4cf4e"
+  integrity sha512-Wnh6jLoo5iinPvRwN1CJf8XCroNJGbF/CGW9tPoPqqmoD8bbPHc01DoNDAuQxSjYH+nXaop9PEWMuF7gPHgsSQ==
   dependencies:
     requireindex "~1.1.0"
 


### PR DESCRIPTION
We changed to use `@typescript-eslint/no-unused-vars`, however we still had a lot of one-off disabling of `eslint/no-unused-vars`.

Instead of disabling the rule, destructure with an alias that starts with `_` so that lint engine ignores it.

We should follow this up by making `no-unused-vars` a default rule.

Also fixes warnings about sort order for React components.

