### PR TITLE
test(acceptance): Inject listener to prevent browser "required" bubbles on form fields

### DIFF
--- a/tests/acceptance/test_auth.py
+++ b/tests/acceptance/test_auth.py
@@ -15,8 +15,12 @@ class AuthTest(AcceptanceTestCase):
         self.browser.snapshot(name="login")
 
     def test_no_credentials(self):
+        self.browser.driver.execute_script(
+            "function _prevent(e) { e.preventDefault(); }; document.addEventListener('invalid', _prevent, true);"
+        )
         self.enter_auth("", "")
         self.browser.snapshot(name="login fields required")
+        self.browser.driver.execute_script("document.removeEventListener('invalid', _prevent);")
 
     def test_invalid_credentials(self):
         self.enter_auth("bad-username", "bad-username")

--- a/tests/acceptance/test_auth.py
+++ b/tests/acceptance/test_auth.py
@@ -16,11 +16,10 @@ class AuthTest(AcceptanceTestCase):
 
     def test_no_credentials(self):
         self.browser.driver.execute_script(
-            "function _prevent(e) { e.preventDefault(); }; document.addEventListener('invalid', _prevent, true);"
+            "document.addEventListener('invalid', function(e) { e.preventDefault(); }, true);"
         )
         self.enter_auth("", "")
         self.browser.snapshot(name="login fields required")
-        self.browser.driver.execute_script("document.removeEventListener('invalid', _prevent);")
 
     def test_invalid_credentials(self):
         self.enter_auth("bad-username", "bad-username")


### PR DESCRIPTION
This injects an event listener to disable the browser "required" popups for form fields to not cause flakes in snapshots