### PR TITLE
feat(metric_alerts): Stop requiring actions when creating a metric rule.

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -180,7 +180,7 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
     # TODO: These might be slow for many projects, since it will query for each
     # individually. If we find this to be a problem then we can look into batching.
     excluded_projects = serializers.ListField(child=ProjectField(), required=False)
-    actions = serializers.ListField(required=True)
+    actions = serializers.ListField(required=False)
 
     class Meta:
         model = AlertRuleTrigger
@@ -209,7 +209,7 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
 
     def create(self, validated_data):
         try:
-            actions = validated_data.pop("actions")
+            actions = validated_data.pop("actions", None)
             alert_rule_trigger = create_alert_rule_trigger(
                 alert_rule=self.context["alert_rule"], **validated_data
             )
@@ -452,14 +452,6 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 threshold_type, warning, data.get("resolve_threshold")
             )
             self._validate_critical_warning_triggers(threshold_type, critical, warning)
-
-        # Triggers have passed checks. Check that all triggers have at least one action now.
-        for trigger in triggers:
-            actions = trigger.get("actions")
-            if not actions:
-                raise serializers.ValidationError(
-                    '"' + trigger["label"] + '" trigger must have an action.'
-                )
 
         return data
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -309,12 +309,15 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
         assert len(resp.data["triggers"][1]["actions"]) == 1
 
-        # Delete the last one, make sure API errors since we have to have an action.
+        # Delete the last one.
         serialized_alert_rule["triggers"][1]["actions"].pop()
 
         with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, alert_rule.id, **serialized_alert_rule)
-            assert resp.status_code == 400
+            resp = self.get_valid_response(
+                self.organization.slug, alert_rule.id, **serialized_alert_rule
+            )
+
+        assert len(resp.data["triggers"][1]["actions"]) == 0
 
     def test_update_trigger_action_type(self):
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -232,9 +232,11 @@ class AlertRuleCreateEndpointTest(APITestCase):
 
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(
-                self.organization.slug, status_code=400, **rule_one_trigger_only_critical_no_action
+                self.organization.slug, status_code=201, **rule_one_trigger_only_critical_no_action
             )
-            assert resp.data == {u"nonFieldErrors": [u'"critical" trigger must have an action.']}
+        assert "id" in resp.data
+        alert_rule = AlertRule.objects.get(id=resp.data["id"])
+        assert resp.data == serialize(alert_rule, self.user)
 
     def test_invalid_projects(self):
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -463,7 +463,6 @@ class TestAlertRuleTriggerSerializer(TestCase):
         assert serializer.errors == {
             "label": field_is_required,
             "alertThreshold": field_is_required,
-            "actions": field_is_required,
         }
 
     def test_threshold_type(self):


### PR DESCRIPTION
We want to be able to create a metric alert without the user providing actions. Just removing
validation around this.