### PR TITLE
ref(ui) Update DebugImages to use new SVG icons

### DIFF
--- a/docs-ui/components/issueDebugMeta.stories.js
+++ b/docs-ui/components/issueDebugMeta.stories.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+
+import SentryTypes from 'app/sentryTypes';
+import DebugMeta from 'app/components/events/interfaces/debugMeta';
+
+const event = {
+  id: 'deadbeef',
+  eventID: 'deadbeef',
+  groupID: '999',
+  title: 'thread failing!',
+  metadata: {
+    function: 'thread_demo',
+    type: 'thread_demo',
+    value: 'Failing!',
+  },
+  tags: {},
+  contexts: {},
+  entries: [
+    {
+      type: 'debugmeta',
+      data: {
+        images: [
+          {
+            code_file: '/Users/uhoh/code/thread-demo.rs',
+            image_vmaddr: '0x0',
+            image_addr: '0x1fe1000',
+            image_size: 439486848,
+            type: 'symbolic',
+            debug_id: '79398811-17a9-3884-9dfb-5552eed86a6f',
+            features: {
+              has_debug_info: true,
+              has_symbols: true,
+            },
+            arch: 'x86',
+            debug_status: 'found',
+            unwind_status: 'found',
+          },
+          {
+            code_file: '/usr/lib/libSystem.B.dylib',
+            image_vmaddr: '0x7fff335cb000',
+            image_addr: '0x7fff3ff1c000',
+            image_size: 439486848,
+            type: 'symbolic',
+            debug_id: 'dfe2454f-2fe3-3b2b-a22b-422947c34c69',
+          },
+          {
+            code_file:
+              '/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation',
+            image_vmaddr: '0x7fff279a8000',
+            image_addr: '0x7fff342f9000',
+            image_size: 439486848,
+            type: 'symbolic',
+            debug_id: '79398803-19x7-3844-9dfb-5516cca93c1a',
+            debug_status: 'malformed',
+            unwind_status: 'malformed',
+          },
+          {
+            code_file:
+              '/System/Library/Frameworks/CoreFoundation.framework/Versions/A/Unused',
+            image_vmaddr: '0x7fff279a8000',
+            image_addr: '0x7fff342f9000',
+            image_size: 439486848,
+            type: 'symbolic',
+            debug_id: '79398803-19x7-3844-9dfb-5516cca93c1a',
+            debug_status: 'unused',
+            unwind_status: 'unused',
+          },
+        ],
+      },
+    },
+    {
+      type: 'exception',
+      data: {
+        values: [
+          {
+            stacktrace: {
+              frames: [{instructionAddr: '0x1fe1000'}],
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+const organization = {
+  id: '1',
+  slug: 'org-slug',
+  access: ['project:releases'],
+};
+
+class OrganizationContext extends React.Component {
+  static childContextTypes = {
+    organization: SentryTypes.Organization,
+  };
+
+  getChildContext() {
+    return {organization};
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+storiesOf('Issues|DebugMeta', module).add(
+  'default',
+  withInfo('Various debug image metadata states')(() => (
+    <div className="section">
+      <OrganizationContext>
+        <DebugMeta
+          event={event}
+          data={event.entries[0].data}
+          orgId={organization.id}
+          projectId="1"
+        />
+      </OrganizationContext>
+    </div>
+  ))
+);

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugImage.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugImage.tsx
@@ -10,9 +10,8 @@ import {PanelItem} from 'app/components/panels';
 import Tooltip from 'app/components/tooltip';
 import {formatAddress, getImageRange} from 'app/components/events/interfaces/utils';
 import {t} from 'app/locale';
-import {IconSearch} from 'app/icons';
+import {IconSearch, IconCircle, IconCheckmark, IconFlag} from 'app/icons';
 import {Organization, Project} from 'app/types';
-import InlineSvg from 'app/components/inlineSvg';
 
 import {getFileName, combineStatus} from './utils';
 
@@ -123,11 +122,23 @@ const DebugImage = React.memo(({image, orgId, projectId, showDetails, style}: Pr
   const renderIconElement = () => {
     switch (combinedStatus) {
       case 'unused':
-        return <ImageIcon type="muted" src="icon-circle-empty" />;
+        return (
+          <IconWrapper>
+            <IconCircle size="sm" />
+          </IconWrapper>
+        );
       case 'found':
-        return <ImageIcon type="success" src="icon-circle-check" />;
+        return (
+          <IconWrapper>
+            <IconCheckmark isCircled size="sm" color="green500" />
+          </IconWrapper>
+        );
       default:
-        return <ImageIcon type="error" src="icon-circle-exclamation" />;
+        return (
+          <IconWrapper>
+            <IconFlag size="sm" color="red400" />
+          </IconWrapper>
+        );
     }
   };
 
@@ -318,12 +329,13 @@ const AddressDivider = styled('br')`
   }
 `;
 
-const ImageIcon = styled(InlineSvg)<{type: 'muted' | 'success' | 'error'}>`
-  font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.alert[p.type].iconColor};
+const IconWrapper = styled('span')`
+  display: inline-block;
+  margin-top: ${space(0.5)};
+  height: 16px;
+
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    font-size: ${p => p.theme.fontSizeExtraLarge};
-    margin-bottom: ${space(0.5)};
+    margin-top: ${space(0.25)};
   }
 `;
 
@@ -332,7 +344,7 @@ const SymbolicationStatus = styled('span')`
   flex-basis: 0;
   margin-right: 1em;
 
-  ${ImageIcon} {
+  svg {
     margin-left: 0.66ex;
   }
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugImage.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugImage.tsx
@@ -124,19 +124,19 @@ const DebugImage = React.memo(({image, orgId, projectId, showDetails, style}: Pr
       case 'unused':
         return (
           <IconWrapper>
-            <IconCircle size="sm" />
+            <IconCircle />
           </IconWrapper>
         );
       case 'found':
         return (
           <IconWrapper>
-            <IconCheckmark isCircled size="sm" color="green500" />
+            <IconCheckmark isCircled color="green500" />
           </IconWrapper>
         );
       default:
         return (
           <IconWrapper>
-            <IconFlag size="sm" color="red400" />
+            <IconFlag color="red400" />
           </IconWrapper>
         );
     }

--- a/src/sentry/static/sentry/app/components/events/interfaces/packageStatus.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/packageStatus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import InlineSvg from 'app/components/inlineSvg';
+import {IconCircle, IconCheckmark, IconFlag} from 'app/icons';
 import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
 
@@ -11,24 +11,22 @@ type Props = {
 };
 
 class PackageStatus extends React.Component<Props> {
-  getIconTypeAndSource(
-    status: Props['status']
-  ): {iconType: PackageStatusIconProps['type']; iconSrc: string} {
+  getIcon(status: Props['status']): React.ReactNode {
     switch (status) {
       case 'success':
-        return {iconType: 'success', iconSrc: 'icon-circle-check'};
+        return <IconCheckmark isCircled color="green500" />;
       case 'empty':
-        return {iconType: 'muted', iconSrc: 'icon-circle-empty'};
+        return <IconCircle />;
       case 'error':
       default:
-        return {iconType: 'error', iconSrc: 'icon-circle-exclamation'};
+        return <IconFlag color="red400" />;
     }
   }
 
   render() {
     const {status, tooltip} = this.props;
 
-    const {iconType, iconSrc} = this.getIconTypeAndSource(status);
+    const icon = this.getIcon(status);
 
     if (status === 'empty') {
       return null;
@@ -36,17 +34,13 @@ class PackageStatus extends React.Component<Props> {
 
     return (
       <Tooltip title={tooltip} disabled={!(tooltip && tooltip.length)}>
-        <PackageStatusIcon type={iconType} src={iconSrc} size="1em" />
+        <PackageStatusIcon>{icon}</PackageStatusIcon>
       </Tooltip>
     );
   }
 }
 
-type PackageStatusIconProps = {
-  type: 'error' | 'success' | 'muted';
-};
-export const PackageStatusIcon = styled(InlineSvg)<PackageStatusIconProps>`
-  color: ${p => p.theme.alert[p.type!].iconColor};
+export const PackageStatusIcon = styled('span')`
   margin-left: ${space(0.5)};
   opacity: 0;
 `;


### PR DESCRIPTION
Add a storybook view to make reviewing all the states simpler in the future.

## Before
![Screen Shot 2020-07-20 at 3 30 27 PM](https://user-images.githubusercontent.com/24086/87981750-bbf38480-caa3-11ea-8c12-df7da7aeca51.png)
![Screen Shot 2020-07-20 at 3 31 16 PM](https://user-images.githubusercontent.com/24086/87981756-bd24b180-caa3-11ea-9030-9e66988cb3fd.png)

## After

![Screen Shot 2020-07-20 at 4 03 30 PM](https://user-images.githubusercontent.com/24086/87981786-c7df4680-caa3-11ea-8809-974656491fe5.png)
![Screen Shot 2020-07-20 at 4 03 45 PM](https://user-images.githubusercontent.com/24086/87981787-c877dd00-caa3-11ea-91de-45dc48208cda.png)

The icons no longer resize in smaller viewports, but the small viewport still looks pretty good to me.