### PR TITLE
fix(discover): Disable top 5 mode when no aggregates present

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -26,7 +26,12 @@ import {
   generateFieldAsString,
 } from './fields';
 import {getSortField} from './fieldRenderers';
-import {CHART_AXIS_OPTIONS, DisplayModes, DISPLAY_MODE_OPTIONS} from './types';
+import {
+  CHART_AXIS_OPTIONS,
+  DisplayModes,
+  DISPLAY_MODE_OPTIONS,
+  DISPLAY_MODE_FALLBACK_OPTIONS,
+} from './types';
 
 // Metadata mapping for discover results.
 export type MetaType = Record<string, ColumnType>;
@@ -1026,12 +1031,13 @@ class EventView {
   }
 
   getDisplayMode() {
+    const display = this.display ?? DisplayModes.DEFAULT;
     const displayOptions = this.getDisplayOptions();
-    const selectedOption = displayOptions.find(option => option.value === this.display);
+    const selectedOption = displayOptions.find(option => option.value === display);
     if (selectedOption && !selectedOption.disabled) {
-      return this.display ?? DisplayModes.DEFAULT;
+      return display;
     }
-    return DisplayModes.DEFAULT;
+    return DISPLAY_MODE_FALLBACK_OPTIONS[display];
   }
 }
 

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -1008,12 +1008,18 @@ class EventView {
   }
 
   getDisplayOptions(): SelectValue<string>[] {
-    if (!this.start && !this.end) {
-      return DISPLAY_MODE_OPTIONS;
-    }
     return DISPLAY_MODE_OPTIONS.map(item => {
       if (item.value === DisplayModes.PREVIOUS) {
-        return {...item, disabled: true};
+        if (this.start || this.end) {
+          return {...item, disabled: true};
+        }
+      } else if (
+        item.value === DisplayModes.TOP5 ||
+        item.value === DisplayModes.DAILYTOP5
+      ) {
+        if (this.getAggregateFields().length === 0) {
+          return {...item, disabled: true};
+        }
       }
       return item;
     });

--- a/src/sentry/static/sentry/app/utils/discover/types.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/types.tsx
@@ -21,6 +21,15 @@ export const DISPLAY_MODE_OPTIONS: SelectValue<string>[] = [
   {value: DisplayModes.DAILYTOP5, label: t('Top 5 Daily')},
 ];
 
+export const DISPLAY_MODE_FALLBACK_OPTIONS = {
+  [DisplayModes.DEFAULT]: DisplayModes.DEFAULT,
+  [DisplayModes.PREVIOUS]: DisplayModes.DEFAULT,
+  [DisplayModes.RELEASES]: DisplayModes.DEFAULT,
+  [DisplayModes.TOP5]: DisplayModes.DEFAULT,
+  [DisplayModes.DAILY]: DisplayModes.DAILY,
+  [DisplayModes.DAILYTOP5]: DisplayModes.DAILY,
+};
+
 // default list of yAxis options
 export const CHART_AXIS_OPTIONS = [
   {label: 'count()', value: 'count()'},

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -53,13 +53,11 @@ class ResultsChart extends React.Component<ResultsChartProps> {
 
     const {utc} = getParams(location.query);
     const apiPayload = eventView.getEventsAPIPayload(location);
+    const display = eventView.getDisplayMode();
     const isTopEvents =
-      eventView.display === DisplayModes.TOP5 ||
-      eventView.display === DisplayModes.DAILYTOP5;
+      display === DisplayModes.TOP5 || display === DisplayModes.DAILYTOP5;
 
-    const isDaily =
-      eventView.display === DisplayModes.DAILYTOP5 ||
-      eventView.display === DisplayModes.DAILY;
+    const isDaily = display === DisplayModes.DAILYTOP5 || display === DisplayModes.DAILY;
 
     return (
       <React.Fragment>
@@ -77,8 +75,8 @@ class ResultsChart extends React.Component<ResultsChartProps> {
               start={start}
               end={end}
               period={globalSelection.statsPeriod}
-              disablePrevious={eventView.display !== DisplayModes.PREVIOUS}
-              disableReleases={eventView.display !== DisplayModes.RELEASES}
+              disablePrevious={display !== DisplayModes.PREVIOUS}
+              disableReleases={display !== DisplayModes.RELEASES}
               field={isTopEvents ? apiPayload.field : undefined}
               interval={eventView.interval}
               showDaily={isDaily}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -204,9 +204,9 @@ class TableView extends React.Component<TableViewProps> {
     }
     const fieldRenderer = getFieldRenderer(String(column.key), tableData.meta);
 
+    const display = eventView.getDisplayMode();
     const isTopEvents =
-      eventView.display === DisplayModes.TOP5 ||
-      eventView.display === DisplayModes.DAILYTOP5;
+      display === DisplayModes.TOP5 || display === DisplayModes.DAILYTOP5;
 
     const count = Math.min(tableData?.data?.length ?? TOP_N, TOP_N);
 

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -2423,6 +2423,26 @@ describe('EventView.getDisplayMode()', function() {
     const displayMode = eventView.getDisplayMode();
     expect(displayMode).toEqual(DisplayModes.DEFAULT);
   });
+
+  it('top 5 should fallback to default when disabled', function() {
+    const eventView = new EventView({
+      ...state,
+      // the lack of an aggregate will disable the TOP5 mode
+      display: DisplayModes.TOP5,
+    });
+    const displayMode = eventView.getDisplayMode();
+    expect(displayMode).toEqual(DisplayModes.DEFAULT);
+  });
+
+  it('top 5 daily should fallback to daily when disabled', function() {
+    const eventView = new EventView({
+      ...state,
+      // the lack of an aggregate will disable the DAILYTOP5 mode
+      display: DisplayModes.DAILYTOP5,
+    });
+    const displayMode = eventView.getDisplayMode();
+    expect(displayMode).toEqual(DisplayModes.DAILY);
+  });
 });
 
 describe('EventView.getAggregateFields()', function() {

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -2351,7 +2351,11 @@ describe('EventView.getDisplayOptions()', function() {
   };
 
   it('should return default options', function() {
-    const eventView = new EventView(state);
+    const eventView = new EventView({
+      ...state,
+      // there needs to exist an aggregate or TOP 5 modes will be disabled
+      fields: [{field: 'count()'}],
+    });
 
     expect(eventView.getDisplayOptions()).toEqual(DISPLAY_MODE_OPTIONS);
   });
@@ -2366,6 +2370,18 @@ describe('EventView.getDisplayOptions()', function() {
     const options = eventView.getDisplayOptions();
     expect(options[1].value).toEqual('previous');
     expect(options[1].disabled).toBeTruthy();
+  });
+
+  it('should disable top 5 period/daily if no aggregates present', function() {
+    const eventView = new EventView({
+      ...state,
+    });
+
+    const options = eventView.getDisplayOptions();
+    expect(options[3].value).toEqual('top5');
+    expect(options[3].disabled).toBeTruthy();
+    expect(options[5].value).toEqual('dailytop5');
+    expect(options[5].disabled).toBeTruthy();
   });
 });
 
@@ -2390,10 +2406,10 @@ describe('EventView.getDisplayMode()', function() {
   it('should return current mode when not disabled', function() {
     const eventView = new EventView({
       ...state,
-      display: DisplayModes.TOP5,
+      display: DisplayModes.DAILY,
     });
     const displayMode = eventView.getDisplayMode();
-    expect(displayMode).toEqual(DisplayModes.TOP5);
+    expect(displayMode).toEqual(DisplayModes.DAILY);
   });
 
   it('should return default mode when disabled', function() {


### PR DESCRIPTION
Top 5 mode should only be available when there is at least one aggregate. If
there are no aggregate present, disable top 5 modes and default back to total
period. This will also cause the top 5 indicators to be hidden when top 5 mode
is turned off.