### PR TITLE
fix(apm): Remove add/exclude cell actions from some fields

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -120,7 +120,11 @@ class CellAction extends React.Component<Props, State> {
       }
     }
 
-    if (column.type !== 'duration') {
+    if (
+      column.type !== 'duration' &&
+      column.type !== 'number' &&
+      column.type !== 'percentage'
+    ) {
       addMenuItem(
         Actions.ADD,
         <ActionItem

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -155,5 +155,53 @@ describe('Discover -> CellAction', function() {
         '2020-06-09T01:46:25+00:00'
       );
     });
+
+    it('show appropriate actions for string cells', function() {
+      wrapper = makeWrapper(view, handleCellAction, 0);
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+      expect(wrapper.find('button[data-test-id="add-to-filter"]').exists()).toBeTruthy();
+      expect(
+        wrapper.find('button[data-test-id="exclude-from-filter"]').exists()
+      ).toBeTruthy();
+      expect(
+        wrapper.find('button[data-test-id="show-values-greater-than"]').exists()
+      ).toBeFalsy();
+      expect(
+        wrapper.find('button[data-test-id="show-values-less-than"]').exists()
+      ).toBeFalsy();
+    });
+
+    it('show appropriate actions for number cells', function() {
+      wrapper = makeWrapper(view, handleCellAction, 1);
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+      expect(wrapper.find('button[data-test-id="add-to-filter"]').exists()).toBeFalsy();
+      expect(
+        wrapper.find('button[data-test-id="exclude-from-filter"]').exists()
+      ).toBeFalsy();
+      expect(
+        wrapper.find('button[data-test-id="show-values-greater-than"]').exists()
+      ).toBeTruthy();
+      expect(
+        wrapper.find('button[data-test-id="show-values-less-than"]').exists()
+      ).toBeTruthy();
+    });
+
+    it('show appropriate actions for date cells', function() {
+      wrapper = makeWrapper(view, handleCellAction, 2);
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+      expect(wrapper.find('button[data-test-id="add-to-filter"]').exists()).toBeTruthy();
+      expect(
+        wrapper.find('button[data-test-id="exclude-from-filter"]').exists()
+      ).toBeTruthy();
+      expect(
+        wrapper.find('button[data-test-id="show-values-greater-than"]').exists()
+      ).toBeTruthy();
+      expect(
+        wrapper.find('button[data-test-id="show-values-less-than"]').exists()
+      ).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
Currently, there are cell actions to add/exclude tpm(), apdex(), failure_rate()
and users to the search conditions. Searching for the exact value for these
fields do not make much sense. This change removes add/remove cell actions from
these fields but keeps the show greater/less than actions.