### PR TITLE
fix(discover): Fixing regex queries with unicode characters

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -58,7 +58,7 @@ def translate(pat):
             res += re.escape(pat[i])
             i += 1
         elif c == "*":
-            res = res + ".*"
+            res += ".*"
         # TODO: We're disabling everything except for wildcard matching for the
         # moment. Just commenting this code out for the moment, since there's a
         # reasonable chance we'll add this back in in the future.
@@ -82,8 +82,13 @@ def translate(pat):
         #         elif stuff[0] == '^':
         #             stuff = '\\' + stuff
         #         res = '%s[%s]' % (res, stuff)
+        # In py3.7 only characters that can have special meaning in a regular expression are escaped
+        # introduced that here so we don't escape those either
+        # https://github.com/python/cpython/blob/3.7/Lib/re.py#L252
+        elif c in "()[]?*+-|^$\\.&~# \t\n\r\v\f":
+            res += re.escape(c)
         else:
-            res = res + re.escape(c)
+            res += c
     return "^" + res + "$"
 
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1092,7 +1092,26 @@ class GetSnubaQueryArgsTest(TestCase):
         _filter = get_filter("release:3.1.* user.email:*@example.com")
         assert _filter.conditions == [
             [["match", ["release", "'(?i)^3\\.1\\..*$'"]], "=", 1],
-            [["match", ["user.email", "'(?i)^.*\\@example\\.com$'"]], "=", 1],
+            [["match", ["user.email", "'(?i)^.*@example\\.com$'"]], "=", 1],
+        ]
+        assert _filter.filter_keys == {}
+
+    def test_wildcard_with_unicode(self):
+        _filter = get_filter(
+            u"message:*\u716e\u6211\u66f4\u591a\u7684\u98df\u7269\uff0c\u6211\u9913\u4e86."
+        )
+        assert _filter.conditions == [
+            [
+                [
+                    "match",
+                    [
+                        "message",
+                        u"'(?i).*\u716e\u6211\u66f4\u591a\u7684\u98df\u7269\uff0c\u6211\u9913\u4e86\\.'",
+                    ],
+                ],
+                "=",
+                1,
+            ]
         ]
         assert _filter.filter_keys == {}
 
@@ -1107,20 +1126,23 @@ class GetSnubaQueryArgsTest(TestCase):
                 [["isNull", ["release"]], "=", 1],
                 [["match", ["release", "'(?i)^3\\.1\\..*$'"]], "!=", 1],
             ],
-            [["match", ["user.email", "'(?i)^.*\\@example\\.com$'"]], "=", 1],
+            [["match", ["user.email", "'(?i)^.*@example\\.com$'"]], "=", 1],
         ]
         assert _filter.filter_keys == {}
 
     def test_escaped_wildcard(self):
         assert get_filter("release:3.1.\\* user.email:\\*@example.com").conditions == [
             [["match", ["release", "'(?i)^3\\.1\\.\\*$'"]], "=", 1],
-            [["match", ["user.email", "'(?i)^\*\\@example\\.com$'"]], "=", 1],
+            [["match", ["user.email", "'(?i)^\*@example\\.com$'"]], "=", 1],
         ]
         assert get_filter("release:\\\\\\*").conditions == [
             [["match", ["release", "'(?i)^\\\\\\*$'"]], "=", 1]
         ]
         assert get_filter("release:\\\\*").conditions == [
             [["match", ["release", "'(?i)^\\\\.*$'"]], "=", 1]
+        ]
+        assert get_filter("message:.*?").conditions == [
+            [["match", ["message", "'(?i)\..*\?'"]], "=", 1]
         ]
 
     def test_wildcard_array_field(self):

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -824,7 +824,7 @@ class QueryTransformTest(TestCase):
             selected_columns=["transaction"],
             conditions=[
                 ["type", "=", "transaction"],
-                [["match", ["email", "'(?i)^.*\@sentry\.io$'"]], "=", 1],
+                [["match", ["email", "'(?i)^.*@sentry\.io$'"]], "=", 1],
                 [["positionCaseInsensitive", ["message", "'recent-searches'"]], "!=", 0],
             ],
             aggregations=[["count", None, "count"]],

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1470,6 +1470,24 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(response.data["data"]) == 1
         assert response.data["meta"]["message"] == "string"
 
+    def test_email_wildcard_condition(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        data = load_data("javascript")
+        data["timestamp"] = self.min_ago
+        self.store_event(data=data, project_id=project.id)
+
+        with self.feature("organizations:discover-basic"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={"field": ["stack.filename", "message"], "query": "user.email:*@example.org"},
+            )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["meta"]["message"] == "string"
+
     def test_transaction_event_type(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
- Queries would fail when a query contains a wildcard and unicode characters, chinese for
  example. Because we're escaping too much would fail when being handled
  in snuba
- This introduces a slightly modified change from py3.7's [re](https://github.com/python/cpython/blob/3.7/Lib/re.py#L252) that only escapes characters
  that have special meaning in regular expressions