### PR TITLE
fix(ui): fixed padding of secondary nav

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
@@ -57,6 +57,9 @@ class SettingsNavigation extends React.Component<Props> {
 }
 
 const PositionStickyWrapper = styled('div')`
+  padding: ${space(4)};
+  padding-right: ${space(2)};
+
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     position: sticky;
     top: 70px;
@@ -64,8 +67,6 @@ const PositionStickyWrapper = styled('div')`
     height: calc(100vh - 70px);
     -ms-overflow-style: none;
     scrollbar-width: none;
-    padding: ${space(4)};
-    padding-right: ${space(2)};
 
     &::-webkit-scrollbar {
       display: none;


### PR DESCRIPTION
## Before

<img width="638" alt="Screen Shot 2020-07-16 at 8 25 24 AM" src="https://user-images.githubusercontent.com/1900676/87690368-3a67c380-c73e-11ea-81b1-ceb431b8f824.png">


## After

<img width="640" alt="Screen Shot 2020-07-16 at 8 26 00 AM" src="https://user-images.githubusercontent.com/1900676/87690381-3d62b400-c73e-11ea-923a-86d433ca7132.png">
