### PR TITLE
fix(settings): Remove dependency on dateutil.tz.UTC

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -5,7 +5,7 @@ import six
 
 from datetime import datetime
 
-from dateutil.tz import UTC
+import pytz
 from rest_framework import serializers, status
 from uuid import uuid4
 
@@ -267,7 +267,7 @@ class OrganizationSerializer(serializers.Serializer):
         return attrs
 
     def save_trusted_relays(self, incoming, changed_data, organization):
-        timestamp_now = datetime.utcnow().replace(tzinfo=UTC).isoformat()
+        timestamp_now = datetime.utcnow().replace(tzinfo=pytz.UTC).isoformat()
         option_key = "sentry:trusted-relays"
         try:
             # get what we already have

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -5,7 +5,7 @@ import six
 
 from datetime import datetime
 
-import pytz
+from pytz import UTC
 from rest_framework import serializers, status
 from uuid import uuid4
 
@@ -267,7 +267,7 @@ class OrganizationSerializer(serializers.Serializer):
         return attrs
 
     def save_trusted_relays(self, incoming, changed_data, organization):
-        timestamp_now = datetime.utcnow().replace(tzinfo=pytz.UTC).isoformat()
+        timestamp_now = datetime.utcnow().replace(tzinfo=UTC).isoformat()
         option_key = "sentry:trusted-relays"
         try:
             # get what we already have

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from datetime import datetime
 
 import dateutil
-import pytz
+from pytz import UTC
 import six
 
 from base64 import b64encode
@@ -168,9 +168,9 @@ class OrganizationDetailsTest(APITestCase):
         data = {"trustedRelays": trusted_relays}
 
         with self.feature("organizations:relay"):
-            start_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
+            start_time = datetime.utcnow().replace(tzinfo=UTC)
             response = self.client.put(url, data=data)
-            end_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
+            end_time = datetime.utcnow().replace(tzinfo=UTC)
             assert response.status_code == 200
             response = self.client.get(url)
             assert response.status_code == 200
@@ -395,9 +395,9 @@ class OrganizationUpdateTest(APITestCase):
         data = {"trustedRelays": trusted_relays}
 
         with self.feature("organizations:relay"):
-            start_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
+            start_time = datetime.utcnow().replace(tzinfo=UTC)
             response = self.client.put(url, data=data)
-            end_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
+            end_time = datetime.utcnow().replace(tzinfo=UTC)
 
             assert response.status_code == 200
             response_data = response.data.get("trustedRelays")
@@ -485,11 +485,11 @@ class OrganizationUpdateTest(APITestCase):
         changed_settings = {"trustedRelays": modified_trusted_relays}
 
         with self.feature("organizations:relay"):
-            start_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
+            start_time = datetime.utcnow().replace(tzinfo=UTC)
             self.client.put(url, data=initial_settings)
-            after_initial = datetime.utcnow().replace(tzinfo=pytz.UTC)
+            after_initial = datetime.utcnow().replace(tzinfo=UTC)
             response = self.client.put(url, data=changed_settings)
-            after_final = datetime.utcnow().replace(tzinfo=pytz.UTC)
+            after_final = datetime.utcnow().replace(tzinfo=UTC)
 
             assert response.status_code == 200
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from datetime import datetime
 
 import dateutil
-import dateutil.tz
+import pytz
 import six
 
 from base64 import b64encode
@@ -168,9 +168,9 @@ class OrganizationDetailsTest(APITestCase):
         data = {"trustedRelays": trusted_relays}
 
         with self.feature("organizations:relay"):
-            start_time = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
+            start_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
             response = self.client.put(url, data=data)
-            end_time = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
+            end_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
             assert response.status_code == 200
             response = self.client.get(url)
             assert response.status_code == 200
@@ -395,9 +395,9 @@ class OrganizationUpdateTest(APITestCase):
         data = {"trustedRelays": trusted_relays}
 
         with self.feature("organizations:relay"):
-            start_time = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
+            start_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
             response = self.client.put(url, data=data)
-            end_time = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
+            end_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
 
             assert response.status_code == 200
             response_data = response.data.get("trustedRelays")
@@ -485,11 +485,11 @@ class OrganizationUpdateTest(APITestCase):
         changed_settings = {"trustedRelays": modified_trusted_relays}
 
         with self.feature("organizations:relay"):
-            start_time = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
+            start_time = datetime.utcnow().replace(tzinfo=pytz.UTC)
             self.client.put(url, data=initial_settings)
-            after_initial = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
+            after_initial = datetime.utcnow().replace(tzinfo=pytz.UTC)
             response = self.client.put(url, data=changed_settings)
-            after_final = datetime.utcnow().replace(tzinfo=dateutil.tz.UTC)
+            after_final = datetime.utcnow().replace(tzinfo=pytz.UTC)
 
             assert response.status_code == 200
 


### PR DESCRIPTION
Remove dependency on dateutil.tz.UTC because it affects getsentry
(dateutil.tz.UTC introduced in 2.7.0, getsentry uses 2.4.2 )