### PR TITLE
fix(discover): Hide save query button once saved

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -108,6 +108,7 @@ class ResultsHeader extends React.Component<Props, State> {
                 savedQuery={savedQuery}
                 savedQueryLoading={loading}
                 disabled={!hasFeature || (errorCode >= 400 && errorCode < 500)}
+                updateCallback={() => this.fetchData()}
               />
             )}
           </Feature>

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -41,6 +41,7 @@ type Props = DefaultProps & {
   savedQuery: SavedQuery | undefined;
   savedQueryLoading: boolean;
   projects: Project[];
+  updateCallback: () => void;
 };
 
 type State = {
@@ -162,12 +163,13 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
     event.preventDefault();
     event.stopPropagation();
 
-    const {api, organization, eventView} = this.props;
+    const {api, organization, eventView, updateCallback} = this.props;
 
     handleUpdateQuery(api, organization, eventView).then((savedQuery: SavedQuery) => {
       const view = EventView.fromSavedQuery(savedQuery);
       this.setState({queryName: ''});
       browserHistory.push(view.getResultsViewUrlTarget(organization.slug));
+      updateCallback();
     });
   };
 

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -27,6 +27,7 @@ function generateWrappedComponent(
       eventView={eventView}
       savedQuery={savedQuery}
       disabled={disabled}
+      updateCallback={() => {}}
     />,
     TestStubs.routerContext()
   );


### PR DESCRIPTION
Upon saving the query, the save button should hide itself. This was not the
current behaviour because when saving, the saved query was not updated in the
component state so the save button will show unless the query was reverted back
to the original save. This is problematic in two use cases. The first is if an
user saves a query, the save button is still present allowing them to
continously save. The more problematic use case is if an user accidentally
saves a query and wants to revert the query back to the way it was. Upon
reconstructing the query, they'll find that the save button is hidden making it
impossible.