### PR TITLE
fix(perf-views) Fix zoom on duration breakdown and missing releases

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -350,7 +350,6 @@ class EventsChart extends React.Component<Props> {
           period={period}
           start={start}
           end={end}
-          api={api}
           projects={projects}
         >
           {({releaseSeries}) => previousChart({...chartProps, releaseSeries})}

--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -27,6 +27,7 @@ function getOrganizationReleases(api, organization, conditions = null) {
       query[key] = value;
     }
   });
+  api.clear();
   return api.requestPromise(`/organizations/${organization.slug}/releases/`, {
     method: 'GET',
     query,
@@ -67,14 +68,18 @@ class ReleaseSeries extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (!isEqual(prevProps.projects, this.props.projects)) {
+    if (
+      !isEqual(prevProps.projects, this.props.projects) ||
+      !isEqual(prevProps.start, this.props.start) ||
+      !isEqual(prevProps.end, this.props.end) ||
+      !isEqual(prevProps.period, this.props.period)
+    ) {
       this.fetchData();
     }
   }
 
   fetchData() {
     const {api, organization, projects, period, start, end} = this.props;
-
     const conditions = {start, end, project: projects, statsPeriod: period};
     getOrganizationReleases(api, organization, conditions)
       .then(releases => {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -153,13 +153,16 @@ class DurationChart extends React.Component<Props> {
                       .reverse()
                   : [];
 
+                // Stack the toolbox under the legend.
+                // so all series names are clickable.
+                zoomRenderProps.toolBox.z = -1;
+
                 return (
                   <ReleaseSeries
                     start={start}
                     end={end}
                     period={statsPeriod}
                     utc={utc}
-                    api={api}
                     projects={project}
                   >
                     {({releaseSeries}) => (
@@ -175,9 +178,6 @@ class DurationChart extends React.Component<Props> {
                                 showSymbol: false,
                               }}
                               tooltip={tooltip}
-                              toolBox={{
-                                show: false,
-                              }}
                               grid={{
                                 left: '10px',
                                 right: '10px',

--- a/tests/js/spec/components/charts/releaseSeries.spec.jsx
+++ b/tests/js/spec/components/charts/releaseSeries.spec.jsx
@@ -119,6 +119,30 @@ describe('ReleaseSeries', function() {
     );
   });
 
+  it('fetches on property updates', async function() {
+    const wrapper = mount(
+      <ReleaseSeries period="14d">{renderFunc}</ReleaseSeries>,
+      routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    const cases = [
+      {period: '7d'},
+      {start: '2020-01-01', end: '2020-01-02'},
+      {projects: [1]},
+    ];
+    for (const scenario of cases) {
+      releasesMock.mockReset();
+
+      wrapper.setProps(scenario);
+      wrapper.update();
+      await tick();
+
+      expect(releasesMock).toHaveBeenCalled();
+    }
+  });
+
   it('generates an eCharts `markLine` series from releases', async function() {
     const wrapper = mount(<ReleaseSeries>{renderFunc}</ReleaseSeries>, routerContext);
 


### PR DESCRIPTION
Hiding the toolbox entirely breaks dataZoom, and the new race prevention in EventsRequest was also clearing the ReleaseSeries requests as the Client instance was shared. Breaking the client instances up prevent cascading cancellation.

The release series was also not reloading its data when zooming. So you could have incorrect data when zooming out, or zooming into an old timeslice.