### PR TITLE
build(github): Fix migration check always failing

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -101,4 +101,4 @@ jobs:
             PGPASSWORD: postgres
           run: |
             # Below will exit with non-zero status if model changes are missing migrations
-            sentry django makemigrations -n ci_test --check --dry-run --no-input || echo '::error::Error: Migration required -- to generate a migration, run `sentry django makemigrations -n <some_name>`' && exit 1
+            sentry django makemigrations -n ci_test --check --dry-run --no-input || (echo '::error::Error: Migration required -- to generate a migration, run `sentry django makemigrations -n <some_name>`' && exit 1)


### PR DESCRIPTION
Order of operations causing migration check to always exit with an error.