### PR TITLE
feat: sync allowed avatar mimetypes with frontend

### DIFF
--- a/bin/scan
+++ b/bin/scan
@@ -26,9 +26,11 @@ ignored=(
     # https://snyk.io/vuln/SNYK-PYTHON-DJANGORESTFRAMEWORK-450194
     # XSS in the "browsable api" drf < 3.9.1 view templates - doesn't apply to us.
 
-
-    # Pillow security issues (no py2 compatible fix)
-    # XXX(josh): Assess impact. Seems like those could hurt us during avatar upload
+    # LOW priority: Pillow
+    # This doesn't apply to us, these issues are related to decoding of some less popular image
+    # formats (FLI, PCX, TIFF, JPEG 2000, SGI-RLE) which we do not allow to be uploaded anyways.
+    # Additionally, Pillow maintainers do not intend on backporting the fixes to their py2 versions.
+    # https://github.com/python-pillow/Pillow/issues/4750
     38449
     38450
     38451

--- a/src/sentry/api/fields/avatar.py
+++ b/src/sentry/api/fields/avatar.py
@@ -44,13 +44,11 @@ class AvatarField(serializers.Field):
         if len(data) > self.max_size:
             raise ImageTooLarge()
 
-        try:
-            with Image.open(BytesIO(data)) as img:
-                width, height = img.size
-                if not self.is_valid_size(width, height):
-                    raise serializers.ValidationError("Invalid image dimensions.")
-        except IOError:
-            raise serializers.ValidationError("Invalid image format.")
+        with Image.open(BytesIO(data)) as img:
+            width, height = img.size
+            if not self.is_valid_size(width, height):
+                raise serializers.ValidationError("Invalid image dimensions.")
+        # raise serializers.ValidationError("Invalid image format.")
 
         return BytesIO(data)
 

--- a/src/sentry/api/fields/avatar.py
+++ b/src/sentry/api/fields/avatar.py
@@ -8,9 +8,10 @@ from six import BytesIO
 
 from sentry.api.exceptions import SentryAPIException
 
+# These values must be synced with the avatar cropper in frontend.
 MIN_DIMENSION = 256
-
 MAX_DIMENSION = 1024
+ALLOWED_MIMETYPES = ("image/gif", "image/jpeg", "image/png")
 
 
 class ImageTooLarge(SentryAPIException):
@@ -45,10 +46,12 @@ class AvatarField(serializers.Field):
             raise ImageTooLarge()
 
         with Image.open(BytesIO(data)) as img:
+            if Image.MIME[img.format] not in ALLOWED_MIMETYPES:
+                raise serializers.ValidationError("Invalid image format.")
+
             width, height = img.size
             if not self.is_valid_size(width, height):
                 raise serializers.ValidationError("Invalid image dimensions.")
-        # raise serializers.ValidationError("Invalid image format.")
 
         return BytesIO(data)
 

--- a/src/sentry/static/sentry/app/components/avatarCropper.tsx
+++ b/src/sentry/static/sentry/app/components/avatarCropper.tsx
@@ -59,8 +59,10 @@ class AvatarCropper extends React.Component<Props, State> {
   image = React.createRef<HTMLImageElement>();
   cropContainer = React.createRef<HTMLDivElement>();
 
+  // These values must be synced with the avatar endpoint in backend.
   MIN_DIMENSION = 256;
   MAX_DIMENSION = 1024;
+  ALLOWED_MIMETYPES = 'image/gif,image/jpeg,image/png';
 
   onSelectFile = (ev: React.ChangeEvent<HTMLInputElement>) => {
     const file = ev.target.files && ev.target.files[0];
@@ -404,7 +406,7 @@ class AvatarCropper extends React.Component<Props, State> {
           <UploadInput
             ref={this.file}
             type="file"
-            accept="image/gif,image/jpeg,image/png"
+            accept={this.ALLOWED_MIMETYPES}
             onChange={this.onSelectFile}
           />
         </div>


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/19662#issuecomment-652572115.

Turns out, frontend's had a mimetype filter already. So we simply sync checks on the backend with it.
