### PR TITLE
ref(sdk): Use new sentry-sdk tracing api for setting up transactions

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -50,7 +50,7 @@ redis==2.10.6
 requests-oauthlib==1.2.0
 requests[security]>=2.20.0,<2.21.0
 sentry-relay>=0.5.10,<0.6.0
-sentry-sdk>=0.13.5,<0.16.0
+sentry-sdk>=0.16.0,<0.17.0
 simplejson>=3.2.0,<3.9.0
 six>=1.11.0,<1.12.0
 sqlparse>=0.2.0,<0.3.0

--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -8,7 +8,6 @@ from rest_framework.response import Response
 from django.conf import settings
 
 from sentry_sdk import Hub
-from sentry_sdk.tracing import Span
 
 from sentry.api.base import Endpoint
 from sentry.api.permissions import RelayPermission
@@ -32,8 +31,8 @@ class RelayProjectConfigsEndpoint(Endpoint):
     permission_classes = (RelayPermission,)
 
     def post(self, request):
-        with Hub.current.start_span(
-            Span(op="http.server", transaction="RelayProjectConfigsEndpoint", sampled=_sample_apm())
+        with Hub.current.start_transaction(
+            op="http.server", name="RelayProjectConfigsEndpoint", sampled=_sample_apm(),
         ):
             return self._post(request)
 

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -115,7 +115,7 @@ def trace_func(**span_kwargs):
             span_kwargs["sampled"] = random.random() < getattr(
                 settings, "SENTRY_INGEST_CONSUMER_APM_SAMPLING", 0
             )
-            with sentry_sdk.start_span(**span_kwargs):
+            with sentry_sdk.start_transaction(**span_kwargs):
                 return f(*args, **kwargs)
 
         return inner
@@ -123,7 +123,7 @@ def trace_func(**span_kwargs):
     return wrapper
 
 
-@trace_func(transaction="ingest_consumer.process_transactions_batch")
+@trace_func(name="ingest_consumer.process_transactions_batch")
 @metrics.wraps("ingest_consumer.process_transactions_batch")
 def process_transactions_batch(messages, projects):
     if options.get("store.transactions-celery") is True:
@@ -221,12 +221,12 @@ def _do_process_event(message, projects):
     event_accepted.send_robust(ip=remote_addr, data=data, project=project, sender=process_event)
 
 
-@trace_func(transaction="ingest_consumer.process_event")
+@trace_func(name="ingest_consumer.process_event")
 def process_event(message, projects):
     return _do_process_event(message, projects)
 
 
-@trace_func(transaction="ingest_consumer.process_attachment_chunk")
+@trace_func(name="ingest_consumer.process_attachment_chunk")
 @metrics.wraps("ingest_consumer.process_attachment_chunk")
 def process_attachment_chunk(message, projects):
     payload = message["payload"]
@@ -240,7 +240,7 @@ def process_attachment_chunk(message, projects):
     )
 
 
-@trace_func(transaction="ingest_consumer.process_individual_attachment")
+@trace_func(name="ingest_consumer.process_individual_attachment")
 @metrics.wraps("ingest_consumer.process_individual_attachment")
 def process_individual_attachment(message, projects):
     event_id = message["event_id"]
@@ -296,7 +296,7 @@ def process_individual_attachment(message, projects):
     attachment.delete()
 
 
-@trace_func(transaction="ingest_consumer.process_userreport")
+@trace_func(name="ingest_consumer.process_userreport")
 @metrics.wraps("ingest_consumer.process_userreport")
 def process_userreport(message, projects):
     project_id = int(message["project_id"])

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -208,9 +208,9 @@ class BaseApiClient(object):
             tags={self.integration_type: self.name},
         )
 
-        with sentry_sdk.start_span(
+        with sentry_sdk.start_transaction(
             op=u"{}.http".format(self.integration_type),
-            transaction=u"{}.http_response.{}".format(self.integration_type, self.name),
+            name=u"{}.http_response.{}".format(self.integration_type, self.name),
         ) as span:
             try:
                 resp = getattr(session, method.lower())(

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -6,7 +6,6 @@ import jsonschema
 import pytz
 import sentry_sdk
 import six
-from sentry_sdk.tracing import Span
 from confluent_kafka import Consumer, KafkaException, OFFSET_INVALID, TopicPartition
 from dateutil.parser import parse as parse_date
 from django.conf import settings
@@ -125,12 +124,10 @@ class QuerySubscriptionConsumer(object):
 
                 i = i + 1
 
-                with sentry_sdk.start_span(
-                    Span(
-                        op="handle_message",
-                        transaction="query_subscription_consumer_process_message",
-                        sampled=True,
-                    )
+                with sentry_sdk.start_transaction(
+                    op="handle_message",
+                    name="query_subscription_consumer_process_message",
+                    sampled=True,
                 ), metrics.timer("snuba_query_subscriber.handle_message"):
                     self.handle_message(message)
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -5,7 +5,6 @@ import time
 import sentry_sdk
 
 from django.conf import settings
-from sentry_sdk.tracing import Span
 
 from sentry import features
 from sentry.utils.cache import cache
@@ -179,8 +178,8 @@ def post_process_group(event, is_new, is_regression, is_new_group_environment, *
             # objects back and forth isn't super efficient
             for callback, futures in rp.apply():
                 has_alert = True
-                with sentry_sdk.start_span(
-                    Span(op="post_process_group", transaction="rule_processor_apply", sampled=True)
+                with sentry_sdk.start_transaction(
+                    op="post_process_group", name="rule_processor_apply", sampled=True
                 ):
                     safe_execute(callback, event, futures)
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -9,7 +9,6 @@ from django.utils import timezone
 from django.conf import settings
 
 import sentry_sdk
-from sentry_sdk.tracing import Span
 from sentry_relay.processing import StoreNormalizer
 
 from sentry import features, reprocessing, options
@@ -296,12 +295,10 @@ def symbolicate_event(cache_key, start_time=None, event_id=None, **kwargs):
     :param int start_time: the timestamp when the event was ingested
     :param string event_id: the event identifier
     """
-    with sentry_sdk.start_span(
-        Span(
-            op="tasks.store.symbolicate_event",
-            transaction="TaskSymbolicateEvent",
-            sampled=sample_symbolicate_event_apm(),
-        )
+    with sentry_sdk.start_transaction(
+        op="tasks.store.symbolicate_event",
+        name="TaskSymbolicateEvent",
+        sampled=sample_symbolicate_event_apm(),
     ):
         return _do_symbolicate_event(
             cache_key=cache_key,
@@ -318,12 +315,10 @@ def symbolicate_event(cache_key, start_time=None, event_id=None, **kwargs):
     soft_time_limit=60,
 )
 def symbolicate_event_from_reprocessing(cache_key, start_time=None, event_id=None, **kwargs):
-    with sentry_sdk.start_span(
-        Span(
-            op="tasks.store.symbolicate_event_from_reprocessing",
-            transaction="TaskSymbolicateEvent",
-            sampled=sample_symbolicate_event_apm(),
-        )
+    with sentry_sdk.start_transaction(
+        op="tasks.store.symbolicate_event_from_reprocessing",
+        name="TaskSymbolicateEvent",
+        sampled=sample_symbolicate_event_apm(),
     ):
         return _do_symbolicate_event(
             cache_key=cache_key,
@@ -553,12 +548,8 @@ def process_event(cache_key, start_time=None, event_id=None, data_has_changed=No
     :param string event_id: the event identifier
     :param boolean data_has_changed: set to True if the event data was changed in previous tasks
     """
-    with sentry_sdk.start_span(
-        Span(
-            op="tasks.store.process_event",
-            transaction="TaskProcessEvent",
-            sampled=sample_process_event_apm(),
-        )
+    with sentry_sdk.start_transaction(
+        op="tasks.store.process_event", name="TaskProcessEvent", sampled=sample_process_event_apm(),
     ):
         return _do_process_event(
             cache_key=cache_key,
@@ -578,12 +569,10 @@ def process_event(cache_key, start_time=None, event_id=None, data_has_changed=No
 def process_event_from_reprocessing(
     cache_key, start_time=None, event_id=None, data_has_changed=None, **kwargs
 ):
-    with sentry_sdk.start_span(
-        Span(
-            op="tasks.store.process_event_from_reprocessing",
-            transaction="TaskProcessEvent",
-            sampled=sample_process_event_apm(),
-        )
+    with sentry_sdk.start_transaction(
+        op="tasks.store.process_event_from_reprocessing",
+        name="TaskProcessEvent",
+        sampled=sample_process_event_apm(),
     ):
         return _do_process_event(
             cache_key=cache_key,

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -142,34 +142,43 @@ def configure_sdk():
     else:
         relay_transport = None
 
-    def capture_event(event):
-        if event.get("type") == "transaction" and options.get(
-            "transaction-events.force-disable-internal-project"
-        ):
-            return
+    class MultiplexingTransport(sentry_sdk.transport.Transport):
+        def capture_envelope(self, envelope):
+            # Assume only transactions get sent via envelopes
+            if options.get("transaction-events.force-disable-internal-project"):
+                return
 
-        # Upstream should get the event first because it is most isolated from
-        # the this sentry installation.
-        if upstream_transport:
-            metrics.incr("internal.captured.events.upstream")
-            # TODO(mattrobenolt): Bring this back safely.
-            # from sentry import options
-            # install_id = options.get('sentry:install-id')
-            # if install_id:
-            #     event.setdefault('tags', {})['install-id'] = install_id
-            upstream_transport.capture_event(event)
+            self._capture_anything("capture_envelope", envelope)
 
-        if relay_transport and options.get("store.use-relay-dsn-sample-rate") == 1:
-            if is_current_event_safe():
-                metrics.incr("internal.captured.events.relay")
-                relay_transport.capture_event(event)
-            else:
-                metrics.incr("internal.uncaptured.events.relay", skip_internal=False)
-                if event.get("type") != "transaction":
-                    sdk_logger.warn("internal-error.unsafe-stacktrace.relay")
+        def capture_event(self, event):
+            if event.get("type") == "transaction" and options.get(
+                "transaction-events.force-disable-internal-project"
+            ):
+                return
+
+            self._capture_anything("capture_event", event)
+
+        def _capture_anything(self, method_name, *args, **kwargs):
+            # Upstream should get the event first because it is most isolated from
+            # the this sentry installation.
+            if upstream_transport:
+                metrics.incr("internal.captured.events.upstream")
+                # TODO(mattrobenolt): Bring this back safely.
+                # from sentry import options
+                # install_id = options.get('sentry:install-id')
+                # if install_id:
+                #     event.setdefault('tags', {})['install-id'] = install_id
+                getattr(upstream_transport, method_name)(*args, **kwargs)
+
+            if relay_transport and options.get("store.use-relay-dsn-sample-rate") == 1:
+                if is_current_event_safe():
+                    metrics.incr("internal.captured.events.relay")
+                    getattr(relay_transport, method_name)(*args, **kwargs)
+                else:
+                    metrics.incr("internal.uncaptured.events.relay", skip_internal=False)
 
     sentry_sdk.init(
-        transport=capture_event,
+        transport=MultiplexingTransport(),
         integrations=[
             DjangoIntegration(),
             CeleryIntegration(),

--- a/src/sentry/web/decorators.py
+++ b/src/sentry/web/decorators.py
@@ -8,7 +8,6 @@ from django.utils.translation import ugettext_lazy as _
 
 from sentry.utils import auth
 from sentry_sdk import Hub
-from sentry_sdk.tracing import Span
 
 ERR_BAD_SIGNATURE = _("The link you followed is invalid or expired.")
 
@@ -45,7 +44,7 @@ def transaction_start(endpoint):
     def decorator(func):
         @wraps(func)
         def wrapped(request, *args, **kwargs):
-            with Hub.current.start_span(Span(op="http.server", transaction=endpoint, sampled=True)):
+            with Hub.current.start_transaction(op="http.server", name=endpoint, sampled=True):
                 return func(request, *args, **kwargs)
 
         return wrapped

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -488,10 +488,10 @@ class SentryWsgiRemoteTest(TransactionTestCase):
 
         def new_disable_transaction_events():
             with configure_scope() as scope:
-                assert scope.span.sampled
-                assert scope.span.transaction
+                assert scope.transaction
+                assert scope.transaction.sampled
                 disable_transaction_events()
-                assert not scope.span.sampled
+                assert not scope.transaction.sampled
 
             calls.append(1)
 


### PR DESCRIPTION
With 0.16.0 release the transaction is setup using `sentry_sdk.start_transaction(..)` and there is no compatibility for `sentry_sdk.start_span(Span(...))`.

More info in docs: https://docs.sentry.io/performance-monitoring/getting-started/?platform=python