### PR TITLE
feat(alerts): Open in Discover opens discover results with Top 5 selected

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
@@ -2,6 +2,7 @@ import {t} from 'app/locale';
 import {Incident, IncidentStats} from 'app/views/alerts/types';
 import {Project} from 'app/types';
 import Link from 'app/components/links/link';
+import {DisplayModes} from 'app/utils/discover/types';
 import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
 import {getIncidentDiscoverUrl, getStartEndFromStats} from 'app/views/alerts/utils';
@@ -172,7 +173,7 @@ function makeGenericTransactionCta(opts: {
   const extraQueryParams = {
     fields: [...new Set(['transaction', 'count()', incident.alertRule.aggregate])],
     orderby: '-count',
-    display: 'top5',
+    display: DisplayModes.TOP5,
   };
 
   const discoverUrl = getIncidentDiscoverUrl({
@@ -214,13 +215,13 @@ function makeFailureRateCta({orgSlug, incident, projects, stats}: PresetCtaOpts)
         {
           fields: ['transaction.status', 'count()'],
           orderby: '-count',
-          display: 'top5',
+          display: DisplayModes.TOP5,
         }
       : // Case 2
         {
           fields: ['transaction', 'failure_rate()'],
           orderby: '-failure_rate',
-          display: 'top5',
+          display: DisplayModes.TOP5,
         };
 
   const discoverUrl = getIncidentDiscoverUrl({
@@ -255,7 +256,7 @@ export function makeDefaultCta({
   }
 
   const extraQueryParams = {
-    display: 'top5',
+    display: DisplayModes.TOP5,
   };
 
   return {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
@@ -247,8 +247,12 @@ export function makeDefaultCta({
   incident,
   stats,
 }: PresetCtaOpts): PresetCta {
+  const extraQueryParams = {
+    display: 'top5',
+  };
+
   return {
     buttonText: t('Open in Discover'),
-    to: getIncidentDiscoverUrl({orgSlug, projects, incident, stats}),
+    to: getIncidentDiscoverUrl({orgSlug, projects, incident, stats, extraQueryParams}),
   };
 }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
@@ -247,6 +247,13 @@ export function makeDefaultCta({
   incident,
   stats,
 }: PresetCtaOpts): PresetCta {
+  if (!incident) {
+    return {
+      buttonText: t('Open in Discover'),
+      to: '',
+    };
+  }
+
   const extraQueryParams = {
     display: 'top5',
   };

--- a/tests/js/spec/views/settings/incidentRules/presets.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/presets.spec.jsx
@@ -61,6 +61,9 @@ describe('Incident Presets', function() {
         projects,
         incident,
         stats: mockStats,
+        extraQueryParams: {
+          display: 'top5',
+        },
       });
 
       expect(cta).toEqual(
@@ -95,6 +98,9 @@ describe('Incident Presets', function() {
         projects,
         incident,
         stats: mockStats,
+        extraQueryParams: {
+          display: 'top5',
+        },
       });
 
       expect(cta).toEqual(

--- a/tests/js/spec/views/settings/incidentRules/presets.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/presets.spec.jsx
@@ -1,5 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
+import {DisplayModes} from 'app/utils/discover/types';
 import {Dataset} from 'app/views/settings/incidentRules/types';
 import {PRESET_AGGREGATES} from 'app/views/settings/incidentRules/presets';
 import {getIncidentDiscoverUrl} from 'app/views/alerts/utils';
@@ -62,7 +63,7 @@ describe('Incident Presets', function() {
         incident,
         stats: mockStats,
         extraQueryParams: {
-          display: 'top5',
+          display: DisplayModes.TOP5,
         },
       });
 
@@ -99,7 +100,7 @@ describe('Incident Presets', function() {
         incident,
         stats: mockStats,
         extraQueryParams: {
-          display: 'top5',
+          display: DisplayModes.TOP5,
         },
       });
 
@@ -138,7 +139,7 @@ describe('Incident Presets', function() {
           incident,
           stats: mockStats,
           extraQueryParams: {
-            display: 'top5',
+            display: DisplayModes.TOP5,
             fields: ['transaction', 'count()', 'p95()'],
             orderby: '-count',
           },
@@ -217,7 +218,7 @@ describe('Incident Presets', function() {
           incident,
           stats: mockStats,
           extraQueryParams: {
-            display: 'top5',
+            display: DisplayModes.TOP5,
             fields: ['transaction', 'count()', 'apdex(300)'],
             orderby: '-count',
           },
@@ -296,7 +297,7 @@ describe('Incident Presets', function() {
           incident,
           stats: mockStats,
           extraQueryParams: {
-            display: 'top5',
+            display: DisplayModes.TOP5,
             fields: ['transaction', 'count()'],
             orderby: '-count',
           },
@@ -373,7 +374,7 @@ describe('Incident Presets', function() {
           incident,
           stats: mockStats,
           extraQueryParams: {
-            display: 'top5',
+            display: DisplayModes.TOP5,
             fields: ['transaction', 'failure_rate()'],
             orderby: '-failure_rate',
           },
@@ -412,7 +413,7 @@ describe('Incident Presets', function() {
           incident,
           stats: mockStats,
           extraQueryParams: {
-            display: 'top5',
+            display: DisplayModes.TOP5,
             fields: ['transaction.status', 'count()'],
             orderby: '-count',
           },


### PR DESCRIPTION
This adds `top5` to default cta query, if the org doesn't have metric alerts feature and `top5` isn't available selector will default to the top option.

Resolves: https://app.asana.com/0/1174156445846705/1178381365132611/f