### PR TITLE
feat(async-csv): Link discover exports back to query

### DIFF
--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {RouteComponentProps} from 'react-router/lib/Router';
 
@@ -136,11 +137,58 @@ class DataDownload extends AsyncView<Props, State> {
       </React.Fragment>
     );
   }
+
+  openInDiscover() {
+    const {
+      download: {
+        query: {info},
+      },
+    } = this.state;
+    const {orgId} = this.props.params;
+
+    const to = {
+      pathname: `/organizations/${orgId}/discover/results/`,
+      query: info,
+    };
+
+    browserHistory.push(to);
+  }
+
+  renderOpenInDiscover() {
+    const {
+      download: {
+        query = {
+          type: ExportQueryType.IssuesByTag,
+          info: {},
+        },
+      },
+    } = this.state;
+
+    // default to IssuesByTag because we dont want to
+    // display this unless we're sure its a discover query
+    const {type = ExportQueryType.IssuesByTag} = query;
+
+    return type === 'Discover' ? (
+      <React.Fragment>
+        <p>{t('Need to make changes?')}</p>
+        <Button
+          priority="primary"
+          icon="icon-discover"
+          onClick={() => this.openInDiscover()}
+        >
+          {t('Open in Discover')}
+        </Button>
+        <br />
+      </React.Fragment>
+    ) : null;
+  }
+
   renderValid(): React.ReactNode {
     const {
       download: {dateExpired, checksum},
     } = this.state;
     const {orgId, dataExportId} = this.props.params;
+
     return (
       <React.Fragment>
         <Header>
@@ -160,6 +208,7 @@ class DataDownload extends AsyncView<Props, State> {
             <br />
             {this.renderDate(dateExpired)}
           </p>
+          {this.renderOpenInDiscover()}
           <small>
             <strong>SHA1:{checksum}</strong>
           </small>
@@ -180,6 +229,7 @@ class DataDownload extends AsyncView<Props, State> {
       </React.Fragment>
     );
   }
+
   renderError(): React.ReactNode {
     const {
       errors: {download: err},

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -209,10 +209,10 @@ class DataDownload extends AsyncView<Props, State> {
             {this.renderDate(dateExpired)}
           </p>
           {this.renderOpenInDiscover()}
-          <small>
-            <strong>SHA1:{checksum}</strong>
-          </small>
           <p>
+            <small>
+              <strong>SHA1:{checksum}</strong>
+            </small>
             {tct('Need help verifying? [link].', {
               link: (
                 <a

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -213,6 +213,7 @@ class DataDownload extends AsyncView<Props, State> {
             <small>
               <strong>SHA1:{checksum}</strong>
             </small>
+            <br />
             {tct('Need help verifying? [link].', {
               link: (
                 <a

--- a/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
+++ b/src/sentry/static/sentry/app/views/dataExport/dataDownload.tsx
@@ -221,7 +221,7 @@ class DataDownload extends AsyncView<Props, State> {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  {t('Check out our docs.')}
+                  {t('Check out our docs')}
                 </a>
               ),
             })}

--- a/tests/js/spec/views/dataExport/dataDownload.spec.jsx
+++ b/tests/js/spec/views/dataExport/dataDownload.spec.jsx
@@ -78,4 +78,34 @@ describe('DataDownload', function() {
     );
     expect(wrapper.find('DateTime').prop('date')).toEqual(new Date(dateExpired));
   });
+
+  it('should render the Open in Discover button when needed', function() {
+    const status = DownloadStatus.Valid;
+    getDataExportDetails({
+      dateExpired,
+      status,
+      query: {
+        type: ExportQueryType.Discover,
+        info: {},
+      },
+    });
+    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
+    const buttonWrapper = wrapper.find('button[aria-label="Open in Discover"]');
+    expect(buttonWrapper.exists()).toBeTruthy();
+  });
+
+  it('should not render the Open in Discover button when not needed', function() {
+    const status = DownloadStatus.Valid;
+    getDataExportDetails({
+      dateExpired,
+      status,
+      query: {
+        type: ExportQueryType.IssuesByTag,
+        info: {},
+      },
+    });
+    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
+    const buttonWrapper = wrapper.find('button[aria-label="Open in Discover"]');
+    expect(buttonWrapper.exists()).toBeFalsy();
+  });
 });


### PR DESCRIPTION
Add a link from the download page back to the original query to allow users to look at the query
itself as well as make any changes then running another export.

**Before:** 
<img width="573" alt="Screen Shot 2020-06-17 at 5 04 19 PM" src="https://user-images.githubusercontent.com/10239353/84950242-99450900-b0bc-11ea-89c1-043ad5d5c35a.png">

**After:**
![Screen Shot 2020-06-18 at 1 52 09 PM](https://user-images.githubusercontent.com/10239353/85055018-f13a4900-b16a-11ea-937b-6cd6573cf5f5.png)