### PR TITLE
fix(js) Fix missing eventView and nerf discover buttons

### DIFF
--- a/src/sentry/static/sentry/app/components/discoverButton.tsx
+++ b/src/sentry/static/sentry/app/components/discoverButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import Button from 'app/components/button';
+import Feature from 'app/components/acl/feature';
+
+type Props = React.PropsWithChildren<{
+  className?: string;
+}> &
+  React.ComponentProps<typeof Button>;
+
+/**
+ * Provide a button that turns itself off if the current organization
+ * doesn't have access to discover results.
+ */
+function DiscoverButton({children, ...buttonProps}: Props) {
+  return (
+    <Feature features={['organizations:discover-basic']}>
+      {({hasFeature}) => (
+        <Button disabled={!hasFeature} {...buttonProps}>
+          {children}
+        </Button>
+      )}
+    </Feature>
+  );
+}
+
+export default DiscoverButton;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -11,7 +11,7 @@ import {generateEventSlug, eventDetailsRoute} from 'app/utils/discover/urls';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {t, tct} from 'app/locale';
 import Alert from 'app/components/alert';
-import Button from 'app/components/button';
+import DiscoverButton from 'app/components/discoverButton';
 import DateTime from 'app/components/dateTime';
 import EventView from 'app/utils/discover/eventView';
 import Link from 'app/components/links/link';
@@ -76,9 +76,16 @@ class SpanDetail extends React.Component<Props, State> {
   }
 
   fetchSpanDescendents(spanID: string, traceID: string): Promise<any> {
-    const {api, orgId, trace} = this.props;
+    const {api, organization, trace} = this.props;
 
-    const url = `/organizations/${orgId}/eventsv2/`;
+    // Skip doing a request if the results will be behind a disabled button.
+    if (!organization.features.includes('discover-basic')) {
+      return new Promise(resolve => {
+        resolve({data: []});
+      });
+    }
+
+    const url = `/organizations/${organization.slug}/eventsv2/`;
 
     const {start, end} = getParams(
       getTraceDateTimeRange({
@@ -106,21 +113,21 @@ class SpanDetail extends React.Component<Props, State> {
       // TODO: Amend size to use theme when we evetually refactor LoadingIndicator
       // 12px is consistent with theme.iconSizes['xs'] but theme returns a string.
       return (
-        <StyledButton size="xsmall" disabled>
+        <StyledDiscoverButton size="xsmall" disabled>
           <StyledLoadingIndicator size={12} />
-        </StyledButton>
+        </StyledDiscoverButton>
       );
     }
 
     if (this.state.transactionResults.length <= 0) {
       return (
-        <StyledButton size="xsmall" disabled>
+        <StyledDiscoverButton size="xsmall" disabled>
           {t('No Children')}
-        </StyledButton>
+        </StyledDiscoverButton>
       );
     }
 
-    const {span, orgId, trace, eventView, organization, event} = this.props;
+    const {span, orgId, trace, eventView, event, organization} = this.props;
 
     assert(!isGapSpan(span));
 
@@ -136,9 +143,9 @@ class SpanDetail extends React.Component<Props, State> {
       };
 
       return (
-        <StyledButton data-test-id="view-child-transaction" size="xsmall" to={to}>
+        <StyledDiscoverButton data-test-id="view-child-transaction" size="xsmall" to={to}>
           {t('View Child')}
-        </StyledButton>
+        </StyledDiscoverButton>
       );
     }
 
@@ -168,13 +175,13 @@ class SpanDetail extends React.Component<Props, State> {
     });
 
     return (
-      <StyledButton
+      <StyledDiscoverButton
         data-test-id="view-child-transactions"
         size="xsmall"
         to={childrenEventView.getResultsViewUrlTarget(orgId)}
       >
         {t('View Children')}
-      </StyledButton>
+      </StyledDiscoverButton>
     );
   }
 
@@ -211,9 +218,12 @@ class SpanDetail extends React.Component<Props, State> {
     });
 
     return (
-      <StyledButton size="xsmall" to={traceEventView.getResultsViewUrlTarget(orgId)}>
+      <StyledDiscoverButton
+        size="xsmall"
+        to={traceEventView.getResultsViewUrlTarget(orgId)}
+      >
         {t('Search by Trace')}
-      </StyledButton>
+      </StyledDiscoverButton>
     );
   }
 
@@ -402,7 +412,7 @@ class SpanDetail extends React.Component<Props, State> {
   }
 }
 
-const StyledButton = styled(Button)`
+const StyledDiscoverButton = styled(DiscoverButton)`
   position: absolute;
   top: ${space(0.75)};
   right: ${space(0.5)};

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
@@ -22,6 +22,7 @@ import TagsTable from 'app/components/tagsTable';
 import Projects from 'app/utils/projects';
 import {ContentBox, HeaderBox, HeaderBottomControls} from 'app/utils/discover/styles';
 import Breadcrumb from 'app/views/performance/breadcrumb';
+import EventView from 'app/utils/discover/eventView';
 import {decodeScalar, appendTagCondition} from 'app/utils/queryString';
 
 import {transactionSummaryRouteWithQuery} from '../transactionSummary/utils';
@@ -119,6 +120,26 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     const transactionName = event.title;
     const query = decodeScalar(location.query.query) || '';
 
+    // Build a new event view so span details links will go to useful results.
+    const eventView = EventView.fromNewQueryWithLocation(
+      {
+        id: undefined,
+        name: 'Related events',
+        fields: [
+          'transaction',
+          'project',
+          'trace.span',
+          'transaction.duration',
+          'timestamp',
+        ],
+        orderby: '-timestamp',
+        version: 2,
+        projects: [],
+        query: appendTagCondition(query, 'transaction', transactionName),
+      },
+      location
+    );
+
     return (
       <React.Fragment>
         <HeaderBox>
@@ -147,6 +168,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                   location={location}
                   showExampleCommit={false}
                   showTagSummary={false}
+                  eventView={eventView}
                 />
               )}
             </Projects>
@@ -165,7 +187,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     );
   }
 
-  renderError(error) {
+  renderError(error: Error) {
     const notFound = Object.values(this.state.errors).find(
       resp => resp && resp.status === 404
     );

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
@@ -6,8 +6,7 @@ import {browserHistory} from 'react-router';
 import {Organization} from 'app/types';
 import space from 'app/styles/space';
 import {t} from 'app/locale';
-import Button from 'app/components/button';
-import Feature from 'app/components/acl/feature';
+import DiscoverButton from 'app/components/discoverButton';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import PanelTable from 'app/components/panels/panelTable';
 import Link from 'app/components/links/link';
@@ -94,22 +93,14 @@ class TransactionList extends React.PureComponent<WrapperProps> {
             ))}
           </DropdownControl>
           <HeaderButtonContainer>
-            <Feature
-              features={['organizations:discover-basic']}
-              organization={organization}
+            <DiscoverButton
+              onClick={this.handleDiscoverViewClick}
+              to={sortedEventView.getResultsViewUrlTarget(organization.slug)}
+              size="small"
+              data-test-id="discover-open"
             >
-              {({hasFeature}) => (
-                <Button
-                  onClick={this.handleDiscoverViewClick}
-                  to={sortedEventView.getResultsViewUrlTarget(organization.slug)}
-                  size="small"
-                  data-test-id="discover-open"
-                  disabled={!hasFeature}
-                >
-                  {t('Open in Discover')}
-                </Button>
-              )}
-            </Feature>
+              {t('Open in Discover')}
+            </DiscoverButton>
           </HeaderButtonContainer>
         </Header>
         <DiscoverQuery

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/issues.tsx
@@ -6,6 +6,7 @@ import {Location} from 'history';
 import {t, tct} from 'app/locale';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import Button from 'app/components/button';
+import DiscoverButton from 'app/components/discoverButton';
 import GroupList from 'app/components/issues/groupList';
 import space from 'app/styles/space';
 import {Panel, PanelBody} from 'app/components/panels';
@@ -189,9 +190,9 @@ class Issues extends React.Component<Props, State> {
 
           <ButtonBar gap={1}>
             <Feature features={['discover-basic']}>
-              <OpenInButton to={this.getDiscoverUrl()}>
+              <OpenDiscoverButton to={this.getDiscoverUrl()}>
                 {t('Open in Discover')}
-              </OpenInButton>
+              </OpenDiscoverButton>
             </Feature>
 
             <OpenInButton to={this.getIssuesUrl()}>{t('Open in Issues')}</OpenInButton>
@@ -217,6 +218,7 @@ class Issues extends React.Component<Props, State> {
 // used in media query
 const FilterButton = styled(DropdownButton)``;
 const OpenInButton = styled(Button)``;
+const OpenDiscoverButton = styled(DiscoverButton)``;
 
 const ControlsWrapper = styled('div')`
   display: flex;
@@ -224,7 +226,9 @@ const ControlsWrapper = styled('div')`
   justify-content: space-between;
   margin-bottom: ${space(1)};
   @media (max-width: ${p => p.theme.breakpoints[2]}) {
-    ${FilterButton}, ${OpenInButton} {
+    ${/* sc-selector */ FilterButton},
+    ${/* sc-selector */ OpenInButton},
+    ${/* sc-selector */ OpenDiscoverButton} {
       font-size: ${p => p.theme.fontSizeSmall};
     }
   }


### PR DESCRIPTION
When looking into the referenced sentry error I found several buttons that were missing Feature gates, as we'll be showing span details to accounts that don't have discover, these buttons should disable themselves.

Fixes JAVASCRIPT-22ED