### PR TITLE
fix(apm) Boolean search was matching or/and at the beginning of other strings

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -159,8 +159,8 @@ duration_format      = ~r"([0-9\.]+)(ms|s|min|m|hr|h|day|d|wk|w)(?=\s|$)"
 # NOTE: the order in which these operators are listed matters
 # because for example, if < comes before <= it will match that
 # even if the operator is <=
-or_operator          = ~r"OR"i
-and_operator         = ~r"AND"i
+or_operator          = ~r"OR(?![^\s])"i
+and_operator         = ~r"AND(?![^\s])"i
 operator             = ">=" / "<=" / ">" / "<" / "=" / "!="
 open_paren           = "("
 closed_paren         = ")"

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1704,6 +1704,15 @@ class ParseBooleanSearchQueryTest(TestCase):
             ],
         ]
 
+    def test_or_does_not_match_organization(self):
+        result = get_filter(
+            "organization.slug:{}".format(self.organization.slug),
+            params={"organization_id": self.organization.id, "project_id": [self.project.id]},
+        )
+        assert result.conditions == [
+            [["ifNull", ["organization.slug", "''"]], "=", "{}".format(self.organization.slug)]
+        ]
+
 
 class GetSnubaQueryArgsTest(TestCase):
     def test_simple(self):


### PR DESCRIPTION
The regex was matching and/or at the begining of other strings, so queries with
`organization` for example would match as 'or' and 'ganization'. So add a
negative lookahead to catch that.