### PR TITLE
ref(GitHub): Update soon-to-be deprecated installation access token endpoint

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -104,7 +104,7 @@ class GitHubClientMixin(ApiClient):
 
     def create_token(self):
         return self.post(
-            u"/installations/{}/access_tokens".format(self.integration.external_id),
+            u"/app/installations/{}/access_tokens".format(self.integration.external_id),
             headers={
                 "Authorization": "Bearer %s" % self.get_jwt(),
                 # TODO(jess): remove this whenever it's out of preview

--- a/src/sentry/integrations/github_enterprise/client.py
+++ b/src/sentry/integrations/github_enterprise/client.py
@@ -21,7 +21,9 @@ class GitHubEnterpriseAppsClient(GitHubClientMixin):
 
     def create_token(self):
         return self.post(
-            u"/installations/{}/access_tokens".format(self.integration.metadata["installation_id"]),
+            u"/app/installations/{}/access_tokens".format(
+                self.integration.metadata["installation_id"]
+            ),
             headers={
                 "Authorization": "Bearer %s" % self.get_jwt(),
                 # TODO(jess): remove this whenever it's out of preview

--- a/src/sentry_plugins/github/client.py
+++ b/src/sentry_plugins/github/client.py
@@ -120,7 +120,7 @@ class GitHubAppsClient(GitHubClientMixin, ApiClient):
 
     def create_token(self):
         return self.post(
-            "/installations/{}/access_tokens".format(self.integration.external_id),
+            "/app/installations/{}/access_tokens".format(self.integration.external_id),
             headers={
                 "Authorization": "Bearer %s" % self.get_jwt(),
                 # TODO(jess): remove this whenever it's out of preview

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -24,7 +24,7 @@ class GitHubAppsClientTest(TestCase):
 
         responses.add(
             method=responses.POST,
-            url="https://api.github.com/installations/1/access_tokens",
+            url="https://api.github.com/app/installations/1/access_tokens",
             body='{"token": "12345token", "expires_at": "2030-01-01T00:00:00Z"}',
             status=200,
             content_type="application/json",

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -43,7 +43,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.POST,
-            self.base_url + "/installations/{}/access_tokens".format(self.installation_id),
+            self.base_url + "/app/installations/{}/access_tokens".format(self.installation_id),
             json={"token": self.access_token, "expires_at": self.expires_at},
         )
 

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -34,7 +34,7 @@ class GitHubIssueBasicTest(TestCase):
     def test_get_allowed_assignees(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            "https://api.github.com/installations/github_external_id/access_tokens",
+            "https://api.github.com/app/installations/github_external_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
@@ -61,7 +61,7 @@ class GitHubIssueBasicTest(TestCase):
     def test_create_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            "https://api.github.com/installations/github_external_id/access_tokens",
+            "https://api.github.com/app/installations/github_external_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
@@ -102,7 +102,7 @@ class GitHubIssueBasicTest(TestCase):
     def test_get_repo_issues(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            "https://api.github.com/installations/github_external_id/access_tokens",
+            "https://api.github.com/app/installations/github_external_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
@@ -126,7 +126,7 @@ class GitHubIssueBasicTest(TestCase):
         issue_id = 321
         responses.add(
             responses.POST,
-            "https://api.github.com/installations/github_external_id/access_tokens",
+            "https://api.github.com/app/installations/github_external_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
@@ -165,7 +165,7 @@ class GitHubIssueBasicTest(TestCase):
 
         responses.add(
             responses.POST,
-            "https://api.github.com/installations/github_external_id/access_tokens",
+            "https://api.github.com/app/installations/github_external_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
@@ -215,7 +215,7 @@ class GitHubIssueBasicTest(TestCase):
     def after_link_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            "https://api.github.com/installations/github_external_id/access_tokens",
+            "https://api.github.com/app/installations/github_external_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
@@ -284,7 +284,7 @@ class GitHubIssueBasicTest(TestCase):
         )
         responses.add(
             responses.POST,
-            "https://api.github.com/installations/github_external_id/access_tokens",
+            "https://api.github.com/app/installations/github_external_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
         event = self.store_event(
@@ -333,7 +333,7 @@ class GitHubIssueBasicTest(TestCase):
         )
         responses.add(
             responses.POST,
-            "https://api.github.com/installations/github_external_id/access_tokens",
+            "https://api.github.com/app/installations/github_external_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
         event = self.store_event(

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -21,7 +21,7 @@ def stub_installation_token():
     ten_hours = datetime.datetime.utcnow() + datetime.timedelta(hours=10)
     responses.add(
         responses.POST,
-        "https://api.github.com/installations/654321/access_tokens",
+        "https://api.github.com/app/installations/654321/access_tokens",
         json={"token": "v1.install-token", "expires_at": ten_hours.strftime("%Y-%m-%dT%H:%M:%SZ")},
     )
 
@@ -215,7 +215,7 @@ class GitHubAppsProviderTest(PluginTestCase):
         assert responses.calls[0].response.status_code == 404
         assert (
             responses.calls[1].response.url
-            == u"https://api.github.com/installations/654321/access_tokens"
+            == u"https://api.github.com/app/installations/654321/access_tokens"
         )
         assert responses.calls[1].response.status_code == 200
         assert (

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -75,7 +75,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.POST,
-            self.base_url + "/installations/{}/access_tokens".format(installation_id),
+            self.base_url + "/app/installations/{}/access_tokens".format(installation_id),
             json={"token": access_token, "expires_at": "3000-01-01T00:00:00Z"},
         )
 

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -38,7 +38,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
     def test_get_allowed_assignees(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            "https://35.232.149.196/api/v3/installations/installation_id/access_tokens",
+            "https://35.232.149.196/api/v3/app/installations/installation_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
@@ -65,7 +65,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
     def test_create_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            "https://35.232.149.196/api/v3/installations/installation_id/access_tokens",
+            "https://35.232.149.196/api/v3/app/installations/installation_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
@@ -106,7 +106,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
     def test_get_repo_issues(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            "https://35.232.149.196/api/v3/installations/installation_id/access_tokens",
+            "https://35.232.149.196/api/v3/app/installations/installation_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
@@ -130,7 +130,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
         issue_id = 321
         responses.add(
             responses.POST,
-            "https://35.232.149.196/api/v3/installations/installation_id/access_tokens",
+            "https://35.232.149.196/api/v3/app/installations/installation_id/access_tokens",
             json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 


### PR DESCRIPTION
In response to the [notice](https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint/) that GitHub will be deprecating the "Create an installation access token" endpoint, this updates the endpoints to use the new endpoint. 