### PR TITLE
fix: Replace instances of @sentry/browser with @sentry/react

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/inlineDocs.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/inlineDocs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/react';
 
 import withApi from 'app/utils/withApi';
 import {Client} from 'app/api';

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import map from 'lodash/map';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/react';
 
 import {Organization, SentryTransactionEvent} from 'app/types';
 import {Client} from 'app/api';


### PR DESCRIPTION
Fixing the codebase ahead of https://github.com/getsentry/eslint-config-sentry/pull/72.