### PR TITLE
test(jest): Fix flakey `<OrganizationContext>` (maybe) and `<IssueList>`

### DIFF
--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -264,6 +264,7 @@ describe('IssueList', function() {
 
       // Update stores with saved searches
       await tick();
+      await tick();
       wrapper.update();
 
       // Main /issues/ request
@@ -299,6 +300,7 @@ describe('IssueList', function() {
       createWrapper();
 
       await tick();
+      await tick();
       wrapper.update();
 
       expect(issuesRequest).toHaveBeenCalledWith(
@@ -332,6 +334,7 @@ describe('IssueList', function() {
       });
       createWrapper();
 
+      await tick();
       await tick();
       wrapper.update();
 
@@ -367,6 +370,7 @@ describe('IssueList', function() {
       createWrapper({params: {searchId: '123'}});
 
       await tick();
+      await tick();
       wrapper.update();
 
       expect(issuesRequest).toHaveBeenCalledWith(
@@ -401,6 +405,7 @@ describe('IssueList', function() {
       createWrapper({location: {query: {query: 'level:error'}}});
 
       await tick();
+      await tick();
       wrapper.update();
 
       expect(issuesRequest).toHaveBeenCalledWith(
@@ -434,6 +439,7 @@ describe('IssueList', function() {
       createWrapper({location: {query: {query: ''}}});
 
       await tick();
+      await tick();
       wrapper.update();
 
       expect(issuesRequest).toHaveBeenCalledWith(
@@ -457,6 +463,7 @@ describe('IssueList', function() {
         body: [localSavedSearch],
       });
       createWrapper();
+      await tick();
       await tick();
       wrapper.update();
 
@@ -521,6 +528,7 @@ describe('IssueList', function() {
       });
       createWrapper();
       await tick();
+      await tick();
       await wrapper.update();
 
       // Update the search input
@@ -550,6 +558,7 @@ describe('IssueList', function() {
         body: [savedSearch],
       });
       createWrapper();
+      await tick();
       await tick();
       wrapper.update();
 
@@ -659,6 +668,7 @@ describe('IssueList', function() {
         body: [savedSearch, assignedToMe],
       });
       createWrapper();
+      await tick();
       await tick();
       wrapper.update();
 
@@ -807,6 +817,7 @@ describe('IssueList', function() {
         },
         location: {query: {project: ['123'], environment: ['prod']}},
       });
+      await tick();
       await tick();
       wrapper.update();
 

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -53,9 +53,15 @@ describe('OrganizationContext', function() {
   });
 
   afterEach(async function() {
+    // Ugh these stores are a pain
+    // It's possible that a test still has an update action in flight
+    // and caues store to update *AFTER* we reset. Attempt to flush out updates
+    await tick();
+    await tick();
     wrapper.unmount();
     OrganizationStore.reset();
     // await for store change to finish propagating
+    await tick();
     await tick();
 
     TeamStore.loadInitialData.mockRestore();


### PR DESCRIPTION
This has been causing us grief for awhile... also needed this on IssuesList from a different PR.