### PR TITLE
feat(perf-views): Add a first attempt at a baseline endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -82,7 +82,7 @@ class OrganizationEventBaseline(OrganizationEventsEndpointBase):
                 params=params,
                 query=request.GET.get("query"),
                 limit=2,
-                referrer="api.transaciton-baseline.get_id",
+                referrer="api.transaction-baseline.get_id",
             )
 
         return Response(result["data"][0])

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -70,13 +70,13 @@ class OrganizationEventBaseline(OrganizationEventsEndpointBase):
                 if baseline_value is None:
                     return Response(status=404)
 
-            difference_column = "difference(transaction.duration,{})".format(baseline_value)
+            delta_column = "absolute_delta(transaction.duration,{})".format(baseline_value)
 
             result = discover.query(
-                selected_columns=["timestamp", "id", "transaction.duration", difference_column],
+                selected_columns=["timestamp", "id", "transaction.duration", delta_column],
                 # Find the most recent transaction that's closest to the baseline value
                 # id as the last item for consistent results
-                orderby=[get_function_alias(difference_column), "-timestamp", "id"],
+                orderby=[get_function_alias(delta_column), "-timestamp", "id"],
                 params=params,
                 query=request.GET.get("query"),
                 limit=1,

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1260,6 +1260,13 @@ FUNCTIONS = {
         "aggregate": ["sum", u"{column}", None],
         "result_type": "duration",
     },
+    # Currently only being used by the baseline PoC
+    "difference": {
+        "name": "difference",
+        "args": [DurationColumn("column"), NumberRange("target", 0, None)],
+        "transform": u"abs(minus({column}, {target:g}))",
+        "result_type": "duration",
+    },
 }
 
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1261,8 +1261,8 @@ FUNCTIONS = {
         "result_type": "duration",
     },
     # Currently only being used by the baseline PoC
-    "difference": {
-        "name": "difference",
+    "absolute_delta": {
+        "name": "absolute_delta",
         "args": [DurationColumn("column"), NumberRange("target", 0, None)],
         "transform": u"abs(minus({column}, {target:g}))",
         "result_type": "duration",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -95,6 +95,7 @@ from .endpoints.organization_events import OrganizationEventsEndpoint, Organizat
 from .endpoints.organization_events_facets import OrganizationEventsFacetsEndpoint
 from .endpoints.organization_events_meta import (
     OrganizationEventsMetaEndpoint,
+    OrganizationEventBaseline,
     OrganizationEventsRelatedIssuesEndpoint,
 )
 from .endpoints.organization_events_stats import OrganizationEventsStatsEndpoint
@@ -822,6 +823,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/events-meta/$",
                     OrganizationEventsMetaEndpoint.as_view(),
                     name="sentry-api-0-organization-events-meta",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/event-baseline/$",
+                    OrganizationEventBaseline.as_view(),
+                    name="sentry-api-0-organization-event-baseline",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/issues/new/$",

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1642,28 +1642,28 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
         assert result["groupby"] == []
 
-    def test_difference_function(self):
-        fields = ["difference(transaction.duration,100)"]
+    def test_absolute_delta_function(self):
+        fields = ["absolute_delta(transaction.duration,100)"]
         result = resolve_field_list(fields, eventstore.Filter())
         assert result["selected_columns"] == []
         assert result["aggregations"] == [
-            ["abs(minus(duration, 100))", None, "difference_transaction_duration_100"],
+            ["abs(minus(duration, 100))", None, "absolute_delta_transaction_duration_100"],
         ]
         assert result["groupby"] == []
 
         with pytest.raises(InvalidSearchQuery) as err:
-            fields = ["difference(transaction,100)"]
+            fields = ["absolute_delta(transaction,100)"]
             resolve_field_list(fields, eventstore.Filter())
         assert (
-            "difference(transaction,100): column argument invalid: transaction is not a duration column"
+            "absolute_delta(transaction,100): column argument invalid: transaction is not a duration column"
             in six.text_type(err)
         )
 
         with pytest.raises(InvalidSearchQuery) as err:
-            fields = ["difference(transaction.duration,blah)"]
+            fields = ["absolute_delta(transaction.duration,blah)"]
             resolve_field_list(fields, eventstore.Filter())
         assert (
-            "difference(transaction.duration,blah): target argument invalid: blah is not a number"
+            "absolute_delta(transaction.duration,blah): target argument invalid: blah is not a number"
             in six.text_type(err)
         )
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1642,6 +1642,31 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
         assert result["groupby"] == []
 
+    def test_difference_function(self):
+        fields = ["difference(transaction.duration,100)"]
+        result = resolve_field_list(fields, eventstore.Filter())
+        assert result["selected_columns"] == []
+        assert result["aggregations"] == [
+            ["abs(minus(duration, 100))", None, "difference_transaction_duration_100"],
+        ]
+        assert result["groupby"] == []
+
+        with pytest.raises(InvalidSearchQuery) as err:
+            fields = ["difference(transaction,100)"]
+            resolve_field_list(fields, eventstore.Filter())
+        assert (
+            "difference(transaction,100): column argument invalid: transaction is not a duration column"
+            in six.text_type(err)
+        )
+
+        with pytest.raises(InvalidSearchQuery) as err:
+            fields = ["difference(transaction.duration,blah)"]
+            resolve_field_list(fields, eventstore.Filter())
+        assert (
+            "difference(transaction.duration,blah): target argument invalid: blah is not a number"
+            in six.text_type(err)
+        )
+
     def test_eps_function(self):
         fields = ["eps(3600)"]
         result = resolve_field_list(fields, eventstore.Filter())

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -195,6 +195,7 @@ class OrganizationEventBaselineEndpoint(APITestCase, SnubaTestCase):
 
         assert data["id"] == "b" * 32
         assert data["transaction.duration"] == 120000
+        assert data["p50"] == 120000.0
 
     def test_get_baseline_duration_tie(self):
         for index, event_id in enumerate(
@@ -217,6 +218,7 @@ class OrganizationEventBaselineEndpoint(APITestCase, SnubaTestCase):
 
         assert data["id"] == "b" * 32
         assert data["transaction.duration"] == 60000
+        assert data["p50"] == 60000
 
     def test_get_baseline_duration_and_timestamp_tie(self):
         for event_id in ["b" * 32, "a" * 32]:  # b then a so we know its not id breaking the tie
@@ -237,6 +239,7 @@ class OrganizationEventBaselineEndpoint(APITestCase, SnubaTestCase):
 
         assert data["id"] == "a" * 32
         assert data["transaction.duration"] == 60000
+        assert data["p50"] == 60000
 
     def test_get_baseline_with_computed_value(self):
         data = self.prototype.copy()
@@ -259,6 +262,7 @@ class OrganizationEventBaselineEndpoint(APITestCase, SnubaTestCase):
 
         assert data["id"] == "a" * 32
         assert data["transaction.duration"] == 60000
+        assert data["p50"] == 80000
 
     def test_get_baseline_with_different_function(self):
         for index, event_id in enumerate(["a" * 32, "b" * 32]):
@@ -282,6 +286,7 @@ class OrganizationEventBaselineEndpoint(APITestCase, SnubaTestCase):
 
         assert data["id"] == "b" * 32
         assert data["transaction.duration"] == 120000
+        assert data["max_transaction_duration"] == 120000
 
 
 class OrganizationEventsRelatedIssuesEndpoint(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -262,7 +262,7 @@ class OrganizationEventBaselineEndpoint(APITestCase, SnubaTestCase):
 
         assert data["id"] == "a" * 32
         assert data["transaction.duration"] == 60000
-        assert data["p50"] == 80000
+        assert data["p50"] == "80000"
 
     def test_get_baseline_with_different_function(self):
         for index, event_id in enumerate(["a" * 32, "b" * 32]):


### PR DESCRIPTION
- Adds a difference function for the baseline
  - Returns the difference between a duration column and a number
  - To be used with the baseline endpoint to find a transaction for comparisons that are closest to a computed value
- Add a baseline endpoint
  - First pass using p50 as the default
  - Optional parameter with baseline value, since there isn't any way to get this result without having to make two queries
