### PR TITLE
fix(ui-components) changes how we handle aysnc for sentry app ui components

### DIFF
--- a/src/sentry/mediators/sentry_app_components/preparer.py
+++ b/src/sentry/mediators/sentry_app_components/preparer.py
@@ -54,8 +54,7 @@ class Preparer(Mediator):
             field.update({"choices": field["options"]})
 
         if "uri" in field:
-            if "async" not in field:
-                field.update(self._request(field["uri"]))
+            field.update(self._request(field["uri"]))
 
     def _request(self, uri):
         return SelectRequester.run(install=self.install, project=self.project, uri=uri)

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.tsx
@@ -24,6 +24,7 @@ type FieldFromSchema = Field & {
   default?: string;
   uri?: string;
   depends_on?: string[];
+  async?: boolean;
 };
 
 type Config = {
@@ -145,7 +146,7 @@ export class SentryAppExternalIssueForm extends React.Component<Props, State> {
     field.uri
       ? {
           loadOptions: (input: string) => this.getOptions(field, input),
-          async: true,
+          async: typeof field.async === 'undefined' ? true : field.async, //default to true
           cache: false,
           onSelectResetsInput: false,
           onCloseResetsInput: false,


### PR DESCRIPTION
This PR makes a couple of changes with how we handle the `async` field for UI components:
1. Always pre-fetch the options if we have a `uri` present so the user has the initial options to choose from
2. Set the default for `async` to be `true`. This is because the way we implemented it originally, the UI component was always getting `async=true` and we don't want to break existing UI components. You can get turn off the async behavior, but only by explicitly setting it to false which no one is doing right now (at least not Clubhouse or ClickUp).

PR: https://github.com/getsentry/sentry-docs/pull/1930