### PR TITLE
fix(search): Reference before assignment

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -991,9 +991,9 @@ def convert_search_boolean_to_snuba_query(terms, params=None):
         if term != SearchBoolean.BOOLEAN_AND:
             new_terms.append(term)
         prev = term
-    if SearchBoolean.is_operator(term):
+    if SearchBoolean.is_operator(prev):
         raise InvalidSearchQuery(
-            u"Condition is missing on the right side of '{}' operator".format(term)
+            u"Condition is missing on the right side of '{}' operator".format(prev)
         )
     terms = new_terms
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -997,7 +997,7 @@ def convert_search_boolean_to_snuba_query(terms, params=None):
         )
     terms = new_terms
 
-    # We put precedence on AND, which sort of counter-intuitevely means we have to split the query
+    # We put precedence on AND, which sort of counter-intuitively means we have to split the query
     # on ORs first, so the ANDs are grouped together. Search through the query for ORs and split the
     # query on each OR.
     # We want to maintain a binary tree, so split the terms on the first OR we can find and recurse on
@@ -1086,7 +1086,7 @@ def get_filter(query=None, params=None):
         for term in parsed_terms
     ):
         # TODO evanh: We can remove all top level ANDs and extend the conditions/having to
-        # avoid unnecesary nesting, e.g. [["and", [["and", [a, b]], ["and", [c, d]]]]] -> [a, b, c, d]
+        # avoid unnecessary nesting, e.g. [["and", [["and", [a, b]], ["and", [c, d]]]]] -> [a, b, c, d]
         (
             condition,
             having,


### PR DESCRIPTION
https://sentry.io/organizations/sentry/issues/1809864258
In the last line of the loop we assign `prev = term` so I'm using that instead.
There may be another bug that's causing `terms` to be empty.