### PR TITLE
fix(apm) Do a better job of handling parens in raw searches

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -84,7 +84,7 @@ def parse_search_query(query):
                 "This is commonly caused by unmatched-parentheses. Enclose any text in double quotes.",
             )
         )
-    return IssueSearchVisitor().visit(tree)
+    return IssueSearchVisitor(allow_boolean=False).visit(tree)
 
 
 def convert_actor_value(value, projects, user, environments):

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -123,6 +123,22 @@ class ParseSearchQueryTest(TestCase):
             ):
                 parse_search_query(invalid_query)
 
+    def test_parens_in_query(self):
+        assert parse_search_query(
+            "TypeError Anonymous function(app/javascript/utils/transform-object-keys)"
+        ) == [
+            SearchFilter(
+                key=SearchKey(name="message"),
+                operator="=",
+                value=SearchValue(raw_value="TypeError Anonymous function"),
+            ),
+            SearchFilter(
+                key=SearchKey(name="message"),
+                operator="=",
+                value=SearchValue(raw_value="(app/javascript/utils/transform-object-keys)"),
+            ),
+        ]
+
 
 class ConvertQueryValuesTest(TestCase):
     def test_valid_converter(self):


### PR DESCRIPTION
The parser was originally matching parens inside raw searches as boolean
expressions and was failing in interesting ways. Change the parser to treat
these as raw searches instead. In the interest of fixing this quickly, the
parser will actually split on the parens and return two expressions.

`TypeError Anonymous function(app/javascript/utils/transform-object-keys)` =>
`message:"TypeError Anonymous function" AND message:"app/javascript/utils/transform-object-keys"`