### PR TITLE
ref(py3): Celery 4.1 patch branch for S4S

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,7 +1,7 @@
 beautifulsoup4>=4.7.1,<4.8
 boto3>=1.4.1,<1.4.6
 botocore<1.5.71
-celery>=3.1.25,<4.0.0
+celery==4.1.1
 click>=5.0,<7.0
 confluent-kafka==0.11.5
 croniter>=0.3.34,<0.4.0
@@ -24,7 +24,6 @@ google-cloud-storage==1.13.3
 googleapis-common-protos==1.6.0
 ipaddress>=1.0.16,<1.1.0 ; python_version < "3.3"
 jsonschema==3.2.0
-kombu==3.0.37
 lxml>=4.3.3,<4.4.0
 maxminddb==1.4.1
 mistune>0.7,<0.9
@@ -65,6 +64,10 @@ ua-parser>=0.10.0,<0.11.0
 unidiff>=0.5.4
 urllib3==1.24.2
 uwsgi>2.0.0,<2.1.0
+
+# celery
+billiard==3.5.0.5
+kombu==4.2.2.post1
 
 # not directly used, but provides a speedup for redis
 hiredis==0.3.1

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     packages=find_packages("src"),
     zip_safe=False,
     install_requires=install_requires,
-    extras_require={"dev": dev_requires},
+    extras_require={"dev": dev_requires, "rabbitmq": ["amqp==2.6.0"]},
     cmdclass=cmdclass,
     license="BSL-1.1",
     include_package_data=True,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -489,6 +489,11 @@ BROKER_TRANSPORT_OPTIONS = {}
 # though it would cause timeouts/recursions in some cases
 CELERY_ALWAYS_EAGER = False
 
+# We use the old task protocol because during benchmarking we noticed that it's faster
+# than the new protocol. If we ever need to bump this it should be fine, there were no
+# compatibility issues, just need to run benchmarks and do some tests to make sure
+# things run ok.
+CELERY_TASK_PROTOCOL = 1
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 CELERY_IGNORE_RESULT = True
 CELERY_SEND_EVENTS = False

--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -41,8 +41,11 @@ class AmqpBackend(object):
         )
 
     def get_conn(self):
-        from librabbitmq import Connection
-
+        try:
+            # TODO: Remove this once we've totally moved away from `librabbitmq`
+            from librabbitmq import Connection
+        except Exception:
+            from amqp import Connection
         return Connection(**self.conn_info)
 
     def _get_size_from_channel(self, channel, queue):

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -84,7 +84,7 @@ def pytest_configure(config):
         settings.SENTRY_NEWSLETTER_OPTIONS = {}
 
     settings.BROKER_BACKEND = "memory"
-    settings.BROKER_URL = None
+    settings.BROKER_URL = "memory://"
     settings.CELERY_ALWAYS_EAGER = False
     settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 


### PR DESCRIPTION
This is a patch branch for testing out Celery 4.1 in Sentry for Sentry. One major thing here is that
we have to stop using `librabbitmq`, since it no longer works for us with Celery 4.1. I've run
benchmarks and I think that the performance change won't be huge, more details here:
https://github.com/getsentry/sentry/pull/19802.

Things we want to confirm:
 - Make sure `amqp==2.6.0` is installed.
 - Make sure `librabbitmq` is not installed (needs to be removed from https://github.com/getsentry/single-tenant/blob/master/bin/bump-release#L194, I believe)
 - We don't suddenly end up with a bunch of errors due to this upgrade.
 - Monitor CPU usage on the workers and see if it significantly changes.