### PR TITLE
fix(discover): Allow cmd+click on saved queries to open new tab

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {browserHistory} from 'react-router';
 
 import ActivityAvatar from 'app/components/activity/item/avatar';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
@@ -24,12 +23,9 @@ type Props = {
 };
 
 class QueryCard extends React.PureComponent<Props> {
-  handleClick = (event: React.MouseEvent) => {
-    event.preventDefault();
-    const {onEventClick, to} = this.props;
-
+  handleClick = () => {
+    const {onEventClick} = this.props;
     callIfFunction(onEventClick);
-    browserHistory.push(to);
   };
 
   render() {


### PR DESCRIPTION
Previously, the context menus used `a` tags which caused problems with nested
anchor elements. Now that context menus no longer use `a` tags, we can enable
cmd+click behaviour on the query card.