### PR TITLE
fix(ui): replaced em values with rem

### DIFF
--- a/src/sentry/static/sentry/app/styles/text.tsx
+++ b/src/sentry/static/sentry/app/styles/text.tsx
@@ -43,23 +43,27 @@ const textStyles = () => css`
   }
 
   h1 {
-    font-size: 2em;
+    font-size: 3.2rem;
   }
 
   h2 {
-    font-size: 1.75em;
+    font-size: 2.8rem;
   }
 
   h3 {
-    font-size: 1.5em;
+    font-size: 2.4rem;
   }
 
   h4 {
-    font-size: 1.25em;
+    font-size: 2rem;
   }
 
   h5 {
-    font-size: 1em;
+    font-size: 1.6rem;
+  }
+
+  h6 {
+    font-size: 1.4rem;
   }
 
   pre {

--- a/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountSubscriptions.spec.jsx.snap
@@ -118,7 +118,7 @@ exports[`AccountSubscriptions renders list and can toggle 1`] = `
                     withPadding={false}
                   >
                     <div
-                      className="css-1ehogmz-FlexBox e1vnwt6f0"
+                      className="css-1nto0rx-FlexBox e1vnwt6f0"
                     >
                       <PanelItem
                         alignItems="center"

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -329,7 +329,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
             withPadding={false}
           >
             <div
-              className="css-1ehogmz-FlexBox e1vnwt6f0"
+              className="css-1nto0rx-FlexBox e1vnwt6f0"
             >
               <StyledPanelItem
                 key="2"

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -772,7 +772,7 @@ exports[`ProjectPluginDetails renders 1`] = `
                                       withPadding={false}
                                     >
                                       <div
-                                        className="e1ueudyh4 css-orfn1j-FlexBox-StyledPanelBody e1vnwt6f0"
+                                        className="e1ueudyh4 css-1nbu7cr-FlexBox-StyledPanelBody e1vnwt6f0"
                                       >
                                         <div
                                           dangerouslySetInnerHTML={

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -217,7 +217,7 @@ exports[`ProjectTags renders 1`] = `
                 withPadding={false}
               >
                 <div
-                  className="css-1ehogmz-FlexBox e1vnwt6f0"
+                  className="css-1nto0rx-FlexBox e1vnwt6f0"
                 >
                   <WithOrganizationMockWrapper
                     access={

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -205,7 +205,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                   withPadding={false}
                 >
                   <div
-                    className="css-1ehogmz-FlexBox e1vnwt6f0"
+                    className="css-1nto0rx-FlexBox e1vnwt6f0"
                   >
                     <EmotionCssPropInternal
                       __EMOTION_TYPE_PLEASE_DO_NOT_USE__={
@@ -756,7 +756,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                     withPadding={false}
                   >
                     <div
-                      className="css-1ehogmz-FlexBox e1vnwt6f0"
+                      className="css-1nto0rx-FlexBox e1vnwt6f0"
                     >
                       <EmptyMessage>
                         <Component

--- a/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
+++ b/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
@@ -85,7 +85,7 @@ exports[`ProjectPlugins renders 1`] = `
             withPadding={false}
           >
             <div
-              className="css-1ehogmz-FlexBox e1vnwt6f0"
+              className="css-1nto0rx-FlexBox e1vnwt6f0"
             >
               <PanelAlert
                 type="warning"

--- a/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
+++ b/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
@@ -56,7 +56,7 @@ exports[`ReleaseCommits organization release commits 1`] = `
                 withPadding={false}
               >
                 <div
-                  className="css-1ehogmz-FlexBox e1vnwt6f0"
+                  className="css-1nto0rx-FlexBox e1vnwt6f0"
                 >
                   <Styled(CommitRow)
                     commit={
@@ -442,7 +442,7 @@ exports[`ReleaseCommits project release commits 1`] = `
                 withPadding={false}
               >
                 <div
-                  className="css-1ehogmz-FlexBox e1vnwt6f0"
+                  className="css-1nto0rx-FlexBox e1vnwt6f0"
                 >
                   <Styled(CommitRow)
                     commit={

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -353,7 +353,7 @@ exports[`OrganizationApiKeysList renders 1`] = `
               withPadding={false}
             >
               <div
-                className="css-1ehogmz-FlexBox e1vnwt6f0"
+                className="css-1nto0rx-FlexBox e1vnwt6f0"
               >
                 <PanelItem
                   alignItems="center"

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -388,7 +388,7 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                       withPadding={false}
                     >
                       <div
-                        className="css-13ovabz-FlexBox-OrganizationProjects e1vnwt6f0"
+                        className="css-ok1i83-FlexBox-OrganizationProjects e1vnwt6f0"
                       >
                         <GridPanelItem
                           key="2"

--- a/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -324,7 +324,7 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
               withPadding={false}
             >
               <div
-                className="css-1ehogmz-FlexBox e1vnwt6f0"
+                className="css-1nto0rx-FlexBox e1vnwt6f0"
               >
                 <EmptyMessage>
                   <Component
@@ -680,7 +680,7 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
               withPadding={false}
             >
               <div
-                className="css-1ehogmz-FlexBox e1vnwt6f0"
+                className="css-1nto0rx-FlexBox e1vnwt6f0"
               >
                 <EmptyMessage>
                   <Component
@@ -1036,7 +1036,7 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
               withPadding={false}
             >
               <div
-                className="css-1ehogmz-FlexBox e1vnwt6f0"
+                className="css-1nto0rx-FlexBox e1vnwt6f0"
               >
                 <EnvironmentRow
                   actionText="Show"

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -349,7 +349,7 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                     withPadding={false}
                   >
                     <div
-                      className="css-1ehogmz-FlexBox e1vnwt6f0"
+                      className="css-1nto0rx-FlexBox e1vnwt6f0"
                     >
                       <EmptyMessage>
                         <Component
@@ -519,7 +519,7 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                     withPadding={false}
                   >
                     <div
-                      className="css-1ehogmz-FlexBox e1vnwt6f0"
+                      className="css-1nto0rx-FlexBox e1vnwt6f0"
                     >
                       <EmptyMessage>
                         <Component


### PR DESCRIPTION
The problem with having our base styles with a font-size set in `em` CSS values is that it’s super hard to debug why some font-sizes are bigger than others. 

Take this example: 

<img width="920" alt="Screenshot 2020-06-15 15 55 00" src="https://user-images.githubusercontent.com/1900676/84716583-6cf88380-af28-11ea-99c4-b51bf334654a.png">

This is crazy big because the base h1 size is set to 2em and the panel is changing the font-size. But h1 -> h6 sizes should always be the same size. That way they’re predictable and don’t do wacky stuff like they are here.

Next step: remove Bootstrap type styles and fix our hierarchy variables.