### PR TITLE
fix(metric_alerts): Fix bug where start bucket can be missing on a very new alert.

### DIFF
--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -126,10 +126,11 @@ def value_from_row(row, tagkey):
 
 def zerofill(data, start, end, rollup):
     rv = []
-    start = (int(to_timestamp(start)) // rollup) * rollup
-    end = (int(to_timestamp(end)) // rollup) * rollup
+    end = int(to_timestamp(end))
+    rollup_start = (int(to_timestamp(start)) // rollup) * rollup
+    rollup_end = (end // rollup) * rollup
     i = 0
-    for key in six.moves.xrange(start, end, rollup):
+    for key in six.moves.xrange(rollup_start, rollup_end, rollup):
         try:
             while data[i][0] < key:
                 rv.append(data[i])
@@ -142,6 +143,11 @@ def zerofill(data, start, end, rollup):
             pass
 
         rv.append((key, []))
+    # Add any remaining rows that are not aligned to the rollup and are lower than the
+    # end date.
+    if i < len(data):
+        rv.extend(row for row in data[i:] if row[0] < rollup_end)
+
     return rv
 
 


### PR DESCRIPTION
This fixes a bug where the start bucket can be missing on a new alert. This typically happens on an
alert with a large time window such as an hour. Basically if the start date is after the last bucket
on the graph, it ends up filtered out by the zerofill code.

An example:
We have an alert rule with a time window of 1 hour.
An alert starts at 11:34pm.
We fetch the data, and only fetch up to bucket 11pm since 12am hasn't happened yet.
We have code that fetches the 11:34pm bucket as well, so that is included. However, the end date of
our result ends up being 11pm still, and so when we do zerofill it excludes that bucket.

This fixes the code to include the max of the stat range or the incident start date.