### PR TITLE
fix(alerts): Add precision to alert chart marklines

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
@@ -86,6 +86,24 @@ const Chart = (props: Props) => {
       ? criticalTrigger?.resolveThreshold
       : undefined;
 
+  const marklinePrecision = Math.max(
+    ...[
+      warningTriggerAlertThreshold,
+      warningTriggerResolveThreshold,
+      criticalTriggerAlertThreshold,
+      criticalTriggerResolveThreshold,
+    ].map(decimal => {
+      if (!decimal || !isFinite(decimal)) return 0;
+      let e = 1;
+      let p = 0;
+      while (Math.round(decimal * e) / e !== decimal) {
+        e *= 10;
+        p += 1;
+      }
+      return p;
+    })
+  );
+
   return (
     <LineChart
       isGroupedByDate
@@ -137,6 +155,7 @@ const Chart = (props: Props) => {
                   yAxis: warningTriggerAlertThreshold,
                 },
               ],
+              precision: marklinePrecision,
               label: {
                 show: true,
                 position: 'insideEndTop',
@@ -159,6 +178,7 @@ const Chart = (props: Props) => {
                   yAxis: warningTriggerResolveThreshold,
                 },
               ],
+              precision: marklinePrecision,
               label: {
                 show: true,
                 position: 'insideEndBottom',
@@ -181,6 +201,7 @@ const Chart = (props: Props) => {
                   yAxis: criticalTriggerAlertThreshold,
                 },
               ],
+              precision: marklinePrecision,
               label: {
                 show: true,
                 position: 'insideEndTop',
@@ -203,6 +224,7 @@ const Chart = (props: Props) => {
                   yAxis: criticalTriggerResolveThreshold,
                 },
               ],
+              precision: marklinePrecision,
               label: {
                 show: true,
                 position: 'insideEndBottom',


### PR DESCRIPTION
This adds a value `precision` to alert chart `markLine`, which is the max number of decimals among all the thresholds of the alert.

Precision is `2` by default in echarts, which makes thresholds' values after 1/100th imprecise. This is a common question on echarts, see here: https://github.com/apache/incubator-echarts/issues/11517#issuecomment-568830612

The precision math: https://stackoverflow.com/a/27865285

Resolves: https://app.asana.com/0/1174156445846705/1181546325366633/f

OLD:
![Screen Shot 2020-06-26 at 12 14 34 PM](https://user-images.githubusercontent.com/15015880/85897316-f58be500-b7ae-11ea-8f43-8685ec49ef99.png)

NEW:
![Screen Shot 2020-06-26 at 12 13 48 PM](https://user-images.githubusercontent.com/15015880/85897346-fde42000-b7ae-11ea-87af-89ca9a82a7ee.png)

