### PR TITLE
feat(error): Add props for tags in ErrorBoundary

### DIFF
--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -19,7 +19,7 @@ type Props = DefaultProps & {
   message?: React.ReactNode;
 
   // To add context for better error reporting
-  errorTag?: {
+  errorTag?: Record<string, string>
     [tag: string]: string;
   };
 };

--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -13,9 +13,15 @@ type DefaultProps = {
 };
 
 type Props = DefaultProps & {
-  message?: React.ReactNode;
-  customComponent?: React.ReactNode;
+  // To add context for better UX
   className?: string;
+  customComponent?: React.ReactNode;
+  message?: React.ReactNode;
+
+  // To add context for better error reporting
+  errorTag?: {
+    [tag: string]: string;
+  };
 };
 
 type State = {
@@ -51,8 +57,14 @@ class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    const {errorTag} = this.props;
+
     this.setState({error});
     Sentry.withScope(scope => {
+      if (errorTag) {
+        Object.keys(errorTag).forEach(tag => scope.setTag(tag, errorTag[tag]));
+      }
+
       scope.setExtra('errorInfo', errorInfo);
       Sentry.captureException(error);
     });
@@ -71,7 +83,7 @@ class ErrorBoundary extends React.Component<Props, State> {
     const {error} = this.state;
 
     if (!error) {
-      //when there's not an error, render children untouched
+      // when there's not an error, render children untouched
       return this.props.children;
     }
 

--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -19,9 +19,7 @@ type Props = DefaultProps & {
   message?: React.ReactNode;
 
   // To add context for better error reporting
-  errorTag?: Record<string, string>
-    [tag: string]: string;
-  };
+  errorTag?: Record<string, string>;
 };
 
 type State = {


### PR DESCRIPTION
Use-case is a component which will render 2 possible children. I want to make it easier to search/separate errors from different code paths, so I can monitor them in Discover.

```
class MyFruitTree {
  render() {
    if (abc) {
      return <ErrorBoundary errorTag={{ case: 'abc' }}><Apple/></ErrorBoundary>
    }

    return <ErrorBoundary errorTag={{ case: 'xyz' }}><Banana/></ErrorBoundary>
  }
}
```
