### PR TITLE
feat(Vercel): Update internal integration scopes

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -355,7 +355,7 @@ class VercelIntegrationProvider(IntegrationProvider):
             "organization": organization,
             "overview": internal_integration_overview.strip(),
             "user": user,
-            "scopes": ["project:releases"],
+            "scopes": ["project:releases", "project:read", "project:write"],
         }
         # create the internal integration and link it to the join table
         sentry_app = InternalCreator.run(**data)


### PR DESCRIPTION
In order to be able to automatically create Sentry projects when a Vercel project is created, we must update the scopes of the generated internal integration whose auth token will be used in the request.