### PR TITLE
fix(discover): Fix down arrows in firefox at different zoom

### DIFF
--- a/src/sentry/static/sentry/app/icons/iconArrow.tsx
+++ b/src/sentry/static/sentry/app/icons/iconArrow.tsx
@@ -19,9 +19,15 @@ const IconArrow = React.forwardRef(function IconArrow(
       ref={ref}
       css={
         direction
-          ? css`
-              transform: rotate(${theme.iconDirections[direction]}deg);
-            `
+          ? direction === 'down'
+            ? // Down arrows have a zoom issue with Firefox inside of tables due to rotate.
+              // Since arrows are symmetric, scaling to only flip vertically works to fix the issue.
+              css`
+                transform: scale(1, -1);
+              `
+            : css`
+                transform: rotate(${theme.iconDirections[direction]}deg);
+              `
           : undefined
       }
     >


### PR DESCRIPTION
### Summary
Our down arrows for descending sort within tables have an issue in Firefox where they won't appear (and will be replaced with ellipsis) due to rotate, when at any zoom other than 100% (likely due to a transform calculation rounding error). Since the arrows are symmetric, `scale(1, -1)` should be identical, and since it doesn't modify the horizontal size of the element, stops this issue from occurring.

### Screenshots
#### Before
![Screen Shot 2020-06-30 at 9 32 16 AM](https://user-images.githubusercontent.com/6111995/86159041-8ff56c80-babe-11ea-98f6-7aa6bd7472e3.png)

#### After
![Screen Shot 2020-06-30 at 9 31 54 AM](https://user-images.githubusercontent.com/6111995/86159025-8835c800-babe-11ea-973c-afd4ebda8930.png)

### Other
Codepen for simpler repro to show issue: https://codepen.io/k-fish/pen/MWKOKWM

#### Screenshot @ 100%
![Screen Shot 2020-06-30 at 10 40 01 AM](https://user-images.githubusercontent.com/6111995/86158945-69cfcc80-babe-11ea-9ab9-bfc07ebb39ba.png)
#### Screenshot @ 110%
![Screen Shot 2020-06-30 at 10 39 54 AM](https://user-images.githubusercontent.com/6111995/86159012-83711400-babe-11ea-8f6d-54cc48035c48.png)
