### PR TITLE
feat(ui): Update `<Tag>` to accept React node for `icon`

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/tag.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/tag.tsx
@@ -7,7 +7,7 @@ import {Theme} from 'app/utils/theme';
 type Props = React.HTMLAttributes<HTMLDivElement> & {
   priority?: keyof Theme['badge'] | keyof Theme['alert'];
   size?: string;
-  icon?: string;
+  icon?: string | React.ReactNode;
   border?: boolean;
   inline?: boolean;
 };
@@ -42,7 +42,7 @@ const Tag = styled(
     ...props
   }: Props) => (
     <div {...props}>
-      {icon && <StyledInlineSvg src={icon} size="12px" />}
+      {typeof icon === 'string' ? <StyledInlineSvg src={icon} size="12px" /> : icon}
       {children}
     </div>
   )

--- a/src/sentry/static/sentry/app/views/settings/components/tag.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/tag.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import InlineSvg from 'app/components/inlineSvg';
 import {Theme} from 'app/utils/theme';
+import space from 'app/styles/space';
 
 type Props = React.HTMLAttributes<HTMLDivElement> & {
   priority?: keyof Theme['badge'] | keyof Theme['alert'];
@@ -42,7 +43,15 @@ const Tag = styled(
     ...props
   }: Props) => (
     <div {...props}>
-      {typeof icon === 'string' ? <StyledInlineSvg src={icon} size="12px" /> : icon}
+      {icon && (
+        <IconWrapper>
+          {typeof icon === 'string' ? (
+            <InlineSvg src={icon} size="12px" />
+          ) : (
+            React.cloneElement(icon, {size: 'xs'})
+          )}
+        </IconWrapper>
+      )}
       {children}
     </div>
   )
@@ -55,7 +64,7 @@ const Tag = styled(
   color: ${p => (p.priority ? '#fff' : p.theme.gray800)};
   text-align: center;
   white-space: nowrap;
-  vertical-align: middle;
+  align-items: center;
   border-radius: ${p => (p.size === 'small' ? '0.25em' : '2em')};
   text-transform: lowercase;
   font-weight: ${p => (p.size === 'small' ? 'bold' : 'normal')};
@@ -64,8 +73,8 @@ const Tag = styled(
   ${p => getMarginLeft(p)};
 `;
 
-const StyledInlineSvg = styled(InlineSvg)`
-  margin-right: 4px;
+const IconWrapper = styled('span')`
+  margin-right: ${space(0.5)};
 `;
 
 export default Tag;

--- a/src/sentry/static/sentry/app/views/settings/components/tag.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/tag.tsx
@@ -45,11 +45,11 @@ const Tag = styled(
     <div {...props}>
       {icon && (
         <IconWrapper>
-          {typeof icon === 'string' ? (
-            <InlineSvg src={icon} size="12px" />
-          ) : (
+          {React.isValidElement(icon) ? (
             React.cloneElement(icon, {size: 'xs'})
-          )}
+          ) : typeof icon === 'string' ? (
+            <InlineSvg src={icon} size="12px" />
+          ) : null}
         </IconWrapper>
       )}
       {children}

--- a/src/sentry/static/sentry/app/views/settings/components/tag.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/tag.tsx
@@ -64,6 +64,7 @@ const Tag = styled(
   color: ${p => (p.priority ? '#fff' : p.theme.gray800)};
   text-align: center;
   white-space: nowrap;
+  vertical-align: middle;
   align-items: center;
   border-radius: ${p => (p.size === 'small' ? '0.25em' : '2em')};
   text-transform: lowercase;

--- a/tests/js/spec/components/__snapshots__/tag.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/tag.spec.jsx.snap
@@ -8,12 +8,12 @@ exports[`Tag renders 1`] = `
 >
   <Component
     border={true}
-    className="css-w9a2kc-Tag e1glkkip0"
+    className="css-16s817c-Tag e1glkkip0"
     priority="info"
     size="small"
   >
     <div
-      className="css-w9a2kc-Tag e1glkkip0"
+      className="css-16s817c-Tag e1glkkip0"
     >
       Text to Copy
     </div>

--- a/tests/js/spec/components/__snapshots__/tag.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/tag.spec.jsx.snap
@@ -8,12 +8,12 @@ exports[`Tag renders 1`] = `
 >
   <Component
     border={true}
-    className="css-16s817c-Tag e1glkkip0"
+    className="css-mpoebz-Tag e1glkkip0"
     priority="info"
     size="small"
   >
     <div
-      className="css-16s817c-Tag e1glkkip0"
+      className="css-mpoebz-Tag e1glkkip0"
     >
       Text to Copy
     </div>

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/__snapshots__/filter.spec.tsx.snap
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/__snapshots__/filter.spec.tsx.snap
@@ -1679,11 +1679,11 @@ exports[`Filter default render 1`] = `
                                   color="blue400"
                                 >
                                   <Component
-                                    className="css-alnj6v-Tag-StyledTag eio8trv0"
+                                    className="css-1dx7owx-Tag-StyledTag eio8trv0"
                                     color="blue400"
                                   >
                                     <div
-                                      className="css-alnj6v-Tag-StyledTag eio8trv0"
+                                      className="css-1dx7owx-Tag-StyledTag eio8trv0"
                                       color="blue400"
                                     >
                                       info
@@ -1765,11 +1765,11 @@ exports[`Filter default render 1`] = `
                                   color="red400"
                                 >
                                   <Component
-                                    className="css-1qvqycp-Tag-StyledTag eio8trv0"
+                                    className="css-eius55-Tag-StyledTag eio8trv0"
                                     color="red400"
                                   >
                                     <div
-                                      className="css-1qvqycp-Tag-StyledTag eio8trv0"
+                                      className="css-eius55-Tag-StyledTag eio8trv0"
                                       color="red400"
                                     >
                                       error

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/__snapshots__/filter.spec.tsx.snap
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/__snapshots__/filter.spec.tsx.snap
@@ -1679,11 +1679,11 @@ exports[`Filter default render 1`] = `
                                   color="blue400"
                                 >
                                   <Component
-                                    className="css-1f6oxrn-Tag-StyledTag eio8trv0"
+                                    className="css-alnj6v-Tag-StyledTag eio8trv0"
                                     color="blue400"
                                   >
                                     <div
-                                      className="css-1f6oxrn-Tag-StyledTag eio8trv0"
+                                      className="css-alnj6v-Tag-StyledTag eio8trv0"
                                       color="blue400"
                                     >
                                       info
@@ -1765,11 +1765,11 @@ exports[`Filter default render 1`] = `
                                   color="red400"
                                 >
                                   <Component
-                                    className="css-1muivxw-Tag-StyledTag eio8trv0"
+                                    className="css-1qvqycp-Tag-StyledTag eio8trv0"
                                     color="red400"
                                   >
                                     <div
-                                      className="css-1muivxw-Tag-StyledTag eio8trv0"
+                                      className="css-1qvqycp-Tag-StyledTag eio8trv0"
                                       color="red400"
                                     >
                                       error


### PR DESCRIPTION
Previously only accepted a string for icon (and used InlineSvg) -- update to accept a string or an Icon component

Only used in getsentry:

![image](https://user-images.githubusercontent.com/79684/85078166-a9222300-b178-11ea-98c5-9cef17d18d36.png)
