### PR TITLE
ref(ui) Convert icon-circle-exclamation to SVG components.

### DIFF
--- a/src/sentry/static/sentry/app/components/commitRow.tsx
+++ b/src/sentry/static/sentry/app/components/commitRow.tsx
@@ -9,7 +9,7 @@ import {t, tct} from 'app/locale';
 import UserAvatar from 'app/components/avatar/userAvatar';
 import CommitLink from 'app/components/commitLink';
 import Hovercard from 'app/components/hovercard';
-import InlineSvg from 'app/components/inlineSvg';
+import {IconFlag} from 'app/icons';
 import Link from 'app/components/links/link';
 import TextOverflow from 'app/components/textOverflow';
 import TimeSince from 'app/components/timeSince';
@@ -78,7 +78,7 @@ class CommitRow extends React.Component<Props> {
           <AvatarWrapper>
             <Hovercard body={this.renderHovercardBody(author)}>
               <UserAvatar size={36} user={author} />
-              <EmailWarningIcon src="icon-circle-exclamation" />
+              <EmailWarningIcon />
             </Hovercard>
           </AvatarWrapper>
         ) : (
@@ -125,7 +125,7 @@ const StyledLink = styled(Link)`
   }
 `;
 
-const EmailWarningIcon = styled(InlineSvg)`
+const EmailWarningIcon = styled(IconFlag)`
   position: relative;
   margin-left: -11px;
   border-radius: 11px;

--- a/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
+++ b/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import HeroIcon from 'app/components/heroIcon';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import {IconWarning} from 'app/icons';
+import {IconFlag, IconWarning} from 'app/icons';
 import space from 'app/styles/space';
 
 type Props = {
@@ -29,7 +29,7 @@ const EmptyStateWarning = ({
     </EmptyMessage>
   ) : (
     <EmptyStreamWrapper data-test-id="empty-state" className={className}>
-      {withIcon && <HeroIcon src="icon-circle-exclamation" size="54" />}
+      {withIcon && <IconFlag size="54px" />}
       {children}
     </EmptyStreamWrapper>
   );

--- a/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
+++ b/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
@@ -52,7 +52,7 @@ const EmptyStreamWrapper = styled('div')`
 
   svg {
     fill: ${p => p.theme.gray400};
-    margin-bottom: 20px;
+    margin-bottom: ${space(2)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
+++ b/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import {IconFlag, IconWarning} from 'app/icons';
+import {IconSearch} from 'app/icons';
 import space from 'app/styles/space';
 
 type Props = {
@@ -22,13 +22,13 @@ const EmptyStateWarning = ({
   small ? (
     <EmptyMessage className={className}>
       <SmallMessage>
-        {withIcon && <StyledIconWarning color="gray500" size="lg" />}
+        {withIcon && <StyledIconSearch color="gray500" size="lg" />}
         {children}
       </SmallMessage>
     </EmptyMessage>
   ) : (
     <EmptyStreamWrapper data-test-id="empty-state" className={className}>
-      {withIcon && <IconFlag size="54px" />}
+      {withIcon && <IconSearch size="54px" />}
       {children}
     </EmptyStreamWrapper>
   );
@@ -64,7 +64,7 @@ const SmallMessage = styled('div')`
   line-height: 1em;
 `;
 
-const StyledIconWarning = styled(IconWarning)`
+const StyledIconSearch = styled(IconSearch)`
   margin-right: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
+++ b/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
-import HeroIcon from 'app/components/heroIcon';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import {IconFlag, IconWarning} from 'app/icons';
 import space from 'app/styles/space';
@@ -51,7 +50,8 @@ const EmptyStreamWrapper = styled('div')`
     }
   }
 
-  ${HeroIcon} {
+  svg {
+    fill: ${p => p.theme.gray400};
     margin-bottom: 20px;
   }
 `;

--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -7,6 +7,7 @@ import * as Sentry from '@sentry/react';
 import {t} from 'app/locale';
 import Alert from 'app/components/alert';
 import DetailedError from 'app/components/errors/detailedError';
+import {IconFlag} from 'app/icons';
 
 type DefaultProps = {
   mini: boolean;
@@ -93,7 +94,7 @@ class ErrorBoundary extends React.Component<Props, State> {
 
     if (mini) {
       return (
-        <Alert type="error" icon="icon-circle-exclamation" className={className}>
+        <Alert type="error" icon={<IconFlag size="md" />} className={className}>
           {message || t('There was a problem rendering this component')}
         </Alert>
       );

--- a/src/sentry/static/sentry/app/components/errors/detailedError.tsx
+++ b/src/sentry/static/sentry/app/components/errors/detailedError.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import * as Sentry from '@sentry/react';
 
 import {t} from 'app/locale';
-import InlineSvg from 'app/components/inlineSvg';
+import {IconFlag} from 'app/icons';
 import Button from 'app/components/button';
 
 type DefaultProps = {
@@ -62,7 +62,7 @@ class DetailedError extends React.Component<Props> {
     return (
       <div className={cx}>
         <div className="detailed-error-icon">
-          <InlineSvg src="icon-circle-exclamation" />
+          <IconFlag size="lg" />
         </div>
         <div className="detailed-error-content">
           <h4>{heading}</h4>

--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText.tsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import InlineSvg from 'app/components/inlineSvg';
+import {IconWarning} from 'app/icons';
 import Tooltip from 'app/components/tooltip';
 import {t, tn} from 'app/locale';
 import {Chunks, Meta, MetaError} from 'app/types';
@@ -107,7 +107,7 @@ function renderErrors(errors: Array<MetaError>) {
 
   return (
     <Tooltip title={tooltip}>
-      <ErrorIcon src="icon-circle-exclamation" />
+      <IconWarning color="red500" />
     </Tooltip>
   );
 }
@@ -144,10 +144,6 @@ const Placeholder = styled(Redaction)`
   :after {
     content: '>';
   }
-`;
-
-const ErrorIcon = styled(InlineSvg)`
-  color: ${props => props.theme.red500};
 `;
 
 export default AnnotatedText;

--- a/src/sentry/static/sentry/app/components/issueList.jsx
+++ b/src/sentry/static/sentry/app/components/issueList.jsx
@@ -6,6 +6,7 @@ import {Panel, PanelBody} from 'app/components/panels';
 import withApi from 'app/utils/withApi';
 import CompactIssue from 'app/components/issues/compactIssue';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import {IconFlag} from 'app/icons';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
@@ -158,7 +159,7 @@ const IssueList = createReactClass({
 
     return (
       <Panel style={panelStyle}>
-        <EmptyMessage icon="icon-circle-exclamation">
+        <EmptyMessage icon={<IconFlag size="xl" />}>
           {emptyText ? emptyText : t('Nothing to show here, move along.')}
         </EmptyMessage>
       </Panel>

--- a/src/sentry/static/sentry/app/components/issueList.jsx
+++ b/src/sentry/static/sentry/app/components/issueList.jsx
@@ -6,7 +6,7 @@ import {Panel, PanelBody} from 'app/components/panels';
 import withApi from 'app/utils/withApi';
 import CompactIssue from 'app/components/issues/compactIssue';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import {IconFlag} from 'app/icons';
+import {IconSearch} from 'app/icons';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
@@ -159,7 +159,7 @@ const IssueList = createReactClass({
 
     return (
       <Panel style={panelStyle}>
-        <EmptyMessage icon={<IconFlag size="xl" />}>
+        <EmptyMessage icon={<IconSearch size="xl" />}>
           {emptyText ? emptyText : t('Nothing to show here, move along.')}
         </EmptyMessage>
       </Panel>

--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
@@ -8,7 +8,7 @@ import space from 'app/styles/space';
 import {t, tct} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
 import marked, {singleLineRenderer} from 'app/utils/marked';
-import InlineSvg from 'app/components/inlineSvg';
+import {IconFlag} from 'app/icons';
 import Tag from 'app/views/settings/components/tag';
 import {toPermissions} from 'app/utils/consolidatedScopes';
 import CircleIndicator from 'app/components/circleIndicator';
@@ -243,7 +243,7 @@ const Author = styled('div')`
 
 const DisabledNotice = styled(({reason, ...p}: {reason: React.ReactNode}) => (
   <div {...p}>
-    <InlineSvg src="icon-circle-exclamation" size="1.5em" />
+    <IconFlag color="red400" size="1.5em" />
     {reason}
   </div>
 ))`

--- a/src/sentry/static/sentry/app/components/modals/sudoModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/sudoModal.jsx
@@ -10,6 +10,7 @@ import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
 import Form from 'app/views/settings/components/forms/form';
 import InputField from 'app/views/settings/components/forms/inputField';
+import {IconFlag} from 'app/icons';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import U2fContainer from 'app/components/u2f/u2fContainer';
 import space from 'app/styles/space';
@@ -127,11 +128,7 @@ class SudoModal extends React.Component {
               </TextBlock>
 
               {this.state.error && (
-                <Alert
-                  css={{marginBottom: 0}}
-                  type="error"
-                  icon="icon-circle-exclamation"
-                >
+                <Alert css={{marginBottom: 0}} type="error" icon={<IconFlag size="md" />}>
                   {t('Incorrect password')}
                 </Alert>
               )}

--- a/src/sentry/static/sentry/app/components/projects/missingProjectMembership.jsx
+++ b/src/sentry/static/sentry/app/components/projects/missingProjectMembership.jsx
@@ -6,7 +6,7 @@ import {addErrorMessage} from 'app/actionCreators/indicator';
 import {joinTeam} from 'app/actionCreators/teams';
 import {t} from 'app/locale';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import HeroIcon from 'app/components/heroIcon';
+import {IconFlag} from 'app/icons';
 import Well from 'app/components/well';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
@@ -118,7 +118,7 @@ class MissingProjectMembership extends React.Component {
     return (
       <div className="container">
         <StyledWell centered>
-          <StyledHeroIcon src="icon-circle-exclamation" />
+          <StyledIconFlag size="xxl" />
           <p>{t("You're not a member of this project.")}</p>
           <p>{this.renderExplanation(features)}</p>
           {this.renderJoinTeams(features)}
@@ -132,7 +132,7 @@ const StyledWell = styled(Well)`
   margin-top: ${space(2)};
 `;
 
-const StyledHeroIcon = styled(HeroIcon)`
+const StyledIconFlag = styled(IconFlag)`
   margin-bottom: ${space(2)};
 `;
 

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -211,6 +211,7 @@ const iconSizes = {
   md: '20px',
   lg: '24px',
   xl: '32px',
+  xxl: '72px',
 };
 
 const theme = {

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -17,6 +17,7 @@ import {fetchProjectsCount} from 'app/actionCreators/projects';
 import Alert from 'app/components/alert';
 import CreateAlertButton from 'app/components/createAlertButton';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
+import {IconFlag} from 'app/icons';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import Confirm from 'app/components/confirm';
@@ -346,7 +347,7 @@ class Results extends React.Component<Props, State> {
       return null;
     }
     return (
-      <Alert type="error" icon="icon-circle-exclamation">
+      <Alert type="error" icon={<IconFlag size="md" />}>
         {error}
       </Alert>
     );

--- a/src/sentry/static/sentry/app/views/integrationInstallation.tsx
+++ b/src/sentry/static/sentry/app/views/integrationInstallation.tsx
@@ -14,6 +14,7 @@ import Alert from 'app/components/alert';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import Field from 'app/views/settings/components/forms/field';
+import {IconFlag} from 'app/icons';
 import NarrowLayout from 'app/components/narrowLayout';
 import SelectControl from 'app/components/forms/selectControl';
 
@@ -153,7 +154,7 @@ export default class IntegrationInstallation extends AsyncView<Props, State> {
         </p>
 
         {selectedOrg && organization && !this.hasAccess(organization) && (
-          <Alert type="error" icon="icon-circle-exclamation">
+          <Alert type="error" icon={<IconFlag size="md" />}>
             <p>
               {tct(
                 `You do not have permission to install integrations in

--- a/src/sentry/static/sentry/app/views/integrationOrganizationLink.tsx
+++ b/src/sentry/static/sentry/app/views/integrationOrganizationLink.tsx
@@ -19,6 +19,7 @@ import Field from 'app/views/settings/components/forms/field';
 import NarrowLayout from 'app/components/narrowLayout';
 import SelectControl from 'app/components/forms/selectControl';
 import IdBadge from 'app/components/idBadge';
+import {IconFlag} from 'app/icons';
 import LoadingIndicator from 'app/components/loadingIndicator';
 
 //installationId present for Github flow
@@ -207,7 +208,7 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
     return (
       <React.Fragment>
         {selectedOrgSlug && organization && !this.hasAccess() && (
-          <Alert type="error" icon="icon-circle-exclamation">
+          <Alert type="error" icon={<IconFlag size="md" />}>
             <p>
               {tct(
                 `You do not have permission to install integrations in

--- a/src/sentry/static/sentry/app/views/organizationActivity/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity/index.tsx
@@ -8,6 +8,7 @@ import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import ErrorBoundary from 'app/components/errorBoundary';
+import {IconFlag} from 'app/icons';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import PageHeading from 'app/components/pageHeading';
 import Pagination from 'app/components/pagination';
@@ -42,7 +43,7 @@ class OrganizationActivity extends AsyncView<Props, State> {
 
   renderEmpty() {
     return (
-      <EmptyMessage icon="icon-circle-exclamation">
+      <EmptyMessage icon={<IconFlag size="md" />}>
         {t('Nothing to show here, move along.')}
       </EmptyMessage>
     );

--- a/src/sentry/static/sentry/app/views/organizationActivity/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity/index.tsx
@@ -6,9 +6,8 @@ import {PageContent} from 'app/styles/organization';
 import {Panel} from 'app/components/panels';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
-import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
 import ErrorBoundary from 'app/components/errorBoundary';
-import {IconSearch} from 'app/icons';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import PageHeading from 'app/components/pageHeading';
 import Pagination from 'app/components/pagination';
@@ -43,9 +42,9 @@ class OrganizationActivity extends AsyncView<Props, State> {
 
   renderEmpty() {
     return (
-      <EmptyMessage icon={<IconSearch size="md" />}>
-        {t('Nothing to show here, move along.')}
-      </EmptyMessage>
+      <EmptyStateWarning>
+        <p>{t('Nothing to show here, move along.')}</p>
+      </EmptyStateWarning>
     );
   }
 

--- a/src/sentry/static/sentry/app/views/organizationActivity/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity/index.tsx
@@ -8,7 +8,7 @@ import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import ErrorBoundary from 'app/components/errorBoundary';
-import {IconFlag} from 'app/icons';
+import {IconSearch} from 'app/icons';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import PageHeading from 'app/components/pageHeading';
 import Pagination from 'app/components/pagination';
@@ -43,7 +43,7 @@ class OrganizationActivity extends AsyncView<Props, State> {
 
   renderEmpty() {
     return (
-      <EmptyMessage icon={<IconFlag size="md" />}>
+      <EmptyMessage icon={<IconSearch size="md" />}>
         {t('Nothing to show here, move along.')}
       </EmptyMessage>
     );

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
@@ -7,7 +7,7 @@ import Button from 'app/components/button';
 import CircleIndicator from 'app/components/circleIndicator';
 import Confirm from 'app/components/confirm';
 import Tooltip from 'app/components/tooltip';
-import {IconDelete, IconSettings, IconWarning} from 'app/icons';
+import {IconDelete, IconFlag, IconSettings, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {IntegrationProvider, Integration, Organization, ObjectStatus} from 'app/types';
@@ -91,7 +91,7 @@ export default class InstalledIntegration extends React.Component<Props> {
 
     const message = (
       <React.Fragment>
-        <Alert type="error" icon="icon-circle-exclamation">
+        <Alert type="error" icon={<IconFlag size="md" />}>
           {t('Deleting this integration has consequences!')}
         </Alert>
         {body}
@@ -109,7 +109,7 @@ export default class InstalledIntegration extends React.Component<Props> {
     const {body, actionText} = integration.provider.aspects.disable_dialog || {};
     const message = (
       <React.Fragment>
-        <Alert type="error" icon="icon-circle-exclamation">
+        <Alert type="error" icon={<IconFlag size="md" />}>
           {t('This integration cannot be removed in Sentry')}
         </Alert>
         {body}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
@@ -6,7 +6,7 @@ import Access from 'app/components/acl/access';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import Alert from 'app/components/alert';
-import {IconDelete, IconSettings} from 'app/icons';
+import {IconDelete, IconFlag, IconSettings} from 'app/icons';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
 import withApi from 'app/utils/withApi';
 import {Client} from 'app/api';
@@ -40,7 +40,7 @@ export class InstalledPlugin extends React.Component<Props> {
   getConfirmMessage() {
     return (
       <React.Fragment>
-        <Alert type="error" icon="icon-circle-exclamation">
+        <Alert type="error" icon={<IconFlag size="md" />}>
           {t(
             'Deleting this installation will disable the integration for this project and remove any configurations.'
           )}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.tsx
@@ -10,7 +10,7 @@ import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownButton from 'app/components/dropdownButton';
-import {IconCommit} from 'app/icons';
+import {IconCommit, IconFlag} from 'app/icons';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import Pagination from 'app/components/pagination';
@@ -198,7 +198,7 @@ export default class IntegrationRepos extends AsyncComponent<Props, State> {
     );
     if (badRequest) {
       return (
-        <Alert type="error" icon="icon-circle-exclamation">
+        <Alert type="error" icon={<IconFlag size="md" />}>
           {t(
             'We were unable to fetch repositories for this integration. Try again later, or reconnect this integration.'
           )}

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -19,6 +19,7 @@ import EventView from 'app/utils/discover/eventView';
 import space from 'app/styles/space';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
+import {IconFlag} from 'app/icons';
 import {decodeScalar} from 'app/utils/queryString';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
@@ -93,7 +94,7 @@ class PerformanceLanding extends React.Component<Props, State> {
     }
 
     return (
-      <Alert type="error" icon="icon-circle-exclamation">
+      <Alert type="error" icon={<IconFlag size="md" />}>
         {error}
       </Alert>
     );

--- a/src/sentry/static/sentry/app/views/releases/detail/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.jsx
@@ -9,6 +9,7 @@ import {tn} from 'app/locale';
 import Alert from 'app/components/alert';
 import AsyncView from 'app/views/asyncView';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
+import {IconFlag} from 'app/icons';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import SentryTypes from 'app/sentryTypes';
@@ -92,7 +93,7 @@ class OrganizationReleaseDetails extends AsyncView {
 
       return (
         <PageContent>
-          <Alert type="error" icon="icon-circle-exclamation">
+          <Alert type="error" icon={<IconFlag size="md" />}>
             {tn(
               'This release may not be in your selected project',
               'This release may not be in your selected projects',

--- a/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
+++ b/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
@@ -15,6 +15,7 @@ import {t, tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import AsyncView from 'app/views/asyncView';
 import Field from 'app/views/settings/components/forms/field';
+import {IconFlag} from 'app/icons';
 import NarrowLayout from 'app/components/narrowLayout';
 import OrganizationAvatar from 'app/components/avatar/organizationAvatar';
 import SelectControl from 'app/components/forms/selectControl';
@@ -178,7 +179,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
   renderInternalAppError() {
     const {sentryApp} = this.state;
     return (
-      <Alert type="error" icon="icon-circle-exclamation">
+      <Alert type="error" icon={<IconFlag size="md" />}>
         {tct(
           'Integration [sentryAppName] is an internal integration. Internal integrations are automatically installed',
           {
@@ -193,7 +194,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
     const {organization, selectedOrgSlug, isInstalled, sentryApp} = this.state;
     if (selectedOrgSlug && organization && !this.hasAccess(organization)) {
       return (
-        <Alert type="error" icon="icon-circle-exclamation">
+        <Alert type="error" icon={<IconFlag size="md" />}>
           <p>
             {tct(
               `You do not have permission to install integrations in
@@ -208,7 +209,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
     }
     if (isInstalled && organization) {
       return (
-        <Alert type="error" icon="icon-circle-exclamation">
+        <Alert type="error" icon={<IconFlag size="md" />}>
           {tct('Integration [sentryAppName] already installed for [organization]', {
             organization: <strong>{organization.name}</strong>,
             sentryAppName: <strong>{sentryApp.name}</strong>,
@@ -221,7 +222,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
       // use the slug of the owner if we have it, otherwise use 'another organization'
       const ownerSlug = sentryApp?.owner?.slug ?? 'another organization';
       return (
-        <Alert type="error" icon="icon-circle-exclamation">
+        <Alert type="error" icon={<IconFlag size="md" />}>
           {tct(
             'Integration [sentryAppName] is an unpublished integration for [otherOrg]. An unpublished integration can only be installed on the organization which created it.',
             {

--- a/src/sentry/static/sentry/app/views/settings/account/accountClose.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountClose.jsx
@@ -16,6 +16,7 @@ import Alert from 'app/components/alert';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
+import {IconFlag} from 'app/icons';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 
@@ -126,7 +127,7 @@ class AccountClose extends AsyncView {
           {t('This will permanently remove all associated data for your user')}.
         </TextBlock>
 
-        <Alert type="error" icon="icon-circle-exclamation">
+        <Alert type="error" icon={<IconFlag size="md" />}>
           <Important>
             {t('Closing your account is permanent and cannot be undone')}!
           </Important>

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
@@ -4,12 +4,13 @@ import styled from '@emotion/styled';
 import {tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import ExternalLink from 'app/components/links/externalLink';
+import {IconFlag} from 'app/icons';
 import space from 'app/styles/space';
 import getPendingInvite from 'app/utils/getPendingInvite';
 
 const TwoFactorRequired = () =>
   !getPendingInvite() ? null : (
-    <StyledAlert data-test-id="require-2fa" type="error" icon="icon-circle-exclamation">
+    <StyledAlert data-test-id="require-2fa" type="error" icon={<IconFlag size="md" />}>
       {tct(
         'You have been invited to an organization that requires [link:two-factor authentication].' +
           ' Setup two-factor authentication below to join your organization.',

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -15,7 +15,7 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import Checkbox from 'app/components/checkbox';
 import Button from 'app/components/button';
 import space from 'app/styles/space';
-import {IconChevron, IconOpen} from 'app/icons';
+import {IconChevron, IconFlag, IconOpen} from 'app/icons';
 import {t} from 'app/locale';
 import {SentryApp, SentryAppWebhookRequest, SentryAppSchemaIssueLink} from 'app/types';
 import {Theme} from 'app/utils/theme';
@@ -259,7 +259,7 @@ export default class RequestLog extends AsyncComponent<Props, State> {
                   </PanelItem>
                 ))
               ) : (
-                <EmptyMessage icon="icon-circle-exclamation">
+                <EmptyMessage icon={<IconFlag size="xl" />}>
                   {t('No requests found in the last 30 days.')}
                 </EmptyMessage>
               )}

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
@@ -7,8 +7,7 @@ import {t, tct} from 'app/locale';
 import UserAvatar from 'app/components/avatar/userAvatar';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
-import InlineSvg from 'app/components/inlineSvg';
-import {IconClose, IconMail, IconSubtract} from 'app/icons';
+import {IconClose, IconCheckmark, IconFlag, IconMail, IconSubtract} from 'app/icons';
 import Link from 'app/components/links/link';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import SentryTypes from 'app/sentryTypes';
@@ -141,7 +140,11 @@ export default class OrganizationMemberRow extends React.PureComponent {
             </React.Fragment>
           ) : (
             <AuthStatus>
-              <AuthIcon has2fa={has2fa} />
+              {has2fa ? (
+                <IconCheckmark isCircled color="success" />
+              ) : (
+                <IconFlag color="error" />
+              )}
               {has2fa ? t('2FA Enabled') : t('2FA Not Enabled')}
             </AuthStatus>
           )}
@@ -265,10 +268,3 @@ const LoadingContainer = styled('div')`
 `;
 
 const AuthStatus = styled(Section)``;
-const AuthIcon = styled(p => (
-  <InlineSvg {...p} src={p.has2fa ? 'icon-circle-check' : 'icon-circle-exclamation'} />
-))`
-  color: ${p => (p.has2fa ? p.theme.success : p.theme.error)};
-  font-size: 18px;
-  margin-bottom: 1px;
-`;

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamProjects.jsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import {Panel, PanelHeader, PanelBody, PanelItem} from 'app/components/panels';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {sortProjects} from 'app/utils';
-import {IconSubtract} from 'app/icons';
+import {IconFlag, IconSubtract} from 'app/icons';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
@@ -159,7 +159,7 @@ class TeamProjects extends React.Component {
         </StyledPanelItem>
       ))
     ) : (
-      <EmptyMessage size="large" icon="icon-circle-exclamation">
+      <EmptyMessage size="large" icon={<IconFlag size="xl" />}>
         {t("This team doesn't have access to any projects.")}
       </EmptyMessage>
     );

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -9,6 +9,7 @@ import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
 import Form from 'app/views/settings/components/forms/form';
 import FormField from 'app/views/settings/components/forms/formField';
+import {IconFlag} from 'app/icons';
 import InputControl from 'app/views/settings/components/forms/controls/input';
 import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
 import space from 'app/styles/space';
@@ -90,7 +91,7 @@ class KeyRateLimitsForm extends React.Component<Props> {
               <PanelHeader>{t('Rate Limits')}</PanelHeader>
 
               <PanelBody>
-                <PanelAlert type="info" icon="icon-circle-exclamation">
+                <PanelAlert type="info" icon={<IconFlag size="md" />}>
                   {t(
                     `Rate limits provide a flexible way to manage your event
                       volume. If you have a noisy project or environment you

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -18,6 +18,7 @@ import DateTime from 'app/components/dateTime';
 import ExternalLink from 'app/components/links/externalLink';
 import Field from 'app/views/settings/components/forms/field';
 import Form from 'app/views/settings/components/forms/form';
+import {IconFlag} from 'app/icons';
 import KeyRateLimitsForm from 'app/views/settings/project/projectKeys/details/keyRateLimitsForm';
 import ProjectKeyCredentials from 'app/views/settings/project/projectKeys/projectKeyCredentials';
 import SelectField from 'app/views/settings/components/forms/selectField';
@@ -170,7 +171,7 @@ class KeySettings extends React.Component<Props, State> {
             <Panel>
               <PanelHeader>{t('Credentials')}</PanelHeader>
               <PanelBody>
-                <PanelAlert type="info" icon="icon-circle-exclamation">
+                <PanelAlert type="info" icon={<IconFlag size="md" />}>
                   {t(
                     'Your credentials are coupled to a public and secret key. Different clients will require different credentials, so make sure you check the documentation before plugging things in.'
                   )}

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/list/index.tsx
@@ -20,7 +20,7 @@ import TextBlock from 'app/views/settings/components/text/textBlock';
 import routeTitleGen from 'app/utils/routeTitle';
 import withOrganization from 'app/utils/withOrganization';
 import withProject from 'app/utils/withProject';
-import {IconAdd} from 'app/icons';
+import {IconAdd, IconFlag} from 'app/icons';
 
 import KeyRow from './keyRow';
 
@@ -128,7 +128,7 @@ class ProjectKeys extends AsyncView<Props, State> {
     return (
       <Panel>
         <EmptyMessage
-          icon="icon-circle-exclamation"
+          icon={<IconFlag size="xl" />}
           description={t('There are no keys active for this project.')}
         />
       </Panel>

--- a/src/sentry/static/sentry/app/views/settings/project/projectReleaseTracking.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectReleaseTracking.jsx
@@ -10,6 +10,7 @@ import AutoSelectText from 'app/components/autoSelectText';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import Field from 'app/views/settings/components/forms/field';
+import {IconFlag} from 'app/icons';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import PluginList from 'app/components/pluginList';
 import SentryTypes from 'app/sentryTypes';
@@ -110,7 +111,7 @@ class ProjectReleaseTracking extends AsyncView {
       <div>
         <SettingsPageHeader title={t('Release Tracking')} />
         {!hasWrite && (
-          <Alert icon="icon-circle-exclamation" type="warning">
+          <Alert icon={<IconFlag size="md" />} type="warning">
             {t(
               'You do not have sufficient permissions to access Release tokens, placeholders are displayed below.'
             )}

--- a/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
@@ -14,6 +14,7 @@ import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import ErrorBoundary from 'app/components/errorBoundary';
 import Field from 'app/views/settings/components/forms/field';
+import {IconFlag} from 'app/icons';
 import ServiceHookSettingsForm from 'app/views/settings/project/serviceHookSettingsForm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import StackedBarChart from 'app/components/stackedBarChart';
@@ -137,7 +138,7 @@ export default class ProjectServiceHookDetails extends AsyncView {
         <Panel>
           <PanelHeader>{t('Event Validation')}</PanelHeader>
           <PanelBody>
-            <PanelAlert type="info" icon="icon-circle-exclamation">
+            <PanelAlert type="info" icon={<IconFlag size="md" />}>
               Sentry will send the <code>X-ServiceHook-Signature</code> header built using{' '}
               <code>HMAC(SHA256, [secret], [payload])</code>. You should always verify
               this signature before trusting the information provided in the webhook.

--- a/src/sentry/static/sentry/app/views/settings/project/projectServiceHooks.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectServiceHooks.jsx
@@ -16,7 +16,7 @@ import Field from 'app/views/settings/components/forms/field';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import Switch from 'app/components/switch';
 import Truncate from 'app/components/truncate';
-import {IconAdd} from 'app/icons';
+import {IconAdd, IconFlag} from 'app/icons';
 
 class ServiceHookRow extends React.Component {
   static propTypes = {
@@ -114,7 +114,7 @@ export default class ProjectServiceHooks extends AsyncView {
       <React.Fragment>
         <PanelHeader key="header">{t('Service Hook')}</PanelHeader>
         <PanelBody key="body">
-          <PanelAlert type="info" icon="icon-circle-exclamation">
+          <PanelAlert type="info" icon={<IconFlag size="md" />}>
             {t(
               'Service Hooks are an early adopter preview feature and will change in the future.'
             )}

--- a/src/sentry/static/sentry/less/errors.less
+++ b/src/sentry/static/sentry/less/errors.less
@@ -10,7 +10,7 @@
 .detailed-error-icon {
   color: @red;
   font-size: 2.4em;
-  padding: 0 18px;
+  padding: 6px 18px 0 18px;
   opacity: 0.3;
 }
 

--- a/tests/js/spec/components/__snapshots__/detailedError.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/detailedError.spec.jsx.snap
@@ -7,8 +7,8 @@ exports[`DetailedError can hide support links 1`] = `
   <div
     className="detailed-error-icon"
   >
-    <InlineSvg
-      src="icon-circle-exclamation"
+    <IconFlag
+      size="lg"
     />
   </div>
   <div
@@ -47,8 +47,8 @@ exports[`DetailedError hides footer when no "Retry" and no support links 1`] = `
   <div
     className="detailed-error-icon"
   >
-    <InlineSvg
-      src="icon-circle-exclamation"
+    <IconFlag
+      size="lg"
     />
   </div>
   <div
@@ -75,8 +75,8 @@ exports[`DetailedError renders 1`] = `
   <div
     className="detailed-error-icon"
   >
-    <InlineSvg
-      src="icon-circle-exclamation"
+    <IconFlag
+      size="lg"
     />
   </div>
   <div
@@ -122,8 +122,8 @@ exports[`DetailedError renders with "Retry" button 1`] = `
   <div
     className="detailed-error-icon"
   >
-    <InlineSvg
-      src="icon-circle-exclamation"
+    <IconFlag
+      size="lg"
     />
   </div>
   <div

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/__snapshots__/filter.spec.tsx.snap
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/__snapshots__/filter.spec.tsx.snap
@@ -608,6 +608,7 @@ exports[`Filter default render 1`] = `
                       "sm": "16px",
                       "xl": "32px",
                       "xs": "12px",
+                      "xxl": "72px",
                     },
                     "orange100": "#FCF8F7",
                     "orange200": "#F9C7B9",

--- a/tests/js/spec/views/organizationActivity/index.spec.jsx
+++ b/tests/js/spec/views/organizationActivity/index.spec.jsx
@@ -5,7 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import OrganizationActivity from 'app/views/organizationActivity';
 
-describe('OrganizationUserFeedback', function() {
+describe('OrganizationActivity', function() {
   const {router, organization, routerContext} = initializeOrg();
   let params = {};
 
@@ -43,7 +43,7 @@ describe('OrganizationUserFeedback', function() {
     const wrapper = mount(<OrganizationActivity {...params} />, routerContext);
 
     expect(wrapper.find('ActivityItem')).toHaveLength(0);
-    expect(wrapper.find('EmptyMessage')).toHaveLength(1);
+    expect(wrapper.find('EmptyStateWarning')).toHaveLength(1);
   });
 
   it('renders not found', function() {
@@ -55,6 +55,6 @@ describe('OrganizationUserFeedback', function() {
     const wrapper = mount(<OrganizationActivity {...params} />, routerContext);
 
     expect(wrapper.find('ActivityItem')).toHaveLength(0);
-    expect(wrapper.find('EmptyMessage')).toHaveLength(1);
+    expect(wrapper.find('EmptyStateWarning')).toHaveLength(1);
   });
 });

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberRow.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberRow.spec.jsx
@@ -63,7 +63,8 @@ describe('OrganizationMemberRow', function() {
         }}
       />
     );
-    expect(wrapper.find('AuthIcon').prop('has2fa')).toBe(true);
+    expect(wrapper.find('IconCheckmark')).toHaveLength(1);
+    expect(wrapper.find('IconFlag')).toHaveLength(0);
   });
 
   it('has 2fa warning if user does not have 2fa enabled', function() {
@@ -79,7 +80,8 @@ describe('OrganizationMemberRow', function() {
         }}
       />
     );
-    expect(wrapper.find('AuthIcon').prop('has2fa')).toBe(false);
+    expect(wrapper.find('IconCheckmark')).toHaveLength(0);
+    expect(wrapper.find('IconFlag')).toHaveLength(1);
   });
 
   describe('Pending user', function() {
@@ -228,7 +230,8 @@ describe('OrganizationMemberRow', function() {
         />
       );
 
-      expect(wrapper.find('AuthIcon').prop('has2fa')).toBe(false);
+      expect(wrapper.find('IconCheckmark')).toHaveLength(0);
+      expect(wrapper.find('IconFlag')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
This icon either represents a warning or a flag depending on the context. The bulk of the conversions were to flag as warning is intended to be used for 'leaning towards bad but not there yet', which doesn't fit with empty states and 'tips' in the application.

EmptyMessage components should have xl icons, as they previously set the icon size to 32px. To accommodate HeroIcon, I've had to introduce a new xxl icon size.