### PR TITLE
test(acceptance): Wait for images to load and input blur before snapshotting

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -190,6 +190,25 @@ class Browser(object):
 
         return self
 
+    def wait_for_images_loaded(self, timeout=10):
+        wait = WebDriverWait(self.driver, timeout)
+        wait.until(
+            lambda driver: driver.execute_script(
+                """return Object.values(document.querySelectorAll('img')).map(el => el.complete).every(i => i)"""
+            )
+        )
+
+        return self
+
+    def blur(self):
+        """
+        Find focused elements and call blur. Useful for snapshot testing that can potentially capture
+        the text cursor blinking
+        """
+        self.driver.execute_script("document.querySelectorAll(':focus').forEach(el => el.blur())")
+
+        return self
+
     @property
     def switch_to(self):
         return self.driver.switch_to
@@ -221,6 +240,9 @@ class Browser(object):
                 time.sleep(1)
 
         if os.environ.get("VISUAL_SNAPSHOT_ENABLE") == "1":
+            # wait for images to be loaded
+            self.wait_for_images_loaded()
+
             self.save_screenshot(
                 u".artifacts/visual-snapshots/acceptance/{}.png".format(slugify(name))
             )

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -49,4 +49,5 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
             self.browser.wait_until_test_id("incident-title")
 
             self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
+            self.browser.blur()
             self.browser.snapshot("incidents - details")

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -169,6 +169,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.page.go_to_subtab("Comments")
 
         self.browser.wait_until_test_id("activity-item")
+        self.browser.blur()
         self.browser.snapshot("issue activity python")
 
     def test_resolved(self):


### PR DESCRIPTION
This adds some methods to our selenium wrapper to wait for images to load before snapshotting. Also adds a method (which must be explicitly called) to force a blur on any focused elements.