### PR TITLE
feat(ui) Add sentry warnings for old style icons

### DIFF
--- a/src/sentry/static/sentry/app/components/alertLink.tsx
+++ b/src/sentry/static/sentry/app/components/alertLink.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import React from 'react';
 import omit from 'lodash/omit';
+import {withScope, captureException, Severity} from '@sentry/react';
 
 import Link from 'app/components/links/link';
 import ExternalLink from 'app/components/links/externalLink';
@@ -52,6 +53,16 @@ class AlertLink extends React.Component<Props> {
       to,
       href,
     } = this.props;
+
+    if (typeof icon === 'string') {
+      withScope(scope => {
+        scope.setLevel(Severity.Warning);
+        scope.setTag('icon', icon);
+        scope.setTag('componentType', 'alertLink');
+        captureException(new Error('Deprecated SVG icon referenced'));
+      });
+    }
+
     return (
       <StyledLink
         to={to}

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
+import {withScope, captureException, Severity} from '@sentry/react';
 
 import {Theme} from 'app/utils/theme';
 import ExternalLink from 'app/components/links/externalLink';
@@ -143,6 +144,15 @@ class Button extends React.Component<ButtonProps, {}> {
     // For `aria-label`
     const screenReaderLabel =
       label || (typeof children === 'string' ? children : undefined);
+
+    if (typeof icon === 'string') {
+      withScope(scope => {
+        scope.setLevel(Severity.Warning);
+        scope.setTag('icon', icon);
+        scope.setTag('componentType', 'button');
+        captureException(new Error('Deprecated SVG icon referenced'));
+      });
+    }
 
     // Buttons come in 4 flavors: <Link>, <ExternalLink>, <a>, and <button>.
     // Let's use props to determine which to serve up, so we don't have to think about it.


### PR DESCRIPTION
I *should* have caught all the string icon props. However, if I didn't logging a sentry warning will help track down any stragglers, or confirm that this code path is safe to remove.