### PR TITLE
fix(grouping-enhancements): Fix request typo

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -157,7 +157,7 @@ class ProjectGeneralSettings extends AsyncView {
       newData.groupingConfig = latestGroupingConfig.id;
     }
     if (latestEnhancementsBase) {
-      newData.groupingEnhancementBases = latestEnhancementsBase.id;
+      newData.groupingEnhancementsBase = latestEnhancementsBase.id;
     }
 
     let riskNote;


### PR DESCRIPTION
closes: https://app.asana.com/0/1158284503473033/1180465239131287

**Description:**

When clicking on the button "Group Strategy", the "Grouping Enhancements Base" selected option doesn't update (in case it should), only the "Grouping Config" selected option. This problem was due to a typo.  In the request, the "groupingEnhancementBases" property shall be "groupingEnhancementsBase"

This PR fixes the issue.