### PR TITLE
Ref(image-loaded): Improve performance

### DIFF
--- a/src/sentry/static/sentry/app/components/clippedBox.tsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.tsx
@@ -15,12 +15,15 @@ type DefaultProps = {
 type Props = {
   clipHeight: number;
   title?: string;
+  renderedHeight?: number;
+  onReveal?: () => void;
   className?: string;
 } & DefaultProps;
 
 type State = {
   isClipped: boolean;
   isRevealed: boolean;
+  renderedHeight?: number;
 };
 
 class ClippedBox extends React.PureComponent<Props, State> {
@@ -33,23 +36,24 @@ class ClippedBox extends React.PureComponent<Props, State> {
   state: State = {
     isClipped: !!this.props.defaultClipped,
     isRevealed: false, // True once user has clicked "Show More" button
+    renderedHeight: this.props.renderedHeight,
   };
 
   componentDidMount() {
     // eslint-disable-next-line react/no-find-dom-node
     const renderedHeight = (ReactDOM.findDOMNode(this) as HTMLElement).offsetHeight;
-
-    if (!this.state.isClipped && renderedHeight > this.props.clipHeight) {
-      /*eslint react/no-did-mount-set-state:0*/
-      // okay if this causes re-render; cannot determine until
-      // rendered first anyways
-      this.setState({
-        isClipped: true,
-      });
-    }
+    this.calcHeight(renderedHeight);
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(_prevProps: Props, prevState: State) {
+    if (prevState.renderedHeight !== this.props.renderedHeight) {
+      this.setRenderedHeight();
+    }
+
+    if (prevState.renderedHeight !== this.state.renderedHeight) {
+      this.calcHeight(this.state.renderedHeight);
+    }
+
     if (this.state.isRevealed || !this.state.isClipped) {
       return;
     }
@@ -62,11 +66,38 @@ class ClippedBox extends React.PureComponent<Props, State> {
     }
   }
 
+  setRenderedHeight() {
+    this.setState({
+      renderedHeight: this.props.renderedHeight,
+    });
+  }
+
+  calcHeight(renderedHeight?: number) {
+    if (!renderedHeight) {
+      return;
+    }
+
+    if (!this.state.isClipped && renderedHeight > this.props.clipHeight) {
+      /*eslint react/no-did-mount-set-state:0*/
+      // okay if this causes re-render; cannot determine until
+      // rendered first anyways
+      this.setState({
+        isClipped: true,
+      });
+    }
+  }
+
   reveal = () => {
+    const {onReveal} = this.props;
+
     this.setState({
       isClipped: false,
       isRevealed: true,
     });
+
+    if (onReveal) {
+      onReveal();
+    }
   };
 
   handleClickReveal = (event: React.MouseEvent) => {

--- a/src/sentry/static/sentry/app/components/debugFileFeature.tsx
+++ b/src/sentry/static/sentry/app/components/debugFileFeature.tsx
@@ -63,6 +63,10 @@ DebugFileFeature.propTypes = {
   feature: PropTypes.oneOf(Object.keys(FEATURE_TOOLTIPS)).isRequired,
 };
 
+DebugFileFeature.defaultProps = {
+  available: true,
+};
+
 const IconWrapper = styled('span')`
   margin-right: 1ex;
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/index.tsx
@@ -297,9 +297,14 @@ class DebugMeta extends React.PureComponent<Props, State> {
   };
 
   getListHeight() {
-    const {showUnused, panelBodyHeight} = this.state;
+    const {showUnused, showDetails, panelBodyHeight} = this.state;
 
-    if (!panelBodyHeight || panelBodyHeight > PANEL_MAX_HEIGHT || showUnused) {
+    if (
+      !panelBodyHeight ||
+      panelBodyHeight > PANEL_MAX_HEIGHT ||
+      showUnused ||
+      showDetails
+    ) {
       return PANEL_MAX_HEIGHT;
     }
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/index.tsx
@@ -78,6 +78,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
 
   componentDidMount() {
     this.unsubscribeFromStore = DebugMetaStore.listen(this.onStoreChange);
+    cache.clearAll();
     this.filterImages();
   }
 
@@ -295,6 +296,16 @@ class DebugMeta extends React.PureComponent<Props, State> {
     );
   };
 
+  getListHeight() {
+    const {showUnused, panelBodyHeight} = this.state;
+
+    if (!panelBodyHeight || panelBodyHeight > PANEL_MAX_HEIGHT || showUnused) {
+      return PANEL_MAX_HEIGHT;
+    }
+
+    return panelBodyHeight;
+  }
+
   renderImageList() {
     const {filteredImages, showDetails, panelBodyHeight, clipHeight} = this.state;
     const {orgId, projectId} = this.props;
@@ -319,9 +330,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
               this.listRef = el;
             }}
             deferredMeasurementCache={cache}
-            height={
-              panelBodyHeight > PANEL_MAX_HEIGHT ? PANEL_MAX_HEIGHT : panelBodyHeight
-            }
+            height={this.getListHeight()}
             overscanRowCount={5}
             rowCount={filteredImages.length}
             rowHeight={cache.rowHeight}

--- a/src/sentry/static/sentry/app/components/events/interfaces/packageLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/packageLink.tsx
@@ -44,7 +44,7 @@ class PackageLink extends React.Component<Props> {
           <span>{'<unknown>'}</span>
         )}
         {children}
-        {isClickable && <LinkChevron direction="right" size="sm" />}
+        {isClickable && <LinkChevron direction="right" size="xs" />}
       </Package>
     );
   }
@@ -52,9 +52,10 @@ class PackageLink extends React.Component<Props> {
 
 const LinkChevron = styled(IconChevron)`
   opacity: 0;
-  transform: translateX(${space(0.25)});
   transition: all 0.2s ease-in-out;
   vertical-align: top;
+  margin-left: ${space(0.5)};
+  flex-shrink: 0;
 `;
 
 const Package = styled('a')<Partial<Props>>`
@@ -65,12 +66,12 @@ const Package = styled('a')<Partial<Props>>`
   cursor: ${p => (p.isClickable ? 'pointer' : 'default')};
   ${PackageStatusIcon} {
     opacity: 0;
+    flex-shrink: 0;
   }
   &:hover {
     color: ${p => p.theme.gray700};
     ${LinkChevron} {
       opacity: 1;
-      transform: translateX(${space(0.5)});
     }
     ${PackageStatusIcon} {
       opacity: 1;

--- a/src/sentry/static/sentry/app/components/panels/panelBody.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelBody.tsx
@@ -11,10 +11,19 @@ type FlexComponentProps = Omit<React.ComponentPropsWithoutRef<typeof Flex>, 'the
 type Props = FlexComponentProps & {
   flexible?: boolean;
   withPadding?: boolean;
+  forwardRef?: React.Ref<HTMLDivElement>;
 };
 
-const PanelBody: React.FunctionComponent<Props> = ({flexible, ...props}: Props) => (
-  <FlexBox {...props} {...(flexible ? {flexDirection: 'column'} : null)} />
+const PanelBody: React.FunctionComponent<Props> = ({
+  flexible,
+  forwardRef,
+  ...props
+}: Props) => (
+  <FlexBox
+    {...props}
+    ref={forwardRef}
+    {...(flexible ? {flexDirection: 'column'} : null)}
+  />
 );
 
 PanelBody.propTypes = {


### PR DESCRIPTION
In the "Images Loaded" section, I noticed that there was a  notable delay when I checking/unchecking the checkboxes. Please see below:

This PR improves the performance by virtualizing the images list, using components of the react-virtualized library. Below you can see a comparison of before and after these changes:

Before:

![image](https://user-images.githubusercontent.com/29228205/86796322-c1e27200-c06e-11ea-933d-9080d4878c91.png)


After:
![image](https://user-images.githubusercontent.com/29228205/86796639-1554c000-c06f-11ea-9433-6419d68286a4.png)






closes: https://app.asana.com/0/1158284503473033/1180996411705689

 ps: I also converted the files to typescript 

#sync-getsentry 