### PR TITLE
refs(py3): Enforce pickle as the default serialization method for celery.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -502,6 +502,9 @@ CELERY_DEFAULT_ROUTING_KEY = "default"
 CELERY_CREATE_MISSING_QUEUES = True
 CELERY_REDIRECT_STDOUTS = False
 CELERYD_HIJACK_ROOT_LOGGER = False
+CELERY_TASK_SERIALIZER = "pickle"
+CELERY_RESULT_SERIALIZER = "pickle"
+CELERY_ACCEPT_CONTENT = {"pickle"}
 CELERY_IMPORTS = (
     "sentry.data_export.tasks",
     "sentry.discover.tasks",
@@ -728,7 +731,7 @@ LOGGING = {
         "important_django_request": {
             "()": "sentry.logging.handlers.MessageContainsFilter",
             "contains": ["CSRF"],
-        },
+        }
     },
     "root": {"level": "NOTSET", "handlers": ["console", "internal"]},
     # LOGGING.overridable is a list of loggers including root that will change


### PR DESCRIPTION
Celery 4.x changes the default serialization method to json. Since we're still pickling models in
tasks we want to have our tasks still default to using pickle. We'll solve py2/py3 pickle
compatibility separately.

https://docs.celeryproject.org/en/4.0/whatsnew-4.0.html#json-is-now-the-default-serializer