### PR TITLE
feat(metric_alerts): Add `thresholdType` and `resolveThreshold` to `AlertRuleSerializer`

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -44,6 +44,8 @@ class AlertRuleSerializer(Serializer):
             "dataset": obj.snuba_query.dataset,
             "query": obj.snuba_query.query,
             "aggregate": aggregate,
+            "thresholdType": obj.threshold_type,
+            "resolveThreshold": obj.resolve_threshold,
             # TODO: Start having the frontend expect seconds
             "timeWindow": obj.snuba_query.time_window / 60,
             "environment": env.name if env else None,

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -23,6 +23,8 @@ class BaseAlertRuleSerializerTest(object):
         assert result["dataset"] == alert_rule.snuba_query.dataset
         assert result["query"] == alert_rule.snuba_query.query
         assert result["aggregate"] == alert_rule.snuba_query.aggregate
+        assert result["thresholdType"] == alert_rule.threshold_type
+        assert result["resolveThreshold"] == alert_rule.resolve_threshold
         assert result["timeWindow"] == alert_rule.snuba_query.time_window / 60
         assert result["resolution"] == alert_rule.snuba_query.resolution / 60
         assert result["thresholdPeriod"] == alert_rule.threshold_period
@@ -71,6 +73,13 @@ class BaseAlertRuleSerializerTest(object):
 class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
     def test_simple(self):
         alert_rule = self.create_alert_rule()
+        result = serialize(alert_rule)
+        self.assert_alert_rule_serialized(alert_rule, result)
+
+    def test_threshold_type_resolve_threshold(self):
+        alert_rule = self.create_alert_rule(
+            threshold_type=AlertRuleThresholdType.BELOW, resolve_threshold=500
+        )
         result = serialize(alert_rule)
         self.assert_alert_rule_serialized(alert_rule, result)
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -236,9 +236,11 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
         self.login_as(self.user)
         alert_rule = self.alert_rule
+        alert_rule.update(resolve_threshold=75)
         # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
         serialized_alert_rule = self.get_serialized_alert_rule()
 
+        serialized_alert_rule["resolveThreshold"] = None
         serialized_alert_rule["triggers"][1]["resolveThreshold"] = None
         serialized_alert_rule["name"] = "AUniqueName"
 
@@ -258,6 +260,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
         self.login_as(self.user)
         alert_rule = self.alert_rule
+        alert_rule.update(resolve_threshold=75)
         # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
         serialized_alert_rule = self.get_serialized_alert_rule()
 
@@ -358,6 +361,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         serialized_alert_rule = self.get_serialized_alert_rule()
 
         serialized_alert_rule["triggers"][0]["alertThreshold"] = 50  # Invalid
+        serialized_alert_rule.pop("resolveThreshold")
         with self.feature("organizations:incidents"):
             self.get_valid_response(
                 self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
@@ -373,6 +377,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             )
         serialized_alert_rule["triggers"][0]["resolveThreshold"] = 100  # Back to normal, valid.
 
+        serialized_alert_rule.pop("thresholdType")
         serialized_alert_rule["triggers"][0][
             "thresholdType"
         ] = 1  # Invalid, different than other trigger.

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -134,6 +134,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         )
 
         test_params = self.valid_params.copy()
+        test_params["resolve_threshold"] = self.alert_rule.resolve_threshold
         test_params.update({"name": "what"})
 
         self.login_as(self.user)
@@ -148,6 +149,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
     def test_not_updated_fields(self):
         test_params = self.valid_params.copy()
+        test_params["resolve_threshold"] = self.alert_rule.resolve_threshold
         test_params["aggregate"] = self.alert_rule.snuba_query.aggregate
 
         self.create_member(


### PR DESCRIPTION
Missed including these on the output serializer.