### PR TITLE
feat(transaction): adding warning banner about missing transaction usage

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {intcomma} from 'app/utils';
 import {t} from 'app/locale';
+import Alert from 'app/components/alert';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
@@ -95,6 +96,9 @@ class OrganizationStats extends React.Component {
           )}
         </div>
         <div>
+          <Alert type="info" icon="icon-circle-info">
+            {t('Transactions and attachments are not present in the graph currently.')}
+          </Alert>
           {statsLoading ? (
             <LoadingIndicator />
           ) : statsError ? (

--- a/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/organizationStatsDetails.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {intcomma} from 'app/utils';
 import {t} from 'app/locale';
-import Alert from 'app/components/alert';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
@@ -17,6 +16,7 @@ import {
   ProjectTableDataElement,
 } from 'app/views/organizationStats/projectTableLayout';
 import {PageContent} from 'app/styles/organization';
+import PerformanceAlert from 'app/views/organizationStats/performanceAlert';
 
 class OrganizationStats extends React.Component {
   static propTypes = {
@@ -80,11 +80,11 @@ class OrganizationStats extends React.Component {
             <TextBlock>
               {t(
                 `The chart below reflects events the system has received
-            across your entire organization. Events are broken down into
-            three categories: Accepted, Rate Limited, and Filtered. Rate
-            Limited events are entries that the system threw away due to quotas
-            being hit, and Filtered events are events that were blocked
-            due to your inbound data filter rules.`
+                across your entire organization. Events are broken down into
+                three categories: Accepted, Rate Limited, and Filtered. Rate
+                Limited events are entries that the system threw away due to quotas
+                being hit, and Filtered events are events that were blocked
+                due to your inbound data filter rules.`
               )}
             </TextBlock>
           </div>
@@ -96,9 +96,7 @@ class OrganizationStats extends React.Component {
           )}
         </div>
         <div>
-          <Alert type="info" icon="icon-circle-info">
-            {t('Transactions and attachments are not present in the graph currently.')}
-          </Alert>
+          <PerformanceAlert />
           {statsLoading ? (
             <LoadingIndicator />
           ) : statsError ? (

--- a/src/sentry/static/sentry/app/views/organizationStats/performanceAlert.tsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/performanceAlert.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {t} from 'app/locale';
+import {IconInfo} from 'app/icons';
+import Alert from 'app/components/alert';
+import Feature from 'app/components/acl/feature';
+
+type Props = {message?: React.ReactNode};
+
+const PerformanceAlert = ({message}: Props) => (
+  <Feature features={['performance-view']}>
+    <AlertContainer>
+      <Alert type="info" icon={<IconInfo />} data-test-id="performance-usage">
+        {message || t('Transactions and attachments are not yet included in the chart.')}
+      </Alert>
+    </AlertContainer>
+  </Feature>
+);
+
+const AlertContainer = styled('div')`
+  display: grid;
+  grid-auto-columns: max-content;
+`;
+
+export default PerformanceAlert;

--- a/tests/js/spec/views/organizationStats/organizationStatsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationStats/organizationStatsDetails.spec.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import OrganizationStats from 'app/views/organizationStats/organizationStatsDetails';
+
+describe('OrganizationStats', function() {
+  it('renders', function() {
+    const organization = TestStubs.Organization();
+    const props = {
+      statsLoading: false,
+      projectsLoading: false,
+      orgTotal: {},
+      orgStats: [],
+      projectTotals: [],
+      projectMap: {},
+      organization,
+    };
+
+    const wrapper = mountWithTheme(
+      <OrganizationStats {...props} />,
+      TestStubs.routerContext([{organization}])
+    );
+
+    expect(wrapper.find('PageHeading').text()).toBe('Organization Stats');
+    expect(wrapper.find('Panel[className="bar-chart"]').exists()).toBe(true);
+    expect(wrapper.find('ProjectTable').exists()).toBe(true);
+    expect(wrapper.find('Alert[data-test-id="performance-usage"]').exists()).toBe(false);
+  });
+
+  it('renders alert for performance feature', function() {
+    const organization = TestStubs.Organization({features: ['performance-view']});
+    const props = {
+      statsLoading: false,
+      projectsLoading: false,
+      orgTotal: {},
+      orgStats: [],
+      projectTotals: [],
+      projectMap: {},
+      organization,
+    };
+
+    const wrapper = mountWithTheme(
+      <OrganizationStats {...props} />,
+      TestStubs.routerContext([{organization}])
+    );
+
+    expect(wrapper.find('PageHeading').text()).toBe('Organization Stats');
+    expect(wrapper.find('Panel[className="bar-chart"]').exists()).toBe(true);
+    expect(wrapper.find('ProjectTable').exists()).toBe(true);
+    expect(wrapper.find('Alert[data-test-id="performance-usage"]').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
adding a banner to let people know that the graph doesn't include transaction and attachment usage yet.