### PR TITLE
fix(eventstream): Fix typo in get_task_kwargs_for_message function

### DIFF
--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -96,7 +96,7 @@ def get_task_kwargs_for_message(value):
     dispatched.
     """
 
-    metrics.timing("evenstream.events.size.data", len(value))
+    metrics.timing("eventstream.events.size.data", len(value))
     payload = json.loads(value)
 
     try:


### PR DESCRIPTION
Replace "evenstream" with "eventstream" in metrics call. Ensure metrics
are emitted with correct tag.