### PR TITLE
fix(discover): Fix disabled styling on 'Saved Query' button

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -262,10 +262,10 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
     }
 
     return (
-      <ButtonSaved disabled={this.props.disabled}>
+      <Button disabled data-test-id="discover2-savedquery-button-saved">
         <StyledIconBookmark isSolid size="xs" color="yellow400" />
         {t('Saved query')}
-      </ButtonSaved>
+      </Button>
     );
   }
 
@@ -352,9 +352,6 @@ const ButtonGroup = styled('div')`
 const ButtonSaveAs = styled(DropdownButton)`
   z-index: ${p => p.theme.zIndex.dropdownAutocomplete.actor};
   white-space: nowrap;
-`;
-const ButtonSaved = styled(Button)`
-  cursor: not-allowed;
 `;
 const ButtonSaveDropDown = styled('div')`
   padding: ${space(1)};

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -8,7 +8,7 @@ import EventView from 'app/utils/discover/eventView';
 import * as utils from 'app/views/eventsV2/savedQuery/utils';
 
 const SELECTOR_BUTTON_SAVE_AS = 'ButtonSaveAs';
-const SELECTOR_BUTTON_SAVED = 'ButtonSaved';
+const SELECTOR_BUTTON_SAVED = '[data-test-id="discover2-savedquery-button-saved"]';
 const SELECTOR_BUTTON_UPDATE = '[data-test-id="discover2-savedquery-button-update"]';
 const SELECTOR_BUTTON_DELETE = '[data-test-id="discover2-savedquery-button-delete"]';
 const SELECTOR_BUTTON_CREATE_ALERT = '[data-test-id="discover2-create-from-discover"]';


### PR DESCRIPTION
### Summary
As per https://github.com/getsentry/sentry/pull/19497#issuecomment-647887937 the button should be disabled instead of hidden. It was previously only restyling button and passing disabled in from SavedQueryButtonGroup, which was false as the group as a whole was not disabled. This removes the extra styled button component and forces disabled to true on this button as it doesn't do anything.

### Screenshots
#### Before
![Screen Shot 2020-07-03 at 10 10 39 AM](https://user-images.githubusercontent.com/6111995/86488792-09879780-bd17-11ea-8943-eb944344c466.png)
#### After
![Screen Shot 2020-07-03 at 10 08 25 AM](https://user-images.githubusercontent.com/6111995/86488774-fecd0280-bd16-11ea-98b9-05c28d7b6ae1.png)
