### PR TITLE
fix(apm): Fix span children traversal button when global views feature is present

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import map from 'lodash/map';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/browser';
 
 import {Organization, SentryTransactionEvent} from 'app/types';
 import {Client} from 'app/api';
@@ -71,8 +72,8 @@ class SpanDetail extends React.Component<Props, State> {
           transactionResults: response.data,
         });
       })
-      .catch(_error => {
-        // don't do anything
+      .catch(error => {
+        Sentry.captureException(error);
       });
   }
 
@@ -105,6 +106,10 @@ class SpanDetail extends React.Component<Props, State> {
       start,
       end,
     };
+
+    if (!query.project) {
+      delete query.project;
+    }
 
     return api.requestPromise(url, {
       method: 'GET',

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -101,11 +101,15 @@ class SpanDetail extends React.Component<Props, State> {
       sort: ['-id'],
       query: `event.type:transaction trace:${traceID} trace.parent_span:${spanID}`,
       project: organization.features.includes('global-views')
-        ? [] // this is expected to be stripped out by $.param
+        ? []
         : [Number(event.projectID)],
       start,
       end,
     };
+
+    if (query.project.length === 0) {
+      delete query.project;
+    }
 
     return api.requestPromise(url, {
       method: 'GET',

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -100,14 +100,12 @@ class SpanDetail extends React.Component<Props, State> {
       field: ['transaction', 'id', 'trace.span'],
       sort: ['-id'],
       query: `event.type:transaction trace:${traceID} trace.parent_span:${spanID}`,
-      project: [] as number[],
+      project: organization.features.includes('global-views')
+        ? [] // this is expected to be stripped out by $.param
+        : [Number(event.projectID)],
       start,
       end,
     };
-
-    if (!organization.features.includes('global-views')) {
-      query.project = [Number(event.projectID)];
-    }
 
     return api.requestPromise(url, {
       method: 'GET',

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -100,15 +100,13 @@ class SpanDetail extends React.Component<Props, State> {
       field: ['transaction', 'id', 'trace.span'],
       sort: ['-id'],
       query: `event.type:transaction trace:${traceID} trace.parent_span:${spanID}`,
-      project: organization.features.includes('global-views')
-        ? undefined
-        : [Number(event.projectID)],
+      project: [] as number[],
       start,
       end,
     };
 
-    if (!query.project) {
-      delete query.project;
+    if (!organization.features.includes('global-views')) {
+      query.project = [Number(event.projectID)];
     }
 
     return api.requestPromise(url, {


### PR DESCRIPTION
I had thought `undefined` query strings would be skipped as in this library: https://github.com/sindresorhus/query-string

But that's not the case with `$.param`:

<img width="244" alt="Screen Shot 2020-06-30 at 11 26 08 AM" src="https://user-images.githubusercontent.com/139499/86145093-81aa4f00-bac4-11ea-8c13-0ee160bd89e6.png">

However, empty arrays would be omitted: https://bugs.jquery.com/ticket/6481

