### PR TITLE
chore(serializer): Remove cleaned up up BitHandler fix code

### DIFF
--- a/src/sentry/api/serializers/models/auditlogentry.py
+++ b/src/sentry/api/serializers/models/auditlogentry.py
@@ -2,16 +2,11 @@ from __future__ import absolute_import
 
 import six
 
-from bitfield.types import BitHandler
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import AuditLogEntry
 
 
 def fix(data):
-    # XXX(dcramer): At some point Organization.flags was serialized as a BitHandler
-    if "flags" in data and isinstance(data["flags"], BitHandler):
-        data["flags"] = int(data["flags"])
-
     # There was a point in time where full Team objects
     # got serialized into our AuditLogEntry.data, so these
     # values need to be stripped and reduced down to integers


### PR DESCRIPTION
This code is no longer required as @wedamija's cleanup migration to remove all badly serialized BitHandlers (https://github.com/getsentry/sentry/blob/f6a974727e5f1c0d97908c371799105950d7b175/src/sentry/migrations/0051_fix_auditlog_pickled_data.py) has already been run