### PR TITLE
feat(discover): Show top 5 indicator in table rows

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -66,7 +66,9 @@ type GridEditableProps<DataRow, ColumnKey> = {
     ) => React.ReactNode;
     renderBodyCell?: (
       column: GridColumnOrder<ColumnKey>,
-      dataRow: DataRow
+      dataRow: DataRow,
+      rowIndex: number,
+      columnIndex: number
     ) => React.ReactNode;
     onResizeColumn?: (
       columnIndex: number,
@@ -331,7 +333,9 @@ class GridEditable<
           ))}
         {columnOrder.map((col, i) => (
           <GridBodyCell key={`${col.key}${i}`}>
-            {grid.renderBodyCell ? grid.renderBodyCell(col, dataRow) : dataRow[col.key]}
+            {grid.renderBodyCell
+              ? grid.renderBodyCell(col, dataRow, row, i)
+              : dataRow[col.key]}
           </GridBodyCell>
         ))}
       </GridRow>

--- a/src/sentry/static/sentry/app/utils/discover/types.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/types.tsx
@@ -1,6 +1,8 @@
 import {t} from 'app/locale';
 import {SelectValue} from 'app/types';
 
+export const TOP_N = 5;
+
 export enum DisplayModes {
   DEFAULT = 'default',
   PREVIOUS = 'previous',

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -12,7 +12,7 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 import {Panel} from 'app/components/panels';
 import getDynamicText from 'app/utils/getDynamicText';
 import EventView from 'app/utils/discover/eventView';
-import {DisplayModes} from 'app/utils/discover/types';
+import {TOP_N, DisplayModes} from 'app/utils/discover/types';
 import {decodeScalar} from 'app/utils/queryString';
 import withApi from 'app/utils/withApi';
 
@@ -82,7 +82,7 @@ class ResultsChart extends React.Component<ResultsChartProps> {
               field={isTopEvents ? apiPayload.field : undefined}
               interval={eventView.interval}
               showDaily={isDaily}
-              topEvents={isTopEvents ? 5 : undefined}
+              topEvents={isTopEvents ? TOP_N : undefined}
               orderby={isTopEvents ? decodeScalar(apiPayload.sort) : undefined}
               utc={utc === 'true'}
               confirmedQuery={confirmedQuery}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -22,6 +22,7 @@ import EventView, {
 import {Column} from 'app/utils/discover/fields';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 import {generateEventSlug, eventDetailsRouteWithEventView} from 'app/utils/discover/urls';
+import {TOP_N, DisplayModes} from 'app/utils/discover/types';
 import withProjects from 'app/utils/withProjects';
 import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
 import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
@@ -192,23 +193,34 @@ class TableView extends React.Component<TableViewProps> {
 
   _renderGridBodyCell = (
     column: TableColumn<keyof TableDataRow>,
-    dataRow: TableDataRow
+    dataRow: TableDataRow,
+    rowIndex: number,
+    columnIndex: number
   ): React.ReactNode => {
-    const {location, organization, tableData} = this.props;
+    const {eventView, location, organization, tableData} = this.props;
 
     if (!tableData || !tableData.meta) {
       return dataRow[column.key];
     }
     const fieldRenderer = getFieldRenderer(String(column.key), tableData.meta);
 
+    const isTopEvents =
+      eventView.display === DisplayModes.TOP5 ||
+      eventView.display === DisplayModes.DAILYTOP5;
+
     return (
-      <CellAction
-        column={column}
-        dataRow={dataRow}
-        handleCellAction={this.handleCellAction(dataRow, column)}
-      >
-        {fieldRenderer(dataRow, {organization, location})}
-      </CellAction>
+      <React.Fragment>
+        {isTopEvents && rowIndex < TOP_N && columnIndex === 0 ? (
+          <TopNIndicator count={TOP_N} index={rowIndex} />
+        ) : null}
+        <CellAction
+          column={column}
+          dataRow={dataRow}
+          handleCellAction={this.handleCellAction(dataRow, column)}
+        >
+          {fieldRenderer(dataRow, {organization, location})}
+        </CellAction>
+      </React.Fragment>
     );
   };
 
@@ -444,6 +456,33 @@ const StyledLink = styled(Link)`
 
 const StyledIcon = styled(IconStack)`
   vertical-align: middle;
+`;
+
+type TopNIndicatorProps = {
+  count: number;
+  index: number;
+};
+
+const TopNIndicator = styled('div')<TopNIndicatorProps>`
+  position: absolute;
+  left: -1px;
+  width: 9px;
+  height: 15px;
+  border-radius: 0 3px 3px 0;
+
+  background-color: ${p => {
+    // this background color needs to match the colors used in
+    // app/components/charts/eventsChart so that the ordering matches
+
+    // the color pallete contains n + 2 colors, so we subtract 2 here
+    return p.theme.charts.getColorPalette(p.count - 2)[p.index];
+  }};
+
+  & span {
+    display: block;
+    width: 9px;
+    height: 15px;
+  }
 `;
 
 export default withProjects(TableView);

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -211,7 +211,7 @@ class TableView extends React.Component<TableViewProps> {
     return (
       <React.Fragment>
         {isTopEvents && rowIndex < TOP_N && columnIndex === 0 ? (
-          <TopNIndicator count={TOP_N} index={rowIndex} />
+          <TopResultsIndicator count={TOP_N} index={rowIndex} />
         ) : null}
         <CellAction
           column={column}
@@ -458,14 +458,15 @@ const StyledIcon = styled(IconStack)`
   vertical-align: middle;
 `;
 
-type TopNIndicatorProps = {
+type TopResultsIndicatorProps = {
   count: number;
   index: number;
 };
 
-const TopNIndicator = styled('div')<TopNIndicatorProps>`
+const TopResultsIndicator = styled('div')<TopResultsIndicatorProps>`
   position: absolute;
   left: -1px;
+  margin-top: 4.5px;
   width: 9px;
   height: 15px;
   border-radius: 0 3px 3px 0;
@@ -477,12 +478,6 @@ const TopNIndicator = styled('div')<TopNIndicatorProps>`
     // the color pallete contains n + 2 colors, so we subtract 2 here
     return p.theme.charts.getColorPalette(p.count - 2)[p.index];
   }};
-
-  & span {
-    display: block;
-    width: 9px;
-    height: 15px;
-  }
 `;
 
 export default withProjects(TableView);

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -208,10 +208,12 @@ class TableView extends React.Component<TableViewProps> {
       eventView.display === DisplayModes.TOP5 ||
       eventView.display === DisplayModes.DAILYTOP5;
 
+    const count = Math.min(tableData?.data?.length ?? TOP_N, TOP_N);
+
     return (
       <React.Fragment>
         {isTopEvents && rowIndex < TOP_N && columnIndex === 0 ? (
-          <TopResultsIndicator count={TOP_N} index={rowIndex} />
+          <TopResultsIndicator count={count} index={rowIndex} />
         ) : null}
         <CellAction
           column={column}


### PR DESCRIPTION
Visually indicate the top 5 results in the table and their corresponding color
in the graph. This relies on the fact that the top 5 results graphed correspond
to the top 5 rows in the table.

Before:
![Screenshot_2020-07-02 Transactions - Discover - sentry - Sentry(1)](https://user-images.githubusercontent.com/10239353/86400508-ba8a2580-bc76-11ea-909d-f7f892081311.png)

After:
<img width="766" alt="image" src="https://user-images.githubusercontent.com/10239353/86409221-671fd380-bc86-11ea-919d-cf70b40e0ff0.png">
