### PR TITLE
chore: update Electron symbol server URL

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1769,7 +1769,7 @@ SENTRY_BUILTIN_SOURCES = {
         "id": "sentry:electron",
         "name": "Electron",
         "layout": {"type": "native"},
-        "url": "https://electron-symbols.githubapp.com/",
+        "url": "https://symbols.electronjs.org/",
         "filters": {"filetypes": ["pdb", "breakpad", "sourcebundle"]},
         "is_public": True,
     },


### PR DESCRIPTION
https://symbols.electronjs.org/ is an alias for the old githubapp.com URL, we can't guarantee the longevity of the old URL so this should be updated.