### PR TITLE
feat(msteams): Create better welcome message

### DIFF
--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -5,8 +5,6 @@ import logging
 from django.views.decorators.csrf import csrf_exempt
 from sentry.api.base import Endpoint
 from sentry.utils.compat import filter
-from sentry.utils.http import absolute_uri
-from sentry.utils.signing import sign
 from sentry.web.decorators import transaction_start
 
 from .client import MsTeamsClient
@@ -46,17 +44,6 @@ class MsTeamsWebhookEndpoint(Endpoint):
                 # send welcome message to the team
                 team_id = channel_data["team"]["id"]
                 client = MsTeamsClient()
-                # sign the params so this can't be forged
-                signed_params = sign(team_id=team_id)
-                url = u"%s?signed_params=%s" % (
-                    absolute_uri("/extensions/msteams/configure/"),
-                    signed_params,
-                )
-                # TODO: Better message
-                payload = {
-                    "type": "message",
-                    "text": url,
-                }
-                client.send_message(team_id, payload)
+                client.send_welcome_message(team_id)
 
         return self.respond(status=200)


### PR DESCRIPTION
Make the welcome message when a user installs to Microsoft Teams look a little prettier than before. Could still use a little bit of tweaking.

<img width="452" alt="Screen Shot 2020-07-09 at 11 38 58 AM" src="https://user-images.githubusercontent.com/32143113/87080460-8e255a80-c1dc-11ea-970d-9238c4231423.png">

Fixes API-1120
