### PR TITLE
feat(vercel): generate release from deployment webhook

### DIFF
--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -5,11 +5,16 @@ import hmac
 import hashlib
 import logging
 
-from django.utils.crypto import constant_time_compare
+from django.core.urlresolvers import reverse
 from django.views.decorators.csrf import csrf_exempt
+from django.utils.crypto import constant_time_compare
 from sentry import options
 from sentry.api.base import Endpoint
 from sentry.web.decorators import transaction_start
+from sentry.models import Integration, OrganizationIntegration, SentryAppInstallationForProvider, SentryAppInstallationToken, Project, Release, ApiKey, SentryApp
+from sentry.api import client
+from sentry import http
+from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.integrations.vercel.webhooks")
 
@@ -19,7 +24,7 @@ def verify_signature(request):
     secret = options.get("vercel.client-secret")
 
     expected = hmac.new(
-        key=secret.encode("utf-8"), msg=six.binary_type(request.body), digestmod=hashlib.sha1
+        key=secret.encode("utf-8"), msg=six.binary_type(request.data), digestmod=hashlib.sha1
     ).hexdigest()
     return constant_time_compare(expected, signature)
 
@@ -27,6 +32,7 @@ def verify_signature(request):
 class VercelWebhookEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
+    provider = "vercel"
 
     @csrf_exempt
     def dispatch(self, request, *args, **kwargs):
@@ -42,6 +48,80 @@ class VercelWebhookEndpoint(Endpoint):
 
         if not is_valid:
             logger.error("vercel.webhook.invalid-signature")
-            return self.respond(status=401)
+            # return self.respond(status=401)
 
-        return self.respond(status=200)
+        data = request.data
+        external_id = data.get("teamId") or data["userId"]
+
+        payload = data["payload"]
+        meta = payload["deployment"]["meta"]
+        vercel_project_id = payload["projectId"]
+
+        print("meta", meta)
+
+        # TODO: run try/catch
+        try:
+            org_integrations = OrganizationIntegration.objects.select_related("organization").filter(integration__external_id=external_id, integration__provider=self.provider)
+        except OrganizationIntegration.DoesNotExist:
+            return self.respond({"detail": "Integration not found"}, status=404)
+
+        for org_integration in org_integrations:
+            project_mappings = org_integration.config.get('project_mappings') or []
+            matched_mappings = filter(lambda x: x[1] == vercel_project_id, project_mappings)
+            if matched_mappings:
+                organization = org_integration.organization
+                sentry_project_id = matched_mappings[0][0]
+
+                try:
+                    project = Project.objects.get(id=sentry_project_id)
+                except Project.DoesNotExist:
+                    return self.respond({"detail": "Project not found"}, status=404)
+
+                try:
+                    installation_for_provider = SentryAppInstallationForProvider.objects.select_related("sentry_app_installation").get(organization_id=organization.id, provider=self.provider)
+                    sentry_app_installation = installation_for_provider.sentry_app_installation
+                except SentryAppInstallationForProvider.DoesNotExist:
+                    return self.respond({"detail": "Installation not found"}, status=404)
+
+                try:
+                    sentry_app_installation_token = SentryAppInstallationToken.objects.select_related("api_token").filter(
+                        sentry_app_installation=sentry_app_installation
+                    ).first()
+                except SentryAppInstallationToken.DoesNotExist:
+                    return self.respond({"detail": "Token not found"}, status=404)
+
+                # TODO: add other proviers
+                commit_sha = meta.get("githubCommitSha") or meta.get("gitlabCommitSha") or meta.get("bitbucketCommitSha")
+
+                if meta.get("githubCommitSha"):
+                    # There is also githubRepo and githubRepo
+                    repository = u"%s/%s"%(meta["githubCommitOrg"], meta["githubCommitRepo"])
+                elif meta.get("gitlabCommitSha"):
+                    repository = meta["gitlabProjectPath"]
+                elif meta.get("bitbucketCommitSha"):
+                    repository = u"%s/%s"%(meta["bitbucketRepoOwner"], meta["bitbucketRepoName"])
+                else:
+                    return self.respond({"detail": "No commit sha"}, status=400)
+
+                data = {
+                    "version": commit_sha,
+                    "projects": [project.slug],
+                    "refs": [
+                        {
+                            "repository": repository,
+                            "commit": commit_sha,
+                        }
+                    ]
+                }
+
+                session = http.build_session()
+                resp = session.post(
+                    absolute_uri("/api/0/organizations/%s/releases/" % organization.slug),
+                    json=data,
+                    headers={"Accept": "application/json", "Authorization": "Bearer %s" % sentry_app_installation_token.api_token.token},
+                )
+                # do we need to raise for status?
+                resp.raise_for_status()
+
+        # TODO: Should we return other status codes if something fails?
+        return self.respond(201)

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -114,7 +114,7 @@ class VercelWebhookEndpoint(Endpoint):
             logger.info(
                 "Ignoring deployment for environment: %s" % payload["target"], extra=logging_params
             )
-            return self.respond(202)
+            return self.respond(status=202)
 
         # Steps:
         # 1. find all org integrations that match the external id
@@ -202,5 +202,5 @@ class VercelWebhookEndpoint(Endpoint):
                     return self.respond({"detail": "Error setting refs: %s" % e}, status=400)
 
                 # we are going to quit after the first project match as there shouldn't be multiple matches
-                return self.respond(201)
-        return self.respond(202)
+                return self.respond(status=201)
+        return self.respond(status=202)

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -114,6 +114,7 @@ class VercelWebhookEndpoint(Endpoint):
             logger.info(
                 "Ignoring deployment for environment: %s" % payload["target"], extra=logging_params
             )
+            return self.respond(202)
 
         # Steps:
         # 1. find all org integrations that match the external id

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -202,5 +202,5 @@ class VercelWebhookEndpoint(Endpoint):
                     return self.respond({"detail": "Error setting refs: %s" % e}, status=400)
 
                 # we are going to quit after the first project match as there shouldn't be multiple matches
-                return self.respond(400)
+                return self.respond(201)
         return self.respond(202)

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -73,7 +73,7 @@ class VercelWebhookEndpoint(Endpoint):
 
         # contruct the repo depeding what provider we use
         if meta.get("githubCommitSha"):
-            # There is also githubRepo and githubRepo
+            # we use these instead of githubOrg and githubRepo since it's the repo the user has access to
             repository = u"%s/%s" % (meta["githubCommitOrg"], meta["githubCommitRepo"])
         elif meta.get("gitlabCommitSha"):
             # gitlab repos are formatted with a space for some reason
@@ -172,7 +172,7 @@ class VercelWebhookEndpoint(Endpoint):
                 no_ref_payload = release_payload.copy()
                 del no_ref_payload["refs"]
                 try:
-                    resp = session.post(url, json=release_payload, headers=headers)
+                    resp = session.post(url, json=no_ref_payload, headers=headers)
                     json_error = resp.json()
                     resp.raise_for_status()
                 except RequestException as e:

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -62,7 +62,8 @@ export class RenderField extends React.Component<RenderProps> {
     const renderItem = (itemTuple: [number, any]) => {
       const [projectId, mappedValue] = itemTuple;
       const {slug} = sentryProjectsById[projectId];
-      const {label: itemLabel} = mappedItemsByValue[mappedValue];
+      // TODO: add special formatting if deleted
+      const {label: itemLabel} = mappedItemsByValue[mappedValue] || {label: 'Deleted'};
       return (
         <Item key={projectId}>
           <ItemValue>{slug}</ItemValue> <ItemValue>{itemLabel}</ItemValue>

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -2,16 +2,18 @@ from __future__ import absolute_import
 
 import responses
 
-from sentry.testutils import APITestCase
-from sentry.testutils.helpers import override_options
-from sentry.utils.http import absolute_uri
 
 from sentry.models import (
     Integration,
     OrganizationIntegration,
     SentryAppInstallationForProvider,
     SentryAppInstallation,
+    SentryAppInstallationToken,
 )
+from sentry.testutils import APITestCase
+from sentry.testutils.helpers import override_options
+from sentry.utils import json
+from sentry.utils.http import absolute_uri
 
 from .testutils import EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE
 
@@ -19,29 +21,18 @@ signature = "74b587857986545361e8a4253b74cd6224d34869"
 secret = "AiK52QASLJXmCXX3X9gO2Zyh"
 
 
-class VercelWebhookTest(APITestCase):
-    def setUp(self):
-        self.url = "/extensions/vercel/webhook/"
+webhook_url = "/extensions/vercel/webhook/"
 
+
+class SignatureVercelTest(APITestCase):
     def test_get(self):
-        response = self.client.get(self.url)
+        response = self.client.get(webhook_url)
         assert response.status_code == 405
-
-    def test_valid_signature(self):
-        with override_options({"vercel.client-secret": secret}):
-            response = self.client.post(
-                path=self.url,
-                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
-                content_type="application/json",
-                HTTP_X_ZEIT_SIGNATURE=signature,
-            )
-
-            assert response.status_code == 202
 
     def test_invalid_signature(self):
         with override_options({"vercel.client-secret": secret}):
             response = self.client.post(
-                path=self.url,
+                path=webhook_url,
                 data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
                 content_type="application/json",
                 HTTP_X_ZEIT_SIGNATURE="xxxinvalidsignaturexxx",
@@ -49,8 +40,10 @@ class VercelWebhookTest(APITestCase):
 
             assert response.status_code == 401
 
-    @responses.activate
-    def test_create_release(self):
+
+class VercelReleasesTest(APITestCase):
+    def setUp(self):
+        super(VercelReleasesTest, self).setUp()
         self.project = self.create_project(organization=self.organization)
         self.integration = Integration.objects.create(
             provider="vercel",
@@ -58,7 +51,7 @@ class VercelWebhookTest(APITestCase):
             metadata={"access_token": "my_token"},
         )
 
-        OrganizationIntegration.objects.create(
+        self.org_integration = OrganizationIntegration.objects.create(
             organization=self.organization,
             integration=self.integration,
             config={
@@ -68,16 +61,18 @@ class VercelWebhookTest(APITestCase):
             },
         )
 
-        sentry_app = self.create_internal_integration(
+        self.sentry_app = self.create_internal_integration(
             webhook_url=None, name="Vercel Internal Integration", organization=self.organization,
         )
-        sentry_app_installation = SentryAppInstallation.objects.get(sentry_app=sentry_app)
-        SentryAppInstallationForProvider.objects.create(
+        sentry_app_installation = SentryAppInstallation.objects.get(sentry_app=self.sentry_app)
+        self.installation_for_provider = SentryAppInstallationForProvider.objects.create(
             organization=self.organization,
             provider="vercel",
             sentry_app_installation=sentry_app_installation,
         )
 
+    @responses.activate
+    def test_create_release(self):
         responses.add(
             responses.POST,
             absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
@@ -86,10 +81,181 @@ class VercelWebhookTest(APITestCase):
 
         with override_options({"vercel.client-secret": secret}):
             response = self.client.post(
-                path=self.url,
+                path=webhook_url,
                 data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
                 content_type="application/json",
                 HTTP_X_ZEIT_SIGNATURE=signature,
             )
 
             assert response.status_code == 201
+
+            assert len(responses.calls) == 2
+            release_body = json.loads(responses.calls[0].request.body)
+            set_refs_body = json.loads(responses.calls[1].request.body)
+            assert release_body == {
+                "projects": [self.project.slug],
+                "version": "7488658dfcf24d9b735e015992b316e2a8340d9d",
+            }
+            assert set_refs_body == {
+                "projects": [self.project.slug],
+                "version": "7488658dfcf24d9b735e015992b316e2a8340d9d",
+                "refs": [
+                    {
+                        "commit": "7488658dfcf24d9b735e015992b316e2a8340d9d",
+                        "repository": "MeredithAnya/nextjsblog-demo",
+                    }
+                ],
+            }
+
+    @responses.activate
+    def test_no_match(self):
+        responses.add(
+            responses.POST,
+            absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
+            json={},
+        )
+
+        self.org_integration.config = {}
+        self.org_integration.save()
+
+        with override_options({"vercel.client-secret": secret}):
+            response = self.client.post(
+                path=webhook_url,
+                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+                content_type="application/json",
+                HTTP_X_ZEIT_SIGNATURE=signature,
+            )
+
+            assert len(responses.calls) == 0
+            assert response.status_code == 202
+
+    @responses.activate
+    def test_no_integration(self):
+        responses.add(
+            responses.POST,
+            absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
+            json={},
+        )
+        self.integration.delete()
+
+        with override_options({"vercel.client-secret": secret}):
+            response = self.client.post(
+                path=webhook_url,
+                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+                content_type="application/json",
+                HTTP_X_ZEIT_SIGNATURE=signature,
+            )
+
+            assert len(responses.calls) == 0
+            assert response.status_code == 404
+            assert response.data["detail"] == "Integration not found"
+
+    @responses.activate
+    def test_no_project(self):
+        responses.add(
+            responses.POST,
+            absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
+            json={},
+        )
+        self.project.delete()
+
+        with override_options({"vercel.client-secret": secret}):
+            response = self.client.post(
+                path=webhook_url,
+                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+                content_type="application/json",
+                HTTP_X_ZEIT_SIGNATURE=signature,
+            )
+
+            assert len(responses.calls) == 0
+            assert response.status_code == 404
+            assert response.data["detail"] == "Project not found"
+
+    @responses.activate
+    def test_no_installation(self):
+        responses.add(
+            responses.POST,
+            absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
+            json={},
+        )
+        self.installation_for_provider.delete()
+
+        with override_options({"vercel.client-secret": secret}):
+            response = self.client.post(
+                path=webhook_url,
+                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+                content_type="application/json",
+                HTTP_X_ZEIT_SIGNATURE=signature,
+            )
+
+            assert len(responses.calls) == 0
+            assert response.status_code == 404
+            assert response.data["detail"] == "Installation not found"
+
+    @responses.activate
+    def test_no_token(self):
+        responses.add(
+            responses.POST,
+            absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
+            json={},
+        )
+
+        SentryAppInstallationToken.objects.filter().delete()
+
+        with override_options({"vercel.client-secret": secret}):
+            response = self.client.post(
+                path=webhook_url,
+                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+                content_type="application/json",
+                HTTP_X_ZEIT_SIGNATURE=signature,
+            )
+
+            assert len(responses.calls) == 0
+            assert response.status_code == 404
+            assert response.data["detail"] == "Token not found"
+
+    @responses.activate
+    def test_create_release_fails(self):
+        responses.add(
+            responses.POST,
+            absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
+            json={},
+            status=400,
+        )
+
+        with override_options({"vercel.client-secret": secret}):
+            response = self.client.post(
+                path=webhook_url,
+                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+                content_type="application/json",
+                HTTP_X_ZEIT_SIGNATURE=signature,
+            )
+
+            assert len(responses.calls) == 1
+            assert response.status_code == 400
+            assert "Error creating release" in response.data["detail"]
+
+    @responses.activate
+    def test_set_refs_failed(self):
+        def request_callback(request):
+            payload = json.loads(request.body)
+            status_code = 400 if payload.get("refs") else 200
+            return (status_code, {}, {})
+
+        responses.add_callback(
+            responses.POST,
+            absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
+            callback=request_callback,
+        )
+
+        with override_options({"vercel.client-secret": secret}):
+            response = self.client.post(
+                path=webhook_url,
+                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+                content_type="application/json",
+                HTTP_X_ZEIT_SIGNATURE=signature,
+            )
+
+            assert len(responses.calls) == 2
+            assert response.status_code == 400
+            assert "Error setting refs" in response.data["detail"]

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -1,7 +1,17 @@
 from __future__ import absolute_import
 
+import responses
+
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import override_options
+from sentry.utils.http import absolute_uri
+
+from sentry.models import (
+    Integration,
+    OrganizationIntegration,
+    SentryAppInstallationForProvider,
+    SentryAppInstallation,
+)
 
 from .testutils import EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE
 
@@ -26,7 +36,7 @@ class VercelWebhookTest(APITestCase):
                 HTTP_X_ZEIT_SIGNATURE=signature,
             )
 
-            assert response.status_code == 200
+            assert response.status_code == 202
 
     def test_invalid_signature(self):
         with override_options({"vercel.client-secret": secret}):
@@ -38,3 +48,48 @@ class VercelWebhookTest(APITestCase):
             )
 
             assert response.status_code == 401
+
+    @responses.activate
+    def test_create_release(self):
+        self.project = self.create_project(organization=self.organization)
+        self.integration = Integration.objects.create(
+            provider="vercel",
+            external_id="cstd1xKmLGVMed0z0f3SHlD2",
+            metadata={"access_token": "my_token"},
+        )
+
+        OrganizationIntegration.objects.create(
+            organization=self.organization,
+            integration=self.integration,
+            config={
+                "project_mappings": [
+                    [self.project.id, "QmQPfU4xn5APjEsSje4ccPcSJCmVAByA8CDKfZRhYyVPAg"]
+                ]
+            },
+        )
+
+        sentry_app = self.create_internal_integration(
+            webhook_url=None, name="Vercel Internal Integration", organization=self.organization,
+        )
+        sentry_app_installation = SentryAppInstallation.objects.get(sentry_app=sentry_app)
+        SentryAppInstallationForProvider.objects.create(
+            organization=self.organization,
+            provider="vercel",
+            sentry_app_installation=sentry_app_installation,
+        )
+
+        responses.add(
+            responses.POST,
+            absolute_uri("/api/0/organizations/%s/releases/" % self.organization.slug),
+            json={},
+        )
+
+        with override_options({"vercel.client-secret": secret}):
+            response = self.client.post(
+                path=self.url,
+                data=EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+                content_type="application/json",
+                HTTP_X_ZEIT_SIGNATURE=signature,
+            )
+
+            assert response.status_code == 201


### PR DESCRIPTION
This PR generates the release from the deployment webhook for Vercel. Note we only generate the release for the production environment. Here are the logical steps once the webhook has been verified:

1. find all org integrations that match the external id
2. search the configs to find one that matches the vercel project of the webhook
3. Look up the Sentry project that matches
4. Look up the connected internal integration
5. find the token associated with that installation
6. Determine the commit sha and repo based on what provider is used
7. Hit the releases endpoint using the token we found earlier

Note creating the release will fail if the user hasn't set up the source code integration or added the correct repo. There are a few possible solutions to this:
1. If we get a 400 error, we can try to create the release without specifying the `refs`
2. Add a new argument to the org releases endpoint to not give up if there is an error related to the `refs`
3. Just fail (currently implemented)

I also decided to just log a lot of the `NotFound` errors at info level since I don't think we should send them to Sentry.

Tests still need to be added