### PR TITLE
fix(alerts): Adjust regex ignoring events in trigger threshold

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/thresholdControl.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/thresholdControl.tsx
@@ -46,7 +46,7 @@ class ThresholdControl extends React.Component<Props, State> {
       return;
     }
 
-    // Only call onChnage if the new number is valid, and not partially typed
+    // Only call onChange if the new number is valid, and not partially typed
     // (eg writing out the decimal '5.')
     if (/\.+0*$/.test(value)) {
       this.setState({currentValue: value});

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/thresholdControl.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/thresholdControl.tsx
@@ -48,7 +48,7 @@ class ThresholdControl extends React.Component<Props, State> {
 
     // Only call onChnage if the new number is valid, and not partially typed
     // (eg writing out the decimal '5.')
-    if (/(\.|0)$/.test(value)) {
+    if (/\.+0*$/.test(value)) {
       this.setState({currentValue: value});
       return;
     }


### PR DESCRIPTION
Bug:
Entering in 200 would not trigger change detection for both "0" characters

- Enforces a decimal be present before ignoring "0" character

https://regex101.com/r/qSGtqN/1