### PR TITLE
fix(am): Don't show same_process_as_parent if it is not set

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -402,7 +402,9 @@ class SpanDetail extends React.Component<Props, State> {
               <Row title="Duration">{durationString}</Row>
               <Row title="Operation">{span.op || ''}</Row>
               <Row title="Same Process as Parent">
-                {String(!!span.same_process_as_parent)}
+                {span.same_process_as_parent !== undefined
+                  ? String(span.same_process_as_parent)
+                  : null}
               </Row>
               <Tags span={span} />
               {map(span?.data ?? {}, (value, key) => (
@@ -457,7 +459,7 @@ const Row = ({
 }: {
   title: string;
   keep?: boolean;
-  children: JSX.Element | string;
+  children: JSX.Element | string | null;
   extra?: React.ReactNode;
 }) => {
   if (!keep && !children) {


### PR DESCRIPTION
If `same_process_as_parent` is undefined, we shouldn't render it under span details.

The JS SDK doesn't set `same_process_as_parent` at all right now, so all JS spans were rendering with `same_process_as_parent: false`.