### PR TITLE
feat(discover): Register option to disable sampling on tag facet

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -242,6 +242,9 @@ register("data-export.rollout-rate", default=0, flags=FLAG_PRIORITIZE_DISK)
 # Max number of tags to combine in a single query in Discover2 tags facet.
 register("discover2.max_tags_to_combine", default=3, flags=FLAG_PRIORITIZE_DISK)
 
+# Enables setting a sampling rate when producing the tag facet.
+register("discover2.tags_facet_enable_sampling", default=True, flags=FLAG_PRIORITIZE_DISK)
+
 # Killswitch for datascrubbing after stacktrace processing. Set to False to
 # disable datascrubbers.
 register("processing.can-use-scrubbers", default=True)


### PR DESCRIPTION
The transactions table only included the sampling key clause in april (for on prem). There is no possible migration there without migrating to a new table. People may have already created that table and there is no support for data migrations in snuba yet.
If we start having users using tracing/preformance on prem, who created the table long before that they may run into troubles when they have enough data in the transactions table to trigger the sampling rate.
Snuba would reject those queries.

This adds an option to disable the sampling rate in those cases as long as we do not have a way to rebuild the snuba table on prem.