### PR TITLE
test(acceptance): Replace snapshot with simple assertion of modal exists

### DIFF
--- a/tests/acceptance/test_organization_releases_v2.py
+++ b/tests/acceptance/test_organization_releases_v2.py
@@ -52,7 +52,7 @@ class OrganizationReleasesV2Test(AcceptanceTestCase):
             )
             self.browser.get(self.path + release.version)
             self.browser.wait_until_not(".loading")
-            self.browser.snapshot("organization releases v2 - detail - pick project")
+            assert "Select a project to continue" in self.browser.element(".modal-header").text
 
     # This is snapshotting feature of globalSelectionHeader project picker where we see only specified projects
     # and a custom footer message saying "Only projects with this release are visible."


### PR DESCRIPTION
The snapshot was causing some flakeyness in snapshots, but it also was not providing much value. The test just needs to know that in this case, you need to select a project before continuing.