### PR TITLE
build: Update relay and import DataCategory

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ redis-py-cluster==1.3.6
 redis==2.10.6
 requests-oauthlib==1.2.0
 requests[security]>=2.20.0,<2.21.0
-sentry-relay>=0.5.10,<0.6.0
+sentry-relay>=0.5.11,<0.6.0
 sentry-sdk>=0.16.0,<0.17.0
 simplejson>=3.2.0,<3.9.0
 six>=1.11.0,<1.12.0

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -8,7 +8,6 @@ import logging
 import os.path
 import six
 from datetime import timedelta
-from enum import IntEnum, unique
 
 from collections import OrderedDict, namedtuple
 from django.conf import settings
@@ -499,43 +498,6 @@ ALL_ACCESS_PROJECTS = {-1}
 # Most number of events for the top-n graph
 MAX_TOP_EVENTS = 5
 
-
-@unique
-class DataCategory(IntEnum):
-    DEFAULT = 0
-    ERROR = 1
-    TRANSACTION = 2
-    SECURITY = 3
-    ATTACHMENT = 4
-    SESSION = 5
-
-    @classmethod
-    def from_event_type(cls, event_type):
-        if event_type == "error":
-            return DataCategory.ERROR
-        elif event_type == "transaction":
-            return DataCategory.TRANSACTION
-        elif event_type in ("csp", "hpkp", "expectct", "expectstaple"):
-            return DataCategory.SECURITY
-        return DataCategory.DEFAULT
-
-    @classmethod
-    def event_categories(cls):
-        return [
-            DataCategory.DEFAULT,
-            DataCategory.ERROR,
-            DataCategory.TRANSACTION,
-            DataCategory.SECURITY,
-        ]
-
-    @classmethod
-    def error_categories(cls):
-        return [DataCategory.DEFAULT, DataCategory.ERROR]
-
-    def api_name(self):
-        return self.name.lower()
-
-
 # org option default values
 PROJECT_RATE_LIMIT_DEFAULT = 100
 ACCOUNT_RATE_LIMIT_DEFAULT = 0
@@ -552,3 +514,6 @@ JOIN_REQUESTS_DEFAULT = True
 
 # `sentry:events_member_admin` - controls whether the 'member' role gets the event:admin scope
 EVENTS_MEMBER_ADMIN_DEFAULT = True
+
+# Defined at https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs
+DataCategory = sentry_relay.DataCategory

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1043,7 +1043,7 @@ class EventManagerTest(TestCase):
             assert o.kwargs["reason"] == FilterStatKeys.DISCARDED_HASH
 
         o = mock_track_outcome.mock_calls[0]
-        assert o.kwargs["category"] == DataCategory.DEFAULT
+        assert o.kwargs["category"] == DataCategory.ERROR
 
         for o in mock_track_outcome.mock_calls[1:]:
             assert o.kwargs["category"] == DataCategory.ATTACHMENT
@@ -1125,7 +1125,7 @@ class EventManagerTest(TestCase):
             manager.save(1)
 
         assert_mock_called_once_with_partial(
-            mock_track_outcome, outcome=Outcome.ACCEPTED, category=DataCategory.DEFAULT
+            mock_track_outcome, outcome=Outcome.ACCEPTED, category=DataCategory.ERROR
         )
 
     def test_attachment_accepted_outcomes(self):
@@ -1154,7 +1154,7 @@ class EventManagerTest(TestCase):
             assert o.kwargs["quantity"] == 5
 
         final = mock_track_outcome.mock_calls[2]
-        assert final.kwargs["category"] == DataCategory.DEFAULT
+        assert final.kwargs["category"] == DataCategory.ERROR
 
     def test_attachment_filtered_outcomes(self):
         manager = EventManager(make_event(message="foo"), project=self.project)
@@ -1190,7 +1190,7 @@ class EventManagerTest(TestCase):
         # Last outcome is the event
         o = mock_track_outcome.mock_calls[2]
         assert o.kwargs["outcome"] == Outcome.ACCEPTED
-        assert o.kwargs["category"] == DataCategory.DEFAULT
+        assert o.kwargs["category"] == DataCategory.ERROR
 
     def test_checksum_rehashed(self):
         checksum = "invalid checksum hash"

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -195,15 +195,11 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
         )
 
     def test_status(self):
-        self.run_test("transaction.status", expected=[("unknown_error", 1), ("ok", 1)])
+        self.run_test("transaction.status", expected=[("unknown", 1), ("ok", 1)])
         self.run_test(
-            "transaction.status",
-            qs_params={"query": "o"},
-            expected=[("unknown_error", 1), ("ok", 1)],
+            "transaction.status", qs_params={"query": "o"}, expected=[("unknown", 1), ("ok", 1)],
         )
-        self.run_test(
-            "transaction.status", qs_params={"query": "ow"}, expected=[("unknown_error", 1)]
-        )
+        self.run_test("transaction.status", qs_params={"query": "ow"}, expected=[("unknown", 1)])
 
     def test_op(self):
         self.run_test("transaction.op", expected=[("bar.server", 1), ("http.server", 1)])


### PR DESCRIPTION
`DataCategory` was moved from Sentry into Relay and is now imported back. In Relay, there is a single definition of that enum, and it is exposed via the C layer to Python. Along with this, all utility functions on DataCategory now call to Rust code to ensure consistency with Relay.

Security events are now considered for error tracking. Most notably, this ensures that security events are covered by spike protection and all error quotas.

See https://github.com/getsentry/relay/pull/651