### PR TITLE
fix(integrations): Remove self link check from bitbucket refs_changed webhook

### DIFF
--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -31,15 +31,7 @@ class Webhook(object):
         """
 
         name_from_event = event["repository"]["project"]["key"] + "/" + event["repository"]["slug"]
-        # build the URL manually since it doesn't come back from the API in
-        # the form that we need
-        url_from_event = event["repository"]["links"]["self"][0]["href"]
-
-        if (
-            repo.name != name_from_event
-            or repo.config.get("name") != name_from_event
-            or repo.url != url_from_event
-        ):
+        if repo.name != name_from_event or repo.config.get("name") != name_from_event:
             repo.update(name=name_from_event, config=dict(repo.config, name=name_from_event))
 
 


### PR DESCRIPTION
We’re trying to access `links`, which doesn’t exist in the [webhook payload](https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html). Fixing this entails making each dictionary look up a .get or just omitting the check altogether. Given the only thing we’re doing after the check is potentially updating name_from_event, it’s safe to remove the check.