### PR TITLE
chore(py3): Bump structlog

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -58,7 +58,7 @@ simplejson>=3.2.0,<3.9.0
 six>=1.11.0,<1.12.0
 sqlparse>=0.2.0,<0.3.0
 statsd>=3.1.0,<3.2.0
-structlog==16.1.0
+structlog==17.1.0
 symbolic>=7.3.5,<8.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.10.0,<0.11.0


### PR DESCRIPTION
Version 17.1.0 is the first to [support python3](https://github.com/hynek/structlog/commit/1d2d41c0c6c5059ffdf22f4b01e891fdeb6aab1d). We were on 16.1, this is a single release bump.

Notable changes:

 * https://github.com/hynek/structlog/commit/cf5d57cc3a75d95df5b8daa6b66445121033e2c0 - `ConsoleRenderer` has become [the default](https://github.com/hynek/structlog/commit/cf5d57cc3a75d95df5b8daa6b66445121033e2c0#diff-e31e771254e0c5415bbe10b8dabbde4fR30) processor.

   **This does not affect us** as we have already configured our own processors: https://github.com/getsentry/sentry/blob/9791f3becbcc810a4a58c7936a4f29130c770691/src/sentry/runner/initializer.py#L220-L226

 * https://github.com/hynek/structlog/commit/705d3a3581ffca1180e72845dd3af829fe1d2ac2 - The `TimeStamper` processor now uses more accurate timestamps.

   **We do NOT use this processor**

 * https://github.com/hynek/structlog/commit/065b69aaba436ec704c4b19eef733af78043e3f1 - `ProcessorFormatter` is added. This is purely an addition.

   **We do NOT use this processor**

 * https://github.com/hynek/structlog/commit/e4731ba2fb250e7aa386dc293797446dbd58d862. - The `PositionalArgumentsFormatter` (**which we DO use**), has had a minor fix for https://github.com/hynek/structlog/issues/82

   > PositionalArgumentsFormatter with remove_positional_args=True is supposed to remove the positional_args from the event dict. However this only happens when positional_args is truthy which is not the case for the empty list.

   This is a minor change and shouldn't break anything

Pretty much all of the other changes are documentation changes, or _minor_ code changes.

Overall this bump should be trivial.