### PR TITLE
ref(ui) Replace icon-processing with SVG icon

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/processingIssueHint.jsx
+++ b/src/sentry/static/sentry/app/components/stream/processingIssueHint.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import {Link} from 'react-router';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styled from '@emotion/styled';
 
+import Button from 'app/components/button';
+import {IconWarning, IconSettings} from 'app/icons';
 import TimeSince from 'app/components/timeSince';
 import {t, tn, tct} from 'app/locale';
+import space from 'app/styles/space';
 
 class ProcessingIssueHint extends React.Component {
   static propTypes = {
@@ -35,13 +37,13 @@ class ProcessingIssueHint extends React.Component {
     if (showProject) {
       project = (
         <span>
-          <strong>{projectId}</strong> &mdash;
+          <strong>{projectId}</strong> &mdash;{' '}
         </span>
       );
     }
 
     if (issue.numIssues > 0) {
-      icon = <span className="icon icon-alert" />;
+      icon = <IconWarning size="sm" color="red400" />;
       text = tn(
         'There is %s issue blocking event processing',
         'There are %s issues blocking event processing',
@@ -59,7 +61,7 @@ class ProcessingIssueHint extends React.Component {
       className['alert-error'] = true;
       showButton = true;
     } else if (issue.issuesProcessing > 0) {
-      icon = <span className="icon icon-processing play" />;
+      icon = <IconSettings size="sm" color="blue400" />;
       className['alert-info'] = true;
       text = tn(
         'Reprocessing %s event …',
@@ -67,7 +69,7 @@ class ProcessingIssueHint extends React.Component {
         issue.issuesProcessing
       );
     } else if (issue.resolveableIssues > 0) {
-      icon = <span className="icon icon-processing" />;
+      icon = <IconSettings size="sm" color="yellow400" />;
       className['alert-warning'] = true;
       text = tn(
         'There is %s event pending reprocessing.',
@@ -81,21 +83,32 @@ class ProcessingIssueHint extends React.Component {
     }
     return (
       <Container className={classNames(className)}>
+        <span>
+          {icon} {project}
+          <strong>{text}</strong> {lastEvent}
+        </span>
         {showButton && (
-          <Link to={link} className="btn btn-default btn-sm pull-right">
+          <Button size="xsmall" to={link}>
             {t('Show details')}
-          </Link>
+          </Button>
         )}
-        {icon} {project}
-        <strong>{text}</strong> {lastEvent}{' '}
       </Container>
     );
   }
 }
 
 const Container = styled('div')`
+  display: flex;
+  justify-content: space-between;
+
   margin: -1px -1px 0;
   padding: 10px 16px;
+
+  svg {
+    position: relative;
+    top: 3px;
+    margin-right: ${space(0.5)};
+  }
 `;
 
 export default ProcessingIssueHint;

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from '@emotion/styled';
 
-import {Panel, PanelItem, PanelBody, PanelAlert} from 'app/components/panels';
+import {IconSettings} from 'app/icons';
+import {Panel, PanelAlert, PanelTable} from 'app/components/panels';
 import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
 import {t, tn} from 'app/locale';
 import Access from 'app/components/acl/access';
@@ -331,21 +333,13 @@ class ProjectProcessingIssues extends React.Component {
     let processingRow = null;
     if (this.state.processingIssues.issuesProcessing > 0) {
       processingRow = (
-        <PanelItem className="alert-info">
-          <div className="row row-flex row-center-vertically">
-            <div className="col-sm-12">
-              <span
-                className="icon icon-processing play"
-                style={{display: 'inline', marginRight: 12}}
-              />
-              {tn(
-                'Reprocessing %s event …',
-                'Reprocessing %s events …',
-                this.state.processingIssues.issuesProcessing
-              )}
-            </div>
-          </div>
-        </PanelItem>
+        <StyledPanelAlert type="info" icon={<IconSettings size="sm" />}>
+          {tn(
+            'Reprocessing %s event …',
+            'Reprocessing %s events …',
+            this.state.processingIssues.issuesProcessing
+          )}
+        </StyledPanelAlert>
       );
     }
 
@@ -367,31 +361,19 @@ class ProjectProcessingIssues extends React.Component {
             )}
           </Access>
         </h3>
-        <div className="panel panel-default">
-          <div className="panel-heading panel-heading-bold hidden-xs">
-            <div className="row">
-              <div className="col-sm-3">{t('Problem')}</div>
-              <div className="col-sm-5">{t('Details')}</div>
-              <div className="col-sm-2">{t('Events')}</div>
-              <div className="col-sm-2">{t('Last seen')}</div>
-            </div>
-          </div>
-          <PanelBody>
-            {processingRow}
-            {this.state.processingIssues.issues.map((item, idx) => (
-              <PanelItem key={idx}>
-                <div className="row row-flex row-center-vertically">
-                  <div className="col-sm-3">{this.renderProblem(item)}</div>
-                  <div className="col-sm-5">{this.renderDetails(item)}</div>
-                  <div className="col-sm-2">{item.numEvents + ''}</div>
-                  <div className="col-sm-2">
-                    <TimeSince date={item.lastSeen} />
-                  </div>
-                </div>
-              </PanelItem>
-            ))}
-          </PanelBody>
-        </div>
+        <PanelTable headers={[t('Problem'), t('Details'), t('Events'), t('Last seen')]}>
+          {processingRow}
+          {this.state.processingIssues.issues.map((item, idx) => (
+            <React.Fragment key={idx}>
+              <div>{this.renderProblem(item)}</div>
+              <div>{this.renderDetails(item)}</div>
+              <div>{item.numEvents + ''}</div>
+              <div>
+                <TimeSince date={item.lastSeen} />
+              </div>
+            </React.Fragment>
+          ))}
+        </PanelTable>
       </div>
     );
   };
@@ -452,6 +434,10 @@ class ProjectProcessingIssues extends React.Component {
     );
   }
 }
+
+const StyledPanelAlert = styled(PanelAlert)`
+  grid-column: 1/5;
+`;
 
 export {ProjectProcessingIssues};
 

--- a/tests/js/spec/components/stream/processingIssueHint.spec.jsx
+++ b/tests/js/spec/components/stream/processingIssueHint.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 
 import ProcessingIssueHint from 'app/components/stream/processingIssueHint';
 
@@ -24,13 +24,13 @@ describe('ProcessingIssueHint', function() {
   describe('numIssues state', function() {
     beforeEach(() => {
       issue.numIssues = 9;
-      wrapper = mount(
+      wrapper = mountWithTheme(
         <ProcessingIssueHint issue={issue} orgId={orgId} projectId={projectId} />
       );
     });
 
     it('displays a button', function() {
-      const button = wrapper.find('Link');
+      const button = wrapper.find('Button');
       expect(button.length).toBe(1);
       expect(button.props().to).toEqual(
         `/settings/${orgId}/projects/${projectId}/processing-issues/`
@@ -38,7 +38,7 @@ describe('ProcessingIssueHint', function() {
     });
 
     it('displays an icon', function() {
-      const icon = wrapper.find('[className*="icon-alert"]');
+      const icon = wrapper.find('IconWarning');
       expect(icon.length).toBe(1);
     });
 
@@ -51,18 +51,18 @@ describe('ProcessingIssueHint', function() {
   describe('issuesProcessing state', function() {
     beforeEach(() => {
       issue.issuesProcessing = 9;
-      wrapper = mount(
+      wrapper = mountWithTheme(
         <ProcessingIssueHint issue={issue} orgId={orgId} projectId={projectId} />
       );
     });
 
     it('does not display a button', function() {
-      const button = wrapper.find('Link');
+      const button = wrapper.find('Button');
       expect(button.length).toBe(0);
     });
 
     it('displays an icon', function() {
-      const icon = wrapper.find('[className*="icon-processing"]');
+      const icon = wrapper.find('IconSettings');
       expect(icon.length).toBe(1);
     });
 
@@ -75,13 +75,13 @@ describe('ProcessingIssueHint', function() {
   describe('resolvableIssues state', function() {
     beforeEach(() => {
       issue.resolveableIssues = 9;
-      wrapper = mount(
+      wrapper = mountWithTheme(
         <ProcessingIssueHint issue={issue} orgId={orgId} projectId={projectId} />
       );
     });
 
     it('displays a button', function() {
-      const button = wrapper.find('Link');
+      const button = wrapper.find('Button');
       expect(button.length).toBe(1);
       expect(button.props().to).toEqual(
         `/settings/${orgId}/projects/${projectId}/processing-issues/`
@@ -89,7 +89,7 @@ describe('ProcessingIssueHint', function() {
     });
 
     it('displays an icon', function() {
-      const icon = wrapper.find('[className*="icon-processing"]');
+      const icon = wrapper.find('IconSettings');
       expect(icon.length).toBe(1);
     });
 
@@ -102,7 +102,7 @@ describe('ProcessingIssueHint', function() {
   describe('showProject state', function() {
     beforeEach(() => {
       issue.numIssues = 9;
-      wrapper = mount(
+      wrapper = mountWithTheme(
         <ProcessingIssueHint
           showProject
           issue={issue}


### PR DESCRIPTION
Replace the icon-processing font icon/animated gif with SVG icons. When updating the project settings page I also noticed that the table was poorly laid out so I replaced it with PanelTable which reduces reliance on bootstrap a bit more as well.

# Before

Issue stream 'alert' box:
![Screen Shot 2020-07-02 at 4 40 16 PM](https://user-images.githubusercontent.com/24086/86412066-317de900-bc8c-11ea-96ae-1f6d36e1f4eb.png)
![Screen Shot 2020-07-02 at 4 41 23 PM](https://user-images.githubusercontent.com/24086/86412069-32af1600-bc8c-11ea-8a55-2c486193af01.png)
![Screen Shot 2020-07-02 at 4 43 07 PM](https://user-images.githubusercontent.com/24086/86412070-3347ac80-bc8c-11ea-9e9e-6db71ae2b819.png)

Project settings:
![Screen Shot 2020-07-02 at 5 13 05 PM](https://user-images.githubusercontent.com/24086/86412109-49556d00-bc8c-11ea-9849-bb5c2cef94cc.png)


# After

Issue stream 'alert' box:

![Screen Shot 2020-07-02 at 4 59 13 PM](https://user-images.githubusercontent.com/24086/86412154-60945a80-bc8c-11ea-8805-e3f839dadc3f.png)
![Screen Shot 2020-07-02 at 5 06 20 PM](https://user-images.githubusercontent.com/24086/86412155-612cf100-bc8c-11ea-9969-3cbe975b005e.png)
![Screen Shot 2020-07-02 at 5 07 18 PM](https://user-images.githubusercontent.com/24086/86412157-61c58780-bc8c-11ea-90ce-c2d04a2d54bf.png)

Project Settings:
![Screen Shot 2020-07-02 at 5 39 27 PM](https://user-images.githubusercontent.com/24086/86412175-6a1dc280-bc8c-11ea-9073-a565d962dcfd.png)
