### PR TITLE
test(plugins): Add support for test groups in plugin tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,14 @@ test-plugins:
 	@echo "--> Building static assets"
 	@$(WEBPACK) --display errors-only
 	@echo "--> Running plugin tests"
-	py.test tests/sentry_plugins -vv --cov . --cov-report="xml:.artifacts/plugins.coverage.xml" --junit-xml=".artifacts/plugins.junit.xml"
+	mkdir -p .artifacts/visual-snapshots/acceptance
+	mkdir -p .artifacts/visual-snapshots/acceptance-mobile
+
+ifndef TEST_GROUP
+	py.test tests/sentry_plugins -vv --cov . --cov-report="xml:.artifacts/plugins.coverage.xml" --junit-xml=".artifacts/plugins.junit.xml" || exit 1
+else
+	py.test tests/sentry_plugins -m group_$(TEST_GROUP) -vv --cov . --cov-report="xml:.artifacts/plugins.coverage.xml" --junit-xml=".artifacts/plugins.junit.xml" || exit 1
+endif
 	@echo ""
 
 test-relay-integration:

--- a/Makefile
+++ b/Makefile
@@ -202,8 +202,6 @@ test-plugins:
 	@echo "--> Building static assets"
 	@$(WEBPACK) --display errors-only
 	@echo "--> Running plugin tests"
-	mkdir -p .artifacts/visual-snapshots/acceptance
-	mkdir -p .artifacts/visual-snapshots/acceptance-mobile
 
 ifndef TEST_GROUP
 	py.test tests/sentry_plugins -vv --cov . --cov-report="xml:.artifacts/plugins.coverage.xml" --junit-xml=".artifacts/plugins.junit.xml" || exit 1


### PR DESCRIPTION
Adds support for test groups in plugin tests. Will be needed for https://github.com/getsentry/getsentry/pull/4240

#sync-getsentry