### PR TITLE
feat(crumbs-v2): Highlight text search results

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntriesBreadcrumbs.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntriesBreadcrumbs.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Feature from 'app/components/acl/feature';
 import BreadcrumbsInterface from 'app/components/events/interfaces/breadcrumbs/breadcrumbs';
-import Breadcrumbs from 'app/components/events/interfaces/breadcrumbsV2/breadcrumbs';
+import Breadcrumbs from 'app/components/events/interfaces/breadcrumbsV2';
 
 type Props = React.ComponentProps<typeof Breadcrumbs>;
 type BreadcrumbsInterfaceProps = React.ComponentProps<typeof BreadcrumbsInterface>;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/category.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/category.tsx
@@ -1,21 +1,25 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import Highlight from 'app/components/highlight';
 import TextOverflow from 'app/components/textOverflow';
 import Tooltip from 'app/components/tooltip';
 import {defined} from 'app/utils';
 import {t} from 'app/locale';
 
 type Props = {
+  searchTerm: string;
   category?: string | null;
 };
 
-const Category = React.memo(({category}: Props) => {
+const Category = React.memo(({category, searchTerm}: Props) => {
   const title = !defined(category) ? t('generic') : category;
   return (
     <Wrapper title={title}>
       <Tooltip title={title} containerDisplayMode="inline-flex">
-        <TextOverflow>{title}</TextOverflow>
+        <TextOverflow>
+          <Highlight text={searchTerm}>{title}</Highlight>
+        </TextOverflow>
       </Tooltip>
     </Wrapper>
   );

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/data.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/data.tsx
@@ -8,24 +8,32 @@ import Http from './http';
 import {Breadcrumb, BreadcrumbType} from '../types';
 
 type Props = {
+  searchTerm: string;
   breadcrumb: Breadcrumb;
   event: Event;
   orgId: string | null;
 };
 
-const Data = ({breadcrumb, event, orgId}: Props) => {
+const Data = ({breadcrumb, event, orgId, searchTerm}: Props) => {
   if (breadcrumb.type === BreadcrumbType.HTTP) {
-    return <Http breadcrumb={breadcrumb} />;
+    return <Http breadcrumb={breadcrumb} searchTerm={searchTerm} />;
   }
 
   if (
     breadcrumb.type === BreadcrumbType.WARNING ||
     breadcrumb.type === BreadcrumbType.ERROR
   ) {
-    return <Exception breadcrumb={breadcrumb} />;
+    return <Exception breadcrumb={breadcrumb} searchTerm={searchTerm} />;
   }
 
-  return <Default event={event} orgId={orgId} breadcrumb={breadcrumb} />;
+  return (
+    <Default
+      event={event}
+      orgId={orgId}
+      breadcrumb={breadcrumb}
+      searchTerm={searchTerm}
+    />
+  );
 };
 
 export default Data;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/default.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/default.tsx
@@ -5,23 +5,26 @@ import {getMeta} from 'app/components/events/meta/metaProxy';
 import withProjects from 'app/utils/withProjects';
 import {generateEventSlug, eventDetailsRoute} from 'app/utils/discover/urls';
 import Link from 'app/components/links/link';
+import Highlight from 'app/components/highlight';
 
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
 import {BreadcrumbTypeDefault, BreadcrumbTypeNavigation} from '../types';
 import Summary from './summary';
 
 type Props = {
+  searchTerm: string;
   breadcrumb: BreadcrumbTypeDefault | BreadcrumbTypeNavigation;
   event: Event;
   orgId: string | null;
 };
 
-const Default = ({breadcrumb, event, orgId}: Props) => (
-  <Summary kvData={breadcrumb.data}>
+const Default = ({breadcrumb, event, orgId, searchTerm}: Props) => (
+  <Summary kvData={breadcrumb.data} searchTerm={searchTerm}>
     {breadcrumb?.message &&
       getBreadcrumbCustomRendererValue({
         value: (
           <FormatMessage
+            searchTerm={searchTerm}
             event={event}
             orgId={orgId}
             breadcrumb={breadcrumb}
@@ -39,6 +42,7 @@ function isEventId(maybeEventId: string): boolean {
 }
 
 const FormatMessage = withProjects(function FormatMessageInner({
+  searchTerm,
   event,
   message,
   breadcrumb,
@@ -46,6 +50,7 @@ const FormatMessage = withProjects(function FormatMessageInner({
   loadingProjects,
   orgId,
 }: {
+  searchTerm: string;
   event: Event;
   projects: Project[];
   loadingProjects: boolean;
@@ -53,6 +58,7 @@ const FormatMessage = withProjects(function FormatMessageInner({
   message: string;
   orgId: string | null;
 }) {
+  const content = <Highlight text={searchTerm}>{message}</Highlight>;
   if (
     !loadingProjects &&
     typeof orgId === 'string' &&
@@ -64,16 +70,16 @@ const FormatMessage = withProjects(function FormatMessageInner({
     });
 
     if (!maybeProject) {
-      return <React.Fragment>{message}</React.Fragment>;
+      return content;
     }
 
     const projectSlug = maybeProject.slug;
     const eventSlug = generateEventSlug({project: projectSlug, id: message});
 
-    return <Link to={eventDetailsRoute({orgSlug: orgId, eventSlug})}>{message}</Link>;
+    return <Link to={eventDetailsRoute({orgSlug: orgId, eventSlug})}>{content}</Link>;
   }
 
-  return <React.Fragment>{message}</React.Fragment>;
+  return content;
 });
 
 export default Default;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/exception.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/exception.tsx
@@ -3,34 +3,44 @@ import omit from 'lodash/omit';
 
 import {getMeta} from 'app/components/events/meta/metaProxy';
 import {defined} from 'app/utils';
+import Highlight from 'app/components/highlight';
 
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
 import {BreadcrumbTypeDefault} from '../types';
 import Summary from './summary';
 
 type Props = {
+  searchTerm: string;
   breadcrumb: BreadcrumbTypeDefault;
 };
 
-const Exception = ({breadcrumb}: Props) => {
+const Exception = ({breadcrumb, searchTerm}: Props) => {
   const {data} = breadcrumb;
   const dataValue = data?.value;
 
   return (
-    <Summary kvData={omit(data, ['type', 'value'])}>
+    <Summary kvData={omit(data, ['type', 'value'])} searchTerm={searchTerm}>
       {data?.type &&
         getBreadcrumbCustomRendererValue({
-          value: <strong>{`${data.type}: `}</strong>,
+          value: (
+            <strong>
+              <Highlight text={searchTerm}>{`${data.type}: `}</Highlight>
+            </strong>
+          ),
           meta: getMeta(data, 'type'),
         })}
       {defined(dataValue) &&
         getBreadcrumbCustomRendererValue({
-          value: breadcrumb?.message ? `${dataValue}. ` : dataValue,
+          value: (
+            <Highlight text={searchTerm}>
+              {breadcrumb?.message ? `${dataValue}. ` : dataValue}
+            </Highlight>
+          ),
           meta: getMeta(data, 'value'),
         })}
       {breadcrumb?.message &&
         getBreadcrumbCustomRendererValue({
-          value: breadcrumb.message,
+          value: <Highlight text={searchTerm}>{breadcrumb.message}</Highlight>,
           meta: getMeta(breadcrumb, 'message'),
         })}
     </Summary>

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/http.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/http.tsx
@@ -5,31 +5,34 @@ import ExternalLink from 'app/components/links/externalLink';
 import {getMeta} from 'app/components/events/meta/metaProxy';
 import {t} from 'app/locale';
 import {defined} from 'app/utils';
+import Highlight from 'app/components/highlight';
 
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
 import {BreadcrumbTypeHTTP} from '../types';
 import Summary from './summary';
 
 type Props = {
+  searchTerm: string;
   breadcrumb: BreadcrumbTypeHTTP;
 };
 
-const Http = ({breadcrumb}: Props) => {
+const Http = ({breadcrumb, searchTerm}: Props) => {
   const {data} = breadcrumb;
 
   const renderUrl = (url: any) => {
     if (typeof url === 'string') {
+      const content = <Highlight text={searchTerm}>{url}</Highlight>;
       return url.match(/^https?:\/\//) ? (
         <ExternalLink data-test-id="http-renderer-external-link" href={url}>
-          {url}
+          {content}
         </ExternalLink>
       ) : (
-        <span>{url}</span>
+        <span>{content}</span>
       );
     }
 
     try {
-      return JSON.stringify(url);
+      return <Highlight text={searchTerm}>{JSON.stringify(url)}</Highlight>;
     } catch {
       return t('Invalid URL');
     }
@@ -38,10 +41,17 @@ const Http = ({breadcrumb}: Props) => {
   const statusCode = data?.status_code;
 
   return (
-    <Summary kvData={omit(data, ['method', 'url', 'status_code'])}>
+    <Summary
+      kvData={omit(data, ['method', 'url', 'status_code'])}
+      searchTerm={searchTerm}
+    >
       {data?.method &&
         getBreadcrumbCustomRendererValue({
-          value: <strong>{`${data.method} `}</strong>,
+          value: (
+            <strong>
+              <Highlight text={searchTerm}>{`${data.method} `}</Highlight>
+            </strong>
+          ),
           meta: getMeta(data, 'method'),
         })}
       {data?.url &&
@@ -52,7 +62,10 @@ const Http = ({breadcrumb}: Props) => {
       {defined(statusCode) &&
         getBreadcrumbCustomRendererValue({
           value: (
-            <span data-test-id="http-renderer-status-code">{` [${statusCode}]`}</span>
+            <Highlight
+              data-test-id="http-renderer-status-code"
+              text={searchTerm}
+            >{` [${statusCode}]`}</Highlight>
           ),
           meta: getMeta(data, 'status_code'),
         })}

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/summary.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/data/summary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import Highlight from 'app/components/highlight';
 import {getMeta} from 'app/components/events/meta/metaProxy';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {defined} from 'app/utils';
@@ -8,6 +9,7 @@ import {defined} from 'app/utils';
 import getBreadcrumbCustomRendererValue from '../../breadcrumbs/getBreadcrumbCustomRendererValue';
 
 type Props = {
+  searchTerm: string;
   kvData?: Record<string, any>;
 };
 
@@ -31,7 +33,7 @@ class Summary extends React.Component<Props, State> {
   };
 
   renderData = () => {
-    const {kvData} = this.props;
+    const {kvData, searchTerm} = this.props;
 
     if (!kvData) {
       return null;
@@ -45,9 +47,11 @@ class Summary extends React.Component<Props, State> {
         return (
           <Data key={key}>
             <StyledPre>
-              <DataLabel>{`${key}: `}</DataLabel>
+              <DataLabel>
+                <Highlight text={searchTerm}>{`${key}: `}</Highlight>
+              </DataLabel>
               {getBreadcrumbCustomRendererValue({
-                value,
+                value: <Highlight text={searchTerm}>{value}</Highlight>,
                 meta: getMeta(kvData, key),
               })}
             </StyledPre>

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/index.tsx
@@ -246,7 +246,7 @@ class Breadcrumbs extends React.Component<Props, State> {
     }
 
     // Slightly hacky, but it works
-    // the string is being stringfy here in order to match exactly the same stringfy string of the loop
+    // the string is being `stringfy`d here in order to match exactly the same `stringfy`d string of the loop
     const searchFor = JSON.stringify(searchTerm)
       // it replaces double backslash generate by JSON.stringfy with single backslash
       .replace(/((^")|("$))/g, '')

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/level.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/level.tsx
@@ -42,7 +42,7 @@ const Level = React.memo(({level, searchTerm = ''}: Props) => {
     default:
       return (
         <Tag>
-          <Highlight text={searchTerm}>{t('undefined')}</Highlight>
+          <Highlight text={searchTerm}>{level || t('undefined')}</Highlight>
         </Tag>
       );
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/level.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/level.tsx
@@ -1,28 +1,50 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import Tag from 'app/views/settings/components/tag';
 import {t} from 'app/locale';
+import Highlight from 'app/components/highlight';
+import Tag from 'app/views/settings/components/tag';
 import {Color} from 'app/utils/theme';
 
 import {BreadcrumbLevelType} from './types';
 
 type Props = {
-  level?: BreadcrumbLevelType;
+  level: BreadcrumbLevelType;
+  searchTerm?: string;
 };
 
-const Level = React.memo(({level}: Props) => {
+const Level = React.memo(({level, searchTerm = ''}: Props) => {
   switch (level) {
     case BreadcrumbLevelType.FATAL:
-      return <StyledTag color="red500">{level}</StyledTag>;
+      return (
+        <StyledTag color="red500">
+          <Highlight text={searchTerm}>{t('fatal')}</Highlight>
+        </StyledTag>
+      );
     case BreadcrumbLevelType.ERROR:
-      return <StyledTag color="red400">{level}</StyledTag>;
+      return (
+        <StyledTag color="red400">
+          <Highlight text={searchTerm}>{t('error')}</Highlight>
+        </StyledTag>
+      );
     case BreadcrumbLevelType.INFO:
-      return <StyledTag color="blue400">{level}</StyledTag>;
+      return (
+        <StyledTag color="blue400">
+          <Highlight text={searchTerm}>{t('info')}</Highlight>
+        </StyledTag>
+      );
     case BreadcrumbLevelType.WARNING:
-      return <StyledTag color="orange400">{level}</StyledTag>;
+      return (
+        <StyledTag color="orange400">
+          <Highlight text={searchTerm}>{t('warning')}</Highlight>
+        </StyledTag>
+      );
     default:
-      return <Tag>{level || t('undefined')}</Tag>;
+      return (
+        <Tag>
+          <Highlight text={searchTerm}>{t('undefined')}</Highlight>
+        </Tag>
+      );
   }
 });
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/list.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/list.tsx
@@ -13,7 +13,14 @@ type Props = {
 
 const List = React.forwardRef(
   (
-    {displayRelativeTime, onSwitchTimeFormat, orgId, event, breadcrumbs}: Props,
+    {
+      displayRelativeTime,
+      onSwitchTimeFormat,
+      orgId,
+      event,
+      breadcrumbs,
+      searchTerm,
+    }: Props,
     ref: React.Ref<HTMLDivElement>
   ) => (
     <Grid ref={ref}>
@@ -22,6 +29,7 @@ const List = React.forwardRef(
         displayRelativeTime={!!displayRelativeTime}
       />
       <ListBody
+        searchTerm={searchTerm}
         event={event}
         orgId={orgId}
         breadcrumbs={breadcrumbs}

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/listBody.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/listBody.tsx
@@ -17,12 +17,13 @@ type Props = {
   breadcrumbs: BreadcrumbsWithDetails;
   event: Event;
   orgId: string | null;
+  searchTerm: string;
   relativeTime?: string;
   displayRelativeTime?: boolean;
 };
 
 const ListBody = React.memo(
-  ({orgId, event, breadcrumbs, relativeTime, displayRelativeTime}: Props) => (
+  ({orgId, event, breadcrumbs, relativeTime, displayRelativeTime, searchTerm}: Props) => (
     <React.Fragment>
       {breadcrumbs.map(({color, icon, id, ...crumb}, idx) => {
         const hasError = crumb.type === BreadcrumbType.ERROR;
@@ -36,19 +37,25 @@ const ListBody = React.memo(
               </Tooltip>
             </GridCellLeft>
             <GridCellCategory hasError={hasError} isLastItem={isLastItem}>
-              <Category category={crumb?.category} />
+              <Category category={crumb?.category} searchTerm={searchTerm} />
             </GridCellCategory>
             <GridCell hasError={hasError} isLastItem={isLastItem}>
-              <Data event={event} orgId={orgId} breadcrumb={crumb as Breadcrumb} />
+              <Data
+                event={event}
+                orgId={orgId}
+                breadcrumb={crumb as Breadcrumb}
+                searchTerm={searchTerm}
+              />
             </GridCell>
             <GridCell hasError={hasError} isLastItem={isLastItem}>
-              <Level level={crumb.level} />
+              <Level level={crumb.level} searchTerm={searchTerm} />
             </GridCell>
             <GridCell hasError={hasError} isLastItem={isLastItem}>
               <Time
                 timestamp={crumb?.timestamp}
                 relativeTime={relativeTime}
                 displayRelativeTime={displayRelativeTime}
+                searchTerm={searchTerm}
               />
             </GridCell>
           </React.Fragment>

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/time/time.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/time/time.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import Highlight from 'app/components/highlight';
 import {defined} from 'app/utils';
 import Tooltip from 'app/components/tooltip';
 import getDynamicText from 'app/utils/getDynamicText';
@@ -9,43 +10,46 @@ import TextOverflow from 'app/components/textOverflow';
 import {getFormattedTimestamp} from './utils';
 
 type Props = {
+  searchTerm: string;
   timestamp?: string;
   relativeTime?: string;
   displayRelativeTime?: boolean;
 };
 
-const Time = React.memo(({timestamp, relativeTime, displayRelativeTime}: Props) => {
-  if (!(defined(timestamp) && defined(relativeTime))) {
-    return null;
+const Time = React.memo(
+  ({timestamp, relativeTime, displayRelativeTime, searchTerm}: Props) => {
+    if (!(defined(timestamp) && defined(relativeTime))) {
+      return null;
+    }
+
+    const {date, time, displayTime} = getFormattedTimestamp(
+      timestamp,
+      relativeTime,
+      displayRelativeTime
+    );
+
+    return (
+      <Wrapper>
+        <Tooltip
+          title={
+            <div>
+              <div>{date}</div>
+              {time !== '\u2014' && <div>{time}</div>}
+            </div>
+          }
+          containerDisplayMode="inline-flex"
+        >
+          <TextOverflow>
+            {getDynamicText({
+              value: <Highlight text={searchTerm}>{displayTime}</Highlight>,
+              fixed: '00:00:00',
+            })}
+          </TextOverflow>
+        </Tooltip>
+      </Wrapper>
+    );
   }
-
-  const {date, time, displayTime} = getFormattedTimestamp(
-    timestamp,
-    relativeTime,
-    displayRelativeTime
-  );
-
-  return (
-    <Wrapper>
-      <Tooltip
-        title={
-          <div>
-            <div>{date}</div>
-            {time !== '\u2014' && <div>{time}</div>}
-          </div>
-        }
-        containerDisplayMode="inline-flex"
-      >
-        <TextOverflow>
-          {getDynamicText({
-            value: displayTime,
-            fixed: '00:00:00',
-          })}
-        </TextOverflow>
-      </Tooltip>
-    </Wrapper>
-  );
-});
+);
 
 export default Time;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/transformCrumbs.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/transformCrumbs.tsx
@@ -1,6 +1,6 @@
 import convertCrumbType from './convertCrumbType';
 import getCrumbDetails from './getCrumbDetails';
-import {Breadcrumb} from './types';
+import {Breadcrumb, BreadcrumbLevelType} from './types';
 
 const transformCrumbs = (breadcrumbs: Array<Breadcrumb>) =>
   breadcrumbs.map((breadcrumb, index) => {
@@ -10,6 +10,7 @@ const transformCrumbs = (breadcrumbs: Array<Breadcrumb>) =>
       id: index,
       ...convertedCrumbType,
       ...crumbDetails,
+      level: convertedCrumbType?.level ?? BreadcrumbLevelType.UNDEFINED,
     };
   });
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/types.tsx
@@ -9,6 +9,7 @@ export enum BreadcrumbLevelType {
   WARNING = 'warning',
   INFO = 'info',
   DEBUG = 'debug',
+  UNDEFINED = 'undefined',
 }
 
 export enum BreadcrumbType {
@@ -30,10 +31,10 @@ export enum BreadcrumbType {
 }
 
 type BreadcrumbTypeBase = {
+  level: BreadcrumbLevelType;
   timestamp?: string; //it's recommended
   category?: string | null;
   message?: string;
-  level?: BreadcrumbLevelType;
   event_id?: string;
 };
 

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/__snapshots__/filter.spec.tsx.snap
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/__snapshots__/filter.spec.tsx.snap
@@ -1672,7 +1672,16 @@ exports[`Filter default render 1`] = `
                                       className="css-1dx7owx-Tag-StyledTag eio8trv0"
                                       color="blue400"
                                     >
-                                      info
+                                      <Highlight
+                                        text=""
+                                      >
+                                        <HighlightComponent
+                                          className="css-hl9lzc-Highlight em9eqvp0"
+                                          text=""
+                                        >
+                                          info
+                                        </HighlightComponent>
+                                      </Highlight>
                                     </div>
                                   </Component>
                                 </StyledTag>
@@ -1758,7 +1767,16 @@ exports[`Filter default render 1`] = `
                                       className="css-eius55-Tag-StyledTag eio8trv0"
                                       color="red400"
                                     >
-                                      error
+                                      <Highlight
+                                        text=""
+                                      >
+                                        <HighlightComponent
+                                          className="css-hl9lzc-Highlight em9eqvp0"
+                                          text=""
+                                        >
+                                          error
+                                        </HighlightComponent>
+                                      </Highlight>
                                     </div>
                                   </Component>
                                 </StyledTag>


### PR DESCRIPTION
**Description:**
. Rename the main file breadcrumbs.tsx to index.tsx
. Pass down the prop searchTerm 
. Use the component Hightlight together with the searchTerm value
. Fix back slash string comparison issue 

Next Steps:

create crumb's React.context provider and consumer, so it won't have to pass the down the props + 
Improve performance 

closes: https://app.asana.com/0/1158284503473033/1180990285597801

