### PR TITLE
ref(ui): Refactor `process.env` usage to `app/constants`

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -1,4 +1,3 @@
-/* global process */
 import 'bootstrap/js/alert';
 import 'bootstrap/js/tab';
 import 'bootstrap/js/dropdown';
@@ -20,6 +19,7 @@ import {Integrations} from '@sentry/apm';
 import {ExtraErrorData} from '@sentry/integrations';
 import * as Sentry from '@sentry/react';
 
+import {NODE_ENV, DISABLE_RR_WEB, SPA_DSN} from 'app/constants';
 import {metric} from 'app/utils/analytics';
 import {init as initApiSentryClient} from 'app/utils/apiSentryClient';
 import ConfigStore from 'app/stores/configStore';
@@ -31,7 +31,7 @@ import {normalizeTransactionName} from 'app/utils/apm';
 
 import {setupFavicon} from './favicon';
 
-if (process.env.NODE_ENV === 'development') {
+if (NODE_ENV === 'development') {
   import(
     /* webpackChunkName: "SilenceReactUnsafeWarnings" */ /* webpackMode: "eager" */ 'app/utils/silence-react-unsafe-warnings'
   );
@@ -87,7 +87,7 @@ function getSentryIntegrations(hasReplays: boolean = false) {
 }
 
 const hasReplays =
-  window.__SENTRY__USER && window.__SENTRY__USER.isStaff && !!process.env.DISABLE_RR_WEB;
+  window.__SENTRY__USER && window.__SENTRY__USER.isStaff && !!DISABLE_RR_WEB;
 
 Sentry.init({
   ...window.__SENTRY__OPTIONS,
@@ -95,8 +95,8 @@ Sentry.init({
    * For SPA mode, we need a way to overwrite the default DSN from backend
    * as well as `whitelistUrls`
    */
-  dsn: process.env.SPA_DSN || window.__SENTRY__OPTIONS.dsn,
-  whitelistUrls: process.env.SPA_DSN
+  dsn: SPA_DSN || window.__SENTRY__OPTIONS.dsn,
+  whitelistUrls: SPA_DSN
     ? ['localhost', 'dev.getsentry.net', 'sentry.dev', 'webpack-internal://']
     : window.__SENTRY__OPTIONS.whitelistUrls,
   integrations: getSentryIntegrations(hasReplays),
@@ -141,7 +141,7 @@ const render = (Component: React.ComponentType) => {
   }
 };
 
-if (process.env.NODE_ENV === 'production') {
+if (NODE_ENV === 'production') {
   setupFavicon();
 }
 

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -1,3 +1,4 @@
+/* global process */
 /**
  * Common constants here
  */
@@ -222,7 +223,6 @@ export const DEFAULT_PER_PAGE = 50;
 export const TEAMS_PER_PAGE = 25;
 
 // Webpack configures DEPLOY_PREVIEW_CONFIG for deploy preview builds.
-// eslint-disable-next-line no-undef
 export const DEPLOY_PREVIEW_CONFIG = (process.env.DEPLOY_PREVIEW_CONFIG as unknown) as
   | undefined
   | {
@@ -233,7 +233,6 @@ export const DEPLOY_PREVIEW_CONFIG = (process.env.DEPLOY_PREVIEW_CONFIG as unkno
     };
 
 // Webpack configures EXPERIMENTAL_SPA.
-// eslint-disable-next-line no-undef
 export const EXPERIMENTAL_SPA = (process.env.EXPERIMENTAL_SPA as unknown) as
   | undefined
   | boolean;
@@ -251,3 +250,9 @@ export const ORGANIZATION_FETCH_ERROR_TYPES = {
 export const CONFIG_DOCS_URL = 'https://docs.sentry.io/server/config/';
 export const DISCOVER2_DOCS_URL =
   'https://docs.sentry.io/performance-monitoring/discover-queries/';
+
+export const IS_CI = !!process.env.IS_CI;
+export const IS_PERCY = !!process.env.IS_PERCY;
+export const NODE_ENV = process.env.NODE_ENV;
+export const DISABLE_RR_WEB = !!process.env.DISABLE_RR_WEB;
+export const SPA_DSN = process.env.SPA_DSN;

--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -1,8 +1,8 @@
-/* global process */
 import React from 'react';
 import {Global, css} from '@emotion/core';
 
 import {Theme} from 'app/utils/theme';
+import {IS_CI} from 'app/constants';
 
 const styles = (theme: Theme) => css`
   body {
@@ -20,7 +20,7 @@ const styles = (theme: Theme) => css`
    *
    * See https://web.dev/prefers-reduced-motion/
    */
-  ${process.env.IS_CI &&
+  ${IS_CI &&
     css`
       *,
       ::before,

--- a/src/sentry/static/sentry/app/utils/emotion-setup.tsx
+++ b/src/sentry/static/sentry/app/utils/emotion-setup.tsx
@@ -1,9 +1,10 @@
-/* global process */
-
 // NEEDS to be true for production because of performance
 // But travis builds with NODE_ENV = production, so turn off speed when
+
+import {IS_PERCY} from 'app/constants';
+
 // IS_PERCY is true (i.e. we are in TRAVIS and PERCY_TOKEN is set)
-if (process.env.IS_PERCY) {
+if (IS_PERCY) {
   const sheet = require('emotion').sheet; // eslint-disable-line emotion/no-vanilla
   sheet.speedy(false);
 }

--- a/src/sentry/static/sentry/app/utils/getDynamicText.tsx
+++ b/src/sentry/static/sentry/app/utils/getDynamicText.tsx
@@ -1,4 +1,4 @@
-/* global process */
+import {IS_CI} from 'app/constants';
 
 // Return a specified "fixed" string when we are in a testing environment
 // (more specifically in a PERCY env (e.g. CI))
@@ -9,5 +9,5 @@ export default function getDynamicText<Value, Fixed = Value>({
   value: Value;
   fixed: Fixed;
 }): Value | Fixed {
-  return process.env.IS_CI || process.env.FIXED_DYNAMIC_CONTENT ? fixed : value;
+  return IS_CI ? fixed : value;
 }

--- a/src/sentry/static/sentry/app/utils/marked.tsx
+++ b/src/sentry/static/sentry/app/utils/marked.tsx
@@ -1,6 +1,8 @@
 import marked from 'marked'; // eslint-disable-line no-restricted-imports
 import dompurify from 'dompurify';
 
+import {IS_CI, NODE_ENV} from 'app/constants';
+
 // Only https and mailto, (e.g. no javascript, vbscript, data protocols)
 const safeLinkPattern = /^(https?:|mailto:)/i;
 
@@ -55,9 +57,7 @@ marked.setOptions({
   //      as a html error, instead of throwing an exception, however none of
   //      our tests are rendering failed markdown so this is likely a safe
   //      tradeoff to turn off off the deprecation warning.
-  //
-  // eslint-disable-next-line no-undef
-  silent: !!process.env.IS_CI || process.env.NODE_ENV === 'test',
+  silent: !!IS_CI || NODE_ENV === 'test',
 });
 
 const sanitizedMarked = (...args: Parameters<typeof marked>) =>

--- a/src/sentry/static/sentry/app/utils/testableTransition.tsx
+++ b/src/sentry/static/sentry/app/utils/testableTransition.tsx
@@ -1,5 +1,6 @@
-/* global process */
 import {Transition} from 'framer-motion';
+
+import {IS_CI} from 'app/constants';
 
 /**
  * Use with a framer-motion transition to disable the animation in testing
@@ -15,7 +16,7 @@ import {Transition} from 'framer-motion';
  *
  * This function simply disables the animation `type`.
  */
-const testableTransition = !process.env.IS_CI
+const testableTransition = !IS_CI
   ? (t?: Transition) => t
   : function(transition?: Transition): Transition {
       return {

--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.jsx
@@ -1,4 +1,3 @@
-/* global process */
 import {browserHistory} from 'react-router';
 import DocumentTitle from 'react-document-title';
 import PropTypes from 'prop-types';
@@ -7,6 +6,7 @@ import {motion, AnimatePresence} from 'framer-motion';
 import scrollToElement from 'scroll-to-element';
 import styled from '@emotion/styled';
 
+import {IS_CI} from 'app/constants';
 import {analytics} from 'app/utils/analytics';
 import {t} from 'app/locale';
 import Hook from 'app/components/hook';
@@ -135,7 +135,7 @@ class Onboarding extends React.Component {
     scrollToElement(`#onboarding_step_${step.id}`, {
       align: 'middle',
       // Disable animations in CI - must be < 0 to disable
-      duration: process.env.IS_CI ? -1 : 300,
+      duration: IS_CI ? -1 : 300,
     });
   };
 

--- a/tests/js/spec/utils/getDynamicText.spec.jsx
+++ b/tests/js/spec/utils/getDynamicText.spec.jsx
@@ -1,7 +1,14 @@
-import getDynamicText from 'app/utils/getDynamicText';
-
 describe('getDynamicText', function() {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
   it('renders actual value', function() {
+    jest.doMock('app/constants', () => ({
+      IS_CI: false,
+    }));
+    const getDynamicText = require('app/utils/getDynamicText').default;
+
     expect(
       getDynamicText({
         fixed: 'Text',
@@ -10,16 +17,17 @@ describe('getDynamicText', function() {
     ).toEqual('Dynamic Content');
   });
 
-  it('renders fixed content when `process.env.IS_CI` is true', function() {
-    // eslint-disable-next-line no-undef
-    process.env.IS_CI = true;
+  it('renders fixed content when `app/constants/IS_CI` is true', function() {
+    jest.doMock('app/constants', () => ({
+      IS_CI: true,
+    }));
+    const getDynamicText = require('app/utils/getDynamicText').default;
+
     expect(
       getDynamicText({
         fixed: 'Text',
         value: 'Dynamic Content',
       })
     ).toEqual('Text');
-    // eslint-disable-next-line no-undef
-    process.env.IS_CI = null;
   });
 });


### PR DESCRIPTION
Instead of using the `process.env` global everywhere, only use it in
`app/constants` and re-export it.