### PR TITLE
fix(discover): Show default display mode if selected mode is disabled

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
+++ b/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
@@ -8,15 +8,10 @@ import {InlineContainer, SectionHeading} from 'app/components/charts/styles';
 import {DropdownItem} from 'app/components/dropdownControl';
 import DropdownBubble from 'app/components/dropdownBubble';
 import space from 'app/styles/space';
-
-type Option = {
-  label: string;
-  value: string;
-  disabled?: boolean;
-};
+import {SelectValue} from 'app/types';
 
 type Props = {
-  options: Option[];
+  options: SelectValue<string>[];
   selected: string;
   onChange: (value: string) => void;
   title: string;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1028,6 +1028,7 @@ export type SavedQueryState = {
 export type SelectValue<T> = {
   label: string;
   value: T;
+  disabled?: boolean;
 };
 
 /**

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -1007,7 +1007,7 @@ class EventView {
     return defaultOption;
   }
 
-  getDisplayOptions() {
+  getDisplayOptions(): SelectValue<string>[] {
     if (!this.start && !this.end) {
       return DISPLAY_MODE_OPTIONS;
     }
@@ -1017,6 +1017,15 @@ class EventView {
       }
       return item;
     });
+  }
+
+  getDisplayMode() {
+    const displayOptions = this.getDisplayOptions();
+    const selectedOption = displayOptions.find(option => option.value === this.display);
+    if (selectedOption && !selectedOption.disabled) {
+      return this.display ?? DisplayModes.DEFAULT;
+    }
+    return DisplayModes.DEFAULT;
   }
 }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -168,7 +168,7 @@ class ResultsChartContainer extends React.Component<ContainerProps> {
           yAxisOptions={eventView.getYAxisOptions()}
           onAxisChange={onAxisChange}
           displayOptions={displayOptions}
-          displayMode={eventView.display || DisplayModes.DEFAULT}
+          displayMode={eventView.getDisplayMode()}
           onDisplayChange={onDisplayChange}
         />
       </StyledPanel>

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -3,7 +3,11 @@ import EventView, {
   pickRelevantLocationQueryStrings,
 } from 'app/utils/discover/eventView';
 import {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable/utils';
-import {CHART_AXIS_OPTIONS, DISPLAY_MODE_OPTIONS} from 'app/utils/discover/types';
+import {
+  CHART_AXIS_OPTIONS,
+  DisplayModes,
+  DISPLAY_MODE_OPTIONS,
+} from 'app/utils/discover/types';
 
 const generateFields = fields =>
   fields.map(field => ({
@@ -2362,6 +2366,46 @@ describe('EventView.getDisplayOptions()', function() {
     const options = eventView.getDisplayOptions();
     expect(options[1].value).toEqual('previous');
     expect(options[1].disabled).toBeTruthy();
+  });
+});
+
+describe('EventView.getDisplayMode()', function() {
+  const state = {
+    fields: [],
+    sorts: [],
+    query: '',
+    project: [],
+    statsPeriod: '42d',
+    environment: [],
+  };
+
+  it('should have default', function() {
+    const eventView = new EventView({
+      ...state,
+    });
+    const displayMode = eventView.getDisplayMode();
+    expect(displayMode).toEqual(DisplayModes.DEFAULT);
+  });
+
+  it('should return current mode when not disabled', function() {
+    const eventView = new EventView({
+      ...state,
+      display: DisplayModes.TOP5,
+    });
+    const displayMode = eventView.getDisplayMode();
+    expect(displayMode).toEqual(DisplayModes.TOP5);
+  });
+
+  it('should return default mode when disabled', function() {
+    const eventView = new EventView({
+      ...state,
+      // the existence of start and end will disable the PREVIOUS mode
+      end: '2020-04-13T12:13:14',
+      start: '2020-04-01T12:13:14',
+      display: DisplayModes.PREVIOUS,
+    });
+    const displayMode = eventView.getDisplayMode();
+    expect(displayMode).toEqual(DisplayModes.DEFAULT);
   });
 });
 


### PR DESCRIPTION
If the current display mode is previous and you do a drag zoom, the previous
display mode will be disabled. However, it is still shown as the current
display mode. This change will change it back to the default display mode.