### PR TITLE
feat: Add rate limits to membership invites

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -859,6 +859,8 @@ SENTRY_FEATURES = {
     "organizations:internal-catchall": False,
     # Enable inviting members to organizations.
     "organizations:invite-members": True,
+    # Enable rate limits for inviting members.
+    "organizations:invite-members-rate-limits": True,
     # Enable org-wide saved searches and user pinned search
     "organizations:org-saved-searches": False,
     # Prefix host with organization ID when giving users DSNs (can be

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -98,6 +98,7 @@ default_manager.add("organizations:symbol-sources", OrganizationFeature)  # NOQA
 default_manager.add("organizations:usage-stats-graph", OrganizationFeature)  # NOQA
 # XXX(mark) Don't use this feature it is going away soon.
 default_manager.add("organizations:transaction-events", OrganizationFeature)  # NOQA
+default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature)  # NOQA
 
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -99,6 +99,9 @@ def pytest_configure(config):
         "nodedata": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
     }
 
+    settings.SENTRY_RATELIMITER = "sentry.ratelimits.redis.RedisRateLimiter"
+    settings.SENTRY_RATELIMITER_OPTIONS = {}
+
     if os.environ.get("USE_SNUBA", False):
         settings.SENTRY_SEARCH = "sentry.search.snuba.EventsDatasetSnubaSearchBackend"
         settings.SENTRY_TSDB = "sentry.tsdb.redissnuba.RedisSnubaTSDB"

--- a/src/sentry/utils/ratelimits.py
+++ b/src/sentry/utils/ratelimits.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry import features
+from sentry.app import ratelimiter
+from sentry.utils.hashlib import md5_text
+
+
+def for_organization_member_invite(organization, email, user=None, auth=None):
+    """
+    Rate limit logic for triggering a user invite email, which should also be applied for generating
+    a brand new member invite when possible.
+    """
+    if not features.has("organizations:invite-members-rate-limits", organization, actor=user):
+        return False
+
+    limits = (
+        ratelimiter.is_limited(
+            u"members:invite-by-user:{}".format(
+                md5_text(user.id if user and user.is_authenticated() else six.text_type(auth))
+            ),
+            # 100 invites from a user per day
+            limit=100,
+            window=3600 * 24,
+        )
+        if (user or auth)
+        else None,
+        ratelimiter.is_limited(
+            u"members:invite-by-org:{}".format(md5_text(organization.id)),
+            # 100 invites from an org per day
+            limit=100,
+            window=3600 * 24,
+        ),
+        ratelimiter.is_limited(
+            u"members:org-invite-to-email:{}-{}".format(
+                organization.id, md5_text(email.lower()).hexdigest()
+            ),
+            # 10 invites per email per org per day
+            limit=10,
+            window=3600 * 24,
+        ),
+    )
+    return any(limits)

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -537,3 +537,11 @@ class OrganizationMemberListPostTest(APITestCase):
         assert om.inviter == self.owner_user
 
         assert not mock_send_invite_email.mock_calls
+
+    @patch("sentry.utils.ratelimits.for_organization_member_invite")
+    def test_rate_limited(self, mock_rate_limit):
+        mock_rate_limit.return_value = True
+
+        resp = self.get_response(self.org.slug, email="jane@gmail.com", role="member",)
+        assert resp.status_code == 429
+        assert not OrganizationMember.objects.filter(email="jane@gmail.com").exists()

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -30,6 +30,7 @@ class OrganizationSerializerTest(TestCase):
                 "integrations-chat-unfurl",
                 "integrations-incident-management",
                 "integrations-event-hooks",
+                "invite-members-rate-limits",
                 "data-forwarding",
                 "invite-members",
                 "sso-saml2",

--- a/tests/sentry/utils/test_ratelimits.py
+++ b/tests/sentry/utils/test_ratelimits.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import
+
+from random import randint
+
+from sentry.models import ApiToken, Organization, User
+from sentry.testutils import TestCase
+from sentry.utils import ratelimits
+
+
+class ForOrganizationMemberTestCase(TestCase):
+    def test_by_email(self):
+        organization = Organization(id=1)
+        email = "foo@example.com"
+        for n in range(10):
+            assert not ratelimits.for_organization_member_invite(organization, email)
+
+        assert ratelimits.for_organization_member_invite(organization, email)
+
+    def test_by_organization(self):
+        organization = Organization(id=1)
+        for n in range(100):
+            assert not ratelimits.for_organization_member_invite(
+                organization, "{}@example.com".format(randint(0, 1000000))
+            )
+
+        assert ratelimits.for_organization_member_invite(organization, "anything@example.com")
+
+    def test_by_api_token(self):
+        token = ApiToken()
+        for n in range(100):
+            assert not ratelimits.for_organization_member_invite(
+                Organization(id=randint(0, 100000)),
+                "{}@example.com".format(randint(0, 1000000)),
+                auth=token,
+            )
+
+        assert ratelimits.for_organization_member_invite(Organization(id=1), "anything@example.com")
+
+    def test_by_user(self):
+        user = User(email="biz@example.com")
+        for n in range(100):
+            assert not ratelimits.for_organization_member_invite(
+                Organization(id=randint(0, 100000)),
+                "{}@example.com".format(randint(0, 1000000)),
+                user=user,
+            )
+
+        assert ratelimits.for_organization_member_invite(Organization(id=1), "anything@example.com")


### PR DESCRIPTION
Implements multiple layers of rate limits to avoid the traditional spam attacks.

Primarily putting this up so bounty hunters stop submitting reports for us not having rate limits here. We've not had valid concerns given we already have various mechanisms in place to avoid automated spammers.