### PR TITLE
refs(py3): Bump redis and redis-py-cluster to support Python 3.6

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -45,8 +45,8 @@ PyYAML>=5.3,<5.4
 qrcode>=6.1.0,<6.2.0
 querystring_parser>=1.2.3,<2.0.0
 rb>=1.7.0,<2.0.0
-redis-py-cluster==1.3.4
-redis>=2.10.3,<2.10.6
+redis-py-cluster==1.3.6
+redis==2.10.6
 requests-oauthlib==1.2.0
 requests[security]>=2.20.0,<2.21.0
 sentry-relay>=0.5.10,<0.6.0

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -12,11 +12,10 @@ from hashlib import md5
 import six
 from django.utils import timezone
 from pkg_resources import resource_string
-from redis.client import Script
 
 from sentry.tsdb.base import BaseTSDB
 from sentry.utils.dates import to_datetime, to_timestamp
-from sentry.utils.redis import check_cluster_versions, get_cluster_from_options
+from sentry.utils.redis import check_cluster_versions, get_cluster_from_options, SentryScript
 from sentry.utils.versioning import Version
 from six.moves import reduce
 from sentry.utils.compat import map
@@ -26,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 SketchParameters = namedtuple("SketchParameters", "depth width capacity")
 
-CountMinScript = Script(None, resource_string("sentry", "scripts/tsdb/cmsketch.lua"))
+CountMinScript = SentryScript(None, resource_string("sentry", "scripts/tsdb/cmsketch.lua"))
 
 
 class SuppressionWrapper(object):

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -11,7 +11,7 @@ import rb
 from django.utils.functional import SimpleLazyObject
 from pkg_resources import resource_string
 from redis.client import Script, StrictRedis
-from redis.connection import ConnectionPool
+from redis.connection import ConnectionPool, Encoder
 from redis.exceptions import ConnectionError, BusyLoadingError
 from rediscluster import StrictRedisCluster
 
@@ -249,7 +249,7 @@ def check_cluster_versions(cluster, required, recommended=None, label=None):
 
 
 def load_script(path):
-    script = Script(None, resource_string("sentry", posixpath.join("scripts", path)))
+    script = []
 
     # This changes the argument order of the ``Script.__call__`` method to
     # encourage using the script with a specific Redis client, rather
@@ -266,6 +266,48 @@ def load_script(path):
         """.format(
             path
         )
-        return script(keys, args, client)
+        # XXX: Script is a list here. We're doing this to work around the lack of
+        # `nonlocal` in python 3, so that we only instantiate the script once.
+        if not script:
+            script.append(
+                Script(client, resource_string("sentry", posixpath.join("scripts", path)))
+            )
+            # Unset the client here to keep things as close to how they worked before
+            # as possible. It will always be overriden on `__call__` anyway.
+            script[0].registered_client = None
+        return script[0](keys, args, client)
 
     return call_script
+
+
+class SentryScript(Script):
+    """
+    XXX: This is a gross workaround to fix a breaking api change in redis-py. When we
+    instantiate a script, we've historically been passing `None` as the client. Then
+    when we call the script we pass the actual client, which Redis uses as an override.
+    The breaking changes relies on there being a client passed in the constructor to
+    determine the encoding of the script before generating the sha.
+
+    To work around this, we create a fake client with a fake connection pool that just
+    returns an encoder that will work. Once this has been done we then set the
+    `registered_client` back to None, so that the behaviour is the same as before.
+
+    This is only needed when we can't use `load_script`, since we have the client
+    available there and can pass it through. So once we remove `RedisTSDB` we can also
+    kill this hack.
+    """
+
+    class FakeConnectionPool(object):
+        def get_encoder(self):
+            return Encoder(encoding="utf-8", encoding_errors="strict", decode_responses=False)
+
+    class FakeEncoderClient(object):
+        def __init__(self):
+            self.connection_pool = SentryScript.FakeConnectionPool()
+
+    def __init__(self, registered_client, script):
+        if registered_client is None:
+            registered_client = self.FakeEncoderClient()
+        super(SentryScript, self).__init__(registered_client, script)
+        if isinstance(self.registered_client, self.FakeEncoderClient):
+            self.registered_client = None


### PR DESCRIPTION
Turns out that we only need minor version bumps of both of these to support Python 3.6. The
changelogs don't have anything that looks like a red flag:
 - https://github.com/andymccurdy/redis-py/blob/master/CHANGES#L323
 - https://github.com/Grokzen/redis-py-cluster/blob/master/docs/release-notes.rst#136-nov-16-2018.
   We use 1.3.6 here since it's pinned to 2.10.6 of Redis, which we're bumping to.

There's one long term issue that was preventing us from bumping these, which is covered in
#5915. Basically, we pass a `None` value for client when we create a redis `Script` class, 
which now breaks since we rely on fetching the encoding from the client. In most cases I was 
able to just pass a client through, but in one place I've had to write a hack to work around it, since 
it's used with RB and isn't easy to pass a client to.