### PR TITLE
feat(msteams): save metric alert

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -20,6 +20,8 @@ class AlertRuleTriggerActionSerializer(Serializer):
             return "Send a PagerDuty notification to " + action.target_display
         elif action.type == action.Type.SLACK.value:
             return "Send a Slack notification to " + action.target_display
+        elif action.type == action.Type.MSTEAMS.value:
+            return "Send a Microsoft Teams notification to " + action.target_display
 
     def serialize(self, obj, attrs, user):
         from sentry.incidents.endpoints.serializers import action_target_type_to_string

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -110,6 +110,24 @@ class SlackActionHandler(ActionHandler):
         send_incident_alert_notification(self.action, self.incident, metric_value)
 
 
+@AlertRuleTriggerAction.register_type(
+    "msteams",
+    AlertRuleTriggerAction.Type.MSTEAMS,
+    [AlertRuleTriggerAction.TargetType.SPECIFIC],
+    integration_provider="msteams",
+)
+class MsTeamsActionHandler(ActionHandler):
+    def fire(self, metric_value):
+        self.send_alert(metric_value)
+
+    def resolve(self, metric_value):
+        self.send_alert(metric_value)
+
+    def send_alert(self, metric_value):
+        # TODO: finish
+        pass
+
+
 def format_duration(minutes):
     """
     Format minutes into a duration string

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1072,13 +1072,20 @@ def update_alert_rule_trigger_action(
         updated_fields["integration"] = integration
     if target_identifier is not None:
         type = updated_fields.get("type", trigger_action.type)
+        integration = updated_fields.get("integration", trigger_action.integration)
+        organization = trigger_action.alert_rule_trigger.alert_rule.organization
 
         if type == AlertRuleTriggerAction.Type.SLACK.value:
-            integration = updated_fields.get("integration", trigger_action.integration)
             channel_id = get_alert_rule_trigger_action_slack_channel_id(
-                trigger_action.alert_rule_trigger.alert_rule.organization,
-                integration.id,
-                target_identifier,
+                organization, integration.id, target_identifier,
+            )
+
+            # Use the channel name for display
+            updated_fields["target_display"] = target_identifier
+            updated_fields["target_identifier"] = channel_id
+        elif type == AlertRuleTriggerAction.Type.MSTEAMS.value:
+            channel_id = get_alert_rule_trigger_action_msteams_channel_id(
+                organization, integration.id, target_identifier,
             )
 
             # Use the channel name for display
@@ -1115,6 +1122,18 @@ def get_alert_rule_trigger_action_slack_channel_id(organization, integration_id,
             "Could not find channel %s. Channel may not exist, or Sentry may not "
             "have been granted permission to access it" % name
         )
+
+    return channel_id
+
+
+def get_alert_rule_trigger_action_msteams_channel_id(organization, integration_id, name):
+    from sentry.integrations.msteams.utils import get_channel_id
+
+    channel_id = get_channel_id(organization, integration_id, name)
+
+    if channel_id is None:
+        # no granting access for msteams channels unlike slack
+        raise InvalidTriggerActionError("Could not find channel %s." % name)
 
     return channel_id
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1028,12 +1028,12 @@ def create_alert_rule_trigger_action(
     """
 
     target_display = None
-    if type in AlertRuleTriggerAction.INTEGRATION_TYPES:
+    if type.value in AlertRuleTriggerAction.INTEGRATION_TYPES:
         if target_type != AlertRuleTriggerAction.TargetType.SPECIFIC:
             raise InvalidTriggerActionError("Must specify specific target type")
 
         channel_id = get_alert_rule_trigger_action_integration_object_id(
-            type, trigger.alert_rule.organization, integration.id, target_identifier
+            type.value, trigger.alert_rule.organization, integration.id, target_identifier
         )
 
         # Use the channel name for display
@@ -1090,9 +1090,9 @@ def update_alert_rule_trigger_action(
 
 
 def get_alert_rule_trigger_action_integration_object_id(type, *args, **kwargs):
-    if type == AlertRuleTriggerAction.Type.SLACK:
+    if type == AlertRuleTriggerAction.Type.SLACK.value:
         return get_alert_rule_trigger_action_slack_channel_id(*args, **kwargs)
-    elif type == AlertRuleTriggerAction.Type.MSTEAMS:
+    elif type == AlertRuleTriggerAction.Type.MSTEAMS.value:
         return get_alert_rule_trigger_action_msteams_channel_id(*args, **kwargs)
     else:
         raise Exception("Not implemented")

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -529,6 +529,8 @@ class AlertRuleTriggerAction(Model):
         SLACK = 2
         MSTEAMS = 3
 
+    INTEGRATION_TYPES = frozenset((Type.PAGERDUTY, Type.SLACK, Type.MSTEAMS))
+
     class TargetType(Enum):
         # A direct reference, like an email address, Slack channel or PagerDuty service
         SPECIFIC = 0

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -529,7 +529,7 @@ class AlertRuleTriggerAction(Model):
         SLACK = 2
         MSTEAMS = 3
 
-    INTEGRATION_TYPES = frozenset((Type.PAGERDUTY, Type.SLACK, Type.MSTEAMS))
+    INTEGRATION_TYPES = frozenset((Type.PAGERDUTY.value, Type.SLACK.value, Type.MSTEAMS.value))
 
     class TargetType(Enum):
         # A direct reference, like an email address, Slack channel or PagerDuty service

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -527,6 +527,7 @@ class AlertRuleTriggerAction(Model):
         EMAIL = 0
         PAGERDUTY = 1
         SLACK = 2
+        MSTEAMS = 3
 
     class TargetType(Enum):
         # A direct reference, like an email address, Slack channel or PagerDuty service

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -11,9 +11,9 @@ def channel_filter(channel, name):
     # the general channel has no name in the list
     # retrieved from the REST API call
     if channel.get("name"):
-        return name == channel.get("name")
+        return name.lower() == channel.get("name").lower()
     else:
-        return name == "General"
+        return name.lower() == "general"
 
 
 def get_channel_id(organization, integration_id, name):
@@ -39,7 +39,9 @@ def get_channel_id(organization, integration_id, name):
         member_list = members.get("members")
         continuation_token = members.get("continuationToken")
 
-        filtered_members = list(filter(lambda x: x.get("name") == name, member_list))
+        filtered_members = list(
+            filter(lambda x: x.get("name").lower() == name.lower(), member_list)
+        )
         if len(filtered_members) > 0:
             # TODO: handle duplicate username case
             user_id = filtered_members[0].get("id")

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -31,6 +31,7 @@ const ActionLabel = {
   [ActionType.EMAIL]: t('E-mail'),
   [ActionType.SLACK]: t('Slack'),
   [ActionType.PAGER_DUTY]: t('Pagerduty'),
+  [ActionType.MSTEAMS]: t('Microsoft Teams'),
 };
 
 const TargetLabel = {
@@ -51,6 +52,18 @@ type Props = {
   className?: string;
   onAdd: (triggerIndex: number, action: Action) => void;
   onChange: (triggerIndex: number, triggers: Trigger[], actions: Action[]) => void;
+};
+
+const getPlaceholderForType = (type: ActionType) => {
+  switch (type) {
+    case ActionType.SLACK:
+      return '@username or #channel';
+    case ActionType.MSTEAMS:
+      //no prefixes for msteams
+      return 'username or channel';
+    default:
+      throw Error('Not implemented');
+  }
 };
 
 /**
@@ -314,7 +327,7 @@ class ActionsPanel extends React.PureComponent<Props> {
                           triggerIndex,
                           i
                         )}
-                        placeholder="@username or #channel"
+                        placeholder={getPlaceholderForType(action.type)}
                       />
                     )}
                     <DeleteActionButton

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -81,6 +81,7 @@ export enum ActionType {
   EMAIL = 'email',
   SLACK = 'slack',
   PAGER_DUTY = 'pagerduty',
+  MSTEAMS = 'msteams',
 }
 
 export enum TargetType {

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -76,6 +76,7 @@ from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.models.integration import Integration
 from sentry.testutils import TestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
+from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 
 
@@ -1392,6 +1393,48 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
         type = AlertRuleTriggerAction.Type.SLACK
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
         channel_name = "#some_channel_that_doesnt_exist"
+        with self.assertRaises(InvalidTriggerActionError):
+            update_alert_rule_trigger_action(
+                self.action,
+                type,
+                target_type,
+                target_identifier=channel_name,
+                integration=integration,
+            )
+
+    @patch("sentry.integrations.msteams.utils.get_channel_id")
+    def test_msteams(self, mock_get_channel_id):
+        mock_get_channel_id.return_value = "some_id"
+        integration = Integration.objects.create(external_id="1", provider="msteams",)
+        integration.add_organization(self.organization, self.user)
+        type = AlertRuleTriggerAction.Type.MSTEAMS
+        target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
+        channel_name = "some_channel"
+        channel_id = "some_id"
+
+        action = update_alert_rule_trigger_action(
+            self.action, type, target_type, target_identifier=channel_name, integration=integration
+        )
+        assert action.alert_rule_trigger == self.trigger
+        assert action.type == type.value
+        assert action.target_type == target_type.value
+        assert action.target_identifier == channel_id
+        assert action.target_display == channel_name
+        assert action.integration == integration
+
+        mock_get_channel_id.assert_called_once_with(
+            self.organization, integration.id, "some_channel"
+        )
+
+    @patch("sentry.integrations.msteams.utils.get_channel_id")
+    def test_msteams_not_existing(self, mock_get_channel_id):
+        mock_get_channel_id.return_value = None
+        integration = Integration.objects.create(external_id="1", provider="msteams",)
+        integration.add_organization(self.organization, self.user)
+        type = AlertRuleTriggerAction.Type.MSTEAMS
+        target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
+        channel_name = "some_channel"
+
         with self.assertRaises(InvalidTriggerActionError):
             update_alert_rule_trigger_action(
                 self.action,

--- a/tests/sentry/integrations/msteams/test_utils.py
+++ b/tests/sentry/integrations/msteams/test_utils.py
@@ -79,10 +79,10 @@ class GetChannelIdTest(TestCase):
         assert get_channel_id(self.organization, self.integration.id, name) is None
 
     def test_general_channel_selected(self):
-        self.run_valid_test("g_c", "General")
+        self.run_valid_test("g_c", "general")
 
     def test_other_channel_selected(self):
-        self.run_valid_test("p_o_d", "Pit of Despair")
+        self.run_valid_test("p_o_d", "pit of Despair")
 
     def test_bad_channel_not_selected(self):
         self.run_invalid_test("Cliffs of Insanity")


### PR DESCRIPTION
This PR adds the ability to save (but not send) a metric alert for the upcoming Microsoft Teams integration (which is hidden behind a feature flag). I also updated the check on the channel/user to be case insensitive.

Note, we are not handling some of the edge cases like when the username is not unique. We can add that in if/when that becomes necessary.

Here's what the UI looks like:

![Screen Shot 2020-07-20 at 5 00 52 PM](https://user-images.githubusercontent.com/8533851/87997685-9fa71600-caaa-11ea-8152-669c870a5bbf.png)
![Screen Shot 2020-07-20 at 5 01 06 PM](https://user-images.githubusercontent.com/8533851/87997686-a0d84300-caaa-11ea-998a-894e3503075a.png)
