### PR TITLE
ref: Increase cache timeout for loader

### DIFF
--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -13,7 +13,7 @@ from sentry.loader.browsersdkversion import get_browser_sdk_version
 
 
 CACHE_CONTROL = (
-    "public, max-age=600, s-maxage=60, stale-while-revalidate=315360000, stale-if-error=315360000"
+    "public, max-age=3600, s-maxage=60, stale-while-revalidate=315360000, stale-if-error=315360000"
 )
 
 


### PR DESCRIPTION
Follow up

https://github.com/getsentry/sentry/pull/12677

Customers reported that 10mins cache timeout is too little compared to how long their users surf their website.
That's why we increase the cache timeout to 60mins to make sure users don't have to fetch the loader twice from the CDN.
