### PR TITLE
tests: Improve timing stability in tests

### DIFF
--- a/src/sentry/testutils/helpers/datetime.py
+++ b/src/sentry/testutils/helpers/datetime.py
@@ -13,7 +13,7 @@ def iso_format(date):
 
 def before_now(**kwargs):
     date = datetime.utcnow() - timedelta(**kwargs)
-    return date.replace(microsecond=0)
+    return date - timedelta(microseconds=date.microsecond % 1000)
 
 
 def timestamp_format(datetime):


### PR DESCRIPTION
`datetime.datetime` does not have a millisecond component, so by zeroing its
microseconds, `before_now` only has a time resolution to the nearest second.
This change adds back the milliseconds component while discarding the
microseconds to increase resolution while maintaining stability.