### PR TITLE
build(): Upgrade to `node@10.21.0` and `yarn@1.22.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "build": "yarn webpack --output-path=public"
   },
   "volta": {
-    "node": "10.16.3",
-    "yarn": "1.21.1"
+    "node": "10.21.0",
+    "yarn": "1.22.4"
   }
 }


### PR DESCRIPTION
Puppeteer requires a newer node version - and might as well do yarn while we are in there (no changes that should affect us)