### PR TITLE
fix(ui): made settings sidebar sticky on scroll

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as Sentry from '@sentry/react';
+import styled from '@emotion/styled';
 
 import SettingsNavigationGroup from 'app/views/settings/components/settingsNavigationGroup';
 import {NavigationSection, NavigationProps} from 'app/views/settings/types';
@@ -44,14 +45,21 @@ class SettingsNavigation extends React.Component<Props> {
     const navWithHooks = navigationObjects.concat(hookConfigs);
 
     return (
-      <div>
+      <PositionStickyWrapper>
         {navWithHooks.map(config => (
           <SettingsNavigationGroup key={config.name} {...otherProps} {...config} />
         ))}
         {hooks.map((Hook, i) => React.cloneElement(Hook, {key: `hook-${i}`}))}
-      </div>
+      </PositionStickyWrapper>
     );
   }
 }
+
+const PositionStickyWrapper = styled('div')`
+  position: sticky;
+  top: 100px;
+  overflow: scroll;
+  height: calc(100vh - 98px);
+`;
 
 export default SettingsNavigation;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
@@ -56,15 +56,17 @@ class SettingsNavigation extends React.Component<Props> {
 }
 
 const PositionStickyWrapper = styled('div')`
-  position: sticky;
-  top: 100px;
-  overflow: scroll;
-  height: calc(100vh - 98px);
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    position: sticky;
+    top: 100px;
+    overflow: scroll;
+    height: calc(100vh - 98px);
+    -ms-overflow-style: none;
+    scrollbar-width: none;
 
-  &::-webkit-scrollbar {
-    display: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
@@ -60,6 +60,12 @@ const PositionStickyWrapper = styled('div')`
   top: 100px;
   overflow: scroll;
   height: calc(100vh - 98px);
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export default SettingsNavigation;


### PR DESCRIPTION
Made it so that the settings nav sticks to the screen as you scroll. Also, when the height of the browser gets too small you can still scroll through the items.

## Before

![ezgif com-video-to-gif(1)](https://user-images.githubusercontent.com/1900676/86949654-d3c22480-c103-11ea-9ebf-f4570383d1f2.gif)

## After

![ezgif com-video-to-gif(2)](https://user-images.githubusercontent.com/1900676/86949695-e2a8d700-c103-11ea-8e4c-eafe203bc431.gif)
