### PR TITLE
fix(issue): Ensure environments are propagated when fetching the latest/oldest event for an issue

### DIFF
--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -43,6 +43,7 @@ class GroupEventsLatestEndpoint(GroupEndpoint):
                     event.organization.slug, event.project.slug, event.event_id
                 ),
                 request=request,
+                data=request.query_params,
             )
         except client.ApiError as e:
             return Response(e.body, status=e.status_code)

--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -43,7 +43,7 @@ class GroupEventsLatestEndpoint(GroupEndpoint):
                     event.organization.slug, event.project.slug, event.event_id
                 ),
                 request=request,
-                data=request.query_params,
+                data={"environment": environments},
             )
         except client.ApiError as e:
             return Response(e.body, status=e.status_code)

--- a/src/sentry/api/endpoints/group_events_oldest.py
+++ b/src/sentry/api/endpoints/group_events_oldest.py
@@ -44,6 +44,7 @@ class GroupEventsOldestEndpoint(GroupEndpoint):
                     event.organization.slug, event.project.slug, event.event_id
                 ),
                 request=request,
+                data=request.query_params,
             )
         except client.ApiError as e:
             return Response(e.body, status=e.status_code)

--- a/src/sentry/api/endpoints/group_events_oldest.py
+++ b/src/sentry/api/endpoints/group_events_oldest.py
@@ -44,7 +44,7 @@ class GroupEventsOldestEndpoint(GroupEndpoint):
                     event.organization.slug, event.project.slug, event.event_id
                 ),
                 request=request,
-                data=request.query_params,
+                data={"environment": environments},
             )
         except client.ApiError as e:
             return Response(e.body, status=e.status_code)

--- a/tests/sentry/api/endpoints/test_group_events_latest.py
+++ b/tests/sentry/api/endpoints/test_group_events_latest.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
+
+
+class GroupEventsLatestEndpointTest(APITestCase, SnubaTestCase):
+    def setUp(self):
+        super(GroupEventsLatestEndpointTest, self).setUp()
+
+        self.login_as(user=self.user)
+        project = self.create_project()
+
+        self.event_a = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "environment": "development",
+                "timestamp": iso_format(before_now(days=1)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=project.id,
+        )
+        self.event_b = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "environment": "production",
+                "timestamp": iso_format(before_now(minutes=5)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=project.id,
+        )
+        self.event_c = self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "environment": "staging",
+                "timestamp": iso_format(before_now(minutes=1)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=project.id,
+        )
+
+    def test_get_simple(self):
+        url = u"/api/0/issues/{}/events/latest/".format(self.event_a.group.id)
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == six.text_type(self.event_c.event_id)
+        assert response.data["previousEventID"] == six.text_type(self.event_b.event_id)
+        assert response.data["nextEventID"] is None
+
+    def test_get_with_environment(self):
+        url = u"/api/0/issues/{}/events/latest/".format(self.event_a.group.id)
+        response = self.client.get(url, format="json", data={"environment": ["production"]})
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == six.text_type(self.event_b.event_id)
+        assert response.data["previousEventID"] is None
+        assert response.data["nextEventID"] is None

--- a/tests/sentry/api/endpoints/test_group_events_oldest.py
+++ b/tests/sentry/api/endpoints/test_group_events_oldest.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
+
+
+class GroupEventsOldestEndpointTest(APITestCase, SnubaTestCase):
+    def setUp(self):
+        super(GroupEventsOldestEndpointTest, self).setUp()
+
+        self.login_as(user=self.user)
+        project = self.create_project()
+
+        self.event_a = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "environment": "development",
+                "timestamp": iso_format(before_now(days=1)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=project.id,
+        )
+        self.event_b = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "environment": "production",
+                "timestamp": iso_format(before_now(minutes=5)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=project.id,
+        )
+        self.event_c = self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "environment": "staging",
+                "timestamp": iso_format(before_now(minutes=1)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=project.id,
+        )
+
+    def test_get_simple(self):
+        url = u"/api/0/issues/{}/events/oldest/".format(self.event_a.group.id)
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == six.text_type(self.event_a.event_id)
+        assert response.data["previousEventID"] is None
+        assert response.data["nextEventID"] == six.text_type(self.event_b.event_id)
+
+    def test_get_with_environment(self):
+        url = u"/api/0/issues/{}/events/oldest/".format(self.event_a.group.id)
+        response = self.client.get(url, format="json", data={"environment": ["production"]})
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == six.text_type(self.event_b.event_id)
+        assert response.data["previousEventID"] is None
+        assert response.data["nextEventID"] is None


### PR DESCRIPTION
The event pagination on the Issues page do not reliably link to the oldest, previous, next, or latest events when the environment query string aren't properly propagated.

------

Likely to have been missed in https://github.com/getsentry/sentry/pull/12404