### PR TITLE
tests: Improve stability of event details snapshot

### DIFF
--- a/src/sentry/data/samples/transaction.json
+++ b/src/sentry/data/samples/transaction.json
@@ -68,7 +68,7 @@
       "trace": {
          "parent_span_id": "8988cec7cc0779c1",
          "type": "trace",
-         "op": "foobar",
+         "op": "http.server",
          "trace_id": "a7d67cf796774551a95be6543cacd459",
          "span_id": "babaae0d4b7512d9",
          "status": "ok"
@@ -139,15 +139,27 @@
    "spans": [
       {
          "same_process_as_parent":true,
-         "description": "Django: SELECT \"countries\".\"id\", \"countries\".\"name\", \"countries\".\"continent\", \"countries\".\"region\", \"countries\".\"surface_area\", \"coun...'CAN'",
+         "description": "django.contrib.messages.middleware.MessageMiddleware.process_request",
          "tags": {
             "error":false
          },
          "parent_span_id": "babaae0d4b7512d9",
          "trace_id": "a7d67cf796774551a95be6543cacd459",
+         "op": "django.middleware",
+         "data": {"duration": 0.02, "offset": 0.02},
+         "span_id": "c048b4fffdc4279d"
+      },
+      {
+         "same_process_as_parent":true,
+         "description": "Django: SELECT \"countries\".\"id\", \"countries\".\"name\", \"countries\".\"continent\", \"countries\".\"region\", \"countries\".\"surface_area\", \"coun...'CAN'",
+         "tags": {
+            "error":false
+         },
+         "parent_span_id": "c048b4fffdc4279d",
+         "trace_id": "a7d67cf796774551a95be6543cacd459",
          "op": "db",
-         "data": {},
-         "span_id": "b048b4c8fdc5168c"
+         "data": {"duration": 0.100, "offset": 1.0},
+         "span_id": "d047a3a8edc3276a"
       }
    ],
    "transaction": "/country_by_code/",

--- a/src/sentry/testutils/helpers/datetime.py
+++ b/src/sentry/testutils/helpers/datetime.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 from datetime import datetime, timedelta
+import time
 
-__all__ = ["iso_format", "before_now"]
+__all__ = ["iso_format", "before_now", "timestamp_format"]
 
 
 def iso_format(date):
@@ -9,4 +10,9 @@ def iso_format(date):
 
 
 def before_now(**kwargs):
-    return datetime.utcnow() - timedelta(**kwargs)
+    date = datetime.utcnow() - timedelta(**kwargs)
+    return date.replace(microsecond=0)
+
+
+def timestamp_format(datetime):
+    return time.mktime(datetime.utctimetuple()) + datetime.microsecond / 1e6

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -2,10 +2,11 @@ from __future__ import absolute_import
 
 import os.path
 import random
+import pytz
+import six
+
 from datetime import datetime, timedelta
 from django.utils import timezone
-
-import six
 
 from sentry.constants import DATA_ROOT, INTEGRATION_ID_TO_PLATFORM_DATA
 from sentry.event_manager import EventManager
@@ -100,7 +101,7 @@ def generate_user(username=None, email=None, ip_address=None, id=None):
     ).to_json()
 
 
-def load_data(platform, default=None, sample_name=None):
+def load_data(platform, default=None, sample_name=None, timestamp=None, start_timestamp=None):
     # NOTE: Before editing this data, make sure you understand the context
     # in which its being used. It is NOT only used for local development and
     # has production consequences.
@@ -149,18 +150,29 @@ def load_data(platform, default=None, sample_name=None):
     if platform in ("csp", "hkpk", "expectct", "expectstaple"):
         return data
 
-    # Fixing up timestamps for all events
-    now = timezone.now()
-    now_time = to_timestamp(now)
-    start_time = to_timestamp(now - timedelta(seconds=2))
-    data.setdefault("timestamp", now_time)
+    # Generate a timestamp in the present.
+    if timestamp is None:
+        timestamp = timezone.now()
+    else:
+        timestamp = timestamp.replace(tzinfo=pytz.utc)
+    data.setdefault("timestamp", to_timestamp(timestamp))
 
     if data.get("type") == "transaction":
-        data["start_timestamp"] = start_time
+        if start_timestamp is None:
+            start_timestamp = timestamp - timedelta(seconds=2)
+        else:
+            start_timestamp = start_timestamp.replace(tzinfo=pytz.utc)
+        data["start_timestamp"] = to_timestamp(start_timestamp)
 
-    for span in data.get("spans") or ():
-        span.setdefault("timestamp", now_time)
-        span.setdefault("start_timestamp", start_time)
+        for span in data.get("spans", []):
+            # Use data to generate span timestamps consistently and based
+            # on event timestamp
+            duration = span.get("data", {}).get("duration", 10.0)
+            offset = span.get("data", {}).get("offset", 0)
+
+            span_start = data["start_timestamp"] + offset
+            span.setdefault("start_timestamp", span_start)
+            span.setdefault("timestamp", span_start + duration)
 
     data["platform"] = platform
     # XXX: Message is a legacy alias for logentry. Do not overwrite if set.

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
 import pytz
-import time
 
 from mock import patch
 
@@ -18,19 +16,6 @@ FEATURE_NAMES = (
     "organizations:discover-basic",
     "organizations:performance-view",
 )
-
-
-def make_event(event_data):
-    start_datetime = before_now(minutes=1)
-    end_datetime = start_datetime + timedelta(milliseconds=500)
-
-    def generate_timestamp(date_time):
-        return time.mktime(date_time.utctimetuple()) + date_time.microsecond / 1e6
-
-    event_data["start_timestamp"] = generate_timestamp(start_datetime)
-    event_data["timestamp"] = generate_timestamp(end_datetime)
-
-    return event_data
 
 
 class PerformanceOverviewTest(AcceptanceTestCase):
@@ -61,7 +46,7 @@ class PerformanceOverviewTest(AcceptanceTestCase):
     def test_with_data(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
-        event = make_event(load_data("transaction"))
+        event = load_data("transaction", timestamp=before_now(minutes=1))
         self.store_event(data=event, project_id=self.project.id)
         self.project.update(flags=F("flags").bitor(Project.flags.has_transactions))
 

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
 import pytz
-import time
 
 from six.moves.urllib.parse import urlencode
 from mock import patch
@@ -17,16 +15,7 @@ FEATURE_NAMES = ("organizations:performance-view",)
 
 
 def make_event(event_data):
-    start_datetime = before_now(minutes=1)
-    end_datetime = start_datetime + timedelta(milliseconds=500)
-
-    def generate_timestamp(date_time):
-        return time.mktime(date_time.utctimetuple()) + date_time.microsecond / 1e6
-
-    event_data["start_timestamp"] = generate_timestamp(start_datetime)
-    event_data["timestamp"] = generate_timestamp(end_datetime)
     event_data["event_id"] = "c" * 32
-
     return event_data
 
 
@@ -53,7 +42,7 @@ class PerformanceSummaryTest(AcceptanceTestCase):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
         # Create a transaction
-        event = make_event(load_data("transaction"))
+        event = make_event(load_data("transaction", timestamp=before_now(minutes=1)))
         self.store_event(data=event, project_id=self.project.id)
 
         self.store_event(
@@ -75,7 +64,7 @@ class PerformanceSummaryTest(AcceptanceTestCase):
     def test_view_details_from_summary(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
-        event = make_event(load_data("transaction"))
+        event = make_event(load_data("transaction", timestamp=before_now(minutes=1)))
         self.store_event(data=event, project_id=self.project.id)
 
         with self.feature(FEATURE_NAMES):

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -242,10 +242,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
     def test_get_key_transactions(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
         project2 = self.create_project(name="foo", organization=self.org)
-        event_data = load_data("transaction")
-        start_timestamp = iso_format(before_now(minutes=1))
-        end_timestamp = iso_format(before_now(minutes=1))
-        event_data.update({"start_timestamp": start_timestamp, "timestamp": end_timestamp})
+        event_data = load_data("transaction", timestamp=before_now(minutes=1))
 
         transactions = [
             (self.project, "/foo_transaction/"),
@@ -340,10 +337,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_get_transaction_with_query(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        start_timestamp = iso_format(before_now(minutes=1))
-        end_timestamp = iso_format(before_now(minutes=1))
-        event_data = load_data("transaction")
-        event_data.update({"start_timestamp": start_timestamp, "timestamp": end_timestamp})
+        event_data = load_data("transaction", timestamp=before_now(minutes=1))
 
         transactions = [("127.0.0.1", "/foo_transaction/"), ("192.168.0.1", "/blah_transaction/")]
 
@@ -385,16 +379,8 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_get_transaction_with_backslash_and_quotes(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        start_timestamp = iso_format(before_now(minutes=1))
-        end_timestamp = iso_format(before_now(minutes=1))
-        event_data = load_data("transaction")
-        event_data.update(
-            {
-                "transaction": "\\someth\"'ing\\",
-                "start_timestamp": start_timestamp,
-                "timestamp": end_timestamp,
-            }
-        )
+        event_data = load_data("transaction", timestamp=before_now(minutes=1))
+        event_data["transaction"] = "\\someth\"'ing\\"
 
         self.store_event(data=event_data, project_id=self.project.id)
         KeyTransaction.objects.create(
@@ -599,14 +585,10 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_key_transaction_stats(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        data = load_data("transaction")
-        event_ids = ["d" * 32, "e" * 32, "f" * 32]
-        data.update(
-            {
-                "timestamp": iso_format(before_now(minutes=30)),
-                "start_timestamp": iso_format(before_now(minutes=31)),
-            }
+        data = load_data(
+            "transaction", timestamp=before_now(minutes=30), start_timestamp=before_now(minutes=31)
         )
+        event_ids = ["d" * 32, "e" * 32, "f" * 32]
         for event_id in event_ids:
             data["event_id"] = event_id
             self.store_event(data=data, project_id=self.project.id)
@@ -684,14 +666,10 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_key_transaction_stats_with_no_key_transactions(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        data = load_data("transaction")
-        event_ids = ["d" * 32, "e" * 32, "f" * 32]
-        data.update(
-            {
-                "timestamp": iso_format(before_now(minutes=30)),
-                "start_timestamp": iso_format(before_now(minutes=31)),
-            }
+        data = load_data(
+            "transaction", timestamp=before_now(minutes=30), start_timestamp=before_now(minutes=31)
         )
+        event_ids = ["d" * 32, "e" * 32, "f" * 32]
         for event_id in event_ids:
             data["event_id"] = event_id
             self.store_event(data=data, project_id=self.project.id)
@@ -721,14 +699,10 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_key_transaction_stats_with_multi_yaxis(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        data = load_data("transaction")
-        event_ids = ["d" * 32, "e" * 32, "f" * 32]
-        data.update(
-            {
-                "timestamp": iso_format(before_now(minutes=30)),
-                "start_timestamp": iso_format(before_now(minutes=31)),
-            }
+        data = load_data(
+            "transaction", timestamp=before_now(minutes=30), start_timestamp=before_now(minutes=31)
         )
+        event_ids = ["d" * 32, "e" * 32, "f" * 32]
         for event_id in event_ids:
             data["event_id"] = event_id
             self.store_event(data=data, project_id=self.project.id)
@@ -768,14 +742,10 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_key_transaction_stats_with_multi_yaxis_no_key_transactions(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        data = load_data("transaction")
-        event_ids = ["d" * 32, "e" * 32, "f" * 32]
-        data.update(
-            {
-                "timestamp": iso_format(before_now(minutes=30)),
-                "start_timestamp": iso_format(before_now(minutes=31)),
-            }
+        data = load_data(
+            "transaction", timestamp=before_now(minutes=30), start_timestamp=before_now(minutes=31)
         )
+        event_ids = ["d" * 32, "e" * 32, "f" * 32]
         for event_id in event_ids:
             data["event_id"] = event_id
             for i in range(5):

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -160,12 +160,8 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
 class TransactionTagKeyValues(OrganizationTagKeyTestCase):
     def setUp(self):
         super(TransactionTagKeyValues, self).setUp()
-        data = load_data("transaction")
-        data["timestamp"] = iso_format(before_now(minutes=1))
-        data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
-        self.store_event(
-            data, project_id=self.project.id,
-        )
+        data = load_data("transaction", timestamp=before_now(minutes=1))
+        self.store_event(data, project_id=self.project.id)
         self.transaction = data.copy()
         self.transaction.update(
             {
@@ -193,17 +189,17 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
         )
 
     def test_op(self):
-        self.run_test("transaction.op", expected=[("bar.server", 1), ("foobar", 1)])
+        self.run_test("transaction.op", expected=[("bar.server", 1), ("http.server", 1)])
         self.run_test(
             "transaction.op",
-            qs_params={"query": "bar"},
-            expected=[("bar.server", 1), ("foobar", 1)],
+            qs_params={"query": "server"},
+            expected=[("bar.server", 1), ("http.server", 1)],
         )
-        self.run_test("transaction.op", qs_params={"query": "server"}, expected=[("bar.server", 1)])
+        self.run_test("transaction.op", qs_params={"query": "bar"}, expected=[("bar.server", 1)])
 
     def test_duration(self):
-        self.run_test("transaction.duration", expected=[("5000", 2)])
-        self.run_test("transaction.duration", qs_params={"query": "5001"}, expected=[("5000", 2)])
+        self.run_test("transaction.duration", expected=[("5000", 1), ("2000", 1)])
+        self.run_test("transaction.duration", qs_params={"query": "5001"}, expected=[("5000", 1)])
         self.run_test("transaction.duration", qs_params={"query": "50"}, expected=[])
 
     def test_transaction_title(self):


### PR DESCRIPTION
Make percy snapshot for event details stable and improve ergonomics of creating transaction events in tests as we had a variety of patterns that can be coalesced now.