### PR TITLE
fix(discover): Event Details with error id and transaction fields

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -79,7 +79,7 @@ def find_reference_event(reference_event):
     try:
         project_slug, event_id = reference_event.slug.split(":")
     except ValueError:
-        raise InvalidSearchQuery("Invalid reference event")
+        raise InvalidSearchQuery("Invalid reference event format")
 
     column_names = [
         resolve_discover_column(col) for col in reference_event.fields if is_real_column(col)
@@ -95,7 +95,7 @@ def find_reference_event(reference_event):
             status=ProjectStatus.VISIBLE,
         )
     except Project.DoesNotExist:
-        raise InvalidSearchQuery("Invalid reference event")
+        raise InvalidSearchQuery("Invalid reference event project")
 
     start = None
     end = None
@@ -117,7 +117,7 @@ def find_reference_event(reference_event):
         referrer="discover.find_reference_event",
     )
     if "error" in event or len(event["data"]) != 1:
-        raise InvalidSearchQuery("Invalid reference event")
+        raise InvalidSearchQuery("Unable to find reference event")
 
     return event["data"][0]
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -91,6 +91,9 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
 
     const query = eventView.getEventsAPIPayload(location);
 
+    // Fields aren't used, reduce complexity by omitting from query entirely
+    query.field = [];
+
     const url = `/organizations/${organization.slug}/events/${eventSlug}/`;
 
     // Get a specific event. This could be coming from


### PR DESCRIPTION
- When opening event details for an error but there are transaction fields getting the reference event fails.
- AFAICT we don't use these fields at all in event details so I figured the easiest fix here would be to drop it entirely from the request
- Also improving the error message a bit since all 3 being the same makes it a bit harder to debug.