### PR TITLE
ref(ui): Changed data source to errors instead of events

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -20,7 +20,11 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import {Panel, PanelBody, PanelFooter} from 'app/components/panels';
 import Button from 'app/components/button';
-import {AlertRuleThresholdType, Trigger} from 'app/views/settings/incidentRules/types';
+import {
+  AlertRuleThresholdType,
+  Dataset,
+  Trigger,
+} from 'app/views/settings/incidentRules/types';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/presets';
 import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/settings/incidentRules/constants';
 
@@ -78,10 +82,14 @@ export default class DetailsBody extends React.Component<Props> {
       ({label}) => label === 'warning'
     );
 
+    const dataSource = incident.alertRule?.dataset;
+
     return (
       <RuleDetails>
         <span>{t('Data Source')}</span>
-        <span>{t(toTitleCase(incident.alertRule?.dataset))}</span>
+        <span>
+          {t(toTitleCase(dataSource === Dataset.ERRORS ? 'errors' : dataSource))}
+        </span>
 
         <span>{t('Metric')}</span>
         <span>{incident.alertRule?.aggregate}</span>

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {Project} from 'app/types';
 import {PageContent} from 'app/styles/organization';
-import {toTitleCase, defined} from 'app/utils';
+import {defined} from 'app/utils';
 import {t, tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import Duration from 'app/components/duration';
@@ -20,11 +20,7 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import {Panel, PanelBody, PanelFooter} from 'app/components/panels';
 import Button from 'app/components/button';
-import {
-  AlertRuleThresholdType,
-  Dataset,
-  Trigger,
-} from 'app/views/settings/incidentRules/types';
+import {AlertRuleThresholdType, Trigger} from 'app/views/settings/incidentRules/types';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/presets';
 import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/settings/incidentRules/constants';
 
@@ -37,7 +33,7 @@ import {
   IncidentStatus,
   IncidentStatusMethod,
 } from '../types';
-import {getIncidentMetricPreset} from '../utils';
+import {getIncidentMetricPreset, DATA_SOURCE_LABELS} from '../utils';
 
 type Props = {
   incident?: Incident;
@@ -82,14 +78,10 @@ export default class DetailsBody extends React.Component<Props> {
       ({label}) => label === 'warning'
     );
 
-    const dataSource = incident.alertRule?.dataset;
-
     return (
       <RuleDetails>
         <span>{t('Data Source')}</span>
-        <span>
-          {t(toTitleCase(dataSource === Dataset.ERRORS ? 'errors' : dataSource))}
-        </span>
+        <span>{DATA_SOURCE_LABELS[incident.alertRule?.dataset]}</span>
 
         <span>{t('Metric')}</span>
         <span>{incident.alertRule?.aggregate}</span>

--- a/src/sentry/static/sentry/app/views/alerts/utils.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils.tsx
@@ -1,4 +1,5 @@
 import {Client} from 'app/api';
+import {t} from 'app/locale';
 import {Project, NewQuery} from 'app/types';
 import {getAggregateAlias} from 'app/utils/discover/fields';
 import {getUtcDateString} from 'app/utils/dates';
@@ -145,3 +146,8 @@ export function getIncidentDiscoverUrl(opts: {
     ...toObject,
   };
 }
+
+export const DATA_SOURCE_LABELS = {
+  [Dataset.ERRORS]: t('Errors'),
+  [Dataset.TRANSACTIONS]: t('Transactions'),
+};

--- a/tests/js/spec/views/alerts/details/index.spec.jsx
+++ b/tests/js/spec/views/alerts/details/index.spec.jsx
@@ -228,4 +228,18 @@ describe('IncidentDetails', function() {
     wrapper.find('SubscribeButton').simulate('click');
     expect(subscribe).toHaveBeenCalled();
   });
+
+  it('renders Errors as data source for Dataset.ERRORS', async function() {
+    const wrapper = createWrapper();
+    await tick();
+    wrapper.update();
+
+    const ruleDetails = wrapper.find('RuleDetails');
+    expect(
+      ruleDetails
+        .find('span')
+        .at(1)
+        .text()
+    ).toBe('Errors');
+  });
 });


### PR DESCRIPTION
In the alert details page, the alert rule's data source will show up as events when the options for creating an alert are either 'Errors' or 'Transactions'. Changed the text to be 'Errors' in order to avoid confusion.

![image](https://user-images.githubusercontent.com/9372512/87493306-87527980-c61a-11ea-9abb-294a8c0eb8a5.png)

Ref: WOR-47