### PR TITLE
fix(discover): Fix stats accessing the wrong property name

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -55,7 +55,7 @@ class UserStats extends React.Component<Props> {
 
     if (stats) {
       const miserableUsers = Number(row[`user_misery_${userMiseryLimit}`]);
-      const totalUsers = Number(row.count_unique);
+      const totalUsers = Number(row.count_unique_user);
       if (!isNaN(miserableUsers) && !isNaN(totalUsers)) {
         userMisery = (
           <UserMisery


### PR DESCRIPTION
## Summary
This should grab the correct data off the payload now that it has been changed. Going to confirm with a test account this time to make sure this looks right.

### Screenshot
It was displaying `-` for user misery as one of the fields was missing.
![Screen Shot 2020-06-16 at 8 58 20 AM](https://user-images.githubusercontent.com/6111995/84798319-a7593380-afaf-11ea-8c3b-6caa9a67ef2c.png)

Going to confirm via preview / percy that this is fixed.

**edit:** confirmed screenshot via preview
![Screen Shot 2020-06-16 at 9 20 37 AM](https://user-images.githubusercontent.com/6111995/84800451-b2619300-afb2-11ea-9b98-4b4342953c22.png)
