### PR TITLE
feat(vercel): Add basic deploy webhook support

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.integrations.client import ApiClient
+from sentry.utils.http import absolute_uri
 
 
 class VercelClient(ApiClient):
@@ -11,6 +12,7 @@ class VercelClient(ApiClient):
     TEAMS_URL = "/v1/teams/%s"
     USER_URL = "/www/user"
     PROJECTS_URL = "/v4/projects/"
+    WEBHOOK_URL = "/v1/integrations/webhooks"
 
     def __init__(self, access_token, team_id=None):
         super(VercelClient, self).__init__()
@@ -35,3 +37,12 @@ class VercelClient(ApiClient):
     def get_projects(self):
         # TODO: we will need pagination since we are limited to 20
         return self.get(self.PROJECTS_URL)["projects"]
+
+    def create_deploy_webhook(self):
+        data = {
+            "name": "sentry_webhook",
+            "url": absolute_uri("/extensions/vercel/webhook/"),
+            "events": ["deployment"],
+        }
+        response = self.post(self.WEBHOOK_URL, data=data)
+        return response

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -40,7 +40,7 @@ class VercelClient(ApiClient):
 
     def create_deploy_webhook(self):
         data = {
-            "name": "sentry_webhook",
+            "name": "Sentry webhook",
             "url": absolute_uri("/extensions/vercel/webhook/"),
             "events": ["deployment"],
         }

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -137,8 +137,8 @@ class VercelIntegrationProvider(IntegrationProvider):
             try:
                 details = err.json["messages"][0].values().pop()
             except Exception:
-                details = ""
-            message = u"Could not create deployment webhook in Vercel. {}".format(details)
+                details = "Unknown Error"
+            message = u"Could not create deployment webhook in Vercel: {}".format(details)
             raise IntegrationError(message)
 
         integration = {

--- a/src/sentry/integrations/vercel/urls.py
+++ b/src/sentry/integrations/vercel/urls.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import, print_function
+
+from django.conf.urls import url
+
+from .webhook import VercelWebhookEndpoint
+
+
+urlpatterns = [
+    url(r"^webhook/$", VercelWebhookEndpoint.as_view()),
+]

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+import six
+import hmac
+import hashlib
+import logging
+
+from django.utils.crypto import constant_time_compare
+from django.views.decorators.csrf import csrf_exempt
+from sentry import options
+from sentry.api.base import Endpoint
+from sentry.web.decorators import transaction_start
+
+logger = logging.getLogger("sentry.integrations.vercel.webhooks")
+
+
+def verify_signature(request):
+    signature = request.META["HTTP_X_ZEIT_SIGNATURE"]
+    secret = options.get("vercel.client-secret")
+
+    expected = hmac.new(
+        key=secret.encode("utf-8"), msg=six.binary_type(request.body), digestmod=hashlib.sha1
+    ).hexdigest()
+    return constant_time_compare(expected, signature)
+
+
+class VercelWebhookEndpoint(Endpoint):
+    authentication_classes = ()
+    permission_classes = ()
+
+    @csrf_exempt
+    def dispatch(self, request, *args, **kwargs):
+        return super(VercelWebhookEndpoint, self).dispatch(request, *args, **kwargs)
+
+    @transaction_start("VercelWebhookEndpoint")
+    def post(self, request):
+        if not request.META.get("HTTP_X_ZEIT_SIGNATURE"):
+            logger.error("vercel.webhook.missing-signature")
+            self.respond(status=401)
+
+        is_valid = verify_signature(request)
+
+        if not is_valid:
+            logger.error("vercel.webhook.invalid-signature")
+            return self.respond(status=401)
+
+        return self.respond(status=200)

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -639,6 +639,7 @@ urlpatterns += [
                 url(r"^vsts/", include("sentry.integrations.vsts.urls")),
                 url(r"^bitbucket/", include("sentry.integrations.bitbucket.urls")),
                 url(r"^bitbucket-server/", include("sentry.integrations.bitbucket_server.urls")),
+                url(r"^vercel/", include("sentry.integrations.vercel.urls")),
             ]
         ),
     ),

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -50,6 +50,12 @@ class VercelIntegrationTest(IntegrationTestCase):
             json={"projects": []},
         )
 
+        responses.add(
+            responses.POST,
+            "https://api.vercel.com/v1/integrations/webhooks%s" % team_query,
+            json={"id": "webhook-id"},
+        )
+
         resp = self.client.get(u"{}?{}".format(self.setup_path, urlencode({"code": "oauth-code"}),))
 
         mock_request = responses.calls[0].request
@@ -75,6 +81,7 @@ class VercelIntegrationTest(IntegrationTestCase):
             "access_token": "my_access_token",
             "installation_id": "my_config_id",
             "installation_type": installation_type,
+            "webhook_id": "webhook-id",
         }
         assert OrganizationIntegration.objects.get(
             integration=integration, organization=self.organization

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+
+from sentry.testutils import APITestCase
+from sentry.testutils.helpers import override_options
+
+from .testutils import EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE
+
+signature = "74b587857986545361e8a4253b74cd6224d34869"
+secret = "AiK52QASLJXmCXX3X9gO2Zyh"
+
+
+class VercelWebhookTest(APITestCase):
+    def setUp(self):
+        self.url = "/extensions/vercel/webhook/"
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        assert response.status_code == 405
+
+    def test_valid_signature(self):
+        with override_options({"vercel.client-secret": secret}):
+            response = self.client.post(
+                path=self.url,
+                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+                content_type="application/json",
+                HTTP_X_ZEIT_SIGNATURE=signature,
+            )
+
+            assert response.status_code == 200
+
+    def test_invalid_signature(self):
+        with override_options({"vercel.client-secret": secret}):
+            response = self.client.post(
+                path=self.url,
+                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+                content_type="application/json",
+                HTTP_X_ZEIT_SIGNATURE="xxxinvalidsignaturexxx",
+            )
+
+            assert response.status_code == 401

--- a/tests/sentry/integrations/vercel/testutils.py
+++ b/tests/sentry/integrations/vercel/testutils.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+
+
+EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE = """
+    {
+        "id": "uev_ZfbZKA3Ts2aEa2Cic6t6wSZx",
+        "ownerId": "cstd1xKmLGVMed0z0f3SHlD2",
+        "type": "deployment",
+        "createdAt": 1592335604941,
+        "payload": {
+            "deploymentId": "dpl_2p92SueSKLagubfcRtheS3CvmcjK",
+            "name": "nextjsblog-demo",
+            "project": "nextjsblog-demo",
+            "url": "nextjsblog-demo-gogovbsz1.vercel.app",
+            "projectId": "QmQPfU4xn5APjEsSje4ccPcSJCmVAByA8CDKfZRhYyVPAg",
+            "plan": "hobby",
+            "regions": ["sfo1"],
+            "target": "production",
+            "alias": ["nextjsblog-demo.now.sh","nextjsblog-demo.meredithanya.vercel.app","nextjsblog-demo-git-master.meredithanya.vercel.app","nextjsblog-demo.meredithanya.now.sh","nextjsblog-demo-git-master.meredithanya.now.sh"],
+            "type": "LAMBDAS",
+            "deployment": {
+                "id": "dpl_2p92SueSKLagubfcRtheS3CvmcjK",
+                "name": "nextjsblog-demo",
+                "url": "nextjsblog-demo-gogovbsz1.vercel.app",
+                "meta": {
+                    "githubDeployment": "1",
+                    "githubOrg": "MeredithAnya",
+                    "githubRepo": "nextjsblog-demo",
+                    "githubCommitOrg": "MeredithAnya",
+                    "githubCommitRepo": "nextjsblog-demo",
+                    "githubCommitRef": "master",
+                    "githubCommitSha": "7488658dfcf24d9b735e015992b316e2a8340d9d",
+                    "githubCommitMessage": "update index.js",
+                    "githubCommitAuthorName": "MeredithAnya",
+                    "githubCommitAuthorLogin": "MeredithAnya"
+                }
+            }
+        },
+        "region": "now-sfo",
+        "teamId": null,
+        "userId": "cstd1xKmLGVMed0z0f3SHlD2"
+    }
+"""


### PR DESCRIPTION
In order to work with release for the Vercel integration, we need to subscribe to the [webhook for deployments](https://vercel.com/docs/api?query=webh#integrations/webhooks/event-payloads/deployment). This PR covers 
* subscribing/creating to the webhooks during installation
* adding the webhook endpoint 
* validating the webhook signature in the endpoint

I've also added the `get_client` method on the integration to handle passing in the team_id to the `VercelClient` if necessary.