### PR TITLE
fix(apm): Add inline tracing docs

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/inlineDocs.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/inlineDocs.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/browser';
 
 import withApi from 'app/utils/withApi';
 import {Client} from 'app/api';
@@ -19,7 +20,6 @@ type State = {
   loading: boolean;
   html: string | undefined;
   link: string | undefined;
-  error: any | undefined;
 };
 
 class InlineDocs extends React.Component<Props, State> {
@@ -27,7 +27,6 @@ class InlineDocs extends React.Component<Props, State> {
     loading: true,
     html: undefined,
     link: undefined,
-    error: undefined,
   };
 
   componentDidMount() {
@@ -63,7 +62,8 @@ class InlineDocs extends React.Component<Props, State> {
       const {html, link} = await loadDocs(api, orgSlug, projectSlug, tracingPlatform);
       this.setState({html, link});
     } catch (error) {
-      this.setState({error});
+      Sentry.captureException(error);
+      this.setState({html: undefined, link: undefined});
     }
 
     this.setState({loading: false});

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/inlineDocs.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/inlineDocs.tsx
@@ -5,6 +5,7 @@ import withApi from 'app/utils/withApi';
 import {Client} from 'app/api';
 import {loadDocs} from 'app/actionCreators/projects';
 import {t, tct} from 'app/locale';
+import LoadingIndicator from 'app/components/loadingIndicator';
 
 type Props = {
   api: Client;
@@ -76,7 +77,11 @@ class InlineDocs extends React.Component<Props, State> {
     }
 
     if (this.state.loading) {
-      return <div>loading</div>;
+      return (
+        <div>
+          <LoadingIndicator />
+        </div>
+      );
     }
 
     if (this.state.html) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/inlineDocs.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/inlineDocs.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import withApi from 'app/utils/withApi';
+import {Client} from 'app/api';
+import {loadDocs} from 'app/actionCreators/projects';
+import {t, tct} from 'app/locale';
+
+type Props = {
+  api: Client;
+
+  platform: string;
+  projectSlug: string;
+  orgSlug: string;
+};
+
+type State = {
+  loading: boolean;
+  html: string | undefined;
+  link: string | undefined;
+  error: any | undefined;
+};
+
+class InlineDocs extends React.Component<Props, State> {
+  state: State = {
+    loading: true,
+    html: undefined,
+    link: undefined,
+    error: undefined,
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  fetchData = async () => {
+    const {platform, api, orgSlug, projectSlug} = this.props;
+
+    if (!platform) {
+      return;
+    }
+
+    this.setState({loading: true});
+
+    let tracingPlatform = '';
+    switch (platform) {
+      case 'sentry.python': {
+        tracingPlatform = 'python-tracing';
+        break;
+      }
+      case 'sentry.javascript.node': {
+        tracingPlatform = 'node-tracing';
+        break;
+      }
+      default: {
+        this.setState({loading: false});
+        return;
+      }
+    }
+
+    try {
+      const {html, link} = await loadDocs(api, orgSlug, projectSlug, tracingPlatform);
+      this.setState({html, link});
+    } catch (error) {
+      this.setState({error});
+    }
+
+    this.setState({loading: false});
+  };
+
+  render() {
+    const {platform} = this.props;
+
+    if (!platform) {
+      return null;
+    }
+
+    if (this.state.loading) {
+      return <div>loading</div>;
+    }
+
+    if (this.state.html) {
+      return (
+        <div>
+          <h2>{t('Requires Manual Instrumentation')}</h2>
+          <DocumentationWrapper dangerouslySetInnerHTML={{__html: this.state.html}} />
+          <p>
+            {tct(
+              `For in-depth instructions on setting up tracing, view [docLink:our documentation].`,
+              {
+                docLink: <a href={this.state.link} />,
+              }
+            )}
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <h2>{t('Requires Manual Instrumentation')}</h2>
+        <p>
+          {tct(
+            `To manually instrument certain regions of your code, view [docLink:our documentation].`,
+            {
+              docLink: (
+                <a href="https://docs.sentry.io/performance/distributed-tracing/#setting-up-tracing" />
+              ),
+            }
+          )}
+        </p>
+      </div>
+    );
+  }
+}
+
+const DocumentationWrapper = styled('div')`
+  p {
+    line-height: 1.5;
+  }
+  pre {
+    word-break: break-all;
+    white-space: pre-wrap;
+  }
+`;
+
+export default withApi(InlineDocs);

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/inlineDocs.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/inlineDocs.tsx
@@ -108,9 +108,7 @@ class InlineDocs extends React.Component<Props, State> {
           {tct(
             `To manually instrument certain regions of your code, view [docLink:our documentation].`,
             {
-              docLink: (
-                <a href="https://docs.sentry.io/performance/distributed-tracing/#setting-up-tracing" />
-              ),
+              docLink: <a href="https://docs.sentry.io/performance-monitoring/setup/" />,
             }
           )}
         </p>

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -25,6 +25,7 @@ import withApi from 'app/utils/withApi';
 import {ProcessedSpanType, RawSpanType, ParsedTraceType, rawSpanKeys} from './types';
 import {isGapSpan, isOrphanSpan, getTraceDateTimeRange} from './utils';
 import * as SpanEntryContext from './context';
+import InlineDocs from './inlineDocs';
 
 type TransactionResult = {
   'project.name': string;
@@ -355,8 +356,20 @@ class SpanDetail extends React.Component<Props, State> {
     );
   }
 
-  render() {
-    const {span} = this.props;
+  renderSpanDetails() {
+    const {span, event, organization} = this.props;
+
+    if (isGapSpan(span)) {
+      return (
+        <SpanDetails>
+          <InlineDocs
+            platform={event.sdk?.name || ''}
+            orgSlug={organization.slug}
+            projectSlug={event.projectSlug}
+          />
+        </SpanDetails>
+      );
+    }
 
     const startTimestamp: number = span.start_timestamp;
     const endTimestamp: number = span.timestamp;
@@ -364,22 +377,12 @@ class SpanDetail extends React.Component<Props, State> {
     const duration = (endTimestamp - startTimestamp) * 1000;
     const durationString = `${duration.toFixed(3)}ms`;
 
-    if (isGapSpan(span)) {
-      return null;
-    }
-
     const unknownKeys = Object.keys(span).filter(key => {
       return !rawSpanKeys.has(key as any);
     });
 
     return (
-      <SpanDetailContainer
-        data-component="span-detail"
-        onClick={event => {
-          // prevent toggling the span detail
-          event.stopPropagation();
-        }}
-      >
+      <React.Fragment>
         {this.renderOrphanSpanMessage()}
         {this.renderSpanErrorMessage()}
         <SpanDetails>
@@ -438,6 +441,20 @@ class SpanDetail extends React.Component<Props, State> {
             </tbody>
           </table>
         </SpanDetails>
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    return (
+      <SpanDetailContainer
+        data-component="span-detail"
+        onClick={event => {
+          // prevent toggling the span detail
+          event.stopPropagation();
+        }}
+      >
+        {this.renderSpanDetails()}
       </SpanDetailContainer>
     );
   }


### PR DESCRIPTION
Using the same pattern here for fetching inline docs: https://github.com/getsentry/sentry/blob/401535d60da018d3a308c44ef6f45a6146757431/src/sentry/static/sentry/app/views/projectInstall/platform.jsx

Corresponding PR to mark sections of the tracing docs to be used for the inline tracing documentation: https://github.com/getsentry/sentry-docs/pull/1784

-----

Node.js docs:

<img width="1313" alt="Screen Shot 2020-06-24 at 7 37 20 AM" src="https://user-images.githubusercontent.com/139499/85550196-b9aa2180-b5ee-11ea-8fcb-df9ad22a4f0d.png">

Python docs:

<img width="1310" alt="Screen Shot 2020-06-24 at 7 36 04 AM" src="https://user-images.githubusercontent.com/139499/85550202-badb4e80-b5ee-11ea-9956-be6ca735e7b2.png">

Fallback when there are no docs: 

<img width="1311" alt="Screen Shot 2020-06-24 at 7 44 05 AM" src="https://user-images.githubusercontent.com/139499/85550194-b9118b00-b5ee-11ea-944c-10f558f2bed0.png">