### PR TITLE
feat(ui): Disable Create alert button

### DIFF
--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -7,6 +7,7 @@ import {IconInfo, IconClose, IconSiren} from 'app/icons';
 import Button from 'app/components/button';
 import EventView from 'app/utils/discover/eventView';
 import Alert from 'app/components/alert';
+import Access from 'app/components/acl/access';
 import {explodeFieldString, AGGREGATIONS, Aggregation} from 'app/utils/discover/fields';
 import {
   errorFieldConfig,
@@ -229,15 +230,25 @@ function CreateAlertButton({
   };
 
   return (
-    <Button
-      type="button"
-      icon={<IconSiren />}
-      to={to}
-      onClick={handleClick}
-      {...buttonProps}
-    >
-      {t('Create alert')}
-    </Button>
+    <Access organization={organization} access={['project:write']}>
+      {({hasAccess}) => (
+        <Button
+          type="button"
+          disabled={!hasAccess}
+          title={
+            !hasAccess
+              ? t('Users with admin permission or higher can create alert rules.')
+              : undefined
+          }
+          icon={<IconSiren />}
+          to={to}
+          onClick={handleClick}
+          {...buttonProps}
+        >
+          {t('Create alert')}
+        </Button>
+      )}
+    </Access>
   );
 }
 

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -101,7 +101,7 @@ class SummaryContent extends React.Component<Props, State> {
     const {eventView, organization, projects} = this.props;
 
     return (
-      <Feature features={['internal-catchall']}>
+      <Feature features={['organizations:incidents-performance']}>
         <CreateAlertButton
           eventView={eventView}
           organization={organization}

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -33,8 +33,8 @@ describe('CreateAlertButton', () => {
 
   it('renders', () => {
     const eventView = EventView.fromSavedQuery(DEFAULT_EVENT_VIEW);
-    const component = generateWrappedComponent(organization, eventView);
-    expect(component.text()).toBe('Create alert');
+    const wrapper = generateWrappedComponent(organization, eventView);
+    expect(wrapper.text()).toBe('Create alert');
   });
 
   it('should warn when project is not selected', () => {
@@ -42,8 +42,8 @@ describe('CreateAlertButton', () => {
       ...DEFAULT_EVENT_VIEW,
       query: 'event.type:error',
     });
-    const component = generateWrappedComponent(organization, eventView);
-    component.simulate('click');
+    const wrapper = generateWrappedComponent(organization, eventView);
+    wrapper.simulate('click');
     expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(1);
     const errorsAlert = mountWithTheme(
       onIncompatibleQueryMock.mock.calls[0][0](onCloseMock)
@@ -59,8 +59,8 @@ describe('CreateAlertButton', () => {
       query: 'event.type:error',
       projects: [-1],
     });
-    const component = generateWrappedComponent(organization, eventView);
-    component.simulate('click');
+    const wrapper = generateWrappedComponent(organization, eventView);
+    wrapper.simulate('click');
     expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(1);
     const errorsAlert = mountWithTheme(
       onIncompatibleQueryMock.mock.calls[0][0](onCloseMock)
@@ -76,8 +76,8 @@ describe('CreateAlertButton', () => {
       query: '',
       projects: [2],
     });
-    const component = generateWrappedComponent(organization, eventView);
-    component.simulate('click');
+    const wrapper = generateWrappedComponent(organization, eventView);
+    wrapper.simulate('click');
     expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(1);
     const errorsAlert = mountWithTheme(
       onIncompatibleQueryMock.mock.calls[0][0](onCloseMock)
@@ -95,8 +95,8 @@ describe('CreateAlertButton', () => {
       projects: [2],
     });
     expect(eventView.getYAxis()).toBe('count_unique(issue.id)');
-    const component = generateWrappedComponent(organization, eventView);
-    component.simulate('click');
+    const wrapper = generateWrappedComponent(organization, eventView);
+    wrapper.simulate('click');
     expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(1);
     const errorsAlert = mountWithTheme(
       onIncompatibleQueryMock.mock.calls[0][0](onCloseMock)
@@ -115,8 +115,8 @@ describe('CreateAlertButton', () => {
       projects: [2],
     });
     expect(eventView.getYAxis()).toBe('apdex(300)');
-    const component = generateWrappedComponent(organization, eventView);
-    component.simulate('click');
+    const wrapper = generateWrappedComponent(organization, eventView);
+    wrapper.simulate('click');
     expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(0);
   });
 
@@ -127,8 +127,8 @@ describe('CreateAlertButton', () => {
       yAxis: 'count_unique(issue.id)',
       projects: [],
     });
-    const component = generateWrappedComponent(organization, eventView);
-    component.simulate('click');
+    const wrapper = generateWrappedComponent(organization, eventView);
+    wrapper.simulate('click');
     expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(1);
     const errorsAlert = mountWithTheme(
       onIncompatibleQueryMock.mock.calls[0][0](onCloseMock)
@@ -142,8 +142,8 @@ describe('CreateAlertButton', () => {
       query: 'event.type:error',
       projects: [2],
     });
-    const component = generateWrappedComponent(organization, eventView);
-    component.simulate('click');
+    const wrapper = generateWrappedComponent(organization, eventView);
+    wrapper.simulate('click');
     expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(0);
     expect(onSuccessMock).toHaveBeenCalledTimes(1);
   });
@@ -152,8 +152,8 @@ describe('CreateAlertButton', () => {
     const eventView = EventView.fromSavedQuery({
       ...DEFAULT_EVENT_VIEW,
     });
-    const component = generateWrappedComponent(organization, eventView);
-    component.simulate('click');
+    const wrapper = generateWrappedComponent(organization, eventView);
+    wrapper.simulate('click');
     expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(1);
     const errorsAlert = mountWithTheme(
       onIncompatibleQueryMock.mock.calls[0][0](onCloseMock)
@@ -163,5 +163,20 @@ describe('CreateAlertButton', () => {
       .at(0)
       .simulate('click');
     expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the create alert button for members', async () => {
+    const eventView = EventView.fromSavedQuery({
+      ...DEFAULT_EVENT_VIEW,
+    });
+    const noAccessOrg = {
+      ...organization,
+      access: [],
+    };
+
+    const wrapper = generateWrappedComponent(noAccessOrg, eventView);
+
+    const button = wrapper.find('button[aria-label="Create alert"]');
+    expect(button.props()['aria-disabled']).toBe(true);
   });
 });


### PR DESCRIPTION
- Disables create alert button when a user does not have access to create alerts
- Switch the feature flag from internal to incidents-performance

<img width="267" alt="Screen Shot 2020-06-29 at 1 53 19 PM" src="https://user-images.githubusercontent.com/1400464/86058597-025e4200-ba16-11ea-8c82-57150ece9014.png">
