### PR TITLE
ref(vsts): Limited scopes version of Azure Devops

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -853,6 +853,8 @@ SENTRY_FEATURES = {
     "organizations:integrations-incident-management": True,
     # Enable the MsTeams integration
     "organizations:integrations-msteams": False,
+    # Allow orgs to install AzureDevops with limited scopes
+    "organizations:integrations-vsts-limited-scopes": False,
     # Enable data forwarding functionality for organizations.
     "organizations:data-forwarding": True,
     # Enable experimental performance improvements.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -78,6 +78,7 @@ default_manager.add("organizations:integrations-alert-rule", OrganizationFeature
 default_manager.add("organizations:integrations-chat-unfurl", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-incident-management", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-msteams", OrganizationFeature)  # NOQA
+default_manager.add("organizations:integrations-vsts-limited-scopes", OrganizationFeature)  # NOQA
 default_manager.add("organizations:internal-catchall", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA
 default_manager.add("organizations:large-debug-files", OrganizationFeature)  # NOQA

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -182,6 +182,8 @@ class OAuth2Provider(Provider):
         if not refresh_token:
             raise IdentityNotValid("Missing refresh token")
 
+        # XXX(meredith): This is used in VSTS's `get_refresh_token_params`
+        kwargs["identity"] = identity
         data = self.get_refresh_token_params(refresh_token, *args, **kwargs)
 
         req = safe_urlopen(

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
-from sentry import http, options
+from sentry import http, options, features
+from sentry.auth.exceptions import IdentityNotValid
+from sentry.utils import json
+from sentry.http import safe_urlopen, safe_urlread
 
 from sentry.identity.oauth2 import OAuth2Provider, OAuth2LoginView, OAuth2CallbackView
 from sentry.utils.http import absolute_uri
@@ -40,12 +43,19 @@ class VSTSIdentityProvider(OAuth2Provider):
 
     oauth_access_token_url = "https://app.vssps.visualstudio.com/oauth2/token"
     oauth_authorize_url = "https://app.vssps.visualstudio.com/oauth2/authorize"
-    oauth_scopes = ("vso.code", "vso.graph", "vso.serviceendpoint_manage", "vso.work_write")
+
+    @property
+    def use_limited_scopes(self):
+        return use_limited_scopes(self.pipeline)
 
     def get_oauth_client_id(self):
+        if self.use_limited_scopes:
+            return options.get("vsts-limited.client-id")
         return options.get("vsts.client-id")
 
     def get_oauth_client_secret(self):
+        if self.use_limited_scopes:
+            return options.get("vsts-limited.client-secret")
         return options.get("vsts.client-secret")
 
     def get_refresh_token_url(self):
@@ -68,17 +78,58 @@ class VSTSIdentityProvider(OAuth2Provider):
     def get_refresh_token_headers(self):
         return {"Content-Type": "application/x-www-form-urlencoded", "Content-Length": "1654"}
 
-    def get_refresh_token_params(self, refresh_token, *args, **kwargs):
+    def get_refresh_token_params(self, refresh_token, identity, *args, **kwargs):
+
+        client_secret = options.get("vsts.client-secret")
+
+        # The token refresh flow does not operate within a pipeline in the same way
+        # that installation does, this means that we have to use the identity.scopes
+        # to determine which client_secret to use.
+        #
+        # If "vso.code" is missing from the identity.scopes, we know that we installed
+        # using the "vsts-limited.client-secret" and therefore should use that to refresh
+        # the token.
+        if "vso.code" not in identity.scopes:
+            client_secret = options.get("vsts-limited.client-secret")
+
         oauth_redirect_url = kwargs.get("redirect_url")
         if oauth_redirect_url is None:
             raise ValueError("VSTS requires oauth redirect url when refreshing identity")
         return {
             "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-            "client_assertion": self.get_oauth_client_secret(),
+            "client_assertion": client_secret,
             "grant_type": "refresh_token",
             "assertion": refresh_token,
             "redirect_uri": absolute_uri(oauth_redirect_url),
         }
+
+    def refresh_identity(self, identity, *args, **kwargs):
+        """
+            Almost identical to OAuth2Provider but passes through the identity
+            into `get_refresh_token_params`. We do this because the identity.scopes
+            tell us which client_secret to use.
+        """
+        refresh_token = identity.data.get("refresh_token")
+
+        if not refresh_token:
+            raise IdentityNotValid("Missing refresh token")
+
+        data = self.get_refresh_token_params(refresh_token, identity, *args, **kwargs)
+
+        req = safe_urlopen(
+            url=self.get_refresh_token_url(), headers=self.get_refresh_token_headers(), data=data
+        )
+
+        try:
+            body = safe_urlread(req)
+            payload = json.loads(body)
+        except Exception:
+            payload = {}
+
+        self.handle_refresh_error(req, payload)
+
+        identity.data.update(self.get_oauth_data(payload))
+        return identity.update(data=identity.data)
 
     def build_identity(self, data):
         data = data["data"]
@@ -117,3 +168,11 @@ class VSTSOAuth2CallbackView(OAuth2CallbackView):
         if req.headers["Content-Type"].startswith("application/x-www-form-urlencoded"):
             return dict(parse_qsl(body))
         return json.loads(body)
+
+
+def use_limited_scopes(pipeline):
+    return features.has(
+        "organizations:integrations-vsts-limited-scopes",
+        pipeline.organization,
+        actor=pipeline.request.user,
+    )

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -30,7 +30,7 @@ from sentry.integrations.vsts.issues import VstsIssueSync
 from sentry.models import Repository
 from sentry.pipeline import NestedPipelineView
 from sentry.identity.pipeline import IdentityProviderPipeline
-from sentry.identity.vsts import VSTSIdentityProvider, get_user_info
+from sentry.identity.vsts import get_user_info, use_limited_scopes
 from sentry.pipeline import PipelineView
 from sentry.web.helpers import render_to_response
 from sentry.tasks.integrations import migrate_repo
@@ -340,8 +340,17 @@ class VstsIntegrationProvider(IntegrationProvider):
                 }
             )
 
+    def get_scopes(self):
+        if use_limited_scopes(self.pipeline):
+            return ("vso.graph", "vso.serviceendpoint_manage", "vso.work_write")
+
+        return ("vso.code", "vso.graph", "vso.serviceendpoint_manage", "vso.work_write")
+
     def get_pipeline_views(self):
-        identity_pipeline_config = {"redirect_url": absolute_uri(self.oauth_redirect_url)}
+        identity_pipeline_config = {
+            "redirect_url": absolute_uri(self.oauth_redirect_url),
+            "oauth_scopes": self.get_scopes(),
+        }
 
         identity_pipeline_view = NestedPipelineView(
             bind_key="identity",
@@ -357,7 +366,7 @@ class VstsIntegrationProvider(IntegrationProvider):
         oauth_data = self.get_oauth_data(data)
         account = state["account"]
         user = get_user_info(data["access_token"])
-        scopes = sorted(VSTSIdentityProvider.oauth_scopes)
+        scopes = sorted(self.get_scopes())
         base_url = self.get_base_url(data["access_token"], account["accountId"])
 
         integration = {

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -140,6 +140,9 @@ register("github-app.client-secret", flags=FLAG_PRIORITIZE_DISK)
 # VSTS Integration
 register("vsts.client-id", flags=FLAG_PRIORITIZE_DISK)
 register("vsts.client-secret", flags=FLAG_PRIORITIZE_DISK)
+# VSTS Integration - with limited scopes
+register("vsts-limited.client-id", flags=FLAG_PRIORITIZE_DISK)
+register("vsts-limited.client-secret", flags=FLAG_PRIORITIZE_DISK)
 
 # PagerDuty Integration
 register("pagerduty.app-id", default="")

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -121,6 +121,8 @@ def pytest_configure(config):
             "github-app.client-secret": "github-client-secret",
             "vsts.client-id": "vsts-client-id",
             "vsts.client-secret": "vsts-client-secret",
+            "vsts-limited.client-id": "vsts-limited-client-id",
+            "vsts-limited.client-secret": "vsts-limited-client-secret",
             "vercel.client-id": "vercel-client-id",
             "vercel.client-secret": "vercel-client-secret",
             "msteams.client-id": "msteams-client-id",

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -5,6 +5,7 @@ import responses
 from time import time
 
 from sentry.models import Identity, IdentityProvider, Integration
+from sentry.testutils.helpers import with_feature
 from .testutils import VstsIntegrationTestCase
 
 
@@ -39,5 +40,46 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         )
 
         identity = Identity.objects.get(id=identity.id)
+        assert identity.scopes == [
+            "vso.code",
+            "vso.graph",
+            "vso.serviceendpoint_manage",
+            "vso.work_write",
+        ]
+        assert identity.data["access_token"] == "new-access-token"
+        assert identity.data["refresh_token"] == "new-refresh-token"
+
+    @with_feature("organizations:integrations-vsts-limited-scopes")
+    def test_refreshes_expired_token_limited_scopes(self):
+        self.assert_installation()
+        integration = Integration.objects.get(provider="vsts")
+
+        # Make the Identity have an expired token
+        idp = IdentityProvider.objects.get(external_id=self.vsts_account_id)
+        identity = Identity.objects.get(idp_id=idp.id)
+        identity.data["expires"] = int(time()) - int(123456789)
+        identity.save()
+
+        # New values VSTS will return on refresh
+        self.access_token = "new-access-token"
+        self.refresh_token = "new-refresh-token"
+        self._stub_vsts()
+
+        # Make a request with expired token
+        integration.get_installation(
+            integration.organizations.first().id
+        ).get_client().get_projects(self.vsts_base_url)
+
+        # Second to last request, before the Projects request, was to refresh
+        # the Access Token.
+        assert responses.calls[-2].request.url == "https://app.vssps.visualstudio.com/oauth2/token"
+
+        # Then we request the Projects with the new token
+        assert responses.calls[-1].request.url == u"{}_apis/projects?stateFilter=WellFormed".format(
+            self.vsts_base_url.lower()
+        )
+
+        identity = Identity.objects.get(id=identity.id)
+        assert identity.scopes == ["vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]
         assert identity.data["access_token"] == "new-access-token"
         assert identity.data["refresh_token"] == "new-refresh-token"

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -5,9 +5,9 @@ import six
 import responses
 from sentry.utils.compat.mock import patch, Mock
 
-from sentry.identity.vsts import VSTSIdentityProvider
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.integrations.vsts import VstsIntegration, VstsIntegrationProvider
+from sentry.testutils.helpers import with_feature
 from sentry.models import (
     Integration,
     IntegrationExternalProject,
@@ -23,6 +23,9 @@ from tests.sentry.plugins.testutils import (
     VstsPlugin,
 )
 from .testutils import VstsIntegrationTestCase, CREATE_SUBSCRIPTION
+
+FULL_SCOPES = ["vso.code", "vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]
+LIMITED_SCOPES = ["vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]
 
 
 class VstsIntegrationProviderTest(VstsIntegrationTestCase):
@@ -45,7 +48,26 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         assert integration.name == self.vsts_account_name
 
         metadata = integration.metadata
-        assert metadata["scopes"] == list(VSTSIdentityProvider.oauth_scopes)
+        assert metadata["scopes"] == [
+            "vso.code",
+            "vso.graph",
+            "vso.serviceendpoint_manage",
+            "vso.work_write",
+        ]
+        assert metadata["subscription"]["id"] == CREATE_SUBSCRIPTION["id"]
+        assert metadata["domain_name"] == self.vsts_base_url
+
+    @with_feature("organizations:integrations-vsts-limited-scopes")
+    def test_limited_scopes_flow(self):
+        self.assert_installation()
+
+        integration = Integration.objects.get(provider="vsts")
+
+        assert integration.external_id == self.vsts_account_id
+        assert integration.name == self.vsts_account_name
+
+        metadata = integration.metadata
+        assert metadata["scopes"] == LIMITED_SCOPES
         assert metadata["subscription"]["id"] == CREATE_SUBSCRIPTION["id"]
         assert metadata["domain_name"] == self.vsts_base_url
 
@@ -149,7 +171,8 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         assert resp.status_code == 200, resp.content
         assert b"No accounts found" in resp.content
 
-    def test_webhook_subscription_created_once(self):
+    @patch("sentry.integrations.vsts.VstsIntegrationProvider.get_scopes", return_value=FULL_SCOPES)
+    def test_webhook_subscription_created_once(self, mock_get_scopes):
         self.assert_installation()
 
         state = {
@@ -174,7 +197,8 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
             == data["metadata"]["subscription"]
         )
 
-    def test_fix_subscription(self):
+    @patch("sentry.integrations.vsts.VstsIntegrationProvider.get_scopes", return_value=FULL_SCOPES)
+    def test_fix_subscription(self, mock_get_scopes):
         external_id = "1234567890"
         Integration.objects.create(metadata={}, provider="vsts", external_id=external_id)
         data = VstsIntegrationProvider().build_integration(
@@ -197,7 +221,8 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
 
 
 class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
-    def test_success(self):
+    @patch("sentry.integrations.vsts.VstsIntegrationProvider.get_scopes", return_value=FULL_SCOPES)
+    def test_success(self, mock_get_scopes):
         state = {
             "account": {"accountName": self.vsts_account_name, "accountId": self.vsts_account_id},
             "base_url": self.vsts_base_url,
@@ -220,11 +245,10 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
 
         assert integration_dict["user_identity"]["type"] == "vsts"
         assert integration_dict["user_identity"]["external_id"] == self.vsts_account_id
-        assert integration_dict["user_identity"]["scopes"] == sorted(
-            VSTSIdentityProvider.oauth_scopes
-        )
+        assert integration_dict["user_identity"]["scopes"] == FULL_SCOPES
 
-    def test_create_subscription_forbidden(self):
+    @patch("sentry.integrations.vsts.VstsIntegrationProvider.get_scopes", return_value=FULL_SCOPES)
+    def test_create_subscription_forbidden(self, mock_get_scopes):
         responses.replace(
             responses.POST,
             u"https://{}.visualstudio.com/_apis/hooks/subscriptions".format(
@@ -258,7 +282,8 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
             integration.build_integration(state)
         assert "sufficient account access to create webhooks" in six.text_type(err)
 
-    def test_create_subscription_unauthorized(self):
+    @patch("sentry.integrations.vsts.VstsIntegrationProvider.get_scopes", return_value=FULL_SCOPES)
+    def test_create_subscription_unauthorized(self, mock_get_scopes):
         responses.replace(
             responses.POST,
             u"https://{}.visualstudio.com/_apis/hooks/subscriptions".format(

--- a/tests/sentry/integrations/vsts_extension/test_provider.py
+++ b/tests/sentry/integrations/vsts_extension/test_provider.py
@@ -11,12 +11,17 @@ from sentry.integrations.vsts_extension import (
 )
 from sentry.models import Integration
 from tests.sentry.integrations.vsts.testutils import VstsIntegrationTestCase
+from tests.sentry.integrations.vsts.test_integration import FULL_SCOPES
 
 
 class VstsExtensionIntegrationProviderTest(VstsIntegrationTestCase):
     provider = VstsExtensionIntegrationProvider()
 
-    def test_get_pipeline_views(self):
+    @patch(
+        "sentry.integrations.vsts.integration.VstsIntegrationProvider.get_scopes",
+        return_value=FULL_SCOPES,
+    )
+    def test_get_pipeline_views(self, mock_get_scopes):
         # Should be same as the VSTS integration, but with a different last
         # step.
         views = self.provider.get_pipeline_views()
@@ -27,7 +32,11 @@ class VstsExtensionIntegrationProviderTest(VstsIntegrationTestCase):
 
     @patch("sentry.integrations.vsts.integration.get_user_info")
     @patch("sentry.integrations.vsts.integration.VstsIntegrationProvider.create_subscription")
-    def test_build_integration(self, create_sub, get_user_info):
+    @patch(
+        "sentry.integrations.vsts.integration.VstsIntegrationProvider.get_scopes",
+        return_value=FULL_SCOPES,
+    )
+    def test_build_integration(self, mock_get_scopes, create_sub, get_user_info):
         get_user_info.return_value = {"id": "987"}
         create_sub.return_value = (1, "sharedsecret")
 


### PR DESCRIPTION
Add support for installing Azure DevOps integrations with limited scopes (more info in https://github.com/getsentry/getsentry/pull/4258)

The refresh token code doesn't happen within a typical pipeline so we don't have the organization readily available. To deal with this, I'm using the `identity.scopes` to be able to determine which credentials to use. 