### PR TITLE
fix(discover) Pass absolute dates to release series better

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import isEqual from 'lodash/isEqual';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
-import {getFormattedDate} from 'app/utils/dates';
+import {getFormattedDate, getUtcDateString} from 'app/utils/dates';
 import {t} from 'app/locale';
 import MarkLine from 'app/components/charts/components/markLine';
 import SentryTypes from 'app/sentryTypes';
@@ -19,8 +19,12 @@ import {formatVersion} from 'app/utils/formatters';
 function getOrganizationReleases(api, organization, conditions = null) {
   const query = {};
   Object.keys(conditions).forEach(key => {
-    if (conditions[key]) {
-      query[key] = conditions[key];
+    let value = conditions[key];
+    if (value && (key === 'start' || key === 'end')) {
+      value = getUtcDateString(value);
+    }
+    if (value) {
+      query[key] = value;
     }
   });
   return api.requestPromise(`/organizations/${organization.slug}/releases/`, {

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -59,8 +59,8 @@ def transactions_query(**kwargs):
 
 
 def generate_transaction():
-    start_datetime = before_now(minutes=1)
-    end_datetime = before_now(minutes=1, milliseconds=500)
+    start_datetime = before_now(minutes=1, milliseconds=500)
+    end_datetime = before_now(minutes=1)
     event_data = load_data("transaction", timestamp=end_datetime, start_timestamp=start_datetime)
     event_data.update({"event_id": "a" * 32})
 

--- a/tests/js/spec/components/charts/releaseSeries.spec.jsx
+++ b/tests/js/spec/components/charts/releaseSeries.spec.jsx
@@ -62,7 +62,7 @@ describe('ReleaseSeries', function() {
     );
   });
 
-  it('fetches releases with start and end dates', async function() {
+  it('fetches releases with start and end date strings', async function() {
     const wrapper = mount(
       <ReleaseSeries start="2020-01-01" end="2020-01-31">
         {renderFunc}
@@ -76,7 +76,28 @@ describe('ReleaseSeries', function() {
     expect(releasesMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        query: {start: '2020-01-01', end: '2020-01-31'},
+        query: {start: '2020-01-01T00:00:00', end: '2020-01-31T00:00:00'},
+      })
+    );
+  });
+
+  it('fetches releases with start and end dates', async function() {
+    const start = new Date(Date.UTC(2020, 0, 1, 12, 13, 14));
+    const end = new Date(Date.UTC(2020, 0, 31, 14, 15, 16));
+    const wrapper = mount(
+      <ReleaseSeries start={start} end={end}>
+        {renderFunc}
+      </ReleaseSeries>,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(releasesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {start: '2020-01-01T12:13:14', end: '2020-01-31T14:15:16'},
       })
     );
   });


### PR DESCRIPTION
Format start/end dates being sent to the release endpoint properly.