### PR TITLE
fix(discover): Apdex was formatting as a percentage in graphs

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -198,7 +198,7 @@ export const AGGREGATIONS = {
         required: true,
       },
     ],
-    outputType: 'percentage',
+    outputType: 'number',
     isSortable: true,
     multiPlotType: 'line',
   },

--- a/tests/js/spec/utils/discover/fields.spec.jsx
+++ b/tests/js/spec/utils/discover/fields.spec.jsx
@@ -112,11 +112,11 @@ describe('aggregateOutputType', function() {
 
   it('handles percentage functions', function() {
     expect(aggregateOutputType('failure_rate()')).toEqual('percentage');
-    expect(aggregateOutputType('apdex()')).toEqual('percentage');
-    expect(aggregateOutputType('apdex(500)')).toEqual('percentage');
   });
 
   it('handles number functions', function() {
+    expect(aggregateOutputType('apdex()')).toEqual('number');
+    expect(aggregateOutputType('apdex(500)')).toEqual('number');
     expect(aggregateOutputType('user_misery(500)')).toEqual('number');
     expect(aggregateOutputType('impact()')).toEqual('number');
     expect(aggregateOutputType('eps()')).toEqual('number');


### PR DESCRIPTION
- This formats it as a number instead ie. 0.96 instead of 96%