### PR TITLE
fix(apm): Various fixes for the span view

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -120,10 +120,12 @@ export class Provider extends React.Component<PropType, StateType> {
 
     selectRefs(this.dividerLineRefs, (dividerDOM: HTMLDivElement) => {
       dividerDOM.style.backgroundColor = 'rgba(73,80,87,0.75)';
+      dividerDOM.style.cursor = 'col-resize';
     });
 
     selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
       dividerDOM.style.display = 'block';
+      dividerDOM.style.cursor = 'col-resize';
     });
   };
 
@@ -172,10 +174,12 @@ export class Provider extends React.Component<PropType, StateType> {
 
     selectRefs(this.dividerLineRefs, (dividerDOM: HTMLDivElement) => {
       dividerDOM.style.backgroundColor = '';
+      dividerDOM.style.cursor = '';
     });
 
     selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
       dividerDOM.style.display = 'none';
+      dividerDOM.style.cursor = '';
     });
 
     this.setState({

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -114,6 +114,8 @@ export class Provider extends React.Component<PropType, StateType> {
     window.addEventListener('mousemove', this.onDragMove);
     window.addEventListener('mouseup', this.onDragEnd);
 
+    this.setHover(true);
+
     // indicate drag has begun
 
     this.isDragging = true;
@@ -124,8 +126,16 @@ export class Provider extends React.Component<PropType, StateType> {
     });
 
     selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
-      dividerDOM.style.display = 'block';
       dividerDOM.style.cursor = 'col-resize';
+
+      const {parentNode} = dividerDOM;
+
+      if (!parentNode) {
+        return;
+      }
+
+      const container = parentNode as HTMLDivElement;
+      container.style.display = 'block';
     });
   };
 
@@ -147,8 +157,16 @@ export class Provider extends React.Component<PropType, StateType> {
 
     const dividerHandlePositionString = toPercent(this.dividerHandlePosition);
 
-    selectRefs(this.dividerLineRefs, (dividerDOM: HTMLDivElement) => {
-      dividerDOM.style.left = dividerHandlePositionString;
+    selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
+      const {parentNode} = dividerDOM;
+
+      if (!parentNode) {
+        return;
+      }
+
+      const container = parentNode as HTMLDivElement;
+
+      container.style.width = `calc(${dividerHandlePositionString} + 0.5px)`;
     });
   };
 
@@ -172,14 +190,24 @@ export class Provider extends React.Component<PropType, StateType> {
 
     this.isDragging = false;
 
+    this.setHover(false);
+
     selectRefs(this.dividerLineRefs, (dividerDOM: HTMLDivElement) => {
       dividerDOM.style.backgroundColor = '';
       dividerDOM.style.cursor = '';
     });
 
     selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
-      dividerDOM.style.display = 'none';
       dividerDOM.style.cursor = '';
+
+      const {parentNode} = dividerDOM;
+
+      if (!parentNode) {
+        return;
+      }
+
+      const container = parentNode as HTMLDivElement;
+      container.style.display = 'none';
     });
 
     this.setState({

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -108,6 +108,7 @@ export class Provider extends React.Component<PropType, StateType> {
       userSelect: 'none',
       MozUserSelect: 'none',
       msUserSelect: 'none',
+      webkitUserSelect: 'none',
     });
 
     // attach event listeners so that the mouse cursor does not select text during a drag

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/dragManager.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/dragManager.tsx
@@ -116,6 +116,7 @@ class DragManager extends React.Component<DragManagerProps, DragManagerState> {
       userSelect: 'none',
       MozUserSelect: 'none',
       msUserSelect: 'none',
+      webkitUserSelect: 'none',
     });
 
     // attach event listeners so that the mouse cursor can drag outside of the
@@ -244,6 +245,7 @@ class DragManager extends React.Component<DragManagerProps, DragManagerState> {
       userSelect: 'none',
       MozUserSelect: 'none',
       msUserSelect: 'none',
+      webkitUserSelect: 'none',
     });
 
     // attach event listeners so that the mouse cursor can drag outside of the

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -875,6 +875,8 @@ const SpanRowCellContainer = styled('div')<SpanRowCellProps>`
   position: relative;
   height: ${SPAN_ROW_HEIGHT}px;
 
+  user-select: none;
+
   &:hover > div[data-type='span-row-cell'] {
     background-color: ${p => (p.showDetail ? p.theme.gray800 : p.theme.gray200)};
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -804,25 +804,28 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           )}
           {this.renderCursorGuide()}
         </SpanRowCell>
-        <DividerLineGhostContainer
-          style={{
-            width: `calc(${toPercent(dividerPosition)} + 0.5px)`,
-            display: 'none',
-          }}
-        >
-          <DividerLine
-            ref={addGhostDividerLineRef()}
+        {!this.state.showDetail && (
+          <DividerLineGhostContainer
             style={{
-              right: 0,
+              width: `calc(${toPercent(dividerPosition)} + 0.5px)`,
+              display: 'none',
             }}
-            onClick={event => {
-              // the ghost divider line should not be interactive.
-              // we prevent the propagation of the clicks from this component to prevent
-              // the span detail from being opened.
-              event.stopPropagation();
-            }}
-          />
-        </DividerLineGhostContainer>
+          >
+            <DividerLine
+              ref={addGhostDividerLineRef()}
+              style={{
+                right: 0,
+              }}
+              className="hovering"
+              onClick={event => {
+                // the ghost divider line should not be interactive.
+                // we prevent the propagation of the clicks from this component to prevent
+                // the span detail from being opened.
+                event.stopPropagation();
+              }}
+            />
+          </DividerLineGhostContainer>
+        )}
       </SpanRowCellContainer>
     );
   }
@@ -893,6 +896,17 @@ const DividerLine = styled('div')`
   width: 1px;
   transition: background-color 125ms ease-in-out;
   z-index: ${zIndex.dividerLine};
+
+  /* enhanced hit-box */
+  &:after {
+    content: '';
+    z-index: -1;
+    position: absolute;
+    left: -2px;
+    top: 0;
+    width: 5px;
+    height: 100%;
+  }
 
   &.hovering {
     background-color: ${p => p.theme.gray800};

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -892,7 +892,7 @@ export const DividerLine = styled('div')`
   &.hovering {
     background-color: ${p => p.theme.gray800};
     width: 2px;
-    cursor: col-resize;
+    cursor: ew-resize;
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -911,9 +911,9 @@ const DividerLine = styled('div')`
 
   &.hovering {
     background-color: ${p => p.theme.gray800};
-    width: 2px;
-    transform: translateX(-25%);
-    margin-right: -1px;
+    width: 3px;
+    transform: translateX(-1px);
+    margin-right: -2px;
 
     cursor: ew-resize;
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -690,8 +690,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
   ) {
     if (this.state.showDetail) {
-      // we would like to hide the divider lines when the span details
-      // has been expanded
+      // Mock component to preserve layout spacing
       return (
         <DividerLine
           style={{

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -916,6 +916,11 @@ const DividerLine = styled('div')`
     margin-right: -2px;
 
     cursor: ew-resize;
+
+    &:after {
+      left: -2px;
+      width: 7px;
+    }
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -292,6 +292,7 @@ export type UserSelectValues = {
   userSelect: string | null;
   MozUserSelect: string | null;
   msUserSelect: string | null;
+  webkitUserSelect: string | null;
 };
 
 export const setBodyUserSelect = (nextValues: UserSelectValues): UserSelectValues => {
@@ -304,13 +305,15 @@ export const setBodyUserSelect = (nextValues: UserSelectValues): UserSelectValue
     // @ts-ignore
     MozUserSelect: document.body.style.MozUserSelect,
     msUserSelect: document.body.style.msUserSelect,
+    webkitUserSelect: document.body.style.webkitUserSelect,
   };
 
   document.body.style.userSelect = nextValues.userSelect || '';
   // MozUserSelect is not typed in TS
   // @ts-ignore
-  document.body.style.MozUserSelect = nextValues.MozUserSelect;
-  document.body.style.msUserSelect = nextValues.msUserSelect;
+  document.body.style.MozUserSelect = nextValues.MozUserSelect || '';
+  document.body.style.msUserSelect = nextValues.msUserSelect || '';
+  document.body.style.webkitUserSelect = nextValues.webkitUserSelect || '';
 
   return previousValues;
 };

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -240,8 +240,8 @@ const theme = {
     },
     traceView: {
       spanTreeToggler: 900,
-      rowInfoMessage: 900,
       dividerLine: 909,
+      rowInfoMessage: 910,
       minimapContainer: 999,
     },
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -143,6 +143,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
       userSelect: 'none',
       MozUserSelect: 'none',
       msUserSelect: 'none',
+      webkitUserSelect: 'none',
     });
 
     // attach event listeners so that the mouse cursor can drag anywhere

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/__snapshots__/filter.spec.tsx.snap
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/__snapshots__/filter.spec.tsx.snap
@@ -703,7 +703,7 @@ exports[`Filter default render 1`] = `
                       "traceView": Object {
                         "dividerLine": 909,
                         "minimapContainer": 999,
-                        "rowInfoMessage": 900,
+                        "rowInfoMessage": 910,
                         "spanTreeToggler": 900,
                       },
                     },


### PR DESCRIPTION
- Polished mouse cursor styles for hover and drag events of the span view split pane divider

![Kapture 2020-07-08 at 19 46 18](https://user-images.githubusercontent.com/139499/86981152-cfbdf300-c153-11ea-8ac2-51d76fdb9bc9.gif)

- Fix and polish span row background hover introduced in https://github.com/getsentry/sentry/pull/19634

- refactor to use width instead of left to reduce repaint jank for 1k+ spans. Should be able to erratically move the split pane divider with ease:

![Kapture 2020-07-08 at 19 44 14](https://user-images.githubusercontent.com/139499/86981039-81105900-c153-11ea-9e32-4c1cb363f06f.gif)

- Fix drag release of the divider unintentionally opening the span detail
- Intentionally set hover on dragstart and dragend. 
- Enhanced divider hitbox region. (@robinrendle  thanks for https://css-tricks.com/enhancing-the-clickable-area-size/ )
- Prevent text selection of the span details pane via multi-clicking on the span row
- Account for Safari's vendor prefixed user-select https://caniuse.com/#feat=user-select-none
- adjust z-index of split pane divider to precede span row messages

## TODO

- [x] check Firefox
- [x] check Safari