### PR TITLE
fix: Update native snapshots after relay update

### DIFF
--- a/tests/symbolicator/__init__.py
+++ b/tests/symbolicator/__init__.py
@@ -65,6 +65,6 @@ def insta_snapshot_stacktrace_data(self, event):
             },
             "debug_meta": event.get("debug_meta"),
             "contexts": event.get("contexts"),
-            "errors": event.get("errors"),
+            "errors": [e for e in event.get("errors") or () if e.get("name") != "timestamp"],
         }
     )

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T18:18:23.771402Z'
+created: '2020-07-23T19:53:44.708761Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---
@@ -252,14 +252,7 @@ debug_meta:
     image_size: 1585152
     type: pe
     unwind_status: missing
-errors:
-- name: timestamp
-  sdk_time: '2018-03-22T10:07:53+00:00'
-  server_time: '2020-07-23T18:18:18.694767700+00:00'
-  type: past_timestamp
-- name: timestamp
-  type: past_timestamp
-  value: 1521713273
+errors: []
 exception:
   values:
   - mechanism:

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-11-19T11:19:42.001799Z'
+created: '2020-07-23T18:18:23.771402Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---
@@ -253,6 +253,10 @@ debug_meta:
     type: pe
     unwind_status: missing
 errors:
+- name: timestamp
+  sdk_time: '2018-03-22T10:07:53+00:00'
+  server_time: '2020-07-23T18:18:18.694767700+00:00'
+  type: past_timestamp
 - name: timestamp
   type: past_timestamp
   value: 1521713273

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_missing_dsym.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_missing_dsym.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-11-19T11:22:56.297739Z'
+created: '2020-07-23T18:18:44.303684Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---
@@ -252,6 +252,10 @@ debug_meta:
     type: pe
     unwind_status: missing
 errors:
+- name: timestamp
+  sdk_time: '2018-03-22T10:07:53+00:00'
+  server_time: '2020-07-23T18:18:41.236555500+00:00'
+  type: past_timestamp
 - name: timestamp
   type: past_timestamp
   value: 1521713273

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_missing_dsym.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_missing_dsym.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T18:18:44.303684Z'
+created: '2020-07-23T19:54:04.468992Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---
@@ -252,13 +252,6 @@ debug_meta:
     type: pe
     unwind_status: missing
 errors:
-- name: timestamp
-  sdk_time: '2018-03-22T10:07:53+00:00'
-  server_time: '2020-07-23T18:18:41.236555500+00:00'
-  type: past_timestamp
-- name: timestamp
-  type: past_timestamp
-  value: 1521713273
 - image_path: C:\projects\breakpad-tools\windows\Release\crash.exe
   image_uuid: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1
   message: None

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-11-19T11:19:56.334183Z'
+created: '2020-07-23T19:33:18.859595Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---
@@ -26,7 +26,7 @@ debug_meta:
     image_addr: '0x2a0000'
     image_size: 36864
     type: symbolic
-errors: null
+errors: []
 exception:
   values:
   - raw_stacktrace:

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_missing_debug_images.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_missing_debug_images.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2019-06-12T09:33:23.111878Z'
+created: '2020-07-23T19:33:26.234043Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---
 contexts: null
 debug_meta: null
-errors: null
+errors: []
 exception:
   values:
   - raw_stacktrace:

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_real_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_real_resolving.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-11-19T11:20:05.461583Z'
+created: '2020-07-23T19:33:42.975020Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---
@@ -24,7 +24,7 @@ debug_meta:
     version_major: 10
     version_minor: 12
     version_patchlevel: 4
-errors: null
+errors: []
 exception:
   values:
   - raw_stacktrace:


### PR DESCRIPTION
See https://github.com/getsentry/relay/pull/662

What I did:

```
docker pull us.gcr.io/sentryio/relay:latest
# docker pull us.gcr.io/sentryio/symbolicator:latest  # not this time, but maybe also useful
SENTRY_SNAPSHOTS_WRITEBACK=1 py.test tests/symbolicator/
```