### PR TITLE
fix(jsomform-fields): Fix display multine value

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/apiApplication.tsx
+++ b/src/sentry/static/sentry/app/data/forms/apiApplication.tsx
@@ -1,4 +1,4 @@
-import {extractMultilineFields} from 'app/utils';
+import {extractMultilineFields, convertMultilineFieldValue} from 'app/utils';
 import getDynamicText from 'app/utils/getDynamicText';
 import {JsonFormObject} from 'app/views/settings/components/forms/type';
 
@@ -53,7 +53,7 @@ const forms: JsonFormObject[] = [
         label: 'Authorized Redirect URIs',
         help: 'Separate multiple entries with a newline.',
         getValue: val => extractMultilineFields(val),
-        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+        setValue: val => convertMultilineFieldValue(val),
       },
       {
         name: 'allowedOrigins',
@@ -63,7 +63,7 @@ const forms: JsonFormObject[] = [
         label: 'Authorized JavaScript Origins',
         help: 'Separate multiple entries with a newline.',
         getValue: val => extractMultilineFields(val),
-        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+        setValue: val => convertMultilineFieldValue(val),
       },
     ],
   },

--- a/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacy.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacy.tsx
@@ -1,4 +1,4 @@
-import {extractMultilineFields} from 'app/utils';
+import {extractMultilineFields, convertMultilineFieldValue} from 'app/utils';
 import {t} from 'app/locale';
 import {
   STORE_CRASH_REPORTS_VALUES,
@@ -129,7 +129,7 @@ const organizationSecurityAndPrivacy: JsonFormObject[] = [
           'Note: These fields will be used in addition to project specific fields.'
         ),
         getValue: val => extractMultilineFields(val),
-        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+        setValue: val => convertMultilineFieldValue(val),
       },
       {
         name: 'safeFields',
@@ -146,7 +146,7 @@ const organizationSecurityAndPrivacy: JsonFormObject[] = [
           'Note: These fields will be used in addition to project specific fields'
         ),
         getValue: val => extractMultilineFields(val),
-        setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+        setValue: val => convertMultilineFieldValue(val),
       },
       {
         name: 'scrubIPAddresses',

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.tsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {extractMultilineFields} from 'app/utils';
+import {extractMultilineFields, convertMultilineFieldValue} from 'app/utils';
 import {t, tct, tn} from 'app/locale';
 import HintPanelItem from 'app/components/panels/hintPanelItem';
 import PlatformIcon from 'app/components/platformIcon';
@@ -316,7 +316,7 @@ export const fields: {[key: string]: Field} = {
       'Additional field names to match against when scrubbing data. Separate multiple entries with a newline'
     ),
     getValue: val => extractMultilineFields(val),
-    setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+    setValue: val => convertMultilineFieldValue(val),
   },
   safeFields: {
     name: 'safeFields',
@@ -330,7 +330,7 @@ export const fields: {[key: string]: Field} = {
       'Field names which data scrubbers should ignore. Separate multiple entries with a newline'
     ),
     getValue: val => extractMultilineFields(val),
-    setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+    setValue: val => convertMultilineFieldValue(val),
   },
   storeCrashReports: {
     name: 'storeCrashReports',
@@ -384,7 +384,7 @@ export const fields: {[key: string]: Field} = {
     label: t('Allowed Domains'),
     help: t('Separate multiple entries with a newline'),
     getValue: val => extractMultilineFields(val),
-    setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
+    setValue: val => convertMultilineFieldValue(val),
   },
   scrapeJavaScript: {
     name: 'scrapeJavaScript',

--- a/src/sentry/static/sentry/app/utils.tsx
+++ b/src/sentry/static/sentry/app/utils.tsx
@@ -199,6 +199,23 @@ export function extractMultilineFields(value: string): Array<string> {
     .filter(f => f !== '');
 }
 
+/**
+ * If the value is of type Array, converts it to type string, keeping the line breaks, if there is any
+ */
+export function convertMultilineFieldValue<T extends string | Array<string>>(
+  value: T
+): string {
+  if (Array.isArray(value)) {
+    return value.join('\n');
+  }
+
+  if (typeof value === 'string') {
+    return value.split('\n').join('\n');
+  }
+
+  return '';
+}
+
 function projectDisplayCompare(a: Project, b: Project): number {
   if (a.isBookmarked !== b.isBookmarked) {
     return a.isBookmarked ? -1 : 1;


### PR DESCRIPTION
closes: https://app.asana.com/0/1158284503473033/1182496710484136

**The bug:** 
The list shows up as empty within the safe fields even though there are fields added to the list

**Expected behavior:** 
The list of fields should be displayed 

**Steps to reproduce:**
1. Add a field to the safe fields
2. Go to a different tab
3. Return to the page
4. The list is empty when it should have at least one field there
