### PR TITLE
feat(ui): Clarify "add a second platform" onboarding task

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -129,6 +129,7 @@ class OnboardingTasksSerializer(Serializer):
             "completionSeen": obj.completion_seen,
             "dateCompleted": obj.date_completed,
             "data": obj.data,
+            "project": obj.project_id,
         }
 
 

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -17,8 +17,9 @@ import {IconLock, IconCheckmark, IconClose, IconEvent} from 'app/icons';
 import Avatar from 'app/components/avatar';
 import LetterAvatar from 'app/components/letterAvatar';
 
-import {taskIsDone} from './utils';
 import SkipConfirm from './skipConfirm';
+import {isSecondPlatformPending, sendEventPromptText} from './taskConfig';
+import {taskIsDone} from './utils';
 
 const recordAnalytics = (
   task: OnboardingTask,
@@ -133,7 +134,11 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
         {IncompleteMarker}
         {task.title}
       </Title>
-      <Description>{`${task.description}. ${task.detailedDescription}`}</Description>
+      <Description>{`${task.description}. ${task.detailedDescription ??
+        ''}`}</Description>
+      {isSecondPlatformPending(task) && (
+        <Description data-test-id="send-event-prompt">{sendEventPromptText}</Description>
+      )}
       {task.requisiteTasks.length === 0 && (
         <ActionBar>
           {task.status === 'pending' ? (

--- a/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
@@ -107,7 +107,7 @@ export function getOnboardingTasks(
         // instructions for the corresponding project to prompt the user to send an event
         // to the new project.
         const projectSlug =
-          (project && org?.projects.find(p => p.id === `${project}`)?.slug) ??
+          (project && org?.projects?.find(p => p.id === `${project}`)?.slug) ??
           ':projectId';
         // if there's no project id associated with the task, sending 'projectId' to the router
         // causes it to display a project selector prompt, then resolve to the given page.

--- a/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
@@ -95,11 +95,24 @@ export function getOnboardingTasks(
     {
       task: OnboardingTaskKey.SECOND_PLATFORM,
       title: t('Add a second platform'),
-      description: t('Add Sentry to a second platform'),
-      detailedDescription: t('Capture errors from both your front and back ends.'),
+      description: t(
+        `Add a new project to capture errors from both your front and back ends for your other platforms`
+      ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
       actionType: 'app',
+      getPendingLocation: (org, project) => {
+        // It's confusing to continue linking to the "create new project"
+        // page after the user has created the new project. Instead, link to the install
+        // instructions for the corresponding project to prompt the user to send an event
+        // to the new project.
+        const projectSlug =
+          (project && org?.projects.find(p => p.id === `${project}`)?.slug) ??
+          ':projectId';
+        // if there's no project id associated with the task, sending 'projectId' to the router
+        // causes it to display a project selector prompt, then resolve to the given page.
+        return `/settings/${org.slug}/projects/${projectSlug}/install/`;
+      },
       location: `/organizations/${organization.slug}/projects/new/`,
       display: true,
     },
@@ -183,6 +196,15 @@ export function getOnboardingTasks(
   ];
 }
 
+export const sendEventPromptText = t(
+  'Complete this task by sending an event to your new project.'
+);
+
+// Enable custom functionality for the "second platform" task when the task status
+// is pending.
+export const isSecondPlatformPending = (task: OnboardingTask) =>
+  task.task === OnboardingTaskKey.SECOND_PLATFORM && task.status === 'pending';
+
 export function getMergedTasks(organization: Organization) {
   const taskDescriptors = getOnboardingTasks(organization);
   const serverTasks = organization.onboardingTasks;
@@ -196,6 +218,17 @@ export function getMergedTasks(organization: Organization) {
         requisiteTasks: [],
       } as OnboardingTask)
   );
+
+  // Change task.location for the "second platform" task when task status is pending.
+  allTasks.map(task => {
+    if (!isSecondPlatformPending(task)) return task;
+    if (
+      !('location' in task && 'getPendingLocation' in task && !!task.getPendingLocation)
+    )
+      return task;
+    task.location = task.getPendingLocation(organization, task.project);
+    return task;
+  });
 
   // Map incomplete requisiteTasks as full task objects
   return allTasks.map(task => ({

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1102,6 +1102,7 @@ export type OnboardingTaskDescriptor = {
   | {
       actionType: 'app' | 'external';
       location: string;
+      getPendingLocation?: (Organization, number?) => string;
     }
   | {
       actionType: 'action';
@@ -1116,6 +1117,7 @@ export type OnboardingTaskStatus = {
   dateCompleted?: string;
   completionSeen?: string;
   data?: object;
+  project?: number;
 };
 
 export type OnboardingTask = OnboardingTaskStatus &

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -128,5 +128,6 @@ describe('Command Palette Modal', function() {
       .simulate('click');
 
     expect(navigateTo).toHaveBeenCalledWith('/billy-org/', expect.anything());
+    navigateTo.mockClear();
   });
 });

--- a/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
+++ b/tests/js/spec/components/onboardingWizard/tasks.spec.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import Task from 'app/components/onboardingWizard/task';
+import {getMergedTasks} from 'app/components/onboardingWizard/taskConfig';
+import {OnboardingTaskKey} from 'app/types';
+import {navigateTo} from 'app/actionCreators/navigation';
+
+jest.mock('app/actionCreators/navigation');
+
+describe('Task', () => {
+  let org;
+  let project;
+  beforeEach(() => {
+    project = TestStubs.Project({id: '1', slug: 'angryGoose'});
+    org = TestStubs.Organization({projects: [project], slug: 'GamesCorp'});
+  });
+  afterEach(() => {
+    navigateTo.mockClear();
+  });
+
+  it('renders', () => {
+    const tasks = getMergedTasks(org);
+    const mockTask = tasks[0];
+
+    const wrapper = mountWithTheme(
+      <Task organization={org} task={mockTask} />,
+      TestStubs.routerContext()
+    );
+
+    expect(wrapper.find('Title').exists()).toBe(true);
+  });
+
+  describe('Add a Second Platform', () => {
+    it('renders without send event prompt initially', () => {
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+
+      expect(wrapper.find('[data-test-id="send-event-prompt"]').exists()).toBe(false);
+    });
+
+    it('renders send event prompt when status is pending', () => {
+      org.onboardingTasks = [
+        {
+          task: OnboardingTaskKey.SECOND_PLATFORM,
+          status: 'pending',
+        },
+      ];
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
+
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+
+      expect(wrapper.find('[data-test-id="send-event-prompt"]').exists()).toBe(true);
+    });
+
+    it('links to create new project page before task is started', () => {
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+      wrapper
+        .find('[data-test-id="setup_second_platform"]')
+        .first()
+        .simulate('click');
+
+      expect(navigateTo).toHaveBeenCalledWith(
+        `${second_platform_task.location}?onboardingTask`,
+        expect.anything()
+      );
+    });
+
+    it('links to project configuration page after project is created', () => {
+      org.onboardingTasks = [
+        {
+          task: OnboardingTaskKey.SECOND_PLATFORM,
+          status: 'pending',
+          project: 1,
+        },
+      ];
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
+
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+      wrapper
+        .find('[data-test-id="setup_second_platform"]')
+        .first()
+        .simulate('click');
+
+      expect(navigateTo).toHaveBeenCalledWith(
+        `/settings/${org.slug}/projects/${project.slug}/install/?onboardingTask`,
+        expect.anything()
+      );
+    });
+
+    it('passes :projectId to router when project id cannot be resolved', () => {
+      org.onboardingTasks = [
+        {
+          task: OnboardingTaskKey.SECOND_PLATFORM,
+          status: 'pending',
+        },
+      ];
+      const tasks = getMergedTasks(org);
+      const second_platform_task = tasks.find(
+        t => t.task === OnboardingTaskKey.SECOND_PLATFORM
+      );
+
+      const wrapper = mountWithTheme(
+        <Task organization={org} task={second_platform_task} />,
+        TestStubs.routerContext()
+      );
+      wrapper
+        .find('[data-test-id="setup_second_platform"]')
+        .first()
+        .simulate('click');
+
+      expect(navigateTo).toHaveBeenCalledWith(
+        `/settings/${org.slug}/projects/:projectId/install/?onboardingTask`,
+        expect.anything()
+      );
+    });
+  });
+});

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1508,7 +1508,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                 <p
                   class="css-127nzq8-Description e9zebce2"
                 >
-                  Add Sentry to a second platform. Capture errors from both your front and back ends.
+                  Add a new project to capture errors from both your front and back ends for your other platforms. 
                 </p>
               </div>
               <div
@@ -1706,9 +1706,9 @@ exports[`Sidebar can have onboarding feature 1`] = `
                   },
                   Object {
                     "actionType": "app",
-                    "description": "Add Sentry to a second platform",
-                    "detailedDescription": "Capture errors from both your front and back ends.",
+                    "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                     "display": true,
+                    "getPendingLocation": [Function],
                     "location": "/organizations/org-slug/projects/new/",
                     "requisiteTasks": Array [
                       Object {
@@ -4199,9 +4199,9 @@ exports[`Sidebar can have onboarding feature 1`] = `
                       task={
                         Object {
                           "actionType": "app",
-                          "description": "Add Sentry to a second platform",
-                          "detailedDescription": "Capture errors from both your front and back ends.",
+                          "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                           "display": true,
+                          "getPendingLocation": [Function],
                           "location": "/organizations/org-slug/projects/new/",
                           "requisiteTasks": Array [
                             Object {
@@ -4280,9 +4280,9 @@ exports[`Sidebar can have onboarding feature 1`] = `
                         task={
                           Object {
                             "actionType": "app",
-                            "description": "Add Sentry to a second platform",
-                            "detailedDescription": "Capture errors from both your front and back ends.",
+                            "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                             "display": true,
+                            "getPendingLocation": [Function],
                             "location": "/organizations/org-slug/projects/new/",
                             "requisiteTasks": Array [
                               Object {
@@ -4329,9 +4329,9 @@ exports[`Sidebar can have onboarding feature 1`] = `
                           task={
                             Object {
                               "actionType": "app",
-                              "description": "Add Sentry to a second platform",
-                              "detailedDescription": "Capture errors from both your front and back ends.",
+                              "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                               "display": true,
+                              "getPendingLocation": [Function],
                               "location": "/organizations/org-slug/projects/new/",
                               "requisiteTasks": Array [
                                 Object {
@@ -4379,9 +4379,9 @@ exports[`Sidebar can have onboarding feature 1`] = `
                             task={
                               Object {
                                 "actionType": "app",
-                                "description": "Add Sentry to a second platform",
-                                "detailedDescription": "Capture errors from both your front and back ends.",
+                                "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                                 "display": true,
+                                "getPendingLocation": [Function],
                                 "location": "/organizations/org-slug/projects/new/",
                                 "requisiteTasks": Array [
                                   Object {
@@ -4458,9 +4458,9 @@ exports[`Sidebar can have onboarding feature 1`] = `
                               task={
                                 Object {
                                   "actionType": "app",
-                                  "description": "Add Sentry to a second platform",
-                                  "detailedDescription": "Capture errors from both your front and back ends.",
+                                  "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                                   "display": true,
+                                  "getPendingLocation": [Function],
                                   "location": "/organizations/org-slug/projects/new/",
                                   "requisiteTasks": Array [
                                     Object {
@@ -4836,9 +4836,9 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                 task={
                                   Object {
                                     "actionType": "app",
-                                    "description": "Add Sentry to a second platform",
-                                    "detailedDescription": "Capture errors from both your front and back ends.",
+                                    "description": "Add a new project to capture errors from both your front and back ends for your other platforms",
                                     "display": true,
+                                    "getPendingLocation": [Function],
                                     "location": "/organizations/org-slug/projects/new/",
                                     "requisiteTasks": Array [
                                       Object {
@@ -4969,7 +4969,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                       <p
                                         className="css-127nzq8-Description e9zebce2"
                                       >
-                                        Add Sentry to a second platform. Capture errors from both your front and back ends.
+                                        Add a new project to capture errors from both your front and back ends for your other platforms. 
                                       </p>
                                     </Description>
                                   </div>

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -152,5 +152,6 @@ describe('SettingsSearch', function() {
       .simulate('click');
 
     expect(navigateTo).toHaveBeenCalledWith('/billy-org/', expect.anything());
+    navigateTo.mockClear();
   });
 });

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -4,10 +4,17 @@ from __future__ import absolute_import
 
 import six
 
+from datetime import timedelta
 from django.conf import settings
+from django.utils import timezone
 
 from sentry.auth import access
-from sentry.api.serializers import serialize, DetailedOrganizationSerializer
+from sentry.api.serializers import (
+    serialize,
+    DetailedOrganizationSerializer,
+    OnboardingTasksSerializer,
+)
+from sentry.models import OnboardingTask, OnboardingTaskStatus, OrganizationOnboardingTask
 from sentry.testutils import TestCase
 
 
@@ -39,6 +46,33 @@ class OrganizationSerializerTest(TestCase):
                 "discover-query",
             ]
         )
+
+
+class OnboardingTasksSerializerTest(TestCase):
+    def test_serializer(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+        now = timezone.now()
+
+        want = OrganizationOnboardingTask(
+            organization_id=organization.id,
+            task=OnboardingTask.FIRST_PROJECT,
+            completion_seen=now,
+            date_completed=now - timedelta(minutes=5),
+            user=user,
+            status=OnboardingTaskStatus.COMPLETE,
+            project_id=100,
+        )
+
+        result = serialize(want, user, OnboardingTasksSerializer())
+
+        assert result["task"] == "create_project"
+        assert result["status"] == "complete"
+        assert result["user"]["id"] == six.text_type(user.id)
+        assert result["completionSeen"] == want.completion_seen
+        assert result["dateCompleted"] == want.date_completed
+        assert result["data"] == want.data
+        assert result["project"] == want.project_id
 
 
 class DetailedOrganizationSerializerTest(TestCase):


### PR DESCRIPTION
Revert "fix(ui): Revert "feat(ui): Clarify "add a second platform" onboarding task (#19225)" (#19361)"

This restores the functionality originally delivered in `d820cee`. It also includes a fix for the runtime type error that caused the original commit to break the site at runtime.