### PR TITLE
ref(ui) Update icon used in service incident sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/serviceIncidents.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/serviceIncidents.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
 import Button from 'app/components/button';
-import InlineSvg from 'app/components/inlineSvg';
+import {IconWarning} from 'app/icons';
 import {loadIncidents} from 'app/actionCreators/serviceIncidents';
 import {SentryServiceStatus} from 'app/types';
 import space from 'app/styles/space';
@@ -61,12 +61,7 @@ class ServiceIncidents extends React.Component<Props, State> {
           orientation={orientation}
           collapsed={collapsed}
           active={active}
-          icon={
-            <InlineSvg
-              src="icon-circle-exclamation"
-              className="animated pulse infinite"
-            />
-          }
+          icon={<IconWarning className="animated pulse infinite" />}
           label={t('Service status')}
           onClick={onShowPanel}
         />


### PR DESCRIPTION
Unlike most icon-circle-exclamation this is being replaced with IconWarning as it is more bad than just a 'heads up' situation.

![Screen Shot 2020-07-20 at 4 27 04 PM](https://user-images.githubusercontent.com/24086/87983837-0a565280-caa7-11ea-81fa-5e7db0f867f6.png)

The icon is funny sized as it has a pulsating animation applied.