### PR TITLE
feat(perf-views) Add hooks to performance sidebar item

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -401,7 +401,11 @@ class Sidebar extends React.Component<Props, State> {
                       </GuideAnchor>
                     </Feature>
                   )}
-                  <Feature features={['performance-view']} organization={organization}>
+                  <Feature
+                    hookName="feature-disabled:discover2-sidebar-item"
+                    features={['performance-view']}
+                    organization={organization}
+                  >
                     <SidebarItem
                       {...sidebarItemProps}
                       onClick={(_id, evt) =>

--- a/src/sentry/static/sentry/app/stores/hookStore.tsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.tsx
@@ -29,6 +29,7 @@ const validHookNames = new Set<HookName>([
   'feature-disabled:events-sidebar-item',
   'feature-disabled:grid-editable-actions',
   'feature-disabled:performance-page',
+  'feature-disabled:performance-sidebar-item',
   'feature-disabled:project-selector-checkbox',
   'feature-disabled:rate-limits',
   'feature-disabled:sso-basic',

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -90,6 +90,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:events-sidebar-item': FeatureDisabledHook;
   'feature-disabled:grid-editable-actions': FeatureDisabledHook;
   'feature-disabled:performance-page': FeatureDisabledHook;
+  'feature-disabled:performance-sidebar-item': FeatureDisabledHook;
   'feature-disabled:project-selector-checkbox': FeatureDisabledHook;
   'feature-disabled:rate-limits': FeatureDisabledHook;
   'feature-disabled:sso-basic': FeatureDisabledHook;


### PR DESCRIPTION
Add a hook to the performance sidebar item so that getsentry can override the disabled state and continue to show the button making the feature promotion page visible.