### PR TITLE
fix(integrations): switch to custom referrer for analytics

### DIFF
--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -149,10 +149,15 @@ export const trackIntegrationEvent = (
     );
   }
 
+  //Amplitude has it's own referrer which intefers with our custom referrer
+  const {referrer: custom_referrer} = analyticsParams;
+  delete analyticsParams.referrer;
+
   const params = {
     analytics_session_id: sessionId,
     organization_id: org?.id,
     role: org?.role,
+    custom_referrer,
     ...features,
     ...analyticsParams,
   };


### PR DESCRIPTION
Amplitude has its own referrer which is interfering with the one we are sending. This is so we send the `referrer` as `custom_referrer` for all integration analytics events.