### PR TITLE
fix(discover): Opening tags in results view should show data

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -53,7 +53,7 @@ class Tags extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    this.fetchData();
+    this.fetchData(true);
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -72,11 +72,14 @@ class Tags extends React.Component<Props, State> {
     return !isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
   };
 
-  fetchData = async () => {
+  fetchData = async (forceFetchData = false) => {
     const {api, organization, eventView, location, confirmedQuery} = this.props;
     this.setState({loading: true, error: '', tags: []});
 
-    if (confirmedQuery === false) {
+    // Fetch should be forced after mounting as confirmedQuery isn't guaranteed
+    // since this component can mount/unmount via show/hide tags separate from
+    // data being loaded for the rest of the page.
+    if (!forceFetchData && confirmedQuery === false) {
       return;
     }
 

--- a/tests/js/spec/views/eventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/eventsV2/tags.spec.jsx
@@ -55,6 +55,7 @@ describe('Tags', function() {
         selection={{projects: [], environments: [], datetime: {}}}
         location={{query: {}}}
         generateUrl={generateUrl}
+        confirmedQuery={false}
       />
     );
 
@@ -93,6 +94,7 @@ describe('Tags', function() {
         selection={{projects: [], environments: [], datetime: {}}}
         location={initialData.router.location}
         generateUrl={generateUrl}
+        confirmedQuery={false}
       />,
       initialData.routerContext
     );


### PR DESCRIPTION
### Summary
If you open the `TagsTable` with 'show tags' in the results view after the page has loaded, it will only show a loading state as `confirmedQuery` is in its resting state (`false`). This affects the tags component since it is not necessarily persistent on the page due to show/hide tags functionality.

This fixes the component so when it is created it will always fetch data independently of `confirmedQuery`.

### Screenshots
#### Before (opening show tags after data is loaded)
![Screen Shot 2020-06-29 at 10 10 28 AM](https://user-images.githubusercontent.com/6111995/86037455-42acc880-b9f4-11ea-9658-e7e5d6ced5cc.png)
#### After (opening show tags after data is loaded)
![Screen Shot 2020-06-29 at 10 09 53 AM](https://user-images.githubusercontent.com/6111995/86037453-42143200-b9f4-11ea-8849-ba97cb3a81eb.png)
