### PR TITLE
ci(release): Smarter and safer auto version setting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,13 @@ jobs:
     steps:
       - id: calver
         if: ${{ !github.event.client_payload.version }}
-        run: echo "::set-output name=version::$(date +'%y.%-m.0')"
+        run: |
+          DATE_PART=$(date +'%y.%-m')
+          PATCH_VERSION=0
+          while curl -sf -o /dev/null "https://api.github.com/repos/$GITHUB_REPOSITORY/git/ref/tags/$DATE_PART.$PATCH_VERSION"; do
+            (( PATCH_VERSION++ ))
+          done
+          echo "::set-output name=version::"$DATE_PART.$PATCH_VERSION""
       - uses: actions/checkout@v2
       - uses: getsentry/craft@master
         if: ${{ !github.event.client_payload.skip_prepare }}


### PR DESCRIPTION
If the release action is run without an explicit version in the same calendar month more than once, all of them will try to release the same version where the patch version is set to 0. This is never the intended action: if we are making a new release in the same month where an old one exists, it is 100% a patch release.

This PR automatically implements patch version increment based on existing versions.
