### PR TITLE
fix(grouping): Do not crash when logentry.formatted is null

### DIFF
--- a/src/sentry/data/samples/invalid-interfaces.json
+++ b/src/sentry/data/samples/invalid-interfaces.json
@@ -88,8 +88,9 @@
     },
     "logentry": {
         "params": [
-            "missing message or formatted"
-        ]
+            "bogus"
+        ],
+        "formatted": 42
     },
     "request": {
         "method": "unknown",

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -110,13 +110,13 @@ def trim_message_for_grouping(string):
 @strategy(id="message:v1", interfaces=["message"], variants=["default"], score=0)
 def message_v1(message_interface, **meta):
     return GroupingComponent(
-        id="message", values=[message_interface.message or message_interface.formatted]
+        id="message", values=[message_interface.message or message_interface.formatted or u""]
     )
 
 
 @strategy(id="message:v2", interfaces=["message"], variants=["default"], score=0)
 def message_v2(message_interface, **meta):
-    message_in = message_interface.message or message_interface.formatted
+    message_in = message_interface.message or message_interface.formatted or u""
     message_trimmed = trim_message_for_grouping(message_in)
     hint = "stripped common values" if message_in != message_trimmed else None
     return GroupingComponent(id="message", values=[message_trimmed], hint=hint)


### PR DESCRIPTION
Fix SENTRY-H29

cc @mitsuhiko not entirely sure if this fix is correct or if we should pretend the interface does not exist at all.