### PR TITLE
ref(ui) Replace icon-trash with IconDelete

### DIFF
--- a/src/sentry/static/sentry/app/icons/iconDelete.tsx
+++ b/src/sentry/static/sentry/app/icons/iconDelete.tsx
@@ -20,6 +20,4 @@ const IconDelete = React.forwardRef<SVGSVGElement, Props>(function IconDelete(
   );
 });
 
-IconDelete.displayName = 'IconDelete';
-
 export {IconDelete};

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
@@ -100,7 +100,7 @@ class DeleteActions extends React.Component {
           )}
           onConfirm={this.props.onDelete}
         >
-          <IconDelete size="xs" />
+          <IconDelete size="xs" css={{position: 'relative', top: '1px'}} />
         </LinkWithConfirmation>
         <DropdownLink caret className="group-delete btn btn-default btn-sm">
           <MenuItem onClick={this.openDiscardModal}>

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
@@ -20,6 +20,7 @@ import FeatureDisabled from 'app/components/acl/featureDisabled';
 import GroupActions from 'app/actions/groupActions';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
 import IgnoreActions from 'app/components/actions/ignore';
+import {IconDelete} from 'app/icons';
 import Link from 'app/components/links/link';
 import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
 import MenuItem from 'app/components/menuItem';
@@ -99,7 +100,7 @@ class DeleteActions extends React.Component {
           )}
           onConfirm={this.props.onDelete}
         >
-          <span className="icon-trash" />
+          <IconDelete size="xs" />
         </LinkWithConfirmation>
         <DropdownLink caret className="group-delete btn btn-default btn-sm">
           <MenuItem onClick={this.openDiscardModal}>

--- a/src/sentry/static/sentry/app/views/settings/organizationApiKeys/organizationApiKeysList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationApiKeys/organizationApiKeysList.jsx
@@ -1,6 +1,7 @@
 import {Box, Flex} from 'reflexbox';
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from '@emotion/styled';
 
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import {t, tct} from 'app/locale';
@@ -8,12 +9,13 @@ import AutoSelectText from 'app/components/autoSelectText';
 import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import ExternalLink from 'app/components/links/externalLink';
+import {IconDelete, IconAdd} from 'app/icons';
 import Link from 'app/components/links/link';
 import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import recreateRoute from 'app/utils/recreateRoute';
-import {IconAdd} from 'app/icons';
+import space from 'app/styles/space';
 
 class OrganizationApiKeysList extends React.Component {
   static propTypes = {
@@ -112,7 +114,7 @@ class OrganizationApiKeysList extends React.Component {
                         message={t('Are you sure you want to remove this API key?')}
                         title={t('Remove API Key?')}
                       >
-                        <span className="icon-trash" />
+                        <StyledIconDelete size="xs" />
                       </LinkWithConfirmation>
                     </Box>
                   </PanelItem>
@@ -124,5 +126,10 @@ class OrganizationApiKeysList extends React.Component {
     );
   }
 }
+
+const StyledIconDelete = styled(IconDelete)`
+  position: relative;
+  top: ${space(0.25)};
+`;
 
 export default OrganizationApiKeysList;

--- a/src/sentry/static/sentry/app/views/settings/organizationApiKeys/organizationApiKeysList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationApiKeys/organizationApiKeysList.jsx
@@ -1,7 +1,6 @@
 import {Box, Flex} from 'reflexbox';
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from '@emotion/styled';
 
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import {t, tct} from 'app/locale';
@@ -15,7 +14,6 @@ import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import recreateRoute from 'app/utils/recreateRoute';
-import space from 'app/styles/space';
 
 class OrganizationApiKeysList extends React.Component {
   static propTypes = {
@@ -114,7 +112,7 @@ class OrganizationApiKeysList extends React.Component {
                         message={t('Are you sure you want to remove this API key?')}
                         title={t('Remove API Key?')}
                       >
-                        <StyledIconDelete size="xs" />
+                        <IconDelete size="xs" css={{position: 'relative', top: '2px'}} />
                       </LinkWithConfirmation>
                     </Box>
                   </PanelItem>
@@ -126,10 +124,5 @@ class OrganizationApiKeysList extends React.Component {
     );
   }
 }
-
-const StyledIconDelete = styled(IconDelete)`
-  position: relative;
-  top: ${space(0.25)};
-`;
 
 export default OrganizationApiKeysList;

--- a/src/sentry/static/sentry/less/auth.less
+++ b/src/sentry/static/sentry/less/auth.less
@@ -149,10 +149,6 @@ section.org-login {
       margin-top: -4px;
     }
 
-    .icon-trash {
-      margin-left: -2px;
-    }
-
     &.enrolled {
       h4:after {
         display: inline-block;

--- a/src/sentry/static/sentry/less/fonts.less
+++ b/src/sentry/static/sentry/less/fonts.less
@@ -236,9 +236,6 @@
 .icon-search:before {
   content: '\e601';
 }
-.icon-trash:before {
-  content: '\e606';
-}
 .icon-settings:before {
   content: '\e60b';
 }

--- a/src/sentry/static/sentry/less/includes/bootstrap/glyphicons.less
+++ b/src/sentry/static/sentry/less/includes/bootstrap/glyphicons.less
@@ -155,11 +155,6 @@
     content: '\e019';
   }
 }
-.glyphicon-trash {
-  &:before {
-    content: '\e020';
-  }
-}
 .glyphicon-home {
   &:before {
     content: '\e021';

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -232,8 +232,7 @@ fieldset[disabled] .btn-danger.active,
     margin-left: -1px;
   }
 
-  .icon-checkmark,
-  .icon-trash {
+  .icon-checkmark {
     position: relative;
     top: 1px;
     margin-right: -1px;

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -434,7 +434,7 @@ exports[`ProjectTags renders 1`] = `
                                                           className="css-dm7gfi-Icon edwq9my2"
                                                           size="xsmall"
                                                         >
-                                                          <IconDelete
+                                                          <ForwardRef(IconDelete)
                                                             size="xs"
                                                           >
                                                             <ForwardRef(SvgIcon)
@@ -466,7 +466,7 @@ exports[`ProjectTags renders 1`] = `
                                                                 />
                                                               </svg>
                                                             </ForwardRef(SvgIcon)>
-                                                          </IconDelete>
+                                                          </ForwardRef(IconDelete)>
                                                         </span>
                                                       </Icon>
                                                     </span>
@@ -648,7 +648,7 @@ exports[`ProjectTags renders 1`] = `
                                                           className="css-dm7gfi-Icon edwq9my2"
                                                           size="xsmall"
                                                         >
-                                                          <IconDelete
+                                                          <ForwardRef(IconDelete)
                                                             size="xs"
                                                           >
                                                             <ForwardRef(SvgIcon)
@@ -680,7 +680,7 @@ exports[`ProjectTags renders 1`] = `
                                                                 />
                                                               </svg>
                                                             </ForwardRef(SvgIcon)>
-                                                          </IconDelete>
+                                                          </ForwardRef(IconDelete)>
                                                         </span>
                                                       </Icon>
                                                     </span>
@@ -862,7 +862,7 @@ exports[`ProjectTags renders 1`] = `
                                                           className="css-dm7gfi-Icon edwq9my2"
                                                           size="xsmall"
                                                         >
-                                                          <IconDelete
+                                                          <ForwardRef(IconDelete)
                                                             size="xs"
                                                           >
                                                             <ForwardRef(SvgIcon)
@@ -894,7 +894,7 @@ exports[`ProjectTags renders 1`] = `
                                                                 />
                                                               </svg>
                                                             </ForwardRef(SvgIcon)>
-                                                          </IconDelete>
+                                                          </ForwardRef(IconDelete)>
                                                         </span>
                                                       </Icon>
                                                     </span>
@@ -1097,7 +1097,7 @@ exports[`ProjectTags renders 1`] = `
                                                                     className="css-dm7gfi-Icon edwq9my2"
                                                                     size="xsmall"
                                                                   >
-                                                                    <IconDelete
+                                                                    <ForwardRef(IconDelete)
                                                                       size="xs"
                                                                     >
                                                                       <ForwardRef(SvgIcon)
@@ -1129,7 +1129,7 @@ exports[`ProjectTags renders 1`] = `
                                                                           />
                                                                         </svg>
                                                                       </ForwardRef(SvgIcon)>
-                                                                    </IconDelete>
+                                                                    </ForwardRef(IconDelete)>
                                                                   </span>
                                                                 </Icon>
                                                               </span>
@@ -1336,7 +1336,7 @@ exports[`ProjectTags renders 1`] = `
                                                                     className="css-dm7gfi-Icon edwq9my2"
                                                                     size="xsmall"
                                                                   >
-                                                                    <IconDelete
+                                                                    <ForwardRef(IconDelete)
                                                                       size="xs"
                                                                     >
                                                                       <ForwardRef(SvgIcon)
@@ -1368,7 +1368,7 @@ exports[`ProjectTags renders 1`] = `
                                                                           />
                                                                         </svg>
                                                                       </ForwardRef(SvgIcon)>
-                                                                    </IconDelete>
+                                                                    </ForwardRef(IconDelete)>
                                                                   </span>
                                                                 </Icon>
                                                               </span>

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -452,7 +452,6 @@ exports[`OrganizationApiKeysList renders 1`] = `
                                 __EMOTION_TYPE_PLEASE_DO_NOT_USE__={
                                   Object {
                                     "$$typeof": Symbol(react.forward_ref),
-                                    "displayName": "IconDelete",
                                     "render": [Function],
                                   }
                                 }
@@ -464,7 +463,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                                 }
                                 size="xs"
                               >
-                                <IconDelete
+                                <ForwardRef(IconDelete)
                                   className="css-17ls4qs-OrganizationApiKeysList"
                                   size="xs"
                                 >
@@ -499,7 +498,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                                       />
                                     </svg>
                                   </ForwardRef(SvgIcon)>
-                                </IconDelete>
+                                </ForwardRef(IconDelete)>
                               </EmotionCssPropInternal>
                             </a>
                             <Modal

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -448,19 +448,32 @@ exports[`OrganizationApiKeysList renders 1`] = `
                               onClick={[Function]}
                               title="Remove API Key?"
                             >
-                              <StyledIconDelete
+                              <EmotionCssPropInternal
+                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "displayName": "IconDelete",
+                                    "render": [Function],
+                                  }
+                                }
+                                css={
+                                  Object {
+                                    "name": "17ls4qs-OrganizationApiKeysList",
+                                    "styles": "position:relative;top:2px;;label:OrganizationApiKeysList;",
+                                  }
+                                }
                                 size="xs"
                               >
                                 <IconDelete
-                                  className="css-yf24ud-StyledIconDelete eszsvtk0"
+                                  className="css-17ls4qs-OrganizationApiKeysList"
                                   size="xs"
                                 >
                                   <ForwardRef(SvgIcon)
-                                    className="css-yf24ud-StyledIconDelete eszsvtk0"
+                                    className="css-17ls4qs-OrganizationApiKeysList"
                                     size="xs"
                                   >
                                     <svg
-                                      className="css-yf24ud-StyledIconDelete eszsvtk0"
+                                      className="css-17ls4qs-OrganizationApiKeysList"
                                       fill="currentColor"
                                       height="12px"
                                       viewBox="0 0 16 16"
@@ -487,7 +500,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
                                     </svg>
                                   </ForwardRef(SvgIcon)>
                                 </IconDelete>
-                              </StyledIconDelete>
+                              </EmotionCssPropInternal>
                             </a>
                             <Modal
                               animation={false}

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -448,9 +448,46 @@ exports[`OrganizationApiKeysList renders 1`] = `
                               onClick={[Function]}
                               title="Remove API Key?"
                             >
-                              <span
-                                className="icon-trash"
-                              />
+                              <StyledIconDelete
+                                size="xs"
+                              >
+                                <IconDelete
+                                  className="css-yf24ud-StyledIconDelete eszsvtk0"
+                                  size="xs"
+                                >
+                                  <ForwardRef(SvgIcon)
+                                    className="css-yf24ud-StyledIconDelete eszsvtk0"
+                                    size="xs"
+                                  >
+                                    <svg
+                                      className="css-yf24ud-StyledIconDelete eszsvtk0"
+                                      fill="currentColor"
+                                      height="12px"
+                                      viewBox="0 0 16 16"
+                                      width="12px"
+                                    >
+                                      <path
+                                        d="M14.71,3.94H1.29a.75.75,0,0,1,0-1.5H14.71a.75.75,0,0,1,0,1.5Z"
+                                      />
+                                      <path
+                                        d="M12.69,15.94H3.31a1.75,1.75,0,0,1-1.75-1.75v-11h1.5v11a.25.25,0,0,0,.25.25h9.38a.25.25,0,0,0,.25-.25v-11h1.5v11A1.75,1.75,0,0,1,12.69,15.94Z"
+                                      />
+                                      <path
+                                        d="M5,13a.74.74,0,0,1-.75-.75V6.14a.75.75,0,0,1,1.5,0v6.1A.75.75,0,0,1,5,13Z"
+                                      />
+                                      <path
+                                        d="M8,13a.75.75,0,0,1-.75-.75V6.14a.75.75,0,0,1,1.5,0v6.1A.75.75,0,0,1,8,13Z"
+                                      />
+                                      <path
+                                        d="M11.05,13a.75.75,0,0,1-.75-.75V6.14a.75.75,0,0,1,1.5,0v6.1A.74.74,0,0,1,11.05,13Z"
+                                      />
+                                      <path
+                                        d="M10.51,3.47l-.81-2H6.3l-.81,2L4.1,2.91,5,.77A1.26,1.26,0,0,1,6.13,0H9.87A1.26,1.26,0,0,1,11,.77l.87,2.14Z"
+                                      />
+                                    </svg>
+                                  </ForwardRef(SvgIcon)>
+                                </IconDelete>
+                              </StyledIconDelete>
                             </a>
                             <Modal
                               animation={false}

--- a/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
@@ -40,7 +40,7 @@ describe('OrganizationApiKeysList', function() {
 
     wrapper.update();
     // Click remove button
-    wrapper.find('IconDelete').simulate('click');
+    wrapper.find('ForwardRef(IconDelete)').simulate('click');
     wrapper.update();
 
     // expect a modal

--- a/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
@@ -40,7 +40,7 @@ describe('OrganizationApiKeysList', function() {
 
     wrapper.update();
     // Click remove button
-    wrapper.find('.icon-trash').simulate('click');
+    wrapper.find('IconDelete').simulate('click');
     wrapper.update();
 
     // expect a modal


### PR DESCRIPTION
I needed to customize organization API keys to retain styling with bootstrap buttons.

## Before
![Screen Shot 2020-06-15 at 4 25 07 PM](https://user-images.githubusercontent.com/24086/84704817-6702a280-af28-11ea-9221-217c2b3a53d3.png)

## After
![Screen Shot 2020-06-15 at 4 51 46 PM](https://user-images.githubusercontent.com/24086/84704956-a0d3a900-af28-11ea-9168-c819930b6281.png)
