### PR TITLE
fix(build): Use correct query-string import

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -2,7 +2,7 @@ import * as ReactRouter from 'react-router';
 import isInteger from 'lodash/isInteger';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
-import qs from 'query-string';
+import * as qs from 'query-string';
 import * as Sentry from '@sentry/react';
 
 import {

--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import qs from 'query-string';
+import * as qs from 'query-string';
 import styled from '@emotion/styled';
 
 import LetterAvatar from 'app/components/letterAvatar';

--- a/src/sentry/static/sentry/app/components/avatar/gravatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/gravatar.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import qs from 'query-string';
+import * as qs from 'query-string';
 import styled from '@emotion/styled';
 
 import ConfigStore from 'app/stores/configStore';

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Link} from 'react-router';
-import queryString from 'query-string';
+import * as queryString from 'query-string';
 import {Query} from 'history';
 
 import {EventTag, Meta} from 'app/types';

--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
@@ -1,6 +1,6 @@
 import isEmpty from 'lodash/isEmpty';
 import isString from 'lodash/isString';
-import queryString from 'query-string';
+import * as queryString from 'query-string';
 import * as Sentry from '@sentry/react';
 
 import {FILTER_MASK} from 'app/constants';

--- a/src/sentry/static/sentry/app/components/globalSelectionLink.jsx
+++ b/src/sentry/static/sentry/app/components/globalSelectionLink.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Link as RouterLink} from 'react-router';
-import qs from 'query-string';
+import * as qs from 'query-string';
 
 import {extractSelectionParameters} from 'app/components/organizations/globalSelectionHeader/utils';
 

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import queryString from 'query-string';
+import * as queryString from 'query-string';
 import debounce from 'lodash/debounce';
 
 import {addSuccessMessage} from 'app/actionCreators/indicator';

--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
-import qs from 'query-string';
+import * as qs from 'query-string';
 
 import {Client} from 'app/api';
 import {Panel, PanelBody} from 'app/components/panels';

--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import isEqual from 'lodash/isEqual';
-import queryString from 'query-string';
+import * as queryString from 'query-string';
 import styled from '@emotion/styled';
 
 import {

--- a/src/sentry/static/sentry/app/stores/configStore.tsx
+++ b/src/sentry/static/sentry/app/stores/configStore.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone';
 import Reflux from 'reflux';
-import qs from 'query-string';
+import * as qs from 'query-string';
 
 import {setLocale} from 'app/locale';
 import {Config} from 'app/types';

--- a/src/sentry/static/sentry/app/utils/getPendingInvite.tsx
+++ b/src/sentry/static/sentry/app/utils/getPendingInvite.tsx
@@ -1,5 +1,5 @@
 import Cookies from 'js-cookie';
-import queryString from 'query-string';
+import * as queryString from 'query-string';
 
 type PendingInvite = {
   memberId: number;

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -1,6 +1,6 @@
 import capitalize from 'lodash/capitalize';
 import React from 'react';
-import qs from 'query-string';
+import * as qs from 'query-string';
 
 import HookStore from 'app/stores/hookStore';
 import {

--- a/src/sentry/static/sentry/app/utils/queryString.tsx
+++ b/src/sentry/static/sentry/app/utils/queryString.tsx
@@ -1,4 +1,4 @@
-import queryString from 'query-string';
+import * as queryString from 'query-string';
 import parseurl from 'parseurl';
 import isString from 'lodash/isString';
 

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getDiscoverUrlPathFromDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getDiscoverUrlPathFromDiscoverQuery.tsx
@@ -1,4 +1,4 @@
-import qs from 'query-string';
+import * as qs from 'query-string';
 
 import {getExternal, getInternal} from 'app/views/discover/aggregations/utils';
 import {getQueryStringFromQuery} from 'app/views/discover/utils';

--- a/src/sentry/static/sentry/app/views/dashboards/utils/getEventsUrlPathFromDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/utils/getEventsUrlPathFromDiscoverQuery.tsx
@@ -1,5 +1,5 @@
 import pickBy from 'lodash/pickBy';
-import qs from 'query-string';
+import * as qs from 'query-string';
 
 import {getUtcDateString} from 'app/utils/dates';
 import {Organization, GlobalSelection} from 'app/types';

--- a/src/sentry/static/sentry/app/views/discover/utils.tsx
+++ b/src/sentry/static/sentry/app/views/discover/utils.tsx
@@ -1,7 +1,7 @@
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import moment from 'moment';
-import qs from 'query-string';
+import * as qs from 'query-string';
 
 import {Client} from 'app/api';
 

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import createReactClass from 'create-react-class';
 import isEqual from 'lodash/isEqual';
 import pickBy from 'lodash/pickBy';
-import qs from 'query-string';
+import * as qs from 'query-string';
 import {withProfiler} from '@sentry/react';
 
 import {Client} from 'app/api';

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupMerged/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupMerged/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
-import queryString from 'query-string';
+import * as queryString from 'query-string';
 
 import {t} from 'app/locale';
 import GroupingActions from 'app/actions/groupingActions';

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilar/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilar/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
-import queryString from 'query-string';
+import * as queryString from 'query-string';
 
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegration.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import queryString from 'query-string';
+import * as queryString from 'query-string';
 
 import {IntegrationProvider, Integration, Organization} from 'app/types';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -4,7 +4,7 @@ import flatten from 'lodash/flatten';
 import groupBy from 'lodash/groupBy';
 import startCase from 'lodash/startCase';
 import uniq from 'lodash/uniq';
-import queryString from 'query-string';
+import * as queryString from 'query-string';
 import React from 'react';
 import {browserHistory} from 'react-router';
 import {RouteComponentProps} from 'react-router/lib/Router';

--- a/src/sentry/static/sentry/app/views/userFeedback/utils.tsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/utils.tsx
@@ -1,5 +1,5 @@
 import pick from 'lodash/pick';
-import qs from 'query-string';
+import * as qs from 'query-string';
 
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 

--- a/tests/js/sentry-test/mockRouterPush.jsx
+++ b/tests/js/sentry-test/mockRouterPush.jsx
@@ -1,4 +1,4 @@
-import qs from 'query-string';
+import * as qs from 'query-string';
 
 // More closely mocks a router push -- updates wrapper's props/context
 // with updated `router` and calls `wrapper.update()`


### PR DESCRIPTION
The query-string package does not have a default export.

However, because query-string is a commonJS module, eslint transforms
the code so this works.

When switching to the typescript import eslint plugin, the old way will
not pass the check, since there truely is not a default export (and the index.d.ts is inline with this).