### PR TITLE
fix(vercel): fix bug in pagination

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -56,6 +56,7 @@ class VercelClient(ApiClient):
             # if we have less projects than the limit, we are done
             if resp["pagination"]["count"] < limit:
                 return projects
+            # continue pagination by setting the until parameter
             params = params.copy()
             params["until"] = resp["pagination"]["next"]
         # log the warning if this happens so we can look into solutions

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -56,9 +56,8 @@ class VercelClient(ApiClient):
             # if we have less projects than the limit, we are done
             if resp["pagination"]["count"] < limit:
                 return projects
-            # continue pagination but increment next by 1
             params = params.copy()
-            params["since"] = resp["pagination"]["next"] + 1
+            params["until"] = resp["pagination"]["next"]
         # log the warning if this happens so we can look into solutions
         logger.warn("Did not finish project pagination", extra={"team_id": self.team_id})
         return projects


### PR DESCRIPTION
I mistakenly used the `since` parameter instead of `until` which is how projects should be paginated