### PR TITLE
fix(ui) Improve alignment of external icon in tag pills

### DIFF
--- a/src/sentry/static/sentry/app/components/pill.tsx
+++ b/src/sentry/static/sentry/app/components/pill.tsx
@@ -104,6 +104,8 @@ const PillValue = styled(PillName)<PillValueProps>`
     `0 ${p.theme.button.borderRadius} ${p.theme.button.borderRadius} 0`};
   font-family: ${p => p.theme.text.familyMono};
   max-width: 100%;
+  display: flex;
+  align-items: center;
 
   > a {
     max-width: 100%;
@@ -119,7 +121,6 @@ const PillValue = styled(PillName)<PillValueProps>`
     display: inline;
     margin: 0 0 0 ${space(1)};
     color: ${p => p.theme.gray500};
-    line-height: 1.2;
     &:hover {
       color: ${p => p.theme.gray700};
     }


### PR DESCRIPTION
Fix the slight off center that the open icon had in pills.