### PR TITLE
fix(slack): Skip over channels with missing channel_ids

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -387,11 +387,11 @@ def _get_channels_from_rules(organization, integration):
             rule_integration_id = rule_action.get("workspace")
             if rule_integration_id and rule_integration_id == six.text_type(integration.id):
 
-                channel_id = rule_action["channel_id"]
+                channel_id = rule_action.get("channel_id")
                 channel_name = rule_action["channel"]
 
-                # don't care if its a user
-                if channel_name[0] == "@":
+                # skip if its a user or if somehow channel_id is missing
+                if channel_name[0] == "@" or not channel_id:
                     continue
 
                 channels.add(Channel(channel_name, channel_id))


### PR DESCRIPTION
If an alert rule is in a bad state (where the `channel_id` is missing), the Slack migration breaks and the org with that alert rule will not be able to upgrade. 

This fixes the migration flow to just skip over that rule, more follow up is probably needed to figure out how an alert rule got into this state in the first place.

REF API-1074
FIXES SENTRY-GS1