### PR TITLE
test(acceptance): Add `elements()` convenience method to selenium wrapper

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -90,6 +90,18 @@ class Browser(object):
             self.wait_until(selector)
             return self.driver.find_element_by_css_selector(selector)
 
+    def elements(self, selector=None, xpath=None):
+        """
+        Get elements from the page. This method will wait for the element to show up.
+        """
+
+        if xpath is not None:
+            self.wait_until(xpath=xpath)
+            return self.driver.find_elements_by_xpath(xpath)
+        else:
+            self.wait_until(selector)
+            return self.driver.find_elements_by_css_selector(selector)
+
     def element_exists(self, selector):
         """
         Check if an element exists on the page. This method will *not* wait for the element.

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -67,7 +67,7 @@ class IssueDetailsPage(BasePage):
         assignee.find_element_by_tag_name("input").send_keys(user)
 
         # Click the member/team
-        options = assignee.find_elements_by_css_selector('[data-test-id="assignee-option"]')
+        options = assignee.elements('[data-test-id="assignee-option"]')
         assert len(options) > 0, "No assignees could be found."
         options[0].click()
 

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -67,7 +67,7 @@ class IssueDetailsPage(BasePage):
         assignee.find_element_by_tag_name("input").send_keys(user)
 
         # Click the member/team
-        options = assignee.elements('[data-test-id="assignee-option"]')
+        options = assignee.find_elements_by_css_selector('[data-test-id="assignee-option"]')
         assert len(options) > 0, "No assignees could be found."
         options[0].click()
 

--- a/tests/acceptance/page_objects/issue_list.py
+++ b/tests/acceptance/page_objects/issue_list.py
@@ -37,4 +37,4 @@ class IssueListPage(BasePage):
         self.browser.wait_until('[data-test-id="group"]')
 
     def find_resolved_issues(self):
-        return self.browser.find_elements_by_css_selector('[data-test-id="resolved-issue"]')
+        return self.browser.elements('[data-test-id="resolved-issue"]')

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -116,4 +116,4 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
         self.browser.click('[data-test-id="token-add"]')
         self.browser.wait_until(".ref-success")
 
-        assert len(self.browser.find_elements_by_css_selector('[data-test-id="token-delete"]')) == 2
+        assert len(self.browser.elements('[data-test-id="token-delete"]')) == 2

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -308,7 +308,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
 
             # View Event
-            self.browser.find_elements_by_css_selector('[data-test-id="view-event"]')[0].click()
+            self.browser.elements('[data-test-id="view-event"]')[0].click()
             self.wait_until_loaded()
 
             header = self.browser.element('[data-test-id="event-header"] span')
@@ -340,7 +340,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
 
             # View Event
-            self.browser.find_elements_by_css_selector('[data-test-id="view-event"]')[0].click()
+            self.browser.elements('[data-test-id="view-event"]')[0].click()
             self.wait_until_loaded()
 
             self.browser.snapshot("events-v2 - error event detail view")
@@ -367,16 +367,16 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
 
             # Open the stack
-            self.browser.find_elements_by_css_selector('[data-test-id="open-stack"]')[0].click()
+            self.browser.elements('[data-test-id="open-stack"]')[0].click()
             self.wait_until_loaded()
 
             # View Event
-            self.browser.find_elements_by_css_selector('[data-test-id="view-event"]')[0].click()
+            self.browser.elements('[data-test-id="view-event"]')[0].click()
             self.wait_until_loaded()
 
             # Open a span detail so we can check the search by trace link.
             # Click on the 6th one as a missing instrumentation span is inserted.
-            self.browser.find_elements_by_css_selector('[data-test-id="span-row"]')[6].click()
+            self.browser.elements('[data-test-id="span-row"]')[6].click()
 
             # Wait until the child event loads.
             child_button = '[data-test-id="view-child-transaction"]'
@@ -531,9 +531,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
 
             assert self.browser.element_exists_by_test_id("grid-editable"), "table should exist."
-            headers = self.browser.find_elements_by_css_selector(
-                '[data-test-id="grid-editable"] thead th'
-            )
+            headers = self.browser.elements('[data-test-id="grid-editable"] thead th')
             expected = ["", "MESSAGE", "PROJECT", "ID"]
             actual = [header.text for header in headers]
             assert expected == actual

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -71,7 +71,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
         self.page.wait_for_stream()
         self.browser.snapshot("organization issues with issues")
 
-        groups = self.browser.find_elements_by_css_selector('[data-test-id="event-issue-header"]')
+        groups = self.browser.elements('[data-test-id="event-issue-header"]')
         assert len(groups) == 2
         assert "oh snap" in groups[0].text
         assert "oh no" in groups[1].text

--- a/tests/acceptance/test_organization_switch.py
+++ b/tests/acceptance/test_organization_switch.py
@@ -37,7 +37,7 @@ class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
             )
 
         def get_project_elements_from_project_selector_dropdown():
-            return self.browser.driver.find_elements_by_css_selector(
+            return self.browser.elements(
                 '[data-test-id="autocomplete-list"] [data-test-id="badge-display-name"]'
             )
 


### PR DESCRIPTION
This adds an `elements()` convenience method similar to `element()` but
calls `find_css_elements_by_selector()` instead. Returns a list of
WebDriver elements.