### PR TITLE
ref(ui): Show create project as primary when no projects

### DIFF
--- a/src/sentry/static/sentry/app/components/noProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/noProjectMessage.tsx
@@ -6,10 +6,10 @@ import {t} from 'app/locale';
 import {LightWeightOrganization, Organization, Project} from 'app/types';
 import Button from 'app/components/button';
 import PageHeading from 'app/components/pageHeading';
-import Tooltip from 'app/components/tooltip';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import ConfigStore from 'app/stores/configStore';
+import ButtonBar from 'app/components/buttonBar';
 
 /* TODO: replace with I/O when finished */
 import img from '../../images/spot/hair-on-fire.svg';
@@ -36,20 +36,56 @@ export default class NoProjectMessage extends React.Component<Props> {
     const canCreateProject = organization.access.includes('project:write');
     const canJoinTeam = organization.access.includes('team:read');
 
-    let hasProjects;
+    let orgHasProjects: boolean;
+    let hasProjectAccess: boolean;
+
     if ('projects' in organization) {
       const {isSuperuser} = ConfigStore.get('user');
 
-      hasProjects = isSuperuser
+      orgHasProjects = organization.projects.length > 0;
+      hasProjectAccess = isSuperuser
         ? organization.projects.some(p => p.hasAccess)
         : organization.projects.some(p => p.isMember && p.hasAccess);
     } else {
-      hasProjects = projects && projects.length > 0;
+      hasProjectAccess = projects ? projects.length > 0 : false;
+      orgHasProjects = hasProjectAccess;
     }
 
-    return hasProjects || loadingProjects ? (
-      children
-    ) : (
+    if (hasProjectAccess || loadingProjects) {
+      return children;
+    }
+
+    // If the organization has some projects, but the user doesn't have access to
+    // those projects, the primary action is to Join a Team. Otherwise the primary
+    // action is to create a project.
+
+    const joinTeamAction = (
+      <Button
+        title={canJoinTeam ? undefined : t('You do not have permission to join a team.')}
+        disabled={!canJoinTeam}
+        priority={orgHasProjects ? 'primary' : 'default'}
+        to={`/settings/${orgId}/teams/`}
+      >
+        {t('Join a Team')}
+      </Button>
+    );
+
+    const createProjectAction = (
+      <Button
+        title={
+          canCreateProject
+            ? undefined
+            : t('You do not have permission to create a project.')
+        }
+        disabled={!canCreateProject}
+        priority={orgHasProjects ? 'default' : 'primary'}
+        to={`/organizations/${orgId}/projects/new/`}
+      >
+        {t('Create project')}
+      </Button>
+    );
+
+    return (
       <Wrapper>
         <HeightWrapper>
           <img src={img} height={350} alt="Nothing to see" />
@@ -58,36 +94,16 @@ export default class NoProjectMessage extends React.Component<Props> {
             <HelpMessage>
               {t('You need at least one project to use this view')}
             </HelpMessage>
-            <CallToActions>
-              <CallToAction>
-                <Tooltip
-                  disabled={canJoinTeam}
-                  title={t('You do not have permission to join a team.')}
-                >
-                  <Button
-                    disabled={!canJoinTeam}
-                    priority="primary"
-                    to={`/settings/${orgId}/teams/`}
-                  >
-                    {t('Join a Team')}
-                  </Button>
-                </Tooltip>
-              </CallToAction>
-
-              <CallToAction>
-                <Tooltip
-                  disabled={canCreateProject}
-                  title={t('You do not have permission to create a project.')}
-                >
-                  <Button
-                    disabled={!canCreateProject}
-                    to={`/organizations/${orgId}/projects/new/`}
-                  >
-                    {t('Create project')}
-                  </Button>
-                </Tooltip>
-              </CallToAction>
-            </CallToActions>
+            <Actions gap={1}>
+              {!orgHasProjects ? (
+                createProjectAction
+              ) : (
+                <React.Fragment>
+                  {joinTeamAction}
+                  {createProjectAction}
+                </React.Fragment>
+              )}
+            </Actions>
           </Content>
         </HeightWrapper>
       </Wrapper>
@@ -98,13 +114,6 @@ export default class NoProjectMessage extends React.Component<Props> {
 const StyledPageHeading = styled(PageHeading)`
   font-size: 28px;
   margin-bottom: ${space(1.5)};
-`;
-
-const CallToAction = styled('div')`
-  margin-right: 8px;
-  &:last-child {
-    margin-right: 0;
-  }
 `;
 
 const HelpMessage = styled('div')`
@@ -131,6 +140,6 @@ const Content = styled(Flex)`
   margin-left: 40px;
 `;
 
-const CallToActions = styled(Flex)`
-  align-items: center;
+const Actions = styled(ButtonBar)`
+  width: fit-content;
 `;

--- a/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
@@ -26,9 +26,19 @@ describe('NoProjectMessage', function() {
     ).toBe(true);
   });
 
-  it('has "Join a Team" button', function() {
+  it('has no "Join a Team" button when projects are missing', function() {
     const wrapper = mountWithTheme(
       <NoProjectMessage organization={org} />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.find('Button[to="/settings/org-slug/teams/"]')).toHaveLength(0);
+  });
+
+  it('has a "Join a Team" button when no projects but org has projects', function() {
+    const wrapper = mountWithTheme(
+      <NoProjectMessage
+        organization={{...org, projects: [TestStubs.Project({hasAccess: false})]}}
+      />,
       TestStubs.routerContext()
     );
     expect(wrapper.find('Button[to="/settings/org-slug/teams/"]')).toHaveLength(1);
@@ -36,7 +46,13 @@ describe('NoProjectMessage', function() {
 
   it('has a disabled "Join a Team" button if no access to `team:read`', function() {
     const wrapper = mountWithTheme(
-      <NoProjectMessage organization={TestStubs.Organization({access: []})} />,
+      <NoProjectMessage
+        organization={{
+          ...org,
+          projects: [TestStubs.Project({hasAccess: false})],
+          access: [],
+        }}
+      />,
       TestStubs.routerContext()
     );
     expect(wrapper.find('Button[to="/settings/org-slug/teams/"]').prop('disabled')).toBe(


### PR DESCRIPTION
This is a direct result of bens video

 * If the org has NO projects, the empty message will only prompt you to create a project
 * If the org has SOME projects, but you have no access to them, it will primarily prompt you to join a team, with create project as a secondary action