### PR TITLE
fix(discover): Fix broken query when clicking tags in eventDetails

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -106,6 +106,13 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     return this.props.eventSlug.split(':')[0];
   }
 
+  generateTagKey = (tag: EventTag) => {
+    // Some tags may be normalized from context, but not all of them are.
+    // This supports a user making a custom tag with the same name as one
+    // that comes from context as all of these are also tags.
+    return `tags[${tag.key}]`;
+  };
+
   generateTagUrl = (tag: EventTag) => {
     const {eventView, organization} = this.props;
     const {event} = this.state;
@@ -116,12 +123,8 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     if (eventReference.id) {
       delete eventReference.id;
     }
-
-    const nextView = getExpandedResults(
-      eventView,
-      {[tag.key]: tag.value},
-      eventReference
-    );
+    const tagKey = this.generateTagKey(tag);
+    const nextView = getExpandedResults(eventView, {[tagKey]: tag.value}, eventReference);
     return nextView.getResultsViewUrlTarget(organization.slug);
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -30,6 +30,7 @@ import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactio
 import {eventDetailsRoute} from 'app/utils/discover/urls';
 import * as Layout from 'app/components/layouts/thirds';
 import ButtonBar from 'app/components/buttonBar';
+import {FIELD_TAGS} from 'app/utils/discover/fields';
 
 import {generateTitle, getExpandedResults} from '../utils';
 import LinkedIssue from './linkedIssue';
@@ -110,7 +111,10 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     // Some tags may be normalized from context, but not all of them are.
     // This supports a user making a custom tag with the same name as one
     // that comes from context as all of these are also tags.
-    return `tags[${tag.key}]`;
+    if (tag.key in FIELD_TAGS) {
+      return `tags[${tag.key}]`;
+    }
+    return tag.key;
   };
 
   generateTagUrl = (tag: EventTag) => {

--- a/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
@@ -58,7 +58,10 @@ describe('EventsV2 > EventDetails', function() {
             data: {},
           },
         ],
-        tags: [{key: 'browser', value: 'Firefox'}],
+        tags: [
+          {key: 'browser', value: 'Firefox'},
+          {key: 'device.uuid', value: 'test-uuid'},
+        ],
       },
     });
     MockApiClient.addMockResponse({
@@ -178,13 +181,27 @@ describe('EventsV2 > EventDetails', function() {
     await wrapper.update();
 
     // Get the first link as we wrap react-router's link
-    const tagLink = wrapper.find('EventDetails TagsTable TagValue Link').first();
+    const browserTagLink = wrapper.find('EventDetails TagsTable TagValue Link').first();
 
     // Should append tag value and other event attributes to results view query.
-    const target = tagLink.props().to;
-    expect(target.pathname).toEqual('/organizations/org-slug/discover/results/');
-    expect(target.query.query).toEqual(
-      'tags[browser]:Firefox title:"Oh no something bad"'
+    const browserTagTarget = browserTagLink.props().to;
+    expect(browserTagTarget.pathname).toEqual(
+      '/organizations/org-slug/discover/results/'
+    );
+    expect(browserTagTarget.query.query).toEqual(
+      'browser:Firefox title:"Oh no something bad"'
+    );
+
+    // Get the second link
+    const deviceUUIDTagLink = wrapper.find('EventDetails TagsTable TagValue Link').at(2);
+
+    // Should append tag value wrapped with tags[] as device.uuid is part of our fields
+    const deviceUUIDTagTarget = deviceUUIDTagLink.props().to;
+    expect(deviceUUIDTagTarget.pathname).toEqual(
+      '/organizations/org-slug/discover/results/'
+    );
+    expect(deviceUUIDTagTarget.query.query).toEqual(
+      'tags[device.uuid]:test-uuid title:"Oh no something bad"'
     );
   });
 
@@ -212,13 +229,27 @@ describe('EventsV2 > EventDetails', function() {
     await wrapper.update();
 
     // Get the first link as we wrap react-router's link
-    const tagLink = wrapper.find('EventDetails TagsTable TagValue Link').first();
+    const browserTagLink = wrapper.find('EventDetails TagsTable TagValue Link').first();
 
     // Should append tag value and other event attributes to results view query.
-    const target = tagLink.props().to;
-    expect(target.pathname).toEqual('/organizations/org-slug/discover/results/');
-    expect(target.query.query).toEqual(
-      'Dumpster tags[browser]:Firefox title:"Oh no something bad"'
+    const browserTagTarget = browserTagLink.props().to;
+    expect(browserTagTarget.pathname).toEqual(
+      '/organizations/org-slug/discover/results/'
+    );
+    expect(browserTagTarget.query.query).toEqual(
+      'Dumpster browser:Firefox title:"Oh no something bad"'
+    );
+
+    // Get the second link
+    const deviceUUIDTagLink = wrapper.find('EventDetails TagsTable TagValue Link').at(2);
+
+    // Should append tag value wrapped with tags[] as device.uuid is part of our fields
+    const deviceUUIDTagTarget = deviceUUIDTagLink.props().to;
+    expect(deviceUUIDTagTarget.pathname).toEqual(
+      '/organizations/org-slug/discover/results/'
+    );
+    expect(deviceUUIDTagTarget.query.query).toEqual(
+      'Dumpster tags[device.uuid]:test-uuid title:"Oh no something bad"'
     );
   });
 });

--- a/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
@@ -183,7 +183,9 @@ describe('EventsV2 > EventDetails', function() {
     // Should append tag value and other event attributes to results view query.
     const target = tagLink.props().to;
     expect(target.pathname).toEqual('/organizations/org-slug/discover/results/');
-    expect(target.query.query).toEqual('browser:Firefox title:"Oh no something bad"');
+    expect(target.query.query).toEqual(
+      'tags[browser]:Firefox title:"Oh no something bad"'
+    );
   });
 
   it('appends tag value to existing query when clicked', async function() {
@@ -216,7 +218,7 @@ describe('EventsV2 > EventDetails', function() {
     const target = tagLink.props().to;
     expect(target.pathname).toEqual('/organizations/org-slug/discover/results/');
     expect(target.query.query).toEqual(
-      'Dumpster browser:Firefox title:"Oh no something bad"'
+      'Dumpster tags[browser]:Firefox title:"Oh no something bad"'
     );
   });
 });


### PR DESCRIPTION
### Summary
This fixes an issue where a user adds a custom tag of the same name as a key from contexts (eg. device.uuid). This currently works because most of these tags come out of normalizing the event, which pulls the context into tags, so the values for both are the same.

### Screenshot
![Screen Shot 2020-06-26 at 10 03 40 AM](https://user-images.githubusercontent.com/6111995/85882565-578b2100-b794-11ea-8722-e9a44dd627cb.png)
![Screen Shot 2020-06-26 at 10 04 17 AM](https://user-images.githubusercontent.com/6111995/85882612-6c67b480-b794-11ea-9424-bd119646f50b.png)

