### PR TITLE
feat(metric_alerts): Start writing to AlertRule.resolve_threshold

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -532,6 +532,7 @@ def create_alert_rule(
     time_window,
     threshold_type,
     threshold_period,
+    resolve_threshold=None,
     environment=None,
     include_all_projects=False,
     excluded_projects=None,
@@ -552,6 +553,8 @@ def create_alert_rule(
     :param threshold_type: An AlertRuleThresholdType
     :param threshold_period: How many update periods the value of the
     subscription needs to exceed the threshold before triggering
+    :param resolve_threshold: Optional value that the subscription needs to reach to
+    resolve the alert
     :param include_all_projects: Whether to include all current and future projects
     from this organization
     :param excluded_projects: List of projects to exclude if we're using
@@ -578,6 +581,7 @@ def create_alert_rule(
             snuba_query=snuba_query,
             name=name,
             threshold_type=threshold_type.value,
+            resolve_threshold=resolve_threshold,
             threshold_period=threshold_period,
             include_all_projects=include_all_projects,
         )
@@ -642,6 +646,7 @@ def update_alert_rule(
     environment=None,
     threshold_type=None,
     threshold_period=None,
+    resolve_threshold=None,
     include_all_projects=None,
     excluded_projects=None,
 ):
@@ -660,6 +665,8 @@ def update_alert_rule(
     :param threshold_type: An AlertRuleThresholdType
     :param threshold_period: How many update periods the value of the
     subscription needs to exceed the threshold before triggering
+    :param resolve_threshold: Optional value that the subscription needs to reach to
+    resolve the alert
     :param include_all_projects: Whether to include all current and future projects
     from this organization
     :param excluded_projects: List of projects to exclude if we're using
@@ -686,6 +693,8 @@ def update_alert_rule(
         updated_query_fields["time_window"] = timedelta(minutes=time_window)
     if threshold_type:
         updated_fields["threshold_type"] = threshold_type.value
+    if resolve_threshold:
+        updated_fields["resolve_threshold"] = resolve_threshold
     if threshold_period:
         updated_fields["threshold_period"] = threshold_period
     if include_all_projects is not None:

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -866,6 +866,7 @@ class Factories(object):
         date_added=None,
         dataset=QueryDatasets.EVENTS,
         threshold_type=AlertRuleThresholdType.ABOVE,
+        resolve_threshold=None,
     ):
         if not name:
             name = petname.Generate(2, " ", letters=10).title()
@@ -879,6 +880,7 @@ class Factories(object):
             time_window,
             threshold_type,
             threshold_period,
+            resolve_threshold=resolve_threshold,
             dataset=dataset,
             environment=environment,
             include_all_projects=include_all_projects,

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -29,6 +29,7 @@ class TestAlertRuleSerializer(TestCase):
             "dataset": QueryDatasets.EVENTS.value,
             "query": "level:error",
             "threshold_type": 0,
+            "resolve_threshold": 100,
             "aggregate": "count()",
             "threshold_period": 1,
             "projects": [self.project.slug],
@@ -241,6 +242,32 @@ class TestAlertRuleSerializer(TestCase):
 
         assert serializer.is_valid(), serializer.errors
         assert serializer.validated_data["threshold_type"] == AlertRuleThresholdType.ABOVE
+
+    def test_alert_rule_resolved_overrides_trigger(self):
+        payload = {
+            "name": "hello_im_a_test",
+            "time_window": 10,
+            "query": "level:error",
+            "aggregate": "count()",
+            "resolve_threshold": 50,
+            "threshold_period": 1,
+            "projects": [self.project.slug],
+            "triggers": [
+                {
+                    "label": "critical",
+                    "alertThreshold": 98,
+                    "resolveThreshold": 100,
+                    "thresholdType": 1,
+                    "actions": [
+                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id}
+                    ],
+                }
+            ],
+        }
+        serializer = AlertRuleSerializer(context=self.context, data=payload, partial=True)
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["resolve_threshold"] == 50
 
     def test_boundary(self):
         payload = {

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -662,6 +662,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         aggregate = "count(*)"
         time_window = 10
         threshold_type = AlertRuleThresholdType.ABOVE
+        resolve_threshold = 10
         threshold_period = 1
         alert_rule = create_alert_rule(
             self.organization,
@@ -672,6 +673,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             time_window,
             threshold_type,
             threshold_period,
+            resolve_threshold=resolve_threshold,
         )
         assert alert_rule.snuba_query.subscriptions.get().project == self.project
         assert alert_rule.name == name
@@ -683,6 +685,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.snuba_query.time_window == time_window * 60
         assert alert_rule.snuba_query.resolution == DEFAULT_ALERT_RULE_RESOLUTION * 60
         assert alert_rule.threshold_type == threshold_type.value
+        assert alert_rule.resolve_threshold == resolve_threshold
         assert alert_rule.threshold_period == threshold_period
 
     def test_include_all_projects(self):


### PR DESCRIPTION
This pr starts writing to the new AlertRule.resolve_threshold field. We aren't using this field
just yet, but we want to start keeping it in sync.

https://github.com/getsentry/sentry/pull/19524