### PR TITLE
fix(integrations): pull referrer directly from window.location for integration analytics

### DIFF
--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -158,7 +158,7 @@ export const trackIntegrationEvent = (
       //Amplitude has it's own referrer which intefers with our custom referrer
       custom_referrer = referrer;
     }
-  } catch (_err) {
+  } catch {
     // ignore if this fails to parse
     // this can happen if we have an invalid query string
     // e.g. unencoded "%"

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -155,7 +155,7 @@ export const trackIntegrationEvent = (
     //pull the referrer from the query parameter of the page
     const {referrer} = qs.parse(window.location.search) || {};
     if (typeof referrer === 'string') {
-      //Amplitude has it's own referrer which intefers with our custom referrer
+      //Amplitude has its own referrer which intefers with our custom referrer
       custom_referrer = referrer;
     }
   } catch {

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -155,7 +155,7 @@ export const trackIntegrationEvent = (
     //pull the referrer from the query parameter of the page
     const {referrer} = qs.parse(window.location.search) || {};
     if (typeof referrer === 'string') {
-      //Amplitude has it's own referrer which intefers with our custom referrer
+      // Amplitude has it's own referrer which inteferes with our custom referrer
       custom_referrer = referrer;
     }
   } catch {

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -1,5 +1,6 @@
 import capitalize from 'lodash/capitalize';
 import React from 'react';
+import qs from 'query-string';
 
 import HookStore from 'app/stores/hookStore';
 import {
@@ -79,7 +80,6 @@ export type SingleIntegrationEvent = {
   plan?: string;
   //include the status since people might do weird things testing unpublished integrations
   integration_status?: SentryAppStatus;
-  referrer?: string; //where did the user come from
 };
 
 type MultipleIntegrationsEvent = {
@@ -149,9 +149,20 @@ export const trackIntegrationEvent = (
     );
   }
 
-  //Amplitude has it's own referrer which intefers with our custom referrer
-  const {referrer: custom_referrer} = analyticsParams;
-  delete analyticsParams.referrer;
+  let custom_referrer: string | undefined;
+
+  try {
+    //pull the referrer from the query parameter of the page
+    const {referrer} = qs.parse(window.location.search) || {};
+    if (typeof referrer === 'string') {
+      //Amplitude has it's own referrer which intefers with our custom referrer
+      custom_referrer = referrer;
+    }
+  } catch (_err) {
+    // ignore if this fails to parse
+    // this can happen if we have an invalid query string
+    // e.g. unencoded "%"
+  }
 
   const params = {
     analytics_session_id: sessionId,

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -209,7 +209,6 @@ class AbstractIntegrationDetailedView<
       integration: this.integrationSlug,
       integration_type: this.integrationType,
       already_installed: this.installationStatus !== 'Not Installed', //pending counts as installed here
-      referrer: this.props.location.query.referrer,
       ...options,
     };
     //type cast here so TS won't complain


### PR DESCRIPTION
We were missing the referrer on the reauth event. Rather than having to pass it through on events, it's easier to read directly from `window.location.search`.