### PR TITLE
chore(py3): Remove embedded re flag in strings._word_sep_re

### DIFF
--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -10,7 +10,7 @@ import zlib
 from django.utils.encoding import force_text, smart_text
 from sentry.utils.compat import map
 
-_word_sep_re = re.compile(r"[\s.;,_-]+(?u)")
+_word_sep_re = re.compile(r"[\s.;,_-]+", re.UNICODE)
 _camelcase_re = re.compile(r"(?:[A-Z]{2,}(?=[A-Z]))|(?:[A-Z][a-z0-9]+)|(?:[a-z0-9]+)")
 _letters_re = re.compile(r"[A-Z]+")
 _digit_re = re.compile(r"\d+")


### PR DESCRIPTION
In python3 this produces the DeprecationWarning:

>  DeprecationWarning: Flags not at the start of the expression '[\\s.;,_-]+(?u)'

Python3 notes: 

> Note that for backward compatibility, the re.U flag still exists (as well as its synonym re.UNICODE and its embedded counterpart (?u)), but these are redundant in Python 3 since matches are Unicode by default for strings (and Unicode matching isn’t allowed for bytes).