### PR TITLE
feat(discover2): Add per cell action to count_unique()

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -19,6 +19,7 @@ export enum Actions {
   SHOW_LESS_THAN = 'show_less_than',
   TRANSACTION = 'transaction',
   RELEASE = 'release',
+  OPEN_STACK = 'open_stack',
 }
 
 type Props = {
@@ -193,6 +194,22 @@ class CellAction extends React.Component<Props, State> {
       );
     }
 
+    if (
+      column.column.kind === 'function' &&
+      column.column.function[0] === 'count_unique'
+    ) {
+      addMenuItem(
+        Actions.OPEN_STACK,
+        <ActionItem
+          key="open-stack"
+          data-test-id="per-cell-open-stack"
+          onClick={() => handleCellAction(Actions.OPEN_STACK, value)}
+        >
+          {t('Open Stack')}
+        </ActionItem>
+      );
+    }
+
     if (actions.length === 0) {
       return null;
     }
@@ -279,11 +296,7 @@ class CellAction extends React.Component<Props, State> {
     const fieldAlias = getAggregateAlias(column.name);
     const value = dataRow[fieldAlias];
 
-    // do not display per cell actions for count() and count_unique()
-    const shouldIgnoreColumn =
-      column.column.kind === 'function' && column.column.function[0] === 'count_unique';
-
-    if (!defined(value) || shouldIgnoreColumn) {
+    if (!defined(value)) {
       // per cell actions do not apply to values that are null
       return <React.Fragment>{children}</React.Fragment>;
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -201,8 +201,8 @@ class CellAction extends React.Component<Props, State> {
       addMenuItem(
         Actions.DRILLDOWN,
         <ActionItem
-          key="open-stack"
-          data-test-id="per-cell-open-stack"
+          key="drilldown"
+          data-test-id="per-cell-drilldown"
           onClick={() => handleCellAction(Actions.DRILLDOWN, value)}
         >
           {t('View Stacks')}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -19,7 +19,7 @@ export enum Actions {
   SHOW_LESS_THAN = 'show_less_than',
   TRANSACTION = 'transaction',
   RELEASE = 'release',
-  OPEN_STACK = 'open_stack',
+  DRILLDOWN = 'drilldown',
 }
 
 type Props = {
@@ -199,13 +199,13 @@ class CellAction extends React.Component<Props, State> {
       column.column.function[0] === 'count_unique'
     ) {
       addMenuItem(
-        Actions.OPEN_STACK,
+        Actions.DRILLDOWN,
         <ActionItem
           key="open-stack"
           data-test-id="per-cell-open-stack"
-          onClick={() => handleCellAction(Actions.OPEN_STACK, value)}
+          onClick={() => handleCellAction(Actions.DRILLDOWN, value)}
         >
-          {t('Open Stack')}
+          {t('View Stacks')}
         </ActionItem>
       );
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -320,7 +320,7 @@ class TableView extends React.Component<TableViewProps> {
 
           return;
         }
-        case Actions.OPEN_STACK: {
+        case Actions.DRILLDOWN: {
           // count_unique(column) drilldown
 
           trackAnalyticsEvent({


### PR DESCRIPTION
Add per-cell action to `count_unique()`, the last remaining Discover column to yet have a per-cell action. 

![Kapture 2020-06-15 at 18 39 17](https://user-images.githubusercontent.com/139499/84712995-febbbd00-af37-11ea-9de7-c6e6e8b3f91c.gif)
