### PR TITLE
ref(alerts): Use withApi on TriggerChart to encapsulate the API client

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -417,7 +417,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
     const chart = (
       <TriggersChart
-        api={this.api}
         organization={organization}
         projects={this.state.projects}
         triggers={triggers}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -9,10 +9,10 @@ import EventsRequest from 'app/components/charts/eventsRequest';
 import LoadingMask from 'app/components/loadingMask';
 import Placeholder from 'app/components/placeholder';
 import space from 'app/styles/space';
+import withApi from 'app/utils/withApi';
 
 import {IncidentRule, TimeWindow, Trigger} from '../../types';
 import ThresholdsChart from './thresholdsChart';
-import withApi from 'app/utils/withApi';
 
 type Props = {
   api: Client;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -12,6 +12,7 @@ import space from 'app/styles/space';
 
 import {IncidentRule, TimeWindow, Trigger} from '../../types';
 import ThresholdsChart from './thresholdsChart';
+import withApi from 'app/utils/withApi';
 
 type Props = {
   api: Client;
@@ -86,7 +87,7 @@ class TriggersChart extends React.PureComponent<Props> {
   }
 }
 
-export default TriggersChart;
+export default withApi(TriggersChart);
 
 const TIME_WINDOW_TO_PERIOD: Record<TimeWindow, string> = {
   [TimeWindow.ONE_MINUTE]: '12h',


### PR DESCRIPTION
EventsRequets was recently changed (caef905) to cancel inflight requests
when parameters change. The issue is it was clearing request in the
API client passed in.

A better solution _may_ be for EventsRequest to get its own client, but
we'll do this for now to avoid any other potential breaking changes