### PR TITLE
fix(ui) Don't show a double tooltip on data export

### DIFF
--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -126,7 +126,7 @@ class DataExport extends React.Component<Props, State> {
 const NewButton = ({children, ...buttonProps}) => (
   <Button {...buttonProps}>
     {children}
-    <FeatureBadge type="new" />
+    <FeatureBadge type="new" noTooltip />
   </Button>
 );
 


### PR DESCRIPTION
## Before
![image (1)](https://user-images.githubusercontent.com/24086/85071795-08d2fb00-b186-11ea-9a31-ee4ba813f6ce.png)

## After
![Screen Shot 2020-06-18 at 4 54 57 PM](https://user-images.githubusercontent.com/24086/85071722-ec36c300-b185-11ea-9549-9ef49e18dd83.png)
