### PR TITLE
dev(direnv): use make node-version-check

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -161,20 +161,11 @@ fi
 
 info "Checking node..."
 
-node_version="10.21.0"
-
-# It would be nice to enforce that node is installed via volta (and is therefore a shim that will check against
-# the node pin in package.json), but for now, let's just explicitly check the node version.
-
 if ! require node; then
-    die "You don't seem to have node installed. We want version ${node_version}.
-It's recommended to use volta - please refer to https://docs.sentry.io/development/contribute/environment"
+    die "You don't seem to have node installed. Install volta (a node version manager): https://develop.sentry.dev/environment/#javascript"
 fi
 
-if [ "$(node -v)" != "v${node_version}" ]; then
-    die "Your node version doesn't match ${node_version}.
-It's recommended to use volta - please refer to https://docs.sentry.io/development/contribute/environment"
-fi
+make node-version-check
 
 if [ ! -x "node_modules/.bin/webpack" ]; then
     info "You don't seem to have yarn packages installed."

--- a/.envrc
+++ b/.envrc
@@ -161,7 +161,7 @@ fi
 
 info "Checking node..."
 
-node_version="10.16.3"
+node_version="10.21.0"
 
 # It would be nice to enforce that node is installed via volta (and is therefore a shim that will check against
 # the node pin in package.json), but for now, let's just explicitly check the node version.


### PR DESCRIPTION
This was updated in https://github.com/getsentry/sentry/pull/19865 but envrc was not updated. Ideally we check to see if they have volta before enforcing the version constraint (or grab version from package.json)