### PR TITLE
fix(tsdb): Route outcome-based models to snuba

### DIFF
--- a/src/sentry/tsdb/redissnuba.py
+++ b/src/sentry/tsdb/redissnuba.py
@@ -60,9 +60,7 @@ assert (
 
 model_backends = {
     # model: (read, write)
-    model: ("redis", "redis")
-    if model not in SnubaTSDB.non_outcomes_query_settings
-    else ("snuba", "dummy")
+    model: ("redis", "redis") if model not in SnubaTSDB.model_query_settings else ("snuba", "dummy")
     for model in BaseTSDB.models
 }
 
@@ -106,9 +104,9 @@ class RedisSnubaTSDBMeta(type):
 class RedisSnubaTSDB(BaseTSDB):
     def __init__(self, switchover_timestamp=None, **options):
         """
-        A TSDB backend that uses the Snuba outcomes dataset for certain models
-        instead of reading/writing to redis. Reading will trigger a Snuba
-        query, while writing is a noop as Snuba reads from outcomes.
+        A TSDB backend that uses the Snuba outcomes and events datasets as far
+        as possible instead of reading/writing to redis. Reading will trigger a
+        Snuba query, while writing is a noop as Snuba reads from outcomes.
 
         Note: Using this backend requires you to start Snuba outcomes consumers
         (not to be confused with the outcomes consumers in Sentry itself).

--- a/tests/sentry/tsdb/test_redissnuba.py
+++ b/tests/sentry/tsdb/test_redissnuba.py
@@ -18,10 +18,12 @@ def get_callargs(model):
 
 
 def test_redissnuba_connects_to_correct_backend():
-    should_resolve_to_redis = set(list(TSDBModel)) - set(
-        SnubaTSDB.non_outcomes_query_settings.keys()
-    )
-    should_resolve_to_snuba = SnubaTSDB.non_outcomes_query_settings.keys()
+    should_resolve_to_redis = set(list(TSDBModel)) - set(SnubaTSDB.model_query_settings.keys())
+    should_resolve_to_snuba = set(SnubaTSDB.model_query_settings.keys())
+
+    # Assert redissnuba routes outcomes-based tsdb metrics to snuba
+    assert TSDBModel.project_total_received in should_resolve_to_snuba
+    assert TSDBModel.organization_total_received in should_resolve_to_snuba
 
     methods = set(method_specifications.keys()) - set(["flush"])
 


### PR DESCRIPTION
When we started to use redissnuba in single-tenant and onpremise, the intent was always that we route tsdb models that *can* be calculated from outcomes to snuba. It turns out that both ST and onpremise currently do not show rate limited and filtered events because of this wrong assumption.

We assumed that's how redissnuba behaves because we mistakenly thought that we already use redissnuba in sentry.io. Turns out we have a bespoke servicedelegator running there.

@manuzope  @fpacifici I would apprechiate it if y'all can take a look at this PR, look at the service delegator in getsentry, and tell me if there's a logical difference between those two. I don't see any. I would like to remove the service delegator in getsentry and use redissnuba everywhere.

#sync-getsentry

Fixes getsentry/onpremise#498