### PR TITLE
feat(discover2): Add per-cell action for count()

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -281,9 +281,7 @@ class CellAction extends React.Component<Props, State> {
 
     // do not display per cell actions for count() and count_unique()
     const shouldIgnoreColumn =
-      column.column.kind === 'function' &&
-      (column.column.function[0] === 'count' ||
-        column.column.function[0] === 'count_unique');
+      column.column.kind === 'function' && column.column.function[0] === 'count_unique';
 
     if (!defined(value) || shouldIgnoreColumn) {
       // per cell actions do not apply to values that are null


### PR DESCRIPTION
Now that we have an enforced navigation drilldown behaviour, we can add per-cell actions to `count()` columns.

<img width="337" alt="Screen Shot 2020-06-15 at 3 36 44 PM" src="https://user-images.githubusercontent.com/139499/84698595-11c19380-af1e-11ea-962f-a077773cfab1.png">
