### PR TITLE
fix(discover) Scope release markers to the current date window

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -345,7 +345,14 @@ class EventsChart extends React.Component<Props> {
     if (!disableReleases) {
       const previousChart = chartImplementation;
       chartImplementation = chartProps => (
-        <ReleaseSeries utc={utc} api={api} projects={projects}>
+        <ReleaseSeries
+          utc={utc}
+          period={period}
+          start={start}
+          end={end}
+          api={api}
+          projects={projects}
+        >
           {({releaseSeries}) => previousChart({...chartProps, releaseSeries})}
         </ReleaseSeries>
       );

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -154,7 +154,14 @@ class DurationChart extends React.Component<Props> {
                   : [];
 
                 return (
-                  <ReleaseSeries utc={utc} api={api} projects={project}>
+                  <ReleaseSeries
+                    start={start}
+                    end={end}
+                    period={statsPeriod}
+                    utc={utc}
+                    api={api}
+                    projects={project}
+                  >
                     {({releaseSeries}) => (
                       <TransitionChart loading={loading} reloading={reloading}>
                         <TransparentLoadingMask visible={reloading} />

--- a/tests/js/spec/components/charts/releaseSeries.spec.jsx
+++ b/tests/js/spec/components/charts/releaseSeries.spec.jsx
@@ -62,6 +62,42 @@ describe('ReleaseSeries', function() {
     );
   });
 
+  it('fetches releases with start and end dates', async function() {
+    const wrapper = mount(
+      <ReleaseSeries start="2020-01-01" end="2020-01-31">
+        {renderFunc}
+      </ReleaseSeries>,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(releasesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {start: '2020-01-01', end: '2020-01-31'},
+      })
+    );
+  });
+
+  it('fetches releases with period', async function() {
+    const wrapper = mount(
+      <ReleaseSeries period="14d">{renderFunc}</ReleaseSeries>,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(releasesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {statsPeriod: '14d'},
+      })
+    );
+  });
+
   it('generates an eCharts `markLine` series from releases', async function() {
     const wrapper = mount(<ReleaseSeries>{renderFunc}</ReleaseSeries>, routerContext);
 


### PR DESCRIPTION
If an org does many releases, they could easily have more than 100 releases in 90 days. Then when looking at results from 30-60 days they would get no release data. Furthermore, we do requests and throw the results away. This also helps improve release marker performance for 7 and 14 day windows by fetching only the releases that will show up.