### PR TITLE
fix(beacons): Handle missing constraint on Broadcast.upstream_id

### DIFF
--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from hashlib import sha1
 from uuid import uuid4
 
-from sentry.app import tsdb
+from sentry.app import locks, tsdb
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.tasks.base import instrumented_task
 from sentry.debug.utils.packages import get_all_package_versions
@@ -92,14 +92,19 @@ def send_beacon():
         upstream_ids = set()
         for notice in data["notices"]:
             upstream_ids.add(notice["id"])
-            Broadcast.objects.create_or_update(
-                upstream_id=notice["id"],
-                defaults={
-                    "title": notice["title"],
-                    "link": notice.get("link"),
-                    "message": notice["message"],
-                },
-            )
+            defaults = {
+                "title": notice["title"],
+                "link": notice.get("link"),
+                "message": notice["message"],
+            }
+            # XXX(dcramer): we're missing a unique constraint on upstream_id
+            # so we're using a lock to work around that. In the future we'd like
+            # to have a data migration to clean up the duplicates and add the constraint
+            lock = locks.get(u"broadcasts:{}".format(notice["id"]), duration=60)
+            with lock.acquire():
+                affected = Broadcast.objects.filter(upstream_id=notice["id"]).update(**defaults)
+                if not affected:
+                    Broadcast.objects.create(upstream_id=notice["id"], **defaults)
 
         Broadcast.objects.filter(upstream_id__isnull=False).exclude(
             upstream_id__in=upstream_ids

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -113,18 +113,34 @@ class SendBeaconTest(TestCase):
         with self.settings():
             send_beacon()
 
+        assert Broadcast.objects.count() == 1
+
         broadcast = Broadcast.objects.get(upstream_id=broadcast_id)
 
         assert broadcast.title == "Hello!"
         assert broadcast.message == "Hello world"
         assert broadcast.is_active
 
+        # ensure we arent duplicating the broadcast
+        with self.settings():
+            send_beacon()
+
+        assert Broadcast.objects.count() == 1
+
+        broadcast = Broadcast.objects.get(upstream_id=broadcast_id)
+
+        assert broadcast.title == "Hello!"
+        assert broadcast.message == "Hello world"
+        assert broadcast.is_active
+
+        # now remove it and it should become inactive
         safe_urlread.return_value = json.dumps({"notices": [], "version": {"stable": "1.0.0"}})
 
         with self.settings():
             send_beacon()
 
-        # test explicit disable
+        assert Broadcast.objects.count() == 1
+
         broadcast = Broadcast.objects.get(upstream_id=broadcast_id)
 
         assert not broadcast.is_active


### PR DESCRIPTION
Due to the missing unique constraint on Broadcast.upstream_id, it means that if upstream broadcasts are received they would continually create a new broadcast entity. This adds a basic lock and better query handling to resolve the situation.

A future patch should be added to remove duplicate rows and add the unique constraint, likely over the course of a few versions.