### PR TITLE
ref(ui) Update icons used in PanelAlert

### DIFF
--- a/docs-ui/components/panels.stories.js
+++ b/docs-ui/components/panels.stories.js
@@ -2,9 +2,11 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {withInfo} from '@storybook/addon-info';
 
+import {IconTelescope} from 'app/icons';
 import Button from 'app/components/button';
 import {
   Panel,
+  PanelAlert,
   PanelHeader,
   PanelBody,
   PanelItem,
@@ -25,6 +27,28 @@ storiesOf('UI|Panels', module)
         <PanelBody>
           <PanelItem>Panel Item</PanelItem>
           <PanelItem>Panel Item</PanelItem>
+          <PanelItem>Panel Item</PanelItem>
+        </PanelBody>
+      </Panel>
+    ))
+  )
+  .add(
+    'Panel Alerts',
+    withInfo({
+      text: 'Alert boxes inside a panel',
+      propTablesExclude: [Button],
+    })(() => (
+      <Panel>
+        <PanelHeader>Panel Header</PanelHeader>
+
+        <PanelBody>
+          <PanelAlert type="info">Info Alert message</PanelAlert>
+          <PanelAlert type="error">Error Alert message</PanelAlert>
+          <PanelAlert type="warning">Warning Alert message</PanelAlert>
+          <PanelAlert type="success">Success Alert message</PanelAlert>
+          <PanelAlert type="info" icon={<IconTelescope />}>
+            Custom Icon message
+          </PanelAlert>
           <PanelItem>Panel Item</PanelItem>
         </PanelBody>
       </Panel>

--- a/docs-ui/components/panels.stories.js
+++ b/docs-ui/components/panels.stories.js
@@ -46,7 +46,7 @@ storiesOf('UI|Panels', module)
           <PanelAlert type="error">Error Alert message</PanelAlert>
           <PanelAlert type="warning">Warning Alert message</PanelAlert>
           <PanelAlert type="success">Success Alert message</PanelAlert>
-          <PanelAlert type="info" icon={<IconTelescope />}>
+          <PanelAlert type="info" icon={<IconTelescope size="md" />}>
             Custom Icon message
           </PanelAlert>
           <PanelItem>Panel Item</PanelItem>

--- a/src/sentry/static/sentry/app/components/panels/panelAlert.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelAlert.tsx
@@ -9,10 +9,10 @@ import space from 'app/styles/space';
 type Props = React.ComponentProps<typeof Alert>;
 
 const DEFAULT_ICONS = {
-  info: <IconInfo />,
-  error: <IconClose isCircled />,
+  info: <IconInfo size="md" />,
+  error: <IconClose isCircled size="md" />,
   warning: <IconWarning />,
-  success: <IconCheckmark isCircled />,
+  success: <IconCheckmark isCircled size="md" />,
 };
 
 // Margin bottom should probably be a different prop

--- a/src/sentry/static/sentry/app/components/panels/panelAlert.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelAlert.tsx
@@ -3,15 +3,16 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'app/components/alert';
+import {IconInfo, IconClose, IconCheckmark, IconWarning} from 'app/icons';
 import space from 'app/styles/space';
 
 type Props = React.ComponentProps<typeof Alert>;
 
 const DEFAULT_ICONS = {
-  info: 'icon-circle-info',
-  error: 'icon-circle-close',
-  warning: 'icon-circle-exclamation',
-  success: 'icon-circle-success',
+  info: <IconInfo />,
+  error: <IconClose isCircled />,
+  warning: <IconWarning />,
+  success: <IconCheckmark isCircled />,
 };
 
 // Margin bottom should probably be a different prop

--- a/src/sentry/static/sentry/app/components/panels/panelAlert.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelAlert.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'app/components/alert';
-import {IconInfo, IconClose, IconCheckmark, IconWarning} from 'app/icons';
+import {IconInfo, IconClose, IconCheckmark, IconFlag} from 'app/icons';
 import space from 'app/styles/space';
 
 type Props = React.ComponentProps<typeof Alert>;
@@ -11,7 +11,7 @@ type Props = React.ComponentProps<typeof Alert>;
 const DEFAULT_ICONS = {
   info: <IconInfo size="md" />,
   error: <IconClose isCircled size="md" />,
-  warning: <IconWarning />,
+  warning: <IconFlag size="md" />,
   success: <IconCheckmark isCircled size="md" />,
 };
 

--- a/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
+++ b/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
@@ -96,14 +96,22 @@ exports[`ProjectPlugins renders 1`] = `
                 >
                   <Alert
                     className="css-148v945-PanelAlert e1cszazt0"
-                    icon={<ForwardRef(IconWarning) />}
+                    icon={
+                      <ForwardRef(IconFlag)
+                        size="md"
+                      />
+                    }
                     iconSize="20px"
                     system={true}
                     type="warning"
                   >
                     <Component
                       className="e1cszazt0 css-1vyifcv-Alert-PanelAlert ejthpj82"
-                      icon={<ForwardRef(IconWarning) />}
+                      icon={
+                        <ForwardRef(IconFlag)
+                          size="md"
+                        />
+                      }
                       iconSize="20px"
                       system={true}
                       type="warning"
@@ -115,28 +123,24 @@ exports[`ProjectPlugins renders 1`] = `
                           <span
                             className="css-1vsw7fz-IconWrapper ejthpj80"
                           >
-                            <IconWarning>
-                              <ForwardRef(SvgIcon)>
+                            <IconFlag
+                              size="md"
+                            >
+                              <ForwardRef(SvgIcon)
+                                size="md"
+                              >
                                 <svg
                                   fill="currentColor"
-                                  height="16px"
+                                  height="20px"
                                   viewBox="0 0 16 16"
-                                  width="16px"
+                                  width="20px"
                                 >
                                   <path
-                                    d="M13.87,15.26H2.13A2.1,2.1,0,0,1,0,13.16a2.07,2.07,0,0,1,.27-1L6.17,1.8a2.1,2.1,0,0,1,1.27-1,2.11,2.11,0,0,1,2.39,1L15.7,12.11a2.1,2.1,0,0,1-1.83,3.15ZM8,2.24a.44.44,0,0,0-.16,0,.58.58,0,0,0-.37.28L1.61,12.86a.52.52,0,0,0-.08.3.6.6,0,0,0,.6.6H13.87a.54.54,0,0,0,.3-.08.59.59,0,0,0,.22-.82L8.53,2.54h0a.61.61,0,0,0-.23-.22A.54.54,0,0,0,8,2.24Z"
-                                  />
-                                  <path
-                                    d="M8,10.37a.75.75,0,0,1-.75-.75V5.92a.75.75,0,0,1,1.5,0v3.7A.74.74,0,0,1,8,10.37Z"
-                                  />
-                                  <circle
-                                    cx="8"
-                                    cy="11.79"
-                                    r="0.76"
+                                    d="M1.69,8.43V2.22H13.53l-2,2.65a.78.78,0,0,0,0,.92l2,2.64Zm0-7.7A.74.74,0,0,0,.94.09.75.75,0,0,0,.19.84V15.16a.75.75,0,0,0,1.5,0V9.93H15.06a.75.75,0,0,0,.59-1.21L13,5.33l2.62-3.4a.73.73,0,0,0,.08-.79.75.75,0,0,0-.67-.42H1.69"
                                   />
                                 </svg>
                               </ForwardRef(SvgIcon)>
-                            </IconWarning>
+                            </IconFlag>
                           </span>
                         </IconWrapper>
                         <StyledTextBlock>

--- a/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
+++ b/tests/js/spec/views/projectPlugins/__snapshots__/projectPlugins.spec.jsx.snap
@@ -96,14 +96,14 @@ exports[`ProjectPlugins renders 1`] = `
                 >
                   <Alert
                     className="css-148v945-PanelAlert e1cszazt0"
-                    icon="icon-circle-exclamation"
+                    icon={<ForwardRef(IconWarning) />}
                     iconSize="20px"
                     system={true}
                     type="warning"
                   >
                     <Component
                       className="e1cszazt0 css-1vyifcv-Alert-PanelAlert ejthpj82"
-                      icon="icon-circle-exclamation"
+                      icon={<ForwardRef(IconWarning) />}
                       iconSize="20px"
                       system={true}
                       type="warning"
@@ -115,28 +115,28 @@ exports[`ProjectPlugins renders 1`] = `
                           <span
                             className="css-1vsw7fz-IconWrapper ejthpj80"
                           >
-                            <InlineSvg
-                              size="20px"
-                              src="icon-circle-exclamation"
-                            >
-                              <ForwardRef
-                                className="css-tbsmsq-InlineSvg enyz4ql0"
-                                size="20px"
-                                src="icon-circle-exclamation"
-                              >
+                            <IconWarning>
+                              <ForwardRef(SvgIcon)>
                                 <svg
-                                  className="css-tbsmsq-InlineSvg enyz4ql0"
-                                  height="20px"
-                                  viewBox={Object {}}
-                                  width="20px"
+                                  fill="currentColor"
+                                  height="16px"
+                                  viewBox="0 0 16 16"
+                                  width="16px"
                                 >
-                                  <use
-                                    href="#test"
-                                    xlinkHref="#test"
+                                  <path
+                                    d="M13.87,15.26H2.13A2.1,2.1,0,0,1,0,13.16a2.07,2.07,0,0,1,.27-1L6.17,1.8a2.1,2.1,0,0,1,1.27-1,2.11,2.11,0,0,1,2.39,1L15.7,12.11a2.1,2.1,0,0,1-1.83,3.15ZM8,2.24a.44.44,0,0,0-.16,0,.58.58,0,0,0-.37.28L1.61,12.86a.52.52,0,0,0-.08.3.6.6,0,0,0,.6.6H13.87a.54.54,0,0,0,.3-.08.59.59,0,0,0,.22-.82L8.53,2.54h0a.61.61,0,0,0-.23-.22A.54.54,0,0,0,8,2.24Z"
+                                  />
+                                  <path
+                                    d="M8,10.37a.75.75,0,0,1-.75-.75V5.92a.75.75,0,0,1,1.5,0v3.7A.74.74,0,0,1,8,10.37Z"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="11.79"
+                                    r="0.76"
                                   />
                                 </svg>
-                              </ForwardRef>
-                            </InlineSvg>
+                              </ForwardRef(SvgIcon)>
+                            </IconWarning>
                           </span>
                         </IconWrapper>
                         <StyledTextBlock>


### PR DESCRIPTION
Add a storybook state for all the standard modes as that was easier than trying to track all the states down in the application.

![Screen Shot 2020-07-14 at 1 28 58 PM](https://user-images.githubusercontent.com/24086/87457220-05d8f800-c5d6-11ea-9e5a-0961b57c87c7.png)
