### PR TITLE
fix(ui): Small fixes to Sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -669,6 +669,7 @@ const StyledSidebar = styled('div')<{collapsed: boolean}>`
 
 const SidebarSectionGroup = styled('div')`
   ${responsiveFlex};
+  flex-shrink: 0; /* prevents shrinking on Safari */
 `;
 
 const SidebarSectionGroupPrimary = styled('div')`
@@ -690,7 +691,7 @@ const PrimaryItems = styled('div')`
   display: flex;
   flex-direction: column;
   -ms-overflow-style: -ms-autohiding-scrollbar;
-  @media (max-height: 600px) and (min-width: ${p => p.theme.breakpoints[1]}) {
+  @media (max-height: 675px) and (min-width: ${p => p.theme.breakpoints[1]}) {
     border-bottom: 1px solid ${p => p.theme.gray600};
     padding-bottom: ${space(1)};
     box-shadow: rgba(0, 0, 0, 0.15) 0px -10px 10px inset;


### PR DESCRIPTION
**Bug 1:** Sidebar was getting crushed on Safari. 
Fix: Set `flex-shrink` to prevent Safari quirkness

Before | After
:-----:|:-----:
<img src="https://user-images.githubusercontent.com/1748388/88015834-fcb8c100-cad6-11ea-965e-9c570c2aa507.png" width="45%"/>  |  <img src="https://user-images.githubusercontent.com/1748388/88015838-004c4800-cad7-11ea-92b9-9878454c3c06.png" width="45%"/>

<br>

---

<br>

**Bug 2:** We added more stuff to the sidebar. The overlap effect was coming too late.
Fix: Breakpoint was adjusted

Before | After
:-----:|:-----:
<img src="https://user-images.githubusercontent.com/1748388/88015849-06422900-cad7-11ea-8884-4691a5753b99.png" width="45%"/>  |  <img src="https://user-images.githubusercontent.com/1748388/88015853-08a48300-cad7-11ea-9b07-4d608483c2a7.png" width="45%"/>
