### PR TITLE
ref(icon refactor): replace icon anchor

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
@@ -6,6 +6,7 @@ import {css} from '@emotion/core';
 import {t} from 'app/locale';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import {DataSection} from 'app/components/events/styles';
+import {IconAnchor} from 'app/icons/iconAnchor';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import space from 'app/styles/space';
@@ -78,9 +79,9 @@ class EventDataSection extends React.Component<Props> {
         {title && (
           <SectionHeader id={type} isCentered={isCentered}>
             <Permalink href={'#' + type} className="permalink">
-              <em className="icon-anchor" />
+              <StyledIconAnchor />
+              {titleNode}
             </Permalink>
-            {titleNode}
             {type === 'extra' && (
               <ButtonBar merged active={raw ? 'raw' : 'formatted'}>
                 <Button
@@ -108,22 +109,26 @@ class EventDataSection extends React.Component<Props> {
   }
 }
 
-const Permalink = styled('a')`
-  font-size: ${p => p.theme.fontSizeSmall};
-  line-height: 27px;
+const StyledIconAnchor = styled(IconAnchor)`
   display: none;
   position: absolute;
-  top: -1.5px;
+  top: 4px;
   left: -22px;
-  color: ${p => p.theme.gray400};
-  padding: ${space(0.25)} 5px;
+`;
+
+const Permalink = styled('a')`
+  position: relative;
+  flex-grow: 1;
+
+  :hover ${StyledIconAnchor} {
+    display: block;
+    color: ${p => p.theme.gray500};
+  }
 `;
 
 const SectionHeader = styled('div')<{isCentered?: boolean}>`
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  position: relative;
   margin-bottom: ${space(3)};
 
   & h3,
@@ -155,10 +160,6 @@ const SectionHeader = styled('div')<{isCentered?: boolean}>`
     color: ${p => p.theme.gray700};
     border-bottom: 1px dotted ${p => p.theme.gray400};
     font-weight: normal;
-  }
-
-  &:hover ${Permalink} {
-    display: block;
   }
 
   @media (min-width: ${props => props.theme.breakpoints[2]}) {

--- a/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
@@ -15,6 +15,7 @@ const defaultProps = {
   wrapTitle: true,
   raw: false,
   isCentered: false,
+  showPermalink: true,
 };
 
 type DefaultProps = Readonly<typeof defaultProps>;
@@ -70,6 +71,7 @@ class EventDataSection extends React.Component<Props> {
       wrapTitle,
       actions,
       isCentered,
+      showPermalink,
     } = this.props;
 
     const titleNode = wrapTitle ? <h3>{title}</h3> : title;
@@ -78,10 +80,14 @@ class EventDataSection extends React.Component<Props> {
       <DataSection className={className || ''}>
         {title && (
           <SectionHeader id={type} isCentered={isCentered}>
-            <Permalink href={'#' + type} className="permalink">
-              <StyledIconAnchor />
-              {titleNode}
-            </Permalink>
+            {showPermalink ? (
+              <Permalink href={'#' + type} className="permalink">
+                <StyledIconAnchor />
+                {titleNode}
+              </Permalink>
+            ) : (
+              <div>{titleNode}</div>
+            )}
             {type === 'extra' && (
               <ButtonBar merged active={raw ? 'raw' : 'formatted'}>
                 <Button
@@ -117,9 +123,6 @@ const StyledIconAnchor = styled(IconAnchor)`
 `;
 
 const Permalink = styled('a')`
-  position: relative;
-  flex-grow: 1;
-
   :hover ${StyledIconAnchor} {
     display: block;
     color: ${p => p.theme.gray500};
@@ -177,6 +180,11 @@ const SectionHeader = styled('div')<{isCentered?: boolean}>`
         display: block;
       }
     `}
+
+  >*:first-child {
+    position: relative;
+    flex-grow: 1;
+  }
 `;
 
 const SectionContents = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -186,33 +186,18 @@ const Wrapper = styled('div')`
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  width: 100%;
 `;
 
-const TitleWrapper = styled('div')`
+const TitleWrapper = styled('span')`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  > * {
-    margin-bottom: ${space(0.5)};
-    :last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  @media (min-width: ${props => props.theme.breakpoints[0]}) {
-    > * {
-      margin-right: ${space(0.5)};
-      margin-bottom: 0;
-      :last-child {
-        margin-right: ${space(1)};
-      }
-    }
-  }
+  flex-grow: 1;
+  justify-content: flex-start;
 `;
 
 const ButtonGroup = styled(ButtonBar)`
-  padding: ${space(1.5)} ${space(1)} ${space(1.5)} 0;
+  padding-right: ${space(1)};
 `;
 
 const ButtonGroupWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threads.jsx
@@ -211,6 +211,7 @@ class ThreadsInterface extends React.Component {
         event={evt}
         type={this.props.type}
         title={title}
+        showPermalink={!threads.length > 1}
         wrapTitle={false}
       >
         <Thread

--- a/tests/js/spec/components/__snapshots__/toggleRawEventData.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/toggleRawEventData.spec.jsx.snap
@@ -12,13 +12,11 @@ exports[`EventDataSection renders formatted 1`] = `
       className="permalink"
       href="#extra"
     >
-      <em
-        className="icon-anchor"
-      />
+      <StyledIconAnchor />
+      <h3>
+        Additional Data
+      </h3>
     </Permalink>
-    <h3>
-      Additional Data
-    </h3>
     <ButtonBar
       active="formatted"
       merged={true}
@@ -55,13 +53,11 @@ exports[`EventDataSection renders raw 1`] = `
       className="permalink"
       href="#extra"
     >
-      <em
-        className="icon-anchor"
-      />
+      <StyledIconAnchor />
+      <h3>
+        Additional Data
+      </h3>
     </Permalink>
-    <h3>
-      Additional Data
-    </h3>
     <ButtonBar
       active="raw"
       merged={true}

--- a/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
@@ -43,7 +43,7 @@ exports[`EventSdkUpdates renders a suggestion to update the sdk and then enable 
       >
         <SectionContents>
           <div
-            className="css-16dhebx-SectionContents e1fbjd862"
+            className="css-16dhebx-SectionContents e1fbjd863"
           >
             <Alert
               icon="icon-upgrade"

--- a/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
@@ -31,6 +31,7 @@ exports[`EventSdkUpdates renders a suggestion to update the sdk and then enable 
   <EventDataSection
     isCentered={false}
     raw={false}
+    showPermalink={true}
     title={null}
     type="sdk-updates"
     wrapTitle={true}

--- a/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
@@ -586,7 +586,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                     isCentered={false}
                                   >
                                     <div
-                                      className="css-n08n7b-SectionHeader e1fbjd861"
+                                      className="css-1kv646v-SectionHeader e1fbjd862"
                                       id="message"
                                     >
                                       <Permalink
@@ -594,22 +594,40 @@ exports[`SharedGroupDetails renders 1`] = `
                                         href="#message"
                                       >
                                         <a
-                                          className="permalink css-rl8enl-Permalink e1fbjd860"
+                                          className="permalink css-1i32h4m-Permalink e1fbjd861"
                                           href="#message"
                                         >
-                                          <em
-                                            className="icon-anchor"
-                                          />
+                                          <StyledIconAnchor>
+                                            <IconAnchor
+                                              className="css-1x65iks-StyledIconAnchor e1fbjd860"
+                                            >
+                                              <ForwardRef(SvgIcon)
+                                                className="css-1x65iks-StyledIconAnchor e1fbjd860"
+                                              >
+                                                <svg
+                                                  className="css-1x65iks-StyledIconAnchor e1fbjd860"
+                                                  fill="currentColor"
+                                                  height="16px"
+                                                  viewBox="0 0 16 16"
+                                                  width="16px"
+                                                >
+                                                  <path
+                                                    d="M8,1.59a.31.31,0,1,0,.31.31A.31.31,0,0,0,8,1.59ZM6.19,1.9A1.81,1.81,0,1,1,8.75,3.55v2h4.66a.75.75,0,0,1,0,1.5H8.75v7.32a6.87,6.87,0,0,0,5.57-4.12.75.75,0,0,1,1.44.3v2.5a.75.75,0,0,1-1.5,0,8.38,8.38,0,0,1-12.52,0,.75.75,0,0,1-1.5,0v-2.5a.75.75,0,0,1,1.44-.3,6.87,6.87,0,0,0,5.57,4.12V7.05H2.59a.75.75,0,1,1,0-1.5H7.25v-2A1.81,1.81,0,0,1,6.19,1.9Z"
+                                                  />
+                                                </svg>
+                                              </ForwardRef(SvgIcon)>
+                                            </IconAnchor>
+                                          </StyledIconAnchor>
+                                          <h3>
+                                            Message
+                                          </h3>
                                         </a>
                                       </Permalink>
-                                      <h3>
-                                        Message
-                                      </h3>
                                     </div>
                                   </SectionHeader>
                                   <SectionContents>
                                     <div
-                                      className="css-16dhebx-SectionContents e1fbjd862"
+                                      className="css-16dhebx-SectionContents e1fbjd863"
                                     >
                                       <pre
                                         className="plain"

--- a/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
@@ -571,6 +571,7 @@ exports[`SharedGroupDetails renders 1`] = `
                               }
                               isCentered={false}
                               raw={false}
+                              showPermalink={true}
                               title="Message"
                               type="message"
                               wrapTitle={true}
@@ -586,7 +587,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                     isCentered={false}
                                   >
                                     <div
-                                      className="css-1kv646v-SectionHeader e1fbjd862"
+                                      className="css-8d8cxx-SectionHeader e1fbjd862"
                                       id="message"
                                     >
                                       <Permalink
@@ -594,7 +595,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                         href="#message"
                                       >
                                         <a
-                                          className="permalink css-1i32h4m-Permalink e1fbjd861"
+                                          className="permalink css-8q4au4-Permalink e1fbjd861"
                                           href="#message"
                                         >
                                           <StyledIconAnchor>


### PR DESCRIPTION
**Context:** This was reverted previously because the width overlapped a link. This time, Permalink width is determined by length of the title. 

**Before:** 
![Screen Shot 2020-06-16 at 11 16 47 AM](https://user-images.githubusercontent.com/4830259/84812240-f066b300-afc2-11ea-9b3e-074eebb10c1d.png)

**After:**
![Screen Shot 2020-06-16 at 11 15 28 AM](https://user-images.githubusercontent.com/4830259/84812250-f492d080-afc2-11ea-97ea-21ebc49ab03c.png)
![Screen Shot 2020-06-20 at 10 20 51 AM](https://user-images.githubusercontent.com/4830259/85207927-29fc2e80-b2e1-11ea-864c-d6842a48e614.png)