### PR TITLE
fix: Disable web crawlers filter for new projects by default

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from sentry.projectoptions import register
 
 # latest epoch
-LATEST_EPOCH = 5
+LATEST_EPOCH = 6
 
 # grouping related configs
 #
@@ -53,7 +53,7 @@ register(
 register(key="filters:legacy-browsers", epoch_defaults={1: "0"})
 
 # Default legacy-browsers filter
-register(key="filters:web-crawlers", epoch_defaults={1: "1"})
+register(key="filters:web-crawlers", epoch_defaults={1: "1", 6: "0"})
 
 # Default legacy-browsers filter
 register(key="filters:browser-extensions", epoch_defaults={1: "0"})

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/True.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/True.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-03-03T15:00:38.166505Z'
+created: '2020-07-08T19:22:25.717243Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -76,7 +76,7 @@ config:
     localhost:
       isEnabled: false
     webCrawlers:
-      isEnabled: true
+      isEnabled: false
   groupingConfig:
     enhancements: eJybzDhxY3J-bm5-npWRgaGlroGxrpHxBABcTQcY
     id: newstyle:2019-10-29


### PR DESCRIPTION
After an internal conversation we've concluded this default only makes sense for JS and is best left disabled by default because it's easier for users to cut down on noise than to figure out why their Slack webhook is crashing without sending events to Sentry.

cc @dcramer 