### PR TITLE
feat(alerts): Move create alert button to transaction summary header

### DIFF
--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -8,7 +8,7 @@ import Button from 'app/components/button';
 import EventView from 'app/utils/discover/eventView';
 import Alert from 'app/components/alert';
 import space from 'app/styles/space';
-import {explodeFieldString} from 'app/utils/discover/fields';
+import {explodeFieldString, AGGREGATIONS, Aggregation} from 'app/utils/discover/fields';
 import {
   errorFieldConfig,
   transactionFieldConfig,
@@ -162,8 +162,13 @@ function incompatibleYAxis(eventView: EventView): boolean {
   const yAxisConfig = dataset === 'error' ? errorFieldConfig : transactionFieldConfig;
 
   const invalidFunction = !yAxisConfig.aggregations.includes(column.function[0]);
-  // Allow empty parameters
-  const invalidParameter = !['', ...yAxisConfig.fields].includes(column.function[1]);
+  // Allow empty parameters, allow all numeric parameters - eg. apdex(300)
+  const aggregation: Aggregation = AGGREGATIONS[column.function[0]];
+  const isNumericParameter = aggregation.parameters.some(
+    param => param.kind === 'value' && param.dataType === 'number'
+  );
+  const invalidParameter =
+    !isNumericParameter && !['', ...yAxisConfig.fields].includes(column.function[1]);
 
   return invalidFunction || invalidParameter;
 }

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -7,7 +7,6 @@ import {IconInfo, IconClose, IconSiren} from 'app/icons';
 import Button from 'app/components/button';
 import EventView from 'app/utils/discover/eventView';
 import Alert from 'app/components/alert';
-import space from 'app/styles/space';
 import {explodeFieldString, AGGREGATIONS, Aggregation} from 'app/utils/discover/fields';
 import {
   errorFieldConfig,
@@ -246,7 +245,7 @@ export default CreateAlertButton;
 
 const StyledAlert = styled(Alert)`
   color: ${p => p.theme.gray700};
-  margin-bottom: ${space(2)};
+  margin-bottom: 0;
 `;
 
 const StyledUnorderedList = styled('ul')`

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -381,8 +381,8 @@ class Results extends React.Component<Props, State> {
               onIncompatibleAlertQuery={this.handleIncompatibleQuery}
             />
             <Layout.Body>
+              {incompatibleAlertNotice && <Top fullWidth>{incompatibleAlertNotice}</Top>}
               <Top fullWidth>
-                {incompatibleAlertNotice}
                 {this.renderError(error)}
                 <StyledSearchBar
                   organization={organization}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -4,7 +4,7 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
-import {Organization} from 'app/types';
+import {Organization, Project} from 'app/types';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import space from 'app/styles/space';
 import {generateQueryWithTag} from 'app/utils';
@@ -13,6 +13,11 @@ import * as Layout from 'app/components/layouts/thirds';
 import Tags from 'app/views/eventsV2/tags';
 import SearchBar from 'app/views/events/searchBar';
 import {decodeScalar} from 'app/utils/queryString';
+import CreateAlertButton from 'app/components/createAlertButton';
+import withProjects from 'app/utils/withProjects';
+import ButtonBar from 'app/components/buttonBar';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
+import Feature from 'app/components/acl/feature';
 
 import TransactionList from './transactionList';
 import UserStats from './userStats';
@@ -28,9 +33,18 @@ type Props = {
   transactionName: string;
   organization: Organization;
   totalValues: number | null;
+  projects: Project[];
 };
 
-class SummaryContent extends React.Component<Props> {
+type State = {
+  incompatibleAlertNotice: React.ReactNode;
+};
+
+class SummaryContent extends React.Component<Props, State> {
+  state: State = {
+    incompatibleAlertNotice: null,
+  };
+
   handleSearch = (query: string) => {
     const {location} = this.props;
 
@@ -58,6 +72,47 @@ class SummaryContent extends React.Component<Props> {
     };
   };
 
+  handleIncompatibleQuery: React.ComponentProps<
+    typeof CreateAlertButton
+  >['onIncompatibleQuery'] = incompatibleAlertNoticeFn => {
+    const {organization} = this.props;
+    trackAnalyticsEvent({
+      eventKey: 'performance_views.summary.create_alert_incompatible',
+      eventName:
+        'Performance Views: Creating an alert from transaction summary was incompatible',
+      organization_id: organization.id,
+    });
+    const incompatibleAlertNotice = incompatibleAlertNoticeFn(() =>
+      this.setState({incompatibleAlertNotice: null})
+    );
+    this.setState({incompatibleAlertNotice});
+  };
+
+  handleCreateAlertSuccess = () => {
+    const {organization} = this.props;
+    trackAnalyticsEvent({
+      eventKey: 'performance_views.summary.create_alert',
+      eventName: 'Performance Views: Create Alert from Transaction Summary',
+      organization_id: organization.id,
+    });
+  };
+
+  renderCreateAlertButton() {
+    const {eventView, organization, projects} = this.props;
+
+    return (
+      <Feature features={['internal-catchall']}>
+        <CreateAlertButton
+          eventView={eventView}
+          organization={organization}
+          projects={projects}
+          onIncompatibleQuery={this.handleIncompatibleQuery}
+          onSuccess={this.handleCreateAlertSuccess}
+        />
+      </Feature>
+    );
+  }
+
   renderKeyTransactionButton() {
     const {eventView, organization, transactionName} = this.props;
 
@@ -72,6 +127,7 @@ class SummaryContent extends React.Component<Props> {
 
   render() {
     const {transactionName, location, eventView, organization, totalValues} = this.props;
+    const {incompatibleAlertNotice} = this.state;
     const query = decodeScalar(location.query.query) || '';
 
     return (
@@ -85,9 +141,17 @@ class SummaryContent extends React.Component<Props> {
             />
             <Layout.Title>{transactionName}</Layout.Title>
           </Layout.HeaderContent>
-          <Layout.HeaderActions>{this.renderKeyTransactionButton()}</Layout.HeaderActions>
+          <Layout.HeaderActions>
+            <ButtonBar gap={1}>
+              {this.renderCreateAlertButton()}
+              {this.renderKeyTransactionButton()}
+            </ButtonBar>
+          </Layout.HeaderActions>
         </Layout.Header>
         <Layout.Body>
+          {incompatibleAlertNotice && (
+            <Layout.Main fullWidth>{incompatibleAlertNotice}</Layout.Main>
+          )}
           <Layout.Main>
             <StyledSearchBar
               organization={organization}
@@ -142,4 +206,4 @@ const StyledSearchBar = styled(SearchBar)`
   margin-bottom: ${space(1)};
 `;
 
-export default SummaryContent;
+export default withProjects(SummaryContent);

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -106,6 +106,20 @@ describe('CreateAlertButton', () => {
     );
   });
 
+  it('should allow yAxis with a number as the parameter', () => {
+    const eventView = EventView.fromSavedQuery({
+      ...DEFAULT_EVENT_VIEW,
+      query: 'event.type:transaction',
+      yAxis: 'apdex(300)',
+      fields: [...DEFAULT_EVENT_VIEW.fields, 'apdex(300)'],
+      projects: [2],
+    });
+    expect(eventView.getYAxis()).toBe('apdex(300)');
+    const component = generateWrappedComponent(organization, eventView);
+    component.simulate('click');
+    expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(0);
+  });
+
   it('should warn with multiple errors, missing event.type and project', () => {
     const eventView = EventView.fromSavedQuery({
       ...ALL_VIEWS.find(view => view.name === 'Errors by URL'),


### PR DESCRIPTION
- Fixes a bug when creating from discover using a yAxis with a number e.g. `apdex(300)`
- Moves the create from alert button to the transaction summary page header

![image](https://user-images.githubusercontent.com/1400464/85904570-f2e4bc00-b7bd-11ea-8904-5ef87f790f83.png)


