### PR TITLE
fix(alerts): Fix alert rule saving when clicking preset rules

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -60,7 +60,7 @@ const help = ({name, model}: {name: string; model: FormModel}) => {
         <Tooltip title={t('This preset is selected')} disabled={!preset.selected}>
           <PresetLink
             onClick={() => model.setValue(name, preset.default)}
-            isSelected={preset.selected}
+            disabled={preset.selected}
           >
             {preset.name}
           </PresetLink>
@@ -125,9 +125,9 @@ const AggregateHeader = styled('div')`
   margin-bottom: ${space(1)};
 `;
 
-const PresetLink = styled(Button)<{isSelected: boolean}>`
+const PresetLink = styled(Button)<{disabled: boolean}>`
   ${p =>
-    p.isSelected &&
+    p.disabled &&
     css`
       color: ${p.theme.gray700};
       &:hover,

--- a/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
@@ -74,13 +74,13 @@ describe('MetricField', function() {
     );
     selectByLabel(wrapper, 'failure_rate()', {selector: 'QueryField'});
 
-    expect(wrapper.find('FieldHelp Button[isSelected=true]').text()).toEqual(
+    expect(wrapper.find('FieldHelp Button[disabled=true]').text()).toEqual(
       'Failure rate'
     );
 
     selectByLabel(wrapper, 'p95()', {selector: 'QueryField'});
 
-    expect(wrapper.find('FieldHelp Button[isSelected=true]').text()).toEqual('Latency');
+    expect(wrapper.find('FieldHelp Button[disabled=true]').text()).toEqual('Latency');
   });
 
   it('changes field values when selecting presets', function() {


### PR DESCRIPTION
This pr fixes a bug where when you clicked a preset that is already selected the alert rule saved and closed.

Added disabled prop to the button when the preset is selected to prevent button event from being triggered and captured.

Resolves: https://app.asana.com/0/1174156445846705/1180070751980529/f