### PR TITLE
ref(slack): Use conversations.list for bot apps

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -25,7 +25,7 @@ from sentry.integrations.slack import post_migration
 from sentry.utils.audit import create_audit_entry
 
 from .client import SlackClient
-from .utils import logger
+from .utils import logger, get_integration_type
 
 from sentry.web.helpers import render_to_response
 
@@ -78,10 +78,7 @@ metadata = IntegrationMetadata(
 
 class SlackIntegration(IntegrationInstallation):
     def get_config_data(self):
-        metadata = self.model.metadata
-        # classic bots had a user_access_token in the metadata
-        default_installation = "classic_bot" if "user_access_token" in metadata else "workspace_app"
-        return {"installationType": metadata.get("installation_type", default_installation)}
+        return {"installationType": get_integration_type(self.model)}
 
 
 class SlackIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -56,6 +56,13 @@ QUERY_AGGREGATION_DISPLAY = {
 }
 
 
+def get_integration_type(integration):
+    metadata = integration.metadata
+    # classic bots had a user_access_token in the metadata
+    default_installation = "classic_bot" if "user_access_token" in metadata else "workspace_app"
+    return metadata.get("installation_type", default_installation)
+
+
 def format_actor_option(actor):
     if isinstance(actor, User):
         return {"text": actor.get_display_name(), "value": u"user:{}".format(actor.id)}
@@ -422,13 +429,9 @@ def get_channel_id_with_timeout(integration, name, timeout):
     # Look for channel ID
     payload = dict(token_payload, **{"exclude_archived": False, "exclude_members": True})
 
-    default_install_type = (
-        "classic_bot" if "user_access_token" in integration.metadata else "workspace_app"
-    )
-
     # workspace tokens are the only tokens that don't works with the conversations.list endpoint,
     # once eveyone is migrated we can remove this check and usages of channels.list
-    if integration.metadata.get("installation_type", default_install_type) == "workspace_app":
+    if get_integration_type(integration) == "workspace_app":
         list_types = LEGACY_LIST_TYPES
     else:
         list_types = LIST_TYPES

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -22,7 +22,7 @@ from sentry.utils.http import absolute_uri
 from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
 
 
-class GetChannelIdTest(TestCase):
+class GetChannelIdWorkspaceTest(TestCase):
     def setUp(self):
         self.resp = responses.mock
         self.resp.__enter__()
@@ -31,7 +31,7 @@ class GetChannelIdTest(TestCase):
             provider="slack",
             name="Awesome Team",
             external_id="TXXXXXXX1",
-            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+            metadata={"access_token": "xoxa-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
         )
         self.integration.add_organization(self.event.project.organization, self.user)
         self.add_list_response(
@@ -88,6 +88,41 @@ class GetChannelIdTest(TestCase):
     def test_invalid_channel_selected(self):
         assert get_channel_id(self.organization, self.integration.id, "#fake-channel")[1] is None
         assert get_channel_id(self.organization, self.integration.id, "@fake-user")[1] is None
+
+
+class GetChannelIdBotTest(GetChannelIdWorkspaceTest):
+    def setUp(self):
+        self.resp = responses.mock
+        self.resp.__enter__()
+
+        self.integration = Integration.objects.create(
+            provider="slack",
+            name="Awesome Team",
+            external_id="TXXXXXXX1",
+            metadata={
+                "access_token": "xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+                "installation_type": "born_as_bot",
+            },
+        )
+        self.integration.add_organization(self.event.project.organization, self.user)
+        self.add_list_response(
+            "conversations",
+            [
+                {"name": "my-channel", "id": "m-c"},
+                {"name": "other-chann", "id": "o-c"},
+                {"name": "my-private-channel", "id": "m-p-c", "is_private": True},
+            ],
+            result_name="channels",
+        )
+        self.add_list_response(
+            "users",
+            [
+                {"name": "morty", "id": "m", "profile": {"display_name": "Morty"}},
+                {"name": "other-user", "id": "o-u", "profile": {"display_name": "Jimbob"}},
+                {"name": "better_morty", "id": "bm", "profile": {"display_name": "Morty"}},
+            ],
+            result_name="members",
+        )
 
 
 class BuildIncidentAttachmentTest(TestCase):


### PR DESCRIPTION
Not too long ago a [PR](https://github.com/getsentry/sentry/pull/19446) was merged that added the option `slack.legacy-app`. This allows Sentry instances with that option set to `False` to be able to utilize the conversations.list endpoint for Slack. 

Sentry.io however, must have this option set to `True` because there are still users that have workspace apps enable and in use. We cannot use the conversations endpoints with the workspace apps because the workspace token is incompatible. 

Instead, we can look at the integration `metadata` to tell us whether or not an integration is a workspace app in order to determine which set of endpoints to use. 

