### PR TITLE
fix(ui): added date since back

### DIFF
--- a/src/sentry/static/sentry/app/components/timeSince.tsx
+++ b/src/sentry/static/sentry/app/components/timeSince.tsx
@@ -19,6 +19,8 @@ type DefaultProps = {
   suffix: string;
 };
 
+type TimeProps = React.HTMLProps<HTMLTimeElement>;
+
 type Props = DefaultProps & {
   /**
    * The date value, can be string, number (e.g. timestamp), or instance of Date
@@ -26,7 +28,7 @@ type Props = DefaultProps & {
   date: RelaxedDateType;
 
   className?: string;
-};
+} & TimeProps;
 
 type State = {
   relative: string;

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -73,7 +73,9 @@ class AlertListRow extends AsyncComponent<Props, State> {
   renderTimeSince(date: string) {
     return (
       <CreatedResolvedTime>
-        <TimeSince date={date} /> <StyledDateTime date={date} utc={false} />
+        <Tooltip title={<DateTime date={date} utc={false} />} position="top">
+          <TimeSince title="" date={date} />
+        </Tooltip>
       </CreatedResolvedTime>
     );
   }
@@ -157,10 +159,8 @@ function ErrorLoadingStatsIcon() {
 const CreatedResolvedTime = styled('div')`
   ${overflowEllipsis}
   line-height: 1.4;
-`;
-
-const StyledDateTime = styled(DateTime)`
-  color: ${p => p.theme.gray500};
+  display: flex;
+  align-items: center;
 `;
 
 const ProjectBadge = styled(IdBadge)`

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -14,6 +14,7 @@ import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
 import Projects from 'app/utils/projects';
 import theme from 'app/utils/theme';
+import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
 import getDynamicText from 'app/utils/getDynamicText';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
@@ -72,7 +73,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
   renderTimeSince(date: string) {
     return (
       <CreatedResolvedTime>
-        <StyledDateTime date={date} utc={false} />
+        <TimeSince date={date} /> <StyledDateTime date={date} utc={false} />
       </CreatedResolvedTime>
     );
   }

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -221,6 +221,13 @@ describe('IncidentsList', function() {
         .exists()
     ).toBeFalsy();
 
+    expect(
+      wrapper
+        .find('IncidentPanelItem')
+        .at(0)
+        .find('TimeSince')
+    ).toHaveLength(1);
+
     expect(incidentsMock).toHaveBeenCalledTimes(1);
 
     expect(incidentsMock).toHaveBeenCalledWith(
@@ -245,6 +252,13 @@ describe('IncidentsList', function() {
         .find('Duration')
         .text()
     ).toBe('2 weeks');
+
+    expect(
+      wrapper
+        .find('IncidentPanelItem')
+        .at(0)
+        .find('TimeSince')
+    ).toHaveLength(2);
 
     expect(incidentsMock).toHaveBeenCalledTimes(2);
     // Stats not called for closed incidents


### PR DESCRIPTION
Added copy to show when the alert fired (2 days ago, etc). There’s been a bit of flip flopping on this and that’s my bad. I kept hearing feedback that it was confusing, so I removed it. I now reckon folks were confused because we stacked `2 days ago` on top of the date `Jun 23, 2020`. 

So now we’re showing the time since the alert fired, then on hover we show the full date. That should make it much clearer and easier to scan the columns, too. 

### Before

<img width="1141" alt="Screen Shot 2020-06-30 at 3 50 54 PM" src="https://user-images.githubusercontent.com/1900676/86184685-87665b80-bae9-11ea-9ae7-b371151f23c8.png">

### After

<img width="915" alt="Screen Shot 2020-07-01 at 8 59 46 AM" src="https://user-images.githubusercontent.com/1900676/86265910-49187d00-bb79-11ea-8d70-c365b9961a3c.png">

