### PR TITLE
fix(discover): Add user to count_unique field

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -41,7 +41,7 @@ class UserStats extends React.Component<Props> {
       },
       {
         kind: 'function',
-        function: ['count_unique', '', undefined],
+        function: ['count_unique', 'user', undefined],
       },
     ]);
 


### PR DESCRIPTION
### Summary
Count_unique for userStats was missing `user` as it's meant to be the count of unique users in this view

### Screenshot
![Screen Shot 2020-06-15 at 5 26 25 PM](https://user-images.githubusercontent.com/6111995/84718451-759f8880-af2d-11ea-81bf-cfca1b87113e.png)
