### PR TITLE
build(github): Remove "placeholder" comment for migration action

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -38,12 +38,6 @@ jobs:
             --health-retries 5
 
       steps:
-        - name: Create placeholder comment
-          uses: getsentry/action-migrations@v1.0.7
-          with:
-            run: placeholder
-            githubToken: ${{ secrets.GITHUB_TOKEN }}
-
         # Checkout codebase
         - uses: actions/checkout@v1
 


### PR DESCRIPTION
This removes the placeholder comment for the migration action. The reason for having it was to make sure that the comment is at the top of the PR, however this also breaks the email workflow if you have github notifications turned on as you would get an email with the placeholder comment. Given the likelyhood of someone commenting before the bot, lets just turn off the placeholder comment.

If we are not happy with this we can follow-up with having the bot change the PR description.