### PR TITLE
fix(discover): Don't trim search terms that will be quoted

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -331,7 +331,18 @@ function generateAdditionalConditions(
     // match their name.
     if (dataRow.hasOwnProperty(dataKey)) {
       const value = dataRow[dataKey];
-      const nextValue = value === null || value === undefined ? '' : String(value).trim();
+      // if the value will be quoted, then do not trim it as the whitespaces
+      // may be important to the query and should not be trimmed
+      const shouldQuote =
+        value === null || value === undefined
+          ? false
+          : /[\s\(\)\\"]/g.test(String(value).trim());
+      const nextValue =
+        value === null || value === undefined
+          ? ''
+          : shouldQuote
+          ? String(value)
+          : String(value).trim();
 
       switch (column.field) {
         case 'timestamp':

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -435,6 +435,18 @@ describe('getExpandedResults()', function() {
     const result = getExpandedResults(view, {}, event);
     expect(result.query).toEqual('project.name:whoosh');
   });
+
+  it('should not trim values that need to be quoted', () => {
+    const view = new EventView({
+      ...state,
+      query: '',
+      fields: [{field: 'title'}],
+    });
+    // needs to be quoted because of whitespace in middle
+    const event = {title: 'hello there '};
+    const result = getExpandedResults(view, {}, event);
+    expect(result.query).toEqual('title:"hello there "');
+  });
 });
 
 describe('downloadAsCsv', function() {


### PR DESCRIPTION
If a search term needs to be quoted, then we should not be trimming leading or
trailing whitespaces as they may be necessary.