### PR TITLE
ref(pii): Expand source group if valid eventId

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/form/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/form/form.tsx
@@ -38,7 +38,7 @@ type State = {
 };
 
 class Form extends React.Component<Props<Rule, KeysOfUnion<Rule>>, State> {
-  state: State = {displayEventId: false};
+  state: State = {displayEventId: !!this.props.eventId};
 
   handleChange = <K extends KeysOfUnion<Rule>>(field: K) => (
     event: React.ChangeEvent<HTMLInputElement>


### PR DESCRIPTION
if the user enters a valid eventId,  it will be saved in the state, and in the next time that she/he/they will open the add/edit dialog, the source group will be expanded by default.