### PR TITLE
fix(apm): Bulletproof span view from crashing whenever a span's span_id is identical to its parent_span_id

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -397,7 +397,7 @@ class ActualMinimap extends React.PureComponent<{trace: ParsedTraceType}> {
     span,
   }: {
     spanNumber: number;
-    childSpans: Readonly<SpanChildrenLookupType>;
+    childSpans: SpanChildrenLookupType;
     generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
     span: Readonly<RawSpanType>;
   }): {
@@ -414,6 +414,13 @@ class ActualMinimap extends React.PureComponent<{trace: ParsedTraceType}> {
     const {left: spanLeft, width: spanWidth} = this.getBounds(bounds);
 
     const spanChildren: Array<RawSpanType> = childSpans?.[getSpanID(span)] ?? [];
+
+    // Mark descendents as being rendered. This is to address potential recursion issues due to malformed data.
+    // For example if a span has a span_id that's identical to its parent_span_id.
+    childSpans = {
+      ...childSpans,
+    };
+    delete childSpans[getSpanID(span)];
 
     type AccType = {
       nextSpanNumber: number;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -137,7 +137,7 @@ class SpanTree extends React.Component<PropType> {
     numOfSpansOutOfViewAbove: number;
     numOfFilteredSpansAbove: number;
     span: Readonly<ProcessedSpanType>;
-    childSpans: Readonly<SpanChildrenLookupType>;
+    childSpans: SpanChildrenLookupType;
     generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
     previousSiblingEndTimestamp: undefined | number;
   }): RenderedSpanTree => {
@@ -145,6 +145,13 @@ class SpanTree extends React.Component<PropType> {
 
     const spanBarColour: string = pickSpanBarColour(getSpanOperation(span));
     const spanChildren: Array<RawSpanType> = childSpans?.[getSpanID(span)] ?? [];
+
+    // Mark descendents as being rendered. This is to address potential recursion issues due to malformed data.
+    // For example if a span has a span_id that's identical to its parent_span_id.
+    childSpans = {
+      ...childSpans,
+    };
+    delete childSpans[getSpanID(span)];
 
     const bounds = generateBounds({
       startTimestamp: span.start_timestamp,


### PR DESCRIPTION
Neither the JavaScript nor Python SDK produce this issue. But we don't ensure the span data is not malformed; so we bulletproof the span view UI to attempt to at least render the span data it is given.