### PR TITLE
fix(bitbucket_server): Considers pagination for bitbucket-server-integration when requesting commits

### DIFF
--- a/src/sentry/integrations/bitbucket_server/repository.py
+++ b/src/sentry/integrations/bitbucket_server/repository.py
@@ -108,7 +108,7 @@ class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
                     client, repo.config["project"], repo.config["repo"], c["id"]
                 ),
             }
-            for c in commit_list["values"]
+            for c in commit_list
         ]
 
     def compare_commits(self, repo, start_sha, end_sha):
@@ -117,12 +117,12 @@ class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
 
         try:
             if "0" * 40 == start_sha or start_sha is None:
-                res = client.get_last_commits(repo.config["project"], repo.config["repo"])
+                commit_list = client.get_last_commits(repo.config["project"], repo.config["repo"])
             else:
-                res = client.get_commits(
+                commit_list = client.get_commits(
                     repo.config["project"], repo.config["repo"], start_sha, end_sha
                 )
-            return self._format_commits(client, repo, res)
+            return self._format_commits(client, repo, commit_list)
         except Exception as e:
             installation.raise_error(e)
 
@@ -142,13 +142,13 @@ class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
 
         return self._transform_patchset(commit_files)
 
-    def _transform_patchset(self, diff):
+    def _transform_patchset(self, values):
         """Convert the patch data from Bitbucket into our internal format
 
         See sentry.models.Release.set_commits
         """
         changes = []
-        for change in diff["values"]:
+        for change in values:
             if change["type"] == "MODIFY":
                 changes.append({"path": change["path"]["toString"], "type": "M"})
             if change["type"] == "ADD":

--- a/tests/sentry/integrations/bitbucket_server/testutils.py
+++ b/tests/sentry/integrations/bitbucket_server/testutils.py
@@ -179,3 +179,140 @@ REPO = {
         ]
     ),
 }
+
+
+COMPARE_COMMITS_WITH_PAGES_1_2_EXAMPLE = {
+    "values": [
+        {
+            "id": "d0352305beb41afb3a4ea79e3a97bf6a97520339",
+            "displayId": "d0352305beb",
+            "author": {
+                "name": "SentryU",
+                "displayName": "Sentry User",
+                "emailAddress": "sentryuser@getsentry.com",
+                "type": "NORMAL",
+            },
+            "message": "Fist commit",
+            "authorTimestamp": 1576763816000,
+        }
+    ],
+    "size": 1,
+    "isLastPage": False,
+    "start": 0,
+    "limit": 1,
+    "nextPageStart": 1,
+}
+
+COMPARE_COMMITS_WITH_PAGES_2_2_EXAMPLE = {
+    "values": [
+        {
+            "id": "042bc8434e0c178d8745c7d9f90bddab9c927887",
+            "displayId": "042bc8434e0",
+            "author": {
+                "name": "SentryU",
+                "displayName": "Sentry User",
+                "emailAddress": "sentryuser@getsentry.com",
+                "type": "NORMAL",
+            },
+            "message": "Second commit",
+            "authorTimestamp": 1576763816000,
+        }
+    ],
+    "size": 1,
+    "isLastPage": True,
+    "start": 1,
+    "limit": 1,
+    "nextPageStart": None,
+}
+
+COMMIT_CHANGELIST_WITH_PAGES_FIRST_COMMIT_EXAMPLE = {
+    "values": [
+        {
+            "path": {
+                "components": ["a.txt"],
+                "parent": "",
+                "name": "a.txt",
+                "extension": "txt",
+                "toString": "a.txt",
+            },
+            "executable": False,
+            "percentUnchanged": -1,
+            "type": "MODIFY",
+            "nodeType": "FILE",
+            "srcExecutable": False,
+            "properties": {"gitChangeType": "MODIFY"},
+        },
+        {
+            "path": {
+                "components": ["b.txt"],
+                "parent": "",
+                "name": "b.txt",
+                "extension": "txt",
+                "toString": "b.txt",
+            },
+            "executable": False,
+            "percentUnchanged": -1,
+            "type": "ADD",
+            "nodeType": "FILE",
+            "srcExecutable": False,
+            "properties": {"gitChangeType": "ADD"},
+        },
+    ]
+}
+
+COMMIT_CHANGELIST_WITH_PAGES_SECOND_COMMIT_EXAMPLE_1_2 = {
+    "values": [
+        {
+            "path": {
+                "components": ["c.txt"],
+                "parent": "",
+                "name": "c.txt",
+                "extension": "txt",
+                "toString": "c.txt",
+            },
+            "executable": False,
+            "percentUnchanged": -1,
+            "type": "DELETE",
+            "nodeType": "FILE",
+            "srcExecutable": False,
+            "properties": {"gitChangeType": "DELETE"},
+        }
+    ],
+    "size": 1,
+    "isLastPage": False,
+    "start": 0,
+    "limit": 1,
+    "nextPageStart": 1,
+}
+
+COMMIT_CHANGELIST_WITH_PAGES_SECOND_COMMIT_EXAMPLE_2_2 = {
+    "values": [
+        {
+            "path": {
+                "components": ["e.txt"],
+                "parent": "",
+                "name": "d.txt",
+                "extension": "txt",
+                "toString": "d.txt",
+            },
+            "srcPath": {
+                "components": ["d.txt"],
+                "parent": "",
+                "name": "e.txt",
+                "extension": "txt",
+                "toString": "e.txt",
+            },
+            "executable": False,
+            "percentUnchanged": -1,
+            "type": "MOVE",
+            "nodeType": "FILE",
+            "srcExecutable": False,
+            "properties": {"gitChangeType": "MOVE"},
+        },
+    ],
+    "size": 1,
+    "isLastPage": True,
+    "start": 1,
+    "limit": 1,
+    "nextPageStart": None,
+}


### PR DESCRIPTION
Implements support for pagination in the bitucket-server-api when the
commits between two commit ids or filechanges are requested

Fixes GH-19201

@getsentry/app-backend