### PR TITLE
fix(apm): If an org has no global views, we set the project id based on the current transaction event

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -77,7 +77,7 @@ class SpanDetail extends React.Component<Props, State> {
   }
 
   fetchSpanDescendents(spanID: string, traceID: string): Promise<any> {
-    const {api, organization, trace} = this.props;
+    const {api, organization, trace, event} = this.props;
 
     // Skip doing a request if the results will be behind a disabled button.
     if (!organization.features.includes('discover-basic')) {
@@ -99,6 +99,9 @@ class SpanDetail extends React.Component<Props, State> {
       field: ['transaction', 'id', 'trace.span'],
       sort: ['-id'],
       query: `event.type:transaction trace:${traceID} trace.parent_span:${spanID}`,
+      project: organization.features.includes('global-views')
+        ? undefined
+        : [Number(event.projectID)],
       start,
       end,
     };


### PR DESCRIPTION
On team plans, without this fix, this just becomes a spinning loader.