### PR TITLE
fix(py3): Bump croniter to 0.3.34+

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -4,7 +4,7 @@ botocore<1.5.71
 celery>=3.1.8,<3.1.19
 click>=5.0,<7.0
 confluent-kafka==0.11.5
-croniter>=0.3.26,<0.4.0
+croniter>=0.3.34,<0.4.0
 datadog>=0.15.0,<0.31.0
 django-crispy-forms==1.7.2
 django-picklefield>=0.3.0,<1.1.0


### PR DESCRIPTION
@joshuarli added in Python 3.6/3.7 trove classifiers for croniter in
https://github.com/taichino/croniter/pull/130. Look like this library supports py3.6+ now, so just
bumping to the supported version.