### PR TITLE
fix(ui): Fix disabling scroll animations in CI

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.jsx
@@ -134,6 +134,7 @@ class Onboarding extends React.Component {
     const step = this.activeStep;
     scrollToElement(`#onboarding_step_${step.id}`, {
       align: 'middle',
+      // Disable animations in CI - must be < 0 to disable
       duration: process.env.IS_CI ? -1 : 300,
     });
   };

--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.jsx
@@ -134,7 +134,7 @@ class Onboarding extends React.Component {
     const step = this.activeStep;
     scrollToElement(`#onboarding_step_${step.id}`, {
       align: 'middle',
-      duration: process.env.IS_CI ? 0 : 300,
+      duration: process.env.IS_CI ? -1 : 300,
     });
   };
 


### PR DESCRIPTION
`duration: 0` does not disable the animations, but `-1` does.