### PR TITLE
build(github): Add a GitHub action to diff PR snapshots against main branch

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -206,6 +206,7 @@ jobs:
             name: visual-snapshots
             path: .artifacts/visual-snapshots
 
+
    visual-diff:
       needs: acceptance
       runs-on: ubuntu-16.04

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -221,7 +221,7 @@ jobs:
         - name: Diff snapshots
           if: ${{ github.ref != 'refs/heads/master' }}
           id: visual-snapshots-diff
-          uses: getsentry/action-visual-snapshot@v1-alpha
+          uses: getsentry/action-visual-snapshot@v1
           with:
             githubToken: ${{ secrets.GITHUB_TOKEN }}
             snapshot-path: .artifacts/visual-snapshots

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -206,31 +206,31 @@ jobs:
             name: visual-snapshots
             path: .artifacts/visual-snapshots
 
-     visual-diff:
-        needs: acceptance
-        runs-on: ubuntu-16.04
+   visual-diff:
+      needs: acceptance
+      runs-on: ubuntu-16.04
 
-        steps:
-          - name: Download base snapshots
-            uses: actions/download-artifact@v2
-            with:
-              name: visual-snapshots
-              path: .artifacts/visual-snapshots
+      steps:
+        - name: Download base snapshots
+          uses: actions/download-artifact@v2
+          with:
+            name: visual-snapshots
+            path: .artifacts/visual-snapshots
 
-          - name: Diff snapshots
-            if: ${{ github.ref != 'refs/heads/master' }}
-            id: visual-snapshots-diff
-            uses: getsentry/action-visual-snapshot@v1-alpha
-            with:
-              githubToken: ${{ secrets.GITHUB_TOKEN }}
-              snapshot-path: .artifacts/visual-snapshots
-              diff-path: .artifacts/visual-snapshots-diff
-              gcs-bucket: 'sentry-visual-snapshots'
-              gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
+        - name: Diff snapshots
+          if: ${{ github.ref != 'refs/heads/master' }}
+          id: visual-snapshots-diff
+          uses: getsentry/action-visual-snapshot@v1-alpha
+          with:
+            githubToken: ${{ secrets.GITHUB_TOKEN }}
+            snapshot-path: .artifacts/visual-snapshots
+            diff-path: .artifacts/visual-snapshots-diff
+            gcs-bucket: 'sentry-visual-snapshots'
+            gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
 
-          - name: Save diffed snapshots
-            if: always()
-            uses: actions/upload-artifact@v2
-            with:
-              name: visual-snapshots-diff
-              path: ${{ steps.visual-snapshots-diff.outputs.diff-path }}
+        - name: Save diffed snapshots
+          if: always()
+          uses: actions/upload-artifact@v2
+          with:
+            name: visual-snapshots-diff
+            path: ${{ steps.visual-snapshots-diff.outputs.diff-path }}

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -207,7 +207,7 @@ jobs:
             path: .artifacts/visual-snapshots
 
 
-   visual-diff:
+    visual-diff:
       needs: acceptance
       runs-on: ubuntu-16.04
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -125,6 +125,7 @@ jobs:
             echo "::set-output name=python-version::2.7"
             echo "::set-output name=matrix-instance-number::$(($MATRIX_INSTANCE+1))"
 
+
         # yarn cache
         - uses: actions/cache@v1
           id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -204,3 +205,32 @@ jobs:
           with:
             name: visual-snapshots
             path: .artifacts/visual-snapshots
+
+     visual-diff:
+        needs: acceptance
+        runs-on: ubuntu-16.04
+
+        steps:
+          - name: Download base snapshots
+            uses: actions/download-artifact@v2
+            with:
+              name: visual-snapshots
+              path: .artifacts/visual-snapshots
+
+          - name: Diff snapshots
+            if: ${{ github.ref != 'refs/heads/master' }}
+            id: visual-snapshots-diff
+            uses: getsentry/action-visual-snapshot@v1-alpha
+            with:
+              githubToken: ${{ secrets.GITHUB_TOKEN }}
+              snapshot-path: .artifacts/visual-snapshots
+              diff-path: .artifacts/visual-snapshots-diff
+              gcs-bucket: 'sentry-visual-snapshots'
+              gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
+
+          - name: Save diffed snapshots
+            if: always()
+            uses: actions/upload-artifact@v2
+            with:
+              name: visual-snapshots-diff
+              path: ${{ steps.visual-snapshots-diff.outputs.diff-path }}

--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -1,3 +1,4 @@
+/* global process */
 import React from 'react';
 import {Global, css} from '@emotion/core';
 
@@ -13,6 +14,26 @@ const styles = (theme: Theme) => css`
   abbr {
     border-bottom: 1px dotted ${theme.gray500};
   }
+
+  /**
+   * TODO: This should apply to the prefer-reduced-motion media query
+   *
+   * See https://web.dev/prefers-reduced-motion/
+   */
+  ${process.env.IS_CI &&
+    css`
+      *,
+      ::before,
+      ::after {
+        animation-delay: -1ms !important;
+        animation-duration: 0ms !important;
+        animation-iteration-count: 1 !important;
+        background-attachment: initial !important;
+        scroll-behavior: auto !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+      }
+    `}
 `;
 
 /**


### PR DESCRIPTION
* Adds CSS to limit animations in CI
* Adds an action to diff snapshots against main branch and saves diffs to the action artifacts

Note this action does not block merging PRs.

Action lives here: https://github.com/getsentry/action-visual-snapshot