### PR TITLE
fix(json): adds serializer for translations

### DIFF
--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -9,10 +9,10 @@ import six
 import decimal
 
 from bitfield.types import BitHandler
-from django.utils.timezone import is_aware
-from django.utils.html import mark_safe
-from django.utils.functional import Promise
 from django.utils.encoding import force_text
+from django.utils.functional import Promise
+from django.utils.html import mark_safe
+from django.utils.timezone import is_aware
 
 
 def better_default_encoder(o):

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -39,6 +39,7 @@ def better_default_encoder(o):
         return int(o)
     elif callable(o):
         return "<function>"
+    # seralization for certain Django objects here: https://docs.djangoproject.com/en/1.8/topics/serialization/
     elif isinstance(o, Promise):
         return force_text(o)
     raise TypeError(repr(o) + " is not JSON serializable")

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -11,6 +11,8 @@ import decimal
 from bitfield.types import BitHandler
 from django.utils.timezone import is_aware
 from django.utils.html import mark_safe
+from django.utils.functional import Promise
+from django.utils.encoding import force_text
 
 
 def better_default_encoder(o):
@@ -37,6 +39,8 @@ def better_default_encoder(o):
         return int(o)
     elif callable(o):
         return "<function>"
+    elif isinstance(o, Promise):
+        return force_text(o)
     raise TypeError(repr(o) + " is not JSON serializable")
 
 

--- a/tests/sentry/utils/json/tests.py
+++ b/tests/sentry/utils/json/tests.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import
 import datetime
 import uuid
 
-from enum import Enum
 from django.utils.translation import ugettext_lazy as _
+from enum import Enum
 
 from unittest import TestCase
 from sentry.utils import json

--- a/tests/sentry/utils/json/tests.py
+++ b/tests/sentry/utils/json/tests.py
@@ -6,6 +6,7 @@ import datetime
 import uuid
 
 from enum import Enum
+from django.utils.translation import ugettext_lazy as _
 
 from unittest import TestCase
 from sentry.utils import json
@@ -48,3 +49,6 @@ class JSONTest(TestCase):
         enum = Enum("foo", "a b c")
         res = enum.a
         self.assertEquals(json.dumps(res), "1")
+
+    def test_translation(self):
+        self.assertEquals(json.dumps(_("word")), u'"word"')


### PR DESCRIPTION
This PR enables serialization of certain Django objects like lazy translations. Docs for this here: https://docs.djangoproject.com/en/1.8/topics/serialization/