### PR TITLE
fix(cell-actions): Maintain sort order when adding greater/less than conditions

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -17,7 +17,6 @@ import Link from 'app/components/links/link';
 import Tooltip from 'app/components/tooltip';
 import EventView, {
   isFieldSortable,
-  MetaType,
   pickRelevantLocationQueryStrings,
 } from 'app/utils/discover/eventView';
 import {Column} from 'app/utils/discover/fields';
@@ -206,7 +205,7 @@ class TableView extends React.Component<TableViewProps> {
       <CellAction
         column={column}
         dataRow={dataRow}
-        handleCellAction={this.handleCellAction(dataRow, column, tableData.meta)}
+        handleCellAction={this.handleCellAction(dataRow, column)}
       >
         {fieldRenderer(dataRow, {organization, location})}
       </CellAction>
@@ -230,11 +229,7 @@ class TableView extends React.Component<TableViewProps> {
     );
   };
 
-  handleCellAction = (
-    dataRow: TableDataRow,
-    column: TableColumn<keyof TableDataRow>,
-    tableMeta: MetaType
-  ) => {
+  handleCellAction = (dataRow: TableDataRow, column: TableColumn<keyof TableDataRow>) => {
     return (action: Actions, value: React.ReactText) => {
       const {eventView, organization, projects} = this.props;
 
@@ -294,22 +289,12 @@ class TableView extends React.Component<TableViewProps> {
           // Remove query token if it already exists
           delete query[column.name];
           query[column.name] = [`>${value}`];
-          const field = {field: column.name, width: column.width};
-
-          // sort descending order
-          nextView = nextView.sortOnField(field, tableMeta, 'desc');
-
           break;
         }
         case Actions.SHOW_LESS_THAN: {
           // Remove query token if it already exists
           delete query[column.name];
           query[column.name] = [`<${value}`];
-          const field = {field: column.name, width: column.width};
-
-          // sort ascending order
-          nextView = nextView.sortOnField(field, tableMeta, 'asc');
-
           break;
         }
         case Actions.TRANSACTION: {

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -5,11 +5,7 @@ import * as ReactRouter from 'react-router';
 import {Organization, Project} from 'app/types';
 import Pagination from 'app/components/pagination';
 import Link from 'app/components/links/link';
-import EventView, {
-  EventData,
-  isFieldSortable,
-  MetaType,
-} from 'app/utils/discover/eventView';
+import EventView, {EventData, isFieldSortable} from 'app/utils/discover/eventView';
 import {TableData, TableDataRow, TableColumn} from 'app/views/eventsV2/table/types';
 import GridEditable, {COL_WIDTH_UNDEFINED, GridColumn} from 'app/components/gridEditable';
 import SortLink from 'app/components/gridEditable/sortLink';
@@ -62,7 +58,7 @@ class Table extends React.Component<Props, State> {
     widths: [],
   };
 
-  handleCellAction = (column: TableColumn<keyof TableDataRow>, tableMeta: MetaType) => {
+  handleCellAction = (column: TableColumn<keyof TableDataRow>) => {
     return (action: Actions, value: React.ReactText) => {
       const {eventView, location, organization} = this.props;
 
@@ -111,15 +107,9 @@ class Table extends React.Component<Props, State> {
           // Remove query token if it already exists
           delete searchConditions[column.name];
           searchConditions[column.name] = [`>${value}`];
-          const field = {field: column.name, width: column.width};
-
-          // sort descending order
-          const nextEventView = eventView.sortOnField(field, tableMeta, 'desc');
-          const queryStringObject = nextEventView.generateQueryStringObject();
 
           nextLocationQuery = {
             query: stringifyQueryObject(searchConditions),
-            sort: queryStringObject.sort,
           };
 
           break;
@@ -128,15 +118,9 @@ class Table extends React.Component<Props, State> {
           // Remove query token if it already exists
           delete searchConditions[column.name];
           searchConditions[column.name] = [`<${value}`];
-          const field = {field: column.name, width: column.width};
-
-          // sort ascending order
-          const nextEventView = eventView.sortOnField(field, tableMeta, 'asc');
-          const queryStringObject = nextEventView.generateQueryStringObject();
 
           nextLocationQuery = {
             query: stringifyQueryObject(searchConditions),
-            sort: queryStringObject.sort,
           };
 
           break;
@@ -195,7 +179,7 @@ class Table extends React.Component<Props, State> {
           <CellAction
             column={column}
             dataRow={dataRow}
-            handleCellAction={this.handleCellAction(column, tableData.meta)}
+            handleCellAction={this.handleCellAction(column)}
             allowActions={allowActions}
           >
             <Link to={target} onClick={this.handleSummaryClick}>
@@ -214,7 +198,7 @@ class Table extends React.Component<Props, State> {
         <CellAction
           column={column}
           dataRow={dataRow}
-          handleCellAction={this.handleCellAction(column, tableData.meta)}
+          handleCellAction={this.handleCellAction(column)}
           allowActions={allowActions}
         >
           {rendered}


### PR DESCRIPTION
When using cell actions to add greater/less than conditions, the table
currently changes the sort to the column being filtered. This change in
sort is unexpected. Instead, we should maintain the existing sort order.