### PR TITLE
fix(ui) Update icons used in integrations

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -64,6 +64,9 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
   get alerts() {
     const provider = this.provider;
     const metadata = this.metadata;
+    // The server response for integration installations includes old icon CSS classes
+    // We map those to the currently in use values to their react equivalents
+    // and fallback to IconFlag just in case.
     const alerts = (metadata.aspects.alerts || []).map(item => {
       switch (item.icon) {
         case 'icon-warning':

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -7,7 +7,7 @@ import {RequestOptions} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
-import {IconOpen, IconWarning} from 'app/icons';
+import {IconFlag, IconOpen, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Integration, IntegrationProvider} from 'app/types';
@@ -64,7 +64,15 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
   get alerts() {
     const provider = this.provider;
     const metadata = this.metadata;
-    const alerts = metadata.aspects.alerts || [];
+    const alerts = (metadata.aspects.alerts || []).map(item => {
+      switch (item.icon) {
+        case 'icon-warning':
+        case 'icon-warning-sm':
+          return {...item, icon: <IconWarning />};
+        default:
+          return {...item, icon: <IconFlag />};
+      }
+    });
 
     if (!provider.canAdd && metadata.aspects.externalInstall) {
       alerts.push({


### PR DESCRIPTION
These icons were missed earlier because the icon classname is defined in Django endpoints and then interpolated into React later.