### PR TITLE
Highlight optional executing node (from python integration)

### DIFF
--- a/src/sentry/data/samples/python.json
+++ b/src/sentry/data/samples/python.json
@@ -139,6 +139,16 @@
         "in_app": false,
         "data": {},
         "context_line": "            **kwargs)",
+        "executing_node": {
+          "start": {
+            "line": 457,
+            "column": 15
+          },
+          "end": {
+            "line": 459,
+            "column": 21
+          }
+        },
         "lineno": 459
       },
       {

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -150,6 +150,7 @@ class Frame(Interface):
             "platform",
             "post_context",
             "pre_context",
+            "executing_node",
             "symbol",
             "symbol_addr",
             "trust",
@@ -177,6 +178,7 @@ class Frame(Interface):
                 "context_line": self.context_line,
                 "pre_context": self.pre_context or None,
                 "post_context": self.post_context or None,
+                "executing_node": self.executing_node or None,
                 "vars": self.vars or None,
                 "data": self.data or None,
                 "errors": self.errors or None,
@@ -206,6 +208,12 @@ class Frame(Interface):
                 pre_context=self.pre_context,
                 post_context=self.post_context,
             ),
+            # TODO make this work instead of hardcoding mock data
+            # "executingNode": self.executing_node,
+            "executingNode": {
+                "start": {"line": 457, "column": 15},
+                "end": {"line": 459, "column": 21},
+            },
             "lineNo": self.lineno,
             "colNo": self.colno,
             "inApp": self.in_app,

--- a/src/sentry/static/sentry/app/components/events/interfaces/contextLine.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/contextLine.jsx
@@ -10,11 +10,23 @@ const Context = styled('div')`
 `;
 
 const ContextLine = function(props) {
-  const {line, isActive, className} = props;
+  const {line, isActive, className, highlightRange} = props;
   let lineWs = '';
   let lineCode = '';
   if (defined(line[1]) && line[1].match) {
     [, lineWs, lineCode] = line[1].match(/^(\s*)(.*?)$/m);
+    if (highlightRange) {
+      let [start, end] = highlightRange;
+      start -= lineWs.length;
+      end -= lineWs.length;
+      lineCode = (
+        <React.Fragment>
+          {lineCode.substring(0, start)}
+          <span className="active">{lineCode.substring(start, end)}</span>
+          {lineCode.substring(end, lineCode.length)}
+        </React.Fragment>
+      );
+    }
   }
   const Component = !props.children ? React.Fragment : Context;
   return (
@@ -31,6 +43,7 @@ const ContextLine = function(props) {
 ContextLine.propTypes = {
   line: PropTypes.array.isRequired,
   isActive: PropTypes.bool,
+  highlightRange: PropTypes.arrayOf(PropTypes.number),
 };
 
 export default ContextLine;

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/frameContext.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/frameContext.tsx
@@ -70,13 +70,27 @@ const FrameContext = ({
 
       {frame.context &&
         contextLines.map((line, index) => {
-          const isActive = frame.lineNo === line[0];
+          let highlightRange: number[] | null = null;
+          if (frame.executingNode) {
+            const {start, end} = frame.executingNode;
+            if (start.line <= line[0] && line[0] <= end.line) {
+              highlightRange = [0, line[1].length];
+              if (start.line === line[0]) {
+                highlightRange[0] = start.column;
+              }
+              if (end.line === line[0]) {
+                highlightRange[1] = end.column;
+              }
+            }
+          }
+          const isActive = frame.lineNo === line[0] && !highlightRange;
           const hasComponents = isActive && components.length > 0;
           return (
             <ContextLine
               key={index}
               line={line}
               isActive={isActive}
+              highlightRange={highlightRange}
               css={
                 hasComponents
                   ? css`

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1326,6 +1326,16 @@ export type EventGroupInfo = Record<EventGroupVariantKey, EventGroupVariant>;
 
 export type PlatformType = 'java' | 'csharp' | 'other';
 
+export type ExecutingNodePosition = {
+  line: number;
+  column: number;
+};
+
+export type ExecutingNode = {
+  start: ExecutingNodePosition;
+  end: ExecutingNodePosition;
+};
+
 export type Frame = {
   filename: string;
   module: string;
@@ -1333,6 +1343,7 @@ export type Frame = {
   preventCollapse: () => void;
   errors: Array<any>;
   context: Array<[number, string]>;
+  executingNode?: ExecutingNode;
   vars: {[key: string]: any};
   inApp: boolean;
   function?: string;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1213,6 +1213,11 @@ div.traceback > ul {
         list-style-type: inherit;
         border-radius: 0;
       }
+
+      span.active {
+        background-color: @purple;
+        color: #fff;
+      }
     }
   }
 

--- a/tests/js/spec/components/events/interfaces/__snapshots__/frame.spec.jsx.snap
+++ b/tests/js/spec/components/events/interfaces/__snapshots__/frame.spec.jsx.snap
@@ -4,6 +4,7 @@ exports[`Frame renderContext() should render context lines 1`] = `
 Array [
   <ContextLine
     className="css-x7wq2i-FrameContext"
+    highlightRange={null}
     isActive={false}
     line={
       Array [
@@ -30,6 +31,7 @@ Array [
   </ContextLine>,
   <ContextLine
     className="css-x7wq2i-FrameContext"
+    highlightRange={null}
     isActive={false}
     line={
       Array [
@@ -56,6 +58,7 @@ Array [
   </ContextLine>,
   <ContextLine
     className="css-x7wq2i-FrameContext"
+    highlightRange={null}
     isActive={false}
     line={
       Array [


### PR DESCRIPTION
This goes with https://github.com/getsentry/sentry-python/pull/761. @untitaker knows the context best.

Essentially it highlights the exact bit of code being executed in a frame, rather than just one active line. This is helpful when it's not clear which part of a line is being executed, or when the executed code spans multiple lines. Currently it looks like this:

![Screen Shot 2020-07-16 at 21 30 35](https://user-images.githubusercontent.com/3627481/87716605-5e172200-c7af-11ea-96fb-4e01619b1de0.png)

As you can see, I'm not very good with design or CSS and could use some help in that area.

Another problem I'm having is that I added an `executing_node` value to the data sample and ran `./bin/load-mocks` but it doesn't make it to the `Frame` interface object. I guess something strips unexpected attributes somewhere in the data pipeline but this is a big unfamiliar codebase and I don't know where to look. Any ideas?