### PR TITLE
feat(metric_alerts): Start using rule level resolve and threshold_type fields in subscription processor

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -32,9 +32,9 @@ logger = logging.getLogger(__name__)
 REDIS_TTL = int(timedelta(days=7).total_seconds())
 ALERT_RULE_BASE_KEY = "{alert_rule:%s:project:%s}"
 ALERT_RULE_BASE_STAT_KEY = "%s:%s"
-ALERT_RULE_STAT_KEYS = ("last_update",)
+ALERT_RULE_STAT_KEYS = ("last_update", "resolve_triggered")
 ALERT_RULE_BASE_TRIGGER_STAT_KEY = "%s:trigger:%s:%s"
-ALERT_RULE_TRIGGER_STAT_KEYS = ("alert_triggered", "resolve_triggered")
+ALERT_RULE_TRIGGER_STAT_KEYS = ("alert_triggered",)
 
 
 class SubscriptionProcessor(object):
@@ -64,10 +64,10 @@ class SubscriptionProcessor(object):
         (
             self.last_update,
             self.trigger_alert_counts,
-            self.trigger_resolve_counts,
+            self.rule_resolve_counts,
         ) = get_alert_rule_stats(self.alert_rule, self.subscription, self.triggers)
         self.orig_trigger_alert_counts = deepcopy(self.trigger_alert_counts)
-        self.orig_trigger_resolve_counts = deepcopy(self.trigger_resolve_counts)
+        self.orig_rule_resolve_counts = self.rule_resolve_counts
 
     @property
     def active_incident(self):
@@ -132,29 +132,46 @@ class SubscriptionProcessor(object):
                 },
             )
         aggregation_value = subscription_update["values"]["data"][0].values()[0]
-
+        alert_operator, resolve_operator = self.THRESHOLD_TYPE_OPERATORS[
+            AlertRuleThresholdType(self.alert_rule.threshold_type)
+        ]
         for trigger in self.triggers:
-            alert_operator, resolve_operator = self.THRESHOLD_TYPE_OPERATORS[
-                AlertRuleThresholdType(trigger.threshold_type)
-            ]
-
             if alert_operator(
                 aggregation_value, trigger.alert_threshold
             ) and not self.check_trigger_status(trigger, TriggerStatus.ACTIVE):
                 metrics.incr("incidents.alert_rules.threshold", tags={"type": "alert"})
                 with transaction.atomic():
                     self.trigger_alert_threshold(trigger, aggregation_value)
-            elif (
-                trigger.resolve_threshold is not None
-                and resolve_operator(aggregation_value, trigger.resolve_threshold)
-                and self.check_trigger_status(trigger, TriggerStatus.ACTIVE)
-            ):
-                metrics.incr("incidents.alert_rules.threshold", tags={"type": "resolve"})
-                with transaction.atomic():
-                    self.trigger_resolve_threshold(trigger, aggregation_value)
             else:
                 self.trigger_alert_counts[trigger.id] = 0
-                self.trigger_resolve_counts[trigger.id] = 0
+
+        if (
+            self.alert_rule.resolve_threshold is not None
+            and resolve_operator(aggregation_value, self.alert_rule.resolve_threshold)
+            and self.active_incident
+        ):
+            self.rule_resolve_counts += 1
+            if self.rule_resolve_counts >= self.alert_rule.threshold_period:
+                # TODO: Make sure we iterate over critical then warning in order.
+                # Potentially also de-dupe actions that are identical. Maybe just
+                # collect all actions, de-dupe and resolve all at once
+                metrics.incr("incidents.alert_rules.threshold", tags={"type": "resolve"})
+                for trigger in self.triggers:
+                    if self.check_trigger_status(trigger, TriggerStatus.ACTIVE):
+                        with transaction.atomic():
+                            self.trigger_resolve_threshold(trigger, aggregation_value)
+
+                update_incident_status(
+                    self.active_incident,
+                    IncidentStatus.CLOSED,
+                    status_method=IncidentStatusMethod.RULE_TRIGGERED,
+                    date_closed=self.calculate_event_date_from_update_date(self.last_update),
+                )
+                self.active_incident = None
+                self.incident_triggers.clear()
+                self.rule_resolve_counts = 0
+        else:
+            self.rule_resolve_counts = 0
 
         # We update the rule stats here after we commit the transaction. This guarantees
         # that we'll never miss an update, since we'll never roll back if the process
@@ -234,46 +251,17 @@ class SubscriptionProcessor(object):
             # once we've triggered an incident.
             self.trigger_alert_counts[trigger.id] = 0
 
-    def check_triggers_resolved(self):
-        """
-        Determines whether all triggers associated with the active incident are
-        resolved. A trigger is considered resolved if it either has no resolve
-        threshold, or is in the `TriggerStatus.Resolved` state.
-        :return:
-        """
-        for incident_trigger in self.incident_triggers.values():
-            if (
-                incident_trigger.alert_rule_trigger.resolve_threshold is not None
-                and incident_trigger.status != TriggerStatus.RESOLVED.value
-            ):
-                return False
-        return True
-
     def trigger_resolve_threshold(self, trigger, metric_value):
         """
         Called when a subscription update exceeds the value defined in
-        `trigger.resolve_threshold` and the trigger is currently ACTIVE.
+        `alert_rule.resolve_threshold` and the trigger is currently ACTIVE.
         :return:
         """
-        self.trigger_resolve_counts[trigger.id] += 1
-        if self.trigger_resolve_counts[trigger.id] >= self.alert_rule.threshold_period:
-            metrics.incr("incidents.alert_rules.trigger", tags={"type": "resolve"})
-            incident_trigger = self.incident_triggers[trigger.id]
-            incident_trigger.status = TriggerStatus.RESOLVED.value
-            incident_trigger.save()
-            self.handle_trigger_actions(incident_trigger, metric_value)
-            self.handle_incident_severity_update()
-
-            if self.check_triggers_resolved():
-                update_incident_status(
-                    self.active_incident,
-                    IncidentStatus.CLOSED,
-                    status_method=IncidentStatusMethod.RULE_TRIGGERED,
-                    date_closed=self.calculate_event_date_from_update_date(self.last_update),
-                )
-                self.active_incident = None
-                self.incident_triggers.clear()
-            self.trigger_resolve_counts[trigger.id] = 0
+        metrics.incr("incidents.alert_rules.trigger", tags={"type": "resolve"})
+        incident_trigger = self.incident_triggers[trigger.id]
+        incident_trigger.status = TriggerStatus.RESOLVED.value
+        incident_trigger.save()
+        self.handle_trigger_actions(incident_trigger, metric_value)
 
     def handle_trigger_actions(self, incident_trigger, metric_value):
         method = "fire" if incident_trigger.status == TriggerStatus.ACTIVE.value else "resolve"
@@ -321,18 +309,16 @@ class SubscriptionProcessor(object):
             for trigger_id, alert_count in self.trigger_alert_counts.items()
             if alert_count != self.orig_trigger_alert_counts[trigger_id]
         }
-        updated_trigger_resolve_counts = {
-            trigger_id: resolve_count
-            for trigger_id, resolve_count in self.trigger_resolve_counts.items()
-            if resolve_count != self.orig_trigger_resolve_counts[trigger_id]
-        }
+        resolve_counts = None
+        if self.rule_resolve_counts != self.orig_rule_resolve_counts:
+            resolve_counts = self.rule_resolve_counts
 
         update_alert_rule_stats(
             self.alert_rule,
             self.subscription,
             self.last_update,
             updated_trigger_alert_counts,
-            updated_trigger_resolve_counts,
+            resolve_counts,
         )
 
 
@@ -383,9 +369,8 @@ def get_alert_rule_stats(alert_rule, subscription, triggers):
      - trigger_alert_counts: A dict of trigger alert counts, where the key is the
        trigger id, and the value is an int representing how many consecutive times we
        have triggered the alert threshold
-     - trigger_resolve_counts: A dict of trigger resolve counts, where the key is the
-       trigger id, and the value is an int representing how many consecutive times we
-       have triggered the resolve threshold
+     - rule_resolve_counts: An int representing how many consecutive times we have
+       triggered the resolve threshold
     """
 
     alert_rule_keys = build_alert_rule_stat_keys(alert_rule, subscription)
@@ -393,25 +378,24 @@ def get_alert_rule_stats(alert_rule, subscription, triggers):
     results = get_redis_client().mget(alert_rule_keys + trigger_keys)
     results = tuple(0 if result is None else int(result) for result in results)
     last_update = to_datetime(results[0])
-    trigger_results = results[1:]
+    rule_resolve_counts = results[1]
+    trigger_results = results[2:]
     trigger_alert_counts = {}
-    trigger_resolve_counts = {}
-    for trigger, trigger_result in zip(
-        triggers, partition(trigger_results, len(ALERT_RULE_TRIGGER_STAT_KEYS))
-    ):
-        trigger_alert_counts[trigger.id] = trigger_result[0]
-        trigger_resolve_counts[trigger.id] = trigger_result[1]
+    for trigger, trigger_result in zip(triggers, trigger_results):
+        trigger_alert_counts[trigger.id] = trigger_result
 
-    return last_update, trigger_alert_counts, trigger_resolve_counts
+    return last_update, trigger_alert_counts, rule_resolve_counts
 
 
-def update_alert_rule_stats(alert_rule, subscription, last_update, alert_counts, resolve_counts):
+def update_alert_rule_stats(
+    alert_rule, subscription, last_update, alert_counts, resolve_count=None
+):
     """
     Updates stats about the alert rule, subscription and triggers if they've changed.
     """
     pipeline = get_redis_client().pipeline()
 
-    counts_with_stat_keys = zip(ALERT_RULE_TRIGGER_STAT_KEYS, (alert_counts, resolve_counts))
+    counts_with_stat_keys = zip(ALERT_RULE_TRIGGER_STAT_KEYS, (alert_counts,))
     for stat_key, trigger_counts in counts_with_stat_keys:
         for trigger_id, alert_count in trigger_counts.items():
             pipeline.set(
@@ -422,8 +406,10 @@ def update_alert_rule_stats(alert_rule, subscription, last_update, alert_counts,
                 ex=REDIS_TTL,
             )
 
-    last_update_key = build_alert_rule_stat_keys(alert_rule, subscription)[0]
+    last_update_key, resolve_count_key = build_alert_rule_stat_keys(alert_rule, subscription)
     pipeline.set(last_update_key, int(to_timestamp(last_update)), ex=REDIS_TTL)
+    if resolve_count is not None:
+        pipeline.set(resolve_count_key, resolve_count, ex=REDIS_TTL)
     pipeline.execute()
 
 

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -80,12 +80,12 @@ class ProcessUpdateTest(TestCase):
             query="",
             aggregate="count()",
             time_window=1,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            resolve_threshold=10,
             threshold_period=1,
         )
         # Make sure the trigger exists
-        trigger = create_alert_rule_trigger(
-            rule, "hi", AlertRuleThresholdType.ABOVE, 100, resolve_threshold=10
-        )
+        trigger = create_alert_rule_trigger(rule, "hi", AlertRuleThresholdType.ABOVE, 100)
         create_alert_rule_trigger_action(
             trigger,
             AlertRuleTriggerAction.Type.EMAIL,
@@ -200,12 +200,12 @@ class ProcessUpdateTest(TestCase):
 
     def assert_trigger_counts(self, processor, trigger, alert_triggers=0, resolve_triggers=0):
         assert processor.trigger_alert_counts[trigger.id] == alert_triggers
-        assert processor.trigger_resolve_counts[trigger.id] == resolve_triggers
+        assert processor.rule_resolve_counts == resolve_triggers
         alert_stats, resolve_stats = get_alert_rule_stats(
             processor.alert_rule, processor.subscription, [trigger]
         )[1:]
         assert alert_stats[trigger.id] == alert_triggers
-        assert resolve_stats[trigger.id] == resolve_triggers
+        assert resolve_stats == resolve_triggers
 
     def test_removed_alert_rule(self):
         message = self.build_subscription_update(self.sub)
@@ -303,10 +303,10 @@ class ProcessUpdateTest(TestCase):
         # related to the alert rule.
         rule = self.rule
         trigger = self.trigger
-        processor = self.send_update(rule, trigger.resolve_threshold - 1)
-        self.assert_trigger_counts(processor, self.trigger, 0, 0)
+        processor = self.send_update(rule, rule.resolve_threshold - 1)
+        self.assert_trigger_counts(processor, trigger, 0, 0)
         self.assert_no_active_incident(rule)
-        self.assert_trigger_does_not_exist(self.trigger)
+        self.assert_trigger_does_not_exist(trigger)
         self.assert_action_handler_called_with_actions(None, [])
 
     def test_resolve(self):
@@ -320,7 +320,7 @@ class ProcessUpdateTest(TestCase):
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
         self.assert_actions_fired_for_incident(incident, [self.action])
 
-        processor = self.send_update(rule, trigger.resolve_threshold - 1, timedelta(minutes=-1))
+        processor = self.send_update(rule, rule.resolve_threshold - 1, timedelta(minutes=-1))
         self.assert_trigger_counts(processor, self.trigger, 0, 0)
         self.assert_no_active_incident(rule)
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.RESOLVED)
@@ -339,13 +339,13 @@ class ProcessUpdateTest(TestCase):
         self.assert_actions_fired_for_incident(incident, [self.action])
 
         rule.update(threshold_period=2)
-        processor = self.send_update(rule, trigger.resolve_threshold - 1, timedelta(minutes=-2))
+        processor = self.send_update(rule, rule.resolve_threshold - 1, timedelta(minutes=-2))
         self.assert_trigger_counts(processor, self.trigger, 0, 1)
         incident = self.assert_active_incident(rule)
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
         self.assert_action_handler_called_with_actions(incident, [])
 
-        processor = self.send_update(rule, trigger.resolve_threshold - 1, timedelta(minutes=-1))
+        processor = self.send_update(rule, rule.resolve_threshold - 1, timedelta(minutes=-1))
         self.assert_trigger_counts(processor, self.trigger, 0, 0)
         self.assert_no_active_incident(rule)
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.RESOLVED)
@@ -365,19 +365,19 @@ class ProcessUpdateTest(TestCase):
         self.assert_actions_fired_for_incident(incident, [self.action])
 
         rule.update(threshold_period=2)
-        processor = self.send_update(rule, trigger.resolve_threshold - 1, timedelta(minutes=-3))
+        processor = self.send_update(rule, rule.resolve_threshold - 1, timedelta(minutes=-3))
         self.assert_trigger_counts(processor, self.trigger, 0, 1)
         self.assert_active_incident(rule)
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
         self.assert_action_handler_called_with_actions(incident, [])
 
-        processor = self.send_update(rule, trigger.resolve_threshold, timedelta(minutes=-2))
+        processor = self.send_update(rule, rule.resolve_threshold, timedelta(minutes=-2))
         self.assert_trigger_counts(processor, self.trigger, 0, 0)
         self.assert_active_incident(rule)
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
         self.assert_action_handler_called_with_actions(incident, [])
 
-        processor = self.send_update(rule, trigger.resolve_threshold - 1, timedelta(minutes=-1))
+        processor = self.send_update(rule, rule.resolve_threshold - 1, timedelta(minutes=-1))
         self.assert_trigger_counts(processor, self.trigger, 0, 1)
         self.assert_active_incident(rule)
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
@@ -387,24 +387,26 @@ class ProcessUpdateTest(TestCase):
         # Test that inverting thresholds correctly alerts
         rule = self.rule
         trigger = self.trigger
-        trigger.update(threshold_type=AlertRuleThresholdType.BELOW.value)
+        rule.update(threshold_type=AlertRuleThresholdType.BELOW.value)
+        trigger.update(alert_threshold=rule.resolve_threshold + 1)
         processor = self.send_update(rule, trigger.alert_threshold + 1, timedelta(minutes=-2))
-        self.assert_trigger_counts(processor, self.trigger, 0, 0)
+        self.assert_trigger_counts(processor, trigger, 0, 0)
         self.assert_no_active_incident(rule)
-        self.assert_trigger_does_not_exist(self.trigger)
+        self.assert_trigger_does_not_exist(trigger)
         self.assert_action_handler_called_with_actions(None, [])
 
         processor = self.send_update(rule, trigger.alert_threshold - 1, timedelta(minutes=-1))
-        self.assert_trigger_counts(processor, self.trigger, 0, 0)
+        self.assert_trigger_counts(processor, trigger, 0, 0)
         incident = self.assert_active_incident(rule)
-        self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
+        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
         self.assert_actions_fired_for_incident(incident, [self.action])
 
     def test_reversed_threshold_resolve(self):
         # Test that inverting thresholds correctly resolves
         rule = self.rule
         trigger = self.trigger
-        trigger.update(threshold_type=AlertRuleThresholdType.BELOW.value)
+        rule.update(threshold_type=AlertRuleThresholdType.BELOW.value)
+        trigger.update(alert_threshold=rule.resolve_threshold + 1)
 
         processor = self.send_update(rule, trigger.alert_threshold - 1, timedelta(minutes=-3))
         self.assert_trigger_counts(processor, self.trigger, 0, 0)
@@ -412,13 +414,13 @@ class ProcessUpdateTest(TestCase):
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
         self.assert_actions_fired_for_incident(incident, [self.action])
 
-        processor = self.send_update(rule, trigger.resolve_threshold - 1, timedelta(minutes=-2))
+        processor = self.send_update(rule, rule.resolve_threshold - 1, timedelta(minutes=-2))
         self.assert_trigger_counts(processor, self.trigger, 0, 0)
         incident = self.assert_active_incident(rule)
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
         self.assert_action_handler_called_with_actions(incident, [])
 
-        processor = self.send_update(rule, trigger.resolve_threshold + 1, timedelta(minutes=-1))
+        processor = self.send_update(rule, rule.resolve_threshold + 1, timedelta(minutes=-1))
         self.assert_trigger_counts(processor, self.trigger, 0, 0)
         self.assert_no_active_incident(rule)
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.RESOLVED)
@@ -480,7 +482,7 @@ class ProcessUpdateTest(TestCase):
         # Now we want to test that resolving is isolated. Send another update through
         # for the first subscription.
         processor = self.send_update(
-            rule, trigger.resolve_threshold - 1, timedelta(minutes=-7), subscription=self.sub
+            rule, rule.resolve_threshold - 1, timedelta(minutes=-7), subscription=self.sub
         )
         self.assert_trigger_counts(processor, self.trigger, 0, 1)
         incident = self.assert_active_incident(rule, self.sub)
@@ -491,7 +493,7 @@ class ProcessUpdateTest(TestCase):
         self.assert_action_handler_called_with_actions(other_incident, [])
 
         processor = self.send_update(
-            rule, trigger.resolve_threshold - 1, timedelta(minutes=-7), subscription=self.other_sub
+            rule, rule.resolve_threshold - 1, timedelta(minutes=-7), subscription=self.other_sub
         )
         self.assert_trigger_counts(processor, self.trigger, 0, 1)
         incident = self.assert_active_incident(rule, self.sub)
@@ -504,7 +506,7 @@ class ProcessUpdateTest(TestCase):
         # This second update for the second subscription should resolve its incident,
         # but not the incident from the first subscription.
         processor = self.send_update(
-            rule, trigger.resolve_threshold - 1, timedelta(minutes=-6), subscription=self.other_sub
+            rule, rule.resolve_threshold - 1, timedelta(minutes=-6), subscription=self.other_sub
         )
         self.assert_trigger_counts(processor, self.trigger, 0, 0)
         incident = self.assert_active_incident(rule, self.sub)
@@ -515,7 +517,7 @@ class ProcessUpdateTest(TestCase):
 
         # This second update for the first subscription should resolve its incident now.
         processor = self.send_update(
-            rule, trigger.resolve_threshold - 1, timedelta(minutes=-6), subscription=self.sub
+            rule, rule.resolve_threshold - 1, timedelta(minutes=-6), subscription=self.sub
         )
         self.assert_trigger_counts(processor, self.trigger, 0, 0)
         self.assert_no_active_incident(rule, self.sub)
@@ -530,7 +532,7 @@ class ProcessUpdateTest(TestCase):
         rule.update(threshold_period=2)
         trigger = self.trigger
         other_trigger = create_alert_rule_trigger(
-            self.rule, "hello", AlertRuleThresholdType.ABOVE, 200, resolve_threshold=50
+            self.rule, "hello", AlertRuleThresholdType.ABOVE, 200
         )
         other_action = create_alert_rule_trigger_action(
             other_trigger, AlertRuleTriggerAction.Type.EMAIL, AlertRuleTriggerAction.TargetType.USER
@@ -567,12 +569,12 @@ class ProcessUpdateTest(TestCase):
         self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.ACTIVE)
         self.assert_actions_fired_for_incident(incident, [other_action])
 
-        # Now send through two updates where we're below threshold for `other_trigger`.
-        # The trigger should end up resolved, but the incident should still be active
+        # Now send through two updates where we're below threshold for the rule. This
+        # should resolve all triggers and the incident should be closed.
         processor = self.send_update(
-            rule, other_trigger.resolve_threshold - 1, timedelta(minutes=-7), subscription=self.sub
+            rule, rule.resolve_threshold - 1, timedelta(minutes=-7), subscription=self.sub
         )
-        self.assert_trigger_counts(processor, trigger, 0, 0)
+        self.assert_trigger_counts(processor, trigger, 0, 1)
         self.assert_trigger_counts(processor, other_trigger, 0, 1)
         incident = self.assert_active_incident(rule, self.sub)
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
@@ -580,61 +582,7 @@ class ProcessUpdateTest(TestCase):
         self.assert_action_handler_called_with_actions(incident, [])
 
         processor = self.send_update(
-            rule, other_trigger.resolve_threshold - 1, timedelta(minutes=-6), subscription=self.sub
-        )
-        self.assert_trigger_counts(processor, trigger, 0, 0)
-        self.assert_trigger_counts(processor, other_trigger, 0, 0)
-        incident = self.assert_active_incident(rule, self.sub)
-        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
-        self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.RESOLVED)
-        self.assert_actions_resolved_for_incident(incident, [other_action])
-
-        # Now we push the other trigger below the resolve threshold twice. This should
-        # close the incident.
-        processor = self.send_update(
-            rule, trigger.resolve_threshold - 1, timedelta(minutes=-5), subscription=self.sub
-        )
-        self.assert_trigger_counts(processor, trigger, 0, 1)
-        self.assert_trigger_counts(processor, other_trigger, 0, 0)
-        incident = self.assert_active_incident(rule, self.sub)
-        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
-        self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.RESOLVED)
-        self.assert_action_handler_called_with_actions(incident, [])
-
-        processor = self.send_update(
-            rule, trigger.resolve_threshold - 1, timedelta(minutes=-4), subscription=self.sub
-        )
-        self.assert_trigger_counts(processor, trigger, 0, 0)
-        self.assert_trigger_counts(processor, other_trigger, 0, 0)
-        self.assert_no_active_incident(rule, self.sub)
-        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.RESOLVED)
-        self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.RESOLVED)
-        self.assert_actions_resolved_for_incident(incident, [self.action])
-
-    def test_multiple_triggers_at_same_time(self):
-        # Check that both triggers fire if an update comes through that exceeds both of
-        # their thresholds
-        rule = self.rule
-        trigger = self.trigger
-        other_trigger = create_alert_rule_trigger(
-            self.rule, "hello", AlertRuleThresholdType.ABOVE, 200, resolve_threshold=50
-        )
-        other_action = create_alert_rule_trigger_action(
-            other_trigger, AlertRuleTriggerAction.Type.EMAIL, AlertRuleTriggerAction.TargetType.USER
-        )
-
-        processor = self.send_update(
-            rule, other_trigger.alert_threshold + 1, timedelta(minutes=-10), subscription=self.sub
-        )
-        self.assert_trigger_counts(processor, trigger, 0, 0)
-        self.assert_trigger_counts(processor, other_trigger, 0, 0)
-        incident = self.assert_active_incident(rule, self.sub)
-        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
-        self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.ACTIVE)
-        self.assert_actions_fired_for_incident(incident, [self.action, other_action])
-
-        processor = self.send_update(
-            rule, trigger.resolve_threshold - 1, timedelta(minutes=-9), subscription=self.sub
+            rule, rule.resolve_threshold - 1, timedelta(minutes=-6), subscription=self.sub
         )
         self.assert_trigger_counts(processor, trigger, 0, 0)
         self.assert_trigger_counts(processor, other_trigger, 0, 0)
@@ -643,7 +591,7 @@ class ProcessUpdateTest(TestCase):
         self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.RESOLVED)
         self.assert_actions_resolved_for_incident(incident, [self.action, other_action])
 
-    def test_multiple_triggers_one_with_no_resolve(self):
+    def test_multiple_triggers_at_same_time(self):
         # Check that both triggers fire if an update comes through that exceeds both of
         # their thresholds
         rule = self.rule
@@ -666,20 +614,23 @@ class ProcessUpdateTest(TestCase):
         self.assert_actions_fired_for_incident(incident, [self.action, other_action])
 
         processor = self.send_update(
-            rule, trigger.resolve_threshold - 1, timedelta(minutes=-9), subscription=self.sub
+            rule, rule.resolve_threshold - 1, timedelta(minutes=-9), subscription=self.sub
         )
         self.assert_trigger_counts(processor, trigger, 0, 0)
         self.assert_trigger_counts(processor, other_trigger, 0, 0)
         self.assert_no_active_incident(rule, self.sub)
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.RESOLVED)
-        self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.ACTIVE)
-        self.assert_actions_resolved_for_incident(incident, [self.action])
+        self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.RESOLVED)
+        self.assert_actions_resolved_for_incident(incident, [self.action, other_action])
 
 
 class TestBuildAlertRuleStatKeys(unittest.TestCase):
     def test(self):
         stat_keys = build_alert_rule_stat_keys(AlertRule(id=1), QuerySubscription(project_id=2))
-        assert stat_keys == ["{alert_rule:1:project:2}:last_update"]
+        assert stat_keys == [
+            "{alert_rule:1:project:2}:last_update",
+            "{alert_rule:1:project:2}:resolve_triggered",
+        ]
 
 
 class TestBuildTriggerStatKeys(unittest.TestCase):
@@ -691,9 +642,7 @@ class TestBuildTriggerStatKeys(unittest.TestCase):
         )
         assert stat_keys == [
             "{alert_rule:1:project:2}:trigger:3:alert_triggered",
-            "{alert_rule:1:project:2}:trigger:3:resolve_triggered",
             "{alert_rule:1:project:2}:trigger:4:alert_triggered",
-            "{alert_rule:1:project:2}:trigger:4:resolve_triggered",
         ]
 
 
@@ -720,11 +669,10 @@ class TestGetAlertRuleStats(TestCase):
         pipeline = client.pipeline()
         timestamp = datetime.now().replace(tzinfo=pytz.utc, microsecond=0)
         pipeline.set("{alert_rule:1:project:2}:last_update", int(to_timestamp(timestamp)))
+        pipeline.set("{alert_rule:1:project:2}:resolve_triggered", 20)
         for key, value in [
             ("{alert_rule:1:project:2}:trigger:3:alert_triggered", 1),
-            ("{alert_rule:1:project:2}:trigger:3:resolve_triggered", 2),
             ("{alert_rule:1:project:2}:trigger:4:alert_triggered", 3),
-            ("{alert_rule:1:project:2}:trigger:4:resolve_triggered", 4),
         ]:
             pipeline.set(key, value)
         pipeline.execute()
@@ -732,7 +680,7 @@ class TestGetAlertRuleStats(TestCase):
         last_update, alert_counts, resolve_counts = get_alert_rule_stats(alert_rule, sub, triggers)
         assert last_update == timestamp
         assert alert_counts == {3: 1, 4: 3}
-        assert resolve_counts == {3: 2, 4: 4}
+        assert resolve_counts == 20
 
 
 class TestUpdateAlertRuleStats(TestCase):
@@ -740,7 +688,7 @@ class TestUpdateAlertRuleStats(TestCase):
         alert_rule = AlertRule(id=1)
         sub = QuerySubscription(project_id=2)
         date = datetime.utcnow().replace(tzinfo=pytz.utc)
-        update_alert_rule_stats(alert_rule, sub, date, {3: 20, 4: 3}, {3: 10, 4: 15})
+        update_alert_rule_stats(alert_rule, sub, date, {3: 20, 4: 3}, 15)
         client = get_redis_client()
         results = map(
             int,
@@ -748,11 +696,10 @@ class TestUpdateAlertRuleStats(TestCase):
                 [
                     "{alert_rule:1:project:2}:last_update",
                     "{alert_rule:1:project:2}:trigger:3:alert_triggered",
-                    "{alert_rule:1:project:2}:trigger:3:resolve_triggered",
                     "{alert_rule:1:project:2}:trigger:4:alert_triggered",
-                    "{alert_rule:1:project:2}:trigger:4:resolve_triggered",
+                    "{alert_rule:1:project:2}:resolve_triggered",
                 ]
             ),
         )
 
-        assert results == [int(to_timestamp(date)), 20, 10, 3, 15]
+        assert results == [int(to_timestamp(date)), 20, 3, 15]


### PR DESCRIPTION
Move to using the new `resolve_threshold` and `threshold_type` fields in the subscription processor.
This allows us to kill the fields on the triggers in a future pr.

It probably makes sense to merge this at the same time as or close to when the frontend changes go
into effect.

Depends on https://github.com/getsentry/sentry/pull/19555