### PR TITLE
fix(discover): Fix key error for project keys

### DIFF
--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -26,6 +26,7 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
                 filter_params["start"],
                 filter_params["end"],
                 query=request.GET.get("query"),
+                include_transactions=request.GET.get("includeTransactions") == "1",
             )
 
         return self.paginate(

--- a/src/sentry/static/sentry/app/actionCreators/tags.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/tags.tsx
@@ -84,7 +84,8 @@ export function fetchTagValues(
   tagKey: string,
   search: string | null = null,
   projectIds: string[] | null = null,
-  endpointParams: Query | null = null
+  endpointParams: Query | null = null,
+  includeTransactions = false
 ) {
   const url = `/organizations/${orgId}/tags/${tagKey}/values/`;
 
@@ -105,6 +106,9 @@ export function fetchTagValues(
     if (endpointParams.statsPeriod) {
       query.statsPeriod = endpointParams.statsPeriod;
     }
+  }
+  if (includeTransactions) {
+    query.includeTransactions = '1';
   }
 
   return api.requestPromise(url, {

--- a/src/sentry/static/sentry/app/views/events/searchBar.tsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.tsx
@@ -69,7 +69,10 @@ class SearchBar extends React.PureComponent<SearchBarProps> {
         tag.key,
         query,
         projectIdStrings,
-        endpointParams
+        endpointParams,
+
+        // allows searching for tags on transactions as well
+        true
       ).then(
         results =>
           flatten(results.filter(({name}) => defined(name)).map(({name}) => name)),

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -669,7 +669,15 @@ class SnubaTagStorage(TagStorage):
         )
 
     def get_tag_value_paginator_for_projects(
-        self, projects, environments, key, start=None, end=None, query=None, order_by="-last_seen"
+        self,
+        projects,
+        environments,
+        key,
+        start=None,
+        end=None,
+        query=None,
+        order_by="-last_seen",
+        include_transactions=False,
     ):
         from sentry.api.paginator import SequencePaginator
 
@@ -678,7 +686,7 @@ class SnubaTagStorage(TagStorage):
 
         dataset = Dataset.Events
         snuba_key = snuba.get_snuba_column_name(key)
-        if snuba_key.startswith("tags["):
+        if include_transactions and snuba_key.startswith("tags["):
             snuba_key = snuba.get_snuba_column_name(key, dataset=Dataset.Discover)
             if not snuba_key.startswith("tags["):
                 dataset = Dataset.Discover
@@ -687,7 +695,7 @@ class SnubaTagStorage(TagStorage):
 
         # transaction status needs a special case so that the user interacts with the names and not codes
         transaction_status = snuba_key == "transaction_status"
-        if transaction_status:
+        if include_transactions and transaction_status:
             conditions.append(
                 [
                     snuba_key,
@@ -706,7 +714,7 @@ class SnubaTagStorage(TagStorage):
             if converted_query is not None:
                 conditions.append([snuba_key, ">=", converted_query - FUZZY_NUMERIC_DISTANCE])
                 conditions.append([snuba_key, "<=", converted_query + FUZZY_NUMERIC_DISTANCE])
-        elif key == PROJECT_ALIAS:
+        elif include_transactions and key == PROJECT_ALIAS:
             project_filters = {
                 "id__in": projects,
             }
@@ -753,23 +761,24 @@ class SnubaTagStorage(TagStorage):
             referrer="tagstore.get_tag_value_paginator_for_projects",
         )
 
-        # With transaction_status we need to map the ids back to their names
-        if transaction_status:
-            results = OrderedDict(
-                [
-                    (SPAN_STATUS_CODE_TO_NAME[result_key], data)
-                    for result_key, data in six.iteritems(results)
-                ]
-            )
-        # With project names we map the ids back to the project slugs
-        elif key == PROJECT_ALIAS:
-            results = OrderedDict(
-                [
-                    (project_slugs[value], data)
-                    for value, data in six.iteritems(results)
-                    if value in project_slugs
-                ]
-            )
+        if include_transactions:
+            # With transaction_status we need to map the ids back to their names
+            if transaction_status:
+                results = OrderedDict(
+                    [
+                        (SPAN_STATUS_CODE_TO_NAME[result_key], data)
+                        for result_key, data in six.iteritems(results)
+                    ]
+                )
+            # With project names we map the ids back to the project slugs
+            elif key == PROJECT_ALIAS:
+                results = OrderedDict(
+                    [
+                        (project_slugs[value], data)
+                        for value, data in six.iteritems(results)
+                        if value in project_slugs
+                    ]
+                )
 
         tag_values = [
             TagValue(key=key, value=six.text_type(value), **fix_tag_value_data(data))

--- a/tests/js/spec/views/events/searchBar.spec.jsx
+++ b/tests/js/spec/views/events/searchBar.spec.jsx
@@ -78,7 +78,9 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {project: ['1', '2'], statsPeriod: '14d'}})
+      expect.objectContaining({
+        query: {project: ['1', '2'], statsPeriod: '14d', includeTransactions: '1'},
+      })
     );
 
     await tick();
@@ -113,7 +115,9 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {project: ['1', '2'], statsPeriod: '14d'}})
+      expect.objectContaining({
+        query: {project: ['1', '2'], statsPeriod: '14d', includeTransactions: '1'},
+      })
     );
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('');
@@ -194,7 +198,9 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {project: ['1', '2'], statsPeriod: '14d'}})
+      expect.objectContaining({
+        query: {project: ['1', '2'], statsPeriod: '14d', includeTransactions: '1'},
+      })
     );
     selectFirstAutocompleteItem(wrapper);
     expect(wrapper.find('input').prop('value')).toBe('!gpu:*"Nvidia 1080ti" ');

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -152,7 +152,16 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
         self.store_event(data={"timestamp": iso_format(self.day_ago)}, project_id=self.project.id)
         self.store_event(data={"timestamp": iso_format(self.min_ago)}, project_id=self.project.id)
         self.store_event(data={"timestamp": iso_format(self.day_ago)}, project_id=other_project.id)
-        self.run_test("project", expected=[(self.project.slug, 2)])
+
+        # without the includeTransactions flag, this will continue to search the Events Dataset for the
+        # projects tag, which doesn't exist here
+        self.run_test("project", expected=[])
+
+        # with the includeTransactions flag, this will search in the Discover Dataset where project
+        # has special meaning to refer to the sentry project rather than the project tag
+        self.run_test(
+            "project", qs_params={"includeTransactions": "1"}, expected=[(self.project.slug, 2)]
+        )
 
     def test_project_name_with_query(self):
         other_project = self.create_project(organization=self.org, name="test1")
@@ -161,10 +170,25 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
         self.store_event(data={"timestamp": iso_format(self.day_ago)}, project_id=other_project.id)
         self.store_event(data={"timestamp": iso_format(self.min_ago)}, project_id=other_project.id)
         self.store_event(data={"timestamp": iso_format(self.day_ago)}, project_id=other_project2.id)
-        self.run_test("project", qs_params={"query": "test"}, expected=[("test1", 2), ("test2", 1)])
-        self.run_test("project", qs_params={"query": "1"}, expected=[("test1", 2)])
-        self.run_test("project", qs_params={"query": "test3"}, expected=[])
-        self.run_test("project", qs_params={"query": "z"}, expected=[])
+
+        # without the includeTransactions flag, this will continue to search the Events Dataset for the
+        # projects tag, which doesn't exist here
+        self.run_test("project", qs_params={"query": "test"}, expected=[])
+
+        # with the includeTransactions flag, this will search in the Discover Dataset where project
+        # has special meaning to refer to the sentry project rather than the project tag
+        self.run_test(
+            "project",
+            qs_params={"includeTransactions": "1", "query": "test"},
+            expected=[("test1", 2), ("test2", 1)],
+        )
+        self.run_test(
+            "project", qs_params={"includeTransactions": "1", "query": "1"}, expected=[("test1", 2)]
+        )
+        self.run_test(
+            "project", qs_params={"includeTransactions": "1", "query": "test3"}, expected=[]
+        )
+        self.run_test("project", qs_params={"includeTransactions": "1", "query": "z"}, expected=[])
 
     def test_array_column(self):
         for i in range(3):
@@ -196,6 +220,13 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
         self.store_event(
             self.transaction, project_id=self.project.id,
         )
+
+    def run_test(self, key, expected, **kwargs):
+        # all tests here require that we search in transactions so make that the default here
+        qs_params = kwargs.get("qs_params", {})
+        qs_params["includeTransactions"] = "1"
+        kwargs["qs_params"] = qs_params
+        super(TransactionTagKeyValues, self).run_test(key, expected, **kwargs)
 
     def test_status(self):
         self.run_test("transaction.status", expected=[("unknown", 1), ("ok", 1)])

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -157,11 +157,14 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
     def test_project_name_with_query(self):
         other_project = self.create_project(organization=self.org, name="test1")
         other_project2 = self.create_project(organization=self.org, name="test2")
+        self.create_project(organization=self.org, name="test3")
         self.store_event(data={"timestamp": iso_format(self.day_ago)}, project_id=other_project.id)
         self.store_event(data={"timestamp": iso_format(self.min_ago)}, project_id=other_project.id)
         self.store_event(data={"timestamp": iso_format(self.day_ago)}, project_id=other_project2.id)
         self.run_test("project", qs_params={"query": "test"}, expected=[("test1", 2), ("test2", 1)])
         self.run_test("project", qs_params={"query": "1"}, expected=[("test1", 2)])
+        self.run_test("project", qs_params={"query": "test3"}, expected=[])
+        self.run_test("project", qs_params={"query": "z"}, expected=[])
 
     def test_array_column(self):
         for i in range(3):


### PR DESCRIPTION
Should always use project_id as snuba_key when searching project the project.
This ensures that we can always find the corresponding project slugs,

Fixes SENTRY-GY4