### PR TITLE
fix(alerts): Prevent rule aggregate change on enter key

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -58,13 +58,13 @@ const help = ({name, model}: {name: string; model: FormModel}) => {
     .map((preset, i, list) => (
       <React.Fragment key={preset.name}>
         <Tooltip title={t('This preset is selected')} disabled={!preset.selected}>
-          <PresetLink
+          <PresetButton
             type="button"
             onClick={() => model.setValue(name, preset.default)}
             disabled={preset.selected}
           >
             {preset.name}
-          </PresetLink>
+          </PresetButton>
         </Tooltip>
         {i + 1 < list.length && ', '}
       </React.Fragment>
@@ -126,7 +126,7 @@ const AggregateHeader = styled('div')`
   margin-bottom: ${space(1)};
 `;
 
-const PresetLink = styled(Button)<{disabled: boolean}>`
+const PresetButton = styled(Button)<{disabled: boolean}>`
   ${p =>
     p.disabled &&
     css`
@@ -138,7 +138,7 @@ const PresetLink = styled(Button)<{disabled: boolean}>`
     `}
 `;
 
-PresetLink.defaultProps = {
+PresetButton.defaultProps = {
   priority: 'link',
   borderless: true,
 };

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -59,6 +59,7 @@ const help = ({name, model}: {name: string; model: FormModel}) => {
       <React.Fragment key={preset.name}>
         <Tooltip title={t('This preset is selected')} disabled={!preset.selected}>
           <PresetLink
+            type="button"
             onClick={() => model.setValue(name, preset.default)}
             disabled={preset.selected}
           >


### PR DESCRIPTION
Should now submit the form as expected? Or I guess, as the browser does by default.

Closes: https://getsentry.atlassian.net/browse/WOR-57