### PR TITLE
feat(discover): Hide warning on zero duration spans for certain browser spans

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -21,6 +21,8 @@ import {
   isOrphanSpan,
   unwrapTreeDepth,
   isOrphanTreeDepth,
+  isEventFromBrowserJavaScriptSDK,
+  durationlessBrowserOps,
 } from './utils';
 import {ParsedTraceType, ProcessedSpanType, TreeDepthType} from './types';
 import {
@@ -259,12 +261,14 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     width: undefined | number;
     isSpanVisibleInView: boolean;
   } {
-    const {span, generateBounds} = this.props;
+    const {event, span, generateBounds} = this.props;
 
     const bounds = generateBounds({
       startTimestamp: span.start_timestamp,
       endTimestamp: span.timestamp,
     });
+
+    const shouldHideSpanWarnings = isEventFromBrowserJavaScriptSDK(event);
 
     switch (bounds.type) {
       case 'TRACE_TIMESTAMPS_EQUAL': {
@@ -284,8 +288,15 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         };
       }
       case 'TIMESTAMPS_EQUAL': {
+        const warning =
+          shouldHideSpanWarnings &&
+          'op' in span &&
+          span.op &&
+          durationlessBrowserOps.includes(span.op)
+            ? void 0
+            : t('Equal start and end times');
         return {
-          warning: t('Equal start and end times'),
+          warning,
           left: bounds.start,
           width: 0.00001,
           isSpanVisibleInView: bounds.isSpanVisibleInView,

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -25,6 +25,7 @@ import {
   getSpanTraceID,
   isGapSpan,
   isOrphanSpan,
+  isEventFromBrowserJavaScriptSDK,
 } from './utils';
 import {DragManagerChildrenProps} from './dragManager';
 import SpanGroup from './spanGroup';
@@ -159,7 +160,7 @@ class SpanTree extends React.Component<PropType> {
 
     // hide gap spans (i.e. "missing instrumentation" spans) for browser js transactions,
     // since they're not useful to indicate
-    const shouldIncludeGap = !isBrowserJavaScriptSDK(event.sdk?.name);
+    const shouldIncludeGap = !isEventFromBrowserJavaScriptSDK(event);
 
     const isValidGap =
       typeof previousSiblingEndTimestamp === 'number' &&
@@ -355,15 +356,5 @@ const TraceViewContainer = styled('div')`
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
 `;
-
-function isBrowserJavaScriptSDK(sdkName?: string): boolean {
-  if (!sdkName) {
-    return false;
-  }
-  // based on https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/version.ts
-  return ['sentry.javascript.browser', 'sentry.javascript.react'].includes(
-    sdkName.toLowerCase()
-  );
-}
 
 export default SpanTree;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -579,3 +579,19 @@ export function unwrapTreeDepth(treeDepth: TreeDepthType): number {
 
   return treeDepth;
 }
+
+export function isEventFromBrowserJavaScriptSDK(event: SentryTransactionEvent): boolean {
+  const sdkName = event.sdk?.name;
+  if (!sdkName) {
+    return false;
+  }
+  // based on https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/version.ts
+  return ['sentry.javascript.browser', 'sentry.javascript.react'].includes(
+    sdkName.toLowerCase()
+  );
+}
+
+// Durationless ops from: https://github.com/getsentry/sentry-javascript/blob/0defcdcc2dfe719343efc359d58c3f90743da2cd/packages/apm/src/integrations/tracing.ts#L629-L688
+// PerformanceMark: Duration is 0 as per https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMark
+// PerformancePaintTiming: Duration is 0 as per https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming
+export const durationlessBrowserOps = ['mark', 'paint'];


### PR DESCRIPTION
### Summary
Some browser spans will always be 0 duration as per spec, for those spans we should not show the warning.

### Screenshots
#### Before
![Screen Shot 2020-06-30 at 1 28 52 PM](https://user-images.githubusercontent.com/6111995/86173981-b07cf100-bad5-11ea-9e1f-2f326aad7c80.png)

#### After
![Screen Shot 2020-06-30 at 1 16 19 PM](https://user-images.githubusercontent.com/6111995/86173132-5a5b7e00-bad4-11ea-9e93-6a562ef9e11a.png)