### PR TITLE
ref(event_manager): Increase attachment blob size to 8MB

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -18,8 +18,6 @@ from sentry.utils.files import get_max_file_size
 from sentry.utils.compat import zip
 
 
-# The blob size must be a power of two
-CHUNK_UPLOAD_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
 MAX_CHUNKS_PER_REQUEST = 64
 MAX_REQUEST_SIZE = 32 * 1024 * 1024
 MAX_CONCURRENCY = settings.DEBUG and 1 or 8
@@ -61,7 +59,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         return Response(
             {
                 "url": endpoint,
-                "chunkSize": CHUNK_UPLOAD_BLOB_SIZE,
+                "chunkSize": settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE,
                 "chunksPerRequest": MAX_CHUNKS_PER_REQUEST,
                 "maxFileSize": get_max_file_size(organization),
                 "maxRequestSize": MAX_REQUEST_SIZE,
@@ -104,7 +102,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         size = 0
         for chunk in files:
             size += chunk.size
-            if chunk.size > CHUNK_UPLOAD_BLOB_SIZE:
+            if chunk.size > settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE:
                 logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
                 return Response(
                     {"error": "Chunk size too large"}, status=status.HTTP_400_BAD_REQUEST

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1411,6 +1411,14 @@ SENTRY_RELAY_PORT = 3000
 SENTRY_REVERSE_PROXY_PORT = 8000
 
 
+# The chunk size for attachments in blob store. Should be a power of two.
+SENTRY_ATTACHMENT_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
+
+# The chunk size for files in the chunk uplooad. This is used for native debug
+# files and source maps, and directly translates to the chunk size in blob
+# store. MUST be a power of two.
+SENTRY_CHUNK_UPLOAD_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
+
 # SENTRY_DEVSERVICES = {
 #     "service-name": {
 #         "image": "image-name:version",

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -80,6 +80,9 @@ SECURITY_REPORT_INTERFACES = ("csp", "hpkp", "expectct", "expectstaple")
 # Timeout for cached group crash report counts
 CRASH_REPORT_TIMEOUT = 24 * 3600  # one day
 
+# The blob size should be a power of two
+ATTACHMENT_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
+
 
 def pop_tag(data, key):
     data["tags"] = [kv for kv in data["tags"] if kv is None or kv[0] != key]
@@ -1310,7 +1313,7 @@ def save_attachment(
         type=attachment.type,
         headers={"Content-Type": attachment.content_type},
     )
-    file.putfile(six.BytesIO(data))
+    file.putfile(six.BytesIO(data), blob_size=ATTACHMENT_BLOB_SIZE)
 
     EventAttachment.objects.create(
         event_id=event_id,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -8,6 +8,7 @@ import ipaddress
 import six
 
 from datetime import datetime, timedelta
+from django.conf import settings
 from django.core.cache import cache
 from django.db import connection, IntegrityError, router, transaction
 from django.db.models import Func
@@ -79,9 +80,6 @@ SECURITY_REPORT_INTERFACES = ("csp", "hpkp", "expectct", "expectstaple")
 
 # Timeout for cached group crash report counts
 CRASH_REPORT_TIMEOUT = 24 * 3600  # one day
-
-# The blob size should be a power of two
-ATTACHMENT_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
 
 
 def pop_tag(data, key):
@@ -1313,7 +1311,7 @@ def save_attachment(
         type=attachment.type,
         headers={"Content-Type": attachment.content_type},
     )
-    file.putfile(six.BytesIO(data), blob_size=ATTACHMENT_BLOB_SIZE)
+    file.putfile(six.BytesIO(data), blob_size=settings.SENTRY_ATTACHMENT_BLOB_SIZE)
 
     EventAttachment.objects.create(
         event_id=event_id,

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division
 
 from hashlib import sha1
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 
@@ -13,7 +14,6 @@ from sentry.api.endpoints.chunk import (
     MAX_CONCURRENCY,
     HASH_ALGORITHM,
     MAX_REQUEST_SIZE,
-    CHUNK_UPLOAD_BLOB_SIZE,
 )
 
 
@@ -34,7 +34,7 @@ class ChunkUploadTest(APITestCase):
             endpoint = options.get("system.url-prefix")
 
         assert response.status_code == 200, response.content
-        assert response.data["chunkSize"] == CHUNK_UPLOAD_BLOB_SIZE
+        assert response.data["chunkSize"] == settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE
         assert response.data["chunksPerRequest"] == MAX_CHUNKS_PER_REQUEST
         assert response.data["maxRequestSize"] == MAX_REQUEST_SIZE
         assert response.data["maxFileSize"] == options.get("system.maximum-file-size")
@@ -142,7 +142,7 @@ class ChunkUploadTest(APITestCase):
 
     def test_too_large_chunk(self):
         files = []
-        content = "x" * (CHUNK_UPLOAD_BLOB_SIZE + 1)
+        content = "x" * (settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE + 1)
         files.append(SimpleUploadedFile(sha1(content).hexdigest(), content))
 
         response = self.client.post(
@@ -156,7 +156,7 @@ class ChunkUploadTest(APITestCase):
 
     def test_checksum_missmatch(self):
         files = []
-        content = "x" * (CHUNK_UPLOAD_BLOB_SIZE + 1)
+        content = "x" * (settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE + 1)
         files.append(SimpleUploadedFile("wrong checksum", content))
 
         response = self.client.post(


### PR DESCRIPTION
Increases the chunk size for attachments in blob store from 1MB to 8MB, which will decrease the maximum number of chunks per attachment from currently 50 down to 7. We can further increase the chunk size at any time. This will significantly reduce the time spent in `save_event` for uploading the chunks into blob store. 

Note this the blob size is completely independent from chunking that Relay performs for Kafka for the processing queue. For now, this chunk size remains at 1MB.

In a follow-up, we will increase the maximum attachment size to _100MB_.
