### PR TITLE
fix(perf-views) Fix layout shifting after data is loaded

### DIFF
--- a/src/sentry/static/sentry/app/components/panels/panelTable.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelTable.tsx
@@ -42,6 +42,11 @@ type Props = {
   disablePadding?: boolean;
 
   className?: string;
+
+  /**
+   * A custom loading indicator.
+   */
+  loader?: React.ReactNode;
 };
 
 /**
@@ -63,9 +68,10 @@ const PanelTable = ({
   children,
   isLoading,
   isEmpty,
-  emptyMessage = t('There are no items to display'),
   disablePadding,
   className,
+  emptyMessage = t('There are no items to display'),
+  loader,
 }: Props) => {
   const shouldShowLoading = isLoading === true;
   const shouldShowEmptyMessage = !shouldShowLoading && isEmpty;
@@ -83,9 +89,7 @@ const PanelTable = ({
       ))}
 
       {shouldShowLoading && (
-        <LoadingWrapper>
-          <LoadingIndicator />
-        </LoadingWrapper>
+        <LoadingWrapper>{loader || <LoadingIndicator />}</LoadingWrapper>
       )}
 
       {shouldShowEmptyMessage && (

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
@@ -252,7 +252,7 @@ class TransactionTable extends React.PureComponent<Props> {
       tableData && tableData.data && tableData.meta && tableData.data.length > 0;
 
     // Custom set the height so we don't have layout shift when results are loaded.
-    const loader = <LoadingIndicator style={{margin: '71px auto'}} />;
+    const loader = <LoadingIndicator style={{margin: '70px auto'}} />;
 
     return (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/transactionList.tsx
@@ -10,6 +10,7 @@ import DiscoverButton from 'app/components/discoverButton';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import PanelTable from 'app/components/panels/panelTable';
 import Link from 'app/components/links/link';
+import LoadingIndicator from 'app/components/loadingIndicator';
 import {TableData, TableDataRow, TableColumn} from 'app/views/eventsV2/table/types';
 import HeaderCell from 'app/views/eventsV2/table/headerCell';
 import EventView, {MetaType} from 'app/utils/discover/eventView';
@@ -250,6 +251,9 @@ class TransactionTable extends React.PureComponent<Props> {
     const hasResults =
       tableData && tableData.data && tableData.meta && tableData.data.length > 0;
 
+    // Custom set the height so we don't have layout shift when results are loaded.
+    const loader = <LoadingIndicator style={{margin: '71px auto'}} />;
+
     return (
       <React.Fragment>
         <PanelTable
@@ -258,6 +262,7 @@ class TransactionTable extends React.PureComponent<Props> {
           headers={this.renderHeader()}
           isLoading={isLoading}
           disablePadding
+          loader={loader}
         >
           {this.renderResults()}
         </PanelTable>

--- a/tests/js/spec/components/panels/panelTable.spec.jsx
+++ b/tests/js/spec/components/panels/panelTable.spec.jsx
@@ -43,6 +43,22 @@ describe('PanelTable', function() {
     expect(wrapper.find('LoadingIndicator')).toBeDefined();
   });
 
+  it('renders custom loader', function() {
+    const wrapper = createWrapper({
+      isLoading: true,
+      loader: <span data-test-id="custom-loader">loading</span>,
+    });
+
+    // Does not render content
+    expect(wrapper.find('[data-test-id="cell"]')).toHaveLength(0);
+
+    // no default loader
+    expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
+
+    // has custom loader
+    expect(wrapper.find('[data-test-id="custom-loader"]')).toHaveLength(1);
+  });
+
   it('ignores empty state when loading', function() {
     const wrapper = createWrapper({isLoading: true, isEmpty: true});
 


### PR DESCRIPTION
Don't shift the layout as we know how big the tranaction list box will be most of the time.

## Before
![transaction list before](https://user-images.githubusercontent.com/24086/84953181-12465f80-b0c1-11ea-986c-2ab905440009.gif)

## After
![transaction list after](https://user-images.githubusercontent.com/24086/84953198-18d4d700-b0c1-11ea-8db8-5c1db8b5e4e8.gif)
