### PR TITLE
fix(event-search): Enable search for exact timestamp

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -137,7 +137,7 @@ def parse_datetime_comparison(value):
     raise InvalidQuery(u"{} is not a valid datetime query".format(value))
 
 
-def parse_datetime_value(value):
+def parse_datetime_value(value, exact_timestamp=False):
     # timezones are not supported and are assumed UTC
     if value[-1:] == "Z":
         value = value[:-1]
@@ -172,7 +172,10 @@ def parse_datetime_value(value):
     if result is None:
         raise InvalidQuery(u"{} is not a valid datetime query".format(value))
 
-    return ((result - timedelta(minutes=5), True), (result + timedelta(minutes=6), False))
+    if exact_timestamp:
+        return ((result, True), (result + timedelta(seconds=1), False))
+    else:
+        return ((result - timedelta(minutes=5), True), (result + timedelta(minutes=6), False))
 
 
 def parse_datetime_expression(value):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1235,6 +1235,15 @@ class GetSnubaQueryArgsTest(TestCase):
         assert _filter.filter_keys == {}
         assert _filter.group_ids == []
 
+    def test_timestamp_filter(self):
+        _filter = get_filter("timestamp:2020-07-09T00:00:00+00:00")
+        assert _filter.conditions == [
+            ["timestamp", ">=", datetime.datetime(2020, 7, 9, 0, 0, 0, tzinfo=timezone.utc)],
+            ["timestamp", "<", datetime.datetime(2020, 7, 9, 0, 0, 1, tzinfo=timezone.utc)],
+        ]
+        assert _filter.filter_keys == {}
+        assert _filter.group_ids == []
+
     def test_environment_param(self):
         params = {"environment": ["", "prod"]}
         _filter = get_filter("", params)


### PR DESCRIPTION
When filtering for a timestamp like timestamp:2020-07-08T00:00:00, the present
behavior is to return a range -5/+6 minutes around the time stamp. This is
undesireable for discover/performance as it can surface a lot of events that
are unexpected. This change will allow the user to filter for that exact second.