### PR TITLE
fix(slack): adds instructions on which Sentry app to add

### DIFF
--- a/src/sentry/integrations/slack/post_migration.py
+++ b/src/sentry/integrations/slack/post_migration.py
@@ -19,7 +19,7 @@ doc_link = "https://docs.sentry.io/workflow/integrations/global-integrations/#up
 def build_migration_attachment():
     return {
         "title": "Action required",
-        "text": "Your Sentry Slack Integration is upgraded and nearly ready to report errors. Mention `@sentry` to get notifications in this channel. To learn more, <%s|see our documentation>."
+        "text": "Your Sentry Slack Integration is upgraded and nearly ready to report errors. Mention @sentry to get notifications in this channel (the one with the pink logo, not Sentry Legacy). To learn more, <%s|see our documentation>."
         % (doc_link),
         "footer": "Sentry API",
         "footer_icon": "https://sentryio-assets.storage.googleapis.com/img/slack/integration-avatar.png",


### PR DESCRIPTION
Since sometimes Slack tags the legacy app instead of the new app for Slack, I've added instructions of which one to tag.