### PR TITLE
fix(ui): make sidebar links without href keyboard accessible

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
@@ -104,9 +104,10 @@ const SidebarItem = ({
       <StyledSidebarItem
         data-test-id={props['data-test-id']}
         active={isActive ? 'true' : undefined}
-        to={(to ? to : href) || ''}
+        to={(to ? to : href) || '#'}
         className={className}
         onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
+          !(to || href) && event.preventDefault();
           typeof onClick === 'function' && onClick(id, event);
           showIsNew && localStorage.setItem(isNewSeenKey, 'true');
         }}

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -2313,25 +2313,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/projects/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/issues/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/releases/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/user-feedback/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/activity/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/stats/",
-                                        ],
-                                        Array [
-                                          "/settings/org-slug/",
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -2355,6 +2346,15 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
                                           "/organizations/org-slug/projects/",
                                         ],
                                         Array [
@@ -2374,6 +2374,45 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         ],
                                         Array [
                                           "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/projects/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/issues/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/releases/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/user-feedback/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/activity/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/stats/",
+                                        ],
+                                        Array [
+                                          "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -2399,8 +2438,81 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         Array [
                                           "https://forum.sentry.io/",
                                         ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
                                       ],
                                       "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
                                         Object {
                                           "type": "return",
                                           "value": undefined,
@@ -2865,25 +2977,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/projects/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/issues/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/releases/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/user-feedback/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/activity/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/stats/",
-                                        ],
-                                        Array [
-                                          "/settings/org-slug/",
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -2907,6 +3010,15 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
                                           "/organizations/org-slug/projects/",
                                         ],
                                         Array [
@@ -2926,6 +3038,45 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         ],
                                         Array [
                                           "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/projects/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/issues/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/releases/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/user-feedback/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/activity/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/stats/",
+                                        ],
+                                        Array [
+                                          "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -2951,8 +3102,81 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         Array [
                                           "https://forum.sentry.io/",
                                         ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
                                       ],
                                       "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
                                         Object {
                                           "type": "return",
                                           "value": undefined,
@@ -3800,25 +4024,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/projects/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/issues/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/releases/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/user-feedback/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/activity/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/stats/",
-                                        ],
-                                        Array [
-                                          "/settings/org-slug/",
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -3842,6 +4057,15 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
                                           "/organizations/org-slug/projects/",
                                         ],
                                         Array [
@@ -3861,6 +4085,45 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         ],
                                         Array [
                                           "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/projects/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/issues/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/releases/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/user-feedback/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/activity/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/stats/",
+                                        ],
+                                        Array [
+                                          "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -3886,8 +4149,81 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         Array [
                                           "https://forum.sentry.io/",
                                         ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
                                       ],
                                       "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
                                         Object {
                                           "type": "return",
                                           "value": undefined,
@@ -4574,25 +4910,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/projects/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/issues/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/releases/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/user-feedback/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/activity/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/stats/",
-                                        ],
-                                        Array [
-                                          "/settings/org-slug/",
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -4616,6 +4943,15 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
                                           "/organizations/org-slug/projects/",
                                         ],
                                         Array [
@@ -4635,6 +4971,45 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         ],
                                         Array [
                                           "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/projects/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/issues/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/releases/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/user-feedback/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/activity/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/stats/",
+                                        ],
+                                        Array [
+                                          "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -4660,8 +5035,81 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         Array [
                                           "https://forum.sentry.io/",
                                         ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
                                       ],
                                       "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
                                         Object {
                                           "type": "return",
                                           "value": undefined,
@@ -5368,25 +5816,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/projects/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/issues/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/releases/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/user-feedback/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/activity/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/stats/",
-                                        ],
-                                        Array [
-                                          "/settings/org-slug/",
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -5410,6 +5849,15 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
                                           "/organizations/org-slug/projects/",
                                         ],
                                         Array [
@@ -5429,6 +5877,45 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         ],
                                         Array [
                                           "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/projects/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/issues/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/releases/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/user-feedback/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/activity/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/stats/",
+                                        ],
+                                        Array [
+                                          "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -5454,8 +5941,81 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         Array [
                                           "https://forum.sentry.io/",
                                         ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
                                       ],
                                       "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
                                         Object {
                                           "type": "return",
                                           "value": undefined,
@@ -6164,25 +6724,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/projects/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/issues/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/releases/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/user-feedback/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/activity/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/stats/",
-                                        ],
-                                        Array [
-                                          "/settings/org-slug/",
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -6206,6 +6757,15 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
                                           "/organizations/org-slug/projects/",
                                         ],
                                         Array [
@@ -6225,6 +6785,45 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         ],
                                         Array [
                                           "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/projects/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/issues/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/releases/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/user-feedback/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/activity/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/stats/",
+                                        ],
+                                        Array [
+                                          "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -6250,8 +6849,81 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         Array [
                                           "https://forum.sentry.io/",
                                         ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
                                       ],
                                       "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
                                         Object {
                                           "type": "return",
                                           "value": undefined,
@@ -6875,25 +7547,16 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/projects/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/issues/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/releases/",
+                                          "#",
                                         ],
                                         Array [
-                                          "/organizations/org-slug/user-feedback/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/activity/",
-                                        ],
-                                        Array [
-                                          "/organizations/org-slug/stats/",
-                                        ],
-                                        Array [
-                                          "/settings/org-slug/",
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -6917,6 +7580,15 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                           "/settings/org-slug/",
                                         ],
                                         Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
                                           "/organizations/org-slug/projects/",
                                         ],
                                         Array [
@@ -6936,6 +7608,45 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         ],
                                         Array [
                                           "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/projects/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/issues/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/releases/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/user-feedback/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/activity/",
+                                        ],
+                                        Array [
+                                          "/organizations/org-slug/stats/",
+                                        ],
+                                        Array [
+                                          "/settings/org-slug/",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
                                         ],
                                         Array [
                                           "/organizations/org-slug/projects/",
@@ -6961,8 +7672,81 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         Array [
                                           "https://forum.sentry.io/",
                                         ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
+                                        Array [
+                                          "#",
+                                        ],
                                       ],
                                       "results": Array [
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
+                                        Object {
+                                          "type": "return",
+                                          "value": undefined,
+                                        },
                                         Object {
                                           "type": "return",
                                           "value": undefined,


### PR DESCRIPTION
some sidebar links like "Help" , "What's New" and "Collapse" were not keyboard accessible although they are interactive elements.
Although they were links, there was no href, and so interactions were not enabled by the browser.
Added a default href="#" for these links. Also on click of these links, we need to `preventDefault` to prevent the page from reloading.