### PR TITLE
feat(direnv): experimental SENTRY_PYTHON3

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -16,7 +16,7 @@ reset="$(tput sgr0)"
 #      so need to use set -e, and return 1.
 trap notice ERR
 
-notice () {
+notice() {
     [ $? -eq 0 ] && return
     cat <<EOF
 ${red}${bold}direnv wasn't able to complete execution.
@@ -29,44 +29,44 @@ and/or reach out to @josh.
 EOF
 }
 
-require () {
-    command -v "$1" 2>&1 > /dev/null
+require() {
+    command -v "$1" 2>&1 >/dev/null
 }
 
-info () {
+info() {
     cat <<EOF
 ${bold}direnv: ${@}${reset}
 EOF
 }
 
-die () {
-    >&2 cat <<EOF
+die() {
+    cat >&2 <<EOF
 ${red}${bold}direnv FATAL: ${@}
 ${reset}
 EOF
     return 1
 }
 
-advice_init_venv () {
+advice_init_venv() {
     deactivate 2>/dev/null || true
     info "To create a virtualenv, please type: python2.7 -m virtualenv .venv"
-    require python2.7 || \
+    require python2.7 ||
         die "You'll need to install python2.7, or make it available on your PATH.
 It's recommended to use pyenv - please refer to https://docs.sentry.io/development/contribute/environment"
     return 1
 }
 
-advice_install_sentry () {
+advice_install_sentry() {
     info "To install sentry, please type: make install-py-dev"
     return 1
 }
 
-advice_install_pre_commit () {
+advice_install_pre_commit() {
     info "To install pre-commit, please type: make setup-git"
     return 1
 }
 
-advice_install_yarn_pkgs () {
+advice_install_yarn_pkgs() {
     info "To install yarn packages, please type: make install-js-dev"
     return 1
 }
@@ -85,29 +85,25 @@ export PIP_DISABLE_PIP_VERSION_CHECK=on
 # increase node's memory limit, required for our webpacking
 export NODE_OPTIONS=--max-old-space-size=4096
 
-
 ### System ###
 
 for pkg in \
-    make            \
-    docker          \
-    chromedriver    \
-    pkg-config      \
-    openssl         ;
-    do
+    make \
+    docker \
+    chromedriver \
+    pkg-config \
+    openssl; do
     if ! require "$pkg"; then
         die "You seem to be missing the system dependency: ${pkg}
 Please install homebrew, and run brew bundle."
     fi
 done
 
-
 ### Git ###
 
 info "Configuring git..."
 
 make setup-git-config
-
 
 ### Python ###
 
@@ -132,11 +128,11 @@ unset PS1
 # We're explicitly disallowing symlinked venvs (python would resolve to the canonical location)
 if [ "$(command -v python)" != "${PWD}/.venv/bin/python" ]; then
     info "Failed to activate virtualenv. Your virtualenv's probably symlinked." \
-    "We want everyone to be on the same page here, so you'll have to recreate your virtualenv."
+        "We want everyone to be on the same page here, so you'll have to recreate your virtualenv."
     advice_init_venv
 fi
 
-python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" || \
+python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" ||
     die "For some reason, the virtualenv isn't Python 2.7."
 
 if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
@@ -146,7 +142,6 @@ if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
     advice_install_sentry
 fi
 
-
 ### pre-commit ###
 
 info "Checking pre-commit..."
@@ -155,7 +150,6 @@ if ! require pre-commit; then
     info "Looks like you don't have pre-commit installed."
     advice_install_pre_commit
 fi
-
 
 ### Node ###
 
@@ -173,7 +167,6 @@ if [ ! -x "node_modules/.bin/webpack" ]; then
 fi
 
 PATH_add node_modules/.bin
-
 
 ### Overrides ###
 

--- a/.envrc
+++ b/.envrc
@@ -9,6 +9,7 @@ set -e
 bold="$(tput bold)"
 red="$(tput setaf 1)"
 green="$(tput setaf 2)"
+yellow="$(tput setaf 3)"
 reset="$(tput sgr0)"
 
 # XXX: we can't trap bash EXIT, because it'll override direnv's finalizing routines.
@@ -33,6 +34,12 @@ require() {
     command -v "$1" 2>&1 >/dev/null
 }
 
+warn() {
+    cat <<EOF
+${yellow}${bold}direnv: ${@}${reset}
+EOF
+}
+
 info() {
     cat <<EOF
 ${bold}direnv: ${@}${reset}
@@ -48,10 +55,13 @@ EOF
 }
 
 advice_init_venv() {
+    python_version="$1"
+    venv_name="$2"
+
     deactivate 2>/dev/null || true
-    info "To create a virtualenv, please type: python2.7 -m virtualenv .venv"
-    require python2.7 ||
-        die "You'll need to install python2.7, or make it available on your PATH.
+    info "To create a virtualenv, please type: ${python_version} -m virtualenv ${venv_name}"
+    require ${python_version} ||
+        die "You'll need to install ${python_version}, or make it available on your PATH.
 It's recommended to use pyenv - please refer to https://docs.sentry.io/development/contribute/environment"
     return 1
 }
@@ -107,36 +117,52 @@ make setup-git-config
 
 ### Python ###
 
+# we're enforcing that virtualenv be in .venv{,3}, since future tooling e.g.
+# venv-update will rely on this.
+venv_name=".venv"
+python_version="python2.7"
+
+if [ "$SENTRY_PYTHON3" = "1" ]; then
+    venv_name=".venv3"
+    python_version="python3.6"
+
+    warn "Running in EXPERIMENTAL Python 3 mode... Good luck"
+fi
+
 info "Activating virtualenv..."
 
-# we're enforcing that virtualenv be in .venv, since future tooling e.g. venv-update will rely on this.
-if [ ! -f ".venv/bin/activate" ]; then
+if [ ! -f "${venv_name}/bin/activate" ]; then
     info "You don't seem to have a virtualenv."
-    advice_init_venv
+    advice_init_venv "$python_version" "$venv_name"
 fi
 
 # The user might be cd'ing into sentry with another non-direnv managed
 # (in that it would be automatically deactivated) virtualenv active.
 deactivate 2>/dev/null || true
 
-source .venv/bin/activate
+source ${venv_name}/bin/activate
 
 # XXX: ideally, direnv is able to export PS1 as modified by sourcing venvs
 #      but we'd have to patch direnv, and ".venv" isn't descriptive anyways
 unset PS1
 
 # We're explicitly disallowing symlinked venvs (python would resolve to the canonical location)
-if [ "$(command -v python)" != "${PWD}/.venv/bin/python" ]; then
+if [ "$(command -v python)" != "${PWD}/${venv_name}/bin/python" ]; then
     info "Failed to activate virtualenv. Your virtualenv's probably symlinked." \
         "We want everyone to be on the same page here, so you'll have to recreate your virtualenv."
-    advice_init_venv
+    advice_init_venv "$python_version" "$venv_name"
 fi
 
-python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" ||
-    die "For some reason, the virtualenv isn't Python 2.7."
+if [ "$SENTRY_PYTHON3"  = "1" ]; then
+    python -c "import sys; sys.exit(sys.version_info[:2] != (3, 6))" ||
+        die "For some reason, the virtualenv isn't Python 3.6."
+else
+    python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" ||
+        die "For some reason, the virtualenv isn't Python 2.7."
+fi
 
-if [ "$(command -v sentry)" != "${PWD}/.venv/bin/sentry" ]; then
-    info "Your .venv is activated, but sentry doesn't seem to be installed."
+if [ "$(command -v sentry)" != "${PWD}/${venv_name}/bin/sentry" ]; then
+    info "Your virtual env is activated, but sentry doesn't seem to be installed."
     # XXX: if direnv fails, the venv won't be activated outside of direnv execution...
     # So, it is critical that make install-py-dev is guarded by scripts/ensure-venv.
     advice_install_sentry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ include='\.py$'
 exclude='''
 (
       \.venv/
+      \.venv3/
     | node_modules/
     | migrations/
 )

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -2,26 +2,40 @@
 
 # optionally opt out of virtualenv creation
 # WARNING: this will be removed (most likely renamed) soon!
-if [ "x$SENTRY_NO_VIRTUALENV_CREATION" == "x1" ]; then
+if [ "$SENTRY_NO_VIRTUALENV_CREATION" == "1" ]; then
     exit 0
 fi
 
+venv_name=".venv"
+python_bin="python2.7"
+
+if [ "$SENTRY_PYTHON3" = "1" ]; then
+    venv_name=".venv3"
+    python_bin="python3.6"
+fi
+
+die() {
+    cat >&2 "${@}"
+    exit 1
+}
+
 if [ -n "$VIRTUAL_ENV" ]; then
     # we're enforcing that virtualenv be in .venv, since future tooling e.g. venv-update will rely on this.
-    if [ "$VIRTUAL_ENV" != "${PWD}/.venv" ]; then
-        echo "You're in a virtualenv, but it's not in the expected location (${PWD}/.venv)"
-        exit 1
+    if [ "$VIRTUAL_ENV" != "${PWD}/${venv_name}" ]; then
+        die "You're in a virtualenv, but it's not in the expected location (${PWD}/${venv_name})"
     fi
-    # TODO: when direnv lands, make the check strictly match .python-version.
-    if ! python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))"; then
-        echo "Your virtualenv's python version isn't 2.7. You'll need to recreate it with the correct python version."
-        exit 1
+
+    # TODO: Update this to strictly check .python-version
+    if [ "$SENTRY_PYTHON3" = "1" ]; then
+        python -c "import sys; sys.exit(sys.version_info[:2] != (3, 6))" ||
+            die "For some reason, the virtualenv isn't Python 3.6."
+    else
+        python -c "import sys; sys.exit(sys.version_info[:2] != (2, 7))" ||
+            die "For some reason, the virtualenv isn't Python 2.7."
     fi
 else
-    if [ ! -f ".venv/bin/activate" ]; then
-        echo "You don't seem to have a virtualenv. Please create one by running: python -m virtualenv .venv"
-        exit 1
+    if [ ! -f "${venv_name}/bin/activate" ]; then
+        die "You don't seem to have a virtualenv. Please create one by running: ${python_bin} -m virtualenv ${venv_name}"
     fi
-    echo "You have a virtualenv, but it doesn't seem to be activated. Please run: source .venv/bin/activate"
-    exit 1
+    die "You have a virtualenv, but it doesn't seem to be activated. Please run: source ${venv_name}/bin/activate"
 fi

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ from __future__ import absolute_import
 import os
 import sys
 
+if os.environ.get("SENTRY_PYTHON3") and sys.version_info[:2] != (3, 6):
+    sys.exit("Error: Sentry [In EXPERIMENTAL python 3 mode] requires Python 3.6.")
+
 if not os.environ.get("SENTRY_PYTHON3") and sys.version_info[:2] != (2, 7):
     sys.exit("Error: Sentry requires Python 2.7.")
 

--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -52,7 +52,7 @@ def get_files(path):
 def get_modified_files(path):
     return [
         s
-        for s in check_output(["git", "diff-index", "--cached", "--name-only", "HEAD"]).split("\n")
+        for s in check_output(["git", "diff-index", "--cached", "--name-only", "HEAD"]).split(b"\n")
         if s
     ]
 


### PR DESCRIPTION
`direnv` now supports a python3 environment by setting the `SENTRY_PYTHON3` flag.

This uses the `.venv3` directory for the virtual env. This makes the assumption that we'll have our tooling support both `.venv` and `.venv3`.

If we don't want to do this, I can definitely have it do some fancy symlink things. But I suspect symlinks are going to cause us more trouble than we might expect.