### PR TITLE
Revert "fix(metric_alerts): Temporarily disable pending incident snapshot processor (#19454)"

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -681,11 +681,11 @@ CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(hours=6),
         "options": {"expires": 60 * 25},
     },
-    # "process_pending_incident_snapshots": {
-    #     "task": "sentry.incidents.tasks.process_pending_incident_snapshots",
-    #     "schedule": timedelta(hours=1),
-    #     "options": {"expires": 3600, "queue": "incidents"},
-    # },
+    "process_pending_incident_snapshots": {
+        "task": "sentry.incidents.tasks.process_pending_incident_snapshots",
+        "schedule": timedelta(hours=1),
+        "options": {"expires": 3600, "queue": "incidents"},
+    },
 }
 
 BGTASKS = {

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -187,9 +187,9 @@ def auto_resolve_snapshot_incidents(alert_rule_id, **kwargs):
         )
 
 
-# @instrumented_task(
-#     name="sentry.incidents.tasks.process_pending_incident_snapshots", queue="incident_snapshots"
-# )
+@instrumented_task(
+    name="sentry.incidents.tasks.process_pending_incident_snapshots", queue="incident_snapshots"
+)
 def process_pending_incident_snapshots():
     """
     Processes PendingIncidentSnapshots and creates a snapshot for any snapshot that


### PR DESCRIPTION
This reverts commit 40c14fb07bf8d6c7d227d81a685ae011549bc751. We've cleared the queue and merged a pr that defines the queue correctly: https://github.com/getsentry/sentry/pull/19385. This task should be good to run now.