### PR TITLE
Fix(openInContextLine): Replace link component with externalLink

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/openInContextLine.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/openInContextLine.tsx
@@ -6,7 +6,7 @@ import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
 import space from 'app/styles/space';
 import {t} from 'app/locale';
 import {recordInteraction} from 'app/utils/recordSentryAppInteraction';
-import Link from 'app/components/links/link';
+import ExternalLink from 'app/components/links/externalLink';
 import {SentryAppComponent} from 'app/types';
 
 type Props = {
@@ -39,9 +39,10 @@ const OpenInContextLine = ({lineNo, filename, components}: Props) => {
           <OpenInLink
             key={component.uuid}
             data-test-id={`stacktrace-link-${slug}`}
-            to={url}
+            href={url}
             onClick={onClickRecordInteraction}
             onContextMenu={onClickRecordInteraction}
+            openInNewTab
           >
             <SentryAppIcon slug={slug} />
             <OpenInName>{t(`${component.sentryApp.name}`)}</OpenInName>
@@ -71,7 +72,7 @@ const OpenInContainer = styled('div')<{columnQuantity: number}>`
   white-space: nowrap;
 `;
 
-const OpenInLink = styled(Link)`
+const OpenInLink = styled(ExternalLink)`
   display: inline-grid;
   align-items: center;
   grid-template-columns: max-content auto;

--- a/tests/js/spec/components/events/interfaces/openInContextLine.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/openInContextLine.spec.jsx
@@ -63,7 +63,7 @@ describe('OpenInContextLine', function() {
       const stacktraceLinkFoo = wrapper.find(
         'OpenInLink[data-test-id="stacktrace-link-foo"]'
       );
-      expect(stacktraceLinkFoo.prop('to')).toEqual(url);
+      expect(stacktraceLinkFoo.prop('href')).toEqual(url);
       expect(stacktraceLinkFoo.text()).toEqual('Foo');
       expect(
         wrapper.find('OpenInLink[data-test-id="stacktrace-link-tesla"]').text()


### PR DESCRIPTION
The link for this part of the UI is broken:

![image](https://user-images.githubusercontent.com/29228205/87231711-c33ad400-c3b9-11ea-8efe-022d4133a9c1.png)

This PR fixes it by replacing the Link Component with the ExternalLink component 

#sync-getsentry