### PR TITLE
fix(async-csv): Lower export limit

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -226,7 +226,9 @@ def store_export_chunk_as_blob(data_export, bytes_written, fileobj, blob_size=DE
         bytes_offset += blob.size
 
         # there is a maximum file size allowed, so we need to make sure we don't exceed it
-        if bytes_written + bytes_offset >= MAX_FILE_SIZE:
+        # NOTE: there seems to be issues with downloading files larger than 1 GB on slower
+        # networks, limit the export to 1 GB for now to improve reliability
+        if bytes_written + bytes_offset >= min(MAX_FILE_SIZE, 2 ** 30):
             transaction.set_rollback(True)
             return 0
 


### PR DESCRIPTION
There are problems with exports larger than 1 GB during the download where they
fail on slower networks. This limits the export to 1 GB to mitigate such issues.