### PR TITLE
fix(perf-events) Don't render descenders for collapsed span subtrees

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -38,15 +38,15 @@ type PropType = {
 };
 
 class TraceViewHeader extends React.Component<PropType> {
-  renderCursorGuide = ({
+  renderCursorGuide({
     cursorGuideHeight,
     showCursorGuide,
     mouseLeft,
-  }: {
+  }): {
     cursorGuideHeight: number;
     showCursorGuide: boolean;
     mouseLeft: number | undefined;
-  }) => {
+  } {
     if (!showCursorGuide || !mouseLeft) {
       return null;
     }
@@ -59,9 +59,9 @@ class TraceViewHeader extends React.Component<PropType> {
         }}
       />
     );
-  };
+  }
 
-  renderViewHandles = ({
+  renderViewHandles({
     isDragging,
     onLeftHandleDragStart,
     leftHandlePosition,
@@ -69,7 +69,7 @@ class TraceViewHeader extends React.Component<PropType> {
     rightHandlePosition,
     viewWindowStart,
     viewWindowEnd,
-  }: DragManagerChildrenProps) => {
+  }: DragManagerChildrenProps) {
     const leftHandleGhost = isDragging ? (
       <Handle
         left={viewWindowStart}
@@ -114,28 +114,30 @@ class TraceViewHeader extends React.Component<PropType> {
         {rightHandle}
       </React.Fragment>
     );
-  };
+  }
 
-  renderFog = (dragProps: DragManagerChildrenProps) => (
-    <React.Fragment>
-      <Fog style={{height: '100%', width: toPercent(dragProps.viewWindowStart)}} />
-      <Fog
-        style={{
-          height: '100%',
-          width: toPercent(1 - dragProps.viewWindowEnd),
-          left: toPercent(dragProps.viewWindowEnd),
-        }}
-      />
-    </React.Fragment>
-  );
+  renderFog(dragProps: DragManagerChildrenProps) {
+    return (
+      <React.Fragment>
+        <Fog style={{height: '100%', width: toPercent(dragProps.viewWindowStart)}} />
+        <Fog
+          style={{
+            height: '100%',
+            width: toPercent(1 - dragProps.viewWindowEnd),
+            left: toPercent(dragProps.viewWindowEnd),
+          }}
+        />
+      </React.Fragment>
+    );
+  }
 
-  renderDurationGuide = ({
+  renderDurationGuide({
     showCursorGuide,
     mouseLeft,
   }: {
     showCursorGuide: boolean;
     mouseLeft: number | undefined;
-  }) => {
+  }) {
     if (!showCursorGuide || !mouseLeft) {
       return null;
     }
@@ -162,15 +164,15 @@ class TraceViewHeader extends React.Component<PropType> {
         <span>{getHumanDuration(duration)}</span>
       </DurationGuideBox>
     );
-  };
+  }
 
-  renderTimeAxis = ({
+  renderTimeAxis({
     showCursorGuide,
     mouseLeft,
   }: {
     showCursorGuide: boolean;
     mouseLeft: number | undefined;
-  }) => {
+  }) {
     const {trace} = this.props;
 
     const duration = Math.abs(trace.traceEndTimestamp - trace.traceStartTimestamp);
@@ -242,9 +244,9 @@ class TraceViewHeader extends React.Component<PropType> {
         })}
       </TimeAxis>
     );
-  };
+  }
 
-  renderWindowSelection = (dragProps: DragManagerChildrenProps) => {
+  renderWindowSelection(dragProps: DragManagerChildrenProps) {
     if (!dragProps.isWindowSelectionDragging) {
       return null;
     }
@@ -262,7 +264,7 @@ class TraceViewHeader extends React.Component<PropType> {
         }}
       />
     );
-  };
+  }
 
   render() {
     return (
@@ -326,7 +328,7 @@ class TraceViewHeader extends React.Component<PropType> {
 }
 
 class ActualMinimap extends React.PureComponent<{trace: ParsedTraceType}> {
-  renderRootSpan = (): JSX.Element => {
+  renderRootSpan(): React.ReactNode {
     const {trace} = this.props;
 
     const generateBounds = boundsGenerator({
@@ -351,14 +353,14 @@ class ActualMinimap extends React.PureComponent<{trace: ParsedTraceType}> {
       span: rootSpan,
       childSpans: trace.childSpans,
     }).spanTree;
-  };
+  }
 
-  getBounds = (
+  getBounds(
     bounds: SpanGeneratedBoundsType
   ): {
     left: string;
     width: string;
-  } => {
+  } {
     switch (bounds.type) {
       case 'TRACE_TIMESTAMPS_EQUAL':
       case 'INVALID_VIEW_WINDOW': {
@@ -386,9 +388,9 @@ class ActualMinimap extends React.PureComponent<{trace: ParsedTraceType}> {
         return _exhaustiveCheck;
       }
     }
-  };
+  }
 
-  renderSpan = ({
+  renderSpan({
     spanNumber,
     childSpans,
     generateBounds,
@@ -401,7 +403,7 @@ class ActualMinimap extends React.PureComponent<{trace: ParsedTraceType}> {
   }): {
     spanTree: JSX.Element;
     nextSpanNumber: number;
-  } => {
+  } {
     const spanBarColour: string = pickSpanBarColour(getSpanOperation(span));
 
     const bounds = generateBounds({
@@ -458,7 +460,7 @@ class ActualMinimap extends React.PureComponent<{trace: ParsedTraceType}> {
         </React.Fragment>
       ),
     };
-  };
+  }
 
   render() {
     return (

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -42,11 +42,11 @@ class TraceViewHeader extends React.Component<PropType> {
     cursorGuideHeight,
     showCursorGuide,
     mouseLeft,
-  }): {
+  }: {
     cursorGuideHeight: number;
     showCursorGuide: boolean;
     mouseLeft: number | undefined;
-  } {
+  }) {
     if (!showCursorGuide || !mouseLeft) {
       return null;
     }

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -223,7 +223,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     }));
   };
 
-  renderDetail = ({isVisible}: {isVisible: boolean}) => {
+  renderDetail({isVisible}: {isVisible: boolean}) {
     if (!this.state.showDetail || !isVisible) {
       return null;
     }
@@ -251,14 +251,14 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         spanErrors={spanErrors}
       />
     );
-  };
+  }
 
-  getBounds = (): {
+  getBounds(): {
     warning: undefined | string;
     left: undefined | number;
     width: undefined | number;
     isSpanVisibleInView: boolean;
-  } => {
+  } {
     const {span, generateBounds} = this.props;
 
     const bounds = generateBounds({
@@ -312,15 +312,16 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         return _exhaustiveCheck;
       }
     }
-  };
+  }
 
-  renderSpanTreeConnector = ({hasToggler}: {hasToggler: boolean}) => {
+  renderSpanTreeConnector({hasToggler}: {hasToggler: boolean}) {
     const {
       isLast,
       isRoot,
       treeDepth: spanTreeDepth,
       continuingTreeDepths,
       span,
+      showSpanTree,
     } = this.props;
 
     const spanID = getSpanID(span);
@@ -359,7 +360,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       );
     });
 
-    if (hasToggler) {
+    if (hasToggler && showSpanTree) {
       // if there is a toggle button, we add a connector bar to create an attachment
       // between the toggle button and any connector bars below the toggle button
       connectorBars.push(
@@ -385,14 +386,12 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         {connectorBars}
       </SpanTreeConnector>
     );
-  };
+  }
 
-  renderSpanTreeToggler = ({left}: {left: number}) => {
-    const {numOfSpanChildren, isRoot} = this.props;
+  renderSpanTreeToggler({left}: {left: number}) {
+    const {numOfSpanChildren, isRoot, showSpanTree} = this.props;
 
-    const chevron = (
-      <StyledIconChevron direction={this.props.showSpanTree ? 'up' : 'down'} />
-    );
+    const chevron = <StyledIconChevron direction={showSpanTree ? 'up' : 'down'} />;
 
     if (numOfSpanChildren <= 0) {
       return (
@@ -409,7 +408,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         {this.renderSpanTreeConnector({hasToggler: true})}
         <SpanTreeToggler
           disabled={!!isRoot}
-          isExpanded={this.props.showSpanTree}
+          isExpanded={showSpanTree}
           onClick={event => {
             event.stopPropagation();
 
@@ -425,9 +424,9 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         </SpanTreeToggler>
       </SpanTreeTogglerContainer>
     );
-  };
+  }
 
-  renderTitle = () => {
+  renderTitle() {
     const {span, treeDepth, spanErrors} = this.props;
 
     const operationName = getSpanOperation(span) ? (
@@ -458,9 +457,9 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         </SpanBarTitle>
       </SpanBarTitleContainer>
     );
-  };
+  }
 
-  connectObservers = () => {
+  connectObservers() {
     if (!this.spanRowDOMRef.current) {
       return;
     }
@@ -622,41 +621,43 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     );
 
     this.intersectionObserver.observe(this.spanRowDOMRef.current);
-  };
+  }
 
-  disconnectObservers = () => {
+  disconnectObservers() {
     if (this.intersectionObserver) {
       this.intersectionObserver.disconnect();
     }
-  };
+  }
 
-  renderCursorGuide = () => (
-    <CursorGuideHandler.Consumer>
-      {({
-        showCursorGuide,
-        traceViewMouseLeft,
-      }: {
-        showCursorGuide: boolean;
-        traceViewMouseLeft: number | undefined;
-      }) => {
-        if (!showCursorGuide || !traceViewMouseLeft) {
-          return null;
-        }
+  renderCursorGuide() {
+    return (
+      <CursorGuideHandler.Consumer>
+        {({
+          showCursorGuide,
+          traceViewMouseLeft,
+        }: {
+          showCursorGuide: boolean;
+          traceViewMouseLeft: number | undefined;
+        }) => {
+          if (!showCursorGuide || !traceViewMouseLeft) {
+            return null;
+          }
 
-        return (
-          <CursorGuide
-            style={{
-              left: toPercent(traceViewMouseLeft),
-            }}
-          />
-        );
-      }}
-    </CursorGuideHandler.Consumer>
-  );
+          return (
+            <CursorGuide
+              style={{
+                left: toPercent(traceViewMouseLeft),
+              }}
+            />
+          );
+        }}
+      </CursorGuideHandler.Consumer>
+    );
+  }
 
-  renderDivider = (
+  renderDivider(
     dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
-  ) => {
+  ) {
     if (this.state.showDetail) {
       // we would like to hide the divider lines when the span details
       // has been expanded
@@ -713,9 +714,9 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         />
       </React.Fragment>
     );
-  };
+  }
 
-  renderWarningText = ({warningText}: {warningText?: string} = {}) => {
+  renderWarningText({warningText}: {warningText?: string} = {}) {
     if (!warningText) {
       return null;
     }
@@ -725,11 +726,11 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         <StyledIconWarning />
       </Tooltip>
     );
-  };
+  }
 
-  renderHeader = (
+  renderHeader(
     dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
-  ) => {
+  ) {
     const {span, spanBarColour, spanBarHatch, spanNumber} = this.props;
     const startTimestamp: number = span.start_timestamp;
     const endTimestamp: number = span.timestamp;
@@ -783,7 +784,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         {this.renderDivider(dividerHandlerChildrenProps)}
       </SpanRowCellContainer>
     );
-  };
+  }
 
   render() {
     const {isCurrentSpanFilteredOut} = this.props;


### PR DESCRIPTION
Don't render descenders on closed subtrees. I've also unbound a bunch of methods that are not used as event handlers.

### Before

![Screen Shot 2020-06-23 at 12 04 52 PM](https://user-images.githubusercontent.com/24086/85617665-a23e5900-b62d-11ea-8b3a-252d9363a63f.png)

### After

![Screen Shot 2020-06-24 at 2 58 47 PM](https://user-images.githubusercontent.com/24086/85617683-a8343a00-b62d-11ea-8e2b-5b876fa37c31.png)
