### PR TITLE
feat(migrations): Add migration operation to create unique index concurrently.

### DIFF
--- a/src/sentry/db/migrations/__init__.py
+++ b/src/sentry/db/migrations/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/db/migrations/concurrent_fields.py
+++ b/src/sentry/db/migrations/concurrent_fields.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+from django.db import migrations
+
+
+class ConcurrentAlterUniqueTogether(migrations.AlterUniqueTogether):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        """
+        Note: This is copied out of
+        django.db.migrations.operations.models.AlterUniqueTogether.database_forwards
+        and modified. We'll need to make sure this keeps working after Django upgrades.
+        """
+        new_model = to_state.apps.get_model(app_label, self.name)
+        if self.allow_migrate_model(schema_editor.connection.alias, new_model):
+            old_model = from_state.apps.get_model(app_label, self.name)
+            self.alter_unique_together(
+                schema_editor,
+                new_model,
+                getattr(old_model._meta, self.option_name, set()),
+                getattr(new_model._meta, self.option_name, set()),
+            )
+
+    def alter_unique_together(self, schema_editor, model, old_unique_together, new_unique_together):
+        """
+        Note: This is copied out of
+        django.db.backends.base.schema::BaseDatabaseSchemaEditor.alter_unique_together
+        and modified. We'll need to make sure this keeps working after Django upgrades.
+
+        Deals with a model changing its unique_together.
+        Note: The input unique_togethers must be doubly-nested, not the single-
+        nested ["foo", "bar"] format.
+        """
+        olds = set(tuple(fields) for fields in old_unique_together)
+        news = set(tuple(fields) for fields in new_unique_together)
+        # Deleted uniques
+        for fields in olds.difference(news):
+            schema_editor._delete_composed_index(
+                model, fields, {"unique": True}, schema_editor.sql_delete_unique
+            )
+
+        # Created uniques
+        for fields in news.difference(olds):
+            columns = [model._meta.get_field(field).column for field in fields]
+
+            name = schema_editor.quote_name(
+                schema_editor._create_index_name(model, columns, suffix="_uniq")
+            )
+            schema_editor.execute(
+                "CREATE UNIQUE INDEX CONCURRENTLY {} ON {} ({})".format(
+                    name,
+                    model._meta.db_table,
+                    ", ".join(schema_editor.quote_name(column) for column in columns),
+                )
+            )
+            schema_editor.execute(
+                "ALTER TABLE {} ADD CONSTRAINT {} UNIQUE USING INDEX {}".format(
+                    model._meta.db_table, name, name
+                )
+            )

--- a/src/sentry/new_migrations/monkey/__init__.py
+++ b/src/sentry/new_migrations/monkey/__init__.py
@@ -18,6 +18,9 @@ to check are:
 - `django.db.migrations.writer.MIGRATION_TEMPLATE`. Verify that the template hasn't
   significantly changed. Details on what we've changed are in a comment on
   `sentry.migrations.monkey.writer.SENTRY_MIGRATION_TEMPLATE`
+- `sentry.db.migrations.concurrent_fields`: This isn't monkey patched, but we should
+  check that the implementation of django migrations that this relies on hasn't changed
+  significantly and that these concurrent fields still work.
 
 When you're happy that these changes are good to go, update
 `LAST_VERIFIED_DJANGO_VERSION` to the version of Django you're upgrading to. If the


### PR DESCRIPTION
This adds in an operation that we can use to replace `AlterUniqueTogether` when we generate
migrations. This changes the operations so that we create the unique index concurrently, and then
apply the unique constraint using that index.

Here's what's generated based on this usage:
```
ConcurrentAlterUniqueTogether(
    name="billingmetricusage",
    unique_together=set(
        [("billing_history", "project", "billing_metric", "outcome", "date", "reason_code")]
    ),
)
```
Previous unique was set up like:
```
ConcurrentAlterUniqueTogether(
    name="billingmetricusage",
    unique_together=set(
        [("billing_history", "project", "billing_metric", "outcome", "date")]
    ),
)
```

Forwards
```
--
-- Alter unique_together for billingmetricusage (1 constraint(s))
--
ALTER TABLE "accounts_billingmetricusage" DROP CONSTRAINT "accounts_billingmetricus_billing_history_id_proje_81c74a62_uniq";
CREATE UNIQUE INDEX CONCURRENTLY "accounts_billingmetricus_billing_history_id_proje_a04e07fd_uniq" ON accounts_billingmetricusage ("billing_history_id", "project_id", "billing_metric", "outcome", "date", "reason_code");
ALTER TABLE accounts_billingmetricusage ADD CONSTRAINT "accounts_billingmetricus_billing_history_id_proje_a04e07fd_uniq" UNIQUE USING INDEX "accounts_billingmetricus_billing_history_id_proje_a04e07fd_uniq";
```

Backwards
```
ALTER TABLE "accounts_billingmetricusage" DROP CONSTRAINT "accounts_billingmetricus_billing_history_id_proje_a04e07fd_uniq";
CREATE UNIQUE INDEX CONCURRENTLY "accounts_billingmetricus_billing_history_id_proje_81c74a62_uniq" ON accounts_billingmetricusage ("billing_history_id", "project_id", "billing_metric", "outcome", "date");
ALTER TABLE accounts_billingmetricusage ADD CONSTRAINT "accounts_billingmetricus_billing_history_id_proje_81c74a62_uniq" UNIQUE USING INDEX "accounts_billingmetricus_billing_history_id_proje_81c74a62_uniq";
--
-- Add field reason_code to billingmetricusage
--
```