### PR TITLE
fix(ui) Improve styling of chart option selector

### DIFF
--- a/docs-ui/components/charts-optionselector.stories.js
+++ b/docs-ui/components/charts-optionselector.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+import {action} from '@storybook/addon-actions';
+import {text} from '@storybook/addon-knobs';
+
+import OptionSelector from 'app/components/charts/optionSelector';
+import space from 'app/styles/space';
+
+const options = [
+  {value: 'all', label: 'All things'},
+  {value: 'none', label: 'No things'},
+  {value: 'top5', label: 'Top 5 things that is a much longer title'},
+  {value: 'nope', disabled: true, label: 'Disabled option'},
+  {value: 'more', label: 'Additional option'},
+];
+
+storiesOf('Charts|OptionSelector', module).add(
+  'default',
+  withInfo('Selector control for chart controls')(() => (
+    <Container>
+      <OptionSelector
+        options={options}
+        selected={text('selected', 'none')}
+        title={text('title', 'Display')}
+        menuWidth={text('menuWidth', '200px')}
+        onChange={action('changed')}
+      />
+    </Container>
+  ))
+);
+
+const Container = styled('div')`
+  padding: ${space(2)} ${space(3)};
+`;

--- a/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
+++ b/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
 import DropdownButton from 'app/components/dropdownButton';
+import DropdownMenu from 'app/components/dropdownMenu';
 import {InlineContainer, SectionHeading} from 'app/components/charts/styles';
-import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
+import {DropdownItem} from 'app/components/dropdownControl';
+import DropdownBubble from 'app/components/dropdownBubble';
 import space from 'app/styles/space';
 
 type Option = {
@@ -27,42 +29,62 @@ function OptionSelector({options, onChange, selected, title, menuWidth = 'auto'}
   return (
     <InlineContainer>
       <SectionHeading>{title}</SectionHeading>
-      <DropdownControl
-        menuWidth={menuWidth}
-        alignRight
-        button={({getActorProps}) => (
-          <StyledDropdownButton {...getActorProps()} size="zero" isOpen={false}>
-            {selectedOption.label}
-          </StyledDropdownButton>
-        )}
-      >
-        {options.map(opt => (
-          <DropdownItem
-            key={opt.value}
-            onSelect={onChange}
-            eventKey={opt.value}
-            disabled={opt.disabled}
-            isActive={selected === opt.value}
-            data-test-id={`option-${opt.value}`}
-          >
-            {opt.label}
-          </DropdownItem>
-        ))}
-      </DropdownControl>
+      <MenuContainer>
+        <DropdownMenu alwaysRenderMenu={false}>
+          {({isOpen, getMenuProps, getActorProps}) => (
+            <React.Fragment>
+              <StyledDropdownButton {...getActorProps()} size="zero" isOpen={isOpen}>
+                {selectedOption.label}
+              </StyledDropdownButton>
+              <StyledDropdownBubble
+                {...getMenuProps()}
+                alignMenu="right"
+                width={menuWidth}
+                isOpen={isOpen}
+                blendWithActor={false}
+                blendCorner
+              >
+                {options.map(opt => (
+                  <DropdownItem
+                    key={opt.value}
+                    onSelect={onChange}
+                    eventKey={opt.value}
+                    disabled={opt.disabled}
+                    isActive={selected === opt.value}
+                    data-test-id={`option-${opt.value}`}
+                  >
+                    {opt.label}
+                  </DropdownItem>
+                ))}
+              </StyledDropdownBubble>
+            </React.Fragment>
+          )}
+        </DropdownMenu>
+      </MenuContainer>
     </InlineContainer>
   );
 }
+
+const MenuContainer = styled('div')`
+  display: inline-block;
+  position: relative;
+`;
 
 const StyledDropdownButton = styled(DropdownButton)`
   padding: ${space(1)} ${space(2)};
   font-weight: normal;
   color: ${p => p.theme.gray600};
+  z-index: ${p => p.theme.zIndex.dropdownAutocomplete.actor};
 
   &:hover,
   &:focus,
   &:active {
     color: ${p => p.theme.gray700};
   }
+`;
+
+const StyledDropdownBubble = styled(DropdownBubble)<{isOpen: boolean}>`
+  display: ${p => (p.isOpen ? 'block' : 'none')};
 `;
 
 OptionSelector.propTypes = {

--- a/src/sentry/static/sentry/app/components/dropdownBubble.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownBubble.tsx
@@ -25,8 +25,6 @@ type Params = {
    * enable the arrow on the menu
    */
   menuWithArrow?: boolean;
-
-  theme: Theme;
 };
 
 /**
@@ -40,7 +38,7 @@ const getMenuBorderRadius = ({
   alignMenu,
   width,
   theme,
-}: Params) => {
+}: Params & {theme: Theme}) => {
   const radius = theme.borderRadius;
   if (!blendCorner) {
     return css`


### PR DESCRIPTION
Make it look better and match the design of our dropdown autocomplete elements.

## Before

![Screen Shot 2020-06-18 at 11 22 35 AM](https://user-images.githubusercontent.com/24086/85043797-c5af6280-b15a-11ea-8d15-8b01f9972a54.png)

## After

![Screen Shot 2020-06-18 at 11 41 37 AM](https://user-images.githubusercontent.com/24086/85043811-ce079d80-b15a-11ea-8e29-4fcb2a0a32b0.png)
