### PR TITLE
ci(release): Use getsentry-bot & sleep after prepare

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
           done
           echo "::set-output name=version::"$DATE_PART.$PATCH_VERSION""
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_SENTRY_BOT_PAT }}
       - uses: getsentry/craft@master
         if: ${{ !github.event.client_payload.skip_prepare }}
         with:
@@ -32,6 +34,10 @@ jobs:
           GIT_AUTHOR_NAME: getsentry-bot
           EMAIL: bot@getsentry.com
           ZEUS_API_TOKEN: ${{ secrets.ZEUS_API_TOKEN }}
+      # Wait until the builds start. Craft should do this automatically
+      # but it is broken now.
+      # TODO: Remove this once getsentry/craft#111 is fixed
+      - run: sleep 10
       - uses: getsentry/craft@master
         with:
           action: publish


### PR DESCRIPTION
These changes are needed to fix the release issues we have:

1. Use getsentry-bot account to be able to bypass protected branch limitations on merge
2. Sleep after prepare step to give time to check runs to start (to not fail in publish)
