### PR TITLE
fix(metric_alerts): Temporarily disable pending incident snapshot processor

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -681,11 +681,11 @@ CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(hours=6),
         "options": {"expires": 60 * 25},
     },
-    "process_pending_incident_snapshots": {
-        "task": "sentry.incidents.tasks.process_pending_incident_snapshots",
-        "schedule": timedelta(hours=1),
-        "options": {"expires": 3600, "queue": "incidents"},
-    },
+    # "process_pending_incident_snapshots": {
+    #     "task": "sentry.incidents.tasks.process_pending_incident_snapshots",
+    #     "schedule": timedelta(hours=1),
+    #     "options": {"expires": 3600, "queue": "incidents"},
+    # },
 }
 
 BGTASKS = {

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -187,9 +187,9 @@ def auto_resolve_snapshot_incidents(alert_rule_id, **kwargs):
         )
 
 
-@instrumented_task(
-    name="sentry.incidents.tasks.process_pending_incident_snapshots", queue="incident_snapshots"
-)
+# @instrumented_task(
+#     name="sentry.incidents.tasks.process_pending_incident_snapshots", queue="incident_snapshots"
+# )
 def process_pending_incident_snapshots():
     """
     Processes PendingIncidentSnapshots and creates a snapshot for any snapshot that


### PR DESCRIPTION
Disabling this so that we can delete/recreate the queue. This is only ever used as a celerybeat task so just commenting out a couple lines.