### PR TITLE
fix(vercel): change error to ValidationError

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -5,6 +5,7 @@ import six
 import logging
 
 from django.utils.translation import ugettext_lazy as _
+from rest_framework.serializers import ValidationError
 
 
 from sentry.integrations import (
@@ -179,11 +180,17 @@ class VercelIntegration(IntegrationInstallation):
             sentry_project = Project.objects.get(id=sentry_project_id)
             enabled_dsn = ProjectKey.get_default(project=sentry_project)
             if not enabled_dsn:
-                raise IntegrationError("You must have an enabled DSN to continue!")
+                raise ValidationError(
+                    {"project_mappings": ["You must have an enabled DSN to continue!"]}
+                )
             source_code_provider = self.get_source_code_provider(vercel_client, vercel_project_id)
             if not source_code_provider:
-                raise IntegrationError(
-                    "You must connect your Vercel project to a Git repository to continue!"
+                raise ValidationError(
+                    {
+                        "project_mappings": [
+                            "You must connect your Vercel project to a Git repository to continue!"
+                        ]
+                    }
                 )
             sentry_project_dsn = enabled_dsn.get_dsn(public=True)
             uuid = uuid4().hex

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -4,7 +4,8 @@ import json
 import responses
 import six
 
-from sentry.utils.compat.mock import patch
+from rest_framework.serializers import ValidationError
+
 
 from six.moves.urllib.parse import parse_qs
 from sentry.integrations.vercel import VercelIntegrationProvider
@@ -17,8 +18,8 @@ from sentry.models import (
     SentryAppInstallationForProvider,
     SentryAppInstallation,
 )
-from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import IntegrationTestCase
+from sentry.utils.compat.mock import patch
 from sentry.utils.http import absolute_uri
 
 
@@ -409,7 +410,7 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         dsn = ProjectKey.get_default(project=Project.objects.get(id=project_id))
         dsn.update(id=dsn.id, status=ProjectKeyStatus.INACTIVE)
-        with self.assertRaises(IntegrationError):
+        with self.assertRaises(ValidationError):
             installation.update_organization_config(data)
 
     @responses.activate
@@ -433,7 +434,7 @@ class VercelIntegrationTest(IntegrationTestCase):
             % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
             json={},
         )
-        with self.assertRaises(IntegrationError):
+        with self.assertRaises(ValidationError):
             installation.update_organization_config(data)
 
     @responses.activate


### PR DESCRIPTION
This PR ensures that we show the validation error when we throw it on the backend when mapping projects:

![Screen Shot 2020-07-15 at 1 26 04 PM](https://user-images.githubusercontent.com/8533851/87592814-58321b80-c69f-11ea-86e0-aac42b8ccabe.png)
