### PR TITLE
fix(ui) Check hasAccess for super user/admin role

### DIFF
--- a/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
+++ b/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
@@ -66,15 +66,17 @@ export default function createQueryBuilder(
     query.range = DEFAULT_STATS_PERIOD;
   }
 
+  const hasGlobalProjectAccess =
+    ConfigStore.get('user').isSuperuser || organization.access.includes('org:admin');
+
   // TODO(lightweight-org): This needs to be refactored so that queries
   // do not depend on organization.projects
   const projectsToUse = specificProjects ?? organization.projects;
-  const defaultProjects = projectsToUse.filter(projects => projects.isMember);
+  const defaultProjects = projectsToUse.filter(projects =>
+    hasGlobalProjectAccess ? projects.hasAccess : projects.isMember
+  );
 
   const defaultProjectIds = getProjectIds(defaultProjects);
-
-  const hasGlobalProjectAccess =
-    ConfigStore.get('user').isSuperuser || organization.access.includes('org:admin');
 
   const projectsToFetchTags = getProjectIds(
     hasGlobalProjectAccess ? projectsToUse : defaultProjects

--- a/tests/js/spec/views/discover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/discover/queryBuilder.spec.jsx
@@ -279,7 +279,11 @@ describe('Query Builder', function() {
     let queryBuilder;
     beforeEach(function() {
       const project = TestStubs.Project({id: '1'});
-      const projectWithoutMembership = TestStubs.Project({id: '2', isMember: false});
+      const projectWithoutMembership = TestStubs.Project({
+        id: '2',
+        hasAccess: false,
+        isMember: false,
+      });
       queryBuilder = createQueryBuilder(
         {},
         TestStubs.Organization({projects: [project, projectWithoutMembership]})


### PR DESCRIPTION
When no projects are selected, use the hasAccess flag instead of isMember for superuser and admin user roles. This matches behavior with how discover 1 and the API endpoints work.