### PR TITLE
fix(discover): Remove apdex, impact, user_misery columns during drilldown

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -1,5 +1,6 @@
 import Papa from 'papaparse';
 import {Location, Query} from 'history';
+import isEmpty from 'lodash/isEmpty';
 import {browserHistory} from 'react-router';
 
 import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
@@ -265,7 +266,15 @@ export function getExpandedResults(
         field = 'id';
       }
 
-      if (!field) {
+      // if at least one of the parameters to the function is an available column,
+      // then we should proceed to replace it with the column, however, for functions
+      // like apdex that takes a number as its parameter we should delete it
+      const {parameters = []} = AGGREGATIONS[exploded.function[0]] ?? {};
+      if (
+        !field ||
+        (!isEmpty(parameters) &&
+          parameters.every(parameter => parameter.kind !== 'column'))
+      ) {
         // This is a function with no field alias. We delete this column as it'll add a blank column in the drilldown.
         fieldsToDelete.push(indexToUpdate);
         return;

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -1,6 +1,5 @@
 import Papa from 'papaparse';
 import {Location, Query} from 'history';
-import isEmpty from 'lodash/isEmpty';
 import {browserHistory} from 'react-router';
 
 import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
@@ -272,7 +271,7 @@ export function getExpandedResults(
       const {parameters = []} = AGGREGATIONS[exploded.function[0]] ?? {};
       if (
         !field ||
-        (!isEmpty(parameters) &&
+        (parameters.length > 0 &&
           parameters.every(parameter => parameter.kind !== 'column'))
       ) {
         // This is a function with no field alias. We delete this column as it'll add a blank column in the drilldown.

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -242,8 +242,9 @@ describe('getExpandedResults()', function() {
         {field: 'custom_tag'},
         {field: 'title'}, // not expected to be dropped
         {field: 'unique_count(id)'},
-        {field: 'apdex()'}, // should be dropped
-        {field: 'impact()'}, // should be dropped
+        {field: 'apdex(300)'}, // should be dropped
+        {field: 'impact(300)'}, // should be dropped
+        {field: 'user_misery(300)'}, // should be dropped
       ],
     });
 


### PR DESCRIPTION
Clicking the Open Stack CTA will expand the arguments to functions including
apdex, impact, and user_misery which previously had no arguments but now
takes a single number. This causes the drilldown to create a column for the
number. This change will remove all aggregations that does not take another
column (apdex, impact and user_misery) as its argument as they cannot be
expanded.