### PR TITLE
refs(py3): Bump hiredis for python 3.6 support.

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -64,7 +64,7 @@ urllib3==1.24.2
 uwsgi>2.0.0,<2.1.0
 
 # not directly used, but provides a speedup for redis
-hiredis>=0.1.0,<0.2.0
+hiredis==0.3.1
 
 # not directly used, but pinned for at least semaphore/symbolic
 cffi>=1.11.5,<2.0


### PR DESCRIPTION
hiredis 0.3.1 supports Python 3.6/3.7, so testing bumping. 1.0.0 has a breaking change, although I'm
not sure how bad this is. https://github.com/redis/hiredis-py/pull/82 is the change, and it
basically implements strict unicode decoding errors, which I assume we'd prefer rather than silently
converting values. So we could potentially ugrade to latest if we think this is ok. Not sure how
we'd validate this tbqh.