### PR TITLE
tests(celery): Make sure that queues specified in celery tasks are always defined.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -565,6 +565,7 @@ CELERY_QUEUES = [
     Queue("events.save_event", routing_key="events.save_event"),
     Queue("files.delete", routing_key="files.delete"),
     Queue("incidents", routing_key="incidents"),
+    Queue("incident_snapshots", routing_key="incident_snapshots"),
     Queue("integrations", routing_key="integrations"),
     Queue("merge", routing_key="merge"),
     Queue("options", routing_key="options"),

--- a/tests/sentry/tasks/test_queues_registered.py
+++ b/tests/sentry/tasks/test_queues_registered.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+
+from celery import current_app
+from django.conf import settings
+
+from sentry.testutils import TestCase
+
+
+class CeleryQueueRegisteredTest(TestCase):
+    def test(self):
+        queue_names = set([q.name for q in settings.CELERY_QUEUES])
+        missing_queue_tasks = []
+        for task in current_app.tasks.values():
+            # Filter out any tasks that aren't sentry specific, or don't specify `queue`.
+            if task.name.startswith("celery.") or not hasattr(task, "queue"):
+                continue
+            if task.queue not in queue_names:
+                missing_queue_tasks.append(" - Task: {}, Queue: {}".format(task.name, task.queue))
+
+        assert not missing_queue_tasks, (
+            "Found tasks with queues that are undefined. These must be defined in "
+            "settings.CELERY_QUEUES.\nTask Info:\n{}.".format("\n".join(missing_queue_tasks))
+        )


### PR DESCRIPTION
Whenever a celery task specifies `queue` this value must also be created in
`settings.CELERY_QUEUES`. This is pretty easy to forget, so this pr adds a test to ensure that the
queues are always defined.

Produces an error message like:
```
Traceback (most recent call last):
  File "/Users/dfuller/code/sentry/tests/sentry/tasks/test_queues_registered.py", line 20, in test
    assert not missing_queue_tasks, (
AssertionError: Found tasks with queues that are undefined. These must be defined in settings.CELERY_QUEUES.
  Task Info:
   - Task: sentry.incidents.tasks.process_pending_incident_snapshots, Queue: incident_snapshots.
assert not [' - Task: sentry.incidents.tasks.process_pending_incident_snapshots, Queue: incident_snapshots']
```