### PR TITLE
ref(ui): Improve visual centering of varying alert icon sizes

### DIFF
--- a/src/sentry/static/sentry/app/components/alert.tsx
+++ b/src/sentry/static/sentry/app/components/alert.tsx
@@ -74,9 +74,10 @@ const IconWrapper = styled('span')`
   display: flex;
   margin-right: ${space(1)};
 
-  /* Minor adjustment to vertically align the icon, without using align-items
-   * which would vertically align it for multi-line alerts. */
-  padding-top: 1px;
+  /* Give the wrapper an explicit height so icons are line height with the
+   * (common) line height. */
+  height: 22px;
+  align-items: center;
 `;
 
 const StyledTextBlock = styled('span')`

--- a/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
@@ -62,7 +62,7 @@ exports[`EventSdkUpdates renders a suggestion to update the sdk and then enable 
                 >
                   <IconWrapper>
                     <span
-                      className="css-gv6q30-IconWrapper ejthpj80"
+                      className="css-1vsw7fz-IconWrapper ejthpj80"
                     >
                       <InlineSvg
                         size="20px"

--- a/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
+++ b/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
@@ -113,7 +113,7 @@ exports[`ProjectPlugins renders 1`] = `
                       >
                         <IconWrapper>
                           <span
-                            className="css-gv6q30-IconWrapper ejthpj80"
+                            className="css-1vsw7fz-IconWrapper ejthpj80"
                           >
                             <InlineSvg
                               size="20px"


### PR DESCRIPTION
Now ever for icons that are smaller than 20px, you will get correct visual alignment