### PR TITLE
fix(makefile): create .git/hooks if needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ setup-git-config:
 
 setup-git: ensure-venv setup-git-config
 	@echo "--> Installing git hooks"
-	cd .git/hooks && ln -sf ../../config/hooks/* ./
+	mkdir -p .git/hooks && cd .git/hooks && ln -sf ../../config/hooks/* ./
 	@PYENV_VERSION=$(REQUIRED_PY3_VERSION) python3 -c '' || (echo 'Please run `make setup-pyenv` to install the required Python 3 version.'; exit 1)
 	$(PIP) install "pre-commit==1.18.2" "virtualenv==20.0.23"
 	@PYENV_VERSION=$(REQUIRED_PY3_VERSION) pre-commit install --install-hooks


### PR DESCRIPTION
On a clean checkout:

```sh
18:11 $ make bootstrap
....
--> Installing git hooks
cd .git/hooks && ln -sf ../../config/hooks/* ./
/bin/sh: line 0: cd: .git/hooks: No such file or directory
make: *** [setup-git] Error 1
```