### PR TITLE
fix(dashboards) Fix users with discover-basic not getting dashboards

### DIFF
--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -24,6 +24,11 @@ class DiscoverQueryPermission(OrganizationPermission):
 class DiscoverQueryEndpoint(OrganizationEndpoint):
     permission_classes = (DiscoverQueryPermission,)
 
+    def has_feature(self, request, organization):
+        return features.has(
+            "organizations:discover", organization, actor=request.user
+        ) or features.has("organizations:discover-basic", organization, actor=request.user)
+
     def handle_results(self, snuba_results, requested_query, projects):
         if "project.name" in requested_query["selected_columns"]:
             project_name_index = requested_query["selected_columns"].index("project.name")
@@ -99,7 +104,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
             )
 
     def post(self, request, organization):
-        if not features.has("organizations:discover", organization, actor=request.user):
+        if not self.has_feature(request, organization):
             return Response(status=404)
 
         try:

--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -467,7 +467,11 @@ class Sidebar extends React.Component<Props, State> {
                 </SidebarSection>
 
                 <SidebarSection>
-                  <Feature features={['discover']} organization={organization}>
+                  <Feature
+                    features={['discover', 'discover-basic']}
+                    organization={organization}
+                    requireAll={false}
+                  >
                     <SidebarItem
                       {...sidebarItemProps}
                       index

--- a/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
@@ -128,7 +128,7 @@ class ExploreWidget extends React.Component {
         target={!flags.discover2 ? '_blank' : ''}
         title={
           flags.discover2
-            ? t('Explore data in the Discover')
+            ? t('Explore data in Discover')
             : t('You do not have access to Discover. Click to learn more.')
         }
       >

--- a/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
@@ -129,7 +129,7 @@ class ExploreWidget extends React.Component {
         title={
           flags.discover2
             ? t('Explore data in the Discover')
-            : t('You do not have access to the Discover. Click to learn more.')
+            : t('You do not have access to Discover. Click to learn more.')
         }
       >
         <IconTelescope size="xs" />

--- a/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
@@ -128,8 +128,8 @@ class ExploreWidget extends React.Component {
         target={!flags.discover2 ? '_blank' : ''}
         title={
           flags.discover2
-            ? t('Explore data in the new Discover')
-            : t('You do not have access to the new Discover. Click to learn more.')
+            ? t('Explore data in the Discover')
+            : t('You do not have access to the Discover. Click to learn more.')
         }
       >
         <IconTelescope size="xs" />

--- a/src/sentry/static/sentry/app/views/dashboards/index.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/index.jsx
@@ -18,7 +18,11 @@ class Dashboards extends React.Component {
     const {organization, children} = this.props;
 
     return (
-      <Feature features={['discover']} renderDisabled>
+      <Feature
+        features={['discover', 'discover-basic']}
+        renderDisabled
+        requireAll={false}
+      >
         <GlobalSelectionHeader showEnvironmentSelector={false}>
           <PageContent>
             <LightWeightNoProjectMessage organization={organization}>


### PR DESCRIPTION
Update the feature flags for dashboards to allow either flavour of discover. The new performance plans will not include discover1 but will include discover2.

Update the discover1 endpoint to accept the discover2 feature flag as that is what dashboards is built against.