### PR TITLE
fix(discover): Fix release legend label clickability

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -175,6 +175,9 @@ class DurationChart extends React.Component<Props> {
                                 showSymbol: false,
                               }}
                               tooltip={tooltip}
+                              toolBox={{
+                                show: false,
+                              }}
                               grid={{
                                 left: '10px',
                                 right: '10px',


### PR DESCRIPTION
### Summary
This fixes a bug where the transparent empty toolbox was overlapping with the 'release' label in the duration breakdown legend. This was causing the release label to be partially unclickable.

### Screenshots
**Empty toolbox element which was interfering with click**
<img width="611" alt="Screen Shot 2020-06-17 at 2 26 12 PM" src="https://user-images.githubusercontent.com/6111995/84954150-b6241100-b0a9-11ea-8bf6-b4d8a3052ba5.png">
