### PR TITLE
fix(deletions): specify an order by column for attachments.

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -183,7 +183,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
     # Deletions that use the `deletions` code path (which handles their child relations)
     # (model, datetime_field, order_by)
     DELETES = [
-        (models.EventAttachment, "date_added", None),
+        (models.EventAttachment, "date_added", "date_added"),
         (models.Group, "last_seen", "last_seen"),
     ]
 


### PR DESCRIPTION
```
assert self.dtfield is not None and self.dtfield == self.order_by
AssertionError
```
womp.

Fixes SENTRY-H8W.