### PR TITLE
fix(metric_alerts): Fix passing `resolve_threshold` and `threshold_type` at the rule level.

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -412,29 +412,19 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                     'Trigger {} must be labeled "{}"'.format(i + 1, expected_label)
                 )
         critical = triggers[0]
-        data["threshold_type"] = threshold_type = data.get(
-            "threshold_type",
-            AlertRuleThresholdType(
+        if "threshold_type" in data:
+            threshold_type = data["threshold_type"]
+            for trigger in triggers:
+                trigger["threshold_type"] = threshold_type.value
+        else:
+            data["threshold_type"] = threshold_type = AlertRuleThresholdType(
                 critical.get("threshold_type", AlertRuleThresholdType.ABOVE.value)
-            ),
-        )
-        self._validate_trigger_thresholds(threshold_type, critical, data.get("resolve_threshold"))
-
-        if len(triggers) == 2:
-            warning = triggers[1]
-            if critical["threshold_type"] != warning["threshold_type"]:
-                raise serializers.ValidationError(
-                    "Must have matching threshold types (i.e. critical and warning "
-                    "triggers must both be an upper or lower bound)"
-                )
-            self._validate_trigger_thresholds(
-                threshold_type, warning, data.get("resolve_threshold")
             )
-            self._validate_critical_warning_triggers(threshold_type, critical, warning)
 
-        # Temporarily fetch resolve threshold from the triggers if one isn't explicitly
-        # passed to the alert rule.
-        if "resolve_threshold" not in data:
+        if "resolve_threshold" in data:
+            for trigger in triggers:
+                trigger["resolve_threshold"] = data["resolve_threshold"]
+        else:
             trigger_resolve_thresholds = [
                 trigger["resolve_threshold"]
                 for trigger in triggers
@@ -448,9 +438,20 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 )
             else:
                 data["resolve_threshold"] = None
-        else:
-            for trigger in triggers:
-                trigger["resolve_threshold"] = data["resolve_threshold"]
+
+        self._validate_trigger_thresholds(threshold_type, critical, data.get("resolve_threshold"))
+
+        if len(triggers) == 2:
+            warning = triggers[1]
+            if critical["threshold_type"] != warning["threshold_type"]:
+                raise serializers.ValidationError(
+                    "Must have matching threshold types (i.e. critical and warning "
+                    "triggers must both be an upper or lower bound)"
+                )
+            self._validate_trigger_thresholds(
+                threshold_type, warning, data.get("resolve_threshold")
+            )
+            self._validate_critical_warning_triggers(threshold_type, critical, warning)
 
         # Triggers have passed checks. Check that all triggers have at least one action now.
         for trigger in triggers:

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -224,6 +224,38 @@ class TestAlertRuleSerializer(TestCase):
 
         assert serializer.is_valid(), serializer.errors
 
+    def test_alert_rule_threshold_resolve_only(self):
+        resolve_threshold = 10
+        payload = {
+            "name": "hello_im_a_test",
+            "time_window": 10,
+            "query": "level:error",
+            "aggregate": "count()",
+            "thresholdType": 0,
+            "resolveThreshold": 10,
+            "threshold_period": 1,
+            "projects": [self.project.slug],
+            "triggers": [
+                {
+                    "label": "critical",
+                    "alertThreshold": 98,
+                    "actions": [
+                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id}
+                    ],
+                }
+            ],
+        }
+        serializer = AlertRuleSerializer(context=self.context, data=payload, partial=True)
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["threshold_type"] == AlertRuleThresholdType.ABOVE
+        assert serializer.validated_data["resolve_threshold"] == resolve_threshold
+        assert (
+            serializer.validated_data["triggers"][0]["threshold_type"]
+            == AlertRuleThresholdType.ABOVE.value
+        )
+        assert serializer.validated_data["triggers"][0]["resolve_threshold"] == resolve_threshold
+
     def test_alert_rule_threshold_overrides_trigger(self):
         payload = {
             "name": "hello_im_a_test",


### PR DESCRIPTION
This fixes an issue with passing the new alert rule level `resolve_threshold` and `threshold_type`
fields without passing the corresponding fields to the triggers. Now we override any value passed to
the triggers if an alert rule level value is passed, and we do so before any validation so that it
will work as expected.