### PR TITLE
feat(msteams): Enable sending of alert rule messages for Microsoft Teams

### DIFF
--- a/src/sentry/integrations/msteams/__init__.py
+++ b/src/sentry/integrations/msteams/__init__.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 from sentry.utils.imports import import_submodules
 from sentry.rules import rules
 
-from .notify_action import MSTeamsNotifyServiceAction
+from .notify_action import MsTeamsNotifyServiceAction
 
 import_submodules(globals(), __name__, __path__)
 
-rules.add(MSTeamsNotifyServiceAction)
+rules.add(MsTeamsNotifyServiceAction)

--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -6,7 +6,6 @@ from six.moves.urllib.parse import urlencode
 
 from sentry import options
 from sentry.integrations.client import ApiClient
-from sentry.utils.http import absolute_uri
 
 
 # five minutes which is industry standard clock skew tolerence
@@ -48,61 +47,7 @@ class MsTeamsAbstractClient(ApiClient):
     def send_message(self, conversation_id, data):
         return self.post(self.ACTIVITY_URL % conversation_id, data=data)
 
-    def send_welcome_message(self, conversation_id, signed_params):
-        url = u"%s?signed_params=%s" % (
-            absolute_uri("/extensions/msteams/configure/"),
-            signed_params,
-        )
-        # TODO: Refactor message creation
-        logo = {
-            "type": "Image",
-            "url": "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png",
-            "size": "Medium",
-        }
-        welcome = {
-            "type": "TextBlock",
-            "weight": "Bolder",
-            "size": "Large",
-            "text": "Welcome to Sentry for Microsoft Teams",
-            "wrap": True,
-        }
-        description = {
-            "type": "TextBlock",
-            "text": "You can use the Sentry app for Microsoft Teams to get notifications that allow you to assign, ignore, or resolve directly in your chat.",
-            "wrap": True,
-        }
-        instruction = {
-            "type": "TextBlock",
-            "text": "If that sounds good to you, finish the setup process.",
-            "wrap": True,
-        }
-        button = {
-            "type": "Action.OpenUrl",
-            "title": "Complete Setup",
-            "url": url,
-        }
-        card = {
-            "type": "AdaptiveCard",
-            "body": [
-                {
-                    "type": "ColumnSet",
-                    "columns": [
-                        {"type": "Column", "items": [logo], "width": "auto"},
-                        {
-                            "type": "Column",
-                            "items": [welcome],
-                            "width": "stretch",
-                            "verticalContentAlignment": "Center",
-                        },
-                    ],
-                },
-                description,
-                instruction,
-            ],
-            "actions": [button],
-            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-            "version": "1.2",
-        }
+    def send_card(self, conversation_id, card):
         payload = {
             "type": "message",
             "attachments": [

--- a/src/sentry/integrations/msteams/notify_action.py
+++ b/src/sentry/integrations/msteams/notify_action.py
@@ -7,7 +7,7 @@ from sentry.rules.actions.base import EventAction
 from sentry.models import Integration
 from sentry.utils import metrics
 
-from .utils import get_channel_id, build_incident_card
+from .utils import get_channel_id, build_group_card
 from .client import MsTeamsClient
 
 
@@ -75,7 +75,6 @@ class MsTeamsNotifyServiceAction(EventAction):
         channel = self.get_option("channel_id")
 
         try:
-            pass
             integration = Integration.objects.get(
                 provider="msteams", organizations=self.project.organization, id=integration_id
             )
@@ -84,7 +83,7 @@ class MsTeamsNotifyServiceAction(EventAction):
 
         def send_notification(event, futures):
             rules = [f.rule for f in futures]
-            card = build_incident_card(event.group, event=event, rules=rules)
+            card = build_group_card(event.group, event=event, rules=rules)
 
             client = MsTeamsClient(integration)
             client.send_card(channel, card)

--- a/src/sentry/integrations/msteams/notify_action.py
+++ b/src/sentry/integrations/msteams/notify_action.py
@@ -11,7 +11,7 @@ from .utils import get_channel_id, build_incident_card
 from .client import MsTeamsClient
 
 
-class MSTeamsNotifyServiceForm(forms.Form):
+class MsTeamsNotifyServiceForm(forms.Form):
     team = forms.ChoiceField(choices=(), widget=forms.Select())
     channel = forms.CharField(widget=forms.TextInput())
     channel_id = forms.HiddenInput()
@@ -20,7 +20,7 @@ class MSTeamsNotifyServiceForm(forms.Form):
         team_list = [(i.id, i.name) for i in kwargs.pop("integrations")]
         self.channel_transformer = kwargs.pop("channel_transformer")
 
-        super(MSTeamsNotifyServiceForm, self).__init__(*args, **kwargs)
+        super(MsTeamsNotifyServiceForm, self).__init__(*args, **kwargs)
 
         if team_list:
             self.fields["team"].initial = team_list[0][0]
@@ -29,7 +29,7 @@ class MSTeamsNotifyServiceForm(forms.Form):
         self.fields["team"].widget.choices = self.fields["team"].choices
 
     def clean(self):
-        cleaned_data = super(MSTeamsNotifyServiceForm, self).clean()
+        cleaned_data = super(MsTeamsNotifyServiceForm, self).clean()
 
         integration_id = cleaned_data.get("team")
         channel = cleaned_data.get("channel", "")
@@ -52,13 +52,13 @@ class MSTeamsNotifyServiceForm(forms.Form):
         return cleaned_data
 
 
-class MSTeamsNotifyServiceAction(EventAction):
-    form_cls = MSTeamsNotifyServiceForm
+class MsTeamsNotifyServiceAction(EventAction):
+    form_cls = MsTeamsNotifyServiceForm
     label = u"Send a notification to the {team} Team to {channel}"
     prompt = "Send a Microsoft Teams notification"
 
     def __init__(self, *args, **kwargs):
-        super(MSTeamsNotifyServiceAction, self).__init__(*args, **kwargs)
+        super(MsTeamsNotifyServiceAction, self).__init__(*args, **kwargs)
         self.form_fields = {
             "team": {
                 "type": "choice",

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -201,6 +201,9 @@ def build_incident_actions(group):
 
     # These targets are made so that the button will toggle its element
     # on or off, and toggle the other elements off.
+
+    # Could probably be done in much fewer lines if we deep
+    # copied a template and then modified for each action
     resolve_targets = [
         {"elementId": "resolveTitle"},
         {"elementId": "resolveInput"},
@@ -364,7 +367,9 @@ def build_incident_assign_card(group):
     teams = [
         {"title": u"#{}".format(u.slug), "value": u"team:{}".format(u.id)}
         for u in group.project.teams.all()
-    ].sort()
+    ]
+    teams.sort()
+    teams = [{"title": "Me", "value": "0"}] + teams
     title_card = {
         "type": "TextBlock",
         "size": "Large",

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -6,6 +6,7 @@ from sentry.utils.http import absolute_uri
 from .client import MsTeamsClient
 
 MSTEAMS_MAX_ITERS = 100
+ME = "ME"
 
 
 def channel_filter(channel, name):
@@ -367,7 +368,7 @@ def build_group_assign_card(group):
         for u in group.project.teams.all()
     ]
     teams.sort()
-    teams = [{"title": "Me", "value": "ME"}] + teams
+    teams = [{"title": "Me", "value": ME}] + teams
     title_card = {
         "type": "TextBlock",
         "size": "Large",

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
-from sentry.models import Integration
+from sentry.models import Integration, Project, GroupStatus
 from sentry.utils.compat import filter
+from sentry.utils.http import absolute_uri
 from .client import MsTeamsClient
 
 MSTEAMS_MAX_ITERS = 100
@@ -54,3 +55,371 @@ def get_channel_id(organization, integration_id, name):
         members = client.get_member_list(team_id, continuation_token)
 
     return None
+
+
+def build_welcome_card(signed_params):
+    url = u"%s?signed_params=%s" % (absolute_uri("/extensions/msteams/configure/"), signed_params,)
+    # TODO: Refactor message creation
+    logo = {
+        "type": "Image",
+        "url": "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png",
+        "size": "Medium",
+    }
+    welcome = {
+        "type": "TextBlock",
+        "weight": "Bolder",
+        "size": "Large",
+        "text": "Welcome to Sentry for Microsoft Teams",
+        "wrap": True,
+    }
+    description = {
+        "type": "TextBlock",
+        "text": "You can use the Sentry app for Microsoft Teams to get notifications that allow you to assign, ignore, or resolve directly in your chat.",
+        "wrap": True,
+    }
+    instruction = {
+        "type": "TextBlock",
+        "text": "If that sounds good to you, finish the setup process.",
+        "wrap": True,
+    }
+    button = {
+        "type": "Action.OpenUrl",
+        "title": "Complete Setup",
+        "url": url,
+    }
+    return {
+        "type": "AdaptiveCard",
+        "body": [
+            {
+                "type": "ColumnSet",
+                "columns": [
+                    {"type": "Column", "items": [logo], "width": "auto"},
+                    {
+                        "type": "Column",
+                        "items": [welcome],
+                        "width": "stretch",
+                        "verticalContentAlignment": "Center",
+                    },
+                ],
+            },
+            description,
+            instruction,
+        ],
+        "actions": [button],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.2",
+    }
+
+
+def build_incident_title(group):
+    # TODO: implement with event as well
+    title = {"type": "TextBlock", "size": "Large", "weight": "Bolder"}
+    ev_metadata = group.get_event_metadata()
+    ev_type = group.get_event_type()
+
+    if ev_type == "error" and "type" in ev_metadata:
+        text = ev_metadata["type"]
+    else:
+        text = group.title
+
+    link = group.get_absolute_url()
+
+    title_text = u"[{}]({})".format(text, link)
+    title["text"] = title_text
+    return title
+
+
+def build_incident_desc(group):
+    # TODO: implement with event as well
+    ev_type = group.get_event_type()
+    if ev_type == "error":
+        ev_metadata = group.get_event_metadata()
+        text = ev_metadata.get("value") or ev_metadata.get("function")
+        return {"type": "TextBlock", "size": "Medium", "weight": "Bolder", "text": text}
+    else:
+        return None
+
+
+def build_rule_url(rule, group, project):
+    org_slug = group.organization.slug
+    project_slug = project.slug
+    rule_url = u"/settings/{}/projects/{}/alerts/rules/{}/".format(org_slug, project_slug, rule.id)
+    return absolute_uri(rule_url)
+
+
+def build_incident_footer(group, rules, project):
+    # TODO: implement with event as well
+    image_column = {
+        "type": "Column",
+        "items": [
+            {
+                "type": "Image",
+                "url": "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png",
+                "height": "20px",
+            }
+        ],
+        "width": "auto",
+    }
+
+    text = u"{}".format(group.qualified_short_id)
+    if rules:
+        rule_url = build_rule_url(rules[0], group, project)
+        text += u" via [{}]({})".format(rules[0].label, rule_url)
+        if len(rules) > 1:
+            text += u" (+{} other)".format(len(rules) - 1)
+
+    text_column = {
+        "type": "Column",
+        "items": [{"type": "TextBlock", "size": "Small", "weight": "Lighter", "text": text}],
+        "isSubtle": True,
+        "width": "auto",
+        "spacing": "none",
+    }
+
+    date = group.last_seen.replace(microsecond=0).isoformat()
+    date_text = "{{DATE(%s, SHORT)}} at {{TIME(%s)}}" % (date, date)
+    date_column = {
+        "type": "Column",
+        "items": [
+            {
+                "type": "TextBlock",
+                "size": "Small",
+                "weight": "Lighter",
+                "horizontalAlignment": "Center",
+                "text": date_text,
+            }
+        ],
+        "width": "auto",
+        "separator": True,
+    }
+
+    return {"type": "ColumnSet", "columns": [image_column, text_column, date_column]}
+
+
+def build_incident_actions(group):
+    status = group.get_status()
+
+    # These targets are made so that the button will toggle its element
+    # on or off, and toggle the other elements off.
+    resolve_targets = [
+        {"elementId": "resolveTitle"},
+        {"elementId": "resolveInput"},
+        {"elementId": "resolveSubmit"},
+        {"elementId": "ignoreTitle", "isVisible": False},
+        {"elementId": "ignoreInput", "isVisible": False},
+        {"elementId": "ignoreSubmit", "isVisible": False},
+        {"elementId": "assignTitle", "isVisible": False},
+        {"elementId": "assignInput", "isVisible": False},
+        {"elementId": "assignSubmit", "isVisible": False},
+    ]
+
+    ignore_targets = [
+        {"elementId": "resolveTitle", "isVisible": False},
+        {"elementId": "resolveInput", "isVisible": False},
+        {"elementId": "resolveSubmit", "isVisible": False},
+        {"elementId": "ignoreTitle"},
+        {"elementId": "ignoreInput"},
+        {"elementId": "ignoreSubmit"},
+        {"elementId": "assignTitle", "isVisible": False},
+        {"elementId": "assignInput", "isVisible": False},
+        {"elementId": "assignSubmit", "isVisible": False},
+    ]
+
+    assign_targets = [
+        {"elementId": "resolveTitle", "isVisible": False},
+        {"elementId": "resolveInput", "isVisible": False},
+        {"elementId": "resolveSubmit", "isVisible": False},
+        {"elementId": "ignoreTitle", "isVisible": False},
+        {"elementId": "ignoreInput", "isVisible": False},
+        {"elementId": "ignoreSubmit", "isVisible": False},
+        {"elementId": "assignTitle"},
+        {"elementId": "assignInput"},
+        {"elementId": "assignSubmit"},
+    ]
+
+    if status == GroupStatus.RESOLVED:
+        resolve_action = {
+            "type": "Action.Submit",
+            "title": "Unresolve",
+            "data": {"actionType": "unresolve"},
+        }
+    else:
+        resolve_action = {
+            "type": "Action.ToggleVisibility",
+            "title": "Resolve",
+            "targetElements": resolve_targets,
+        }
+
+    if status == GroupStatus.IGNORED:
+        ignore_action = {
+            "type": "Action.Submit",
+            "title": "Stop Ignoring",
+            "data": {"actionType": "unignore"},
+        }
+    else:
+        ignore_action = {
+            "type": "Action.ToggleVisibility",
+            "title": "Ignore",
+            "targetElements": ignore_targets,
+        }
+
+    assign_text = "Assign"
+    assign_action = {
+        "type": "Action.ToggleVisibility",
+        "title": assign_text,
+        "targetElements": assign_targets,
+    }
+
+    return {
+        "type": "ColumnSet",
+        "columns": [
+            {
+                "type": "Column",
+                "items": [{"type": "ActionSet", "actions": [resolve_action]}],
+                "width": "stretch",
+            },
+            {
+                "type": "Column",
+                "items": [{"type": "ActionSet", "actions": [ignore_action]}],
+                "width": "stretch",
+            },
+            {
+                "type": "Column",
+                "items": [{"type": "ActionSet", "actions": [assign_action]}],
+                "width": "stretch",
+            },
+        ],
+    }
+
+
+def build_incident_resolve_card():
+    title_card = {
+        "type": "TextBlock",
+        "size": "Large",
+        "text": "Resolve",
+        "weight": "Bolder",
+        "id": "resolveTitle",
+        "isVisible": False,
+    }
+
+    input_card = {
+        "type": "Input.ChoiceSet",
+        "value": "0",
+        "id": "resolveInput",
+        "isVisible": False,
+        "choices": [
+            {"title": "Immediately", "value": "0"},
+            {"title": "In the current release", "value": "1"},
+            {"title": "In the next release", "value": "2"},
+        ],
+    }
+
+    submit_card = {
+        "type": "ActionSet",
+        "id": "resolveSubmit",
+        "isVisible": False,
+        "actions": [
+            {"type": "Action.Submit", "title": "Resolve", "data": {"actionType": "resolve"}}
+        ],
+    }
+
+    return [title_card, input_card, submit_card]
+
+
+def build_incident_ignore_card():
+    title_card = {
+        "type": "TextBlock",
+        "size": "Large",
+        "text": "Ignore until this happens again...",
+        "weight": "Bolder",
+        "id": "ignoreTitle",
+        "isVisible": False,
+    }
+
+    input_card = {
+        "type": "Input.ChoiceSet",
+        "value": "0",
+        "id": "ignoreInput",
+        "isVisible": False,
+        "choices": [
+            {"title": "1 time", "value": "0"},
+            {"title": "10 times", "value": "1"},
+            {"title": "100 times", "value": "2"},
+            {"title": "1,000 times", "value": "3"},
+            {"title": "10,000 times", "value": "4"},
+        ],
+    }
+
+    submit_card = {
+        "type": "ActionSet",
+        "id": "ignoreSubmit",
+        "isVisible": False,
+        "actions": [{"type": "Action.Submit", "title": "Ignore", "data": {"actionType": "ignore"}}],
+    }
+
+    return [title_card, input_card, submit_card]
+
+
+def build_incident_assign_card(group):
+    teams = [
+        {"title": u"#{}".format(u.slug), "value": u"team:{}".format(u.id)}
+        for u in group.project.teams.all()
+    ].sort()
+    title_card = {
+        "type": "TextBlock",
+        "size": "Large",
+        "text": "Assign to...",
+        "weight": "Bolder",
+        "id": "assignTitle",
+        "isVisible": False,
+    }
+
+    input_card = {
+        "type": "Input.ChoiceSet",
+        "id": "assignInput",
+        "isVisible": False,
+        "choices": teams,
+    }
+
+    submit_card = {
+        "type": "ActionSet",
+        "id": "assignSubmit",
+        "isVisible": False,
+        "actions": [{"type": "Action.Submit", "title": "Assign", "data": {"actionType": "assign"}}],
+    }
+
+    return [title_card, input_card, submit_card]
+
+
+def build_incident_action_cards(group):
+    status = group.get_status()
+    action_cards = []
+    if status != GroupStatus.RESOLVED:
+        action_cards += build_incident_resolve_card()
+    if status != GroupStatus.IGNORED:
+        action_cards += build_incident_ignore_card()
+    action_cards += build_incident_assign_card(group)
+
+    return {"type": "ColumnSet", "columns": [{"type": "Column", "items": action_cards}]}
+
+
+def build_incident_card(group, event, rules):
+    project = Project.objects.get_from_cache(id=group.project_id)
+
+    title = build_incident_title(group)
+    body = [title]
+
+    desc = build_incident_desc(group)
+    if desc:
+        body.append(desc)
+
+    footer = build_incident_footer(group, rules, project)
+    body.append(footer)
+
+    actions = build_incident_actions(group)
+    body.append(actions)
+
+    action_cards = build_incident_action_cards(group)
+    body.append(action_cards)
+
+    return {"type": "AdaptiveCard", "body": body}

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -17,6 +17,7 @@ from sentry.utils.signing import sign
 from sentry.web.decorators import transaction_start
 
 from .client import MsTeamsPreInstallClient, MsTeamsJwtClient, get_token_data, CLOCK_SKEW
+from .utils import build_welcome_card
 
 logger = logging.getLogger("sentry.integrations.msteams.webhooks")
 
@@ -135,7 +136,8 @@ class MsTeamsWebhookEndpoint(Endpoint):
 
         # send welcome message to the team
         client = MsTeamsPreInstallClient(access_token, data["serviceUrl"])
-        client.send_welcome_message(team["id"], signed_params)
+        card = build_welcome_card(signed_params)
+        client.send_card(team["id"], card)
         return self.respond(status=201)
 
     def handle_member_removed(self, request):

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -63,7 +63,7 @@ class MsTeamsNotifyActionTest(RuleTestCase):
         # with MS Teams cards.
         title_card = attachments[0]["content"]["body"][0]
         title_pattern = "\[%s\](.*)" % event.title
-        assert re.match(title_pattern, title_card["text"]) is not None
+        assert re.match(title_pattern, title_card["text"])
 
     def test_render_label(self):
         rule = self.get_rule(data={"team": self.integration.id, "channel": "Tatooine"})

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -1,0 +1,147 @@
+from __future__ import absolute_import
+
+import responses
+import time
+import re
+
+from sentry.utils import json
+from sentry.models import Integration
+from sentry.testutils.cases import RuleTestCase
+from sentry.integrations.msteams import MsTeamsNotifyServiceAction
+
+
+class MsTeamsNotifyActionTest(RuleTestCase):
+    rule_cls = MsTeamsNotifyServiceAction
+
+    def setUp(self):
+        event = self.get_event()
+
+        self.integration = Integration.objects.create(
+            provider="msteams",
+            name="Galactic Empire",
+            external_id="D4r7h_Pl4gu315_th3_w153",
+            metadata={
+                "service_url": "https://smba.trafficmanager.net/amer",
+                "access_token": "d4rk51d3",
+                "expires_at": int(time.time()) + 86400,
+            },
+        )
+        self.integration.add_organization(event.project.organization, self.user)
+
+    def assert_form_valid(self, form, expected_channel_id, expected_channel):
+        assert form.is_valid()
+        assert form.cleaned_data["channel_id"] == expected_channel_id
+        assert form.cleaned_data["channel"] == expected_channel
+
+    @responses.activate
+    def test_applies_correctly(self):
+        event = self.get_event()
+
+        rule = self.get_rule(
+            data={"team": self.integration.id, "channel": "Naboo", "channel_id": "nb"}
+        )
+
+        results = list(rule.after(event=event, state=self.get_state()))
+        assert len(results) == 1
+
+        responses.add(
+            method=responses.POST,
+            url="https://smba.trafficmanager.net/amer/v3/conversations/nb/activities",
+            status=200,
+            json={},
+        )
+
+        results[0].callback(event, futures=[])
+        data = json.loads(responses.calls[0].request.body)
+
+        assert "attachments" in data
+        attachments = data["attachments"]
+        assert len(attachments) == 1
+
+        # Wish there was a better way to do this, but we
+        # can't pass the title and title link separately
+        # with MS Teams cards.
+        title_card = attachments[0]["content"]["body"][0]
+        title_pattern = "\[%s\](.*)" % event.title
+        assert re.match(title_pattern, title_card["text"]) is not None
+
+    def test_render_label(self):
+        rule = self.get_rule(data={"team": self.integration.id, "channel": "Tatooine"})
+
+        assert rule.render_label() == "Send a notification to the Galactic Empire Team to Tatooine"
+
+    def test_render_label_without_integration(self):
+        self.integration.delete()
+
+        rule = self.get_rule(data={"team": self.integration.id, "channel": "Coruscant"})
+
+        assert rule.render_label() == "Send a notification to the [removed] Team to Coruscant"
+
+    @responses.activate
+    def test_valid_channel_selected(self):
+        rule = self.get_rule(data={"team": self.integration.id, "channel": "Death Star"})
+
+        channels = [{"id": "d_s", "name": "Death Star"}]
+
+        responses.add(
+            method=responses.GET,
+            url="https://smba.trafficmanager.net/amer/v3/teams/D4r7h_Pl4gu315_th3_w153/conversations",
+            json={"conversations": channels},
+        )
+
+        form = rule.get_form_instance()
+        self.assert_form_valid(form, "d_s", "Death Star")
+
+    @responses.activate
+    def test_valid_member_selected(self):
+        rule = self.get_rule(data={"team": self.integration.id, "channel": "Darth Vader"})
+
+        channels = [{"id": "i_s_d", "name": "Imperial Star Destroyer"}]
+
+        responses.add(
+            method=responses.GET,
+            url="https://smba.trafficmanager.net/amer/v3/teams/D4r7h_Pl4gu315_th3_w153/conversations",
+            json={"conversations": channels},
+        )
+
+        members = [{"name": "Darth Vader", "id": "d_v", "tenantId": "1428-5714-2857"}]
+
+        responses.add(
+            method=responses.GET,
+            url="https://smba.trafficmanager.net/amer/v3/conversations/D4r7h_Pl4gu315_th3_w153/pagedmembers?pageSize=500",
+            json={"members": members},
+        )
+
+        responses.add(
+            method=responses.POST,
+            url="https://smba.trafficmanager.net/amer/v3/conversations",
+            json={"id": "i_am_your_father"},
+        )
+
+        form = rule.get_form_instance()
+        self.assert_form_valid(form, "i_am_your_father", "Darth Vader")
+
+    @responses.activate
+    def test_invalid_channel_selected(self):
+        rule = self.get_rule(data={"team": self.integration.id, "channel": "Alderaan"})
+
+        channels = [{"name": "Hoth", "id": "hh"}]
+
+        responses.add(
+            method=responses.GET,
+            url="https://smba.trafficmanager.net/amer/v3/teams/D4r7h_Pl4gu315_th3_w153/conversations",
+            json={"conversations": channels},
+        )
+
+        members = [{"name": "Darth Sidious", "id": "d_s", "tenantId": "0102-0304-0506"}]
+
+        responses.add(
+            method=responses.GET,
+            url="https://smba.trafficmanager.net/amer/v3/conversations/D4r7h_Pl4gu315_th3_w153/pagedmembers?pageSize=500",
+            json={"members": members},
+        )
+
+        form = rule.get_form_instance()
+
+        assert not form.is_valid()
+        assert len(form.errors) == 1


### PR DESCRIPTION
Allow messages to be sent to MS Teams when an alert rule is created and triggered. Some manual testing, and some unit tests as well. Also refactor welcome message creation and change class names to be more consistent.

Alert rule message looks like this:
![image](https://user-images.githubusercontent.com/32143113/88243834-8b981b80-cc46-11ea-93d0-ac2b0213b2e4.png)

Fixes API-1126