### PR TITLE
fix(discover): Render empty release cells correctly

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -264,10 +264,12 @@ const SPECIAL_FIELDS: SpecialFields = {
   release: {
     sortField: 'release',
     renderFunc: data =>
-      data.release && (
+      data.release ? (
         <VersionContainer>
           <Version version={data.release} anchor={false} tooltipRawVersion truncate />
         </VersionContainer>
+      ) : (
+        <Container>{emptyValue}</Container>
       ),
   },
 };

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -184,7 +184,7 @@ class CellAction extends React.Component<Props, State> {
       );
     }
 
-    if (column.column.kind === 'field' && column.column.field === 'release') {
+    if (column.column.kind === 'field' && column.column.field === 'release' && value) {
       addMenuItem(
         Actions.RELEASE,
         <ActionItem

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -28,6 +28,7 @@ describe('getFieldRenderer', function() {
       latest_event: 'deadbeef',
       project: project.slug,
       user: userAlias,
+      release: 'F2520C43515BD1F0E8A6BD46233324641A370BF6',
     };
 
     MockApiClient.addMockResponse({
@@ -99,6 +100,17 @@ describe('getFieldRenderer', function() {
 
     const badge = wrapper.find('UserBadge');
     expect(badge).toHaveLength(0);
+
+    const value = wrapper.find('EmptyValueContainer');
+    expect(value).toHaveLength(1);
+    expect(value.text()).toEqual('n/a');
+  });
+
+  it('can render null release fields', function() {
+    const renderer = getFieldRenderer('release', {release: 'string'});
+
+    delete data.release;
+    const wrapper = mount(renderer(data, {location, organization}));
 
     const value = wrapper.find('EmptyValueContainer');
     expect(value).toHaveLength(1);

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -5,14 +5,14 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import CellAction from 'app/views/eventsV2/table/cellAction';
 import EventView from 'app/utils/discover/eventView';
 
-function makeWrapper(eventView, handleCellAction, columnIndex = 0) {
-  const data = {
-    transaction: 'best-transaction',
-    count: 19,
-    timestamp: '2020-06-09T01:46:25+00:00',
-    release: 'F2520C43515BD1F0E8A6BD46233324641A370BF6',
-    nullValue: null,
-  };
+const defaultData = {
+  transaction: 'best-transaction',
+  count: 19,
+  timestamp: '2020-06-09T01:46:25+00:00',
+  release: 'F2520C43515BD1F0E8A6BD46233324641A370BF6',
+  nullValue: null,
+};
+function makeWrapper(eventView, handleCellAction, columnIndex = 0, data = defaultData) {
   return mountWithTheme(
     <CellAction
       dataRow={data}
@@ -213,6 +213,21 @@ describe('Discover -> CellAction', function() {
       expect(
         wrapper.find('button[data-test-id="show-values-less-than"]').exists()
       ).toBeTruthy();
+    });
+
+    it('show appropriate actions for release cells', function() {
+      wrapper = makeWrapper(view, handleCellAction, 3);
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+      expect(wrapper.find('button[data-test-id="release"]').exists()).toBeTruthy();
+
+      wrapper = makeWrapper(view, handleCellAction, 3, {
+        ...defaultData,
+        release: null,
+      });
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+      expect(wrapper.find('button[data-test-id="release"]').exists()).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
Render empty release cells with n/a instead of an empty string and disable the
go to release cell action when this happens.