### PR TITLE
ref(vercel): Handle multiple vercel integrations across orgs

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -18,6 +18,7 @@ from sentry.pipeline import NestedPipelineView
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.utils.http import absolute_uri
 from sentry.models import (
+    Integration,
     Project,
     ProjectKey,
     User,
@@ -206,6 +207,20 @@ class VercelIntegrationProvider(IntegrationProvider):
 
         return [identity_pipeline_view]
 
+    def get_configuration_metadata(self, external_id):
+        # If a vercel team or user was already installed on another sentry org
+        # we want to make sure we don't overwrite the existing configurations. We
+        # keep all the configurations so that if one of them is deleted from vercel's
+        # side, the other sentry org will still have a working vercel integration.
+        try:
+            integration = Integration.objects.get(external_id=external_id, provider=self.key)
+        except Integration.DoesNotExist:
+            # not sure if we care to log this, maybe we should just log if
+            # we do find an existing integration
+            return {}
+
+        return integration.metadata["configurations"]
+
     def build_integration(self, state):
         data = state["identity"]["data"]
         access_token = data["access_token"]
@@ -237,6 +252,8 @@ class VercelIntegrationProvider(IntegrationProvider):
             message = u"Could not create deployment webhook in Vercel: {}".format(details)
             raise IntegrationError(message)
 
+        configurations = self.get_configuration_metadata(external_id)
+
         integration = {
             "name": name,
             "external_id": external_id,
@@ -245,13 +262,30 @@ class VercelIntegrationProvider(IntegrationProvider):
                 "installation_id": data["installation_id"],
                 "installation_type": installation_type,
                 "webhook_id": webhook["id"],
+                "configurations": configurations,
             },
-            "post_install_data": {"user_id": state["user_id"]},
+            "post_install_data": {
+                "user_id": state["user_id"],
+                # new configuration data
+                "configuration_id": data["installation_id"],
+                "access_token": access_token,
+                "webhook_id": webhook["id"],
+            },
         }
 
         return integration
 
     def post_install(self, integration, organization, extra=None):
+        # add new configuration information to metadata
+        configurations = integration.metadata.get("configurations") or {}
+        configurations[extra["configuration_id"]] = {
+            "access_token": extra["access_token"],
+            "webhook_id": extra["webhook_id"],
+            "organization_id": organization.id,
+        }
+        integration.metadata["configurations"] = configurations
+        integration.save()
+
         # check if we have an installation already
         if SentryAppInstallationForProvider.objects.filter(
             organization=organization, provider="vercel"

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -93,6 +93,13 @@ class VercelIntegrationTest(IntegrationTestCase):
             "installation_id": "my_config_id",
             "installation_type": installation_type,
             "webhook_id": "webhook-id",
+            "configurations": {
+                "my_config_id": {
+                    "access_token": "my_access_token",
+                    "webhook_id": "webhook-id",
+                    "organization_id": self.organization.id,
+                }
+            },
         }
         assert OrganizationIntegration.objects.get(
             integration=integration, organization=self.organization


### PR DESCRIPTION
**Context:** 
When you install an integration on Vercel's end, it creates a configuration, which is tied to an access token. Because we allow you to install Vercel on multiple sentry orgs, this mean you'd go through the install process twice, one for each org. This creates multiple configurations. We store the most recent `access_token` in the integration metatdata. 

**Problem:**
This is problematic if we just store one access token because someone could go into Vercel, delete the configuration, and the access token would no longer be valid. If we don't have the other access tokens, then the integrations across all the other sentry orgs would break. 

**Solution:**
We can store all of the access tokens (mapped to the configuration id which we get on the DELETE hook from Vercel) so that when one configuration is removed, we can update the 'main' access token with the next in line. It doesn't matter which one since the tokens will have the same access as each other (for the Vercel team or user)

We needed to know which configuration was linked to what organization and I think it could have been done in a couple ways:
* Add the data to the `OrganizationIntegration` config field, or a new column on that table
    _Not great because we use this for the project mapping already and it gets updated outside of the pipeline flow_
* Add a new join table to map the data from the configuration to the `OrganizationIntegration`
    _Not great because it's so vercel specific in addition to an edge case (vs the `PagerDutyServiceProject` table)_

* Add the configuration data to the `Integration` metadata 
   
So we went with the last option. The main change here was to check for an existing integration during the installation flow so that we make sure we don't overwrite the metadata for `configurations` each time we install Vercel. `post_install` takes care of adding the new configuration. 

**Note:**
When you delete a configuration in Vercel, any webhook created using the access token tied to that configuration also gets deleted which is why we store the `webhook_id` as well. 
