### PR TITLE
Adding support for new incident activity item

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -109,7 +109,12 @@ def create_incident(
 
 
 def update_incident_status(
-    incident, status, user=None, comment=None, status_method=IncidentStatusMethod.RULE_TRIGGERED
+    incident,
+    status,
+    user=None,
+    comment=None,
+    status_method=IncidentStatusMethod.RULE_TRIGGERED,
+    date_closed=None,
 ):
     """
     Updates the status of an Incident and write an IncidentActivity row to log
@@ -135,7 +140,7 @@ def update_incident_status(
 
         kwargs = {"status": status.value, "status_method": status_method.value}
         if status == IncidentStatus.CLOSED:
-            kwargs["date_closed"] = timezone.now()
+            kwargs["date_closed"] = date_closed if date_closed else timezone.now()
         elif status == IncidentStatus.OPEN:
             # If we're moving back out of closed status then unset the closed
             # date

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -97,6 +97,9 @@ def create_incident(
                     sender=type(incident_project), instance=incident_project, created=True
                 )
 
+        create_incident_activity(
+            incident, IncidentActivityType.STARTED, user=user, date_added=date_started
+        )
         create_incident_activity(incident, IncidentActivityType.DETECTED, user=user)
         analytics.record(
             "incident.created",
@@ -200,11 +203,15 @@ def create_incident_activity(
     previous_value=None,
     comment=None,
     mentioned_user_ids=None,
+    date_added=None,
 ):
     if activity_type == IncidentActivityType.COMMENT and user:
         subscribe_to_incident(incident, user)
     value = six.text_type(value) if value is not None else value
     previous_value = six.text_type(previous_value) if previous_value is not None else previous_value
+    kwargs = {}
+    if date_added:
+        kwargs["date_added"] = date_added
     activity = IncidentActivity.objects.create(
         incident=incident,
         type=activity_type.value,
@@ -212,6 +219,7 @@ def create_incident_activity(
         value=value,
         previous_value=previous_value,
         comment=comment,
+        **kwargs
     )
 
     if mentioned_user_ids:

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -241,6 +241,7 @@ class IncidentActivityType(Enum):
     DETECTED = 1
     STATUS_CHANGE = 2
     COMMENT = 3
+    STARTED = 4
 
 
 class IncidentActivity(Model):

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -163,6 +163,25 @@ class SubscriptionProcessor(object):
         # before the next one then we might alert twice.
         self.update_alert_rule_stats()
 
+    def calculate_event_date_from_update_date(self, update_date):
+        """
+        Calculates the date that an event actually happened based on the date that we
+        received the update. This takes into account time window and threshold period.
+        :return:
+        """
+        # Subscriptions label buckets by the end of the bucket, whereas discover
+        # labels them by the front. This causes us an off-by-one error with event dates,
+        # so to prevent this we subtract a bucket off of the date.
+        update_date -= timedelta(seconds=self.alert_rule.snuba_query.time_window)
+        # We want to also subtract `frequency * (threshold_period - 1)` from the date.
+        # This allows us to show the actual start of the event, rather than the date
+        # of the last update that we received.
+        return update_date - timedelta(
+            seconds=(
+                self.alert_rule.snuba_query.resolution * (self.alert_rule.threshold_period - 1)
+            )
+        )
+
     def trigger_alert_threshold(self, trigger):
         """
         Called when a subscription update exceeds the value defined in the
@@ -177,21 +196,7 @@ class SubscriptionProcessor(object):
             metrics.incr("incidents.alert_rules.trigger", tags={"type": "fire"})
             # Only create a new incident if we don't already have an active one
             if not self.active_incident:
-                detected_at = self.last_update
-                # Subscriptions label buckets by the end of the bucket, whereas discover
-                # labels them by the front. This causes us an off-by-one error with
-                # alert start dates, so to prevent this we subtract a bucket off of the
-                # start date.
-                detected_at -= timedelta(seconds=self.alert_rule.snuba_query.time_window)
-                # We want to also subtract `frequency * (threshold_period - 1)` from the
-                # query. This allows us to show the actual start date of the alert,
-                # rather than the start of the last update that we received.
-                detected_at -= timedelta(
-                    seconds=(
-                        self.alert_rule.snuba_query.resolution
-                        * (self.alert_rule.threshold_period - 1)
-                    )
-                )
+                detected_at = self.calculate_event_date_from_update_date(self.last_update)
                 self.active_incident = create_incident(
                     self.alert_rule.organization,
                     IncidentType.ALERT_TRIGGERED,
@@ -261,6 +266,7 @@ class SubscriptionProcessor(object):
                     self.active_incident,
                     IncidentStatus.CLOSED,
                     status_method=IncidentStatusMethod.RULE_TRIGGERED,
+                    date_closed=self.calculate_event_date_from_update_date(self.last_update),
                 )
                 self.active_incident = None
                 self.incident_triggers.clear()

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -204,6 +204,9 @@ class SubscriptionProcessor(object):
                     self.alert_rule.name,
                     alert_rule=self.alert_rule,
                     date_started=detected_at,
+                    # TODO: This should probably be either the current time or the
+                    # message time. Current time likely makes most sense, since this is
+                    # when we actually noticed the problem.
                     date_detected=detected_at,
                     projects=[self.subscription.project],
                 )

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -182,11 +182,15 @@ class SubscriptionProcessor(object):
                 # labels them by the front. This causes us an off-by-one error with
                 # alert start dates, so to prevent this we subtract a bucket off of the
                 # start date.
-                # We also multiply by threshold_period so that we can show when the
-                # alert actually started happening, rather than when we detected it.
+                detected_at -= timedelta(seconds=self.alert_rule.snuba_query.time_window)
+                # We want to also subtract `frequency * (threshold_period - 1)` from the
+                # query. This allows us to show the actual start date of the alert,
+                # rather than the start of the last update that we received.
                 detected_at -= timedelta(
-                    seconds=self.alert_rule.snuba_query.time_window
-                    * self.alert_rule.threshold_period
+                    seconds=(
+                        self.alert_rule.snuba_query.resolution
+                        * (self.alert_rule.threshold_period - 1)
+                    )
                 )
                 self.active_incident = create_incident(
                     self.alert_rule.organization,

--- a/src/sentry/static/sentry/app/views/alerts/details/activity/statusItem.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/statusItem.tsx
@@ -37,6 +37,7 @@ class StatusItem extends React.Component<Props> {
     const {activity, authorName, incident, showTime} = this.props;
 
     const isDetected = activity.type === IncidentActivityType.DETECTED;
+    const isStarted = activity.type === IncidentActivityType.STARTED;
     const isClosed =
       activity.type === IncidentActivityType.STATUS_CHANGE &&
       activity.value === `${IncidentStatus.CLOSED}`;
@@ -44,7 +45,7 @@ class StatusItem extends React.Component<Props> {
       activity.type === IncidentActivityType.STATUS_CHANGE && !isClosed;
 
     // Unknown activity, don't render anything
-    if (!isDetected && !isClosed && !isTriggerChange) {
+    if (!isStarted && !isDetected && !isClosed && !isTriggerChange) {
       return null;
     }
 
@@ -83,12 +84,16 @@ class StatusItem extends React.Component<Props> {
               })}
             {isDetected &&
               (incident?.alertRule
-                ? tct('[user] was triggered', {
+                ? tct('[user] was detected', {
                     user: <StatusValue>{incident.alertRule.name}</StatusValue>,
                   })
                 : tct('[user] created an alert', {
                     user: <StatusValue>{authorName}</StatusValue>,
                   }))}
+            {isStarted &&
+              tct('[rule] started', {
+                rule: <StatusValue>{incident.alertRule.name}</StatusValue>,
+              })}
           </div>
         }
         date={getDynamicText({value: activity.dateCreated, fixed: new Date(0)})}

--- a/src/sentry/static/sentry/app/views/alerts/types.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/types.tsx
@@ -66,10 +66,11 @@ export enum IncidentType {
 }
 
 export enum IncidentActivityType {
-  CREATED,
-  DETECTED,
-  STATUS_CHANGE,
-  COMMENT,
+  CREATED = 0,
+  DETECTED = 1,
+  STATUS_CHANGE = 2,
+  COMMENT = 3,
+  STARTED = 4,
 }
 
 export enum IncidentStatus {

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -81,7 +81,7 @@ class CreateIncidentTest(TestCase):
     def test_simple(self):
         incident_type = IncidentType.ALERT_TRIGGERED
         title = "hello"
-        date_started = timezone.now()
+        date_started = timezone.now() - timedelta(minutes=5)
         alert_rule = create_alert_rule(
             self.organization, [self.project], "hello", "level:error", "count()", 10, 1
         )
@@ -105,6 +105,12 @@ class CreateIncidentTest(TestCase):
         assert IncidentProject.objects.filter(
             incident=incident, project__in=[self.project]
         ).exists()
+        assert (
+            IncidentActivity.objects.filter(
+                incident=incident, type=IncidentActivityType.STARTED.value, date_added=date_started
+            ).count()
+            == 1
+        )
         assert (
             IncidentActivity.objects.filter(
                 incident=incident, type=IncidentActivityType.DETECTED.value


### PR DESCRIPTION
We now write two activity items when an incident is created. 
They are 1: when the incident started and 2: when the incident was detected.

The backend adds support for this in #19358 and this adds the frontend support.

Before:
![Screen Shot 2020-06-18 at 8 00 27 AM](https://user-images.githubusercontent.com/6395250/85018272-e798ed00-b13a-11ea-98c2-23e93a13e25a.png)

After:
![Screen Shot 2020-06-18 at 8 02 23 AM](https://user-images.githubusercontent.com/6395250/85018290-f089be80-b13a-11ea-8fb8-ee55841bf994.png)

Looking for some feedback on the copy here from @adhiraj & others.