### PR TITLE
style(eslint): Restrict usage of `@sentry/browser`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,16 +9,7 @@ module.exports = {
     tick: true,
     jest: true,
   },
-  rules: {
-    'no-restricted-imports': [
-      'error',
-      {
-        name: 'lodash/get',
-        message:
-          'Optional chaining `?.` and nullish coalescing operators `??` are available and preferred over using `lodash/get`',
-      },
-    ],
-  },
+  rules: {},
   overrides: [
     {
       files: ['*.ts', '*.tsx'],

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "enzyme-adapter-react-16": "1.15.1",
     "enzyme-to-json": "3.4.3",
     "eslint": "5.11.1",
-    "eslint-config-sentry-app": "1.42.0",
+    "eslint-config-sentry-app": "^1.43.0",
     "html-webpack-plugin": "^4.3.0",
     "jest": "24.9.0",
     "jest-canvas-mock": "^2.2.0",

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/localStorage.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/localStorage.tsx
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/react';
 
 import localStorage from 'app/utils/localStorage';
 
@@ -36,6 +36,7 @@ function saveToStorage(obj: StorageValue) {
     Sentry.captureException(err);
     Sentry.withScope(scope => {
       scope.setExtra('storage', obj);
+
       Sentry.captureException(err);
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6658,16 +6658,16 @@ eslint-config-prettier@6.3.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-sentry-app@1.42.0:
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.42.0.tgz#f78ad00161f99003ac0e2b4ce1737fa5d7f3a430"
-  integrity sha512-m0M7yZCx/jymzmMmuNZGx+Sl/uN4o9j5SAFxppe6H62qua5R1WX3gkEaWmUu8NdH/ybk+RUZYkeSZz/oS1DfqA==
+eslint-config-sentry-app@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.43.0.tgz#28a116bea9e32dd03af59785fcdefcec91d604d9"
+  integrity sha512-e8Andi4ShqvQKh5XeFKwtOYwNHP/phfl86YCRIVW6w3r+ojGBnMWxB9zRkeEwBuIIcQDS1YGMsIidFDH1upcMA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^3.5.0"
     "@typescript-eslint/parser" "^3.5.0"
     eslint-config-prettier "6.3.0"
-    eslint-config-sentry "^1.42.0"
-    eslint-config-sentry-react "^1.42.0"
+    eslint-config-sentry "^1.43.0"
+    eslint-config-sentry-react "^1.43.0"
     eslint-import-resolver-typescript "^2.0.0"
     eslint-import-resolver-webpack "^0.12.2"
     eslint-plugin-emotion "^10.0.27"
@@ -6675,19 +6675,19 @@ eslint-config-sentry-app@1.42.0:
     eslint-plugin-jest "22.17.0"
     eslint-plugin-prettier "3.1.1"
     eslint-plugin-react "7.15.1"
-    eslint-plugin-sentry "^1.42.0"
+    eslint-plugin-sentry "^1.43.0"
 
-eslint-config-sentry-react@^1.42.0:
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.42.0.tgz#40154b7f213ab00731065b70d94eca6d4c281bb2"
-  integrity sha512-mZ845mM95Lj99AZvRpHVF9f128R3u3JvenIDHvz482CD+haLuDbp/Ygc6dozzXaRmnweVT+Tejd3T24kymixng==
+eslint-config-sentry-react@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.43.0.tgz#2b89d727076d89699a7be72adf2c0256bd03021f"
+  integrity sha512-1TiupDlaWqIFt7fbH1NRUz1rlAB04e6CLj0aIdLdrzXo1hbhSQbjrRZI4w5TfmKkGtGlD5qwRTu4F6mmzbt3Bg==
   dependencies:
-    eslint-config-sentry "^1.42.0"
+    eslint-config-sentry "^1.43.0"
 
-eslint-config-sentry@^1.42.0:
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.42.0.tgz#884f1d2ddc5fbe5f9bb64a8a6f6f2563247cf07b"
-  integrity sha512-BMudMw/ehmOmW1xwuVuB18jax4b8A63DZ9onSpCuiZyKI6+yGyvLKCrJHiNhrN1j5wCOJ3Yx3azNHCtdNV7VOw==
+eslint-config-sentry@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.43.0.tgz#c751e62773edc5527afd7a05a38708c4a2d244da"
+  integrity sha512-Id9Q1o6XFii9WkNgH1yRUZJeBhV23peG2887fy3aB9klHbNUkiQx1LAZloeeU4sgaGOpCH5HRLBEC8fECG1L5Q==
 
 eslint-import-resolver-node@^0.3.3:
   version "0.3.4"
@@ -6785,10 +6785,10 @@ eslint-plugin-react@7.15.1:
     prop-types "^15.7.2"
     resolve "^1.12.0"
 
-eslint-plugin-sentry@^1.42.0:
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.42.0.tgz#648415360cc8dacc98442321a907162ba70903a5"
-  integrity sha512-AmLiqmf8t9RYH9+Cy9YrzbaXotL63HuAV17rFmbZRI36Wm5Kc0lHJWHrT6eAVicLp+JQ6ZhH0b2zTYgbkiS07w==
+eslint-plugin-sentry@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.43.0.tgz#114e248e63260054ad68ae5178f41122a4c5e77c"
+  integrity sha512-ick0N35r7nwHuv/cDGkB0PTmygE6xFjnAL531s39ykukHxDHeP7jTPya0vrRmYTlCzrgcZFCJXqxLaqp0alSyA==
   dependencies:
     requireindex "~1.1.0"
 


### PR DESCRIPTION
Only allow importing `@sentry/react` instead of `@sentry/browser` - See https://github.com/getsentry/eslint-config-sentry/pull/72