### PR TITLE
fix(async-csv): Enable acks_late on export tasks

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
     queue="data_export",
     default_retry_delay=30,
     max_retries=3,
+    acks_late=True,
 )
 def assemble_download(
     data_export_id,
@@ -230,7 +231,7 @@ def store_export_chunk_as_blob(data_export, bytes_written, fileobj, blob_size=DE
             return 0
 
 
-@instrumented_task(name="sentry.data_export.tasks.merge_blobs", queue="data_export")
+@instrumented_task(name="sentry.data_export.tasks.merge_blobs", queue="data_export", acks_late=True)
 def merge_export_blobs(data_export_id, **kwargs):
     try:
         data_export = ExportedData.objects.get(id=data_export_id)


### PR DESCRIPTION
Export tasks aren't being restarted if they are killed in a deploy. This change enables
acks_late=True to retry if the task do not complete. This is safe as export tasks are
idempotent so they can be safely restarted.