### PR TITLE
ref(ui) Replace icon-alert with SVG icons

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionStacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionStacktraceContent.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {defined} from 'app/utils';
 import StacktraceContent from 'app/components/events/interfaces/stacktraceContent';
 import {Panel} from 'app/components/panels';
+import {IconWarning} from 'app/icons';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import SentryTypes from 'app/sentryTypes';
 import {Stacktrace, StackViewType} from 'app/types/stacktrace';
@@ -38,7 +39,7 @@ const ExceptionStacktraceContent = ({
     return (
       <Panel dashedBorder>
         <EmptyMessage
-          icon="icon-warning-sm"
+          icon={<IconWarning size="xs" />}
           title="No app only stacktrace has been found!"
         />
       </Panel>

--- a/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
@@ -9,7 +9,7 @@ import ActorAvatar from 'app/components/avatar/actorAvatar';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import Hovercard from 'app/components/hovercard';
-import {IconCommit} from 'app/icons';
+import {IconCommit, IconWarning} from 'app/icons';
 import Link from 'app/components/links/link';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
@@ -76,7 +76,7 @@ class SuggestedOwnerHovercard extends React.Component {
               {actor.name || actor.email}
             </HovercardHeader>
             {actor.id === undefined && (
-              <EmailAlert icon="icon-warning-sm" type="warning">
+              <EmailAlert icon={<IconWarning size="xs" />} type="warning">
                 {tct(
                   'The email [actorEmail] is not a member of your organization. [inviteUser:Invite] them or link additional emails in [accountSettings:account settings].',
                   {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
@@ -157,7 +157,7 @@ class GroupEventToolbar extends React.Component {
               date={getDynamicText({value: evt.dateCreated, fixed: 'Dummy timestamp'})}
               style={style}
             />
-            {isOverLatencyThreshold && <StyledIconWarning />}
+            {isOverLatencyThreshold && <StyledIconWarning color="yellow500" />}
           </Tooltip>
           <ExternalLink href={jsonUrl} className="json-link">
             {'JSON'} (<FileSize bytes={evt.size} />)

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import moment from 'moment-timezone';
 import styled from '@emotion/styled';
 
-import {IconNext, IconPrevious} from 'app/icons';
+import {IconNext, IconPrevious, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -15,6 +15,7 @@ import FileSize from 'app/components/fileSize';
 import SentryTypes from 'app/sentryTypes';
 import Tooltip from 'app/components/tooltip';
 import getDynamicText from 'app/utils/getDynamicText';
+import space from 'app/styles/space';
 
 const formatDateDelta = (reference, observed) => {
   const duration = moment.duration(Math.abs(+observed - +reference));
@@ -156,7 +157,7 @@ class GroupEventToolbar extends React.Component {
               date={getDynamicText({value: evt.dateCreated, fixed: 'Dummy timestamp'})}
               style={style}
             />
-            {isOverLatencyThreshold && <span className="icon-alert" />}
+            {isOverLatencyThreshold && <StyledIconWarning />}
           </Tooltip>
           <ExternalLink href={jsonUrl} className="json-link">
             {'JSON'} (<FileSize bytes={evt.size} />)
@@ -169,6 +170,12 @@ class GroupEventToolbar extends React.Component {
 
 const NavigationButtons = styled(ButtonBar)`
   float: right;
+`;
+
+const StyledIconWarning = styled(IconWarning)`
+  margin-left: ${space(0.5)};
+  position: relative;
+  top: ${space(0.25)};
 `;
 
 export default GroupEventToolbar;

--- a/src/sentry/static/sentry/app/views/settings/project/permissionAlert.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/permissionAlert.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {t} from 'app/locale';
 import Access from 'app/components/acl/access';
 import Alert from 'app/components/alert';
+import {IconWarning} from 'app/icons';
 
 type Props = React.ComponentPropsWithoutRef<typeof Alert> &
   Pick<React.ComponentProps<typeof Access>, 'access'>;
@@ -12,7 +13,7 @@ const PermissionAlert = ({access = ['project:write'], ...props}: Props) => (
   <Access access={access}>
     {({hasAccess}) =>
       !hasAccess && (
-        <Alert type="warning" icon="icon-warning-sm" {...props}>
+        <Alert type="warning" icon={<IconWarning size="xs" />} {...props}>
           {t(
             'These settings can only be edited by users with the organization owner, manager, or admin role.'
           )}

--- a/tests/js/spec/components/events/interfaces/__snapshots__/exceptionStacktraceContent.spec.jsx.snap
+++ b/tests/js/spec/components/events/interfaces/__snapshots__/exceptionStacktraceContent.spec.jsx.snap
@@ -138,12 +138,20 @@ exports[`ExceptionStacktraceContent default behaviour 1`] = `
         className="css-19vwpr4-Panel e119nu470"
       >
         <EmptyMessage
-          icon="icon-warning-sm"
+          icon={
+            <ForwardRef(IconWarning)
+              size="xs"
+            />
+          }
           title="No app only stacktrace has been found!"
         >
           <Component
             className="css-4ypuko-EmptyMessage-EmptyMessage e1h3yfdx0"
-            icon="icon-warning-sm"
+            icon={
+              <ForwardRef(IconWarning)
+                size="xs"
+              />
+            }
             title="No app only stacktrace has been found!"
           >
             <div
@@ -154,28 +162,32 @@ exports[`ExceptionStacktraceContent default behaviour 1`] = `
                 <div
                   className="css-9jue1w-IconWrapper e1h3yfdx1"
                 >
-                  <InlineSvg
-                    size="32px"
-                    src="icon-warning-sm"
+                  <IconWarning
+                    size="xs"
                   >
-                    <ForwardRef
-                      className="css-tbsmsq-InlineSvg enyz4ql0"
-                      size="32px"
-                      src="icon-warning-sm"
+                    <ForwardRef(SvgIcon)
+                      size="xs"
                     >
                       <svg
-                        className="css-tbsmsq-InlineSvg enyz4ql0"
-                        height="32px"
-                        viewBox={Object {}}
-                        width="32px"
+                        fill="currentColor"
+                        height="12px"
+                        viewBox="0 0 16 16"
+                        width="12px"
                       >
-                        <use
-                          href="#test"
-                          xlinkHref="#test"
+                        <path
+                          d="M13.87,15.26H2.13A2.1,2.1,0,0,1,0,13.16a2.07,2.07,0,0,1,.27-1L6.17,1.8a2.1,2.1,0,0,1,1.27-1,2.11,2.11,0,0,1,2.39,1L15.7,12.11a2.1,2.1,0,0,1-1.83,3.15ZM8,2.24a.44.44,0,0,0-.16,0,.58.58,0,0,0-.37.28L1.61,12.86a.52.52,0,0,0-.08.3.6.6,0,0,0,.6.6H13.87a.54.54,0,0,0,.3-.08.59.59,0,0,0,.22-.82L8.53,2.54h0a.61.61,0,0,0-.23-.22A.54.54,0,0,0,8,2.24Z"
+                        />
+                        <path
+                          d="M8,10.37a.75.75,0,0,1-.75-.75V5.92a.75.75,0,0,1,1.5,0v3.7A.74.74,0,0,1,8,10.37Z"
+                        />
+                        <circle
+                          cx="8"
+                          cy="11.79"
+                          r="0.76"
                         />
                       </svg>
-                    </ForwardRef>
-                  </InlineSvg>
+                    </ForwardRef(SvgIcon)>
+                  </IconWarning>
                 </div>
               </IconWrapper>
               <Title>


### PR DESCRIPTION
All of these icons are now warnings in the new icon set.

Hovercard that can't be caught by percy:

![Screen Shot 2020-07-15 at 5 00 38 PM](https://user-images.githubusercontent.com/24086/87596817-bd493980-c6be-11ea-88b3-cdf3ef5240ea.png)
