### PR TITLE
ref(apm): Add project column to the baseline transaction endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -73,7 +73,13 @@ class OrganizationEventBaseline(OrganizationEventsEndpointBase):
             delta_column = "absolute_delta(transaction.duration,{})".format(baseline_value)
 
             result = discover.query(
-                selected_columns=["timestamp", "id", "transaction.duration", delta_column],
+                selected_columns=[
+                    "project",
+                    "timestamp",
+                    "id",
+                    "transaction.duration",
+                    delta_column,
+                ],
                 # Find the most recent transaction that's closest to the baseline value
                 # id as the last item for consistent results
                 orderby=[get_function_alias(delta_column), "-timestamp", "id"],

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -196,6 +196,7 @@ class OrganizationEventBaselineEndpoint(APITestCase, SnubaTestCase):
         assert data["id"] == "b" * 32
         assert data["transaction.duration"] == 120000
         assert data["p50"] == 120000.0
+        assert data["project"] == self.project.slug
 
     def test_get_baseline_duration_tie(self):
         for index, event_id in enumerate(


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/19819

Need this for https://github.com/getsentry/sentry/pull/18610 to be able to construct eventslugs reliably. 