### PR TITLE
fix(integrations): Invalid Incident ID

### DIFF
--- a/src/sentry/api/bases/incident.py
+++ b/src/sentry/api/bases/incident.py
@@ -32,6 +32,9 @@ class IncidentEndpoint(OrganizationEndpoint):
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
 
+        if not incident_identifier.isdigit():
+            raise ResourceDoesNotExist
+
         try:
             incident = kwargs["incident"] = Incident.objects.get(
                 organization=organization, identifier=incident_identifier


### PR DESCRIPTION
So far only Sentaurs have encountered this error. It looks like it's rare for us to use an integer rather than a slug so I added a check before hitting DB.
