### PR TITLE
fix/redirect-users-to-discover-v2

### DIFF
--- a/src/sentry/static/sentry/app/views/discover/index.tsx
+++ b/src/sentry/static/sentry/app/views/discover/index.tsx
@@ -3,11 +3,14 @@ import {browserHistory, WithRouterProps} from 'react-router';
 import DocumentTitle from 'react-document-title';
 
 import {getUserTimezone, getUtcToLocalDateObject} from 'app/utils/dates';
+import {t} from 'app/locale';
 import {updateProjects, updateDateTime} from 'app/actionCreators/globalSelection';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import Feature from 'app/components/acl/feature';
+import Alert from 'app/components/alert';
 import {GlobalSelection, Organization} from 'app/types';
+import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
 import Redirect from 'app/utils/redirect';
 
 import Discover from './discover';
@@ -204,11 +207,14 @@ class DiscoverContainer extends React.Component<Props, State> {
   renderNoAccess = () => {
     const {router, organization} = this.props;
 
-    const route = organization.features.includes('discover-query')
-      ? `/organizations/${organization.slug}/discover/queries/`
-      : `/organizations/${organization.slug}/discover/results/`;
-
-    return <Redirect router={router} to={route} />;
+    if (
+      organization.features.includes('discover-query') ||
+      organization.features.includes('discover-basic')
+    ) {
+      return <Redirect router={router} to={getDiscoverLandingUrl(organization)} />;
+    } else {
+      return <Alert type="warning">{t("You don't have access to this feature")}</Alert>;
+    }
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/discover/index.tsx
+++ b/src/sentry/static/sentry/app/views/discover/index.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import {browserHistory} from 'react-router';
+import {browserHistory, WithRouterProps} from 'react-router';
 import DocumentTitle from 'react-document-title';
 
 import {getUserTimezone, getUtcToLocalDateObject} from 'app/utils/dates';
-import {t} from 'app/locale';
 import {updateProjects, updateDateTime} from 'app/actionCreators/globalSelection';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
 import {GlobalSelection, Organization} from 'app/types';
+import Redirect from 'app/utils/redirect';
 
 import Discover from './discover';
 import createQueryBuilder from './queryBuilder';
@@ -22,14 +21,12 @@ import {
 import {DiscoverWrapper} from './styles';
 import {SavedQuery} from './types';
 
-const AlertAsAny: any = Alert;
-
 type Props = {
   organization: Organization;
   selection: GlobalSelection;
   params: any;
   location: any;
-};
+} & Pick<WithRouterProps, 'router'>;
 
 type State = {
   isLoading: boolean;
@@ -204,11 +201,16 @@ class DiscoverContainer extends React.Component<Props, State> {
     });
   };
 
-  renderNoAccess() {
+  renderNoAccess = () => {
+    const {router, organization} = this.props;
+
     return (
-      <AlertAsAny type="warning">{t("You don't have access to this feature")}</AlertAsAny>
+      <Redirect
+        router={router}
+        to={`/organizations/${organization.slug}/discover/queries/`}
+      />
     );
-  }
+  };
 
   render() {
     const {isLoading, savedQuery, view} = this.state;

--- a/src/sentry/static/sentry/app/views/discover/index.tsx
+++ b/src/sentry/static/sentry/app/views/discover/index.tsx
@@ -204,11 +204,24 @@ class DiscoverContainer extends React.Component<Props, State> {
   renderNoAccess = () => {
     const {router, organization} = this.props;
 
-    return (
+    const redirectDiscoverQuery = () => (
       <Redirect
         router={router}
-        to={`/organizations/${organization.slug}/discover/queries/`}
+        to={`/organizations/${organization.slug}/discover/results/`}
       />
+    );
+
+    return (
+      <Feature
+        features={['discover-query']}
+        organization={organization}
+        renderDisabled={redirectDiscoverQuery}
+      >
+        <Redirect
+          router={router}
+          to={`/organizations/${organization.slug}/discover/queries/`}
+        />
+      </Feature>
     );
   };
 

--- a/src/sentry/static/sentry/app/views/discover/index.tsx
+++ b/src/sentry/static/sentry/app/views/discover/index.tsx
@@ -204,25 +204,11 @@ class DiscoverContainer extends React.Component<Props, State> {
   renderNoAccess = () => {
     const {router, organization} = this.props;
 
-    const redirectDiscoverQuery = () => (
-      <Redirect
-        router={router}
-        to={`/organizations/${organization.slug}/discover/results/`}
-      />
-    );
+    const route = organization.features.includes('discover-query')
+      ? `/organizations/${organization.slug}/discover/queries/`
+      : `/organizations/${organization.slug}/discover/results/`;
 
-    return (
-      <Feature
-        features={['discover-query']}
-        organization={organization}
-        renderDisabled={redirectDiscoverQuery}
-      >
-        <Redirect
-          router={router}
-          to={`/organizations/${organization.slug}/discover/queries/`}
-        />
-      </Feature>
-    );
+    return <Redirect router={router} to={route} />;
   };
 
   render() {

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -54,7 +54,7 @@ class OrganizationDiscoverTest(AcceptanceTestCase, SnubaTestCase):
 
     def test_no_access(self):
         with self.feature(
-            {"organization:discover-basic": False, "organization:discover-query": False}
+            {"organizations:discover-basic": False, "organizations:discover-query": False}
         ):
             self.browser.get(self.path)
             self.browser.wait_until_not(".loading")

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -54,11 +54,7 @@ class OrganizationDiscoverTest(AcceptanceTestCase, SnubaTestCase):
 
     def test_no_access(self):
         with self.feature(
-            {
-                "organization:discover-page": False,
-                "organization:discover-basic": False,
-                "organization:discover-query": False,
-            }
+            {"organization:discover-basic": False, "organization:discover-query": False}
         ):
             self.browser.get(self.path)
             self.browser.wait_until_not(".loading")

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -53,9 +53,16 @@ class OrganizationDiscoverTest(AcceptanceTestCase, SnubaTestCase):
         self.path = u"/organizations/{}/discover/".format(self.org.slug)
 
     def test_no_access(self):
-        self.browser.get(self.path)
-        self.browser.wait_until_not(".loading")
-        self.browser.snapshot("discover - no access")
+        with self.feature(
+            {
+                "organization:discover-page": False,
+                "organization:discover-basic": False,
+                "organization:discover-query": False,
+            }
+        ):
+            self.browser.get(self.path)
+            self.browser.wait_until_not(".loading")
+            self.browser.snapshot("discover - no access")
 
     def test_query_builder(self):
         with self.feature("organizations:discover"):

--- a/tests/js/spec/views/discover/index.spec.jsx
+++ b/tests/js/spec/views/discover/index.spec.jsx
@@ -265,8 +265,11 @@ describe('DiscoverContainer', function() {
   });
 
   describe('no access', function() {
-    it('redirects to discover v2', async function() {
-      const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
+    it('redirects to discover query if they have access to discover-query', async function() {
+      const organization = TestStubs.Organization({
+        projects: [TestStubs.Project()],
+        features: ['discover-query'],
+      });
       const router = TestStubs.router();
       mountWithTheme(
         <DiscoverContainer
@@ -280,6 +283,24 @@ describe('DiscoverContainer', function() {
       );
       expect(router.replace).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/discover/queries/`
+      );
+    });
+
+    it('redirects to discover results if they have no access to discover-query', async function() {
+      const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
+      const router = TestStubs.router();
+      mountWithTheme(
+        <DiscoverContainer
+          location={{query: {}, search: ''}}
+          params={{}}
+          selection={{datetime: {}}}
+          organization={organization}
+          router={router}
+        />,
+        TestStubs.routerContext()
+      );
+      expect(router.replace).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/discover/results/`
       );
     });
   });

--- a/tests/js/spec/views/discover/index.spec.jsx
+++ b/tests/js/spec/views/discover/index.spec.jsx
@@ -265,18 +265,22 @@ describe('DiscoverContainer', function() {
   });
 
   describe('no access', function() {
-    it('display no access message', async function() {
+    it('redirects to discover v2', async function() {
       const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
-      const wrapper = mountWithTheme(
+      const router = TestStubs.router();
+      mountWithTheme(
         <DiscoverContainer
           location={{query: {}, search: ''}}
           params={{}}
           selection={{datetime: {}}}
           organization={organization}
+          router={router}
         />,
         TestStubs.routerContext()
       );
-      expect(wrapper.text()).toBe("You don't have access to this feature");
+      expect(router.replace).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/discover/queries/`
+      );
     });
   });
 });

--- a/tests/js/spec/views/discover/index.spec.jsx
+++ b/tests/js/spec/views/discover/index.spec.jsx
@@ -265,7 +265,7 @@ describe('DiscoverContainer', function() {
   });
 
   describe('no access', function() {
-    it('redirects to discover query if they have access to discover-query', async function() {
+    it('redirects to discover query if they have access to discover-query', function() {
       const organization = TestStubs.Organization({
         projects: [TestStubs.Project()],
         features: ['discover-query'],
@@ -286,8 +286,11 @@ describe('DiscoverContainer', function() {
       );
     });
 
-    it('redirects to discover results if they have no access to discover-query', async function() {
-      const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
+    it('redirects to discover results if they have access to discover-basic', function() {
+      const organization = TestStubs.Organization({
+        projects: [TestStubs.Project()],
+        features: ['discover-basic'],
+      });
       const router = TestStubs.router();
       mountWithTheme(
         <DiscoverContainer
@@ -302,6 +305,20 @@ describe('DiscoverContainer', function() {
       expect(router.replace).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/discover/results/`
       );
+    });
+
+    it('shows no feature alert if they have no access', function() {
+      const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
+      const wrapper = mountWithTheme(
+        <DiscoverContainer
+          location={{query: {}, search: ''}}
+          params={{}}
+          selection={{datetime: {}}}
+          organization={organization}
+        />,
+        TestStubs.routerContext()
+      );
+      expect(wrapper.text()).toBe("You don't have access to this feature");
     });
   });
 });


### PR DESCRIPTION
Currently, if an user without access to discover v1 tries to visits
`/organizations/:orgId/discover/queries/`, they will be presented with an error.
This change will redirect these users to the new discover v2.