### PR TITLE
fix(am): Fix transaction child traversal to stay within their respective product pages

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -119,7 +119,7 @@ class EventEntries extends React.Component {
   }
 
   renderEntries() {
-    const {event, project, organization, isShare, eventView} = this.props;
+    const {event, project, organization, isShare} = this.props;
 
     const entries = event && event.entries;
 
@@ -138,12 +138,6 @@ class EventEntries extends React.Component {
           return null;
         }
 
-        // inject additional props for certain interfaces
-        const extraProps = {};
-        if (entry.type === 'spans' && eventView) {
-          extraProps.eventView = eventView;
-        }
-
         return (
           <Component
             key={'entry-' + entryIdx}
@@ -153,7 +147,6 @@ class EventEntries extends React.Component {
             type={entry.type}
             data={entry.data}
             isShare={isShare}
-            {...extraProps}
           />
         );
       } catch (ex) {

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -73,7 +73,6 @@ class EventEntries extends React.Component {
     isShare: PropTypes.bool,
     showExampleCommit: PropTypes.bool,
     showTagSummary: PropTypes.bool,
-    eventView: PropTypes.object,
   };
 
   static defaultProps = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/context.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/context.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {LocationDescriptor} from 'history';
+
+export type SpanEntryContextChildrenProps = {
+  getViewChildTransactionTarget: (props: {
+    'project.name': string;
+    transaction: string;
+    id: string;
+    eventSlug: string;
+  }) => LocationDescriptor | undefined;
+};
+
+const SpanEntryContext = React.createContext<SpanEntryContextChildrenProps>({
+  getViewChildTransactionTarget: () => undefined,
+});
+
+export const Provider = SpanEntryContext.Provider;
+
+export const Consumer = SpanEntryContext.Consumer;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/context.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/context.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import {LocationDescriptor} from 'history';
 
+type ChildTransaction = {
+  'project.name': string;
+  transaction: string;
+  id: string;
+  eventSlug: string;
+};
+
 export type SpanEntryContextChildrenProps = {
-  getViewChildTransactionTarget: (props: {
-    'project.name': string;
-    transaction: string;
-    id: string;
-    eventSlug: string;
-  }) => LocationDescriptor | undefined;
+  getViewChildTransactionTarget: (
+    props: ChildTransaction
+  ) => LocationDescriptor | undefined;
 };
 
 const SpanEntryContext = React.createContext<SpanEntryContextChildrenProps>({

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -24,7 +24,6 @@ import TraceView from './traceView';
 type Props = {
   orgId: string;
   event: SentryTransactionEvent;
-  eventView: EventView;
   organization: Organization;
 } & ReactRouter.WithRouterProps;
 
@@ -88,7 +87,7 @@ class SpansInterface extends React.Component<Props, State> {
   }
 
   render() {
-    const {event, orgId, eventView, location, organization} = this.props;
+    const {event, orgId, location, organization} = this.props;
     const {parsedTrace} = this.state;
 
     // construct discover query to fetch error events associated with this transaction
@@ -161,7 +160,6 @@ class SpansInterface extends React.Component<Props, State> {
                     searchQuery={this.state.searchQuery}
                     orgId={orgId}
                     organization={organization}
-                    eventView={eventView}
                     parsedTrace={parsedTrace}
                     spansWithErrors={spansWithErrors}
                   />

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -9,7 +9,6 @@ import space from 'app/styles/space';
 import Count from 'app/components/count';
 import Tooltip from 'app/components/tooltip';
 import InlineSvg from 'app/components/inlineSvg';
-import EventView from 'app/utils/discover/eventView';
 import {TableDataRow} from 'app/views/eventsV2/table/types';
 
 import {
@@ -188,7 +187,6 @@ type SpanBarProps = {
   isRoot?: boolean;
   toggleSpanTree: () => void;
   isCurrentSpanFilteredOut: boolean;
-  eventView: EventView;
   totalNumberOfErrors: number;
   spanErrors: TableDataRow[];
 };
@@ -235,7 +233,6 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       orgId,
       organization,
       isRoot,
-      eventView,
       trace,
       totalNumberOfErrors,
       spanErrors,
@@ -249,7 +246,6 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         organization={organization}
         event={event}
         isRoot={!!isRoot}
-        eventView={eventView}
         trace={trace}
         totalNumberOfErrors={totalNumberOfErrors}
         spanErrors={spanErrors}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -39,7 +39,6 @@ type Props = {
   event: Readonly<SentryTransactionEvent>;
   span: Readonly<ProcessedSpanType>;
   isRoot: boolean;
-  eventView: EventView;
   trace: Readonly<ParsedTraceType>;
   totalNumberOfErrors: number;
   spanErrors: TableDataRow[];

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {Organization, SentryTransactionEvent} from 'app/types';
-import EventView from 'app/utils/discover/eventView';
 import {TableData, TableDataRow} from 'app/views/eventsV2/table/types';
 
 import {SpanBoundsType, SpanGeneratedBoundsType, isGapSpan, getSpanID} from './utils';
@@ -12,7 +11,6 @@ type PropType = {
   orgId: string;
   organization: Organization;
   event: Readonly<SentryTransactionEvent>;
-  eventView: EventView;
   span: Readonly<ProcessedSpanType>;
   trace: Readonly<ParsedTraceType>;
   generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
@@ -94,14 +92,12 @@ class SpanGroup extends React.Component<PropType, State> {
       isCurrentSpanFilteredOut,
       orgId,
       organization,
-      eventView,
       event,
     } = this.props;
 
     return (
       <React.Fragment>
         <SpanBar
-          eventView={eventView}
           organization={organization}
           event={event}
           orgId={orgId}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import {SentryTransactionEvent, Organization} from 'app/types';
 import {t} from 'app/locale';
-import EventView from 'app/utils/discover/eventView';
 import {TableData} from 'app/views/eventsV2/table/types';
 
 import {
@@ -43,7 +42,6 @@ type RenderedSpanTree = {
 type PropType = {
   orgId: string;
   organization: Organization;
-  eventView: EventView;
   trace: ParsedTraceType;
   dragProps: DragManagerChildrenProps;
   filterSpans: FilterSpans | undefined;
@@ -142,7 +140,7 @@ class SpanTree extends React.Component<PropType> {
     generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
     previousSiblingEndTimestamp: undefined | number;
   }): RenderedSpanTree => {
-    const {orgId, eventView, event, spansWithErrors, organization} = this.props;
+    const {orgId, event, spansWithErrors, organization} = this.props;
 
     const spanBarColour: string = pickSpanBarColour(getSpanOperation(span));
     const spanChildren: Array<RawSpanType> = childSpans?.[getSpanID(span)] ?? [];
@@ -249,7 +247,6 @@ class SpanTree extends React.Component<PropType> {
     const spanGapComponent =
       isValidGap && isSpanDisplayed ? (
         <SpanGroup
-          eventView={eventView}
           orgId={orgId}
           organization={organization}
           event={event}
@@ -278,7 +275,6 @@ class SpanTree extends React.Component<PropType> {
           {infoMessage}
           {spanGapComponent}
           <SpanGroup
-            eventView={eventView}
             orgId={orgId}
             organization={organization}
             event={event}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -4,7 +4,6 @@ import pick from 'lodash/pick';
 import {t} from 'app/locale';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
-import EventView from 'app/utils/discover/eventView';
 import {TableData} from 'app/views/eventsV2/table/types';
 import {SentryTransactionEvent, Organization} from 'app/types';
 
@@ -40,7 +39,6 @@ type Props = {
   event: Readonly<SentryTransactionEvent>;
   parsedTrace: ParsedTraceType;
   searchQuery: string | undefined;
-  eventView: EventView;
   spansWithErrors: TableData | null | undefined;
 };
 
@@ -185,7 +183,7 @@ class TraceView extends React.PureComponent<Props, State> {
       );
     }
 
-    const {orgId, organization, eventView, spansWithErrors} = this.props;
+    const {orgId, organization, spansWithErrors} = this.props;
 
     return (
       <DragManager interactiveLayerRef={this.minimapInteractiveRef}>
@@ -198,7 +196,6 @@ class TraceView extends React.PureComponent<Props, State> {
             {this.renderHeader(dragProps, parsedTrace)}
             <SpanTree
               event={event}
-              eventView={eventView}
               trace={parsedTrace}
               dragProps={dragProps}
               filterSpans={this.state.filterSpans}

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
 import {BorderlessEventEntries} from 'app/components/events/eventEntries';
+import * as SpanEntryContext from 'app/components/events/interfaces/spans/context';
 import {EventQuery} from 'app/actionCreators/events';
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
@@ -25,6 +26,7 @@ import AsyncComponent from 'app/components/asyncComponent';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import Projects from 'app/utils/projects';
 import EventView from 'app/utils/discover/eventView';
+import {eventDetailsRoute} from 'app/utils/discover/urls';
 import {ContentBox, HeaderBox, HeaderBottomControls} from 'app/utils/discover/styles';
 
 import {generateTitle, getExpandedResults} from '../utils';
@@ -164,16 +166,32 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
           <div style={{gridColumn: isSidebarVisible ? '1/2' : '1/3'}}>
             <Projects orgId={organization.slug} slugs={[this.projectId]}>
               {({projects}) => (
-                <BorderlessEventEntries
-                  api={api}
-                  organization={organization}
-                  event={event}
-                  project={projects[0]}
-                  location={location}
-                  showExampleCommit={false}
-                  showTagSummary={false}
-                  eventView={eventView}
-                />
+                <SpanEntryContext.Provider
+                  value={{
+                    getViewChildTransactionTarget: childTransactionProps => {
+                      const childTransactionLink = eventDetailsRoute({
+                        eventSlug: childTransactionProps.eventSlug,
+                        orgSlug: organization.slug,
+                      });
+
+                      return {
+                        pathname: childTransactionLink,
+                        query: eventView.generateQueryStringObject(),
+                      };
+                    },
+                  }}
+                >
+                  <BorderlessEventEntries
+                    api={api}
+                    organization={organization}
+                    event={event}
+                    project={projects[0]}
+                    location={location}
+                    showExampleCommit={false}
+                    showTagSummary={false}
+                    eventView={eventView}
+                  />
+                </SpanEntryContext.Provider>
               )}
             </Projects>
           </div>

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -189,7 +189,6 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                     location={location}
                     showExampleCommit={false}
                     showTagSummary={false}
-                    eventView={eventView}
                   />
                 </SpanEntryContext.Provider>
               )}

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
@@ -23,7 +23,6 @@ import TagsTable from 'app/components/tagsTable';
 import Projects from 'app/utils/projects';
 import {ContentBox, HeaderBox, HeaderBottomControls} from 'app/utils/discover/styles';
 import Breadcrumb from 'app/views/performance/breadcrumb';
-import EventView from 'app/utils/discover/eventView';
 import {decodeScalar, appendTagCondition} from 'app/utils/queryString';
 
 import {transactionSummaryRouteWithQuery} from '../transactionSummary/utils';
@@ -122,26 +121,6 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     const transactionName = event.title;
     const query = decodeScalar(location.query.query) || '';
 
-    // Build a new event view so span details links will go to useful results.
-    const eventView = EventView.fromNewQueryWithLocation(
-      {
-        id: undefined,
-        name: 'Related events',
-        fields: [
-          'transaction',
-          'project',
-          'trace.span',
-          'transaction.duration',
-          'timestamp',
-        ],
-        orderby: '-timestamp',
-        version: 2,
-        projects: [],
-        query: appendTagCondition(query, 'transaction', transactionName),
-      },
-      location
-    );
-
     return (
       <React.Fragment>
         <HeaderBox>
@@ -182,7 +161,6 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                     location={location}
                     showExampleCommit={false}
                     showTagSummary={false}
-                    eventView={eventView}
                   />
                 </SpanEntryContext.Provider>
               )}

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
@@ -12,6 +12,7 @@ import {Organization, Event, EventTag} from 'app/types';
 import SentryTypes from 'app/sentryTypes';
 import EventMetadata from 'app/components/events/eventMetadata';
 import {BorderlessEventEntries} from 'app/components/events/eventEntries';
+import * as SpanEntryContext from 'app/components/events/interfaces/spans/context';
 import Button from 'app/components/button';
 import LoadingError from 'app/components/loadingError';
 import NotFound from 'app/components/errors/notFound';
@@ -26,6 +27,7 @@ import EventView from 'app/utils/discover/eventView';
 import {decodeScalar, appendTagCondition} from 'app/utils/queryString';
 
 import {transactionSummaryRouteWithQuery} from '../transactionSummary/utils';
+import {getTransactionDetailsUrl} from '../utils';
 
 type Props = {
   organization: Organization;
@@ -160,16 +162,29 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
           <div style={{gridColumn: isSidebarVisible ? '1/2' : '1/3'}}>
             <Projects orgId={organization.slug} slugs={[this.projectId]}>
               {({projects}) => (
-                <BorderlessEventEntries
-                  api={api}
-                  organization={organization}
-                  event={event}
-                  project={projects[0]}
-                  location={location}
-                  showExampleCommit={false}
-                  showTagSummary={false}
-                  eventView={eventView}
-                />
+                <SpanEntryContext.Provider
+                  value={{
+                    getViewChildTransactionTarget: childTransactionProps => {
+                      return getTransactionDetailsUrl(
+                        organization,
+                        childTransactionProps.eventSlug,
+                        childTransactionProps.transaction,
+                        location.query
+                      );
+                    },
+                  }}
+                >
+                  <BorderlessEventEntries
+                    api={api}
+                    organization={organization}
+                    event={event}
+                    project={projects[0]}
+                    location={location}
+                    showExampleCommit={false}
+                    showTagSummary={false}
+                    eventView={eventView}
+                  />
+                </SpanEntryContext.Provider>
               )}
             </Projects>
           </div>


### PR DESCRIPTION
Before the transaction event details page was added to the Performance tab (see https://github.com/getsentry/sentry/pull/19278), direct child transaction traversal only occurred within Discover.

Today, direct child transaction traversal from the Performance tab will lead to Discover; rather than viewing the transaction from within the Performance tab. 

This PR addresses that issue.