### PR TITLE
ref(ui): Alert Rule creation form now uses enum mapping

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {Client} from 'app/api';
+import {DATA_SOURCE_LABELS} from 'app/views/alerts/utils';
 import {Environment, Organization} from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {addErrorMessage} from 'app/actionCreators/indicator';
@@ -121,8 +122,8 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                     model.setValue('aggregate', DEFAULT_AGGREGATE);
                   }}
                   choices={[
-                    [Dataset.ERRORS, t('Errors')],
-                    [Dataset.TRANSACTIONS, t('Transactions')],
+                    [Dataset.ERRORS, DATA_SOURCE_LABELS[Dataset.ERRORS]],
+                    [Dataset.TRANSACTIONS, DATA_SOURCE_LABELS[Dataset.TRANSACTIONS]],
                   ]}
                 />
               )}


### PR DESCRIPTION
#19879 added a mapping from dataset enum ('events', 'transactions') to translated strings. Utilizing it here for alert rule creation.


