### PR TITLE
fix(ui) Correct feature flags for dashboards

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -458,7 +458,7 @@ class Sidebar extends React.Component<Props, State> {
 
                 <SidebarSection>
                   <Feature
-                    features={['discover', 'discover-basic']}
+                    features={['discover', 'discover-query']}
                     organization={organization}
                     requireAll={false}
                   >

--- a/src/sentry/static/sentry/app/views/dashboards/index.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/index.jsx
@@ -19,7 +19,7 @@ class Dashboards extends React.Component {
 
     return (
       <Feature
-        features={['discover', 'discover-basic']}
+        features={['discover', 'discover-query']}
         renderDisabled
         requireAll={false}
       >


### PR DESCRIPTION
Dashboards should only be shown to accounts that have full discover. This makes the feature flags match what we communicate on the pricing page.