### PR TITLE
ref(vercel): Add uninstall hook endpoint

### DIFF
--- a/src/sentry/integrations/vercel/uninstall.py
+++ b/src/sentry/integrations/vercel/uninstall.py
@@ -4,6 +4,8 @@ import logging
 
 from django.views.decorators.csrf import csrf_exempt
 from sentry.api.base import Endpoint
+from sentry.models import AuditLogEntryEvent, Integration, OrganizationIntegration, Organization
+from sentry.utils.audit import create_audit_entry
 from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger("sentry.integrations.vercel.uninstall")
@@ -18,13 +20,77 @@ class VercelUninstallEndpoint(Endpoint):
         return super(VercelUninstallEndpoint, self).dispatch(request, *args, **kwargs)
 
     @transaction_start("VercelUninstallEndpoint")
-    def delete(self, request):
+    def post(self, request):
+        # userId should always be present
+        external_id = request.data.get("teamId") or request.data.get("userId")
+        configuration_id = request.data.get("configurationId")
 
-        # data = request.data
-        # team_id = request.data.get("teamId")
+        try:
+            integration = Integration.objects.get(provider="vercel", external_id=external_id)
+        except Integration.DoesNotExist:
+            logger.info(
+                "vercel.uninstall.missing-integration",
+                extra={"configuration_id": configuration_id, "external_id": external_id},
+            )
+            return self.respond(status=404)
 
-        # we need to delete the webhook associated with the integration
+        orgs = integration.organizations.all()
 
-        # then delete the organizationIntegration
+        if len(orgs) == 1:
+            create_audit_entry(
+                request=request,
+                organization=integration.organizations.all()[0],
+                target_object=integration.id,
+                event=AuditLogEntryEvent.INTEGRATION_REMOVE,
+                # TODO(meredith): If we create vercel identities from the userId
+                # we could attempt to find the user in Sentry and pass that in for
+                # the actor instead.
+                actor_label="Vercel User",
+                data={"provider": integration.provider, "name": integration.name},
+            )
+            integration.delete()
+            return self.respond(status=202)
+
+        configuration = integration.metadata["configurations"].pop(configuration_id)
+        if configuration_id == integration.metadata["installation_id"]:
+            # if we are uninstalling a primary configuration, and there are
+            # multiple orgs connected to this integration we must update
+            # the crendentials (access_token, webhook_id etc)
+            next_config_id, next_config = integration.metadata["configurations"].items()[0]
+
+            integration.metadata["access_token"] = next_config["access_token"]
+            integration.metadata["webhook_id"] = next_config["webhook_id"]
+            integration.metadata["installation_id"] = next_config_id
+
+        try:
+            OrganizationIntegration.objects.get(
+                organization_id=configuration["organization_id"], integration_id=integration.id
+            ).delete()
+        except OrganizationIntegration.DoesNotExist:
+            logger.info(
+                "vercel.uninstall.missing-org-integration",
+                extra={
+                    "configuration_id": configuration_id,
+                    "external_id": external_id,
+                    "integration_id": integration.id,
+                    "organization_id": configuration["organization_id"],
+                },
+            )
+            return self.respond(status=404)
+
+        integration.save()
+
+        organization = Organization.objects.get(id=configuration["organization_id"])
+        create_audit_entry(
+            request=request,
+            organization=organization,
+            target_object=integration.id,
+            event=AuditLogEntryEvent.INTEGRATION_REMOVE,
+            # TODO(meredith): If we create vercel identities from the userId
+            # we could attempt to find the user in Sentry and pass that in for
+            # the actor instead.
+            actor_label="Vercel User",
+            data={"provider": integration.provider, "name": integration.name},
+        )
 
         return self.respond(status=202)

--- a/src/sentry/integrations/vercel/uninstall.py
+++ b/src/sentry/integrations/vercel/uninstall.py
@@ -39,7 +39,7 @@ class VercelUninstallEndpoint(Endpoint):
         if len(orgs) == 1:
             create_audit_entry(
                 request=request,
-                organization=integration.organizations.all()[0],
+                organization=orgs[0],
                 target_object=integration.id,
                 event=AuditLogEntryEvent.INTEGRATION_REMOVE,
                 # TODO(meredith): If we create vercel identities from the userId

--- a/src/sentry/integrations/vercel/uninstall.py
+++ b/src/sentry/integrations/vercel/uninstall.py
@@ -20,7 +20,7 @@ class VercelUninstallEndpoint(Endpoint):
         return super(VercelUninstallEndpoint, self).dispatch(request, *args, **kwargs)
 
     @transaction_start("VercelUninstallEndpoint")
-    def post(self, request):
+    def delete(self, request):
         # userId should always be present
         external_id = request.data.get("teamId") or request.data.get("userId")
         configuration_id = request.data.get("configurationId")
@@ -49,7 +49,7 @@ class VercelUninstallEndpoint(Endpoint):
                 data={"provider": integration.provider, "name": integration.name},
             )
             integration.delete()
-            return self.respond(status=202)
+            return self.respond(status=204)
 
         configuration = integration.metadata["configurations"].pop(configuration_id)
         if configuration_id == integration.metadata["installation_id"]:
@@ -67,7 +67,7 @@ class VercelUninstallEndpoint(Endpoint):
                 organization_id=configuration["organization_id"], integration_id=integration.id
             ).delete()
         except OrganizationIntegration.DoesNotExist:
-            logger.info(
+            logger.error(
                 "vercel.uninstall.missing-org-integration",
                 extra={
                     "configuration_id": configuration_id,
@@ -93,4 +93,4 @@ class VercelUninstallEndpoint(Endpoint):
             data={"provider": integration.provider, "name": integration.name},
         )
 
-        return self.respond(status=202)
+        return self.respond(status=204)

--- a/src/sentry/integrations/vercel/uninstall.py
+++ b/src/sentry/integrations/vercel/uninstall.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+
+import logging
+
+from django.views.decorators.csrf import csrf_exempt
+from sentry.api.base import Endpoint
+from sentry.web.decorators import transaction_start
+
+logger = logging.getLogger("sentry.integrations.vercel.uninstall")
+
+
+class VercelUninstallEndpoint(Endpoint):
+    authentication_classes = ()
+    permission_classes = ()
+
+    @csrf_exempt
+    def dispatch(self, request, *args, **kwargs):
+        return super(VercelUninstallEndpoint, self).dispatch(request, *args, **kwargs)
+
+    @transaction_start("VercelUninstallEndpoint")
+    def delete(self, request):
+
+        # data = request.data
+        # team_id = request.data.get("teamId")
+
+        # we need to delete the webhook associated with the integration
+
+        # then delete the organizationIntegration
+
+        return self.respond(status=202)

--- a/src/sentry/integrations/vercel/urls.py
+++ b/src/sentry/integrations/vercel/urls.py
@@ -3,10 +3,12 @@ from __future__ import absolute_import, print_function
 from django.conf.urls import url
 
 from .webhook import VercelWebhookEndpoint
+from .uninstall import VercelUninstallEndpoint
 from sentry.web.frontend.vercel_extension_configuration import VercelExtensionConfigurationView
 
 
 urlpatterns = [
     url(r"^webhook/$", VercelWebhookEndpoint.as_view()),
     url(r"^configure/$", VercelExtensionConfigurationView.as_view()),
+    url(r"^delete/$", VercelUninstallEndpoint.as_view()),
 ]

--- a/tests/sentry/integrations/vercel/test_uninstall.py
+++ b/tests/sentry/integrations/vercel/test_uninstall.py
@@ -71,7 +71,7 @@ class VercelUninstallTest(APITestCase):
             path=self.url, data=PRIMARY_UNINSTALL_RESPONSE, content_type="application/json",
         )
 
-        assert response.status_code == 202
+        assert response.status_code == 204
         assert len(OrganizationIntegration.objects.all()) == 1
 
         integration = Integration.objects.get(id=self.integration.id)
@@ -100,7 +100,7 @@ class VercelUninstallTest(APITestCase):
             path=self.url, data=NONPRIMARY_UNINSTALL_RESPONSE, content_type="application/json",
         )
 
-        assert response.status_code == 202
+        assert response.status_code == 204
         assert len(OrganizationIntegration.objects.all()) == 1
 
         integration = Integration.objects.get(id=self.integration.id)
@@ -147,7 +147,7 @@ class VercelUninstallTest(APITestCase):
             path=self.url, data=USERID_UNINSTALL_RESPONSE, content_type="application/json",
         )
 
-        assert response.status_code == 202
+        assert response.status_code == 204
         assert not Integration.objects.filter(id=integration.id).exists()
         assert not OrganizationIntegration.objects.filter(
             integration_id=integration.id, organization_id=org.id

--- a/tests/sentry/integrations/vercel/test_uninstall.py
+++ b/tests/sentry/integrations/vercel/test_uninstall.py
@@ -67,7 +67,7 @@ class VercelUninstallTest(APITestCase):
 
         assert len(OrganizationIntegration.objects.all()) == 2
 
-        response = self.client.post(
+        response = self.client.delete(
             path=self.url, data=PRIMARY_UNINSTALL_RESPONSE, content_type="application/json",
         )
 
@@ -96,7 +96,7 @@ class VercelUninstallTest(APITestCase):
 
         assert len(OrganizationIntegration.objects.all()) == 2
 
-        response = self.client.post(
+        response = self.client.delete(
             path=self.url, data=NONPRIMARY_UNINSTALL_RESPONSE, content_type="application/json",
         )
 
@@ -143,7 +143,7 @@ class VercelUninstallTest(APITestCase):
         )
         integration.add_organization(org)
 
-        response = self.client.post(
+        response = self.client.delete(
             path=self.url, data=USERID_UNINSTALL_RESPONSE, content_type="application/json",
         )
 

--- a/tests/sentry/integrations/vercel/test_uninstall.py
+++ b/tests/sentry/integrations/vercel/test_uninstall.py
@@ -1,0 +1,150 @@
+from __future__ import absolute_import
+
+from sentry.models import (
+    Integration,
+    OrganizationIntegration,
+)
+from sentry.testutils import APITestCase
+
+
+PRIMARY_UNINSTALL_RESPONSE = """{
+    "configurationId": "my_config_id",
+    "teamId": "vercel_team_id",
+    "userId": "vercel_user_id"
+}"""
+
+NONPRIMARY_UNINSTALL_RESPONSE = """{
+    "configurationId": "my_config_id2",
+    "teamId": "vercel_team_id",
+    "userId": "vercel_user_id"
+}"""
+
+USERID_UNINSTALL_RESPONSE = """{
+    "configurationId": "my_config_id",
+    "teamId": null,
+    "userId": "vercel_user_id"
+}"""
+
+
+class VercelUninstallTest(APITestCase):
+    def setUp(self):
+        self.url = "/extensions/vercel/delete/"
+        self.second_org = self.create_organization(name="Blah", owner=self.user)
+        metadata = {
+            "access_token": "my_access_token",
+            "installation_id": "my_config_id",
+            "webhook_id": "my_webhook_id",
+            "configurations": {
+                "my_config_id": {
+                    "access_token": "my_access_token",
+                    "webhook_id": "my_webhook_id",
+                    "organization_id": self.organization.id,
+                },
+                "my_config_id2": {
+                    "access_token": "my_access_token2",
+                    "webhook_id": "my_webhook_id2",
+                    "organization_id": self.second_org.id,
+                },
+            },
+        }
+        self.integration = Integration.objects.create(
+            provider="vercel",
+            external_id="vercel_team_id",
+            name="My Vercel Team",
+            metadata=metadata,
+        )
+        self.integration.add_organization(self.organization)
+        self.integration.add_organization(self.second_org)
+
+    def test_uninstall_primary_configuration(self):
+        """
+        Test uninstalling the configuration whose credentials
+            * access_token
+            * webhook_id
+            * installation_id
+        are used in the primary metadata for the integration.
+        """
+
+        assert len(OrganizationIntegration.objects.all()) == 2
+
+        response = self.client.post(
+            path=self.url, data=PRIMARY_UNINSTALL_RESPONSE, content_type="application/json",
+        )
+
+        assert response.status_code == 202
+        assert len(OrganizationIntegration.objects.all()) == 1
+
+        integration = Integration.objects.get(id=self.integration.id)
+        assert integration.metadata == {
+            "access_token": "my_access_token2",
+            "installation_id": "my_config_id2",
+            "webhook_id": "my_webhook_id2",
+            "configurations": {
+                "my_config_id2": {
+                    "access_token": "my_access_token2",
+                    "webhook_id": "my_webhook_id2",
+                    "organization_id": self.second_org.id,
+                }
+            },
+        }
+
+    def test_uninstall_non_primary_configuration(self):
+        """
+        Test uninstalling a configuration that is only stored
+        in the "configurations" metadata.
+        """
+
+        assert len(OrganizationIntegration.objects.all()) == 2
+
+        response = self.client.post(
+            path=self.url, data=NONPRIMARY_UNINSTALL_RESPONSE, content_type="application/json",
+        )
+
+        assert response.status_code == 202
+        assert len(OrganizationIntegration.objects.all()) == 1
+
+        integration = Integration.objects.get(id=self.integration.id)
+        assert integration.metadata == {
+            "access_token": "my_access_token",
+            "installation_id": "my_config_id",
+            "webhook_id": "my_webhook_id",
+            "configurations": {
+                "my_config_id": {
+                    "access_token": "my_access_token",
+                    "webhook_id": "my_webhook_id",
+                    "organization_id": self.organization.id,
+                }
+            },
+        }
+
+    def test_uninstall_single_configuration(self):
+        org = self.create_organization(owner=self.user)
+        metadata = {
+            "access_token": "my_access_token",
+            "installation_id": "my_config_id",
+            "webhook_id": "my_webhook_id",
+            "configurations": {
+                "my_config_id": {
+                    "access_token": "my_access_token",
+                    "webhook_id": "my_webhook_id",
+                    "organization_id": org.id,
+                }
+            },
+        }
+        integration = Integration.objects.create(
+            provider="vercel",
+            external_id="vercel_user_id",
+            name="My Vercel Team",
+            metadata=metadata,
+        )
+        integration.add_organization(org)
+
+        response = self.client.post(
+            path=self.url, data=USERID_UNINSTALL_RESPONSE, content_type="application/json",
+        )
+
+        assert response.status_code == 202
+        assert not Integration.objects.filter(id=integration.id).exists()
+        assert not OrganizationIntegration.objects.filter(
+            integration_id=integration.id, organization_id=org.id
+        ).exists()

--- a/tests/sentry/integrations/vercel/test_uninstall.py
+++ b/tests/sentry/integrations/vercel/test_uninstall.py
@@ -118,6 +118,10 @@ class VercelUninstallTest(APITestCase):
         }
 
     def test_uninstall_single_configuration(self):
+        """
+        Test uninstalling an integration with only one organization
+        associated with it.
+        """
         org = self.create_organization(owner=self.user)
         metadata = {
             "access_token": "my_access_token",


### PR DESCRIPTION
This PR adds support for uninstalling the Vercel integration from Vercel's side of things. They have a configuration option for integrations called the [Delete Hook](https://vercel.com/docs/integrations?#delete-hooks/setting-up). For Sentry, the url we will specify for that option is `https://sentry.io/extensions/vercel/delete/`.

**Simple uninstall**
If the Vercel integration is only installed on one organization, we'll delete both the `OrganizationIntegration` and the `Integration` - there is no need to have a disabled status for this integration.

**"Complicated" uninstall**

Definitions:
* _Primary_: used to describe the configuration whose credentials (`access_token`, `webhook_id`, `installation_id`) are currently used by the integration.
* _Non-primary_: used to describe any configurations that are being stored, but not actively used.

Since we handle multiple installations (see https://github.com/getsentry/sentry/pull/19534), we need to determine whether the `configurationId` in the delete hook payload is a primary or non-primary configuration.

For both cases we need to remove data from the "configurations" metadata and delete the `OrganizationIntegration`, but for a primary configuration, we also need to update the `access_token`, `webhook_id`, and `installation_id` from a non-primary configuration to be the new primary one. 

**Note:** We are not deleting the internal integration that we created when installing the Vercel integration, however our Vercel docs will include steps on how to do this should people want. 
