### PR TITLE
fix(dev): Set Relay kafka message size to 2MB

### DIFF
--- a/config/relay/config.yml
+++ b/config/relay/config.yml
@@ -12,4 +12,7 @@ processing:
   enabled: true
   kafka_config:
     - {name: 'bootstrap.servers', value: 'sentry_kafka:9093'}
+    # The maximum attachment chunk size is 1MB. Together with some meta data,
+    # messages will never get larger than 2MB in total.
+    - {name: 'message.max.bytes', value: 2097176}
   redis: redis://sentry_redis:6379


### PR DESCRIPTION
The maximum attachment chunk size is 1MB. Together with some meta data, messages will never get larger than 2MB in total. This needs to be increased in the Relay Kafka configuration, as the default message limit is 1MB.
