### PR TITLE
perf(artifacts): Remove check for archives with at least one artifact

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -7,7 +7,7 @@ import logging
 import posixpath
 
 from django.db import transaction
-from django.db.models import Q, Count, Exists, OuterRef
+from django.db.models import Q, Count
 from django.http import StreamingHttpResponse, HttpResponse, Http404
 from rest_framework.response import Response
 from symbolic import normalize_debug_id, SymbolicError
@@ -382,13 +382,8 @@ class SourceMapsEndpoint(ProjectEndpoint):
         try:
             queryset = (
                 Release.objects.filter(projects=project, organization_id=project.organization_id)
-                .annotate(
-                    has_file=Exists(
-                        ReleaseFile.objects.filter(release=OuterRef("id")).values_list("id")
-                    )
-                )
-                .values("id", "version", "date_added")
-                .filter(has_file=True)
+                .annotate(file_count=Count("releasefile"))
+                .values("id", "version", "date_added", "file_count")
             )
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
@@ -402,25 +397,14 @@ class SourceMapsEndpoint(ProjectEndpoint):
 
             queryset = queryset.filter(query_q)
 
-        def expose_release(release, count):
+        def expose_release(release):
             return {
                 "type": "release",
                 "id": release["id"],
                 "name": release["version"],
                 "date": release["date_added"],
-                "fileCount": count,
+                "fileCount": release["file_count"],
             }
-
-        def serialize_results(results):
-            file_counts = (
-                Release.objects.filter(id__in=[r["id"] for r in results])
-                .annotate(count=Count("releasefile"))
-                .values("count", "id")
-            )
-            file_count_map = {r["id"]: r["count"] for r in file_counts}
-            return serialize(
-                [expose_release(r, file_count_map[r["id"]]) for r in results], request.user
-            )
 
         return self.paginate(
             request=request,
@@ -428,7 +412,9 @@ class SourceMapsEndpoint(ProjectEndpoint):
             order_by="-date_added",
             paginator_cls=OffsetPaginator,
             default_per_page=10,
-            on_results=serialize_results,
+            on_results=lambda releases: serialize(
+                [expose_release(r) for r in releases], request.user
+            ),
         )
 
     def delete(self, request, project):

--- a/tests/sentry/api/endpoints/test_debug_files.py
+++ b/tests/sentry/api/endpoints/test_debug_files.py
@@ -273,8 +273,9 @@ class DebugFilesUploadTest(APITestCase):
         project = self.create_project(name="foo")
 
         release = Release.objects.create(organization_id=project.organization_id, version="1")
-        Release.objects.create(organization_id=project.organization_id, version="2")
+        release2 = Release.objects.create(organization_id=project.organization_id, version="2")
         release.add_project(project)
+        release2.add_project(project)
 
         ReleaseFile.objects.create(
             organization_id=project.organization_id,
@@ -299,9 +300,10 @@ class DebugFilesUploadTest(APITestCase):
         response = self.client.get(url)
 
         assert response.status_code == 200, response.content
-        assert len(response.data) == 1
-        assert response.data[0]["name"] == text_type(release.version)
-        assert response.data[0]["fileCount"] == 2
+        assert len(response.data) == 2
+        assert response.data[0]["name"] == text_type(release2.version)
+        assert response.data[0]["fileCount"] == 0
+        assert response.data[1]["fileCount"] == 2
 
     def test_source_maps_delete_archive(self):
         project = self.create_project(name="foo")


### PR DESCRIPTION
We are removing the filter for releases with at least one artifact because it was an expensive query causing major performance issues.

#sync-getsentry