### PR TITLE
ref(app): Use beforeNavigate to set transaction name

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -35,6 +35,22 @@ if (process.env.NODE_ENV === 'development') {
   );
 }
 
+// App setup
+if (window.__initialData) {
+  ConfigStore.loadInitialData(window.__initialData);
+
+  if (window.__initialData.dsn_requests) {
+    initApiSentryClient(window.__initialData.dsn_requests);
+  }
+}
+
+// SDK INIT  --------------------------------------------------------
+const config = ConfigStore.getConfig();
+
+const tracesSampleRate = config ? config.apmSampling : 0;
+
+const appRoutes = Router.createRoutes(routes());
+
 function getSentryIntegrations(hasReplays: boolean = false) {
   const integrations = [
     new ExtraErrorData({
@@ -46,6 +62,9 @@ function getSentryIntegrations(hasReplays: boolean = false) {
       debug: {
         spanDebugTimingInfo: true,
         writeAsBreadcrumbs: true,
+      },
+      beforeNavigate: (location: Location) => {
+        return normalizeTransactionName(appRoutes, location);
       },
     }),
   ];
@@ -65,24 +84,8 @@ function getSentryIntegrations(hasReplays: boolean = false) {
   return integrations;
 }
 
-// App setup
-if (window.__initialData) {
-  ConfigStore.loadInitialData(window.__initialData);
-
-  if (window.__initialData.dsn_requests) {
-    initApiSentryClient(window.__initialData.dsn_requests);
-  }
-}
-
-// SDK INIT  --------------------------------------------------------
-const config = ConfigStore.getConfig();
-
-const tracesSampleRate = config ? config.apmSampling : 0;
-
 const hasReplays =
   window.__SENTRY__USER && window.__SENTRY__USER.isStaff && !!process.env.DISABLE_RR_WEB;
-
-const appRoutes = Router.createRoutes(routes());
 
 Sentry.init({
   ...window.__SENTRY__OPTIONS,
@@ -96,10 +99,6 @@ Sentry.init({
     : window.__SENTRY__OPTIONS.whitelistUrls,
   integrations: getSentryIntegrations(hasReplays),
   tracesSampleRate,
-});
-
-Sentry.addGlobalEventProcessor(async event => {
-  return normalizeTransactionName(appRoutes, event);
 });
 
 if (window.__SENTRY__USER) {

--- a/src/sentry/static/sentry/app/utils/apm.tsx
+++ b/src/sentry/static/sentry/app/utils/apm.tsx
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/browser';
 import * as Router from 'react-router';
 import {createMemoryHistory} from 'history';
-import set from 'lodash/set';
 
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 
@@ -17,63 +16,33 @@ export function setTransactionName(name: string) {
   });
 }
 
-export async function normalizeTransactionName(
+export function normalizeTransactionName(
   appRoutes: Router.PlainRoute[],
-  event: Sentry.Event
-): Promise<Sentry.Event> {
-  if (event.type !== 'transaction') {
-    return event;
-  }
-
+  location: Location
+): string {
+  const defaultName = location.pathname;
   // For JavaScript transactions, translate the transaction name if it exists and doesn't start with /
   // using the app's react-router routes. If the transaction name doesn't exist, use the window.location.pathname
   // as the fallback.
-
-  let prevTransactionName = event.transaction;
-
-  if (typeof prevTransactionName === 'string' && prevTransactionName.length > 0) {
-    if (prevTransactionName.startsWith('/')) {
-      return event;
-    }
-
-    set(event, ['tags', 'transaction.rename.source'], 'existing transaction name');
-  } else {
-    set(event, ['tags', 'transaction.rename.source'], 'window.location.pathname');
-
-    prevTransactionName = window.location.pathname;
-  }
-
-  const transactionName: string = await new Promise(function(resolve) {
-    Router.match(
-      {
-        routes: appRoutes,
-        location: createLocation(prevTransactionName),
-      },
-      (error, _redirectLocation, renderProps) => {
-        if (error) {
-          set(event, ['tags', 'transaction.rename.router-match'], 'error');
-          return resolve(window.location.pathname);
-        }
-
-        set(event, ['tags', 'transaction.rename.router-match'], 'success');
-
-        const routePath = getRouteStringFromRoutes(renderProps?.routes ?? []);
-
-        if (routePath.length === 0 || routePath === '/*') {
-          return resolve(window.location.pathname);
-        }
-
-        return resolve(routePath);
+  Router.match(
+    {
+      routes: appRoutes,
+      location: createLocation(location.href),
+    },
+    (error, _redirectLocation, renderProps) => {
+      if (error) {
+        return defaultName;
       }
-    );
-  });
 
-  event.transaction = transactionName;
+      const routePath = getRouteStringFromRoutes(renderProps?.routes ?? []);
 
-  set(event, ['tags', 'transaction.rename.before'], prevTransactionName);
-  set(event, ['tags', 'transaction.rename.after'], transactionName);
+      if (routePath.length === 0 || routePath === '/*') {
+        return defaultName;
+      }
 
-  set(event, ['tags', 'ui.route'], transactionName);
+      return routePath;
+    }
+  );
 
-  return event;
+  return defaultName;
 }

--- a/src/sentry/static/sentry/app/utils/apm.tsx
+++ b/src/sentry/static/sentry/app/utils/apm.tsx
@@ -27,7 +27,7 @@ export function normalizeTransactionName(
   Router.match(
     {
       routes: appRoutes,
-      location: createLocation(location.href),
+      location: createLocation(location.pathname),
     },
     (error, _redirectLocation, renderProps) => {
       if (error) {


### PR DESCRIPTION
Now that we have `5.18.0` on the JS SDK, we can use `beforeNavigate` to set a pageload/navigation transaction name.

See this commit for what `beforeNavigate` does: https://github.com/getsentry/sentry-javascript/commit/fb56978acf98ffddcb461ed7e016aba26a9546ca