### PR TITLE
fix(ui) Fix checkmark icon alignment

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/actionLink.tsx
+++ b/src/sentry/static/sentry/app/components/actions/actionLink.tsx
@@ -73,5 +73,7 @@ export default class ActionLink extends React.Component<ActionLinkProps> {
   }
 }
 const ActionLinkAnchor = styled('a')<{disabled?: boolean}>`
+  display: flex;
+  align-items: center;
   pointer-events: ${p => (p.disabled ? 'none' : 'auto')};
 `;

--- a/src/sentry/static/sentry/app/components/actions/ignore.tsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import styled from '@emotion/styled';
 
+import {IconNot} from 'app/icons';
 import {ResolutionStatusDetails} from 'app/types';
 import {t, tn} from 'app/locale';
 import MenuItem from 'app/components/menuItem';
@@ -11,6 +13,7 @@ import CustomIgnoreCountModal from 'app/components/customIgnoreCountModal';
 import CustomIgnoreDurationModal from 'app/components/customIgnoreDurationModal';
 import ActionLink from 'app/components/actions/actionLink';
 import Tooltip from 'app/components/tooltip';
+import space from 'app/styles/space';
 
 enum ModalStates {
   COUNT,
@@ -108,7 +111,7 @@ export default class IgnoreActions extends React.Component<Props, State> {
               data-test-id="button-unresolve"
               onClick={() => onUpdate({status: 'unresolved'})}
             >
-              <span className="icon-ban" />
+              <IconNot size="xs" />
             </a>
           </Tooltip>
         </div>
@@ -149,7 +152,7 @@ export default class IgnoreActions extends React.Component<Props, State> {
             className={linkClassName}
             onAction={() => onUpdate({status: 'ignored'})}
           >
-            <span className="icon-ban hidden-xs" style={{marginRight: 5}} />
+            <StyledIconNot size="xs" />
             {t('Ignore')}
           </ActionLink>
 
@@ -294,3 +297,10 @@ export default class IgnoreActions extends React.Component<Props, State> {
     );
   }
 }
+
+const StyledIconNot = styled(IconNot)`
+  margin-right: ${space(0.5)};
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    display: none;
+  }
+`;

--- a/src/sentry/static/sentry/app/components/actions/ignore.tsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.tsx
@@ -111,7 +111,7 @@ export default class IgnoreActions extends React.Component<Props, State> {
               data-test-id="button-unresolve"
               onClick={() => onUpdate({status: 'unresolved'})}
             >
-              <IconNot size="xs" />
+              <SoloIconNot size="xs" />
             </a>
           </Tooltip>
         </div>
@@ -303,4 +303,12 @@ const StyledIconNot = styled(IconNot)`
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: none;
   }
+`;
+
+// The icon with no text label needs positioning tweaks
+// inside the bootstrap button. Hopefully this can be removed
+// bootstrap buttons are converted.
+const SoloIconNot = styled(IconNot)`
+  position: relative;
+  top: 1px;
 `;

--- a/src/sentry/static/sentry/app/components/actions/resolve.tsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.tsx
@@ -237,8 +237,6 @@ class ResolveActions extends React.Component<Props, State> {
 }
 
 const StyledIconCheckmark = styled(IconCheckmark)`
-  position: relative;
-  top: 1px;
   margin-right: ${space(0.5)};
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: none;

--- a/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
@@ -117,16 +117,16 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                 size="xs"
               >
                 <IconCheckmark
-                  className="css-1t3bmo8-StyledIconCheckmark enkvoq90"
+                  className="css-g5t06q-StyledIconCheckmark enkvoq90"
                   size="xs"
                 >
                   <ForwardRef(SvgIcon)
-                    className="css-1t3bmo8-StyledIconCheckmark enkvoq90"
+                    className="css-g5t06q-StyledIconCheckmark enkvoq90"
                     data-test-id="icon-check-mark"
                     size="xs"
                   >
                     <svg
-                      className="css-1t3bmo8-StyledIconCheckmark enkvoq90"
+                      className="css-g5t06q-StyledIconCheckmark enkvoq90"
                       data-test-id="icon-check-mark"
                       fill="currentColor"
                       height="12px"
@@ -574,7 +574,7 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                                     >
                                       <a
                                         aria-label="Another version"
-                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                        className=" css-dhyg0k-ActionLinkAnchor ehtyk0g0"
                                         data-test-id="action-link-another-version"
                                         disabled={false}
                                         onClick={[Function]}
@@ -705,7 +705,7 @@ exports[`ResolveActions without confirmation renders 1`] = `
           >
             <a
               aria-label="Resolve"
-              className="btn btn-default btn-sm css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+              className="btn btn-default btn-sm css-dhyg0k-ActionLinkAnchor ehtyk0g0"
               data-test-id="action-link-resolve"
               disabled={false}
               onClick={[Function]}
@@ -714,16 +714,16 @@ exports[`ResolveActions without confirmation renders 1`] = `
                 size="xs"
               >
                 <IconCheckmark
-                  className="css-1t3bmo8-StyledIconCheckmark enkvoq90"
+                  className="css-g5t06q-StyledIconCheckmark enkvoq90"
                   size="xs"
                 >
                   <ForwardRef(SvgIcon)
-                    className="css-1t3bmo8-StyledIconCheckmark enkvoq90"
+                    className="css-g5t06q-StyledIconCheckmark enkvoq90"
                     data-test-id="icon-check-mark"
                     size="xs"
                   >
                     <svg
-                      className="css-1t3bmo8-StyledIconCheckmark enkvoq90"
+                      className="css-g5t06q-StyledIconCheckmark enkvoq90"
                       data-test-id="icon-check-mark"
                       fill="currentColor"
                       height="12px"
@@ -896,7 +896,7 @@ exports[`ResolveActions without confirmation renders 1`] = `
                                     >
                                       <a
                                         aria-label="The next release"
-                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                        className=" css-dhyg0k-ActionLinkAnchor ehtyk0g0"
                                         data-test-id="action-link-the-next-release"
                                         disabled={false}
                                         onClick={[Function]}
@@ -953,7 +953,7 @@ exports[`ResolveActions without confirmation renders 1`] = `
                                     >
                                       <a
                                         aria-label="The current release"
-                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                        className=" css-dhyg0k-ActionLinkAnchor ehtyk0g0"
                                         data-test-id="action-link-the-current-release"
                                         disabled={false}
                                         onClick={[Function]}
@@ -1010,7 +1010,7 @@ exports[`ResolveActions without confirmation renders 1`] = `
                                     >
                                       <a
                                         aria-label="Another version"
-                                        className=" css-1lugp7w-ActionLinkAnchor ehtyk0g0"
+                                        className=" css-dhyg0k-ActionLinkAnchor ehtyk0g0"
                                         data-test-id="action-link-another-version"
                                         disabled={false}
                                         onClick={[Function]}

--- a/tests/js/spec/components/actions/ignore.spec.jsx
+++ b/tests/js/spec/components/actions/ignore.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import $ from 'jquery';
 
-import {mount, mountWithTheme} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 
 import IgnoreActions from 'app/components/actions/ignore';
 
@@ -13,7 +13,10 @@ describe('IgnoreActions', function() {
     const spy = jest.fn();
 
     beforeEach(function() {
-      component = mount(<IgnoreActions onUpdate={spy} disabled />, routerContext);
+      component = mountWithTheme(
+        <IgnoreActions onUpdate={spy} disabled />,
+        routerContext
+      );
       button = component.find('a.btn.btn-default').first();
     });
 
@@ -31,7 +34,10 @@ describe('IgnoreActions', function() {
     let component;
     const spy = jest.fn();
     beforeEach(function() {
-      component = mount(<IgnoreActions onUpdate={spy} isIgnored />, routerContext);
+      component = mountWithTheme(
+        <IgnoreActions onUpdate={spy} isIgnored />,
+        routerContext
+      );
     });
 
     it('displays ignored view', function() {
@@ -51,7 +57,7 @@ describe('IgnoreActions', function() {
     const spy = jest.fn();
 
     beforeEach(function() {
-      component = mount(<IgnoreActions onUpdate={spy} />, routerContext);
+      component = mountWithTheme(<IgnoreActions onUpdate={spy} />, routerContext);
     });
 
     it('calls spy with ignore details when clicked', function() {


### PR DESCRIPTION
It was off by a pixel in chrome. This makes the alignment consistent between chrome an firefox.