### PR TITLE
ref(jsonschema): Move everything from Draft4 to Draft7

### DIFF
--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import logging
 import json
 
-from jsonschema import Draft4Validator
+from jsonschema import Draft7Validator
 from jsonschema.exceptions import best_match
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 
@@ -243,6 +243,6 @@ def validate_ui_element_schema(instance):
 
 
 def validate(instance, schema):
-    v = Draft4Validator(schema)
+    v = Draft7Validator(schema)
     if not v.is_valid(instance):
         raise best_match(v.iter_errors(instance))

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -590,7 +590,7 @@ INTERFACE_SCHEMAS = {
 def validator_for_interface(name):
     if name not in INTERFACE_SCHEMAS:
         return None
-    return jsonschema.Draft4Validator(
+    return jsonschema.Draft7Validator(
         INTERFACE_SCHEMAS[name],
         types={"array": (list, tuple)},
         format_checker=jsonschema.FormatChecker(),

--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from jsonschema import Draft4Validator
+from jsonschema import Draft7Validator
 from requests.exceptions import Timeout
 
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
@@ -34,7 +34,7 @@ SCHEMA_LIST = {"select": SELECT_OPTIONS_SCHEMA, "issue_link": ISSUE_LINKER_SCHEM
 
 def validate(instance, schema_type):
     schema = SCHEMA_LIST[schema_type]
-    v = Draft4Validator(schema)
+    v = Draft7Validator(schema)
 
     if not v.is_valid(instance):
         return False


### PR DESCRIPTION

Follow up to #19765. Since we don't have anything incompatible w/ Draft 7, which is the default now, abandon the Draft 4 usage.
