### PR TITLE
fix(discover): Exclude time aggregates from Y axis

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -976,7 +976,8 @@ class EventView {
       this.getAggregateFields()
         // Exclude last_seen and latest_event as they don't produce useful graphs.
         .filter(
-          (field: Field) => ['last_seen', 'latest_event'].includes(field.field) === false
+          (field: Field) =>
+            ['last_seen()', 'latest_event()'].includes(field.field) === false
         )
         .map((field: Field) => ({label: field.field, value: field.field}))
         .concat(CHART_AXIS_OPTIONS),

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -2273,8 +2273,8 @@ describe('EventView.getYAxisOptions()', function() {
       fields: generateFields([
         'ignored-field',
         'count_unique(issue)',
-        'last_seen',
-        'latest_event',
+        'last_seen()',
+        'latest_event()',
       ]),
     });
 


### PR DESCRIPTION
The aggregates `last_seen` and `latest_event` have been updated to `last_seen()`
and `latest_event()` to indicate they're functions. This change reflects this
update so that they are still filtered out in the discover y-axis as they do
not produce useful graphs.