### PR TITLE
build(snapshot): Updates `action-visual-snapshot` to simplify workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -201,10 +201,10 @@ jobs:
 
         - name: Save snapshots
           if: always()
-          uses: actions/upload-artifact@v2
+          uses: getsentry/action-visual-snapshot@v2
           with:
-            name: visual-snapshots
-            path: .artifacts/visual-snapshots
+            save-only: true
+            snapshot-path: .artifacts/visual-snapshots
 
 
     visual-diff:
@@ -213,24 +213,10 @@ jobs:
       runs-on: ubuntu-16.04
 
       steps:
-        - name: Download base snapshots
-          uses: actions/download-artifact@v2
-          with:
-            name: visual-snapshots
-            path: .artifacts/visual-snapshots
-
         - name: Diff snapshots
           id: visual-snapshots-diff
-          uses: getsentry/action-visual-snapshot@v1
+          uses: getsentry/action-visual-snapshot@v2
           with:
             githubToken: ${{ secrets.GITHUB_TOKEN }}
-            snapshot-path: .artifacts/visual-snapshots
-            diff-path: .artifacts/visual-snapshots-diff
             gcs-bucket: 'sentry-visual-snapshots'
             gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
-
-        - name: Save diffed snapshots
-          uses: actions/upload-artifact@v2
-          with:
-            name: visual-snapshots-diff
-            path: ${{ steps.visual-snapshots-diff.outputs.diff-path }}


### PR DESCRIPTION
Moved downloading/upload artifacts into the action so that the workflow has less configuration.