### PR TITLE
test(js): Remove explicit `enzyme-to-json` usage

### DIFF
--- a/tests/js/spec/components/checkbox.spec.jsx
+++ b/tests/js/spec/components/checkbox.spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import toJson from 'enzyme-to-json';
 
 import {shallow} from 'sentry-test/enzyme';
 
@@ -9,6 +8,6 @@ describe('Checkbox', function() {
   it('renders', function() {
     const component = shallow(<Checkbox />);
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 });

--- a/tests/js/spec/components/eventOrGroupExtraDetails.spec.jsx
+++ b/tests/js/spec/components/eventOrGroupExtraDetails.spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import toJson from 'enzyme-to-json';
 
 import {shallow} from 'sentry-test/enzyme';
 
@@ -17,7 +16,7 @@ describe('EventOrGroupExtraDetails', function() {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 
   it('renders only first seen', function() {
@@ -30,7 +29,7 @@ describe('EventOrGroupExtraDetails', function() {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 
   it('renders only last seen', function() {
@@ -43,7 +42,7 @@ describe('EventOrGroupExtraDetails', function() {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 
   it('renders all details', function() {
@@ -65,7 +64,7 @@ describe('EventOrGroupExtraDetails', function() {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 
   it('renders assignee and status', function() {
@@ -89,7 +88,7 @@ describe('EventOrGroupExtraDetails', function() {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 
   it('details when mentioned', function() {
@@ -108,6 +107,6 @@ describe('EventOrGroupExtraDetails', function() {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 });

--- a/tests/js/spec/components/eventOrGroupHeader.spec.jsx
+++ b/tests/js/spec/components/eventOrGroupHeader.spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import toJson from 'enzyme-to-json';
 
 import {shallow} from 'sentry-test/enzyme';
 
@@ -37,7 +36,7 @@ describe('EventOrGroupHeader', function() {
         />
       );
 
-      expect(toJson(component)).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
 
     it('renders with `type = csp`', function() {
@@ -53,7 +52,7 @@ describe('EventOrGroupHeader', function() {
         />
       );
 
-      expect(toJson(component)).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
 
     it('renders with `type = default`', function() {
@@ -69,7 +68,7 @@ describe('EventOrGroupHeader', function() {
         />
       );
 
-      expect(toJson(component)).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
   });
 
@@ -95,7 +94,7 @@ describe('EventOrGroupHeader', function() {
         />
       );
 
-      expect(toJson(component)).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
 
     it('renders with `type = csp`', function() {
@@ -111,7 +110,7 @@ describe('EventOrGroupHeader', function() {
         />
       );
 
-      expect(toJson(component)).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
 
     it('renders with `type = default`', function() {
@@ -127,7 +126,7 @@ describe('EventOrGroupHeader', function() {
         />
       );
 
-      expect(toJson(component)).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
 
     it('hides level tag', function() {
@@ -144,7 +143,7 @@ describe('EventOrGroupHeader', function() {
         />
       );
 
-      expect(toJson(component)).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
 
     it('keeps sort in link when query has sort', function() {

--- a/tests/js/spec/components/eventOrGroupTitle.spec.jsx
+++ b/tests/js/spec/components/eventOrGroupTitle.spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import toJson from 'enzyme-to-json';
 
 import {shallow} from 'sentry-test/enzyme';
 
@@ -28,7 +27,7 @@ describe('EventOrGroupTitle', function() {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 
   it('renders with subtitle when `type = csp`', function() {
@@ -43,7 +42,7 @@ describe('EventOrGroupTitle', function() {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 
   it('renders with no subtitle when `type = default`', function() {
@@ -58,6 +57,6 @@ describe('EventOrGroupTitle', function() {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 });

--- a/tests/js/spec/components/spreadLayout.spec.jsx
+++ b/tests/js/spec/components/spreadLayout.spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import toJson from 'enzyme-to-json';
 
 import {shallow} from 'sentry-test/enzyme';
 
@@ -13,7 +12,7 @@ describe('SpreadLayout', function() {
       </SpreadLayout>
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 
   it('renders with multiple children', function() {
@@ -24,6 +23,6 @@ describe('SpreadLayout', function() {
       </SpreadLayout>
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This is outdated and no longer necessary, you can call `toMatchSnapshot()` on the wrapper directly