### PR TITLE
fix(ui): fixed sidenav active state

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsLayout.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsLayout.tsx
@@ -168,8 +168,6 @@ const SidebarWrapper = styled('div')<{isVisible: boolean; offsetTop: number}>`
   width: ${p => p.theme.settings.sidebarWidth};
   background: ${p => p.theme.white};
   border-right: 1px solid ${p => p.theme.borderLight};
-  padding: ${space(4)};
-  padding-right: ${space(2)};
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: ${p => (p.isVisible ? 'block' : 'none')};

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as Sentry from '@sentry/react';
 import styled from '@emotion/styled';
 
+import space from 'app/styles/space';
 import SettingsNavigationGroup from 'app/views/settings/components/settingsNavigationGroup';
 import {NavigationSection, NavigationProps} from 'app/views/settings/types';
 
@@ -58,11 +59,13 @@ class SettingsNavigation extends React.Component<Props> {
 const PositionStickyWrapper = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     position: sticky;
-    top: 100px;
+    top: 70px;
     overflow: scroll;
-    height: calc(100vh - 98px);
+    height: calc(100vh - 70px);
     -ms-overflow-style: none;
     scrollbar-width: none;
+    padding: ${space(4)};
+    padding-right: ${space(2)};
 
     &::-webkit-scrollbar {
       display: none;


### PR DESCRIPTION
This secondary sidenav bar is pretty complex. We want it to be sticky when scrolling the main content area, but also let you scroll within the menu itself when the browser window cuts off the items. In my previous change I didn’t take into consideration that the scroll overflow would cut off the active state, so I’m fixing that here by moving the padding from the outer nav to the sticky positioned component.

## Before
<img width="468" alt="Screen Shot 2020-07-14 at 4 37 50 PM" src="https://user-images.githubusercontent.com/1900676/87486624-84db2a00-c5f0-11ea-986a-e17d621e9f64.png">


## After
  
<img width="468" alt="Screen Shot 2020-07-14 at 4 36 37 PM" src="https://user-images.githubusercontent.com/1900676/87486612-7e4cb280-c5f0-11ea-8b15-e6cc75f0e2e7.png">
