### PR TITLE
ref(ts): Convert dashboard/utils to typescript

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1310,7 +1310,7 @@ export type Widget = {
   title: React.ReactNode;
   type: WIDGET_DISPLAY;
   fieldLabelMap?: object;
-  yAxisMapping?: [number, number];
+  yAxisMapping?: [number[], number[]];
   includeReleases?: boolean;
   includePreviousPeriod?: boolean;
 };

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -8,7 +8,9 @@ import {
   NOT_INSTALLED,
   PENDING,
 } from 'app/views/organizationIntegrations/constants';
+import {WIDGET_DISPLAY} from 'app/views/dashboards/constants';
 import {Props as AlertProps} from 'app/components/alert';
+import {Query as DiscoverQuery} from 'app/views/discover/types';
 
 declare global {
   interface Window {
@@ -1299,6 +1301,18 @@ export type Artifact = {
   sha1: string;
   size: number;
   headers: {'Content-Type': string};
+};
+
+export type Widget = {
+  queries: {
+    discover: DiscoverQuery[];
+  };
+  title: React.ReactNode;
+  type: WIDGET_DISPLAY;
+  fieldLabelMap?: object;
+  yAxisMapping?: [number, number];
+  includeReleases?: boolean;
+  includePreviousPeriod?: boolean;
 };
 
 export type EventGroupInfo = Record<EventGroupVariantKey, EventGroupVariant>;

--- a/src/sentry/static/sentry/app/views/dashboards/constants.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/constants.tsx
@@ -1,10 +1,10 @@
-export const WIDGET_DISPLAY = {
-  LINE_CHART: 'line',
-  AREA_CHART: 'area',
-  STACKED_AREA_CHART: 'stacked-area',
-  BAR_CHART: 'bar',
-  PIE_CHART: 'pie',
-  TABLE: 'table',
-  WORLD_MAP: 'world-map',
-  PERCENTAGE_AREA_CHART: 'percentage-area',
-} as const;
+export enum WIDGET_DISPLAY {
+  LINE_CHART = 'line',
+  AREA_CHART = 'area',
+  STACKED_AREA_CHART = 'stacked-area',
+  BAR_CHART = 'bar',
+  PIE_CHART = 'pie',
+  TABLE = 'table',
+  WORLD_MAP = 'world-map',
+  PERCENTAGE_AREA_CHART = 'percentage-area',
+}

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getChartComponent.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getChartComponent.tsx
@@ -18,7 +18,7 @@ const CHART_MAP = {
   [WIDGET_DISPLAY.WORLD_MAP]: WorldMapChart,
   [WIDGET_DISPLAY.TABLE]: PercentageTableChart,
   [WIDGET_DISPLAY.PERCENTAGE_AREA_CHART]: PercentageAreaChart,
-};
+} as {[key: string]: React.Component};
 
 export function getChartComponent({type}: {type: WIDGET_DISPLAY}) {
   return CHART_MAP[type];

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getChartComponent.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getChartComponent.tsx
@@ -20,6 +20,6 @@ const CHART_MAP = {
   [WIDGET_DISPLAY.PERCENTAGE_AREA_CHART]: PercentageAreaChart,
 };
 
-export function getChartComponent({type}) {
+export function getChartComponent({type}: {type: WIDGET_DISPLAY}) {
   return CHART_MAP[type];
 }

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getChartComponent.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getChartComponent.tsx
@@ -9,7 +9,7 @@ import WorldMapChart from 'app/components/charts/worldMapChart';
 
 import {WIDGET_DISPLAY} from '../constants';
 
-const CHART_MAP = {
+const CHART_MAP: Record<WIDGET_DISPLAY, React.Component> = {
   [WIDGET_DISPLAY.LINE_CHART]: LineChart,
   [WIDGET_DISPLAY.AREA_CHART]: AreaChart,
   [WIDGET_DISPLAY.STACKED_AREA_CHART]: StackedAreaChart,
@@ -18,7 +18,7 @@ const CHART_MAP = {
   [WIDGET_DISPLAY.WORLD_MAP]: WorldMapChart,
   [WIDGET_DISPLAY.TABLE]: PercentageTableChart,
   [WIDGET_DISPLAY.PERCENTAGE_AREA_CHART]: PercentageAreaChart,
-} as {[key: string]: React.Component};
+};
 
 export function getChartComponent({type}: {type: WIDGET_DISPLAY}) {
   return CHART_MAP[type];

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getChartDataFunc.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getChartDataFunc.tsx
@@ -1,4 +1,5 @@
 import {getChartDataForWidget, getChartDataByDay} from 'app/views/discover/result/utils';
+import {Widget} from 'app/types';
 
 import {isTimeSeries} from './isTimeSeries';
 import {WIDGET_DISPLAY} from '../constants';
@@ -6,7 +7,7 @@ import {WIDGET_DISPLAY} from '../constants';
 /**
  * Get data function based on widget properties
  */
-export function getChartDataFunc({queries, type, fieldLabelMap}) {
+export function getChartDataFunc({queries, type, fieldLabelMap}: Widget) {
   if (queries.discover.some(isTimeSeries)) {
     return [
       getChartDataByDay,

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getChartDataFunc.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getChartDataFunc.tsx
@@ -7,7 +7,11 @@ import {WIDGET_DISPLAY} from '../constants';
 /**
  * Get data function based on widget properties
  */
-export function getChartDataFunc({queries, type, fieldLabelMap}: Widget) {
+export function getChartDataFunc({
+  queries,
+  type,
+  fieldLabelMap,
+}: Widget): [Function, object[]] {
   if (queries.discover.some(isTimeSeries)) {
     return [
       getChartDataByDay,

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getData.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getData.tsx
@@ -1,11 +1,13 @@
 import {t} from 'app/locale';
+import {Widget} from 'app/types';
+import {SnubaResult} from 'app/views/discover/types';
 
 import {WIDGET_DISPLAY} from '../constants';
 import {getChartDataFunc} from './getChartDataFunc';
 import {isTimeSeries} from './isTimeSeries';
 
 // TODO(billy): Currently only supports discover queries
-export function getData(results, widget) {
+export function getData(results: SnubaResult[], widget: Widget) {
   const {type, queries, yAxisMapping} = widget;
   const isTable = type === WIDGET_DISPLAY.TABLE;
   const [chartDataFunc, chartDataFuncArgs] = getChartDataFunc(widget);
@@ -36,7 +38,7 @@ export function getData(results, widget) {
 
   // Has 2 y axes
   if (hasYAxes) {
-    yAxisMapping.forEach((mappings, yAxisIndex) => {
+    yAxisMapping?.forEach((mappings, yAxisIndex) => {
       mappings.forEach(seriesIndex => {
         if (typeof series[seriesIndex] === 'undefined') {
           return;

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getDiscoverConditionsToSearchString.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getDiscoverConditionsToSearchString.tsx
@@ -4,12 +4,13 @@ import {
   WILDCARD_OPERATORS,
 } from 'app/views/discover/data';
 import {defined} from 'app/utils';
+import {Condition} from 'app/views/discover/types';
 
 const checkIsNegation = operator => NEGATION_OPERATORS.includes(operator);
 const checkIsNull = operator => NULL_OPERATORS.includes(operator);
 const checkIsWildcard = operator => WILDCARD_OPERATORS.includes(operator);
 
-function getDiscoverConditionToSearchString(condition = []) {
+function getDiscoverConditionToSearchString(condition: Condition) {
   const [field, operator, value] = condition;
   const isNegation = checkIsNegation(operator);
   const negationStr = isNegation ? '!' : '';
@@ -26,14 +27,14 @@ function getDiscoverConditionToSearchString(condition = []) {
 
   if (checkIsWildcard(operator)) {
     // Do we support both?
-    coercedValue = coercedValue.replace(/%/g, '*');
+    coercedValue = `${coercedValue}`.replace(/%/g, '*');
   }
 
   // TODO(billy): Handle number operators on server
   return `${negationStr}${field}:${coercedValue}`;
 }
 
-export function getDiscoverConditionsToSearchString(conditions = []) {
+export function getDiscoverConditionsToSearchString(conditions: Condition[] = []) {
   return conditions
     .map(getDiscoverConditionToSearchString)
     .join(' ')

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getEventsUrlFromDiscoverQueryWithConditions.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getEventsUrlFromDiscoverQueryWithConditions.tsx
@@ -11,15 +11,24 @@ import zipWith from 'lodash/zipWith';
 
 import {OPERATOR} from 'app/views/discover/data';
 import {escapeQuotes} from 'app/components/events/interfaces/utils';
+import {Organization, GlobalSelection} from 'app/types';
+import {Condition, Query} from 'app/views/discover/types';
 
 import {getEventsUrlPathFromDiscoverQuery} from './getEventsUrlPathFromDiscoverQuery';
+
+type Props = {
+  values: string[];
+  organization: Organization;
+  selection: GlobalSelection;
+  query: Query;
+};
 
 export function getEventsUrlFromDiscoverQueryWithConditions({
   values,
   query,
   selection,
   organization,
-}) {
+}: Props) {
   return getEventsUrlPathFromDiscoverQuery({
     organization,
     selection,
@@ -30,11 +39,16 @@ export function getEventsUrlFromDiscoverQueryWithConditions({
         // For each `field`, create a condition that joins it with each `rowObject.name` value (separated by commas)
         // e.g. fields: ['browser', 'device'],  rowObject.name: "Chrome, iPhone"
         //      ----> [['browser', '=', 'Chrome'], ['device', '=', 'iPhone']]
-        ...zipWith(query.fields, values, (field, value) => [
-          field,
-          OPERATOR.EQUAL,
-          value === null ? '""' : `"${escapeQuotes(value)}"`,
-        ]),
+        ...zipWith(
+          query.fields,
+          values,
+          (field, value) =>
+            [
+              field,
+              OPERATOR.EQUAL,
+              value === null ? '""' : `"${escapeQuotes(value)}"`,
+            ] as Condition
+        ),
       ],
     },
   });

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getEventsUrlPathFromDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getEventsUrlPathFromDiscoverQuery.tsx
@@ -2,10 +2,22 @@ import pickBy from 'lodash/pickBy';
 import qs from 'query-string';
 
 import {getUtcDateString} from 'app/utils/dates';
+import {Organization, GlobalSelection} from 'app/types';
+import {Query} from 'app/views/discover/types';
 
 import {getDiscoverConditionsToSearchString} from './getDiscoverConditionsToSearchString';
 
-export function getEventsUrlPathFromDiscoverQuery({organization, selection, query}) {
+type Props = {
+  organization: Organization;
+  selection: GlobalSelection;
+  query: Query;
+};
+
+export function getEventsUrlPathFromDiscoverQuery({
+  organization,
+  selection,
+  query,
+}: Props) {
   const {projects, datetime, environments: _environments, ...restSelection} = selection;
 
   return `/organizations/${organization.slug}/events/?${qs.stringify(

--- a/src/sentry/static/sentry/app/views/dashboards/utils/isTimeSeries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/isTimeSeries.tsx
@@ -1,8 +1,6 @@
-type Query = {
-  groupby: string[];
-};
+import {Query} from 'app/views/discover/types';
 
 // Consider a query a time series if
 export function isTimeSeries(query: Query) {
-  return query.groupby.includes('time');
+  return query?.groupby?.includes('time');
 }

--- a/src/sentry/static/sentry/app/views/discover/types.tsx
+++ b/src/sentry/static/sentry/app/views/discover/types.tsx
@@ -10,6 +10,7 @@ export type Query = {
   version?: number;
   query?: string;
   orderby?: string;
+  groupby?: string;
   limit?: number;
   range?: string;
   start?: string;

--- a/src/sentry/static/sentry/app/views/discover/types.tsx
+++ b/src/sentry/static/sentry/app/views/discover/types.tsx
@@ -11,6 +11,8 @@ export type Query = {
   query?: string;
   orderby?: string;
   groupby?: string;
+  rollup?: number;
+  name?: string;
   limit?: number;
   range?: string;
   start?: string;


### PR DESCRIPTION
### Summary
This converts `app/views/dashboards/utils/*` over to typescript.

- Switched `WIDGET_DISPLAY` to `Enum` and `CHART_MAP` to `Record` to ensure mapping exists for all Enum members.