### PR TITLE
fix(py): Specify celery memory broker broker url correctly.

### DIFF
--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -84,7 +84,7 @@ def pytest_configure(config):
         settings.SENTRY_NEWSLETTER_OPTIONS = {}
 
     settings.BROKER_BACKEND = "memory"
-    settings.BROKER_URL = None
+    settings.BROKER_URL = "memory://"
     settings.CELERY_ALWAYS_EAGER = False
     settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 


### PR DESCRIPTION
In Celery 3.x it seems fine to just specify the `memory` backend and set `BROKER_URL=None`. In
Celery 4.x this ends up defaulting to a url like `amqp:...`, which causes a failure when we attempt
to flush the queue after each test. Luckily, all we need to do is specify the url like `memory://`
and it is correctly picked up again.

This change works fine in both Celery 3.x and 4.x