### PR TITLE
refs(py3): Upgrade celery to 3.1.25

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,7 +1,7 @@
 beautifulsoup4>=4.7.1,<4.8
 boto3>=1.4.1,<1.4.6
 botocore<1.5.71
-celery>=3.1.8,<3.1.19
+celery>=3.1.25,<4.0.0
 click>=5.0,<7.0
 confluent-kafka==0.11.5
 croniter>=0.3.34,<0.4.0
@@ -24,7 +24,7 @@ google-cloud-storage==1.13.3
 googleapis-common-protos==1.6.0
 ipaddress>=1.0.16,<1.1.0 ; python_version < "3.3"
 jsonschema==2.6.0
-kombu==3.0.35
+kombu==3.0.37
 lxml>=4.3.3,<4.4.0
 maxminddb==1.4.1
 mistune>0.7,<0.9


### PR DESCRIPTION
We want to get to 3.1.25 so that we have forwards compatibility with the celery 4.x message protocol, since a version of 4.x is required for python 3.

This version requires:
 - billiard == 3.3.0.23. We don't even pin this here, but we're already pinned to this version in getsentry, so should be safe.
 - kombu == 3.0.37. Bumping this here.
 - librabbitmq==1.6.1. We're already pinned to this so should be fine.

Not sure if this is a great test since we mostly run things in process if we use celery. Will have
to do some manual testing too.

I've done some basic manual testing. Task format doesn't look to have changed at all, and we're still able to fire/run tasks.