### PR TITLE
fix(ui) Fix PanelTable overflows in safari

### DIFF
--- a/src/sentry/static/sentry/app/components/panels/panelTable.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelTable.tsx
@@ -142,6 +142,9 @@ const Wrapper = styled(Panel, {
     border: none;
     grid-column: auto / span ${p => p.columns};
   }
+
+  /* safari needs an overflow value or the contents will spill out */
+  overflow: auto;
 `;
 
 export const PanelTableHeader = styled('div')`


### PR DESCRIPTION
Safari isn't so great at CSS grid, and handles resizing content and overflows with poorer results than other browsers. Having an overflow lets safari to apply scrollbars when it can't resize content. This also solves layout problems in very narrow viewports for other browsers.

### Before

![Screen Shot 2020-06-25 at 11 02 36 AM](https://user-images.githubusercontent.com/24086/85756271-a7a6ac80-b6dc-11ea-8f48-54d08b347ae5.png)

### After

![Screen Shot 2020-06-25 at 12 04 09 PM](https://user-images.githubusercontent.com/24086/85756299-ae352400-b6dc-11ea-8be1-6d3be28bb74f.png)
