### PR TITLE
test(acceptance): Hide text caret in acceptance tests

### DIFF
--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Global, css} from '@emotion/core';
 
+import {IS_CI} from 'app/constants';
 import {Theme} from 'app/utils/theme';
 
 const styles = (theme: Theme) => css`
@@ -30,6 +31,15 @@ const styles = (theme: Theme) => css`
       transition-delay: 0s !important;
     }
   }
+
+  ${IS_CI
+    ? css`
+        input,
+        select {
+          caret-color: transparent;
+        }
+      `
+    : ''}
 `;
 
 /**


### PR DESCRIPTION
This hides the blinking text cursor in input fields that  cause flakey snapshots