### PR TITLE
Standardize spacing of abbreviated units

### DIFF
--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -66,7 +66,7 @@ export function getDuration(
   }
   if (value >= 172800000) {
     const {label, result} = roundWithFixed(value / DAY, fixedDigits);
-    return `${label}${abbreviation ? t('d') : `${tn('day', 'days', result)}`}`;
+    return `${label}${abbreviation ? t('d') : ` ${tn('day', 'days', result)}`}`;
   }
   if (value >= 7200000) {
     const {label, result} = roundWithFixed(value / HOUR, fixedDigits);

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -62,23 +62,23 @@ export function getDuration(
 
   if (value >= WEEK) {
     const {label, result} = roundWithFixed(value / WEEK, fixedDigits);
-    return `${label} ${abbreviation ? t('wk') : tn('week', 'weeks', result)}`;
+    return `${label}${abbreviation ? t('wk') : ` ${tn('week', 'weeks', result)}`}`;
   }
   if (value >= 172800000) {
     const {label, result} = roundWithFixed(value / DAY, fixedDigits);
-    return `${label} ${abbreviation ? t('d') : tn('day', 'days', result)}`;
+    return `${label}${abbreviation ? t('d') : `${tn('day', 'days', result)}`}`;
   }
   if (value >= 7200000) {
     const {label, result} = roundWithFixed(value / HOUR, fixedDigits);
-    return `${label} ${abbreviation ? t('hr') : tn('hour', 'hours', result)}`;
+    return `${label}${abbreviation ? t('hr') : ` ${tn('hour', 'hours', result)}`}`;
   }
   if (value >= 120000) {
     const {label, result} = roundWithFixed(value / MINUTE, fixedDigits);
-    return `${label} ${abbreviation ? t('min') : tn('minute', 'minutes', result)}`;
+    return `${label}${abbreviation ? t('min') : ` ${tn('minute', 'minutes', result)}`}`;
   }
   if (value >= SECOND) {
     const {label, result} = roundWithFixed(value / SECOND, fixedDigits);
-    return `${label} ${abbreviation ? t('s') : tn('second', 'seconds', result)}`;
+    return `${label}${abbreviation ? t('s') : ` ${tn('second', 'seconds', result)}`}`;
   }
 
   const {label} = roundWithFixed(value, fixedDigits);


### PR DESCRIPTION
Abbreviated durations had different spacing. Keeps the space for abbreviated units. Also tested with a screen reader to ensure that both ways were properly spoken. 

Before:
![Screen Shot 2020-07-17 at 10 15 33 AM](https://user-images.githubusercontent.com/155016/87795785-8b4aeb00-c816-11ea-9c9d-c08114f77940.png)

After:
![Screen Shot 2020-07-17 at 10 15 02 AM](https://user-images.githubusercontent.com/155016/87795800-8f770880-c816-11ea-9af5-8f3c916b8401.png)

