### PR TITLE
fix(search): Autocomplete user tag better

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -995,14 +995,29 @@ class SmartSearchBar extends React.Component<Props, State> {
       const prefix = last.startsWith(NEGATION_OPERATOR) ? NEGATION_OPERATOR : '';
       const valuePrefix = newQuery.endsWith(SEARCH_WILDCARD) ? SEARCH_WILDCARD : '';
 
-      // newQuery is "<term>:"
+      // newQuery is all the terms up to the current term: "... <term>:"
       // replaceText should be the selected value
-      newQuery =
-        last.indexOf(':') > -1
-          ? // tag key present: replace everything after colon with replaceText
-            newQuery.replace(/\:"[^"]*"?$|\:\S*$/, `:${valuePrefix}` + replaceText)
-          : // no tag key present: replace last token with replaceText
-            newQuery.replace(/\S+$/, `${prefix}${replaceText}`);
+      if (last.indexOf(':') > -1) {
+        let replacement = `:${valuePrefix}${replaceText}`;
+
+        // NOTE: The user tag is a special case here as it store values like
+        // `id:1` or `ip:127.0.0.1`. To handle autocompletion for it correctly,
+        // and efficiently, we convert the tag to be `user.id` or `user.ip` etc.
+        if (last.startsWith('user:')) {
+          const colonIndex = replaceText.indexOf(':');
+          if (colonIndex > -1) {
+            const tagEnding = replaceText.substring(0, colonIndex);
+            const tagValue = replaceText.substring(colonIndex + 1);
+            replacement = `.${tagEnding}:${valuePrefix}` + tagValue;
+          }
+        }
+
+        // tag key present: replace everything after colon with replaceText
+        newQuery = newQuery.replace(/\:"[^"]*"?$|\:\S*$/, replacement);
+      } else {
+        // no tag key present: replace last token with replaceText
+        newQuery = newQuery.replace(/\S+$/, `${prefix}${replaceText}`);
+      }
 
       newQuery = newQuery.concat(query.slice(lastTermIndex));
     }

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -606,6 +606,28 @@ describe('SmartSearchBar', function() {
       searchBar.onAutoComplete('title:', {});
       expect(searchBar.state.query).toEqual('event.type:error !title:');
     });
+
+    it('handles special case for user tag', function() {
+      const props = {
+        query: '',
+        organization,
+        supportedTags,
+      };
+      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = smartSearchBar.instance();
+      const input = smartSearchBar.find('input');
+
+      input.simulate('change', {target: {value: 'user:'}});
+      searchBar.getCursorPosition = jest.fn().mockReturnValueOnce(5);
+      searchBar.onAutoComplete('id:1', {});
+      expect(searchBar.state.query).toEqual('user.id:1');
+
+      // try it with the SEARCH_WILDCARD
+      input.simulate('change', {target: {value: 'user:1*'}});
+      searchBar.getCursorPosition = jest.fn().mockReturnValueOnce(5);
+      searchBar.onAutoComplete('ip:127.0.0.1', {});
+      expect(searchBar.state.query).toEqual('user.ip:*127.0.0.1');
+    });
   });
 
   describe('onTogglePinnedSearch()', function() {


### PR DESCRIPTION
Autocomplete suggestions for the user tag contain values like `id:1` or
`ip:127.0.0.1`. Using autocomplete with these values result in broken searches
like `user:id:1`. These values are what's stored so we special case the
autocompletion for the user tag to convert `user:id:1` to `user.id:1`.