### PR TITLE
fix(ui) Fix activity log on 404

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationActivity/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity/index.tsx
@@ -48,6 +48,15 @@ class OrganizationActivity extends AsyncView<Props, State> {
     );
   }
 
+  renderError(error?: Error, disableLog = false, disableReport = false): React.ReactNode {
+    const {errors} = this.state;
+    const notFound = Object.values(errors).find(resp => resp && resp.status === 404);
+    if (notFound) {
+      return this.renderBody();
+    }
+    return super.renderError(error, disableLog, disableReport);
+  }
+
   renderBody() {
     const {loading, activity, activityPageLinks} = this.state;
 
@@ -56,8 +65,8 @@ class OrganizationActivity extends AsyncView<Props, State> {
         <PageHeading withMargins>{t('Activity')}</PageHeading>
         <Panel>
           {loading && <LoadingIndicator />}
-          {!loading && !activity.length && this.renderEmpty()}
-          {!loading && !!activity.length && (
+          {!loading && !activity?.length && this.renderEmpty()}
+          {!loading && activity?.length > 0 && (
             <div data-test-id="activity-feed-list">
               {activity.map(item => (
                 <ErrorBoundary

--- a/tests/js/spec/views/organizationActivity/index.spec.jsx
+++ b/tests/js/spec/views/organizationActivity/index.spec.jsx
@@ -45,4 +45,16 @@ describe('OrganizationUserFeedback', function() {
     expect(wrapper.find('ActivityItem')).toHaveLength(0);
     expect(wrapper.find('EmptyMessage')).toHaveLength(1);
   });
+
+  it('renders not found', function() {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/activity/',
+      body: [],
+      statusCode: 404,
+    });
+    const wrapper = mount(<OrganizationActivity {...params} />, routerContext);
+
+    expect(wrapper.find('ActivityItem')).toHaveLength(0);
+    expect(wrapper.find('EmptyMessage')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
When the activity endpoint returns a 404 which can happen when the query ends up with a bad join we shouldn't fail rendering and show a user-feedback modal.

Fixes JAVASCRIPT-229S