### PR TITLE
fix(ui): hyphenate commit messages in suggested owner hovercard

### DIFF
--- a/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
@@ -174,6 +174,7 @@ const CommitMessage = styled(({message = '', date, ...props}) => (
   color: ${p => p.theme.gray800};
   font-size: 11px;
   margin-top: ${space(0.25)};
+  hyphens: auto;
 `;
 
 const CommitDate = styled(({date, ...props}) => (


### PR DESCRIPTION
Since the commit message can contain long strings, it might overflow the hovercard container.
Added `hyphens:auto` to make sure that long non-breaking strings are correctly broken and hyphenated.

Fixes #19455 

<img width="357" alt="Screenshot 2020-06-19 at 12 23 14 AM" src="https://user-images.githubusercontent.com/12510548/85062479-2d4ec780-b1c6-11ea-8b9e-df34d4c5c05c.png">
<img width="343" alt="Screenshot 2020-06-19 at 12 23 37 AM" src="https://user-images.githubusercontent.com/12510548/85062484-2fb12180-b1c6-11ea-830f-e93fece421e4.png">
