### PR TITLE
fix(store): Fix Repository HOC getting bad data from store

### DIFF
--- a/src/sentry/static/sentry/app/stores/repositoryStore.tsx
+++ b/src/sentry/static/sentry/app/stores/repositoryStore.tsx
@@ -4,9 +4,8 @@ import RepoActions from 'app/actions/repositoryActions';
 import {Repository} from 'app/types';
 
 type RepositoryStoreInterface = {
-  get(
-    orgSlug?: string
-  ): {
+  get(): {
+    orgSlug?: string;
     repositories?: Repository[];
     repositoriesLoading?: boolean;
     repositoriesError?: Error;
@@ -77,22 +76,8 @@ export const RepositoryStoreConfig: Reflux.StoreDefinition & RepositoryStoreInte
     this.trigger(this.state);
   },
 
-  /**
-   * `orgSlug` is optional. If present, method will run a check if data in the
-   * store originated from the same organization
-   */
-  get(orgSlug?: string) {
-    const {orgSlug: stateOrgSlug, ...data} = this.state;
-
-    if (orgSlug !== undefined && orgSlug !== stateOrgSlug) {
-      return {
-        repositories: undefined,
-        repositoriesLoading: undefined,
-        repositoriesError: undefined,
-      };
-    }
-
-    return {...data};
+  get() {
+    return {...this.state};
   },
 };
 

--- a/src/sentry/static/sentry/app/utils/withRelease.tsx
+++ b/src/sentry/static/sentry/app/utils/withRelease.tsx
@@ -50,7 +50,10 @@ const withRelease = <P extends DependentProps>(
         DependentProps;
       const releaseData = ReleaseStore.get(projectSlug, releaseVersion);
 
-      if (!releaseData.release && !releaseData.releaseLoading) {
+      if (
+        (!releaseData.release && !releaseData.releaseLoading) ||
+        releaseData.releaseError
+      ) {
         getProjectRelease(api, {orgSlug, projectSlug, releaseVersion});
       }
     },
@@ -60,7 +63,10 @@ const withRelease = <P extends DependentProps>(
         DependentProps;
       const releaseData = ReleaseStore.get(projectSlug, releaseVersion);
 
-      if (!releaseData.deploys && !releaseData.deploysLoading) {
+      if (
+        (!releaseData.deploys && !releaseData.deploysLoading) ||
+        releaseData.deploysError
+      ) {
         getReleaseDeploys(api, {orgSlug, projectSlug, releaseVersion});
       }
     },


### PR DESCRIPTION
Previous implementation did not prevent duplicate requests because short-circuit hack updates `store.repositoriesLoading` but not `store.orgSlug`. That resulted in `store.get(orgSlug)` returning bad data.

`store.orgSlug` was removed as it is redundant. An action to reset the store will be emitted when the user change organizations.