### PR TITLE
fix: Make sure that gatsby traces don't have missing instrumentation

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -589,9 +589,11 @@ export function isEventFromBrowserJavaScriptSDK(event: SentryTransactionEvent): 
     return false;
   }
   // based on https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/version.ts
-  return ['sentry.javascript.browser', 'sentry.javascript.react'].includes(
-    sdkName.toLowerCase()
-  );
+  return [
+    'sentry.javascript.browser',
+    'sentry.javascript.react',
+    'sentry.javascript.gatsby',
+  ].includes(sdkName.toLowerCase());
 }
 
 // Durationless ops from: https://github.com/getsentry/sentry-javascript/blob/0defcdcc2dfe719343efc359d58c3f90743da2cd/packages/apm/src/integrations/tracing.ts#L629-L688


### PR DESCRIPTION
Currently traces sent using @sentry/gatsby + @sentry/apm (soon to be tracing)
display the missing instrumentation signal, which shouldn't be displayed.

![image](https://user-images.githubusercontent.com/18689448/87797685-0d3c1380-c819-11ea-89b0-a2774ed0c6aa.png)

Good looking trace otherwise 😎 

This brings the package in alignment with browser and react.