### PR TITLE
fix(perf-views): Show at least 1 user misery

### DIFF
--- a/src/sentry/static/sentry/app/components/userMisery.tsx
+++ b/src/sentry/static/sentry/app/components/userMisery.tsx
@@ -18,7 +18,7 @@ function UserMisery(props: Props) {
   const {bars, barHeight, miserableUsers, miseryLimit, totalUsers} = props;
 
   const palette = new Array(bars).fill(theme.purpleDarkest);
-  const score = Math.floor((miserableUsers / Math.max(totalUsers, 1)) * palette.length);
+  const score = Math.ceil((miserableUsers / Math.max(totalUsers, 1)) * palette.length);
   const miseryPercentage = ((100 * miserableUsers) / Math.max(totalUsers, 1)).toFixed(2);
 
   const title = tct(


### PR DESCRIPTION
When there is at least 1 miserable user, show at least 1 bar in the visuals. If there are no bars
showing, it must be that there are no miserable users.