### PR TITLE
feat(Vercel): Env vars pt 2

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -17,8 +17,7 @@ class VercelClient(ApiClient):
     ENV_VAR_URL = "/v4/projects/%s/env"
     GET_ENV_VAR_URL = "/v5/projects/%s/env"
     SECRETS_URL = "/v2/now/secrets"
-    GET_SECRET_URL = "/v3/now/secrets/%s"
-    DELETE_ENV_VAR_URL = "/v4/projects/%s/env/%s?target=%s"
+    DELETE_ENV_VAR_URL = "/v4/projects/%s/env/%s"
 
     def __init__(self, access_token, team_id=None):
         super(VercelClient, self).__init__()
@@ -61,9 +60,6 @@ class VercelClient(ApiClient):
     def get_env_vars(self, vercel_project_id):
         return self.get(self.GET_ENV_VAR_URL % vercel_project_id)
 
-    def get_secret(self, name):
-        return self.get(self.GET_SECRET_URL % name.lower())["uid"]
-
     def create_secret(self, vercel_project_id, name, value):
         data = {"name": name, "value": value}
         response = self.post(self.SECRETS_URL, data=data)["uid"]
@@ -76,7 +72,8 @@ class VercelClient(ApiClient):
 
     def update_env_variable(self, vercel_project_id, key, value):
         self.delete(
-            self.DELETE_ENV_VAR_URL % (vercel_project_id, key, "production"), allow_text=True
+            self.DELETE_ENV_VAR_URL % (vercel_project_id, key),
+            allow_text=True,
+            params={"target": "production"},
         )
-        response = self.create_env_variable(vercel_project_id, key, value)
-        return response
+        return self.create_env_variable(vercel_project_id, key, value)

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -11,6 +11,7 @@ class VercelClient(ApiClient):
 
     TEAMS_URL = "/v1/teams/%s"
     USER_URL = "/www/user"
+    PROJECT_URL = "/v1/projects/%s"
     PROJECTS_URL = "/v4/projects/"
     WEBHOOK_URL = "/v1/integrations/webhooks"
     ENV_VAR_URL = "/v4/projects/%s/env"
@@ -24,6 +25,7 @@ class VercelClient(ApiClient):
         self.team_id = team_id
 
     def request(self, method, path, data=None, params=None):
+        print("path: ", path, method, data)
         if self.team_id:
             # always need to use the team_id as a param for requests
             params = params or {}
@@ -42,6 +44,9 @@ class VercelClient(ApiClient):
         # TODO: we will need pagination since we are limited to 20
         return self.get(self.PROJECTS_URL)["projects"]
 
+    def get_source_code_provider(self, vercel_project_id):
+        return self.get(self.PROJECT_URL % vercel_project_id)["link"]["type"]
+
     def create_deploy_webhook(self):
         data = {
             "name": "Sentry webhook",
@@ -55,6 +60,9 @@ class VercelClient(ApiClient):
         return self.get(self.GET_ENV_VAR_URL % vercel_project_id)
 
     def get_secret(self, name):
+        print("getting dat secret")
+        print(name)
+        print(name.lower())
         return self.get(self.GET_SECRET_URL % name.lower())["uid"]
 
     def create_secret(self, vercel_project_id, name, value):
@@ -64,5 +72,13 @@ class VercelClient(ApiClient):
 
     def create_env_variable(self, vercel_project_id, key, value):
         data = {"key": key, "value": value, "target": "production"}
+        print("here in create env var")
+        print(key)
         response = self.post(self.ENV_VAR_URL % vercel_project_id, data=data)
+        return response
+
+    def update_env_variable(self, vercel_project_id, key, value):
+        print("here updating")
+        data = {"key": key, "value": value, "target": "production"}
+        response = self.put(self.ENV_VAR_URL % vercel_project_id, data=data)
         return response

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -175,67 +175,38 @@ class VercelIntegration(IntegrationInstallation):
                     "You must connect your Vercel project to a Git repository to continue!"
                 )
             sentry_project_dsn = enabled_dsn.get_dsn(public=True)
-            random_suffix = uuid4().hex
-            # random_suffix = "1234567"
+            uuid = uuid4().hex
+
             sentry_auth_token = SentryAppInstallationForProvider.objects.get(
                 organization=sentry_project.organization.id, provider="vercel"
             )
-            # secret_names = [
-            #     "SENTRY_ORG_%s" % random_suffix,
-            #     "SENTRY_PROJECT_%s" % random_suffix,
-            #     "NEXT_PUBLIC_SENTRY_DSN_%s" % random_suffix,
-            #     "SENTRY_AUTH_TOKEN_%s" % random_suffix,
-            # ]
-            # values = [
-            #     sentry_project.organization.slug,
-            #     sentry_project.slug,
-            #     sentry_project_dsn,
-            #     sentry_auth_token.sentry_app_installation.api_token.token,
-            # ]
-            # env_var_names = [
-            #     "SENTRY_ORG",
-            #     "SENTRY_PROJECT",
-            #     "NEXT_PUBLIC_SENTRY_DSN",
-            #     "SENTRY_AUTH_TOKEN",
-            #     "VERCEL_%s_COMMIT_SHA" % source_code_provider.upper(),
-            # ]
-
-            # secrets = []
-            # for name, val in zip(secret_names, values):
-            #     secrets.append(self.create_secret(vercel_client, vercel_project_id, name, val))
-
-            # secrets.append("")
-            # for secret, env_var in zip(secrets, env_var_names):
-            #     self.create_env_var(vercel_client, vercel_project_id, env_var, secret)
-
-            # TODO make this DRYer
-            org_secret = self.create_secret(
-                vercel_client, vercel_project_id, "SENTRY_ORG_%s" % random_suffix, sentry_project.organization.slug
-            )
-            project_secret = self.create_secret(
-                vercel_client,
-                vercel_project_id,
-                "SENTRY_PROJECT_%s" % random_suffix,
+            secret_names = [
+                "SENTRY_ORG_%s" % uuid,
+                "SENTRY_PROJECT_%s" % uuid,
+                "NEXT_PUBLIC_SENTRY_DSN_%s" % uuid,
+                "SENTRY_AUTH_TOKEN_%s" % uuid,
+            ]
+            values = [
+                sentry_project.organization.slug,
                 sentry_project.slug,
-            )
-            dsn_secret = self.create_secret(
-                vercel_client,
-                vercel_project_id,
-                "NEXT_PUBLIC_SENTRY_DSN_%s" % random_suffix,
                 sentry_project_dsn,
-            )
-            auth_secret = self.create_secret(
-                vercel_client,
-                vercel_project_id,
-                "SENTRY_AUTH_TOKEN_%s" % random_suffix,
                 sentry_auth_token.sentry_app_installation.api_token.token,
-            )
+            ]
+            env_var_names = [
+                "SENTRY_ORG",
+                "SENTRY_PROJECT",
+                "NEXT_PUBLIC_SENTRY_DSN",
+                "SENTRY_AUTH_TOKEN",
+                "VERCEL_%s_COMMIT_SHA" % source_code_provider.upper(),
+            ]
 
-            self.create_env_var(vercel_client, vercel_project_id, "SENTRY_ORG", org_secret)
-            self.create_env_var(vercel_client, vercel_project_id, "SENTRY_PROJECT", project_secret)
-            self.create_env_var(vercel_client, vercel_project_id, "NEXT_PUBLIC_SENTRY_DSN", dsn_secret)
-            self.create_env_var(vercel_client, vercel_project_id, "SENTRY_AUTH_TOKEN", auth_secret)
-            self.create_env_var(vercel_client, vercel_project_id, "VERCEL_%s_COMMIT_SHA" % source_code_provider.upper(), "")
+            secrets = []
+            for name, val in zip(secret_names, values):
+                secrets.append(self.create_secret(vercel_client, vercel_project_id, name, val))
+
+            secrets.append("")
+            for secret, env_var in zip(secrets, env_var_names):
+                self.create_env_var(vercel_client, vercel_project_id, env_var, secret)
 
         config.update(data)
         self.org_integration.update(config=config)
@@ -274,13 +245,9 @@ class VercelIntegration(IntegrationInstallation):
             return client.create_secret(vercel_project_id, name, value)
 
     def create_env_var(self, client, vercel_project_id, key, value):
-        # if self.env_var_already_exists(client, vercel_project_id, key):
-        #     print("here already existing")
-        #     client.update_env_variable(vercel_project_id, key, value)
-        # else:
         if not self.env_var_already_exists(client, vercel_project_id, key):
-            print("here not existing yet")
-            client.create_env_variable(vercel_project_id, key, value)
+            return client.create_env_variable(vercel_project_id, key, value)
+        return client.update_env_variable(vercel_project_id, key, value)
 
 
 class VercelIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from uuid import uuid4
 import six
 import logging
 
@@ -156,7 +157,6 @@ class VercelIntegration(IntegrationInstallation):
         # data = {"project_mappings": [[sentry_project_id, vercel_project_id]]}
         vercel_client = self.get_client()
         config = self.org_integration.config
-
         new_mappings = data["project_mappings"]
         old_mappings = config.get("project_mappings") or []
 
@@ -165,37 +165,86 @@ class VercelIntegration(IntegrationInstallation):
             if mapping in old_mappings:
                 continue
             [sentry_project_id, vercel_project_id] = mapping
-
             sentry_project = Project.objects.get(id=sentry_project_id)
             enabled_dsn = ProjectKey.get_default(project=sentry_project)
             if not enabled_dsn:
                 raise IntegrationError("You must have an enabled DSN to continue!")
+            source_code_provider = self.get_source_code_provider(vercel_client, vercel_project_id)
+            if not source_code_provider:
+                raise IntegrationError(
+                    "You must connect your Vercel project to a Git repository to continue!"
+                )
             sentry_project_dsn = enabled_dsn.get_dsn(public=True)
+            random_suffix = uuid4().hex
+            # random_suffix = "1234567"
+            sentry_auth_token = SentryAppInstallationForProvider.objects.get(
+                organization=sentry_project.organization.id, provider="vercel"
+            )
+            # secret_names = [
+            #     "SENTRY_ORG_%s" % random_suffix,
+            #     "SENTRY_PROJECT_%s" % random_suffix,
+            #     "NEXT_PUBLIC_SENTRY_DSN_%s" % random_suffix,
+            #     "SENTRY_AUTH_TOKEN_%s" % random_suffix,
+            # ]
+            # values = [
+            #     sentry_project.organization.slug,
+            #     sentry_project.slug,
+            #     sentry_project_dsn,
+            #     sentry_auth_token.sentry_app_installation.api_token.token,
+            # ]
+            # env_var_names = [
+            #     "SENTRY_ORG",
+            #     "SENTRY_PROJECT",
+            #     "NEXT_PUBLIC_SENTRY_DSN",
+            #     "SENTRY_AUTH_TOKEN",
+            #     "VERCEL_%s_COMMIT_SHA" % source_code_provider.upper(),
+            # ]
 
+            # secrets = []
+            # for name, val in zip(secret_names, values):
+            #     secrets.append(self.create_secret(vercel_client, vercel_project_id, name, val))
+
+            # secrets.append("")
+            # for secret, env_var in zip(secrets, env_var_names):
+            #     self.create_env_var(vercel_client, vercel_project_id, env_var, secret)
+
+            # TODO make this DRYer
             org_secret = self.create_secret(
-                vercel_client, vercel_project_id, "SENTRY_ORG", sentry_project.organization.slug
+                vercel_client, vercel_project_id, "SENTRY_ORG_%s" % random_suffix, sentry_project.organization.slug
             )
             project_secret = self.create_secret(
                 vercel_client,
                 vercel_project_id,
-                "SENTRY_PROJECT_%s" % sentry_project_id,
+                "SENTRY_PROJECT_%s" % random_suffix,
                 sentry_project.slug,
             )
             dsn_secret = self.create_secret(
                 vercel_client,
                 vercel_project_id,
-                "NEXT_PUBLIC_SENTRY_DSN_%s" % sentry_project_id,
+                "NEXT_PUBLIC_SENTRY_DSN_%s" % random_suffix,
                 sentry_project_dsn,
+            )
+            auth_secret = self.create_secret(
+                vercel_client,
+                vercel_project_id,
+                "SENTRY_AUTH_TOKEN_%s" % random_suffix,
+                sentry_auth_token.sentry_app_installation.api_token.token,
             )
 
             self.create_env_var(vercel_client, vercel_project_id, "SENTRY_ORG", org_secret)
             self.create_env_var(vercel_client, vercel_project_id, "SENTRY_PROJECT", project_secret)
-            self.create_env_var(
-                vercel_client, vercel_project_id, "NEXT_PUBLIC_SENTRY_DSN", dsn_secret
-            )
+            self.create_env_var(vercel_client, vercel_project_id, "NEXT_PUBLIC_SENTRY_DSN", dsn_secret)
+            self.create_env_var(vercel_client, vercel_project_id, "SENTRY_AUTH_TOKEN", auth_secret)
+            self.create_env_var(vercel_client, vercel_project_id, "VERCEL_%s_COMMIT_SHA" % source_code_provider.upper(), "")
 
         config.update(data)
         self.org_integration.update(config=config)
+
+    def get_source_code_provider(self, client, vercel_project_id):
+        try:
+            return client.get_source_code_provider(vercel_project_id)
+        except KeyError:
+            return None
 
     def get_env_vars(self, client, vercel_project_id):
         return client.get_env_vars(vercel_project_id)
@@ -225,7 +274,12 @@ class VercelIntegration(IntegrationInstallation):
             return client.create_secret(vercel_project_id, name, value)
 
     def create_env_var(self, client, vercel_project_id, key, value):
+        # if self.env_var_already_exists(client, vercel_project_id, key):
+        #     print("here already existing")
+        #     client.update_env_variable(vercel_project_id, key, value)
+        # else:
         if not self.env_var_already_exists(client, vercel_project_id, key):
+            print("here not existing yet")
             client.create_env_variable(vercel_project_id, key, value)
 
 

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -28,6 +28,21 @@ class SentryAppInstallationForProvider(DefaultFieldsModel):
         db_table = "sentry_sentryappinstallationforprovider"
         unique_together = (("provider", "organization"),)
 
+    @classmethod
+    def get_token(cls, organization_id, provider):
+        installation_for_provider = SentryAppInstallationForProvider.objects.select_related(
+            "sentry_app_installation"
+        ).get(organization_id=organization_id, provider=provider)
+        sentry_app_installation = installation_for_provider.sentry_app_installation
+
+        # find a token associated with the installation so we can use it for authentication
+        sentry_app_installation_token = (
+            SentryAppInstallationToken.objects.select_related("api_token")
+            .filter(sentry_app_installation=sentry_app_installation)
+            .first()
+        )
+        return sentry_app_installation_token.api_token.token
+
 
 class SentryAppInstallationToken(Model):
     __core__ = False

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -759,11 +759,6 @@ class IntegrationTestCase(TestCase):
         self.pipeline.initialize()
         self.save_session()
 
-        class MockUuid4:
-            hex = "1234567"
-
-        self.mock_uuid4 = MockUuid4
-
     def assertDialogSuccess(self, resp):
         assert b"window.opener.postMessage(" in resp.content
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -759,6 +759,11 @@ class IntegrationTestCase(TestCase):
         self.pipeline.initialize()
         self.save_session()
 
+        class MockUuid4:
+            hex = "1234567"
+
+        self.mock_uuid4 = MockUuid4
+
     def assertDialogSuccess(self, resp):
         assert b"window.opener.postMessage(" in resp.content
 

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -190,9 +190,6 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         for i, name in enumerate(secret_names):
             responses.add(
-                responses.GET, "https://api.vercel.com/v3/now/secrets/%s" % name, status=404
-            )
-            responses.add(
                 responses.POST, "https://api.vercel.com/v2/now/secrets", json={"uid": "sec_%s" % i},
             )
         # mock get envs for all
@@ -244,43 +241,43 @@ class VercelIntegrationTest(IntegrationTestCase):
             "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
         }
 
-        req_params = json.loads(responses.calls[6].request.body)
+        req_params = json.loads(responses.calls[5].request.body)
         assert req_params["name"] == "SENTRY_ORG_%s" % uuid
         assert req_params["value"] == org.slug
 
-        req_params = json.loads(responses.calls[8].request.body)
+        req_params = json.loads(responses.calls[6].request.body)
         assert req_params["name"] == "SENTRY_PROJECT_%s" % uuid
         assert req_params["value"] == self.project.slug
 
-        req_params = json.loads(responses.calls[10].request.body)
+        req_params = json.loads(responses.calls[7].request.body)
         assert req_params["name"] == "NEXT_PUBLIC_SENTRY_DSN_%s" % uuid
         assert req_params["value"] == enabled_dsn
 
-        req_params = json.loads(responses.calls[12].request.body)
+        req_params = json.loads(responses.calls[8].request.body)
         assert req_params["name"] == "SENTRY_AUTH_TOKEN_%s" % uuid
         assert req_params["value"] == sentry_auth_token
 
-        req_params = json.loads(responses.calls[14].request.body)
+        req_params = json.loads(responses.calls[10].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == "sec_0"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[16].request.body)
+        req_params = json.loads(responses.calls[12].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == "sec_1"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[18].request.body)
+        req_params = json.loads(responses.calls[14].request.body)
         assert req_params["key"] == "NEXT_PUBLIC_SENTRY_DSN"
         assert req_params["value"] == "sec_2"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[20].request.body)
+        req_params = json.loads(responses.calls[16].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
         assert req_params["value"] == "sec_3"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[22].request.body)
+        req_params = json.loads(responses.calls[18].request.body)
         assert req_params["key"] == "VERCEL_GITHUB_COMMIT_SHA"
         assert req_params["value"] == ""
         assert req_params["target"] == "production"
@@ -312,13 +309,11 @@ class VercelIntegrationTest(IntegrationTestCase):
             % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
             json={"link": {"type": "github"}},
         )
+
         for i, name in enumerate(secret_names):
             responses.add(
-                responses.GET,
-                "https://api.vercel.com/v3/now/secrets/%s" % name,
-                json={"uid": "sec_%s" % i, "name": name},
+                responses.POST, "https://api.vercel.com/v2/now/secrets", json={"uid": "sec_%s" % i},
             )
-
         for i, env_var_name in enumerate(env_var_names):
             responses.add(
                 responses.GET,
@@ -328,7 +323,6 @@ class VercelIntegrationTest(IntegrationTestCase):
                     "envs": [{"value": "sec_%s" % i, "target": "production", "key": env_var_name}],
                 },
             )
-
         for i, env_var_name in enumerate(env_var_names):
             responses.add(
                 responses.DELETE,
@@ -372,6 +366,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         assert org_integration.config == {
             "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
         }
+
         req_params = json.loads(responses.calls[11].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == "sec_0"

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -413,6 +413,30 @@ class VercelIntegrationTest(IntegrationTestCase):
             installation.update_organization_config(data)
 
     @responses.activate
+    def test_upgrade_org_config_no_source_code_provider(self):
+        """Test that the function doesn't progress if the Vercel project hasn't been connected to a Git repository"""
+
+        with self.tasks():
+            self.assert_setup_flow()
+
+        project_id = self.project.id
+        org = self.organization
+        data = {
+            "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
+        }
+        integration = Integration.objects.get(provider=self.provider.key)
+        installation = integration.get_installation(org.id)
+
+        responses.add(
+            responses.GET,
+            "https://api.vercel.com/v1/projects/%s"
+            % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
+            json={},
+        )
+        with self.assertRaises(IntegrationError):
+            installation.update_organization_config(data)
+
+    @responses.activate
     def test_ui_hook_options(self):
         """Test that the response to the UI hook CORS pre-flight OPTIONS request is handled correctly"""
 
@@ -450,26 +474,3 @@ class VercelIntegrationTest(IntegrationTestCase):
             )
             in resp.content
         )
-
-    def test_upgrade_org_config_no_source_code_provider(self):
-        """Test that the function doesn't progress if the Vercel project hasn't been connected to a Git repository"""
-
-        with self.tasks():
-            self.assert_setup_flow()
-
-        project_id = self.project.id
-        org = self.organization
-        data = {
-            "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
-        }
-        integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(org.id)
-
-        responses.add(
-            responses.GET,
-            "https://api.vercel.com/v1/projects/%s"
-            % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
-            json={},
-        )
-        with self.assertRaises(IntegrationError):
-            installation.update_organization_config(data)

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -436,6 +436,7 @@ class VercelIntegrationTest(IntegrationTestCase):
                 }
             },
         )
+
         data = b"""{"configurationId":"icfg_Gdv8qI5s0h3T3xeLZvifuhCb", "teamId":{}, "user":{"id":"hIwec0PQ34UDEma7XmhCRQ3x"}}"""
 
         resp = self.client.post(path=uihook_url, data=data, content_type="application/json")
@@ -449,6 +450,7 @@ class VercelIntegrationTest(IntegrationTestCase):
             )
             in resp.content
         )
+
     def test_upgrade_org_config_no_source_code_provider(self):
         """Test that the function doesn't progress if the Vercel project hasn't been connected to a Git repository"""
 


### PR DESCRIPTION
This is the second part of https://github.com/getsentry/sentry/pull/19380 which adds the `SENTRY_AUTH_TOKEN` and source code provider env var (i.e. `VERCEL_GITHUB_COMMIT_SHA`). 

This also adds a uuid as a suffix to the secrets' keys to handle potential conflicts like when a user installs the integration in multiple organizations.

Also, if an environment variable already exists we will now delete and re-create it in case you map a project, delete the mapping, and map it to a different project. 