### PR TITLE
build: Bump maxminddb reader

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -26,7 +26,7 @@ ipaddress>=1.0.16,<1.1.0 ; python_version < "3.3"
 jsonschema==3.2.0
 kombu==3.0.37
 lxml>=4.3.3,<4.4.0
-maxminddb==1.4.1
+maxminddb==1.5.0
 mistune>0.7,<0.9
 mmh3>=2.3.1,<2.4
 msgpack>=0.6.1,<0.7.0


### PR DESCRIPTION
I'm specifically bumping this for [0], to fix errors in python3 mode. You can read more about the removal of the deprecated `Features` API here [1].

This is only a one version minor bump, and the changelog can be found at [2].

[0]: https://github.com/maxmind/MaxMind-DB-Reader-python/commit/3aac426e354f91814f6fd0829baee137b0bb093f
[1]: https://github.com/pypa/setuptools/issues/2017
[2]: https://github.com/maxmind/MaxMind-DB-Reader-python/releases/tag/v1.5.0