### PR TITLE
ref(ui) Convert several clock icons to new icons.

### DIFF
--- a/src/sentry/static/sentry/app/components/group/times.tsx
+++ b/src/sentry/static/sentry/app/components/group/times.tsx
@@ -3,8 +3,8 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
+import {IconClock} from 'app/icons';
 import space from 'app/styles/space';
-import InlineSvg from 'app/components/inlineSvg';
 import TimeSince from 'app/components/timeSince';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 
@@ -23,7 +23,7 @@ const Times = ({lastSeen, firstSeen}: Props) => (
     <FlexWrapper>
       {lastSeen && (
         <React.Fragment>
-          <GroupTimeIcon src="icon-clock-sm" />
+          <StyledIconClock size="11px" />
           <TimeSince date={lastSeen} suffix={t('ago')} />
         </React.Fragment>
       )}
@@ -54,10 +54,9 @@ const FlexWrapper = styled('div')`
   align-items: center;
 `;
 
-const GroupTimeIcon = styled(InlineSvg)`
+const StyledIconClock = styled(IconClock)`
   /* this is solely for optics, since TimeSince always begins
   with a number, and numbers do not have descenders */
-  font-size: ${p => p.theme.fontSizeExtraSmall};
   margin-right: ${space(0.5)};
 `;
 

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
+import {IconClock} from 'app/icons';
 import {t} from 'app/locale';
 import Count from 'app/components/count';
 import ExternalLink from 'app/components/links/externalLink';
@@ -59,7 +60,7 @@ export default class ReleaseHeader extends React.Component {
               </div>
             )}
             <div className="release-meta">
-              <span className="icon icon-clock" />{' '}
+              <IconClock size="11px" />
               <TimeSince date={release.dateCreated} />
             </div>
           </div>

--- a/src/sentry/static/sentry/app/views/releases/list/latestDeployOrReleaseTime.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/latestDeployOrReleaseTime.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
+import {IconClock} from 'app/icons';
 import RepoLabel from 'app/components/repoLabel';
 import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
@@ -55,16 +56,14 @@ const ReleaseRepoLabel = styled(RepoLabel)`
 
 const TimeWithIcon = styled(({date, ...props}) => (
   <span {...props}>
-    <ClockIcon className="icon icon-clock" />
-    <TimeSince date={date} />
+    <IconClock size="11px" /> <TimeSince date={date} />
   </span>
 ))`
   display: inline-flex;
   align-items: center;
   color: ${p => p.theme.gray500};
   font-size: ${p => p.theme.fontSizeSmall};
-`;
-
-const ClockIcon = styled('span')`
-  margin-right: ${space(0.25)};
+  & > svg {
+    margin-right: ${space(0.25)};
+  }
 `;


### PR DESCRIPTION
This moves most (but not all) clock icons to the new icon implementation. The remaining icon-clock hits are inside the SmartSearchBar component which needs all its icons replaced at once.