### PR TITLE
fix: Correct language on newsletter consent

### DIFF
--- a/src/sentry/static/sentry/app/views/newsletterConsent.tsx
+++ b/src/sentry/static/sentry/app/views/newsletterConsent.tsx
@@ -44,7 +44,7 @@ export default class NewsletterConsent extends React.Component<Props> {
                   `We'd love to keep you updated via email with product and feature
                    announcements, promotions, educational materials, and events. Our updates
                    focus on relevant information, and we'll never sell your data to third
-                   parties. See our [link:Priacy Policy]{' '} for more details.
+                   parties. See our [link:Privacy Policy] for more details.
                    `,
                   {link: <ExternalLink href="https://sentry.io/privacy/" />}
                 )}


### PR DESCRIPTION
Invalid marker `{' '}` was present, likely due to a previous update where the ext was rendered via React.