### PR TITLE
test(acceptance): Run acceptance tests emulating `prefers-reduced-motion` media query

### DIFF
--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {Global, css} from '@emotion/core';
 
 import {Theme} from 'app/utils/theme';
-import {IS_CI} from 'app/constants';
 
 const styles = (theme: Theme) => css`
   body {
@@ -16,24 +15,21 @@ const styles = (theme: Theme) => css`
   }
 
   /**
-   * TODO: This should apply to the prefer-reduced-motion media query
-   *
    * See https://web.dev/prefers-reduced-motion/
    */
-  ${IS_CI &&
-    css`
-      *,
-      ::before,
-      ::after {
-        animation-delay: -1ms !important;
-        animation-duration: 0ms !important;
-        animation-iteration-count: 1 !important;
-        background-attachment: initial !important;
-        scroll-behavior: auto !important;
-        transition-duration: 0s !important;
-        transition-delay: 0s !important;
-      }
-    `}
+  @media (prefers-reduced-motion) {
+    *,
+    ::before,
+    ::after {
+      animation-delay: -1ms !important;
+      animation-duration: 0ms !important;
+      animation-iteration-count: 1 !important;
+      background-attachment: initial !important;
+      scroll-behavior: auto !important;
+      transition-duration: 0s !important;
+      transition-delay: 0s !important;
+    }
+  }
 `;
 
 /**

--- a/src/sentry/static/sentry/images/spot/background-space.svg
+++ b/src/sentry/static/sentry/images/spot/background-space.svg
@@ -79,6 +79,18 @@
         fill: #ce5d9e;
       }
 
+      @media (prefers-reduced-motion) {
+        *, .twinkles {
+         animation-delay: -1ms !important;
+         animation-duration: 0ms !important;
+         animation-iteration-count: 1 !important;
+         background-attachment: initial !important;
+         scroll-behavior: auto !important;
+         transition-duration: 0s !important;
+         transition-delay: 0s !important;
+        }
+      }
+
     </style>
     <linearGradient id="linear-gradient" x1="580" y1="-163.62" x2="580" y2="289.19" gradientUnits="userSpaceOnUse">
       <stop offset="0.19" stop-color="#7a2878"/>

--- a/src/sentry/static/sentry/images/spot/background-space.svg
+++ b/src/sentry/static/sentry/images/spot/background-space.svg
@@ -78,19 +78,6 @@
       .cls-13 {
         fill: #ce5d9e;
       }
-
-      @media (prefers-reduced-motion) {
-        *, .twinkles {
-         animation-delay: -1ms !important;
-         animation-duration: 0ms !important;
-         animation-iteration-count: 1 !important;
-         background-attachment: initial !important;
-         scroll-behavior: auto !important;
-         transition-duration: 0s !important;
-         transition-delay: 0s !important;
-        }
-      }
-
     </style>
     <linearGradient id="linear-gradient" x1="580" y1="-163.62" x2="580" y2="289.19" gradientUnits="userSpaceOnUse">
       <stop offset="0.19" stop-color="#7a2878"/>

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -70,6 +70,14 @@ class Browser(object):
         self._has_initialized_cookie_store = True
         return self
 
+    def set_emulated_media(self, features, media=""):
+        """
+        This is used to emulate different media features (e.g. color scheme)
+        """
+        return self.driver.execute_cdp_cmd(
+            "Emulation.setEmulatedMedia", {"media": media, "features": features}
+        )
+
     def element(self, selector=None, xpath=None):
         """
         Get an element from the page. This method will wait for the element to show up.
@@ -420,6 +428,10 @@ def browser(request, percy, live_server):
     request.addfinalizer(fin)
 
     browser = Browser(driver, live_server, percy)
+
+    browser.set_emulated_media(
+        [{"name": "prefers-reduced-motion", "value": "reduce"},]
+    )
 
     if hasattr(request, "cls"):
         request.cls.browser = browser

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -429,9 +429,7 @@ def browser(request, percy, live_server):
 
     browser = Browser(driver, live_server, percy)
 
-    browser.set_emulated_media(
-        [{"name": "prefers-reduced-motion", "value": "reduce"},]
-    )
+    browser.set_emulated_media([{"name": "prefers-reduced-motion", "value": "reduce"}])
 
     if hasattr(request, "cls"):
         request.cls.browser = browser


### PR DESCRIPTION
Change global CSS that depended on env var to now use media query.

TODO: Move this into ConfigStore so that JS animations/libraries also
respect the media query.