### PR TITLE
chore(async-csv): Remove data-export feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -809,8 +809,6 @@ SENTRY_FEATURES = {
     # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION
     # is not enabled).
     "organizations:create": True,
-    # Enable the 'data-export' interface.
-    "organizations:data-export": False,
     # Enable the 'discover' interface.
     "organizations:discover": False,
     # Enable attaching arbitrary files to events.

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -33,8 +33,9 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
         Create a new asynchronous file export task, and
         email user upon completion,
         """
-        # Ensure new data-export features are enabled
-        if not features.has("organizations:data-export", organization):
+        # The data export feature is only available alongside `discover-query`.
+        # So to export issue tags, they must have have `discover-query`
+        if not features.has("organizations:discover-query", organization):
             return Response(status=404)
 
         # Get environment_id and limit if available
@@ -65,9 +66,6 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         # Discover Pre-processing
         if data["query_type"] == ExportQueryType.DISCOVER_STR:
-            if not features.has("organizations:discover-basic", organization, actor=request.user):
-                return Response(status=403)
-
             query_info = data["query_info"]
 
             if len(query_info.get("field", [])) > MAX_FIELDS:

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -23,7 +23,7 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
         Used to populate page emailed to the user.
         """
 
-        if not features.has("organizations:data-export", organization):
+        if not features.has("organizations:discover-query", organization):
             return Response(status=404)
 
         try:

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -60,7 +60,6 @@ default_manager.add("organizations:artifacts-in-settings", OrganizationFeature) 
 default_manager.add("organizations:boolean-search", OrganizationFeature)  # NOQA
 default_manager.add("organizations:breadcrumbs-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-symbol-sources", OrganizationFeature)  # NOQA
-default_manager.add("organizations:data-export", OrganizationFeature)  # NOQA
 default_manager.add("organizations:data-forwarding", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover-basic", OrganizationFeature)  # NOQA

--- a/src/sentry/static/sentry/app/components/dataExport.tsx
+++ b/src/sentry/static/sentry/app/components/dataExport.tsx
@@ -93,7 +93,7 @@ class DataExport extends React.Component<Props, State> {
     const {inProgress} = this.state;
     const {children, disabled, icon} = this.props;
     return (
-      <Feature features={['organizations:data-export']}>
+      <Feature features={['organizations:discover-query']}>
         {inProgress ? (
           <NewButton
             size="small"

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
@@ -44,7 +44,7 @@ function renderDownloadButton(canEdit: boolean, props: Props) {
   } else {
     return (
       <Feature
-        features={['organizations:data-export']}
+        features={['organizations:discover-query']}
         renderDisabled={() => renderBrowserExportButton(canEdit, props)}
       >
         {renderAsyncExportButton(canEdit, props)}

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -13,7 +13,7 @@ describe('DataExport', function() {
     features: [],
   });
   const mockAuthorizedOrg = TestStubs.Organization({
-    features: ['data-export'],
+    features: ['discover-query'],
   });
   const mockPayload = {
     queryType: 'Issues-by-Tag',

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -21,18 +21,16 @@ class DataExportTest(APITestCase):
         self.login_as(user=self.user)
 
     def test_authorization(self):
-        # Without the data-export feature, the endpoint should 404
-        self.get_valid_response(self.organization.slug, status_code=404, **self.payload)
+        with self.feature({"organizations:discover-query": False}):
+            # Without the discover-query feature, the endpoint should 404
+            self.get_valid_response(self.organization.slug, status_code=404, **self.payload)
         # Without project permissions, the endpoint should 403
         modified_payload = {"query_type": self.payload["query_type"], "query_info": {"project": -5}}
-        with self.feature("organizations:data-export"):
+        with self.feature("organizations:discover-query"):
             self.get_valid_response(self.organization.slug, status_code=403, **modified_payload)
-        # Without the discover-basic feature, the endpoint should 403
+        # With the right permissions, the endpoint should 201
         discover_payload = {"query_type": "Discover", "query_info": self.payload["query_info"]}
-        with self.feature("organizations:data-export"):
-            self.get_valid_response(self.organization.slug, status_code=403, **discover_payload)
-        # With both, the endpoint should 201
-        with self.feature(["organizations:data-export", "organizations:discover-basic"]):
+        with self.feature("organizations:discover-query"):
             self.get_valid_response(self.organization.slug, status_code=201, **discover_payload)
 
     def test_new_export(self):
@@ -40,7 +38,7 @@ class DataExportTest(APITestCase):
         Ensures that a request to this endpoint returns a 201 status code
         and an appropriate response object
         """
-        with self.feature("organizations:data-export"):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(
                 self.organization.slug, status_code=201, **self.payload
             )
@@ -66,10 +64,10 @@ class DataExportTest(APITestCase):
         Checks to make sure that identical requests (same payload, organization, user)
         are routed to the same ExportedData object, with a 200 status code
         """
-        with self.feature("organizations:data-export"):
+        with self.feature("organizations:discover-query"):
             response1 = self.get_response(self.organization.slug, **self.payload)
         data_export = ExportedData.objects.get(id=response1.data["id"])
-        with self.feature("organizations:data-export"):
+        with self.feature("organizations:discover-query"):
             response2 = self.get_valid_response(self.organization.slug, **self.payload)
         assert response2.data == {
             "id": data_export.id,
@@ -99,9 +97,7 @@ class DataExportTest(APITestCase):
             "query_type": ExportQueryType.DISCOVER_STR,
             "query_info": {"env": "test", "field": ["id"] * (MAX_FIELDS + 1)},
         }
-        with self.feature(
-            {"organizations:data-export": True, "organizations:discover-basic": True}
-        ):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(self.organization.slug, status_code=400, **payload)
         assert response.data == {
             "detail": "You can export up to 20 fields at a time. Please delete some and try again."
@@ -116,9 +112,7 @@ class DataExportTest(APITestCase):
             "query_type": ExportQueryType.DISCOVER_STR,
             "query_info": {"env": "test", "statsPeriod": "24h"},
         }
-        with self.feature(
-            {"organizations:data-export": True, "organizations:discover-basic": True}
-        ):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(self.organization.slug, status_code=201, **payload)
         data_export = ExportedData.objects.get(id=response.data["id"])
         query_info = data_export.query_info
@@ -141,9 +135,7 @@ class DataExportTest(APITestCase):
             "query_type": ExportQueryType.DISCOVER_STR,
             "query_info": {"env": "test", "statsPeriodStart": "1w", "statsPeriodEnd": "5d"},
         }
-        with self.feature(
-            {"organizations:data-export": True, "organizations:discover-basic": True}
-        ):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(self.organization.slug, status_code=201, **payload)
         data_export = ExportedData.objects.get(id=response.data["id"])
         query_info = data_export.query_info
@@ -169,9 +161,7 @@ class DataExportTest(APITestCase):
                 "end": "2020-05-19T14:00:00",
             },
         }
-        with self.feature(
-            {"organizations:data-export": True, "organizations:discover-basic": True}
-        ):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(self.organization.slug, status_code=201, **payload)
         data_export = ExportedData.objects.get(id=response.data["id"])
         query_info = data_export.query_info

--- a/tests/sentry/data_export/endpoints/test_data_export_details.py
+++ b/tests/sentry/data_export/endpoints/test_data_export_details.py
@@ -24,7 +24,7 @@ class DataExportDetailsTest(APITestCase):
         )
 
     def test_content(self):
-        with self.feature("organizations:data-export"):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(self.organization.slug, self.data_export.id)
         assert response.data["id"] == self.data_export.id
         assert response.data["user"] == {
@@ -39,7 +39,7 @@ class DataExportDetailsTest(APITestCase):
         }
 
     def test_early(self):
-        with self.feature("organizations:data-export"):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(self.organization.slug, self.data_export.id)
         assert response.data["dateFinished"] is None
         assert response.data["dateExpired"] is None
@@ -50,7 +50,7 @@ class DataExportDetailsTest(APITestCase):
             date_finished=timezone.now() - timedelta(weeks=2),
             date_expired=timezone.now() + timedelta(weeks=1),
         )
-        with self.feature("organizations:data-export"):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(self.organization.slug, self.data_export.id)
         assert response.data["dateFinished"] is not None
         assert response.data["dateFinished"] == self.data_export.date_finished
@@ -63,7 +63,7 @@ class DataExportDetailsTest(APITestCase):
             date_finished=timezone.now() - timedelta(weeks=2),
             date_expired=timezone.now() - timedelta(weeks=1),
         )
-        with self.feature("organizations:data-export"):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(self.organization.slug, self.data_export.id)
         assert response.data["dateFinished"] is not None
         assert response.data["dateFinished"] == self.data_export.date_finished
@@ -72,7 +72,7 @@ class DataExportDetailsTest(APITestCase):
         assert response.data["status"] == ExportStatus.Expired
 
     def test_no_file(self):
-        with self.feature("organizations:data-export"):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(self.organization.slug, self.data_export.id)
         assert response.data["checksum"] is None
         assert response.data["fileName"] is None
@@ -84,7 +84,7 @@ class DataExportDetailsTest(APITestCase):
         )
         file.putfile(six.BytesIO(contents))
         self.data_export.update(file=file)
-        with self.feature("organizations:data-export"):
+        with self.feature("organizations:discover-query"):
             response = self.get_valid_response(self.organization.slug, self.data_export.id)
         assert response.data["checksum"] == sha1(contents).hexdigest()
         assert response.data["fileName"] == "test.csv"


### PR DESCRIPTION
Removing the data-export feature flag here and coupling the feature with the
discover-query feature flag. This has the implication that in order to use data
export with issue tags, they must first have the discover-query feature enabled.