### PR TITLE
fix(thread-selector): Fix empty space

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/option.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/option.tsx
@@ -6,7 +6,7 @@ import {t, tct} from 'app/locale';
 import Tooltip from 'app/components/tooltip';
 import TextOverflow from 'app/components/textOverflow';
 import {EntryTypeData} from 'app/types';
-import {IconFire, IconCheckmark} from 'app/icons';
+import {IconFire} from 'app/icons';
 
 import {Grid, GridCell} from './styles';
 
@@ -58,10 +58,11 @@ const Option = ({id, details, name, crashed, crashedInfo}: Props) => {
         </InnerCell>
       </GridCell>
       <GridCell>
-        <InnerCell isCentered>
-          {crashed ? (
-            crashedInfo ? (
+        {crashed && (
+          <InnerCell isCentered>
+            {crashedInfo ? (
               <Tooltip
+                skipWrapper
                 title={tct('Errored with [crashedInfo]', {
                   crashedInfo: crashedInfo.values[0].type,
                 })}
@@ -71,11 +72,9 @@ const Option = ({id, details, name, crashed, crashedInfo}: Props) => {
               </Tooltip>
             ) : (
               <IconFire color="red400" />
-            )
-          ) : (
-            <IconCheckmark color="green400" size="xs" />
-          )}
-        </InnerCell>
+            )}
+          </InnerCell>
+        )}
       </GridCell>
     </Grid>
   );
@@ -86,7 +85,6 @@ export default Option;
 const InnerCell = styled('div')<{isCentered?: boolean; color?: Color; isBold?: boolean}>`
   display: flex;
   align-items: center;
-  height: 100%;
   justify-content: ${p => (p.isCentered ? 'center' : 'flex-start')};
   font-weight: ${p => (p.isBold ? 600 : 400)};
   ${p => p.color && `color: ${p.theme[p.color]}`}

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/styles.tsx
@@ -6,17 +6,15 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 const Grid = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   display: grid;
-  height: 100%;
   grid-gap: ${space(1)};
   align-items: center;
   grid-template-columns: 30px 2.5fr 4fr 0fr 40px;
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    grid-template-columns: 40px 2.5fr 3.5fr 2.5fr 40px;
+    grid-template-columns: 40px 2.5fr 3.5fr 105px 40px;
   }
 `;
 
 const GridCell = styled('div')`
-  height: 100%;
   ${overflowEllipsis};
 `;
 


### PR DESCRIPTION
**Type:** Fix
**Description:**

- In Safari, the thread selector component displays a blank space before the options. This PR fixes the issue. 
- Remove the Checkmark icon
- Centralize the icon Fire 

closes: https://getsentry.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=ISSUE&modal=detail&selectedIssue=ISSUE-935&search=adobe

ps: Refactoring this component to use grid layouts would be better, avoiding other possible problems. This component currently uses the DropDownAutoComplete component that was not designed to display a table/grid but a list. 



