### PR TITLE
Revert "ref(icon refactor): replace icon-anchor"

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
@@ -9,7 +9,6 @@ import {DataSection} from 'app/components/events/styles';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import space from 'app/styles/space';
-import {IconAnchor} from 'app/icons/iconAnchor';
 
 const defaultProps = {
   wrapTitle: true,
@@ -79,7 +78,7 @@ class EventDataSection extends React.Component<Props> {
         {title && (
           <SectionHeader id={type} isCentered={isCentered}>
             <Permalink href={'#' + type} className="permalink">
-              <IconAnchor />
+              <em className="icon-anchor" />
             </Permalink>
             {titleNode}
             {type === 'extra' && (
@@ -110,12 +109,14 @@ class EventDataSection extends React.Component<Props> {
 }
 
 const Permalink = styled('a')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  line-height: 27px;
   display: none;
   position: absolute;
-  top: 4px;
+  top: -1.5px;
   left: -22px;
-  color: ${p => p.theme.gray500};
-  width: 100%;
+  color: ${p => p.theme.gray400};
+  padding: ${space(0.25)} 5px;
 `;
 
 const SectionHeader = styled('div')<{isCentered?: boolean}>`
@@ -157,7 +158,6 @@ const SectionHeader = styled('div')<{isCentered?: boolean}>`
   }
 
   &:hover ${Permalink} {
-    color: ${p => p.theme.gray500};
     display: block;
   }
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -212,7 +212,7 @@ const TitleWrapper = styled('div')`
 `;
 
 const ButtonGroup = styled(ButtonBar)`
-  padding-right: ${space(1)};
+  padding: ${space(1.5)} ${space(1)} ${space(1.5)} 0;
 `;
 
 const ButtonGroupWrapper = styled('div')`

--- a/tests/js/spec/components/__snapshots__/toggleRawEventData.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/toggleRawEventData.spec.jsx.snap
@@ -12,7 +12,9 @@ exports[`EventDataSection renders formatted 1`] = `
       className="permalink"
       href="#extra"
     >
-      <ForwardRef />
+      <em
+        className="icon-anchor"
+      />
     </Permalink>
     <h3>
       Additional Data
@@ -53,7 +55,9 @@ exports[`EventDataSection renders raw 1`] = `
       className="permalink"
       href="#extra"
     >
-      <ForwardRef />
+      <em
+        className="icon-anchor"
+      />
     </Permalink>
     <h3>
       Additional Data

--- a/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
@@ -586,7 +586,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                     isCentered={false}
                                   >
                                     <div
-                                      className="css-1c6ejai-SectionHeader e1fbjd861"
+                                      className="css-n08n7b-SectionHeader e1fbjd861"
                                       id="message"
                                     >
                                       <Permalink
@@ -594,23 +594,12 @@ exports[`SharedGroupDetails renders 1`] = `
                                         href="#message"
                                       >
                                         <a
-                                          className="permalink css-uap9sr-Permalink e1fbjd860"
+                                          className="permalink css-rl8enl-Permalink e1fbjd860"
                                           href="#message"
                                         >
-                                          <ForwardRef>
-                                            <ForwardRef(SvgIcon)>
-                                              <svg
-                                                fill="currentColor"
-                                                height="16px"
-                                                viewBox="0 0 16 16"
-                                                width="16px"
-                                              >
-                                                <path
-                                                  d="M8,1.59a.31.31,0,1,0,.31.31A.31.31,0,0,0,8,1.59ZM6.19,1.9A1.81,1.81,0,1,1,8.75,3.55v2h4.66a.75.75,0,0,1,0,1.5H8.75v7.32a6.87,6.87,0,0,0,5.57-4.12.75.75,0,0,1,1.44.3v2.5a.75.75,0,0,1-1.5,0,8.38,8.38,0,0,1-12.52,0,.75.75,0,0,1-1.5,0v-2.5a.75.75,0,0,1,1.44-.3,6.87,6.87,0,0,0,5.57,4.12V7.05H2.59a.75.75,0,1,1,0-1.5H7.25v-2A1.81,1.81,0,0,1,6.19,1.9Z"
-                                                />
-                                              </svg>
-                                            </ForwardRef(SvgIcon)>
-                                          </ForwardRef>
+                                          <em
+                                            className="icon-anchor"
+                                          />
                                         </a>
                                       </Permalink>
                                       <h3>


### PR DESCRIPTION
Reverts getsentry/sentry#19364

I am reverting this refactor, because newly positioned permalink is overlaying actions on the right and renders them unclickable.

![image](https://user-images.githubusercontent.com/9060071/84751238-9f53c080-afbc-11ea-8cb4-2a4de9a14cbb.png)

![image](https://user-images.githubusercontent.com/9060071/84751331-bbeff880-afbc-11ea-8759-99c12f46bff4.png)
