### PR TITLE
ref(test): Various test cleanups

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -211,33 +211,13 @@ class BaseTestCase(Fixtures, Exam):
             return fp.read()
 
     def _pre_setup(self):
-        pass
-
-    def _post_teardown(self):
-        pass
-
-    @pytest.fixture(autouse=True)
-    def pre_setup_and_post_teardown(self):
-        """
-        Massive hack to make py.test --pdb work correctly. When pytest is
-        passed this flag, it refuses to call _post_teardown() after any failing
-        or xfailing test, causing leaking teststate to crash subsequent tests
-        as well.
-
-        To fix this issue we make sure _pre_setup and _post_teardown are noops,
-        and drive the underlying code from Django using this fixture, which
-        seems to be correctly set up and torn down by pytest.
-
-        In the end the amount of times _pre_setup and _post_teardown are called
-        for regular tests does not change, it's always before/after each test
-        function.
-        """
         super(BaseTestCase, self)._pre_setup()
 
         cache.clear()
         ProjectOption.objects.clear_local_cache()
         GroupMeta.objects.clear_local_cache()
-        yield
+
+    def _post_teardown(self):
         super(BaseTestCase, self)._post_teardown()
 
     def options(self, options):

--- a/tests/sentry/db/models/fields/bitfield/test_bitfield.py
+++ b/tests/sentry/db/models/fields/bitfield/test_bitfield.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
+import unittest
 import pickle
+
 import six
 
 from django import forms
@@ -27,7 +29,7 @@ class BitFieldTestModelForm(forms.ModelForm):
         exclude = tuple()
 
 
-class BitHandlerTest(TestCase):
+class BitHandlerTest(unittest.TestCase):
     def test_comparison(self):
         bithandler_1 = BitHandler(0, ("FLAG_0", "FLAG_1", "FLAG_2", "FLAG_3"))
         bithandler_2 = BitHandler(1, ("FLAG_0", "FLAG_1", "FLAG_2", "FLAG_3"))
@@ -109,7 +111,7 @@ class BitHandlerTest(TestCase):
         self.assertEquals(bithandler.FLAG_2, False)
 
 
-class BitTest(TestCase):
+class BitTest(unittest.TestCase):
     def test_int(self):
         bit = Bit(0)
         self.assertEquals(int(bit), 1)
@@ -341,8 +343,15 @@ class BitFieldTest(TestCase):
         field = TestModel._meta.get_field("flags")
         self.assertEquals(field.default, TestModel.flags.FLAG_1 | TestModel.flags.FLAG_2)
 
+    def test_pickle_integration(self):
+        inst = BitFieldTestModel.objects.create(flags=1)
+        data = pickle.dumps(inst)
+        inst = pickle.loads(data)
+        self.assertEquals(type(inst.flags), BitHandler)
+        self.assertEquals(int(inst.flags), 1)
 
-class BitFieldSerializationTest(TestCase):
+
+class BitFieldSerializationTest(unittest.TestCase):
     def test_can_unserialize_bithandler(self):
         bf = BitFieldTestModel()
         bf.flags.FLAG_0 = 1
@@ -351,13 +360,6 @@ class BitFieldSerializationTest(TestCase):
         inst = pickle.loads(data)
         self.assertTrue(inst.flags.FLAG_0)
         self.assertFalse(inst.flags.FLAG_1)
-
-    def test_pickle_integration(self):
-        inst = BitFieldTestModel.objects.create(flags=1)
-        data = pickle.dumps(inst)
-        inst = pickle.loads(data)
-        self.assertEquals(type(inst.flags), BitHandler)
-        self.assertEquals(int(inst.flags), 1)
 
     def test_added_field(self):
         bf = BitFieldTestModel()

--- a/tests/sentry/utils/locking/test_lock.py
+++ b/tests/sentry/utils/locking/test_lock.py
@@ -1,15 +1,15 @@
 from __future__ import absolute_import
 
+import unittest
 from sentry.utils.compat import mock
 import pytest
 
-from sentry.testutils import TestCase
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.locking.backends import LockBackend
 from sentry.utils.locking.lock import Lock
 
 
-class LockTestCase(TestCase):
+class LockTestCase(unittest.TestCase):
     def test_procedural_interface(self):
         backend = mock.Mock(spec=LockBackend)
         key = "lock"

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import unittest
+
 from datetime import datetime, timedelta
 from django.utils import timezone
 
@@ -203,7 +205,7 @@ class PrepareQueryParamsTest(TestCase):
             _prepare_query_params(query_params)
 
 
-class QuantizeTimeTest(TestCase):
+class QuantizeTimeTest(unittest.TestCase):
     def setUp(self):
         self.now = timezone.now().replace(microsecond=0)
 


### PR DESCRIPTION
* Remove unused helper functions
* Swap `sentry.testutils.TestCase` usage out for `unittest.TestCase` when DB is not used (faster)
* ~Add hack to get `pytest --pdb` working~