### PR TITLE
feat(ui): Better wording in project settings of crash reports

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.tsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.tsx
@@ -337,10 +337,10 @@ export const fields: {[key: string]: Field} = {
     type: 'range',
     label: t('Store Native Crash Reports'),
     help: t(
-      'Store native crash reports such as Minidumps for improved processing and download in issue details.  Overrides organization settings when enabled.'
+      'Store native crash reports such as Minidumps for improved processing and download in issue details. Overrides organization settings.'
     ),
     visible: ({features}) => features.has('event-attachments'),
-    formatLabel: formatStoreCrashReports,
+    formatLabel: value => formatStoreCrashReports(value, {inProjectSettings: true}),
     allowedValues: STORE_CRASH_REPORTS_VALUES,
   },
   allowedDomains: {

--- a/src/sentry/static/sentry/app/utils/crashReports.tsx
+++ b/src/sentry/static/sentry/app/utils/crashReports.tsx
@@ -1,13 +1,24 @@
 import {t, tct} from 'app/locale';
 
-export function formatStoreCrashReports(value: number | ''): React.ReactNode {
+type formatConfig = {
+  inProjectSettings?: boolean;
+};
+
+export function formatStoreCrashReports(
+  value: number | '',
+  formatConfig: formatConfig = {}
+): React.ReactNode {
   if (value === -1) {
     return t('Unlimited');
-  } else if (value === 0) {
-    return t('Disabled');
-  } else {
-    return tct('[value] per issue', {value});
   }
+  if (value === 0 && formatConfig.inProjectSettings) {
+    return t('Inherit organization settings');
+  }
+  if (value === 0) {
+    return t('Disabled');
+  }
+
+  return tct('[value] per issue', {value});
 }
 
 function getStoreCrashReportsValues() {

--- a/src/sentry/static/sentry/app/utils/crashReports.tsx
+++ b/src/sentry/static/sentry/app/utils/crashReports.tsx
@@ -11,11 +11,10 @@ export function formatStoreCrashReports(
   if (value === -1) {
     return t('Unlimited');
   }
-  if (value === 0 && formatConfig.inProjectSettings) {
-    return t('Inherit organization settings');
-  }
   if (value === 0) {
-    return t('Disabled');
+    return formatConfig.inProjectSettings
+      ? t('Inherit organization settings')
+      : t('Disabled');
   }
 
   return tct('[value] per issue', {value});


### PR DESCRIPTION
"Disabled" meant to inherit the organization-wide setting so we decided to make it more clear.

We are working on adding the proper disable storing crash reports option to per-project setting right now.

Before:
![image](https://user-images.githubusercontent.com/9060071/88560761-d04cf980-d02e-11ea-8833-213fd8f2a380.png)


After:
![image](https://user-images.githubusercontent.com/9060071/88560632-b01d3a80-d02e-11ea-9e25-7459573c4b75.png)
