### PR TITLE
ref(ts): Fix converted fields to omit type

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/dateTimeField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/dateTimeField.tsx
@@ -4,6 +4,6 @@ import InputField from './inputField';
 
 type Props = InputField['props'];
 
-export default function DateTimeField(props: Props) {
+export default function DateTimeField(props: Omit<Props, 'type'>) {
   return <InputField {...props} type="datetime-local" />;
 }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/emailField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/emailField.tsx
@@ -4,6 +4,6 @@ import InputField from './inputField';
 
 type Props = InputField['props'];
 
-export default function EmailField(props: Props) {
+export default function EmailField(props: Omit<Props, 'type'>) {
   return <InputField {...props} type="email" />;
 }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/numberField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/numberField.tsx
@@ -4,6 +4,6 @@ import InputField from './inputField';
 
 type Props = InputField['props'];
 
-export default function NumberField(props: Props) {
+export default function NumberField(props: Omit<Props, 'type'>) {
   return <InputField {...props} type="number" />;
 }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/textField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/textField.tsx
@@ -4,7 +4,7 @@ import InputField from 'app/views/settings/components/forms/inputField';
 
 type Props = InputField['props'];
 
-export default function TextField(props: Props) {
+export default function TextField(props: Omit<Props, 'type'>) {
   return <InputField {...props} type="text" />;
 }
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleNameForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleNameForm.tsx
@@ -19,7 +19,6 @@ class RuleNameForm extends React.PureComponent<Props> {
           <TextField
             disabled={disabled}
             name="name"
-            type="text"
             label={t('Rule Name')}
             help={t('Give your rule a name so it is easy to manage later')}
             placeholder={t('Something really bad happened')}


### PR DESCRIPTION
### Summary

Previously in #19501 I converted a few field components over to typescript without omitting type. Since type isn't consumed this fixes the props to omit it and tell consumers that type is not accepted.