### PR TITLE
fix(perf-view) Format span durations with locale formatting

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -383,7 +383,7 @@ class SpanDetail extends React.Component<Props, State> {
     const endTimestamp: number = span.timestamp;
 
     const duration = (endTimestamp - startTimestamp) * 1000;
-    const durationString = `${duration.toFixed(3)}ms`;
+    const durationString = `${Number(duration.toFixed(3)).toLocaleString()}ms`;
 
     const unknownKeys = Object.keys(span).filter(key => {
       return !rawSpanKeys.has(key as any);

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -250,7 +250,7 @@ export const getHumanDuration = (duration: number): string => {
   // note: duration is assumed to be in seconds
 
   const durationMS = duration * 1000;
-  return `${durationMS.toFixed(2)}ms`;
+  return `${Number(durationMS.toFixed(2)).toLocaleString()}ms`;
 };
 
 const getLetterIndex = (letter: string): number => {


### PR DESCRIPTION
Use toLocaleString() and toFixed() to get well formatted durations that don't include x.999 values which came up when only using toLocaleString().

### Before
![Screen Shot 2020-07-24 at 6 02 01 PM](https://user-images.githubusercontent.com/24086/88439241-a4383b00-cdd8-11ea-9e90-87a03297e383.png)
 
### After

![Screen Shot 2020-07-24 at 6 09 22 PM](https://user-images.githubusercontent.com/24086/88439308-d6e23380-cdd8-11ea-9504-6323d508b272.png)

