### PR TITLE
fix(workflow): Removing duplicates in queryset when subscribed to multiple projects

### DIFF
--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -311,7 +311,7 @@ class AlertRuleManager(BaseManager):
     def fetch_for_organization(self, organization, projects=None):
         queryset = self.filter(organization=organization)
         if projects is not None:
-            queryset = queryset.filter(snuba_query__subscriptions__project__in=projects)
+            queryset = queryset.filter(snuba_query__subscriptions__project__in=projects).distinct()
 
         return queryset
 


### PR DESCRIPTION
When fetching by organization and including project ids, this seemed to return duplicates for each alert rule that was subscribed to multiple projects. Adding `.distinct()` seems to fix the issue.