### PR TITLE
feat(metric_alerts): Start writing to AlertRule.threshold_type

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -663,7 +663,14 @@ def main(num_events=1, extra_events=False):
             try:
                 # Metric alerts
                 alert_rule = create_alert_rule(
-                    org, [project], "My Alert Rule", "level:error", "count()", 10, 1
+                    org,
+                    [project],
+                    "My Alert Rule",
+                    "level:error",
+                    "count()",
+                    10,
+                    AlertRuleThresholdType.ABOVE,
+                    1,
                 )
                 create_alert_rule_trigger(alert_rule, "critical", AlertRuleThresholdType.ABOVE, 10)
                 create_incident(

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -193,7 +193,10 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
             "excluded_projects",
             "actions",
         ]
-        extra_kwargs = {"label": {"min_length": 1, "max_length": 64}}
+        extra_kwargs = {
+            "label": {"min_length": 1, "max_length": 64},
+            "threshold_type": {"required": False},
+        }
 
     def validate_threshold_type(self, threshold_type):
         try:
@@ -299,6 +302,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             "query",
             "time_window",
             "environment",
+            "threshold_type",
             "threshold_period",
             "aggregate",
             "projects",
@@ -309,6 +313,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         extra_kwargs = {
             "name": {"min_length": 1, "max_length": 64},
             "include_all_projects": {"default": False},
+            "threshold_type": {"required": False},
         }
 
     def validate_aggregate(self, aggregate):
@@ -327,6 +332,15 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         except ValueError:
             raise serializers.ValidationError(
                 "Invalid dataset, valid values are %s" % [item.value for item in QueryDatasets]
+            )
+
+    def validate_threshold_type(self, threshold_type):
+        try:
+            return AlertRuleThresholdType(threshold_type)
+        except ValueError:
+            raise serializers.ValidationError(
+                "Invalid threshold type, valid values are %s"
+                % [item.value for item in AlertRuleThresholdType]
             )
 
     def validate(self, data):
@@ -396,7 +410,13 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                     'Trigger {} must be labeled "{}"'.format(i + 1, expected_label)
                 )
         critical = triggers[0]
-        self._validate_trigger_thresholds(critical)
+        data["threshold_type"] = threshold_type = data.get(
+            "threshold_type",
+            AlertRuleThresholdType(
+                critical.get("threshold_type", AlertRuleThresholdType.ABOVE.value)
+            ),
+        )
+        self._validate_trigger_thresholds(threshold_type, critical)
 
         if len(triggers) == 2:
             warning = triggers[1]
@@ -405,8 +425,8 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                     "Must have matching threshold types (i.e. critical and warning "
                     "triggers must both be an upper or lower bound)"
                 )
-            self._validate_trigger_thresholds(warning)
-            self._validate_critical_warning_triggers(critical, warning)
+            self._validate_trigger_thresholds(threshold_type, warning)
+            self._validate_critical_warning_triggers(threshold_type, critical, warning)
 
         # Triggers have passed checks. Check that all triggers have at least one action now.
         for trigger in triggers:
@@ -418,7 +438,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
 
         return data
 
-    def _validate_trigger_thresholds(self, trigger):
+    def _validate_trigger_thresholds(self, threshold_type, trigger):
         if trigger.get("resolve_threshold") is None:
             return
         # Since we're comparing non-inclusive thresholds here (>, <), we need
@@ -426,7 +446,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         # Alert > 0, resolve < 1. This means that we want to alert on values
         # of 1 or more, and resolve on values of 0 or less. This is valid, but
         # without modifying the values, this boundary case will fail.
-        if trigger["threshold_type"] == AlertRuleThresholdType.ABOVE.value:
+        if threshold_type == AlertRuleThresholdType.ABOVE:
             alert_op, alert_add, resolve_add = operator.lt, 1, -1
         else:
             alert_op, alert_add, resolve_add = operator.gt, -1, 1
@@ -438,11 +458,11 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 "{} alert threshold must be above resolution threshold".format(trigger["label"])
             )
 
-    def _validate_critical_warning_triggers(self, critical, warning):
-        if critical["threshold_type"] == AlertRuleThresholdType.ABOVE.value:
+    def _validate_critical_warning_triggers(self, threshold_type, critical, warning):
+        if threshold_type == AlertRuleThresholdType.ABOVE:
             alert_op = operator.lt
             threshold_type = "above"
-        elif critical["threshold_type"] == AlertRuleThresholdType.BELOW.value:
+        elif threshold_type == AlertRuleThresholdType.BELOW:
             alert_op = operator.gt
             threshold_type = "below"
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -530,6 +530,7 @@ def create_alert_rule(
     query,
     aggregate,
     time_window,
+    threshold_type,
     threshold_period,
     environment=None,
     include_all_projects=False,
@@ -548,6 +549,7 @@ def create_alert_rule(
     :param aggregate: A string representing the aggregate used in this alert rule
     :param time_window: Time period to aggregate over, in minutes
     :param environment: An optional environment that this rule applies to
+    :param threshold_type: An AlertRuleThresholdType
     :param threshold_period: How many update periods the value of the
     subscription needs to exceed the threshold before triggering
     :param include_all_projects: Whether to include all current and future projects
@@ -575,6 +577,7 @@ def create_alert_rule(
             organization=organization,
             snuba_query=snuba_query,
             name=name,
+            threshold_type=threshold_type.value,
             threshold_period=threshold_period,
             include_all_projects=include_all_projects,
         )
@@ -637,6 +640,7 @@ def update_alert_rule(
     aggregate=None,
     time_window=None,
     environment=None,
+    threshold_type=None,
     threshold_period=None,
     include_all_projects=None,
     excluded_projects=None,
@@ -653,6 +657,7 @@ def update_alert_rule(
     :param aggregate: A string representing the aggregate used in this alert rule
     :param time_window: Time period to aggregate over, in minutes.
     :param environment: An optional environment that this rule applies to
+    :param threshold_type: An AlertRuleThresholdType
     :param threshold_period: How many update periods the value of the
     subscription needs to exceed the threshold before triggering
     :param include_all_projects: Whether to include all current and future projects
@@ -679,6 +684,8 @@ def update_alert_rule(
         updated_query_fields["aggregate"] = aggregate
     if time_window:
         updated_query_fields["time_window"] = timedelta(minutes=time_window)
+    if threshold_type:
+        updated_fields["threshold_type"] = threshold_type.value
     if threshold_period:
         updated_fields["threshold_period"] = threshold_period
     if include_all_projects is not None:

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -861,6 +861,7 @@ class Factories(object):
         excluded_projects=None,
         date_added=None,
         dataset=QueryDatasets.EVENTS,
+        threshold_type=AlertRuleThresholdType.ABOVE,
     ):
         if not name:
             name = petname.Generate(2, " ", letters=10).title()
@@ -872,6 +873,7 @@ class Factories(object):
             query,
             aggregate,
             time_window,
+            threshold_type,
             threshold_period,
             dataset=dataset,
             environment=environment,

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -5,7 +5,6 @@ import pytz
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.incidents.logic import create_alert_rule
 
 FEATURE_NAME = "organizations:incidents"
 
@@ -25,10 +24,7 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
             self.browser.snapshot("incidents - empty state")
 
     def test_incidents_list(self):
-        alert_rule = create_alert_rule(
-            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
-        )
-
+        alert_rule = self.create_alert_rule()
         incident = self.create_incident(
             self.organization,
             title="Incident #1",

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -10,7 +10,7 @@ from sentry.api.serializers.models.alert_rule import (
     CombinedRuleSerializer,
 )
 from sentry.models import Rule
-from sentry.incidents.logic import create_alert_rule, create_alert_rule_trigger
+from sentry.incidents.logic import create_alert_rule_trigger
 from sentry.incidents.models import AlertRuleThresholdType
 from sentry.testutils import TestCase, APITestCase
 
@@ -70,9 +70,7 @@ class BaseAlertRuleSerializerTest(object):
 
 class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
     def test_simple(self):
-        alert_rule = create_alert_rule(
-            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
-        )
+        alert_rule = self.create_alert_rule()
         result = serialize(alert_rule)
         self.assert_alert_rule_serialized(alert_rule, result)
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -4,7 +4,6 @@ from exam import fixture
 from freezegun import freeze_time
 
 from sentry.api.serializers import serialize
-from sentry.incidents.logic import create_alert_rule
 from sentry.incidents.models import AlertRule
 from sentry.testutils import APITestCase
 
@@ -26,9 +25,7 @@ class AlertRuleListEndpointTest(APITestCase):
 
     def test_simple(self):
         self.create_team(organization=self.organization, members=[self.user])
-        alert_rule = create_alert_rule(
-            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
-        )
+        alert_rule = self.create_alert_rule()
 
         self.login_as(self.user)
         with self.feature("organizations:incidents"):

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from exam import fixture
 
 from sentry.api.serializers import serialize
-from sentry.incidents.logic import create_alert_rule
 from sentry.incidents.models import AlertRule, AlertRuleStatus, Incident, IncidentStatus
 from sentry.testutils import APITestCase
 
@@ -74,9 +73,7 @@ class AlertRuleDetailsBase(object):
 
     @fixture
     def alert_rule(self):
-        return create_alert_rule(
-            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
-        )
+        return self.create_alert_rule(name="hello")
 
     def test_invalid_rule_id(self):
         self.create_member(
@@ -121,15 +118,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
         )
         self.login_as(self.user)
-        alert_rule = create_alert_rule(
-            self.organization,
-            [self.project],
-            "hello",
-            "level:error",
-            "count_unique(tags[sentry:user])",
-            10,
-            1,
-        )
+        alert_rule = self.create_alert_rule(aggregate="count_unique(tags[sentry:user])")
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(self.organization.slug, self.project.slug, alert_rule.id)
             assert resp.data["aggregate"] == "count_unique(user)"

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -9,7 +9,6 @@ from exam import fixture
 from freezegun import freeze_time
 
 from sentry.api.serializers import serialize
-from sentry.incidents.logic import create_alert_rule
 from sentry.incidents.models import AlertRule
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils import TestCase, APITestCase
@@ -36,9 +35,7 @@ class AlertRuleListEndpointTest(APITestCase):
 
     def test_simple(self):
         self.create_team(organization=self.organization, members=[self.user])
-        alert_rule = create_alert_rule(
-            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
-        )
+        alert_rule = self.create_alert_rule()
 
         self.login_as(self.user)
         with self.feature("organizations:incidents"):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -141,7 +141,7 @@ class TestAlertRuleSerializer(TestCase):
             {"aggregate": ["Invalid Metric: count_unique(123, hello): expected 1 arguments"]},
         )
         self.run_fail_validation_test(
-            {"aggregate": "max()"}, {"aggregate": ["Invalid Metric: max(): expected 1 arguments"]},
+            {"aggregate": "max()"}, {"aggregate": ["Invalid Metric: max(): expected 1 arguments"]}
         )
         aggregate = "count_unique(tags[sentry:user])"
         base_params = self.valid_params.copy()
@@ -178,7 +178,6 @@ class TestAlertRuleSerializer(TestCase):
             "name": "hello_im_a_test",
             "time_window": 10,
             "query": "level:error",
-            "threshold_type": 0,
             "aggregate": "count()",
             "threshold_period": 1,
             "projects": [self.project.slug],
@@ -197,6 +196,7 @@ class TestAlertRuleSerializer(TestCase):
         serializer = AlertRuleSerializer(context=self.context, data=payload, partial=True)
 
         assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["threshold_type"] == AlertRuleThresholdType.BELOW
 
         # Now do a two trigger test:
         payload["triggers"].append(
@@ -216,12 +216,37 @@ class TestAlertRuleSerializer(TestCase):
 
         assert serializer.is_valid(), serializer.errors
 
+    def test_alert_rule_threshold_overrides_trigger(self):
+        payload = {
+            "name": "hello_im_a_test",
+            "time_window": 10,
+            "query": "level:error",
+            "aggregate": "count()",
+            "thresholdType": 0,
+            "threshold_period": 1,
+            "projects": [self.project.slug],
+            "triggers": [
+                {
+                    "label": "critical",
+                    "alertThreshold": 98,
+                    "resolveThreshold": None,
+                    "thresholdType": 1,
+                    "actions": [
+                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id}
+                    ],
+                }
+            ],
+        }
+        serializer = AlertRuleSerializer(context=self.context, data=payload, partial=True)
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["threshold_type"] == AlertRuleThresholdType.ABOVE
+
     def test_boundary(self):
         payload = {
             "name": "hello_im_a_test",
             "time_window": 10,
             "query": "level:error",
-            "threshold_type": 0,
             "aggregate": "count()",
             "threshold_period": 1,
             "projects": [self.project.slug],
@@ -371,7 +396,6 @@ class TestAlertRuleTriggerSerializer(TestCase):
         field_is_required = ["This field is required."]
         assert serializer.errors == {
             "label": field_is_required,
-            "thresholdType": field_is_required,
             "alertThreshold": field_is_required,
             "actions": field_is_required,
         }

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -84,9 +84,7 @@ class CreateIncidentTest(TestCase):
         incident_type = IncidentType.ALERT_TRIGGERED
         title = "hello"
         date_started = timezone.now() - timedelta(minutes=5)
-        alert_rule = create_alert_rule(
-            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
-        )
+        alert_rule = self.create_alert_rule()
 
         self.record_event.reset_mock()
         incident = create_incident(
@@ -559,9 +557,7 @@ class CreateIncidentSnapshotTest(TestCase, BaseIncidentsTest):
         # end to actually be, so we have logic to cap it to 10 datapoints, or 10 days, whichever is less. This tests that logic.
 
         time_window = 1500  # more than 24 hours, so gets capped at 10 days
-        alert_rule = create_alert_rule(
-            self.organization, [self.project], "hello", "level:error", "count()", time_window, 1
-        )
+        alert_rule = self.create_alert_rule(time_window=time_window)
 
         incident = self.create_incident(self.organization)
         incident.update(status=IncidentStatus.CLOSED.value, alert_rule=alert_rule)
@@ -665,9 +661,17 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         query = "level:error"
         aggregate = "count(*)"
         time_window = 10
+        threshold_type = AlertRuleThresholdType.ABOVE
         threshold_period = 1
         alert_rule = create_alert_rule(
-            self.organization, [self.project], name, query, aggregate, time_window, threshold_period
+            self.organization,
+            [self.project],
+            name,
+            query,
+            aggregate,
+            time_window,
+            threshold_type,
+            threshold_period,
         )
         assert alert_rule.snuba_query.subscriptions.get().project == self.project
         assert alert_rule.name == name
@@ -678,6 +682,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.snuba_query.aggregate == aggregate
         assert alert_rule.snuba_query.time_window == time_window * 60
         assert alert_rule.snuba_query.resolution == DEFAULT_ALERT_RULE_RESOLUTION * 60
+        assert alert_rule.threshold_type == threshold_type.value
         assert alert_rule.threshold_period == threshold_period
 
     def test_include_all_projects(self):
@@ -696,25 +701,64 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     def test_invalid_query(self):
         with self.assertRaises(InvalidSearchQuery):
-            create_alert_rule(self.organization, [self.project], "hi", "has:", "count()", 1, 1)
+            create_alert_rule(
+                self.organization,
+                [self.project],
+                "hi",
+                "has:",
+                "count()",
+                1,
+                AlertRuleThresholdType.ABOVE,
+                1,
+            )
 
     def test_existing_name(self):
         name = "uh oh"
-        create_alert_rule(self.organization, [self.project], name, "level:error", "count()", 1, 1)
+        create_alert_rule(
+            self.organization,
+            [self.project],
+            name,
+            "level:error",
+            "count()",
+            1,
+            AlertRuleThresholdType.ABOVE,
+            1,
+        )
         with self.assertRaises(AlertRuleNameAlreadyUsedError):
             create_alert_rule(
-                self.organization, [self.project], name, "level:error", "count()", 1, 1
+                self.organization,
+                [self.project],
+                name,
+                "level:error",
+                "count()",
+                1,
+                AlertRuleThresholdType.ABOVE,
+                1,
             )
 
     def test_existing_name_allowed_when_archived(self):
         name = "allowed"
         alert_rule_1 = create_alert_rule(
-            self.organization, [self.project], name, "level:error", "count()", 1, 1
+            self.organization,
+            [self.project],
+            name,
+            "level:error",
+            "count()",
+            1,
+            AlertRuleThresholdType.ABOVE,
+            1,
         )
         alert_rule_1.update(status=AlertRuleStatus.SNAPSHOT.value)
 
         alert_rule_2 = create_alert_rule(
-            self.organization, [self.project], name, "level:error", "count()", 1, 1
+            self.organization,
+            [self.project],
+            name,
+            "level:error",
+            "count()",
+            1,
+            AlertRuleThresholdType.ABOVE,
+            1,
         )
 
         assert alert_rule_1.name == alert_rule_2.name
@@ -728,12 +772,26 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
     def test_two_archived_with_same_name(self):
         name = "allowed"
         alert_rule_1 = create_alert_rule(
-            self.organization, [self.project], name, "level:error", "count()", 1, 1
+            self.organization,
+            [self.project],
+            name,
+            "level:error",
+            "count()",
+            1,
+            AlertRuleThresholdType.ABOVE,
+            1,
         )
         alert_rule_1.update(status=AlertRuleStatus.SNAPSHOT.value)
 
         alert_rule_2 = create_alert_rule(
-            self.organization, [self.project], name, "level:error", "count()", 1, 1
+            self.organization,
+            [self.project],
+            name,
+            "level:error",
+            "count()",
+            1,
+            AlertRuleThresholdType.ABOVE,
+            1,
         )
         alert_rule_2.update(status=AlertRuleStatus.SNAPSHOT.value)
 
@@ -745,15 +803,14 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
 class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
     @fixture
     def alert_rule(self):
-        return create_alert_rule(
-            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
-        )
+        return self.create_alert_rule(name="hello")
 
     def test(self):
         name = "uh oh"
         query = "level:warning"
         aggregate = "count_unique(tags[sentry:user])"
         time_window = 50
+        threshold_type = AlertRuleThresholdType.BELOW
         threshold_period = 2
 
         updated_projects = [self.project, self.create_project(fire_project_created=True)]
@@ -765,6 +822,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             query=query,
             aggregate=aggregate,
             time_window=time_window,
+            threshold_type=threshold_type,
             threshold_period=threshold_period,
         )
         assert self.alert_rule.id == updated_rule.id
@@ -780,6 +838,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert self.alert_rule.snuba_query.query == query
         assert self.alert_rule.snuba_query.aggregate == aggregate
         assert self.alert_rule.snuba_query.time_window == time_window * 60
+        assert self.alert_rule.threshold_type == threshold_type.value
         assert self.alert_rule.threshold_period == threshold_period
 
     def test_update_subscription(self):
@@ -796,9 +855,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
     def test_name_used(self):
         used_name = "uh oh"
-        create_alert_rule(
-            self.organization, [self.project], used_name, "level:error", "count()", 10, 1
-        )
+        self.create_alert_rule(name=used_name)
         with self.assertRaises(AlertRuleNameAlreadyUsedError):
             update_alert_rule(self.alert_rule, name=used_name)
 
@@ -807,27 +864,15 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             update_alert_rule(self.alert_rule, query="has:")
 
     def test_delete_projects(self):
-        alert_rule = create_alert_rule(
-            self.organization,
-            [self.project, self.create_project(fire_project_created=True)],
-            "something",
-            "level:error",
-            "count()",
-            10,
-            1,
+        alert_rule = self.create_alert_rule(
+            projects=[self.project, self.create_project(fire_project_created=True)]
         )
         update_alert_rule(alert_rule, projects=[self.project])
         assert self.alert_rule.snuba_query.subscriptions.get().project == self.project
 
     def test_new_updated_deleted_projects(self):
-        alert_rule = create_alert_rule(
-            self.organization,
-            [self.project, self.create_project(fire_project_created=True)],
-            "something",
-            "level:error",
-            "count()",
-            10,
-            1,
+        alert_rule = self.create_alert_rule(
+            projects=[self.project, self.create_project(fire_project_created=True)]
         )
         query_update = "level:warning"
         new_project = self.create_project(fire_project_created=True)
@@ -969,9 +1014,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):
     @fixture
     def alert_rule(self):
-        return create_alert_rule(
-            self.organization, [self.project], "hello", "level:error", "count()", 10, 1
-        )
+        return self.create_alert_rule()
 
     def test(self):
         alert_rule_id = self.alert_rule.id

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -12,11 +12,7 @@ from exam import fixture, patcher
 from freezegun import freeze_time
 from sentry.utils.compat.mock import call, Mock
 
-from sentry.incidents.logic import (
-    create_alert_rule,
-    create_alert_rule_trigger,
-    create_alert_rule_trigger_action,
-)
+from sentry.incidents.logic import create_alert_rule_trigger, create_alert_rule_trigger_action
 from sentry.incidents.models import (
     AlertRule,
     AlertRuleThresholdType,
@@ -78,10 +74,9 @@ class ProcessUpdateTest(TestCase):
 
     @fixture
     def rule(self):
-        rule = create_alert_rule(
-            self.organization,
-            [self.project, self.other_project],
-            "some rule",
+        rule = self.create_alert_rule(
+            projects=[self.project, self.other_project],
+            name="some rule",
             query="",
             aggregate="count()",
             time_window=1,

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -13,11 +13,7 @@ from exam import fixture
 from freezegun import freeze_time
 
 from sentry.incidents.action_handlers import EmailActionHandler
-from sentry.incidents.logic import (
-    create_alert_rule,
-    create_alert_rule_trigger,
-    create_alert_rule_trigger_action,
-)
+from sentry.incidents.logic import create_alert_rule_trigger, create_alert_rule_trigger_action
 from sentry.incidents.models import (
     AlertRuleThresholdType,
     AlertRuleTriggerAction,
@@ -55,14 +51,8 @@ class HandleSnubaQueryUpdateTest(TestCase):
     @fixture
     def rule(self):
         with self.tasks():
-            rule = create_alert_rule(
-                self.organization,
-                [self.project],
-                "some rule",
-                query="",
-                aggregate="count()",
-                time_window=1,
-                threshold_period=1,
+            rule = self.create_alert_rule(
+                name="some rule", query="", aggregate="count()", time_window=1, threshold_period=1
             )
             trigger = create_alert_rule_trigger(
                 rule, "hi", AlertRuleThresholdType.ABOVE, 100, resolve_threshold=10


### PR DESCRIPTION
This pr starts writing to the new `AlertRule.threshold_type` field. We aren't using this field
just yet, but we want to start keeping it in sync.

Depends on https://github.com/getsentry/sentry/pull/19522