### PR TITLE
fix(search): Keep negation when autocompleting

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -990,10 +990,9 @@ class SmartSearchBar extends React.Component<Props, State> {
       newQuery = `${query}${replaceText}`;
     } else {
       const last = terms.pop() ?? '';
-
       newQuery = query.slice(0, lastTermIndex); // get text preceding last term
 
-      const prefix = newQuery.startsWith(NEGATION_OPERATOR) ? NEGATION_OPERATOR : '';
+      const prefix = last.startsWith(NEGATION_OPERATOR) ? NEGATION_OPERATOR : '';
       const valuePrefix = newQuery.endsWith(SEARCH_WILDCARD) ? SEARCH_WILDCARD : '';
 
       // newQuery is "<term>:"

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -589,6 +589,23 @@ describe('SmartSearchBar', function() {
       searchBar.onAutoComplete('12345', {type: 'tag-value'});
       expect(searchBar.state.query).toEqual('event.type:error id:12345 ');
     });
+
+    it('keeps the negation operator is present', function() {
+      const props = {
+        query: '',
+        organization,
+        supportedTags,
+      };
+      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = smartSearchBar.instance();
+      const input = smartSearchBar.find('input');
+      // start typing part of the tag prefixed by the negation operator!
+      input.simulate('change', {target: {value: 'event.type:error !ti'}});
+      searchBar.getCursorPosition = jest.fn().mockReturnValueOnce(20);
+      // use autocompletion to do the rest
+      searchBar.onAutoComplete('title:', {});
+      expect(searchBar.state.query).toEqual('event.type:error !title:');
+    });
   });
 
   describe('onTogglePinnedSearch()', function() {


### PR DESCRIPTION
When using autocomplete to enter a negated tag name (e.g. completing `!titl` to be `!title:`), the negation operator was being dropped due to incorrect prefix detection. This change ensures that the negation detection operators on the current term in order to maintain the negation.