### PR TITLE
fix(images-loaded): Update list height after cleaning the filter

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/index.tsx
@@ -93,7 +93,9 @@ class DebugMeta extends React.PureComponent<Props, State> {
 
     if (
       !isEqual(prevState.foundFrame, this.state.foundFrame) ||
-      this.state.showDetails !== prevState.showDetails
+      this.state.showDetails !== prevState.showDetails ||
+      prevState.showUnused !== this.state.showUnused ||
+      (prevState.filter && !this.state.filter)
     ) {
       this.updateGrid();
     }


### PR DESCRIPTION
Update list height after cleaning the filter and checking/unchecking "showUnused" 