### PR TITLE
build: remove pip install -e, add -U everywhere

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -143,7 +143,7 @@ jobs:
         # setup pip
         - name: Install pip
           run: |
-            pip install --no-cache-dir --upgrade "pip>=20.0.2"
+            pip install -U --no-cache-dir --upgrade "pip>=20.0.2"
 
         # pip cache
         - name: Get pip cache dir
@@ -173,8 +173,8 @@ jobs:
             PGPASSWORD: postgres
           run: |
             python setup.py install_egg_info
-            pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
-            pip install ".[dev]"
+            pip install -U wheel # GitHub Actions does not have this installed by default (unlike Travis)
+            pip install -U ".[dev]"
             psql -c 'create database sentry;' -h localhost -U postgres
             sentry init
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -174,7 +174,7 @@ jobs:
           run: |
             python setup.py install_egg_info
             pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
-            pip install -U -e ".[dev]"
+            pip install ".[dev]"
             psql -c 'create database sentry;' -h localhost -U postgres
             sentry init
 

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -71,7 +71,7 @@ jobs:
         # setup pip
         - name: Install pip
           run: |
-            pip install --no-cache-dir --upgrade "pip>=20.0.2"
+            pip install -U --no-cache-dir --upgrade "pip>=20.0.2"
 
         # pip cache
         - name: Get pip cache dir
@@ -97,8 +97,8 @@ jobs:
             PGPASSWORD: postgres
           run: |
             python setup.py install_egg_info
-            pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
-            pip install ".[dev]"
+            pip install -U wheel # GitHub Actions does not have this installed by default (unlike Travis)
+            pip install -U ".[dev]"
             psql -c 'create database sentry;' -h localhost -U postgres
             sentry init
 

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -98,7 +98,7 @@ jobs:
           run: |
             python setup.py install_egg_info
             pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
-            pip install -U -e ".[dev]"
+            pip install ".[dev]"
             psql -c 'create database sentry;' -h localhost -U postgres
             sentry init
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,7 +64,7 @@ jobs:
         # setup pip
         - name: Install pip
           run: |
-            pip install --no-cache-dir --upgrade "pip>=20.0.2"
+            pip install -U --no-cache-dir --upgrade "pip>=20.0.2"
 
         # pip cache
         - name: Get pip cache dir
@@ -90,8 +90,8 @@ jobs:
             PGPASSWORD: postgres
           run: |
             python setup.py install_egg_info
-            pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
-            pip install ".[dev]"
+            pip install -U wheel # GitHub Actions does not have this installed by default (unlike Travis)
+            pip install -U ".[dev]"
             psql -c 'create database sentry;' -h localhost -U postgres
             sentry init
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -91,7 +91,7 @@ jobs:
           run: |
             python setup.py install_egg_info
             pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
-            pip install -U -e ".[dev]"
+            pip install ".[dev]"
             psql -c 'create database sentry;' -h localhost -U postgres
             sentry init
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ after_script:
   - |
     coverage_files=$(ls .artifacts/*coverage.xml || true)
     if [[ -n "$coverage_files" || -f .artifacts/coverage/cobertura-coverage.xml ]]; then
-      pip install -U codecov
+      pip install codecov
       codecov -e TEST_SUITE
     fi
   - *install_volta
@@ -132,7 +132,7 @@ base_postgres: &postgres_default
     - docker ps -a
   install:
     - python setup.py install_egg_info
-    - pip install -U -e ".[dev]"
+    - pip install ".[dev]"
   before_script:
     - psql -c 'create database sentry;' -U postgres
 
@@ -151,7 +151,7 @@ base_acceptance: &acceptance_default
   install:
     - *install_node_dependencies
     - python setup.py install_egg_info
-    - pip install -U -e ".[dev]"
+    - pip install ".[dev]"
     - |
       CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
       wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})/chromedriver_linux64.zip" -P ~/
@@ -194,7 +194,7 @@ matrix:
         # XXX: ideally we don't have to install sentry in its entirety just to scan dependencies...
         # see the note in bin/scan on why this needs to be done for now.
         # Note that this will mostly noop because we pull in a cached venv from Travis.
-        - SENTRY_LIGHT_BUILD=1 SENTRY_PYTHON3=1 pip install -e .
+        - SENTRY_LIGHT_BUILD=1 SENTRY_PYTHON3=1 pip install .
         - pip install safety
         # XXX: fun fact, as of April 2020 travis preinstalls numpy 1.15.4 in their 3.7 environments
         # and the safety scanner won't like that (safety id 36810)
@@ -242,7 +242,7 @@ matrix:
         - redis-server
       install:
         - python setup.py install_egg_info
-        - pip install -U -e ".[dev]"
+        - pip install ".[dev]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -283,7 +283,7 @@ matrix:
         - docker ps -a
       install:
         - python setup.py install_egg_info
-        - pip install -U -e ".[dev]"
+        - pip install ".[dev]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
@@ -304,9 +304,9 @@ matrix:
     #     - docker ps -a
     #   install:
     #     - python setup.py install_egg_info
-    #     - pip install -U -e ".[dev]"
+    #     - pip install ".[dev]"
     #     - pip uninstall -y rb
-    #     - pip install -e git+https://github.com/joshuarli/rb.git@505ad7665baba66c7c492b01b0e83d433ed2eb8e#egg=rb
+    #     - pip install git+https://github.com/joshuarli/rb.git@505ad7665baba66c7c492b01b0e83d433ed2eb8e#egg=rb
     #   before_script:
     #     - psql -c 'create database sentry;' -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
     - PYTEST_ADDOPTS="--reruns 5"
 
 base_install: &base_install |-
-  pip install --no-cache-dir "pip>=20.0.2"
+  pip install -U --no-cache-dir "pip>=20.0.2"
 
   docker run \
     --name sentry_zookeeper \
@@ -107,7 +107,7 @@ after_script:
   - |
     coverage_files=$(ls .artifacts/*coverage.xml || true)
     if [[ -n "$coverage_files" || -f .artifacts/coverage/cobertura-coverage.xml ]]; then
-      pip install codecov
+      pip install -U codecov
       codecov -e TEST_SUITE
     fi
   - *install_volta
@@ -132,7 +132,7 @@ base_postgres: &postgres_default
     - docker ps -a
   install:
     - python setup.py install_egg_info
-    - pip install ".[dev]"
+    - pip install -U ".[dev]"
   before_script:
     - psql -c 'create database sentry;' -U postgres
 
@@ -151,7 +151,7 @@ base_acceptance: &acceptance_default
   install:
     - *install_node_dependencies
     - python setup.py install_egg_info
-    - pip install ".[dev]"
+    - pip install -U ".[dev]"
     - |
       CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
       wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})/chromedriver_linux64.zip" -P ~/
@@ -194,8 +194,8 @@ matrix:
         # XXX: ideally we don't have to install sentry in its entirety just to scan dependencies...
         # see the note in bin/scan on why this needs to be done for now.
         # Note that this will mostly noop because we pull in a cached venv from Travis.
-        - SENTRY_LIGHT_BUILD=1 SENTRY_PYTHON3=1 pip install .
-        - pip install safety
+        - SENTRY_LIGHT_BUILD=1 SENTRY_PYTHON3=1 pip install -U .
+        - pip install -U safety
         # XXX: fun fact, as of April 2020 travis preinstalls numpy 1.15.4 in their 3.7 environments
         # and the safety scanner won't like that (safety id 36810)
         # Previously we had 36810 ignored in bin/scan until it was removed because it was fixed in
@@ -242,7 +242,7 @@ matrix:
         - redis-server
       install:
         - python setup.py install_egg_info
-        - pip install ".[dev]"
+        - pip install -U ".[dev]"
       before_script:
         - psql -c 'create database sentry;' -U postgres
 


### PR DESCRIPTION
Editable installs aren't necessary at all for CI, only development.

Also, we need -U everywhere since we cache the venv itself in Travis. (Adding to GHA for consistency - it doesn't hurt.) Consider the following scenario where foo 0.2 is installed, and we have `>=0.1,<0.3` specified. Now say we bumped to `>=0.1,<0.4`... it won't take effect in CI until the cache is removed, because we don't have `-U, --upgrade` and so pip will see that the range pin is already satisfied.

Unfortunately this probably makes things slower since pip does more network calls to check every time.

So, I would really like to have a lockfile soon. Maybe I'll take a stab at poetry again when I'm bored, but I remember that being very nontrivial.

Or this could also be an argument against range pins. All == pins combined with pip's hashing feature would basically be a lockfile.
