### PR TITLE
ref(ui) Remove transaction-events feature flag further

### DIFF
--- a/docs-ui/components/columnEditor.stories.js
+++ b/docs-ui/components/columnEditor.stories.js
@@ -15,7 +15,7 @@ storiesOf('Discover|ColumnEditor', module).add(
   })(() => {
     const organization = {
       slug: 'test-org',
-      features: ['transaction-events'],
+      features: ['discover-query', 'performance-view'],
     };
     const tags = ['browser.name', 'custom-field', 'project'];
     const columns = [

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -96,6 +96,7 @@ default_manager.add("organizations:sso-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:sso-rippling", OrganizationFeature)  # NOQA
 default_manager.add("organizations:sso-saml2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:symbol-sources", OrganizationFeature)  # NOQA
+# XXX(mark) Don't use this feature it is going away soon.
 default_manager.add("organizations:transaction-events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:tweak-grouping-config", OrganizationFeature)  # NOQA
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/alertTypeChooser.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/alertTypeChooser.tsx
@@ -75,7 +75,7 @@ const TypeChooserCards = ({onChange, organization, selected}: Props) => {
         <Feature
           requireAll
           features={[
-            'organizations:transaction-events',
+            'organizations:performance-view',
             'organizations:incidents-performance',
           ]}
         >


### PR DESCRIPTION
Another use of `transaction-events` snuck in. Replace it with `performance-view` as `transaction-events` is being removed/replaced with that feature flag.