### PR TITLE
feat(msteams): implements token refresh and stores service url

### DIFF
--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -89,19 +89,19 @@ class MsTeamsAbstractClient(ApiClient):
         self.send_message(conversation_id, payload)
 
 
-# MsTeamsClient is used with the access token and service url as arguments to the constructor
+# MsTeamsPreInstallClient is used with the access token and service url as arguments to the constructor
 # It will not handle token refreshing
-class MsTeamsClient(MsTeamsAbstractClient):
+class MsTeamsPreInstallClient(MsTeamsAbstractClient):
     def __init__(self, access_token, service_url):
-        super(MsTeamsClient, self).__init__()
+        super(MsTeamsPreInstallClient, self).__init__()
         self.access_token = access_token
         self.base_url = service_url.rstrip("/")
 
 
-# MsTeamsIntegrationClient is used with an existing integration object and handles token refreshing
-class MsTeamsIntegrationClient(MsTeamsAbstractClient):
+# MsTeamsClient is used with an existing integration object and handles token refreshing
+class MsTeamsClient(MsTeamsAbstractClient):
     def __init__(self, integration):
-        super(MsTeamsIntegrationClient, self).__init__()
+        super(MsTeamsClient, self).__init__()
         self.integration = integration
 
     @property
@@ -129,7 +129,7 @@ class MsTeamsIntegrationClient(MsTeamsAbstractClient):
 # OAuthMsTeamsClient is used only for the exchanging the token
 class OAuthMsTeamsClient(ApiClient):
     base_url = "https://login.microsoftonline.com/botframework.com"
-    integration_name = "msteams_oauth"
+    integration_name = "msteams"
 
     TOKEN_URL = "/oauth2/v2.0/token"
 

--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -13,7 +13,7 @@ from sentry.utils.http import absolute_uri
 EXPIRATION_OFFSET = 60
 
 
-# this abstract client does not handle setting the base url or auth token
+# MsTeamsAbstractClient abstract client does not handle setting the base url or auth token
 class MsTeamsAbstractClient(ApiClient):
     integration_name = "msteams"
     TEAM_URL = "/v3/teams/%s"
@@ -89,6 +89,8 @@ class MsTeamsAbstractClient(ApiClient):
         self.send_message(conversation_id, payload)
 
 
+# MsTeamsClient is used with the access token and service url as arguments to the constructor
+# It will not handle token refreshing
 class MsTeamsClient(MsTeamsAbstractClient):
     def __init__(self, access_token, service_url):
         super(MsTeamsClient, self).__init__()
@@ -96,6 +98,7 @@ class MsTeamsClient(MsTeamsAbstractClient):
         self.base_url = service_url.rstrip("/")
 
 
+# MsTeamsIntegrationClient is used with an existing integration object and handles token refreshing
 class MsTeamsIntegrationClient(MsTeamsAbstractClient):
     def __init__(self, integration):
         super(MsTeamsIntegrationClient, self).__init__()
@@ -123,6 +126,7 @@ class MsTeamsIntegrationClient(MsTeamsAbstractClient):
         return access_token
 
 
+# OAuthMsTeamsClient is used only for the exchanging the token
 class OAuthMsTeamsClient(ApiClient):
     base_url = "https://login.microsoftonline.com/botframework.com"
     integration_name = "msteams_oauth"

--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -13,7 +13,7 @@ from sentry.integrations import (
     FeatureDescription,
 )
 from sentry.pipeline import PipelineView
-from .client import MsTeamsClient, get_token_data
+from .client import MsTeamsPreInstallClient, get_token_data
 
 logger = logging.getLogger("sentry.integrations.msteams")
 
@@ -82,7 +82,7 @@ class MsTeamsIntegrationProvider(IntegrationProvider):
         token_data = get_token_data()
         access_token = token_data["access_token"]
 
-        client = MsTeamsClient(access_token, service_url)
+        client = MsTeamsPreInstallClient(access_token, service_url)
         team = client.get_team_info(team_id)
         integration = {
             "name": team["name"],

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -5,9 +5,10 @@ import logging
 from django.views.decorators.csrf import csrf_exempt
 from sentry.api.base import Endpoint
 from sentry.utils.compat import filter
+from sentry.utils.signing import sign
 from sentry.web.decorators import transaction_start
 
-from .client import MsTeamsClient
+from .client import MsTeamsClient, get_token_data
 
 logger = logging.getLogger("sentry.integrations.msteams.webhooks")
 
@@ -20,6 +21,7 @@ def verify_signature(request):
 class MsTeamsWebhookEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
+    provider = "msteams"
 
     @csrf_exempt
     def dispatch(self, request, *args, **kwargs):
@@ -41,9 +43,18 @@ class MsTeamsWebhookEndpoint(Endpoint):
             # only care if our bot is the new member added
             matches = filter(lambda x: x["id"] == data["recipient"]["id"], data["membersAdded"])
             if matches:
-                # send welcome message to the team
                 team_id = channel_data["team"]["id"]
-                client = MsTeamsClient()
-                client.send_welcome_message(team_id)
+
+                access_token = get_token_data()["access_token"]
+
+                # need to keep track of the service url since we won't get it later
+                signed_data = {"team_id": team_id, "service_url": data["serviceUrl"]}
+
+                # sign the params so this can't be forged
+                signed_params = sign(**signed_data)
+
+                # send welcome message to the team
+                client = MsTeamsClient(access_token, data["serviceUrl"])
+                client.send_welcome_message(team_id, signed_params)
 
         return self.respond(status=200)

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -8,7 +8,7 @@ from sentry.utils.compat import filter
 from sentry.utils.signing import sign
 from sentry.web.decorators import transaction_start
 
-from .client import MsTeamsClient, get_token_data
+from .client import MsTeamsPreInstallClient, get_token_data
 
 logger = logging.getLogger("sentry.integrations.msteams.webhooks")
 
@@ -54,7 +54,7 @@ class MsTeamsWebhookEndpoint(Endpoint):
                 signed_params = sign(**signed_data)
 
                 # send welcome message to the team
-                client = MsTeamsClient(access_token, data["serviceUrl"])
+                client = MsTeamsPreInstallClient(access_token, data["serviceUrl"])
                 client.send_welcome_message(team_id, signed_params)
 
         return self.respond(status=200)

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -123,6 +123,8 @@ def pytest_configure(config):
             "vsts.client-secret": "vsts-client-secret",
             "vercel.client-id": "vercel-client-id",
             "vercel.client-secret": "vercel-client-secret",
+            "msteams.client-id": "msteams-client-id",
+            "msteams.client-secret": "msteams-client-secret",
         }
     )
 

--- a/tests/sentry/integrations/msteams/__init__.py
+++ b/tests/sentry/integrations/msteams/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/integrations/msteams/test_client.py
+++ b/tests/sentry/integrations/msteams/test_client.py
@@ -5,7 +5,7 @@ import responses
 from six.moves.urllib.parse import urlencode
 
 from sentry.models import Integration
-from sentry.integrations.msteams.client import MsTeamsIntegrationClient
+from sentry.integrations.msteams.client import MsTeamsClient
 from sentry.testutils import TestCase
 from sentry.utils.compat.mock import patch
 
@@ -27,7 +27,7 @@ class MsTeamsClientTest(TestCase):
             json=access_json,
         )
 
-        self.client = MsTeamsIntegrationClient(self.integration)
+        self.client = MsTeamsClient(self.integration)
 
     @responses.activate
     def test_token_refreshes(self):

--- a/tests/sentry/integrations/msteams/test_client.py
+++ b/tests/sentry/integrations/msteams/test_client.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+
+import responses
+
+from six.moves.urllib.parse import urlencode
+
+from sentry.models import Integration
+from sentry.integrations.msteams.client import MsTeamsIntegrationClient
+from sentry.testutils import TestCase
+from sentry.utils.compat.mock import patch
+
+
+class MsTeamsClientTest(TestCase):
+    def setUp(self):
+        self.expires_at = 1594768808
+        self.integration = Integration.objects.create(
+            provider="msteams",
+            name="my_team",
+            metadata={"access_token": "my_token", "expires_at": self.expires_at},
+        )
+
+        # token mock
+        access_json = {"expires_in": 86399, "access_token": "my_new_token"}
+        responses.add(
+            responses.POST,
+            u"https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
+            json=access_json,
+        )
+
+        self.client = MsTeamsIntegrationClient(self.integration)
+
+    @responses.activate
+    def test_token_refreshes(self):
+        with patch("time.time") as mock_time:
+            mock_time.return_value = self.expires_at
+            # accessing the property should refresh the token
+            self.client.access_token
+            body = responses.calls[0].request.body
+            assert body == urlencode(
+                {
+                    "client_id": "msteams-client-id",
+                    "client_secret": "msteams-client-secret",
+                    "grant_type": "client_credentials",
+                    "scope": "https://api.botframework.com/.default",
+                }
+            )
+
+            integration = Integration.objects.get(provider="msteams")
+            assert integration.metadata == {
+                "access_token": "my_new_token",
+                "expires_at": self.expires_at + 86399 - 60,
+            }
+
+    @responses.activate
+    def test_no_token_refresh(self):
+        with patch("time.time") as mock_time:
+            mock_time.return_value = self.expires_at - 100
+            # accessing the property should refresh the token
+            self.client.access_token
+            assert not responses.calls
+
+            integration = Integration.objects.get(provider="msteams")
+            assert integration.metadata == {
+                "access_token": "my_token",
+                "expires_at": self.expires_at,
+            }

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -1,0 +1,82 @@
+from __future__ import absolute_import
+
+
+import responses
+
+from six.moves.urllib.parse import urlencode
+
+
+from sentry.integrations.msteams import MsTeamsIntegrationProvider
+from sentry.models import Integration, OrganizationIntegration
+from sentry.testutils import IntegrationTestCase
+from sentry.utils.compat.mock import patch
+from sentry.utils.signing import sign
+
+
+team_id = "19:8d46058cda57449380517cc374727f2a@thread.tacv2"
+
+
+class MsTeamsIntegrationTest(IntegrationTestCase):
+    provider = MsTeamsIntegrationProvider
+
+    def assert_setup_flow(self):
+        responses.reset()
+
+        with patch("time.time") as mock_time:
+            mock_time.return_value = 1594768808
+            # token mock
+            access_json = {"expires_in": 86399, "access_token": "my_token"}
+            responses.add(
+                responses.POST,
+                u"https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
+                json=access_json,
+            )
+
+            responses.add(
+                responses.GET,
+                "https://smba.trafficmanager.net/amer/v3/teams/%s" % team_id,
+                json={"name": "my_team"},
+            )
+
+            pipeline_state = {
+                "team_id": team_id,
+                "service_url": "https://smba.trafficmanager.net/amer/",
+            }
+
+            params = {"signed_params": sign(**pipeline_state)}
+
+            self.pipeline.bind_state(self.provider.key, pipeline_state)
+            resp = self.client.get(self.setup_path, params)
+
+            body = responses.calls[0].request.body
+            assert body == urlencode(
+                {
+                    "client_id": "msteams-client-id",
+                    "client_secret": "msteams-client-secret",
+                    "grant_type": "client_credentials",
+                    "scope": "https://api.botframework.com/.default",
+                }
+            )
+
+            assert resp.status_code == 200
+            self.assertDialogSuccess(resp)
+
+            integration = Integration.objects.get(provider=self.provider.key)
+
+            assert integration.external_id == team_id
+            assert integration.name == "my_team"
+            assert integration.metadata == {
+                "access_token": "my_token",
+                "service_url": "https://smba.trafficmanager.net/amer/",
+                "expires_at": 1594768808 + 86399 - 60,
+            }
+            assert OrganizationIntegration.objects.get(
+                integration=integration, organization=self.organization
+            )
+
+    @responses.activate
+    def test_installation(self):
+        """Test that the function doesn't progress if there is no active DSN"""
+
+        with self.tasks():
+            self.assert_setup_flow()

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -76,7 +76,5 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
 
     @responses.activate
     def test_installation(self):
-        """Test that the function doesn't progress if there is no active DSN"""
-
         with self.tasks():
             self.assert_setup_flow()

--- a/tests/sentry/integrations/msteams/test_utils.py
+++ b/tests/sentry/integrations/msteams/test_utils.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+
+EXAMPLE_MEMBER_ADDED = {
+    "recipient": {"id": "28:5710acff-f313-453f-8b75-44fff54bab14", "name": "Steve-Bot-5"},
+    "from": {
+        "aadObjectId": "a6de2a64-9501-4e16-9e50-74df223570a3",
+        "id": "29:1Q2o9Y0pyxOhK7QU6o7DatYWMy4MFapyiHoA1r_xB2s5XsGTSxIrKOH_JGmxDXpex30trbSo3Oyh3pkXF8RnlVQ",
+    },
+    "conversation": {
+        "id": "19:8d46058cda57449380517cc374727f2a@thread.tacv2",
+        "conversationType": "channel",
+        "isGroup": True,
+        "tenantId": "f5ffd8cf-a1aa-4242-adad-86509faa3be5",
+    },
+    "timestamp": "2020-07-13T19:54:30.8044041Z",
+    "channelId": "msteams",
+    "membersAdded": [{"id": "28:5710acff-f313-453f-8b75-44fff54bab14"}],
+    "serviceUrl": "https://smba.trafficmanager.net/amer/",
+    "channelData": {
+        "eventType": "teamMemberAdded",
+        "tenant": {"id": "f5ffd8cf-a1aa-4242-adad-86509faa3be5"},
+        "team": {
+            "name": "testsentry",
+            "aadGroupId": "c2d5a19b-f3a9-48ed-ade3-fc41aa861a18",
+            "id": "19:8d46058cda57449380517cc374727f2a@thread.tacv2",
+        },
+    },
+    "type": "conversationUpdate",
+    "id": "f:8e005ef8-f848-156f-55b1-0a5bb3207225",
+}

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+
+import responses
+from six.moves.urllib.parse import urlencode
+
+from sentry.testutils import APITestCase
+
+from .test_utils import EXAMPLE_MEMBER_ADDED
+
+
+webhook_url = "/extensions/msteams/webhook/"
+team_id = "19:8d46058cda57449380517cc374727f2a@thread.tacv2"
+
+
+class MsTeamsWebhookTest(APITestCase):
+    def setUp(self):
+        super(MsTeamsWebhookTest, self).setUp()
+
+        access_json = {"expires_in": 86399, "access_token": "my_token"}
+        responses.add(
+            responses.POST,
+            u"https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
+            json=access_json,
+        )
+        responses.add(
+            responses.POST,
+            u"https://smba.trafficmanager.net/amer/v3/conversations/%s/activities" % team_id,
+            json={},
+        )
+
+    @responses.activate
+    def test_member_added(self):
+        self.client.post(
+            path=webhook_url, data=EXAMPLE_MEMBER_ADDED, format="json",
+        )
+
+        # integration = Integration.objects.get(provider="msteams")
+        # installation = integration.get_installation(self.organization.id)
+
+        body = responses.calls[0].request.body
+        assert body == urlencode(
+            {
+                "client_id": "msteams-client-id",
+                "client_secret": "msteams-client-secret",
+                "grant_type": "client_credentials",
+                "scope": "https://api.botframework.com/.default",
+            }
+        )
+
+        assert (
+            responses.calls[1].request.url
+            == "https://smba.trafficmanager.net/amer/v3/conversations/%s/activities" % team_id
+        )

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -34,9 +34,6 @@ class MsTeamsWebhookTest(APITestCase):
             path=webhook_url, data=EXAMPLE_MEMBER_ADDED, format="json",
         )
 
-        # integration = Integration.objects.get(provider="msteams")
-        # installation = integration.get_installation(self.organization.id)
-
         body = responses.calls[0].request.body
         assert body == urlencode(
             {

--- a/tests/sentry/web/frontend/test_msteams_extension.py
+++ b/tests/sentry/web/frontend/test_msteams_extension.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+
+from sentry.testutils import TestCase
+from sentry.web.frontend.msteams_extension_configuration import MsTeamsExtensionConfigurationView
+from sentry.utils.signing import sign
+
+
+class MsTeamsExtensionConfigurationTest(TestCase):
+    def test_map_params(self):
+        config_view = MsTeamsExtensionConfigurationView()
+        data = {"my_param": "test"}
+        signed_data = sign(**data)
+        params = {"signed_params": signed_data}
+        assert data == config_view.map_params_to_state(params)


### PR DESCRIPTION
This PR adds the handing of token refreshes and storing the `service_url` in the integration metadata. The `service_url` is the URL we need to use when using Teams' APIs and we will need to update it when it changes. Updating the URL is not being handled in this PR (this PR just stores the initial value we get).

With regards to refreshing, I basically copied the strategy we use with Github. We pass the `integration` as a parameter to the API client `MsTeamsIntegrationClient`. When we try to use the token and we detect it's expired, generate a new one and save it.

Because the refresh strategy requires an existing `Integration` row, I have a different API client (`MsTeamsClient`) that we can use before the integration is created. We just have to pass an access token and the service url to this client to use it. We use it to send the welcome message and retrieve the team information before saving the integration.

Regarding the reset strategy, I have subtracted a 60-second offset from the expiration time because of the propagation delay between requests. Better to be safe than sorry when the token is close to expiring!