### PR TITLE
feat(store): Refund filtered and dropped attachments

### DIFF
--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -30,6 +30,7 @@ class CachedAttachment(object):
         chunks=None,
         cache=None,
         rate_limited=None,
+        size=None,
         **kwargs
     ):
         self.key = key
@@ -40,6 +41,13 @@ class CachedAttachment(object):
         self.type = type or "event.attachment"
         assert isinstance(self.type, string_types), self.type
         self.rate_limited = rate_limited
+
+        if size is not None:
+            self.size = size
+        elif data is not None:
+            self.size = len(data)
+        else:
+            self.size = 0
 
         self._data = data
         self.chunks = chunks
@@ -85,6 +93,7 @@ class CachedAttachment(object):
                 "content_type": self.content_type,
                 "type": self.type,
                 "chunks": self.chunks,
+                "size": self.size or None,  # None for backwards compatibility
                 "rate_limited": self.rate_limited,
             }
         )

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -44,7 +44,7 @@ class CachedAttachment(object):
 
         if size is not None:
             self.size = size
-        elif data is not None:
+        elif data not in (None, UNINITIALIZED_DATA):
             self.size = len(data)
         else:
             self.size = 0

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -543,7 +543,8 @@ class EventManager(object):
         # posting to eventstream to make sure all counters and eventstream are
         # incremented for sure. Also wait for grouping to remove attachments
         # based on the group counter.
-        attachments = get_attachments(cache_key, job)
+        with metrics.timer("event_manager.get_attachments"):
+            attachments = get_attachments(cache_key, job)
 
         try:
             job["group"], job["is_new"], job["is_regression"] = _save_aggregate(
@@ -590,7 +591,9 @@ class EventManager(object):
         # XXX: DO NOT MUTATE THE EVENT PAYLOAD AFTER THIS POINT
         _materialize_event_metrics(jobs)
 
-        attachments = filter_attachments_for_group(attachments, job)
+        with metrics.timer("event_manager.filter_attachments_for_group"):
+            attachments = filter_attachments_for_group(attachments, job)
+
         for attachment in attachments:
             key = "bytes.stored.%s" % (attachment.type,)
             old_bytes = job["event_metrics"].get(key) or 0
@@ -627,7 +630,8 @@ class EventManager(object):
 
         # Do this last to ensure signals get emitted even if connection to the
         # file store breaks temporarily.
-        save_attachments(cache_key, attachments, job)
+        with metrics.timer("event_manager.save_attachments"):
+            save_attachments(cache_key, attachments, job)
 
         metric_tags = {"from_relay": "_relay_processed" in job["data"]}
 

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -263,7 +263,7 @@ class Quota(Service):
         """
         return NotRateLimited()
 
-    def refund(self, project, key=None, timestamp=None):
+    def refund(self, project, key=None, timestamp=None, category=None, quantity=None):
         """
         Signals event rejection after ``quotas.is_rate_limited`` has been called
         successfully, and refunds the previously consumed quota.
@@ -275,6 +275,13 @@ class Quota(Service):
         :param timestamp: The timestamp at which data was ingested. This is used
                           to determine the correct quota window to refund the
                           previously consumed data to.
+        :param category:  The data category of the item to refund. This is used
+                          to determine the quotas that should be refunded.
+                          Defaults to ``DataCategory.ERROR``.
+        :param quantity:  The quantity to refund. Defaults to ``1``, which is
+                          the only value that should be used for events. For
+                          attachments, this should be set to the size of the
+                          attachment in bytes.
         """
         pass
 

--- a/src/sentry/utils/data_filters.py
+++ b/src/sentry/utils/data_filters.py
@@ -26,7 +26,8 @@ class FilterStatKeys(object):
     WEB_CRAWLER = "web-crawlers"
     INVALID_CSP = "invalid-csp"
     CORS = "cors"
-    DISCARDED_HASH = "discarded-hash"
+    DISCARDED_HASH = "discarded-hash"  # Not replicated in Relay
+    CRASH_REPORT_LIMIT = "crash-report-limit"  # Not replicated in Relay
 
 
 FILTER_STAT_KEYS_TO_VALUES = {

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -61,7 +61,11 @@ def mark_tsdb_incremented(project_id, event_id):
     mark_tsdb_incremented_many([(project_id, event_id)])
 
 
-def tsdb_increments_from_outcome(org_id, project_id, key_id, outcome, reason):
+def tsdb_increments_from_outcome(org_id, project_id, key_id, outcome, reason, category):
+    category = category if category is not None else DataCategory.ERROR
+    if category not in DataCategory.event_categories():
+        return
+
     if outcome != Outcome.INVALID:
         # This simply preserves old behavior. We never counted invalid events
         # (too large, duplicate, CORS) toward regular `received` counts.
@@ -136,7 +140,12 @@ def track_outcome(
     if not tsdb_in_consumer:
         increment_list = list(
             tsdb_increments_from_outcome(
-                org_id=org_id, project_id=project_id, key_id=key_id, outcome=outcome, reason=reason
+                org_id=org_id,
+                project_id=project_id,
+                key_id=key_id,
+                outcome=outcome,
+                reason=reason,
+                category=category,
             )
         )
 


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/19567. Tracks outcomes for all paths in which we discard or drop attachments and refunds their quota.

Refunds are more theoretical. We currently do not have any tracked rate limits for attachments, and it's unlikely that we ever will.

#sync-getsentry