### PR TITLE
build(github): Auto-generate SQL statements for PRs w/ migrations

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,118 @@
+name: migrations
+on:
+  pull_request:
+    paths:
+      - 'src/sentry/migrations/*'
+
+jobs:
+    sql:
+      name: Generate SQL
+      runs-on: ubuntu-16.04
+
+      env:
+        PIP_DISABLE_PIP_VERSION_CHECK: on
+        SENTRY_LIGHT_BUILD: 1
+        SENTRY_SKIP_BACKEND_VALIDATION: 1
+        MIGRATIONS_TEST_MIGRATE: 0
+
+        # The hostname used to communicate with the PostgreSQL from sentry
+        DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
+
+        # Use this to override the django version in the requirements file.
+        DJANGO_VERSION: ">=1.11,<1.12"
+
+      services:
+        postgres:
+          image: postgres:9.6
+          env:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+          ports:
+            # Maps tcp port 5432 on service container to the host
+            - 5432:5432
+          # needed because the postgres container does not provide a healthcheck
+          options: >-
+            --health-cmd pg_isready
+            --health-interval 10s
+            --health-timeout 5s
+            --health-retries 5
+
+      steps:
+        - name: Create placeholder comment
+          uses: getsentry/action-migrations@v1.0.7
+          with:
+            run: placeholder
+            githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+        # Checkout codebase
+        - uses: actions/checkout@v1
+
+        - name: Get changed migration files
+          id: file
+          run: |
+            echo $(git diff --diff-filter=AM --name-only origin/master HEAD)
+            echo "::set-output name=modified::$(git diff --diff-filter=AM --name-only origin/master HEAD | grep 'src/sentry/migrations/')"
+
+
+        # Python
+        #   Use `.python-version` to avoid duplication
+        #   XXX: can't actually read from .python-version because GitHub Actions
+        #   does not support our version (2.7.16)
+        #
+        #   XXX: Using `2.7` as GHA image only seems to keep one minor version around and will break
+        #   CI if we pin it to a specific patch version.
+        - name: Set up outputs
+          id: config
+          env:
+            MATRIX_INSTANCE: ${{ matrix.instance }}
+          run: |
+            echo "::set-output name=python-version::2.7"
+
+        # setup python
+        - name: Set up Python ${{ steps.config.outputs.python-version }}
+          uses: actions/setup-python@v1
+          with:
+            python-version: ${{ steps.config.outputs.python-version}}
+
+        # setup pip
+        - name: Install pip
+          run: |
+            pip install --no-cache-dir --upgrade "pip>=20.0.2"
+
+        # pip cache
+        - name: Get pip cache dir
+          id: pip-cache
+          run: |
+            echo "::set-output name=dir::$(pip cache dir)"
+
+        - name: pip cache
+          uses: actions/cache@v1
+          with:
+            path: ${{ steps.pip-cache.outputs.dir }}
+            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
+            restore-keys: |
+              ${{ runner.os }}-pip-
+
+        - name: Install System Dependencies
+          run: |
+            sudo apt-get update
+            sudo apt-get install libxmlsec1-dev libmaxminddb-dev
+
+        - name: Install Python Dependencies
+          env:
+            PGPASSWORD: postgres
+          run: |
+            python setup.py install_egg_info
+            pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
+            pip install -U -e ".[dev]"
+            psql -c 'create database sentry;' -h localhost -U postgres
+            sentry init
+
+        - name: Generate SQL for migration
+          uses: getsentry/action-migrations@v1.0.7
+          env:
+            SENTRY_LOG_LEVEL: ERROR
+            PGPASSWORD: postgres
+          with:
+            githubToken: ${{ secrets.GITHUB_TOKEN }}
+            migration: ${{ steps.file.outputs.modified }}


### PR DESCRIPTION
This adds an Action to auto generate the SQL statements that will be run for a migration. The Action will add a comment with the SQL and updates the same comment for each push. See https://github.com/getsentry/action-migrations/ for source for the action.