### PR TITLE
fix(alerts): Add item button type, disable team dropdown

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -276,7 +276,7 @@ class ActionsPanel extends React.PureComponent<Props> {
 
                     {availableAction && availableAction.allowedTargetTypes.length > 1 ? (
                       <SelectControl
-                        disabled={disabled || loading}
+                        isDisabled={disabled || loading}
                         value={action.targetType}
                         options={availableAction?.allowedTargetTypes?.map(
                           allowedType => ({

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -330,6 +330,7 @@ class ActionsPanel extends React.PureComponent<Props> {
           })}
           <StyledPanelItem>
             <Button
+              type="button"
               disabled={disabled || loading}
               size="small"
               icon={<IconAdd isCircled color="gray500" />}


### PR DESCRIPTION
- Member/team dropdown use isDisabled to disable select control
- Add missing button type on add item, prevent submitting form on click