### PR TITLE
fix(vercel): stop caching requests

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -40,10 +40,10 @@ class VercelClient(ApiClient):
 
     def get_team(self):
         assert self.team_id
-        return self.get_cached(self.TEAMS_URL % self.team_id)
+        return self.get(self.TEAMS_URL % self.team_id)
 
     def get_user(self):
-        return self.get_cached(self.USER_URL)["user"]
+        return self.get(self.USER_URL)["user"]
 
     def get_projects(self):
         limit = 20

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -241,43 +241,43 @@ class VercelIntegrationTest(IntegrationTestCase):
             "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
         }
 
-        req_params = json.loads(responses.calls[5].request.body)
+        req_params = json.loads(responses.calls[6].request.body)
         assert req_params["name"] == "SENTRY_ORG_%s" % uuid
         assert req_params["value"] == org.slug
 
-        req_params = json.loads(responses.calls[6].request.body)
+        req_params = json.loads(responses.calls[7].request.body)
         assert req_params["name"] == "SENTRY_PROJECT_%s" % uuid
         assert req_params["value"] == self.project.slug
 
-        req_params = json.loads(responses.calls[7].request.body)
+        req_params = json.loads(responses.calls[8].request.body)
         assert req_params["name"] == "NEXT_PUBLIC_SENTRY_DSN_%s" % uuid
         assert req_params["value"] == enabled_dsn
 
-        req_params = json.loads(responses.calls[8].request.body)
+        req_params = json.loads(responses.calls[9].request.body)
         assert req_params["name"] == "SENTRY_AUTH_TOKEN_%s" % uuid
         assert req_params["value"] == sentry_auth_token
 
-        req_params = json.loads(responses.calls[10].request.body)
+        req_params = json.loads(responses.calls[11].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == "sec_0"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[12].request.body)
+        req_params = json.loads(responses.calls[13].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == "sec_1"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[14].request.body)
+        req_params = json.loads(responses.calls[15].request.body)
         assert req_params["key"] == "NEXT_PUBLIC_SENTRY_DSN"
         assert req_params["value"] == "sec_2"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[16].request.body)
+        req_params = json.loads(responses.calls[17].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
         assert req_params["value"] == "sec_3"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[18].request.body)
+        req_params = json.loads(responses.calls[19].request.body)
         assert req_params["key"] == "VERCEL_GITHUB_COMMIT_SHA"
         assert req_params["value"] == ""
         assert req_params["target"] == "production"
@@ -367,27 +367,27 @@ class VercelIntegrationTest(IntegrationTestCase):
             "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
         }
 
-        req_params = json.loads(responses.calls[11].request.body)
+        req_params = json.loads(responses.calls[12].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == "sec_0"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[14].request.body)
+        req_params = json.loads(responses.calls[15].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == "sec_1"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[17].request.body)
+        req_params = json.loads(responses.calls[18].request.body)
         assert req_params["key"] == "NEXT_PUBLIC_SENTRY_DSN"
         assert req_params["value"] == "sec_2"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[20].request.body)
+        req_params = json.loads(responses.calls[21].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
         assert req_params["value"] == "sec_3"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[22].request.body)
+        req_params = json.loads(responses.calls[23].request.body)
         assert req_params["key"] == "VERCEL_GITHUB_COMMIT_SHA"
         assert req_params["value"] == ""
         assert req_params["target"] == "production"


### PR DESCRIPTION
We shouldn't cache these endpoints because the user endpoint is the same for everyone and people might change the slug for their team.