### PR TITLE
ref(relay): Remove trusted relays field

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacy.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacy.tsx
@@ -73,21 +73,6 @@ const organizationSecurityAndPrivacy: JsonFormObject[] = [
         formatLabel: formatStoreCrashReports,
       },
       {
-        name: 'trustedRelays',
-        type: 'string',
-        multiline: true,
-        autosize: true,
-        maxRows: 10,
-        placeholder: t('Paste the relay public keys here'),
-        label: t('Trusted Relays'),
-        help: t(
-          'The list of relay public keys that should be trusted. Any relay in this list will be permitted to access org and project configs. Separate multiple entries with a newline.'
-        ),
-        getValue: val => extractMultilineFields(val),
-        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
-        visible: ({features}) => features.has('relay'),
-      },
-      {
         name: 'allowJoinRequests',
         type: 'boolean',
 


### PR DESCRIPTION
we don't need this field anymore, because now the Relay has its own tab