### PR TITLE
ref(vercel): Force uninstall via Vercel

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -136,7 +136,7 @@ class VercelIntegration(IntegrationInstallation):
         next_url = None
         configuration_id = self.get_configuration_id()
         if configuration_id:
-            next_url = u"https://vercel.com/dashboard/integrations/%s" % configuration_id
+            next_url = u"%s/dashboard/integrations/%s" % (base_url, configuration_id)
 
         proj_fields = ["id", "platform", "name", "slug"]
         sentry_projects = map(

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -62,6 +62,13 @@ external_install = {
 
 configure_integration = {"title": _("Connect Your Projects")}
 
+disable_dialog = {
+    "actionText": "Visit Vercel",
+    "body": "In order to uninstall this integration, you must go"
+    " to Vercel and uninstall there by clicking 'Remove Configuration'.",
+}
+
+
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
     features=FEATURES,
@@ -69,7 +76,11 @@ metadata = IntegrationMetadata(
     noun=_("Installation"),
     issue_url="https://github.com/getsentry/sentry/issues/new?title=Vercel%20Integration:%20&labels=Component%3A%20Integrations",
     source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/vercel",
-    aspects={"externalInstall": external_install, "configure_integration": configure_integration},
+    aspects={
+        "externalInstall": external_install,
+        "configure_integration": configure_integration,
+        "disable_dialog": disable_dialog,
+    },
 )
 
 internal_integration_overview = (
@@ -249,6 +260,7 @@ class VercelIntegrationProvider(IntegrationProvider):
     name = "Vercel"
     requires_feature_flag = True
     can_add = False
+    can_disable = True
     metadata = metadata
     integration_cls = VercelIntegration
     features = frozenset([IntegrationFeatures.DEPLOYMENT])

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -136,8 +136,17 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
 
   onDisable = (integration: Integration) => {
     let url: string;
-    const [domainName, orgName] = integration.domainName.split('/');
 
+    if (integration.provider.key === 'vercel') {
+      // kind of a hack since this isn't what the url was stored for
+      // but it's exactly what we need and contains the configuration id
+      // e.g. https://vercel.com/dashboard/integrations/icfg_ySlF4UDnHcIPrAAXjGEiwtxo
+      url = integration.configOrganization[0].nextButton.url;
+      window.open(url, '_blank');
+      return;
+    }
+
+    const [domainName, orgName] = integration.domainName.split('/');
     if (integration.accountType === 'User') {
       url = `https://${domainName}/settings/installations/`;
     } else {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -11,6 +11,7 @@ import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Integration, IntegrationProvider} from 'app/types';
+import {ProjectMapperType} from 'app/views/settings/components/forms/type';
 import {sortArray} from 'app/utils';
 import {isSlackWorkspaceApp, getReauthAlertText} from 'app/utils/integrationUtil';
 import withOrganization from 'app/utils/withOrganization';
@@ -140,9 +141,16 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     if (integration.provider.key === 'vercel') {
       // kind of a hack since this isn't what the url was stored for
       // but it's exactly what we need and contains the configuration id
-      // e.g. https://vercel.com/dashboard/integrations/icfg_ySlF4UDnHcIPrAAXjGEiwtxo
-      url = integration.configOrganization[0].nextButton.url;
-      window.open(url, '_blank');
+      // e.g. https://vercel.com/dashboard/<team>/integrations/icfg_ySlF4UDnHcIPrAAXjGEiwtxo
+      const field = integration.configOrganization.find(
+        config => config.type === 'project_mapper'
+      );
+
+      if (field) {
+        const mappingField = field as ProjectMapperType;
+        url = mappingField.nextButton.url || '';
+        window.open(url, '_blank');
+      }
       return;
     }
 


### PR DESCRIPTION
**Context**
Since you have to go to Vercel to install, it makes sense to send them there to uninstall. We have a delete hook setup that will take care of removing the integration on Sentry's end. 

**Using 'Disable Dialog'**
We've previously set up an aspect called `disable_dialog`, along with an attribute on the integration called `can_disable`. Having both of these means that in the UI we will redirect the user to the external service to do the uninstalling. Currently this disable flag is only used for GH, which makes my addition a little hacky. 

**Alternative Option**
We could have also created a new aspect named `external_uninstall`, but I figured they basically did the same thing, so maybe at some point we can handle formatting the redirect url/updating the integration serializer return `external_config_url` or something. 


FIXES SENTRY-H26