### PR TITLE
feat(Integrations): Unlink Slack identity

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -20,7 +20,7 @@ from .utils import build_group_attachment, logger
 
 LINK_IDENTITY_MESSAGE = "Looks like you haven't linked your Sentry account with your Slack identity yet! <{associate_url}|Link your identity now> to perform actions in Sentry through Slack."
 
-UNLINK_IDENTITY_MESSAGE = "Looks like this Slack identity is linked to the Sentry user <{user_email}> who is not a member of organization <{org_name}> used with this Slack integration <{associate_url}|Unlink your identity now>."
+UNLINK_IDENTITY_MESSAGE = "Looks like this Slack identity is linked to the Sentry user *{user_email}* who is not a member of organization *{org_name}* used with this Slack integration <{associate_url}|Unlink your identity now>."
 
 DEFAULT_ERROR_MESSAGE = "Sentry can't perform that action right now on your behalf!"
 
@@ -51,7 +51,7 @@ class SlackActionEndpoint(Endpoint):
 
         if error.status_code == 403:
             return self.respond(
-                {"response_type": "ephemeral", "replace_original": False, "text": text,}
+                {"response_type": "ephemeral", "replace_original": False, "text": text}
             )
 
         return self.respond(

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -50,11 +50,7 @@ class SlackActionEndpoint(Endpoint):
         logger.info("slack.action.api-error", extra=logging_data)
 
         return self.respond(
-            {
-                "response_type": "ephemeral",
-                "replace_original": False,
-                "text": error_text,
-            }
+            {"response_type": "ephemeral", "replace_original": False, "text": error_text,}
         )
 
     def on_assign(self, request, identity, group, action):

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -50,7 +50,7 @@ class SlackActionEndpoint(Endpoint):
         logger.info("slack.action.api-error", extra=logging_data)
 
         return self.respond(
-            {"response_type": "ephemeral", "replace_original": False, "text": error_text,}
+            {"response_type": "ephemeral", "replace_original": False, "text": error_text}
         )
 
     def on_assign(self, request, identity, group, action):
@@ -226,13 +226,11 @@ class SlackActionEndpoint(Endpoint):
                 self.on_status(request, identity, group, action, data, integration)
             except client.ApiError as e:
 
-                unlinking_url = build_unlinking_url(
-                    integration.id, group.organization.id, user_id, channel_id, response_url
-                )
-
                 if e.status_code == 403:
                     text = UNLINK_IDENTITY_MESSAGE.format(
-                        associate_url=unlinking_url,
+                        associate_url=build_unlinking_url(
+                            integration.id, group.organization.id, user_id, channel_id, response_url
+                        ),
                         user_email=identity.user,
                         org_name=group.organization.name,
                     )
@@ -280,13 +278,11 @@ class SlackActionEndpoint(Endpoint):
                     defer_attachment_update = True
         except client.ApiError as e:
 
-            unlinking_url = build_unlinking_url(
-                integration.id, group.organization.id, user_id, channel_id, response_url
-            )
-
             if e.status_code == 403:
                 text = UNLINK_IDENTITY_MESSAGE.format(
-                    associate_url=unlinking_url,
+                    associate_url=build_unlinking_url(
+                        integration.id, group.organization.id, user_id, channel_id, response_url
+                    ),
                     user_email=identity.user,
                     org_name=group.organization.name,
                 )

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -20,7 +20,7 @@ from .utils import build_group_attachment, logger
 
 LINK_IDENTITY_MESSAGE = "Looks like you haven't linked your Sentry account with your Slack identity yet! <{associate_url}|Link your identity now> to perform actions in Sentry through Slack."
 
-UNLINK_IDENTITY_MESSAGE = "Looks like this Slack identity is linked to the Sentry user *{user_email}* who is not a member of organization *{org_name}* used with this Slack integration <{associate_url}|Unlink your identity now>."
+UNLINK_IDENTITY_MESSAGE = "Looks like this Slack identity is linked to the Sentry user *{user_email}* who is not a member of organization *{org_name}* used with this Slack integration. <{associate_url}|Unlink your identity now>."
 
 DEFAULT_ERROR_MESSAGE = "Sentry can't perform that action right now on your behalf!"
 

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -42,7 +42,7 @@ class SlackActionEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
 
-    def api_error(self, error, action_type, logging_data, text):
+    def api_error(self, error, action_type, logging_data, unauthorized_error_text):
         logging_data = logging_data.copy()
         logging_data["response"] = six.text_type(error.body)
         logging_data["action_type"] = action_type
@@ -51,7 +51,7 @@ class SlackActionEndpoint(Endpoint):
 
         if error.status_code == 403:
             return self.respond(
-                {"response_type": "ephemeral", "replace_original": False, "text": text}
+                {"response_type": "ephemeral", "replace_original": False, "text": unauthorized_error_text}
             )
 
         return self.respond(

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -16,7 +16,7 @@ from sentry.web.helpers import render_to_response
 from sentry.shared_integrations.exceptions import ApiError
 
 from .client import SlackClient
-from .utils import logger, getIdentity
+from .utils import logger, get_identity
 
 
 def build_linking_url(integration, organization, slack_id, channel_id, response_url):
@@ -39,7 +39,9 @@ class SlackLinkIdentityView(BaseView):
     def handle(self, request, signed_params):
         params = unsign(signed_params.encode("ascii", errors="ignore"))
 
-        organization, integration, idp = getIdentity(request, params)
+        organization, integration, idp = get_identity(
+            request.user, params["organization_id"], params["integration_id"]
+        )
 
         if request.method != "POST":
             return render_to_response(

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -4,11 +4,10 @@ import six
 
 from django.core.urlresolvers import reverse
 from django.db import IntegrityError
-from django.http import Http404
 from django.utils import timezone
 from django.views.decorators.cache import never_cache
 
-from sentry.models import Integration, Identity, IdentityProvider, IdentityStatus, Organization
+from sentry.models import Identity, IdentityStatus
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 from sentry.web.decorators import transaction_start
@@ -17,7 +16,7 @@ from sentry.web.helpers import render_to_response
 from sentry.shared_integrations.exceptions import ApiError
 
 from .client import SlackClient
-from .utils import logger
+from .utils import logger, getIdentity
 
 
 def build_linking_url(integration, organization, slack_id, channel_id, response_url):
@@ -40,24 +39,7 @@ class SlackLinkIdentityView(BaseView):
     def handle(self, request, signed_params):
         params = unsign(signed_params.encode("ascii", errors="ignore"))
 
-        try:
-            organization = Organization.objects.get(
-                id__in=request.user.get_orgs(), id=params["organization_id"]
-            )
-        except Organization.DoesNotExist:
-            raise Http404
-
-        try:
-            integration = Integration.objects.get(
-                id=params["integration_id"], organizations=organization
-            )
-        except Integration.DoesNotExist:
-            raise Http404
-
-        try:
-            idp = IdentityProvider.objects.get(external_id=integration.external_id, type="slack")
-        except IdentityProvider.DoesNotExist:
-            raise Http404
+        organization, integration, idp = getIdentity(request, params)
 
         if request.method != "POST":
             return render_to_response(

--- a/src/sentry/integrations/slack/unlink_identity.py
+++ b/src/sentry/integrations/slack/unlink_identity.py
@@ -16,7 +16,7 @@ from sentry.web.helpers import render_to_response
 from sentry.shared_integrations.exceptions import ApiError
 
 from .client import SlackClient
-from .utils import logger, getIdentity
+from .utils import logger, get_identity
 
 
 def build_unlinking_url(integration_id, organization_id, slack_id, channel_id, response_url):
@@ -39,7 +39,9 @@ class SlackUnlinkIdentityView(BaseView):
     def handle(self, request, signed_params):
         params = unsign(signed_params.encode("ascii", errors="ignore"))
 
-        organization, integration, idp = getIdentity(request, params)
+        organization, integration, idp = get_identity(
+            request.user, params["organization_id"], params["integration_id"]
+        )
 
         if request.method != "POST":
             return render_to_response(

--- a/src/sentry/integrations/slack/unlink_identity.py
+++ b/src/sentry/integrations/slack/unlink_identity.py
@@ -1,0 +1,99 @@
+from __future__ import absolute_import, print_function
+
+import six
+
+from django.core.urlresolvers import reverse
+from django.db import IntegrityError
+from django.http import Http404
+from django.views.decorators.cache import never_cache
+
+from sentry.models import Integration, Identity, IdentityProvider, Organization
+from sentry.utils.http import absolute_uri
+from sentry.utils.signing import sign, unsign
+from sentry.web.decorators import transaction_start
+from sentry.web.frontend.base import BaseView
+from sentry.web.helpers import render_to_response
+from sentry.shared_integrations.exceptions import ApiError
+
+from .client import SlackClient
+from .utils import logger
+
+
+def build_unlinking_url(integration_id, organization_id, slack_id, channel_id, response_url):
+    signed_params = sign(
+        integration_id=integration_id,
+        organization_id=organization_id,
+        slack_id=slack_id,
+        channel_id=channel_id,
+        response_url=response_url,
+    )
+
+    return absolute_uri(
+        reverse("sentry-integration-slack-unlink-identity", kwargs={"signed_params": signed_params})
+    )
+
+
+class SlackUnlinkIdentityView(BaseView):
+    @transaction_start("SlackUnlinkIdentityView")
+    @never_cache
+    def handle(self, request, signed_params):
+        params = unsign(signed_params.encode("ascii", errors="ignore"))
+
+        try:
+            organization = Organization.objects.get(
+                id__in=request.user.get_orgs(), id=params["organization_id"]
+            )
+        except Organization.DoesNotExist:
+            raise Http404
+
+        try:
+            integration = Integration.objects.get(
+                id=params["integration_id"], organizations=organization
+            )
+        except Integration.DoesNotExist:
+            raise Http404
+
+        try:
+            idp = IdentityProvider.objects.get(external_id=integration.external_id, type="slack")
+        except IdentityProvider.DoesNotExist:
+            raise Http404
+
+        if request.method != "POST":
+            return render_to_response(
+                "sentry/auth-unlink-identity.html",
+                request=request,
+                context={"organization": organization, "provider": integration.get_provider()},
+            )
+
+        # Delete the wrong slack identity.
+        try:
+            identity = Identity.objects.get(idp=idp, external_id=params["slack_id"])
+            identity.delete()
+        except IntegrityError as e:
+            logger.error("slack.unlink.integrity-error", extra=e)
+            raise Http404
+
+        payload = {
+            "replace_original": False,
+            "response_type": "ephemeral",
+            "text": "Your Slack identity has been unlinked from your Sentry account.",
+        }
+
+        client = SlackClient()
+        try:
+            client.post(params["response_url"], data=payload, json=True)
+        except ApiError as e:
+            message = six.text_type(e)
+            # If the user took their time to link their slack account, we may no
+            # longer be able to respond, and we're not guaranteed able to post into
+            # the channel. Ignore Expired url errors.
+            #
+            # XXX(epurkhiser): Yes the error string has a space in it.
+            if message != "Expired url":
+                logger.error("slack.unlink-notify.response-error", extra={"error": message})
+
+        return render_to_response(
+            "sentry/slack-unlinked.html",
+            request=request,
+            context={"channel_id": params["channel_id"], "team_id": integration.external_id},
+        )

--- a/src/sentry/integrations/slack/urls.py
+++ b/src/sentry/integrations/slack/urls.py
@@ -5,7 +5,7 @@ from django.conf.urls import url
 from .action_endpoint import SlackActionEndpoint
 from .event_endpoint import SlackEventEndpoint
 from .link_identity import SlackLinkIdentityView
-
+from .unlink_identity import SlackUnlinkIdentityView
 
 urlpatterns = [
     url(r"^action/$", SlackActionEndpoint.as_view()),
@@ -14,5 +14,10 @@ urlpatterns = [
         r"^link-identity/(?P<signed_params>[^\/]+)/$",
         SlackLinkIdentityView.as_view(),
         name="sentry-integration-slack-link-identity",
+    ),
+    url(
+        r"^unlink-identity/(?P<signed_params>[^\/]+)/$",
+        SlackUnlinkIdentityView.as_view(),
+        name="sentry-integration-slack-unlink-identity",
     ),
 ]

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
+from django.http import Http404
 
 from sentry import tagstore
 from sentry import options
@@ -24,7 +25,9 @@ from sentry.models import (
     Project,
     User,
     Identity,
+    IdentityProvider,
     Integration,
+    Organization,
     Team,
     ReleaseProject,
 )
@@ -488,3 +491,26 @@ def send_incident_alert_notification(action, incident, metric_value):
         client.post("/chat.postMessage", data=payload, timeout=5)
     except ApiError as e:
         logger.info("rule.fail.slack_post", extra={"error": six.text_type(e)})
+
+
+def getIdentity(request, params):
+    try:
+        organization = Organization.objects.get(
+            id__in=request.user.get_orgs(), id=params["organization_id"]
+        )
+    except Organization.DoesNotExist:
+        raise Http404
+
+    try:
+        integration = Integration.objects.get(
+            id=params["integration_id"], organizations=organization
+        )
+    except Integration.DoesNotExist:
+        raise Http404
+
+    try:
+        idp = IdentityProvider.objects.get(external_id=integration.external_id, type="slack")
+    except IdentityProvider.DoesNotExist:
+        raise Http404
+
+    return organization, integration, idp

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -493,18 +493,14 @@ def send_incident_alert_notification(action, incident, metric_value):
         logger.info("rule.fail.slack_post", extra={"error": six.text_type(e)})
 
 
-def getIdentity(request, params):
+def get_identity(user, organization_id, integration_id):
     try:
-        organization = Organization.objects.get(
-            id__in=request.user.get_orgs(), id=params["organization_id"]
-        )
+        organization = Organization.objects.get(id__in=user.get_orgs(), id=organization_id)
     except Organization.DoesNotExist:
         raise Http404
 
     try:
-        integration = Integration.objects.get(
-            id=params["integration_id"], organizations=organization
-        )
+        integration = Integration.objects.get(id=integration_id, organizations=organization)
     except Integration.DoesNotExist:
         raise Http404
 

--- a/src/sentry/templates/sentry/auth-unlink-identity.html
+++ b/src/sentry/templates/sentry/auth-unlink-identity.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load sentry_assets %}
 
-{% block title %}{% trans "Link Identity" %} | {{ block.super }}{% endblock %}
+{% block title %}{% trans "Unlink Identity" %} | {{ block.super }}{% endblock %}
 
 {% block auth_main %}
 <form class="form-stacked" action="" method="post">

--- a/src/sentry/templates/sentry/auth-unlink-identity.html
+++ b/src/sentry/templates/sentry/auth-unlink-identity.html
@@ -1,0 +1,29 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% load sentry_assets %}
+
+{% block title %}{% trans "Link Identity" %} | {{ block.super }}{% endblock %}
+
+{% block auth_main %}
+<form class="form-stacked" action="" method="post">
+  {% csrf_token %}
+
+  <div class="align-center">
+    <img src="{% asset_url "sentry" "images/logos/default-organization-logo.png" %}" class="org-avatar">
+
+    <h3>{{ organization.name }}</h3>
+  </div>
+
+  <div class="align-center">
+    <p>Confirm that you'd like to unlink your {{ provider.name }} identity from your Sentry account.</p>
+
+    <p>
+      <button type="submit" class="btn btn-default btn-login-{{ provider.key }}">
+        <span class="provider-logo {{ provider.key }}"></span> Unlink with {{ provider.name }}
+      </button>
+    </p>
+  </div>
+</form>
+{% endblock %}

--- a/src/sentry/templates/sentry/slack-unlinked.html
+++ b/src/sentry/templates/sentry/slack-unlinked.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Slack Linked" %} | {{ block.super }}{% endblock %}
+{% block title %}{% trans "Slack Unlinked" %} | {{ block.super }}{% endblock %}
 {% block wrapperclass %}narrow auth{% endblock %}
 
 {% block main %}

--- a/src/sentry/templates/sentry/slack-unlinked.html
+++ b/src/sentry/templates/sentry/slack-unlinked.html
@@ -1,0 +1,19 @@
+{% extends "sentry/bases/modal.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Slack Linked" %} | {{ block.super }}{% endblock %}
+{% block wrapperclass %}narrow auth{% endblock %}
+
+{% block main %}
+  <div class="align-center">
+    <p>
+      {% trans "Your Slack identity has been unassociated with your Sentry account." %}
+    </p>
+    <p>
+      <a href="slack://channel?id={{ channel_id }}&team={{ team_id }}" class="btn btn-default btn-login-slack">
+        <span class="provider-logo slack"></span> Go back to Slack
+      </a>
+    </p>
+  </div>
+{% endblock %}

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -21,8 +21,9 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase
 from sentry.utils import json
-from sentry.integrations.slack.action_endpoint import LINK_IDENTITY_MESSAGE
+from sentry.integrations.slack.action_endpoint import LINK_IDENTITY_MESSAGE, UNLINK_IDENTITY_MESSAGE
 from sentry.integrations.slack.link_identity import build_linking_url
+from sentry.integrations.slack.unlink_identity import build_unlinking_url
 
 
 class BaseEventTest(APITestCase):
@@ -329,12 +330,14 @@ class StatusActionTest(BaseEventTest):
         )
         self.group1 = Group.objects.get(id=self.group1.id)
 
-        assert resp.status_code == 200, resp.content
-        assert not self.group1.get_status() == GroupStatus.IGNORED
+        associate_url = build_unlinking_url(
+            self.integration.id, self.org.id, "slack_id2", "C065W1189", self.response_url
+        )
 
+        assert resp.status_code == 200, resp.content
         assert resp.data["response_type"] == "ephemeral"
         assert not resp.data["replace_original"]
-        assert resp.data["text"] == "Sentry can't perform that action right now on your behalf!"
+        assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
 
     @responses.activate
     @patch("sentry.api.client.put")
@@ -388,8 +391,12 @@ class StatusActionTest(BaseEventTest):
 
         client_put.asser_called()
 
+        associate_url = build_unlinking_url(
+            self.integration.id, self.org.id, "slack_id", "C065W1189", self.response_url
+        )
+
         assert resp.status_code == 200, resp.content
-        assert resp.data["text"] == "Sentry can't perform that action right now on your behalf!"
+        assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
 
     def test_invalid_token(self):
         resp = self.post_webhook(token="invalid")

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -337,7 +337,9 @@ class StatusActionTest(BaseEventTest):
         assert resp.status_code == 200, resp.content
         assert resp.data["response_type"] == "ephemeral"
         assert not resp.data["replace_original"]
-        assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
+        assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
+            associate_url=associate_url, user_email=user2.email, org_name=self.org.name
+        )
 
     @responses.activate
     @patch("sentry.api.client.put")
@@ -396,7 +398,9 @@ class StatusActionTest(BaseEventTest):
         )
 
         assert resp.status_code == 200, resp.content
-        assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
+        assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
+            associate_url=associate_url, user_email=self.user.email, org_name=self.org.name
+        )
 
     def test_invalid_token(self):
         resp = self.post_webhook(token="invalid")

--- a/tests/sentry/integrations/slack/test_unlink_identity.py
+++ b/tests/sentry/integrations/slack/test_unlink_identity.py
@@ -1,0 +1,80 @@
+from __future__ import absolute_import
+
+import responses
+
+from sentry.utils.compat.mock import patch
+
+from sentry.models import (
+    Identity,
+    IdentityProvider,
+    IdentityStatus,
+    Integration,
+    OrganizationIntegration,
+)
+from sentry.testutils import TestCase
+from sentry.integrations.slack.unlink_identity import build_unlinking_url
+
+
+class SlackIntegrationLinkIdentityTest(TestCase):
+    def setUp(self):
+        super(TestCase, self).setUp()
+        self.user1 = self.create_user(is_superuser=False)
+        self.user2 = self.create_user(is_superuser=False)
+        self.org = self.create_organization(owner=None)
+        self.team = self.create_team(organization=self.org, members=[self.user1, self.user2])
+
+        self.login_as(self.user1)
+
+        self.integration = Integration.objects.create(
+            provider="slack",
+            external_id="TXXXXXXX1",
+            metadata={"access_token": "xoxa-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
+        OrganizationIntegration.objects.create(organization=self.org, integration=self.integration)
+
+        self.idp = IdentityProvider.objects.create(type="slack", external_id="TXXXXXXX1", config={})
+
+    @responses.activate
+    @patch("sentry.integrations.slack.link_identity.unsign")
+    def test_basic_flow(self, unsign):
+
+        Identity.objects.create(
+            user=self.user1, idp=self.idp, external_id="new-slack-id", status=IdentityStatus.VALID
+        )
+
+        unsign.return_value = {
+            "integration_id": self.integration.id,
+            "organization_id": self.org.id,
+            "slack_id": "new-slack-id",
+            "channel_id": "my-channel",
+            "response_url": "http://example.slack.com/response_url",
+        }
+
+        unlinking_url = build_unlinking_url(
+            self.integration.id,
+            self.org.id,
+            "new-slack-id",
+            "my-channel",
+            "http://example.slack.com/response_url",
+        )
+
+        resp = self.client.get(unlinking_url)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/auth-unlink-identity.html")
+
+        responses.add(
+            method=responses.POST,
+            url="http://example.slack.com/response_url",
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+
+        # Unlink identity of user
+        resp = self.client.post(unlinking_url)
+
+        identity = Identity.objects.filter(external_id="new-slack-id", user=self.user1)
+
+        assert len(identity) == 0
+        assert len(responses.calls) == 1


### PR DESCRIPTION
## Objective
We often see complaints from support that users get the error `Sentry can't perform that action right now on your behalf` when interacting with a Slack alert message (e.g. pressing ignore). The reason for the error is that the Slack identity is linked to a user that is not part of the organization for the Slack integration installation. Right now, there is no way to unlink the identity which is the source of the problem.

The solution is to make a very simple unlink identity view where the user can unlink their Slack identity. If we have a 403 unauthorized error in the function `api_error`, we should tell the user the problem is that they don't have access and if they think that is an error, they should go to the link in the message to unlink their identity.

## Flow
![unlink-slack-identity-flow](https://user-images.githubusercontent.com/10491193/86707789-2816b880-bfcd-11ea-8e42-ddd2a31d5746.gif)

## Test Plan
I have updated existing tests and wrote a new integration test for the unlinking flow.