### PR TITLE
fix(discover): Removing unused pagination

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -193,7 +193,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
             },
         )
         with self.feature("organizations:discover-basic"):
-            response = self.client.get(url, format="json",)
+            response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
         trace = response.data["contexts"]["trace"]

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -67,6 +67,8 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         ):
             response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
+        assert response.data["id"] == "a" * 32
+        assert response.data["projectSlug"] == self.project.slug
 
     def test_simple(self):
         url = reverse(
@@ -83,43 +85,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == "a" * 32
-        assert response.data["previousEventID"] is None
-        assert response.data["nextEventID"] == format_project_event(self.project.slug, "b" * 32)
         assert response.data["projectSlug"] == self.project.slug
-
-    def test_simple_out_of_range_pagination(self):
-        two_weeks_ago = iso_format(before_now(days=14))
-        self.store_event(
-            data={
-                "event_id": "d" * 32,
-                "message": "very old, very bad",
-                "timestamp": two_weeks_ago,
-                "fingerprint": ["group-3"],
-            },
-            project_id=self.project.id,
-        )
-        url = reverse(
-            "sentry-api-0-organization-event-details",
-            kwargs={
-                "organization_slug": self.project.organization.slug,
-                "project_slug": self.project.slug,
-                "event_id": "d" * 32,
-            },
-        )
-
-        with self.feature("organizations:discover-basic"):
-            response = self.client.get(
-                url,
-                data={"field": ["title", "count_unique(user)"], "statsPeriod": "24h"},
-                format="json",
-            )
-
-        assert response.status_code == 200, response.content
-        assert response.data["id"] == "d" * 32
-        assert response.data["previousEventID"] is None
-        assert response.data["nextEventID"] is None
-        assert response.data["latestEventID"] is None
-        assert response.data["oldestEventID"] is None
 
     def test_simple_transaction(self):
         min_ago = iso_format(before_now(minutes=1))
@@ -146,43 +112,8 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json")
         assert response.status_code == 200
-
-    def test_multi_project_pagination(self):
-        self.store_event(
-            data={
-                "event_id": "d" * 32,
-                "message": "hello world",
-                "timestamp": iso_format(before_now(minutes=2, seconds=30)),
-                "fingerprint": ["group-3"],
-            },
-            project_id=self.project_2.id,
-        )
-        url = reverse(
-            "sentry-api-0-organization-event-details",
-            kwargs={
-                "organization_slug": self.project_2.organization.slug,
-                "project_slug": self.project_2.slug,
-                "event_id": "d" * 32,
-            },
-        )
-
-        with self.feature("organizations:discover-basic"):
-            response = self.client.get(
-                url,
-                data={
-                    "field": ["project", "count(id)", "count_unique(issue.id)"],
-                    "statsPeriod": "24h",
-                    "sort": "-count_id",
-                },
-                format="json",
-            )
-
-        assert response.status_code == 200, response.content
         assert response.data["id"] == "d" * 32
-        assert response.data["previousEventID"] == format_project_event(self.project.slug, "a" * 32)
-        assert response.data["nextEventID"] == format_project_event(self.project.slug, "b" * 32)
-        assert response.data["latestEventID"] == format_project_event(self.project.slug, "c" * 32)
-        assert response.data["oldestEventID"] == format_project_event(self.project.slug, "a" * 32)
+        assert response.data["type"] == "transaction"
 
     def test_no_access_missing_feature(self):
         with self.feature({"organizations:discover-basic": False}):
@@ -245,272 +176,6 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 404, response.content
 
-    def test_event_links_with_field_parameter(self):
-        # Create older and newer events
-        ten_sec_ago = iso_format(before_now(seconds=10))
-        self.store_event(
-            data={"event_id": "2" * 32, "message": "no match", "timestamp": ten_sec_ago},
-            project_id=self.project.id,
-        )
-        thirty_sec_ago = iso_format(before_now(seconds=30))
-        self.store_event(
-            data={"event_id": "1" * 32, "message": "very bad", "timestamp": thirty_sec_ago},
-            project_id=self.project.id,
-        )
-        five_min_ago = iso_format(before_now(minutes=5))
-        self.store_event(
-            data={"event_id": "d" * 32, "message": "very bad", "timestamp": five_min_ago},
-            project_id=self.project.id,
-        )
-        seven_min_ago = iso_format(before_now(minutes=7))
-        self.store_event(
-            data={"event_id": "e" * 32, "message": "very bad", "timestamp": seven_min_ago},
-            project_id=self.project.id,
-        )
-        eight_min_ago = iso_format(before_now(minutes=8))
-        self.store_event(
-            data={"event_id": "f" * 32, "message": "no match", "timestamp": eight_min_ago},
-            project_id=self.project.id,
-        )
-
-        url = reverse(
-            "sentry-api-0-organization-event-details",
-            kwargs={
-                "organization_slug": self.project.organization.slug,
-                "project_slug": self.project.slug,
-                "event_id": "b" * 32,
-            },
-        )
-        with self.feature("organizations:discover-basic"):
-            response = self.client.get(url, format="json", data={"field": ["message", "count()"]})
-        assert response.data["eventID"] == "b" * 32
-        assert response.data["nextEventID"] == format_project_event(
-            self.project.slug, "c" * 32
-        ), "c is newer & matches message"
-        assert response.data["previousEventID"] == format_project_event(
-            self.project.slug, "d" * 32
-        ), "d is older & matches message"
-        assert response.data["oldestEventID"] == format_project_event(
-            self.project.slug, "e" * 32
-        ), "e is oldest matching message"
-        assert response.data["latestEventID"] == format_project_event(
-            self.project.slug, "1" * 32
-        ), "1 is newest matching message"
-
-    def test_event_links_with_date_range(self):
-        # Create older in and out of range events
-        ten_day_ago = iso_format(before_now(days=14))
-        self.store_event(
-            data={"event_id": "3" * 32, "message": "very bad", "timestamp": ten_day_ago},
-            project_id=self.project.id,
-        )
-        seven_min_ago = iso_format(before_now(minutes=7))
-        self.store_event(
-            data={"event_id": "2" * 32, "message": "very bad", "timestamp": seven_min_ago},
-            project_id=self.project.id,
-        )
-
-        url = reverse(
-            "sentry-api-0-organization-event-details",
-            kwargs={
-                "organization_slug": self.project.organization.slug,
-                "project_slug": self.project.slug,
-                "event_id": "b" * 32,
-            },
-        )
-        with self.feature("organizations:discover-basic"):
-            response = self.client.get(
-                url, format="json", data={"field": ["message", "count()"], "statsPeriod": "7d"}
-            )
-        assert response.data["eventID"] == "b" * 32
-        assert response.data["nextEventID"] == format_project_event(
-            self.project.slug, "c" * 32
-        ), "c is newer & matches message + range"
-        assert response.data["previousEventID"] == format_project_event(
-            self.project.slug, "2" * 32
-        ), "d is older & matches message + range"
-        assert response.data["oldestEventID"] == format_project_event(
-            self.project.slug, "2" * 32
-        ), "3 is outside range, no match"
-        assert response.data["latestEventID"] == format_project_event(
-            self.project.slug, "c" * 32
-        ), "c is newest matching message"
-
-    def test_event_links_with_tag_fields(self):
-        # Create events that overlap with other event messages but
-        # with different tags
-        ten_sec_ago = iso_format(before_now(seconds=10))
-        self.store_event(
-            data={
-                "event_id": "2" * 32,
-                "message": "very bad",
-                "timestamp": ten_sec_ago,
-                "tags": {"important": "yes"},
-            },
-            project_id=self.project.id,
-        )
-        thirty_sec_ago = iso_format(before_now(seconds=30))
-        self.store_event(
-            data={
-                "event_id": "1" * 32,
-                "message": "very bad",
-                "timestamp": thirty_sec_ago,
-                "tags": {"important": "yes"},
-            },
-            project_id=self.project.id,
-        )
-        five_min_ago = iso_format(before_now(minutes=5))
-        self.store_event(
-            data={
-                "event_id": "d" * 32,
-                "message": "very bad",
-                "timestamp": five_min_ago,
-                "tags": {"important": "no"},
-            },
-            project_id=self.project.id,
-        )
-
-        url = reverse(
-            "sentry-api-0-organization-event-details",
-            kwargs={
-                "organization_slug": self.project.organization.slug,
-                "project_slug": self.project.slug,
-                "event_id": "1" * 32,
-            },
-        )
-        with self.feature("organizations:discover-basic"):
-            response = self.client.get(url, format="json", data={"field": ["important", "count()"]})
-        assert response.data["eventID"] == "1" * 32
-        assert response.data["previousEventID"] is None, "no matching tags"
-        assert response.data["oldestEventID"] is None, "no older matching events"
-        assert response.data["nextEventID"] == format_project_event(
-            self.project.slug, "2" * 32
-        ), "2 is older and has matching tags "
-        assert response.data["latestEventID"] == format_project_event(
-            self.project.slug, "2" * 32
-        ), "2 is oldest matching message"
-
-    def test_event_links_with_transaction_events(self):
-        prototype = {
-            "type": "transaction",
-            "transaction": "api.issue.delete",
-            "spans": [],
-            "contexts": {"trace": {"op": "foobar", "trace_id": "a" * 32, "span_id": "a" * 16}},
-            "tags": {"important": "yes"},
-        }
-        fixtures = (
-            ("d" * 32, before_now(minutes=1)),
-            ("e" * 32, before_now(minutes=2)),
-            ("f" * 32, before_now(minutes=3)),
-        )
-        for fixture in fixtures:
-            data = prototype.copy()
-            data["event_id"] = fixture[0]
-            data["timestamp"] = iso_format(fixture[1])
-            data["start_timestamp"] = iso_format(fixture[1] - timedelta(seconds=5))
-            self.store_event(data=data, project_id=self.project.id)
-
-        url = reverse(
-            "sentry-api-0-organization-event-details",
-            kwargs={
-                "organization_slug": self.project.organization.slug,
-                "project_slug": self.project.slug,
-                "event_id": "e" * 32,
-            },
-        )
-        with self.feature("organizations:discover-basic"):
-            response = self.client.get(
-                url,
-                format="json",
-                data={"field": ["important", "count()"], "query": "transaction.duration:>2"},
-            )
-        assert response.status_code == 200
-        assert response.data["nextEventID"] == format_project_event(self.project.slug, "d" * 32)
-        assert response.data["previousEventID"] == format_project_event(self.project.slug, "f" * 32)
-
-    def test_event_links_with_transaction_events_aggregate_fields(self):
-        prototype = {
-            "type": "transaction",
-            "transaction": "api.issue.delete",
-            "spans": [],
-            "contexts": {"trace": {"op": "foobar", "trace_id": "a" * 32, "span_id": "a" * 16}},
-            "tags": {"important": "yes"},
-        }
-        fixtures = (
-            ("d" * 32, before_now(minutes=1)),
-            ("e" * 32, before_now(minutes=2)),
-            ("f" * 32, before_now(minutes=3)),
-        )
-        for fixture in fixtures:
-            data = prototype.copy()
-            data["event_id"] = fixture[0]
-            data["timestamp"] = iso_format(fixture[1])
-            data["start_timestamp"] = iso_format(fixture[1] - timedelta(seconds=5))
-            self.store_event(data=data, project_id=self.project.id)
-
-        url = reverse(
-            "sentry-api-0-organization-event-details",
-            kwargs={
-                "organization_slug": self.project.organization.slug,
-                "project_slug": self.project.slug,
-                "event_id": "e" * 32,
-            },
-        )
-        with self.feature("organizations:discover-basic"):
-            response = self.client.get(
-                url,
-                format="json",
-                data={
-                    "field": ["important", "count()", "p95()"],
-                    "query": "transaction.duration:>2",
-                },
-            )
-        assert response.status_code == 200
-        assert response.data["nextEventID"] == format_project_event(self.project.slug, "d" * 32)
-        assert response.data["previousEventID"] == format_project_event(self.project.slug, "f" * 32)
-
-    def test_event_links_with_transaction_events_aggregate_conditions(self):
-        prototype = {
-            "type": "transaction",
-            "transaction": "api.issue.delete",
-            "spans": [],
-            "contexts": {"trace": {"op": "foobar", "trace_id": "a" * 32, "span_id": "a" * 16}},
-            "tags": {"important": "yes"},
-        }
-        fixtures = (
-            ("d" * 32, before_now(minutes=1)),
-            ("e" * 32, before_now(minutes=2)),
-            ("f" * 32, before_now(minutes=3)),
-        )
-        for fixture in fixtures:
-            data = prototype.copy()
-            data["event_id"] = fixture[0]
-            data["timestamp"] = iso_format(fixture[1])
-            data["start_timestamp"] = iso_format(fixture[1] - timedelta(seconds=5))
-            self.store_event(data=data, project_id=self.project.id)
-
-        url = reverse(
-            "sentry-api-0-organization-event-details",
-            kwargs={
-                "organization_slug": self.project.organization.slug,
-                "project_slug": self.project.slug,
-                "event_id": "e" * 32,
-            },
-        )
-        with self.feature("organizations:discover-basic"):
-            response = self.client.get(
-                url,
-                format="json",
-                data={
-                    "field": ["important", "count()", "p95()"],
-                    "query": "transaction.duration:>2 p95():>0",
-                },
-            )
-
-        assert response.status_code == 200, response.content
-        assert response.data["nextEventID"] == format_project_event(self.project.slug, "d" * 32)
-        assert response.data["previousEventID"] == format_project_event(self.project.slug, "f" * 32)
-
     def test_long_trace_description(self):
         data = load_data("transaction")
         data["event_id"] = "d" * 32
@@ -528,14 +193,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
             },
         )
         with self.feature("organizations:discover-basic"):
-            response = self.client.get(
-                url,
-                format="json",
-                data={
-                    "field": ["important", "count()", "p95()"],
-                    "query": "transaction.duration:>2 p95():>0",
-                },
-            )
+            response = self.client.get(url, format="json",)
 
         assert response.status_code == 200, response.content
         trace = response.data["contexts"]["trace"]
@@ -563,6 +221,4 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == "a" * 32
-        assert response.data["previousEventID"] is None
-        assert response.data["nextEventID"] == format_project_event(self.project.slug, "b" * 32)
         assert response.data["projectSlug"] == self.project.slug


### PR DESCRIPTION
- This endpoint is no longer needs pagination due to the new flow we
  have.
  - Removing fields since this was used to get the reference event
  - Removing tests that were based on pagination/fields