### PR TITLE
test(acceptance): Refactor selenium window re-sizing

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -97,10 +97,10 @@ class Browser(object):
         if remember_previous_size and not self._last_window_size:
             self._last_window_size = previous_size
 
-        width = width if width is None else previous_size["width"]
+        width = width if width is not None else previous_size["width"]
         height = (
             height
-            if height is None
+            if height is not None
             # adapted from https://stackoverflow.com/questions/41721734/take-screenshot-of-full-page-with-selenium-python-with-chromedriver/52572919#52572919
             else self.driver.execute_script("return document.body.parentNode.scrollHeight")
         )

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -116,8 +116,8 @@ class Browser(object):
             "current": {"width": width, "height": height},
         }
 
-    def set_viewport(self, width, height):
-        size = self.set_window_size(width, height)
+    def set_viewport(self, width, height, fit_content):
+        size = self.set_window_size(width, height, fit_content)
         try:
             yield size
         finally:

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -98,12 +98,20 @@ class Browser(object):
             self._last_window_size = previous_size
 
         width = width if width is not None else previous_size["width"]
-        height = (
-            height
-            if height is not None
-            # adapted from https://stackoverflow.com/questions/41721734/take-screenshot-of-full-page-with-selenium-python-with-chromedriver/52572919#52572919
-            else self.driver.execute_script("return document.body.parentNode.scrollHeight")
-        )
+
+        if height is None and width != previous_size["width"]:
+            # In order to set window height to content height, we must make sure
+            # width has not changed (otherwise contents will shift,
+            # and we require two resizes)
+            self.driver.set_window_size(width, 1)
+            height = self.driver.execute_script("return document.body.parentNode.scrollHeight")
+        else:
+            height = (
+                height
+                if height is not None
+                # adapted from https://stackoverflow.com/questions/41721734/take-screenshot-of-full-page-with-selenium-python-with-chromedriver/52572919#52572919
+                else self.driver.execute_script("return document.body.parentNode.scrollHeight")
+            )
 
         self.driver.set_window_size(width, height)
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -308,24 +308,17 @@ class Browser(object):
             # Note: below will fail if these directories do not exist
 
             if not mobile_only:
+                # This will make sure we resize viewport height to fit contents
                 with self.full_viewport():
-                    # calling this with no width/height will resize height to fit
-                    # content's height so that we can take full page screenshot
-                    #  self.set_window_size(remember_previous_size=True)
-
-                    # finds body tag to screenshot in order to avoid scrollbar
-                    self.driver.find_element_by_tag_name("body").screenshot(
+                    self.driver.screenshot(
                         u".artifacts/visual-snapshots/acceptance/{}.png".format(slugify(name))
                     )
 
             with self.mobile_viewport():
-                # switch to mobile width and a fixed height
-
-                self.driver.find_element_by_tag_name("body").screenshot(
+                # switch to a mobile sized viewport
+                self.driver.screenshot(
                     u".artifacts/visual-snapshots/acceptance-mobile/{}.png".format(slugify(name))
                 )
-
-            #  self.reset_window_size()
 
         self.percy.snapshot(name=name)
         return self

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -88,7 +88,7 @@ class Browser(object):
 
         return self.driver.execute_script("return document.body.parentNode.scrollHeight")
 
-    def set_window_size(self, width=None, height=None):
+    def set_window_size(self, width=None, height=None, fit_content=False):
         """
         Sets the window size.
 
@@ -98,10 +98,9 @@ class Browser(object):
         """
 
         previous_size = self.driver.get_window_size()
-
         width = width if width is not None else previous_size["width"]
 
-        if height is None and width != previous_size["width"]:
+        if fit_content:
             # In order to set window height to content height, we must make sure
             # width has not changed (otherwise contents will shift,
             # and we require two resizes)
@@ -127,11 +126,11 @@ class Browser(object):
 
     @contextmanager
     def full_viewport(self, width=None, height=None):
-        return self.set_viewport(width, height)
+        return self.set_viewport(width, height, fit_content=True)
 
     @contextmanager
-    def mobile_viewport(self, width=375, height=None):
-        return self.set_viewport(width, height)
+    def mobile_viewport(self, width=375, height=812):
+        return self.set_viewport(width, height, fit_content=True)
 
     def element(self, selector=None, xpath=None):
         """

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -103,7 +103,7 @@ class Browser(object):
             # In order to set window height to content height, we must make sure
             # width has not changed (otherwise contents will shift,
             # and we require two resizes)
-            self.driver.set_window_size(width, 1)
+            self.driver.set_window_size(width, 812)
             height = self.driver.execute_script("return document.body.parentNode.scrollHeight")
         else:
             height = (
@@ -127,7 +127,7 @@ class Browser(object):
         self.set_window_size(self._last_window_size["width"], self._last_window_size["height"])
         self._last_window_size = None
 
-    def set_to_mobile_size(self, width=375, height=812, **kwargs):
+    def set_to_mobile_size(self, width=375, height=None, **kwargs):
         """
         Sets window size to a "mobile" dimensions
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -310,13 +310,13 @@ class Browser(object):
             if not mobile_only:
                 # This will make sure we resize viewport height to fit contents
                 with self.full_viewport():
-                    self.driver.screenshot(
+                    self.driver.find_element_by_tag_name("body").screenshot(
                         u".artifacts/visual-snapshots/acceptance/{}.png".format(slugify(name))
                     )
 
             with self.mobile_viewport():
                 # switch to a mobile sized viewport
-                self.driver.screenshot(
+                self.driver.find_element_by_tag_name("body").screenshot(
                     u".artifacts/visual-snapshots/acceptance-mobile/{}.png".format(slugify(name))
                 )
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -40,6 +40,7 @@ class Browser(object):
         self.percy = percy
         self.domain = urlparse(self.live_server_url).hostname
         self._has_initialized_cookie_store = False
+        self._last_window_size = None
 
     def __getattr__(self, attr):
         return getattr(self.driver, attr)

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -127,7 +127,7 @@ class Browser(object):
         self.set_window_size(self._last_window_size["width"], self._last_window_size["height"])
         self._last_window_size = None
 
-    def set_to_mobile_size(self, width=375, height=None, **kwargs):
+    def set_to_mobile_size(self, width=375, height=812, **kwargs):
         """
         Sets window size to a "mobile" dimensions
 

--- a/tests/acceptance/test_project_general_settings.py
+++ b/tests/acceptance/test_project_general_settings.py
@@ -25,10 +25,11 @@ class ProjectGeneralSettingsTest(AcceptanceTestCase):
         It is only possible to open the menu at mobile widths
         """
         path = u"/{}/{}/settings/".format(self.org.slug, self.project.slug)
-        self.browser.set_to_mobile_size(remember_previous_size=True)
-        self.browser.get(path)
-        self.browser.wait_until_not(".loading-indicator")
 
-        self.browser.click('[aria-label="Open the menu"]')
-        self.browser.wait_until("body.scroll-lock")
-        self.browser.snapshot("project settings - mobile menu", mobile_only=True)
+        with self.browser.mobile_viewport():
+            self.browser.get(path)
+            self.browser.wait_until_not(".loading-indicator")
+
+            self.browser.click('[aria-label="Open the menu"]')
+            self.browser.wait_until("body.scroll-lock")
+            self.browser.snapshot("project settings - mobile menu", mobile_only=True)

--- a/tests/acceptance/test_project_general_settings.py
+++ b/tests/acceptance/test_project_general_settings.py
@@ -25,7 +25,7 @@ class ProjectGeneralSettingsTest(AcceptanceTestCase):
         It is only possible to open the menu at mobile widths
         """
         path = u"/{}/{}/settings/".format(self.org.slug, self.project.slug)
-        self.set_to_mobile_size(remember_previous_size=True)
+        self.browser.set_to_mobile_size(remember_previous_size=True)
         self.browser.get(path)
         self.browser.wait_until_not(".loading-indicator")
 

--- a/tests/acceptance/test_project_general_settings.py
+++ b/tests/acceptance/test_project_general_settings.py
@@ -21,15 +21,14 @@ class ProjectGeneralSettingsTest(AcceptanceTestCase):
         self.browser.snapshot("project settings - general settings")
 
     def test_mobile_menu(self):
+        """
+        It is only possible to open the menu at mobile widths
+        """
         path = u"/{}/{}/settings/".format(self.org.slug, self.project.slug)
+        self.set_to_mobile_size(remember_previous_size=True)
         self.browser.get(path)
         self.browser.wait_until_not(".loading-indicator")
 
-        try:
-            self.browser.click('[aria-label="Open the menu"]')
-            self.browser.wait_until("body.scroll-lock")
-
-        except Exception:
-            pass
-
-        self.browser.snapshot("project settings - mobile menu")
+        self.browser.click('[aria-label="Open the menu"]')
+        self.browser.wait_until("body.scroll-lock")
+        self.browser.snapshot("project settings - mobile menu", mobile_only=True)


### PR DESCRIPTION
This abstracts the window resizing logic a bit and allows for tests to control the window sizing easier, as well as only taking "mobile" snapshots. This may change if we wanted to snapshot more breakpoints.

The mobile menu test that is fixed here, is impossible to capture in Percy since Percy handles the responsive rendering and the menu button only appears at our lowest breakpoint.