### PR TITLE
fix(ui) Fix stacking of option selectors

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
+++ b/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
@@ -74,7 +74,7 @@ const StyledDropdownButton = styled(DropdownButton)`
   padding: ${space(1)} ${space(2)};
   font-weight: normal;
   color: ${p => p.theme.gray600};
-  z-index: ${p => p.theme.zIndex.dropdownAutocomplete.actor};
+  z-index: ${p => (p.isOpen ? p.theme.zIndex.dropdownAutocomplete.actor : 'auto')};
 
   &:hover,
   &:focus,


### PR DESCRIPTION
When not open the higher z-index places these buttons above the search filter dropdown which looks bad.