### PR TITLE
fix(UI): Fix text word-break and overflow

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/item/index.tsx
+++ b/src/sentry/static/sentry/app/components/activity/item/index.tsx
@@ -83,7 +83,7 @@ function ActivityItem({
         <StyledActivityAvatar type={author.type} user={author.user} size={avatarSize} />
       )}
 
-      <ActivityBubble {...bubbleProps}>
+      <StyledActivityBubble {...bubbleProps}>
         {header && isRenderFunc<ChildFunction>(header) && header()}
         {header && !isRenderFunc<ChildFunction>(header) && (
           <ActivityHeader>
@@ -103,7 +103,7 @@ function ActivityItem({
         {footer && !isRenderFunc<ChildFunction>(footer) && (
           <ActivityFooter>{footer}</ActivityFooter>
         )}
-      </ActivityBubble>
+      </StyledActivityBubble>
     </ActivityItemWrapper>
   );
 }
@@ -154,7 +154,6 @@ const ActivityFooter = styled(HeaderAndFooter)`
 
 const ActivityBody = styled('div')`
   padding: ${space(2)} ${space(2)};
-  word-break: break-all;
   ${textStyles}
 `;
 
@@ -168,6 +167,11 @@ const StyledTimeSince = styled(TimeSince)`
 
 const StyledDateTime = styled(DateTime)`
   color: ${p => p.theme.gray500};
+`;
+
+const StyledActivityBubble = styled(ActivityBubble)`
+  width: 75%;
+  overflow-wrap: break-word;
 `;
 
 export default ActivityItem;


### PR DESCRIPTION
Fix text word-break and overflow for Activity comments and User Feedback. Also possibly a better fix than https://github.com/getsentry/sentry/pull/18689 for [ISSUE-786](https://getsentry.atlassian.net/browse/ISSUE-786) (single word is too long/text overflow).

Note: Not setting a `width` causes weird sizing with the `ActivityBubble` component when a single word is really long when using `overflow-wrap: break-word`.
<img width="500" alt="Screen Shot 2020-06-28 at 6 40 55 PM" src="https://user-images.githubusercontent.com/20312973/85964567-ee133a00-b96e-11ea-91ec-2a629da98bff.png">

Fixes [ISSUE-896](https://getsentry.atlassian.net/browse/ISSUE-896)

### Before
<img width="500" alt="Screen Shot 2020-06-28 at 6 17 14 PM" src="https://user-images.githubusercontent.com/20312973/85963753-f74ed780-b96b-11ea-8249-ae407863d9df.png">

### After
<img width="500" alt="Screen Shot 2020-06-28 at 6 19 02 PM" src="https://user-images.githubusercontent.com/20312973/85963759-02096c80-b96c-11ea-915b-c2abba2e03c8.png">

