### PR TITLE
fix(slack): channel api deprecated

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -9,6 +9,7 @@ from django.core.cache import cache
 from django.core.urlresolvers import reverse
 
 from sentry import tagstore
+from sentry import options
 from sentry.api.fields.actor import Actor
 from sentry.incidents.logic import get_incident_aggregates
 from sentry.incidents.models import IncidentStatus, IncidentTrigger
@@ -373,11 +374,12 @@ def build_incident_attachment(incident, metric_value=None):
 
 # Different list types in slack that we'll use to resolve a channel name. Format is
 # (<list_name>, <result_name>, <prefix>).
-LIST_TYPES = [
+LEGACY_LIST_TYPES = [
     ("channels", "channels", CHANNEL_PREFIX),
     ("groups", "groups", CHANNEL_PREFIX),
     ("users", "members", MEMBER_PREFIX),
 ]
+LIST_TYPES = [("conversations", "channels", CHANNEL_PREFIX), ("users", "members", MEMBER_PREFIX)]
 
 
 def strip_channel_name(name):
@@ -418,12 +420,18 @@ def get_channel_id_with_timeout(integration, name, timeout):
     # Look for channel ID
     payload = dict(token_payload, **{"exclude_archived": False, "exclude_members": True})
 
+    if options.get("slack.legacy-app") is True:
+        list_types = LEGACY_LIST_TYPES
+    else:
+        list_types = LIST_TYPES
+        payload = dict(payload, **{"types": "public_channel,private_channel"})
+
     time_to_quit = time.time() + timeout
 
     client = SlackClient()
     id_data = None
     found_duplicate = False
-    for list_type, result_name, prefix in LIST_TYPES:
+    for list_type, result_name, prefix in list_types:
         cursor = ""
         while True:
             endpoint = "/%s.list" % list_type

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -122,6 +122,7 @@ register("slack.client-id", flags=FLAG_PRIORITIZE_DISK)
 register("slack.client-secret", flags=FLAG_PRIORITIZE_DISK)
 register("slack.verification-token", flags=FLAG_PRIORITIZE_DISK)
 register("slack.signing-secret", flags=FLAG_PRIORITIZE_DISK)
+register("slack.legacy-app", flags=FLAG_PRIORITIZE_DISK, type=Bool, default=True)
 
 # Slack V2 Integration
 register("slack-v2.client-id", flags=FLAG_PRIORITIZE_DISK)

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -115,6 +115,7 @@ def pytest_configure(config):
             "slack.client-id": "slack-client-id",
             "slack.client-secret": "slack-client-secret",
             "slack.verification-token": "slack-verification-token",
+            "slack.legacy-app": True,
             "github-app.name": "sentry-test-app",
             "github-app.client-id": "github-client-id",
             "github-app.client-secret": "github-client-secret",


### PR DESCRIPTION
Slack api https://slack.com/api/channels.* is deprecated see:
[Deprecating early methods in favor of the Conversations API](https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api)
All new slack apps created after June 10th, 2020 will give error, which
creates issue for on premise sentry.

This commit fixes the issue by adding `slack.legacy-app=(true/false)` to `sentry.yml`
config so that it continues support for legacy slack apps while new apps
can toggle this option for new slack API support

Resolves: #7897