### PR TITLE
ref(ui) Replace icon-arrow-left and right with SVG icons

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -23,7 +23,7 @@ import {
 import BackToIssues from 'app/components/organizations/backToIssues';
 import HeaderItemPosition from 'app/components/organizations/headerItemPosition';
 import HeaderSeparator from 'app/components/organizations/headerSeparator';
-import InlineSvg from 'app/components/inlineSvg';
+import {IconArrow} from 'app/icons';
 import MultipleEnvironmentSelector from 'app/components/organizations/multipleEnvironmentSelector';
 import MultipleProjectSelector from 'app/components/organizations/multipleProjectSelector';
 import Projects from 'app/utils/projects';
@@ -301,7 +301,7 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
             data-test-id="back-to-issues"
             to={`/organizations/${organization.slug}/issues/${location.search}`}
           >
-            <InlineSvg src="icon-arrow-left" />
+            <IconArrow direction="left" size="sm" />
           </BackToIssues>
         </Tooltip>
       </BackButtonWrapper>

--- a/src/sentry/static/sentry/app/components/pagination.tsx
+++ b/src/sentry/static/sentry/app/components/pagination.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {Query} from 'history';
 
+import {IconChevron} from 'app/icons';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -58,23 +59,33 @@ class Pagination extends React.Component<Props> {
       <div className={className}>
         <ButtonBar merged>
           <Button
+            icon={
+              <IconChevron
+                direction="left"
+                size="sm"
+                color={previousDisabled ? 'gray400' : 'gray700'}
+              />
+            }
             aria-label={t('Previous')}
             disabled={previousDisabled}
             onClick={() => {
               callIfFunction(onCursor, links.previous.cursor, path, query, -1);
             }}
-          >
-            <IconSpan className="icon-arrow-left" disabled={previousDisabled} />
-          </Button>
+          />
           <Button
+            icon={
+              <IconChevron
+                direction="right"
+                size="sm"
+                color={nextDisabled ? 'gray400' : 'gray700'}
+              />
+            }
             aria-label={t('Next')}
             disabled={nextDisabled}
             onClick={() => {
               callIfFunction(onCursor, links.next.cursor, path, query, 1);
             }}
-          >
-            <IconSpan className="icon-arrow-right" disabled={nextDisabled} />
-          </Button>
+          />
         </ButtonBar>
       </div>
     );
@@ -86,15 +97,4 @@ export default styled(Pagination)`
   align-items: center;
   justify-content: flex-end;
   margin: 20px 0 0 0;
-
-  .icon-arrow-right,
-  .icon-arrow-left {
-    font-size: 20px !important;
-  }
-`;
-
-// TODO this component and the icons should be replaced with IconChevron but
-// that icon has rendering issues on percy.
-const IconSpan = styled('span')<{disabled: boolean}>`
-  color: ${p => (p.disabled ? p.theme.disabled : p.theme.gray700)};
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
 import DropdownMenu from 'app/components/dropdownMenu';
-import {IconAdd} from 'app/icons';
+import {IconAdd, IconChevron} from 'app/icons';
 import withOrganizations from 'app/utils/withOrganizations';
 import SidebarOrgSummary from 'app/components/sidebar/sidebarOrgSummary';
 import SidebarMenuItem from 'app/components/sidebar/sidebarMenuItem';
@@ -40,7 +40,7 @@ const SwitchOrganization = ({organizations, canCreateOrganization}: Props) => (
           {t('Switch organization')}
 
           <SubMenuCaret>
-            <i className="icon-arrow-right" />
+            <IconChevron size="xs" direction="right" />
           </SubMenuCaret>
         </SwitchOrganizationMenuActor>
 

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -490,9 +490,52 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                             <span
                               className="css-3ur4f5-SubMenuCaret ev3suul2"
                             >
-                              <i
-                                className="icon-arrow-right"
-                              />
+                              <IconChevron
+                                direction="right"
+                                size="xs"
+                              >
+                                <EmotionCssPropInternal
+                                  __EMOTION_LABEL_PLEASE_DO_NOT_USE__="IconChevron"
+                                  __EMOTION_TYPE_PLEASE_DO_NOT_USE__={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "propTypes": Object {
+                                        "color": [Function],
+                                        "size": [Function],
+                                        "viewBox": [Function],
+                                      },
+                                      "render": [Function],
+                                    }
+                                  }
+                                  css={
+                                    Object {
+                                      "map": undefined,
+                                      "name": "72rehw-IconChevron",
+                                      "next": undefined,
+                                      "styles": "transform:rotate(90deg);;label:IconChevron;",
+                                      "toString": [Function],
+                                    }
+                                  }
+                                  size="xs"
+                                >
+                                  <ForwardRef(SvgIcon)
+                                    className="css-72rehw-IconChevron"
+                                    size="xs"
+                                  >
+                                    <svg
+                                      className="css-72rehw-IconChevron"
+                                      fill="currentColor"
+                                      height="12px"
+                                      viewBox="0 0 16 16"
+                                      width="12px"
+                                    >
+                                      <path
+                                        d="M14,11.75a.74.74,0,0,1-.53-.22L8,6.06,2.53,11.53a.75.75,0,0,1-1.06-1.06l6-6a.75.75,0,0,1,1.06,0l6,6a.75.75,0,0,1,0,1.06A.74.74,0,0,1,14,11.75Z"
+                                      />
+                                    </svg>
+                                  </ForwardRef(SvgIcon)>
+                                </EmotionCssPropInternal>
+                              </IconChevron>
                             </span>
                           </SubMenuCaret>
                         </span>

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -1130,7 +1130,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
           "hasProjectBeenRenamed": [Function],
         }
       }
-      className="css-yneqnx e1vkspke0"
+      className="css-1vzq2o e1vkspke0"
       location={
         Object {
           "query": Object {},

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupMergedView.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupMergedView.spec.jsx.snap
@@ -2013,7 +2013,7 @@ exports[`Issues -> Merged View renders with mocked data 1`] = `
           onCursor={[Function]}
         >
           <Pagination
-            className="css-yneqnx e1vkspke0"
+            className="css-1vzq2o e1vkspke0"
             onCursor={[Function]}
           />
         </Styled(Pagination)>

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -1894,7 +1894,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
           onCursor={[Function]}
         >
           <Pagination
-            className="css-yneqnx e1vkspke0"
+            className="css-1vzq2o e1vkspke0"
             onCursor={[Function]}
           />
         </Styled(Pagination)>


### PR DESCRIPTION
I'm going to try the pagination buttons again as it seems like it didn't go so well last time.

I've not removed the css class names for left and right arrows because they are still used by django rendered templates in SSO flows.