### PR TITLE
ref(discover): Update prebuilt Discover queries

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -48,7 +48,7 @@ export const ALL_VIEWS: Readonly<Array<NewQuery>> = [
   {
     id: undefined,
     name: t('Errors by URL'),
-    fields: ['url', 'count()', 'count_unique(issue.id)'],
+    fields: ['url', 'count()', 'count_unique(issue)'],
     orderby: '-count',
     query: 'event.type:error has:url',
     projects: [],

--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -49,9 +49,10 @@ export const ALL_VIEWS: Readonly<Array<NewQuery>> = [
     name: t('Errors by URL'),
     fields: ['url', 'count()', 'count_unique(issue.id)'],
     orderby: '-count',
-    query: 'event.type:error',
+    query: 'event.type:error has:url',
     projects: [],
     version: 2,
     range: '24h',
+    display: 'top5',
   },
 ];

--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -43,6 +43,7 @@ export const ALL_VIEWS: Readonly<Array<NewQuery>> = [
     projects: [],
     version: 2,
     range: '24h',
+    display: 'top5',
   },
   {
     id: undefined,

--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -15,7 +15,7 @@ export const DEFAULT_EVENT_VIEW: Readonly<NewQuery> = {
 export const TRANSACTION_VIEWS: Readonly<Array<NewQuery>> = [
   {
     id: undefined,
-    name: t('Transactions'),
+    name: t('Transactions by Volume'),
     fields: [
       'transaction',
       'project',

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -91,10 +91,10 @@ describe('CreateAlertButton', () => {
     const eventView = EventView.fromSavedQuery({
       ...ALL_VIEWS.find(view => view.name === 'Errors by URL'),
       query: 'event.type:error',
-      yAxis: 'count_unique(issue.id)',
+      yAxis: 'count_unique(issue)',
       projects: [2],
     });
-    expect(eventView.getYAxis()).toBe('count_unique(issue.id)');
+    expect(eventView.getYAxis()).toBe('count_unique(issue)');
     const wrapper = generateWrappedComponent(organization, eventView);
     wrapper.simulate('click');
     expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(1);
@@ -102,7 +102,7 @@ describe('CreateAlertButton', () => {
       onIncompatibleQueryMock.mock.calls[0][0](onCloseMock)
     );
     expect(errorsAlert.text()).toBe(
-      'An alert can’t use the metric count_unique(issue.id) just yet. Select another metric and try again.'
+      'An alert can’t use the metric count_unique(issue) just yet. Select another metric and try again.'
     );
   });
 


### PR DESCRIPTION
Update prebuilt Discover queries as follows:

- Rename "Transactions" to "Transactions by Volume"
- Update "Errors by Title" to display "Top 5 period" graph
- Update "Errors by URL" to display "Top 5 period" graph, and add `has:url` to the search conditions.