### PR TITLE
feat(alerts): Allow org alert rules to filter on project

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -20,9 +20,11 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint):
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
 
+        project_ids = self.get_requested_project_ids(request) or None
+
         return self.paginate(
             request,
-            queryset=AlertRule.objects.fetch_for_organization(organization),
+            queryset=AlertRule.objects.fetch_for_organization(organization, project_ids),
             order_by="-date_added",
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(x, request.user),

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -298,8 +298,12 @@ class AlertRuleManager(BaseManager):
             .exclude(status=AlertRuleStatus.SNAPSHOT.value)
         )
 
-    def fetch_for_organization(self, organization):
-        return self.filter(organization=organization)
+    def fetch_for_organization(self, organization, projects=None):
+        queryset = self.filter(organization=organization)
+        if projects is not None:
+            queryset = queryset.filter(snuba_query__subscriptions__project__in=projects)
+
+        return queryset
 
     def fetch_for_project(self, project):
         return self.filter(snuba_query__subscriptions__project=project)

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -384,6 +384,40 @@ class IncidentCurrentEndDateTest(unittest.TestCase):
         assert incident.current_end_date == timezone.now() - timedelta(minutes=10)
 
 
+class AlertRuleFetchForOrganizationTest(TestCase):
+    def test_empty(self):
+        alert_rule = AlertRule.objects.fetch_for_organization(self.organization)
+        assert [] == list(alert_rule)
+
+    def test_simple(self):
+        alert_rule = self.create_alert_rule()
+
+        assert [alert_rule] == list(AlertRule.objects.fetch_for_organization(self.organization))
+
+    def test_with_projects(self):
+        project = self.create_project()
+        alert_rule = self.create_alert_rule(projects=[project])
+
+        assert [] == list(
+            AlertRule.objects.fetch_for_organization(self.organization, [self.project])
+        )
+        assert [alert_rule] == list(
+            AlertRule.objects.fetch_for_organization(self.organization, [project])
+        )
+
+    def test_multi_project(self):
+        project = self.create_project()
+        alert_rule1 = self.create_alert_rule(projects=[project, self.project])
+        alert_rule2 = self.create_alert_rule(projects=[project])
+
+        assert [alert_rule1] == list(
+            AlertRule.objects.fetch_for_organization(self.organization, [self.project])
+        )
+        assert [alert_rule1, alert_rule2] == list(
+            AlertRule.objects.fetch_for_organization(self.organization, [project])
+        )
+
+
 class AlertRuleTriggerActionTargetTest(TestCase):
     def test_user(self):
         trigger = AlertRuleTriggerAction(


### PR DESCRIPTION
Can add some tests if we'd like :)

I didn't see any for the `fetch_for_organization` on the AlertManager