### PR TITLE
fix(discover): Allow newlines in messages

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -50,7 +50,9 @@ MAX_HASHES = 5000
 MAX_FIELDS = 20
 
 SAFE_FUNCTION_RE = re.compile(r"-?[a-zA-Z_][a-zA-Z0-9_]*$")
-QUOTED_LITERAL_RE = re.compile(r"^'.*'$")
+# Match any text surrounded by quotes, can't use `.*` here since it
+# doesn't include new lines,
+QUOTED_LITERAL_RE = re.compile(r"^'[\s\S]*'$")
 
 # Global Snuba request option override dictionary. Only intended
 # to be used with the `options_override` contextmanager below.

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1166,6 +1166,11 @@ class GetSnubaQueryArgsTest(TestCase):
             ]
         ]
 
+    def test_message_with_newlines(self):
+        assert get_filter('message:"nice \n a newline\n"').conditions == [
+            [["positionCaseInsensitive", ["message", "'nice \n a newline\n'"]], "!=", 0]
+        ]
+
     def test_malformed_groups(self):
         with pytest.raises(InvalidSearchQuery):
             get_filter("(user.email:foo@example.com OR user.email:bar@example.com")


### PR DESCRIPTION
- Messages failed to work since the text wouldn't match the quoted
  literal re and get treated as a tag instead, this is because `.` in
  regex means Any Single Character except newlines
- Needs the change in https://github.com/getsentry/snuba/pull/1097 before queries with newlines will work