### PR TITLE
fix(perf-views): Updating onboarding doc link

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/onboarding.tsx
+++ b/src/sentry/static/sentry/app/views/performance/onboarding.tsx
@@ -17,7 +17,7 @@ function Onboarding() {
       <Button
         priority="primary"
         target="_blank"
-        href="https://docs.sentry.io/performance/distributed-tracing/#setting-up-tracing"
+        href="https://docs.sentry.io/performance-monitoring/setup/"
       >
         {t('Start Setup')}
       </Button>


### PR DESCRIPTION
- Was still pointing to the old doc location