### PR TITLE
fix(ui): Make the export buttons the same size on the tags page

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -9,6 +9,7 @@ import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
 import UserBadge from 'app/components/idBadge/userBadge';
 import Button from 'app/components/button';
+import ButtonBar from 'app/components/buttonBar';
 import DeviceName from 'app/components/deviceName';
 import ExternalLink from 'app/components/links/externalLink';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
@@ -124,7 +125,7 @@ class GroupTagValues extends AsyncComponent<
       <React.Fragment>
         <Header>
           <HeaderTitle>{tag.key === 'user' ? t('Affected Users') : tag.name}</HeaderTitle>
-          <HeaderButtons>
+          <HeaderButtons gap={1}>
             <BrowserExportButton
               size="small"
               priority="default"
@@ -174,12 +175,8 @@ const HeaderTitle = styled('h3')`
   margin: 0;
 `;
 
-const HeaderButtons = styled('div')`
-  display: grid;
-  grid-gap: ${space(1)};
-  grid-auto-flow: column;
-  grid-auto-columns: auto;
-  justify-items: end;
+const HeaderButtons = styled(ButtonBar)`
+  align-items: stretch;
   margin: 0px ${space(1.5)};
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -123,25 +123,26 @@ class GroupTagValues extends AsyncComponent<
     return (
       <React.Fragment>
         <Header>
-          {tag.key === 'user' ? t('Affected Users') : tag.name}
-          <BrowserExportButton
-            size="small"
-            priority="default"
-            href={`/${orgId}/${group.project.slug}/issues/${group.id}/tags/${tagKey}/export/`}
-          >
-            {t('Export Page to CSV')}
-          </BrowserExportButton>
-          <a />
-          <DataExport
-            payload={{
-              queryType: ExportQueryType.IssuesByTag,
-              queryInfo: {
-                project: group.project.id,
-                group: group.id,
-                key: tagKey,
-              },
-            }}
-          />
+          <HeaderTitle>{tag.key === 'user' ? t('Affected Users') : tag.name}</HeaderTitle>
+          <HeaderButtons>
+            <BrowserExportButton
+              size="small"
+              priority="default"
+              href={`/${orgId}/${group.project.slug}/issues/${group.id}/tags/${tagKey}/export/`}
+            >
+              {t('Export Page to CSV')}
+            </BrowserExportButton>
+            <DataExport
+              payload={{
+                queryType: ExportQueryType.IssuesByTag,
+                queryInfo: {
+                  project: group.project.id,
+                  group: group.id,
+                  key: tagKey,
+                },
+              }}
+            />
+          </HeaderButtons>
         </Header>
         <table className="table table-striped">
           <thead>
@@ -163,13 +164,28 @@ class GroupTagValues extends AsyncComponent<
     );
   }
 }
-const Header = styled('h3')`
+const Header = styled('div')`
   display: flex;
-  align-items: flex-end;
+  align-items: center;
+  margin: 0 0 20px;
+`;
+
+const HeaderTitle = styled('h3')`
+  margin: 0;
+`;
+
+const HeaderButtons = styled('div')`
+  display: grid;
+  grid-gap: ${space(1)};
+  grid-auto-flow: column;
+  grid-auto-columns: auto;
+  justify-items: end;
+  margin: 0px ${space(1.5)};
 `;
 
 const BrowserExportButton = styled(Button)`
-  margin: 0 ${space(1.5)};
+  display: flex;
+  align-items: center;
 `;
 
 const TableHeader = styled('th')<{width: number}>`


### PR DESCRIPTION
Before:
![Screenshot_2020-06-23 ConnectionError SafeHTTPSConnectionPool(host='pypi org', port=443) Max retries exceeded with url pypi (1)](https://user-images.githubusercontent.com/10239353/85477596-9ea4c680-b588-11ea-8273-29c5bc4cd011.png)

After:
![Screenshot_2020-06-23 ConnectionError SafeHTTPSConnectionPool(host='pypi org', port=443) Max retries exceeded with url pypi](https://user-images.githubusercontent.com/10239353/85477591-9ba9d600-b588-11ea-8e5c-4d5365c6fb5e.png)