### PR TITLE
feat(discover): Integrate releases series into other display modes

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -1031,7 +1031,10 @@ class EventView {
   }
 
   getDisplayMode() {
-    const display = this.display ?? DisplayModes.DEFAULT;
+    const mode = this.display ?? DisplayModes.DEFAULT;
+    const display = (Object.values(DisplayModes) as string[]).includes(mode)
+      ? mode
+      : DisplayModes.DEFAULT;
     const displayOptions = this.getDisplayOptions();
     const selectedOption = displayOptions.find(option => option.value === display);
     if (selectedOption && !selectedOption.disabled) {

--- a/src/sentry/static/sentry/app/utils/discover/types.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/types.tsx
@@ -6,7 +6,6 @@ export const TOP_N = 5;
 export enum DisplayModes {
   DEFAULT = 'default',
   PREVIOUS = 'previous',
-  RELEASES = 'releases',
   TOP5 = 'top5',
   DAILY = 'daily',
   DAILYTOP5 = 'dailytop5',
@@ -15,7 +14,6 @@ export enum DisplayModes {
 export const DISPLAY_MODE_OPTIONS: SelectValue<string>[] = [
   {value: DisplayModes.DEFAULT, label: t('Total Period')},
   {value: DisplayModes.PREVIOUS, label: t('Previous Period')},
-  {value: DisplayModes.RELEASES, label: t('Release Markers')},
   {value: DisplayModes.TOP5, label: t('Top 5 Period')},
   {value: DisplayModes.DAILY, label: t('Total Daily')},
   {value: DisplayModes.DAILYTOP5, label: t('Top 5 Daily')},
@@ -24,7 +22,6 @@ export const DISPLAY_MODE_OPTIONS: SelectValue<string>[] = [
 export const DISPLAY_MODE_FALLBACK_OPTIONS = {
   [DisplayModes.DEFAULT]: DisplayModes.DEFAULT,
   [DisplayModes.PREVIOUS]: DisplayModes.DEFAULT,
-  [DisplayModes.RELEASES]: DisplayModes.DEFAULT,
   [DisplayModes.TOP5]: DisplayModes.DEFAULT,
   [DisplayModes.DAILY]: DisplayModes.DAILY,
   [DisplayModes.DAILYTOP5]: DisplayModes.DAILY,

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -76,7 +76,7 @@ class ResultsChart extends React.Component<ResultsChartProps> {
               end={end}
               period={globalSelection.statsPeriod}
               disablePrevious={display !== DisplayModes.PREVIOUS}
-              disableReleases={display !== DisplayModes.RELEASES}
+              disableReleases={isDaily}
               field={isTopEvents ? apiPayload.field : undefined}
               interval={eventView.interval}
               showDaily={isDaily}

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -56,8 +56,9 @@ class ResultsChart extends React.Component<ResultsChartProps> {
     const display = eventView.getDisplayMode();
     const isTopEvents =
       display === DisplayModes.TOP5 || display === DisplayModes.DAILYTOP5;
-
+    const isPeriod = display === DisplayModes.DEFAULT || display === DisplayModes.TOP5;
     const isDaily = display === DisplayModes.DAILYTOP5 || display === DisplayModes.DAILY;
+    const isPrevious = display === DisplayModes.PREVIOUS;
 
     return (
       <React.Fragment>
@@ -75,8 +76,8 @@ class ResultsChart extends React.Component<ResultsChartProps> {
               start={start}
               end={end}
               period={globalSelection.statsPeriod}
-              disablePrevious={display !== DisplayModes.PREVIOUS}
-              disableReleases={isDaily}
+              disablePrevious={!isPrevious}
+              disableReleases={!isPeriod}
               field={isTopEvents ? apiPayload.field : undefined}
               interval={eventView.interval}
               showDaily={isDaily}

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -2378,10 +2378,10 @@ describe('EventView.getDisplayOptions()', function() {
     });
 
     const options = eventView.getDisplayOptions();
-    expect(options[3].value).toEqual('top5');
-    expect(options[3].disabled).toBeTruthy();
-    expect(options[5].value).toEqual('dailytop5');
-    expect(options[5].disabled).toBeTruthy();
+    expect(options[2].value).toEqual('top5');
+    expect(options[2].disabled).toBeTruthy();
+    expect(options[4].value).toEqual('dailytop5');
+    expect(options[4].disabled).toBeTruthy();
   });
 });
 

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -294,7 +294,7 @@ describe('EventsV2 > Results', function() {
     wrapper.update();
 
     const eventsRequest = wrapper.find('EventsChart').props();
-    expect(eventsRequest.disableReleases).toEqual(true);
+    expect(eventsRequest.disableReleases).toEqual(false);
     expect(eventsRequest.disablePrevious).toEqual(true);
   });
 


### PR DESCRIPTION
Currently the releases series can only be view in Release mode. This change
removes the Releases mode and overlays the releases series over the period
modes. The release series is not visible in the daily modes as it messes up
the bar graphs.

### Before
<img width="1532" alt="Screen Shot 2020-07-13 at 5 09 11 PM" src="https://user-images.githubusercontent.com/10239353/87354479-965afe00-c52c-11ea-81f4-5b330c848192.png">

### After
<img width="1547" alt="Screen Shot 2020-07-13 at 5 08 45 PM" src="https://user-images.githubusercontent.com/10239353/87354408-83e0c480-c52c-11ea-91a1-9ee0bb1b5634.png">