### PR TITLE
fix(discover): Fix race condition when updating date range

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsRequest.tsx
@@ -245,6 +245,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     }));
 
     try {
+      api.clear();
       timeseriesData = await doEventsRequest(api, props);
     } catch (resp) {
       if (resp && resp.responseJSON && resp.responseJSON.detail) {

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -253,7 +253,7 @@ class Results extends React.Component<Props, State> {
   };
 
   render() {
-    const {organization, location, router, api} = this.props;
+    const {organization, location, router} = this.props;
     const {eventView, error, errorCode, totalValues, showTags} = this.state;
     const query = location.query.query || '';
     const title = this.getDocumentTitle();
@@ -279,7 +279,6 @@ class Results extends React.Component<Props, State> {
                   onSearch={this.handleSearch}
                 />
                 <ResultsChart
-                  api={api}
                   router={router}
                   organization={organization}
                   eventView={eventView}

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -80,10 +80,12 @@ class Results extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Props, prevState: State) {
     const {api, location, organization, selection} = this.props;
     const {eventView} = this.state;
+
     if (
       !isEqual(prevProps.selection.projects, selection.projects) ||
       !isEqual(prevProps.selection.datetime, selection.datetime)
     ) {
+      api.clear();
       loadOrganizationTags(api, organization.slug, selection);
     }
 
@@ -91,6 +93,7 @@ class Results extends React.Component<Props, State> {
     const currentQuery = eventView.getEventsAPIPayload(location);
     const prevQuery = prevState.eventView.getEventsAPIPayload(prevProps.location);
     if (!isAPIPayloadSimilar(currentQuery, prevQuery)) {
+      api.clear();
       this.fetchTotalCount();
     }
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -89,6 +89,8 @@ class Results extends React.Component<Props, State> {
       this.fetchTotalCount();
       if (
         !isEqual(prevQuery.statsPeriod, currentQuery.statsPeriod) ||
+        !isEqual(prevQuery.start, currentQuery.start) ||
+        !isEqual(prevQuery.end, currentQuery.end) ||
         !isEqual(prevQuery.project, currentQuery.project)
       ) {
         loadOrganizationTags(api, organization.slug, selection);

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -81,20 +81,18 @@ class Results extends React.Component<Props, State> {
     const {api, location, organization, selection} = this.props;
     const {eventView} = this.state;
 
-    if (
-      !isEqual(prevProps.selection.projects, selection.projects) ||
-      !isEqual(prevProps.selection.datetime, selection.datetime)
-    ) {
-      api.clear();
-      loadOrganizationTags(api, organization.slug, selection);
-    }
-
     this.checkEventView();
     const currentQuery = eventView.getEventsAPIPayload(location);
     const prevQuery = prevState.eventView.getEventsAPIPayload(prevProps.location);
     if (!isAPIPayloadSimilar(currentQuery, prevQuery)) {
       api.clear();
       this.fetchTotalCount();
+      if (
+        !isEqual(prevQuery.statsPeriod, currentQuery.statsPeriod) ||
+        !isEqual(prevQuery.project, currentQuery.project)
+      ) {
+        loadOrganizationTags(api, organization.slug, selection);
+      }
     }
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -14,6 +14,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import EventView from 'app/utils/discover/eventView';
 import {DisplayModes} from 'app/utils/discover/types';
 import {decodeScalar} from 'app/utils/queryString';
+import withApi from 'app/utils/withApi';
 
 import ChartFooter from './chartFooter';
 
@@ -167,7 +168,7 @@ class ResultsChartContainer extends React.Component<ContainerProps> {
   }
 }
 
-export default ResultsChartContainer;
+export default withApi(ResultsChartContainer);
 
 export const StyledPanel = styled(Panel)`
   @media (min-width: ${p => p.theme.breakpoints[1]}) {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -92,6 +92,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
     this.setState({isLoading: true, tableFetchID});
     metric.mark({name: `discover-events-start-${apiPayload.query}`});
 
+    this.props.api.clear();
     this.props.api
       .requestPromise(url, {
         method: 'GET',

--- a/tests/js/spec/components/charts/eventsRequest.spec.jsx
+++ b/tests/js/spec/components/charts/eventsRequest.spec.jsx
@@ -18,7 +18,7 @@ describe('EventsRequest', function() {
   const organization = TestStubs.Organization();
   const mock = jest.fn(() => null);
   const DEFAULTS = {
-    api: {},
+    api: new MockApiClient(),
     projects: [parseInt(project.id, 10)],
     environments: [],
     period: '24h',


### PR DESCRIPTION
### Summary
Changing date range for eventsv2 could sometimes lead to a race condition if the requests take significant amounts of time because the latest request finishes while the older request is still in-flight.

This clears the existing api requests before fetching again.