### PR TITLE
ref(django): Clarify comment on django.conf.settings hack

### DIFF
--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -145,10 +145,10 @@ def configure(ctx, py, yaml, skip_service_validation=False):
 
     install("sentry_config", py, DEFAULT_SETTINGS_MODULE)
 
-    # HACK: we need to force access of django.conf.settings to
-    # ensure we don't hit any import-driven recursive behavior
     from django.conf import settings
 
+    # HACK: we need to force access of django.conf.settings to
+    # ensure we don't hit any import-driven recursive behavior
     hasattr(settings, "INSTALLED_APPS")
 
     from .initializer import initialize_app


### PR DESCRIPTION
When we applied black it put a space between the import and the `hasattr` call. This just moves the comment to the more relevant part.