### PR TITLE
feat(ui): Hide artifacts on release detail page

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
@@ -41,24 +41,28 @@ class ReleaseArtifacts extends AsyncView<Props> {
     return (
       <React.Fragment>
         <Feature features={['artifacts-in-settings']}>
-          <AlertLink
-            to={`/settings/${organization.slug}/projects/${
-              project.slug
-            }/source-maps/${encodeURIComponent(params.release)}/`}
-            priority="info"
-          >
-            {tct('Artifacts were moved to [sourceMaps] in Settings.', {
-              sourceMaps: <u>{t('Source Maps')}</u>,
-            })}
-          </AlertLink>
+          {hasFeature =>
+            hasFeature ? (
+              <AlertLink
+                to={`/settings/${organization.slug}/projects/${
+                  project.slug
+                }/source-maps/${encodeURIComponent(params.release)}/`}
+                priority="info"
+              >
+                {tct('Artifacts were moved to [sourceMaps] in Settings.', {
+                  sourceMaps: <u>{t('Source Maps')}</u>,
+                })}
+              </AlertLink>
+            ) : (
+              <ReleaseArtifactsV1
+                params={params}
+                location={location}
+                projectId={project.slug}
+                smallEmptyMessage
+              />
+            )
+          }
         </Feature>
-
-        <ReleaseArtifactsV1
-          params={params}
-          location={location}
-          projectId={project.slug}
-          smallEmptyMessage
-        />
       </React.Fragment>
     );
   }

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/artifacts/index.tsx
@@ -41,7 +41,7 @@ class ReleaseArtifacts extends AsyncView<Props> {
     return (
       <React.Fragment>
         <Feature features={['artifacts-in-settings']}>
-          {hasFeature =>
+          {({hasFeature}) =>
             hasFeature ? (
               <AlertLink
                 to={`/settings/${organization.slug}/projects/${


### PR DESCRIPTION
We want to hide artifacts on the release detail page if `artifacts-in-settings` feature flag is present. We will show info message that they were moved to settings instead.

![image](https://user-images.githubusercontent.com/9060071/84776768-06836c00-afe1-11ea-8592-1ba410cbfe1e.png)
