### PR TITLE
feat(ui): Fix Issue Details layout when loading

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {RouteComponentProps} from 'react-router/lib/Router';
 import * as Sentry from '@sentry/react';
+import styled from '@emotion/styled';
 
 import {Client} from 'app/api';
 import {metric} from 'app/utils/analytics';
@@ -31,6 +32,7 @@ type Props = RouteComponentProps<
   project: Project;
   organization: Organization;
   environments: Environment[];
+  className?: string;
 };
 
 type State = {
@@ -191,11 +193,11 @@ class GroupEventDetails extends React.Component<Props, State> {
   }
 
   render() {
-    const {group, project, organization, environments, location} = this.props;
+    const {className, group, project, organization, environments, location} = this.props;
     const evt = withMeta(this.state.event);
 
     return (
-      <div>
+      <div className={className}>
         <div className="event-details-container">
           <div className="primary">
             {evt && (
@@ -247,4 +249,8 @@ class GroupEventDetails extends React.Component<Props, State> {
   }
 }
 
-export default GroupEventDetails;
+export default styled(GroupEventDetails)`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+`;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -313,6 +313,7 @@
   margin: -20px -40px;
   background: #fff;
   flex-direction: column;
+  flex: 1;
 
   @media (min-width: 1200px) {
     flex-direction: row;


### PR DESCRIPTION
The content does not stretch to the footer

Old:
![image](https://user-images.githubusercontent.com/79684/88428233-5b1cc280-cda9-11ea-84cf-7fa0647fe7be.png)

New:
![image](https://user-images.githubusercontent.com/79684/88428252-68d24800-cda9-11ea-947e-c60874ebbf9c.png)
