### PR TITLE
feat(vercel): adds support for project pagination

### DIFF
--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -54,7 +54,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         responses.add(
             responses.GET,
             "https://api.vercel.com/v4/projects/%s" % team_query,
-            json={"projects": []},
+            json={"projects": [], "pagination": {"count": 0}},
         )
 
         responses.add(

--- a/tests/sentry/web/frontend/test_vercel_extension_configuration.py
+++ b/tests/sentry/web/frontend/test_vercel_extension_configuration.py
@@ -36,7 +36,9 @@ class VercelExtensionConfigurationTest(TestCase):
         )
 
         responses.add(
-            responses.GET, "https://api.vercel.com/v4/projects/", json={"projects": []},
+            responses.GET,
+            "https://api.vercel.com/v4/projects/",
+            json={"projects": [], "pagination": {"count": 0}},
         )
 
         responses.add(


### PR DESCRIPTION
Vercel only can return a max of 20 projects at once. To handle pagination, I used a for loop which sets the parameter `since` to the value `next` of the response plus one. If we ever get fewer results than the max of 20, we quit the loop and just return the value. [Docs here](https://vercel.com/docs/api#endpoints/projects/get-projects). Note I put a hard max of 10 iterations on the loop since I don't think we should get past that and I want to make sure this doesn't take forever if there is ever a pagination bug.