### PR TITLE
ref(alerts): Remove incidents-performance flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -840,8 +840,6 @@ SENTRY_FEATURES = {
     "organizations:rule-page": False,
     # Enable incidents feature
     "organizations:incidents": False,
-    # Enable incidents performance feature
-    "organizations:incidents-performance": False,
     # Enable integration functionality to create and link groups to issues on
     # external services.
     "organizations:integrations-issue-basic": True,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -73,7 +73,6 @@ default_manager.add("organizations:events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:global-views", OrganizationFeature)  # NOQA
 default_manager.add("organizations:grouping-info", OrganizationFeature)  # NOQA
 default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
-default_manager.add("organizations:incidents-performance", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-event-hooks", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-issue-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-issue-sync", OrganizationFeature)  # NOQA

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -115,7 +115,7 @@ class SubscriptionProcessor(object):
             metrics.incr("incidents.alert_rules.ignore_update_missing_incidents")
             return
         elif dataset == "transactions" and not features.has(
-            "organizations:incidents-performance", self.subscription.project.organization
+            "organizations:performance-view", self.subscription.project.organization
         ):
             # They have downgraded since these subscriptions have been created. So we just ignore updates for now.
             metrics.incr("incidents.alert_rules.ignore_update_missing_incidents_performance")

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -17,7 +17,6 @@ import CreateAlertButton from 'app/components/createAlertButton';
 import withProjects from 'app/utils/withProjects';
 import ButtonBar from 'app/components/buttonBar';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import Feature from 'app/components/acl/feature';
 
 import TransactionList from './transactionList';
 import UserStats from './userStats';
@@ -101,15 +100,13 @@ class SummaryContent extends React.Component<Props, State> {
     const {eventView, organization, projects} = this.props;
 
     return (
-      <Feature features={['organizations:incidents-performance']}>
-        <CreateAlertButton
-          eventView={eventView}
-          organization={organization}
-          projects={projects}
-          onIncompatibleQuery={this.handleIncompatibleQuery}
-          onSuccess={this.handleCreateAlertSuccess}
-        />
-      </Feature>
+      <CreateAlertButton
+        eventView={eventView}
+        organization={organization}
+        projects={projects}
+        onIncompatibleQuery={this.handleIncompatibleQuery}
+        onSuccess={this.handleCreateAlertSuccess}
+      />
     );
   }
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -104,13 +104,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
       <Panel>
         <PanelHeader>{t('Configure Rule Conditions')}</PanelHeader>
         <PanelBody>
-          <Feature
-            requireAll
-            features={[
-              'organizations:performance-view',
-              'organizations:incidents-performance',
-            ]}
-          >
+          <Feature requireAll features={['organizations:performance-view']}>
             <FormField required name="dataset" label="Data source">
               {({onChange, onBlur, value, model, label}) => (
                 <RadioGroup

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/alertTypeChooser.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/alertTypeChooser.tsx
@@ -72,13 +72,7 @@ const TypeChooserCards = ({onChange, organization, selected}: Props) => {
           {t('Metric Alert')}
           <FeatureBadge type="beta" />
         </RadioLabel>
-        <Feature
-          requireAll
-          features={[
-            'organizations:performance-view',
-            'organizations:incidents-performance',
-          ]}
-        >
+        <Feature requireAll features={['organizations:performance-view']}>
           {({hasFeature}) =>
             hasFeature ? (
               <React.Fragment>

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -131,7 +131,7 @@ class ProcessUpdateTest(TestCase):
             subscription = self.sub
         processor = SubscriptionProcessor(subscription)
         message = self.build_subscription_update(subscription, value=value, time_delta=time_delta)
-        with self.feature(["organizations:incidents", "organizations:incidents-performance"]):
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
             processor.process_update(message)
         return processor
 
@@ -211,7 +211,7 @@ class ProcessUpdateTest(TestCase):
     def test_removed_alert_rule(self):
         message = self.build_subscription_update(self.sub)
         self.rule.delete()
-        with self.feature(["organizations:incidents", "organizations:incidents-performance"]):
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
             SubscriptionProcessor(self.sub).process_update(message)
         self.metrics.incr.assert_called_once_with(
             "incidents.alert_rules.no_alert_rule_for_subscription"

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -120,7 +120,7 @@ class HandleSnubaQueryUpdateTest(TestCase):
             ).exclude(status=IncidentStatus.CLOSED.value)
 
         consumer = QuerySubscriptionConsumer("hi", topic=self.topic)
-        with self.feature(["organizations:incidents", "organizations:incidents-performance"]):
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
             with self.assertChanges(
                 lambda: active_incident().exists(), before=False, after=True
             ), self.tasks():


### PR DESCRIPTION
Instead of using this flag, we will simply be gating on whether or not the user has the `performance-view` flag.

Will also require https://github.com/getsentry/getsentry/pull/4103