### PR TITLE
fix(ui): removed time since in Alert list

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -14,7 +14,6 @@ import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
 import Projects from 'app/utils/projects';
 import theme from 'app/utils/theme';
-import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
 import getDynamicText from 'app/utils/getDynamicText';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
@@ -73,8 +72,6 @@ class AlertListRow extends AsyncComponent<Props, State> {
   renderTimeSince(date: string) {
     return (
       <CreatedResolvedTime>
-        <TimeSince date={date} />
-        <br />
         <StyledDateTime date={date} utc={false} />
       </CreatedResolvedTime>
     );
@@ -162,7 +159,6 @@ const CreatedResolvedTime = styled('div')`
 `;
 
 const StyledDateTime = styled(DateTime)`
-  font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.gray500};
 `;
 

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -111,7 +111,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
                 <IncidentLink
                   to={`/organizations/${orgId}/alerts/${incident.identifier}/`}
                 >
-                  #{incident.id}
+                  Alert #{incident.id}
                 </IncidentLink>
                 {incident.title}
               </Title>

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -221,13 +221,6 @@ describe('IncidentsList', function() {
         .exists()
     ).toBeFalsy();
 
-    expect(
-      wrapper
-        .find('IncidentPanelItem')
-        .at(0)
-        .find('TimeSince')
-    ).toHaveLength(1);
-
     expect(incidentsMock).toHaveBeenCalledTimes(1);
 
     expect(incidentsMock).toHaveBeenCalledWith(
@@ -252,13 +245,6 @@ describe('IncidentsList', function() {
         .find('Duration')
         .text()
     ).toBe('2 weeks');
-
-    expect(
-      wrapper
-        .find('IncidentPanelItem')
-        .at(0)
-        .find('TimeSince')
-    ).toHaveLength(2);
 
     expect(incidentsMock).toHaveBeenCalledTimes(2);
     // Stats not called for closed incidents


### PR DESCRIPTION
Got some feedback that the triggered date is confusing so I’m removing the `x days ago` copy for now:

### Before
<img width="1042" alt="Screenshot 2020-06-15 12 49 42" src="https://user-images.githubusercontent.com/1900676/84699630-b46e1800-af06-11ea-819f-47b8120eea88.png">


### After
<img width="1038" alt="Screenshot 2020-06-15 12 43 36" src="https://user-images.githubusercontent.com/1900676/84699525-84bf1000-af06-11ea-9d18-34b865840ea5.png">
