### PR TITLE
fix(discover): Shorten time interval when searching by timestamps

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -137,7 +137,7 @@ def parse_datetime_comparison(value):
     raise InvalidQuery(u"{} is not a valid datetime query".format(value))
 
 
-def parse_datetime_value(value):
+def parse_datetime_value(value, adjust_interval):
     # timezones are not supported and are assumed UTC
     if value[-1:] == "Z":
         value = value[:-1]
@@ -172,7 +172,10 @@ def parse_datetime_value(value):
     if result is None:
         raise InvalidQuery(u"{} is not a valid datetime query".format(value))
 
-    return ((result - timedelta(minutes=5), True), (result + timedelta(minutes=6), False))
+    return (
+        (result - timedelta(minutes=adjust_interval), True),
+        (result + timedelta(minutes=adjust_interval + 1), False),
+    )
 
 
 def parse_datetime_expression(value):

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -490,7 +490,7 @@ def query(
         )
         query = transform_deprecated_functions_in_query(query)
 
-        snuba_filter = get_filter(query, params)
+        snuba_filter = get_filter(query, params, adjust_interval=1)
         if not use_aggregate_conditions:
             snuba_filter.having = []
 
@@ -636,7 +636,7 @@ def get_timeseries_snuba_filter(selected_columns, query, params, rollup, referen
     selected_columns, _ = transform_deprecated_functions_in_columns(selected_columns)
     query = transform_deprecated_functions_in_query(query)
 
-    snuba_filter = get_filter(query, params)
+    snuba_filter = get_filter(query, params, adjust_interval=1)
     if not snuba_filter.start and not snuba_filter.end:
         raise InvalidSearchQuery("Cannot get timeseries result without a start and end.")
 
@@ -961,7 +961,7 @@ def get_pagination_ids(event, query, params, organization, reference_event=None,
     # to use the new function values
     query = transform_deprecated_functions_in_query(query)
 
-    snuba_filter = get_filter(query, params)
+    snuba_filter = get_filter(query, params, adjust_interval=1)
 
     if reference_event:
         ref_conditions = create_reference_event_conditions(reference_event)
@@ -1025,7 +1025,7 @@ def get_facets(query, params, limit=10, referrer=None):
         # to use the new function values
         query = transform_deprecated_functions_in_query(query)
 
-        snuba_filter = get_filter(query, params)
+        snuba_filter = get_filter(query, params, adjust_interval=1)
 
         # Resolve the public aliases into the discover dataset names.
         snuba_filter, translated_columns = resolve_discover_aliases(snuba_filter)


### PR DESCRIPTION
Filtering events by exact timestamp like `timestamp:2020-07-03T05:24:32+00:00`
isn't very useful, so the time range is currently modified to be
`[x-5 minutes, x+6 minutes)`. These values are produces a range too large for
discover/performance queries as the most relevant events are likely to have
happened very close by. This change makes it so that the time range is modified
to be `[x-1 minutes, x+2 minutes)`.