### PR TITLE
fix(discover) Improve rendering of null and add cell actions for null values

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -11,6 +11,7 @@ import ProjectBadge from 'app/components/idBadge/projectBadge';
 import UserBadge from 'app/components/idBadge/userBadge';
 import UserMisery from 'app/components/userMisery';
 import Version from 'app/components/version';
+import {defined} from 'app/utils';
 import getDynamicText from 'app/utils/getDynamicText';
 import {formatFloat, formatPercentage} from 'app/utils/formatters';
 import {getAggregateAlias, AGGREGATIONS} from 'app/utils/discover/fields';
@@ -64,10 +65,10 @@ type FieldFormatters = {
 
 export type FieldTypes = keyof FieldFormatters;
 
-const emptyValue = <span>{t('n/a')}</span>;
-const EmptyValueContainer = styled(Container)`
+const EmptyValueContainer = styled('span')`
   color: ${p => p.theme.gray500};
 `;
+const emptyValue = <EmptyValueContainer>{t('n/a')}</EmptyValueContainer>;
 
 /**
  * A mapping of field types to their rendering function.
@@ -137,7 +138,11 @@ const FIELD_FORMATTERS: FieldFormatters = {
     isSortable: true,
     renderFunc: (field, data) => {
       // Some fields have long arrays in them, only show the tail of the data.
-      const value = Array.isArray(data[field]) ? data[field].slice(-1) : data[field];
+      const value = Array.isArray(data[field])
+        ? data[field].slice(-1)
+        : defined(data[field])
+        ? data[field]
+        : emptyValue;
       return <Container>{value}</Container>;
     },
   },
@@ -253,7 +258,7 @@ const SPECIAL_FIELDS: SpecialFields = {
         return <Container>{badge}</Container>;
       }
 
-      return <EmptyValueContainer>{emptyValue}</EmptyValueContainer>;
+      return <Container>{emptyValue}</Container>;
     },
   },
   release: {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -5,7 +5,6 @@ import * as PopperJS from 'popper.js';
 import {Manager, Reference, Popper} from 'react-popper';
 
 import {t} from 'app/locale';
-import {defined} from 'app/utils';
 import {IconEllipsis} from 'app/icons';
 import space from 'app/styles/space';
 import {getAggregateAlias} from 'app/utils/discover/fields';
@@ -148,7 +147,7 @@ class CellAction extends React.Component<Props, State> {
       );
     }
 
-    if (column.type !== 'string' && column.type !== 'boolean') {
+    if (['date', 'duration', 'integer', 'number', 'percentage'].includes(column.type)) {
       addMenuItem(
         Actions.SHOW_GREATER_THAN,
         <ActionItem
@@ -295,15 +294,6 @@ class CellAction extends React.Component<Props, State> {
   render() {
     const {children} = this.props;
     const {isHovering} = this.state;
-
-    const {dataRow, column} = this.props;
-    const fieldAlias = getAggregateAlias(column.name);
-    const value = dataRow[fieldAlias];
-
-    if (!defined(value)) {
-      // per cell actions do not apply to values that are null
-      return <React.Fragment>{children}</React.Fragment>;
-    }
 
     return (
       <Container

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -274,6 +274,10 @@ class TableView extends React.Component<TableViewProps> {
             if (!query.hasOwnProperty('has')) {
               query.has = [];
             }
+            // Remove exclusion if it exists.
+            if (Array.isArray(query['!has']) && query['!has'].length) {
+              query['!has'] = query['!has'].filter(item => item !== column.name);
+            }
             query.has.push(column.name);
           } else {
             // Remove positive if it exists.

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -251,19 +251,40 @@ class TableView extends React.Component<TableViewProps> {
 
       switch (action) {
         case Actions.ADD:
-          // Remove exclusion if it exists.
-          delete query[`!${column.name}`];
-          query[column.name] = [`${value}`];
+          // If the value is null/undefined create a has !has condition.
+          if (value === null || value === undefined) {
+            // Adding a null value is the same as excluding truthy values.
+            if (!query.hasOwnProperty('!has')) {
+              query['!has'] = [];
+            }
+            // Remove inclusion if it exists.
+            if (Array.isArray(query.has) && query.has.length) {
+              query.has = query.has.filter(item => item !== column.name);
+            }
+            query['!has'].push(column.name);
+          } else {
+            // Remove exclusion if it exists.
+            delete query[`!${column.name}`];
+            query[column.name] = [`${value}`];
+          }
           break;
         case Actions.EXCLUDE:
-          // Remove positive if it exists.
-          delete query[column.name];
-          // Negations should stack up.
-          const negation = `!${column.name}`;
-          if (!query.hasOwnProperty(negation)) {
-            query[negation] = [];
+          if (value === null || value === undefined) {
+            // Excluding a null value is the same as including truthy values.
+            if (!query.hasOwnProperty('has')) {
+              query.has = [];
+            }
+            query.has.push(column.name);
+          } else {
+            // Remove positive if it exists.
+            delete query[column.name];
+            // Negations should stack up.
+            const negation = `!${column.name}`;
+            if (!query.hasOwnProperty(negation)) {
+              query[negation] = [];
+            }
+            query[negation].push(`${value}`);
           }
-          query[negation].push(`${value}`);
           break;
         case Actions.SHOW_GREATER_THAN: {
           // Remove query token if it already exists

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -9,7 +9,7 @@ describe('utils/tokenizeSearch', function() {
         object: {query: [], is: ['unresolved']},
       },
       {
-        name: 'should convert qutoed strings',
+        name: 'should convert quoted strings',
         string: 'is:unresolved browser:"Chrome 36"',
         object: {query: [], is: ['unresolved'], browser: ['Chrome 36']},
       },
@@ -22,6 +22,16 @@ describe('utils/tokenizeSearch', function() {
         name: 'should tokenize the text query',
         string: 'python   exception',
         object: {query: ['python', 'exception']},
+      },
+      {
+        name: 'should tokenize has condition',
+        string: 'has:user has:browser',
+        object: {query: [], has: ['user', 'browser']},
+      },
+      {
+        name: 'should tokenize !has condition',
+        string: '!has:user has:browser',
+        object: {query: [], '!has': ['user'], has: ['browser']},
       },
       {
         name: 'should remove spaces in the query',

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -11,6 +11,7 @@ function makeWrapper(eventView, handleCellAction, columnIndex = 0) {
     count: 19,
     timestamp: '2020-06-09T01:46:25+00:00',
     release: 'F2520C43515BD1F0E8A6BD46233324641A370BF6',
+    nullValue: null,
   };
   return mountWithTheme(
     <CellAction
@@ -28,7 +29,7 @@ describe('Discover -> CellAction', function() {
     query: {
       id: '42',
       name: 'best query',
-      field: ['transaction', 'count()', 'timestamp', 'release'],
+      field: ['transaction', 'count()', 'timestamp', 'release', 'nullValue'],
       widths: ['437', '647', '416', '905'],
       sort: ['title'],
       query: 'event.type:transaction',
@@ -170,6 +171,16 @@ describe('Discover -> CellAction', function() {
       expect(
         wrapper.find('button[data-test-id="show-values-less-than"]').exists()
       ).toBeFalsy();
+    });
+
+    it('show appropriate actions for string cells with null values', function() {
+      wrapper = makeWrapper(view, handleCellAction, 4);
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+      expect(wrapper.find('button[data-test-id="add-to-filter"]').exists()).toBeTruthy();
+      expect(
+        wrapper.find('button[data-test-id="exclude-from-filter"]').exists()
+      ).toBeTruthy();
     });
 
     it('show appropriate actions for number cells', function() {

--- a/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import {browserHistory} from 'react-router';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import EventView from 'app/utils/discover/eventView';
+import TableView from 'app/views/eventsV2/table/tableView';
+
+describe('TableView > CellActions', function() {
+  let initialData, rows, onChangeShowTags;
+
+  const location = {
+    pathname: '/organizations/org-slug/discover/results/',
+    query: {
+      id: '42',
+      name: 'best query',
+      field: ['title', 'transaction', 'count()', 'timestamp', 'release'],
+      sort: ['title'],
+      query: '',
+      project: [123],
+      statsPeriod: '14d',
+      environment: ['staging'],
+      yAxis: 'p95',
+    },
+  };
+  const eventView = EventView.fromLocation(location);
+  const tagKeys = ['size', 'shape', 'direction'];
+
+  function makeWrapper(context, tableData) {
+    return mountWithTheme(
+      <TableView
+        organization={context.organization}
+        location={location}
+        eventView={eventView}
+        tagKeys={tagKeys}
+        isLoading={false}
+        projects={context.organization.projects}
+        tableData={tableData}
+        onChangeShowTags={onChangeShowTags}
+      />,
+      context.routerContext
+    );
+  }
+
+  function openContextMenu(wrapper, cellIndex) {
+    const menu = wrapper.find('CellAction').at(cellIndex);
+    // Hover over the menu
+    menu
+      .find('Container > div')
+      .at(0)
+      .simulate('mouseEnter');
+    wrapper.update();
+
+    // Open the menu
+    wrapper.find('MenuButton').simulate('click');
+
+    // Return the menu wrapper so we can interact with it.
+    return wrapper
+      .find('CellAction')
+      .at(cellIndex)
+      .find('Menu');
+  }
+
+  beforeEach(function() {
+    browserHistory.push.mockReset();
+
+    const organization = TestStubs.Organization({
+      features: ['discover-basic'],
+      projects: [TestStubs.Project()],
+    });
+
+    initialData = initializeOrg({
+      organization,
+      router: {location},
+    });
+
+    onChangeShowTags = jest.fn();
+
+    rows = {
+      meta: {
+        title: 'string',
+        transaction: 'string',
+        'count()': 'integer',
+        timestamp: 'date',
+        release: 'string',
+      },
+      data: [
+        {
+          title: 'some title',
+          transaction: '/organizations/',
+          count: 9,
+          timestamp: '2019-05-23T22:12:48+00:00',
+          release: 'v1.0.2',
+        },
+      ],
+    };
+  });
+
+  it('handles add cell action on null value', function() {
+    rows.data[0].title = null;
+
+    const wrapper = makeWrapper(initialData, rows);
+    const menu = openContextMenu(wrapper, 0);
+    menu.find('button[data-test-id="add-to-filter"]').simulate('click');
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: location.pathname,
+      query: expect.objectContaining({
+        query: '!has:title',
+      }),
+    });
+  });
+
+  it('handles add cell action on string value', function() {
+    const wrapper = makeWrapper(initialData, rows);
+    const menu = openContextMenu(wrapper, 0);
+    menu.find('button[data-test-id="add-to-filter"]').simulate('click');
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: location.pathname,
+      query: expect.objectContaining({
+        query: 'title:"some title"',
+      }),
+    });
+  });
+
+  it('handles exclude cell action on string value', function() {
+    const wrapper = makeWrapper(initialData, rows);
+    const menu = openContextMenu(wrapper, 0);
+    menu.find('button[data-test-id="exclude-from-filter"]').simulate('click');
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: location.pathname,
+      query: expect.objectContaining({
+        query: '!title:"some title"',
+      }),
+    });
+  });
+
+  it('handles exclude cell action on null value', function() {
+    rows.data[0].title = null;
+
+    const wrapper = makeWrapper(initialData, rows);
+    const menu = openContextMenu(wrapper, 0);
+    menu.find('button[data-test-id="exclude-from-filter"]').simulate('click');
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: location.pathname,
+      query: expect.objectContaining({
+        query: 'has:title',
+      }),
+    });
+  });
+
+  it('handles greater than cell action on number value', function() {
+    const wrapper = makeWrapper(initialData, rows);
+    const menu = openContextMenu(wrapper, 2);
+    menu.find('button[data-test-id="show-values-greater-than"]').simulate('click');
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: location.pathname,
+      query: expect.objectContaining({
+        query: 'count():>9',
+      }),
+    });
+  });
+
+  it('handles less than cell action on number value', function() {
+    const wrapper = makeWrapper(initialData, rows);
+    const menu = openContextMenu(wrapper, 2);
+    menu.find('button[data-test-id="show-values-less-than"]').simulate('click');
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: location.pathname,
+      query: expect.objectContaining({
+        query: 'count():<9',
+      }),
+    });
+  });
+
+  it('handles go to transaction', function() {
+    const wrapper = makeWrapper(initialData, rows);
+    const menu = openContextMenu(wrapper, 1);
+    menu.find('button[data-test-id="transaction-summary"]').simulate('click');
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: '/organizations/org-slug/performance/summary/',
+      query: expect.objectContaining({
+        transaction: '/organizations/',
+      }),
+    });
+  });
+
+  it('handles go to release', function() {
+    const wrapper = makeWrapper(initialData, rows);
+    const menu = openContextMenu(wrapper, 4);
+    menu.find('button[data-test-id="release"]').simulate('click');
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: '/organizations/org-slug/releases/v1.0.2/',
+      query: expect.objectContaining({
+        environment: eventView.environment,
+      }),
+    });
+  });
+});


### PR DESCRIPTION
When a string typed field has a null/undefined value we should show n/a to disambiguate it from ''.

Add include/exclude actions for null values that manipulate the has and !has filter options. I've also re-added tests for the tableview actions as they were removed in a refactoring last week.