### PR TITLE
ref(pii): Hide event id field

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/form/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/form/form.tsx
@@ -6,6 +6,8 @@ import space from 'app/styles/space';
 import {t} from 'app/locale';
 import Input from 'app/views/settings/components/forms/controls/input';
 import Field from 'app/views/settings/components/forms/field';
+import Button from 'app/components/button';
+import {IconChevron} from 'app/icons';
 
 import EventIdField from './eventIdField';
 import SelectField from './selectField';
@@ -31,136 +33,169 @@ type Props<R extends Rule, K extends KeysOfUnion<R>> = {
   eventId?: EventId;
 };
 
-const Form = ({
-  rule,
-  errors,
-  sourceSuggestions,
-  onUpdateEventId,
-  eventId,
-  onChange,
-  onValidate,
-}: Props<Rule, KeysOfUnion<Rule>>) => {
-  const {source, type, method} = rule;
+type State = {
+  displayEventId: boolean;
+};
 
-  const handleChange = <K extends KeysOfUnion<Rule>>(field: K) => (
+class Form extends React.Component<Props<Rule, KeysOfUnion<Rule>>, State> {
+  state: State = {displayEventId: false};
+
+  handleChange = <K extends KeysOfUnion<Rule>>(field: K) => (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    onChange(field, event.target.value);
+    this.props.onChange(field, event.target.value);
   };
 
-  return (
-    <React.Fragment>
-      <GroupField hasTwoColumns={rule.method === MethodType.REPLACE}>
-        <Field
-          label={t('Method')}
-          help={t('What to do')}
-          inline={false}
-          flexibleControlStateSize
-          stacked
-          showHelpInTooltip
-        >
-          <SelectField
-            placeholder={t('Select method')}
-            name="method"
-            options={sortBy(Object.values(MethodType)).map(value => ({
-              ...getMethodLabel(value),
-              value,
-            }))}
-            value={method}
-            onChange={({value}) => onChange('method', value)}
-          />
-        </Field>
-        {rule.method === MethodType.REPLACE && (
+  handleToggleEventId = () => {
+    this.setState(prevState => ({displayEventId: !prevState.displayEventId}));
+  };
+
+  render() {
+    const {
+      rule,
+      onChange,
+      errors,
+      onValidate,
+      onUpdateEventId,
+      sourceSuggestions,
+      eventId,
+    } = this.props;
+    const {method, type, source} = rule;
+    const {displayEventId} = this.state;
+
+    return (
+      <React.Fragment>
+        <FieldGroup hasTwoColumns={rule.method === MethodType.REPLACE}>
           <Field
-            label={t('Custom Placeholder (Optional)')}
-            help={t('It will replace the default placeholder [Filtered]')}
+            label={t('Method')}
+            help={t('What to do')}
             inline={false}
             flexibleControlStateSize
             stacked
             showHelpInTooltip
           >
-            <Input
-              type="text"
-              name="placeholder"
-              placeholder={`[${t('Filtered')}]`}
-              onChange={handleChange('placeholder')}
-              value={rule.placeholder}
+            <SelectField
+              placeholder={t('Select method')}
+              name="method"
+              options={sortBy(Object.values(MethodType)).map(value => ({
+                ...getMethodLabel(value),
+                value,
+              }))}
+              value={method}
+              onChange={({value}) => onChange('method', value)}
             />
           </Field>
-        )}
-      </GroupField>
-      <GroupField hasTwoColumns={rule.type === RuleType.PATTERN}>
-        <Field
-          label={t('Data Type')}
-          help={t(
-            'What to look for. Use an existing pattern or define your own using regular expressions.'
+          {rule.method === MethodType.REPLACE && (
+            <Field
+              label={t('Custom Placeholder (Optional)')}
+              help={t('It will replace the default placeholder [Filtered]')}
+              inline={false}
+              flexibleControlStateSize
+              stacked
+              showHelpInTooltip
+            >
+              <Input
+                type="text"
+                name="placeholder"
+                placeholder={`[${t('Filtered')}]`}
+                onChange={this.handleChange('placeholder')}
+                value={rule.placeholder}
+              />
+            </Field>
           )}
-          inline={false}
-          flexibleControlStateSize
-          stacked
-          showHelpInTooltip
-        >
-          <SelectField
-            placeholder={t('Select type')}
-            name="type"
-            options={sortBy(Object.values(RuleType)).map(value => ({
-              label: getRuleLabel(value),
-              value,
-            }))}
-            value={type}
-            onChange={({value}) => onChange('type', value)}
-          />
-        </Field>
-        {rule.type === RuleType.PATTERN && (
+        </FieldGroup>
+        <FieldGroup hasTwoColumns={rule.type === RuleType.PATTERN}>
           <Field
-            label={t('Regex matches')}
-            help={t('Custom Perl-style regex (PCRE)')}
+            label={t('Data Type')}
+            help={t(
+              'What to look for. Use an existing pattern or define your own using regular expressions.'
+            )}
             inline={false}
-            error={errors?.pattern}
+            flexibleControlStateSize
+            stacked
+            showHelpInTooltip
+          >
+            <SelectField
+              placeholder={t('Select type')}
+              name="type"
+              options={sortBy(Object.values(RuleType)).map(value => ({
+                label: getRuleLabel(value),
+                value,
+              }))}
+              value={type}
+              onChange={({value}) => onChange('type', value)}
+            />
+          </Field>
+          {rule.type === RuleType.PATTERN && (
+            <Field
+              label={t('Regex matches')}
+              help={t('Custom Perl-style regex (PCRE)')}
+              inline={false}
+              error={errors?.pattern}
+              flexibleControlStateSize
+              stacked
+              required
+              showHelpInTooltip
+            >
+              <RegularExpression
+                type="text"
+                name="pattern"
+                placeholder={t('[a-zA-Z0-9]+')}
+                onChange={this.handleChange('pattern')}
+                value={rule.pattern}
+                onBlur={onValidate('pattern')}
+              />
+            </Field>
+          )}
+        </FieldGroup>
+        {onUpdateEventId && (
+          <React.Fragment>
+            <ToggleWrapper>
+              {displayEventId ? (
+                <Toggle priority="link" onClick={this.handleToggleEventId}>
+                  {t('Hide Event ID field')}
+                  <IconChevron direction="up" size="xs" />
+                </Toggle>
+              ) : (
+                <Toggle priority="link" onClick={this.handleToggleEventId}>
+                  {t('Use Event ID for auto-completion')}
+                  <IconChevron direction="down" size="xs" />
+                </Toggle>
+              )}
+            </ToggleWrapper>
+          </React.Fragment>
+        )}
+        <SourceGroup isExpanded={displayEventId}>
+          {onUpdateEventId && displayEventId && (
+            <EventIdField onUpdateEventId={onUpdateEventId} eventId={eventId} />
+          )}
+          <Field
+            label={t('Source')}
+            help={t('Where to look. In the simplest case this can be an attribute name.')}
+            inline={false}
+            error={errors?.source}
             flexibleControlStateSize
             stacked
             required
             showHelpInTooltip
           >
-            <RegularExpression
-              type="text"
-              name="pattern"
-              placeholder={t('[a-zA-Z0-9]+')}
-              onChange={handleChange('pattern')}
-              value={rule.pattern}
-              onBlur={onValidate('pattern')}
+            <SourceField
+              onChange={value => onChange('source', value)}
+              value={source}
+              onBlur={onValidate('source')}
+              isRegExMatchesSelected={type === RuleType.PATTERN}
+              suggestions={sourceSuggestions}
             />
           </Field>
-        )}
-      </GroupField>
-      {onUpdateEventId && (
-        <EventIdField onUpdateEventId={onUpdateEventId} eventId={eventId} />
-      )}
-      <Field
-        label={t('Source')}
-        help={t('Where to look. In the simplest case this can be an attribute name.')}
-        inline={false}
-        error={errors?.source}
-        flexibleControlStateSize
-        stacked
-        required
-        showHelpInTooltip
-      >
-        <SourceField
-          onChange={value => onChange('source', value)}
-          value={source}
-          onBlur={onValidate('source')}
-          isRegExMatchesSelected={type === RuleType.PATTERN}
-          suggestions={sourceSuggestions}
-        />
-      </Field>
-    </React.Fragment>
-  );
-};
+        </SourceGroup>
+      </React.Fragment>
+    );
+  }
+}
 
 export default Form;
 
-const GroupField = styled('div')<{hasTwoColumns: boolean}>`
+const FieldGroup = styled('div')<{hasTwoColumns: boolean}>`
   display: grid;
   margin-bottom: ${space(2)};
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
@@ -170,9 +205,45 @@ const GroupField = styled('div')<{hasTwoColumns: boolean}>`
   }
 `;
 
+const SourceGroup = styled('div')<{isExpanded: boolean}>`
+  height: 65px;
+  transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition-property: height;
+  ${p =>
+    p.isExpanded &&
+    `
+    border-radius: ${p.theme.borderRadius};
+    border: 1px solid ${p.theme.borderDark};
+    box-shadow: ${p.theme.dropShadowLight};
+    margin: ${space(2)} 0 ${space(3)} 0;
+    padding: ${space(2)};
+    height: 180px;
+  `}
+`;
+
 const RegularExpression = styled(Input)`
   font-size: ${p => p.theme.fontSizeSmall};
   input {
     font-family: ${p => p.theme.text.familyMono};
+  }
+`;
+
+const ToggleWrapper = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const Toggle = styled(Button)`
+  font-weight: 700;
+  color: ${p => p.theme.gray600};
+  &:hover,
+  &:focus {
+    color: ${p => p.theme.gray700};
+  }
+  > *:first-child {
+    display: grid;
+    grid-gap: ${space(0.5)};
+    grid-template-columns: repeat(2, max-content);
+    align-items: center;
   }
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/index.tsx
@@ -239,7 +239,13 @@ class DataScrubbing<T extends ProjectId = undefined> extends React.Component<
   };
 
   handleToggleAddRuleModal = (showAddRuleModal: boolean) => () => {
-    this.setState({showAddRuleModal});
+    this.setState(prevState => ({
+      showAddRuleModal,
+      eventId:
+        prevState.eventId?.status === EventIdStatus.LOADED
+          ? {value: ''}
+          : prevState.eventId,
+    }));
   };
 
   handleUpdateEventId = (eventId: string) => {

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/organizationRules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/organizationRules.tsx
@@ -60,7 +60,7 @@ class OrganizationRules extends React.Component<Props, State> {
         <Header onClick={this.handleToggleCollapsed}>
           <div>{t('Organization Rules')}</div>
           <Button
-            label={
+            title={
               isCollapsed
                 ? t('Expand Organization Rules')
                 : t('Collapse Organization Rules')

--- a/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
@@ -90,7 +90,7 @@ exports[`ConfirmDelete renders 1`] = `
                         className="css-wufuns-FieldLabel e16ushrl0"
                       >
                         <span>
-                          Please enter 
+                          Please enter
                           <code
                             key="1"
                           >

--- a/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
@@ -90,7 +90,7 @@ exports[`ConfirmDelete renders 1`] = `
                         className="css-wufuns-FieldLabel e16ushrl0"
                       >
                         <span>
-                          Please enter
+                          Please enter 
                           <code
                             key="1"
                           >


### PR DESCRIPTION
**Description:**

Because of some feedback we got, we decided to hide the event id field by default:

Before:

![image](https://user-images.githubusercontent.com/29228205/85024259-2a2beb00-b176-11ea-98fb-bf7d3aed9dd6.png)


After:

![Kapture 2020-06-18 at 15 11 37](https://user-images.githubusercontent.com/29228205/85024319-387a0700-b176-11ea-8e42-fad55171fd43.gif)

