### PR TITLE
fix(discover): Loading tags on selection change

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -95,14 +95,12 @@ class Results extends React.Component<Props, State> {
     if (!isAPIPayloadSimilar(currentQuery, prevQuery)) {
       api.clear();
       this.canLoadEvents();
-      if (
-        !isEqual(prevQuery.statsPeriod, currentQuery.statsPeriod) ||
-        !isEqual(prevQuery.start, currentQuery.start) ||
-        !isEqual(prevQuery.end, currentQuery.end) ||
-        !isEqual(prevQuery.project, currentQuery.project)
-      ) {
-        loadOrganizationTags(api, organization.slug, selection);
-      }
+    }
+    if (
+      !isEqual(prevProps.selection.datetime, selection.datetime) ||
+      !isEqual(prevProps.selection.projects, selection.projects)
+    ) {
+      loadOrganizationTags(api, organization.slug, selection);
     }
 
     if (prevState.confirmedQuery !== confirmedQuery) this.fetchTotalCount();


### PR DESCRIPTION
- When selection changed, tags would load one behind
 - ie. selecting a project wouldn't have any impact on the tags query until something else changed. or selection changed again (but would be for the previous selection)
- I think this will still preserve the change expected in #19398