### PR TITLE
fix(ui): Added project id to view transaction summary link

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
@@ -159,6 +159,9 @@ function makeGenericTransactionCta(opts: {
     const summaryUrl = transactionSummaryRouteWithQuery({
       orgSlug,
       transaction,
+      projectID: projects
+        .filter(({slug}) => incident.projects.includes(slug))
+        .map(({id}) => id),
       query: {...period},
     });
 

--- a/tests/js/spec/views/settings/incidentRules/presets.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/presets.spec.jsx
@@ -175,6 +175,7 @@ describe('Incident Presets', function() {
         expect(transactionSummaryRouteWithQuery).toHaveBeenCalledWith({
           orgSlug: org.slug,
           transaction: 'do_work',
+          projectID: [],
           query: {
             start: '1970-01-01T00:00:00',
             end: '1970-01-01T00:02:00',
@@ -254,6 +255,7 @@ describe('Incident Presets', function() {
         expect(transactionSummaryRouteWithQuery).toHaveBeenCalledWith({
           orgSlug: org.slug,
           transaction: 'do_work',
+          projectID: [],
           query: {
             start: '1970-01-01T00:00:00',
             end: '1970-01-01T00:02:00',
@@ -332,6 +334,7 @@ describe('Incident Presets', function() {
         expect(transactionSummaryRouteWithQuery).toHaveBeenCalledWith({
           orgSlug: org.slug,
           transaction: 'do_work',
+          projectID: [],
           query: {
             start: '1970-01-01T00:00:00',
             end: '1970-01-01T00:02:00',


### PR DESCRIPTION
When clicking on "view transaction summary" from the alert details page it will lead to a transaction summary which inherits the project selection from the global header. Oftentimes this is correct, however if the global header project selection doesn't include the transaction's project then no results will be shown. This can happen if a user is linked to an alert details page and the global header state is loaded from a previous session. 

Changed so that the project related to the alert is included in the url to the transaction summary. This is similar to the behavior of the "Open in Discover" issue alert button (also on the alert details page).

Ref: WOR-46