### PR TITLE
fix(cleanup): Move EventAttachment to DELETES to clean up subsequent files as well.

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -175,7 +175,6 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
     # Deletions that use `BulkDeleteQuery` (and don't need to worry about child relations)
     # (model, datetime_field, order_by)
     BULK_QUERY_DELETES = [
-        (models.EventAttachment, "date_added", None),
         (models.UserReport, "date_added", None),
         (models.GroupEmailThread, "date", None),
         (models.GroupRuleStatus, "date_added", None),
@@ -183,7 +182,10 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
 
     # Deletions that use the `deletions` code path (which handles their child relations)
     # (model, datetime_field, order_by)
-    DELETES = ((models.Group, "last_seen", "last_seen"),)
+    DELETES = [
+            (models.EventAttachment, "date_added", None),
+            (models.Group, "last_seen", "last_seen"),
+    ]
 
     if not silent:
         click.echo("Removing expired values for LostPasswordHash")

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -183,8 +183,8 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
     # Deletions that use the `deletions` code path (which handles their child relations)
     # (model, datetime_field, order_by)
     DELETES = [
-            (models.EventAttachment, "date_added", None),
-            (models.Group, "last_seen", "last_seen"),
+        (models.EventAttachment, "date_added", None),
+        (models.Group, "last_seen", "last_seen"),
     ]
 
     if not silent:


### PR DESCRIPTION
This will require a follow-up pull request to remove `File` objects that match attachment types that have been de-referenced from the `EventAttachment` objects that have yet to be removed from the `File` table.