### PR TITLE
fix(perf-empty): img user select and sizing

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/onboarding.tsx
+++ b/src/sentry/static/sentry/app/views/performance/onboarding.tsx
@@ -39,12 +39,19 @@ function Onboarding() {
 
 const PerfImage = styled('img')`
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    user-select: none;
     position: absolute;
     width: 450px;
     top: 20%;
   }
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    top: 25%;
+    width: 480px;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    top: 20%;
     width: 600px;
   }
 `;

--- a/src/sentry/static/sentry/app/views/performance/onboarding.tsx
+++ b/src/sentry/static/sentry/app/views/performance/onboarding.tsx
@@ -41,17 +41,18 @@ const PerfImage = styled('img')`
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     user-select: none;
     position: absolute;
+    top: 0;
+    bottom: 0;
     width: 450px;
-    top: 20%;
+    margin-top: auto;
+    margin-bottom: auto;
   }
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
-    top: 25%;
     width: 480px;
   }
 
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
-    top: 20%;
     width: 600px;
   }
 `;


### PR DESCRIPTION
**Before:**
![Screen Shot 2020-06-29 at 4 29 38 PM](https://user-images.githubusercontent.com/4830259/86065965-bddaa280-ba25-11ea-88e9-513b243cc194.png)

**After:**
![perf-empty](https://user-images.githubusercontent.com/4830259/86065848-7c49f780-ba25-11ea-87d6-e1b3917d0f9c.gif)

- Added User Select: None to image 
- Tweaked bg image to be auto centered