### PR TITLE
fix(perf-view): Persist series selection in duration breakdown

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -132,6 +132,8 @@ class BaseChart extends React.Component {
 
     onFinished: PropTypes.func,
 
+    onLegendSelectChanged: PropTypes.func,
+
     // Forwarded Ref
     forwardedRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
 
@@ -188,6 +190,8 @@ class BaseChart extends React.Component {
     datazoom: (...args) => callIfFunction(this.props.onDataZoom, ...args),
     restore: (...args) => callIfFunction(this.props.onRestore, ...args),
     finished: (...args) => callIfFunction(this.props.onFinished, ...args),
+    legendselectchanged: (...args) =>
+      callIfFunction(this.props.onLegendSelectChanged, ...args),
   };
 
   handleChartReady = (...args) => {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -51,7 +51,7 @@ const YAXIS_VALUES = ['p50()', 'p75()', 'p95()', 'p99()', 'p100()'];
  * percentiles over the past 7 days
  */
 class DurationChart extends React.Component<Props> {
-  handleLegendSelectChanged = (legendChange, _event) => {
+  handleLegendSelectChanged = legendChange => {
     const {location} = this.props;
     const {selected} = legendChange;
     const unselected = Object.keys(selected).filter(key => !selected[key]);
@@ -78,17 +78,14 @@ class DurationChart extends React.Component<Props> {
       router,
     } = this.props;
 
-    const {
-      query: {unselectedSeries = []},
-    } = location;
-    const seriesSelection = {};
-    if (typeof unselectedSeries === 'string') {
-      seriesSelection[unselectedSeries] = false;
-    } else {
-      for (const unselected of unselectedSeries) {
-        seriesSelection[unselected] = false;
-      }
-    }
+    const unselectedSeries = location.query.unselectedSeries ?? [];
+    const unselectedMetrics = Array.isArray(unselectedSeries)
+      ? unselectedSeries
+      : [unselectedSeries];
+    const seriesSelection = unselectedMetrics.reduce((selection, metric) => {
+      selection[metric] = false;
+      return selection;
+    }, {});
 
     const start = this.props.start
       ? getUtcToLocalDateObject(this.props.start)


### PR DESCRIPTION
In a transaction summary, the series selection in a duration break down will reset on page refresh and a drag zoom. This is not ideal as it will force the user to reconstruct their previous selection. This change will persist the series selection in the query params allowing the change to be persisted in these situations.