### PR TITLE
fix(async-csv): Always use export all if available

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
@@ -38,19 +38,14 @@ function handleDownloadAsCsv(title: string, {organization, eventView, tableData}
 }
 
 function renderDownloadButton(canEdit: boolean, props: Props) {
-  const {tableData} = props;
-  if (!tableData || (tableData.data && tableData.data.length < 50)) {
-    return renderBrowserExportButton(canEdit, props);
-  } else {
-    return (
-      <Feature
-        features={['organizations:discover-query']}
-        renderDisabled={() => renderBrowserExportButton(canEdit, props)}
-      >
-        {renderAsyncExportButton(canEdit, props)}
-      </Feature>
-    );
-  }
+  return (
+    <Feature
+      features={['organizations:discover-query']}
+      renderDisabled={() => renderBrowserExportButton(canEdit, props)}
+    >
+      {renderAsyncExportButton(canEdit, props)}
+    </Feature>
+  );
 }
 
 function renderBrowserExportButton(canEdit: boolean, {isLoading, ...props}: Props) {


### PR DESCRIPTION
Only allowing them to use export all when we detect that there is more than
50 rows of results leads to a content shift once the results finished loading.
This causes users to misclick export all when they mean to click columns.
Instead, if they have access to export all, it should be displayed all all
times and disabled while loading.