### PR TITLE
fix: handle Heroku release if no user

### DIFF
--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -147,5 +147,4 @@ class HerokuPlugin(CorePluginMixin, ReleaseTrackingPlugin):
         )
 
     def get_release_hook(self):
-        print("Heroku")
         return HerokuReleaseHook

--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -26,10 +26,8 @@ class HerokuReleaseHook(ReleaseHook):
             user = User.objects.get(
                 email__iexact=email, sentry_orgmember_set__organization__project=self.project
             )
-            self.finish_release(
-                version=request.POST["head_long"], url=request.POST["url"], owner=user
-            )
         except (User.DoesNotExist, User.MultipleObjectsReturned):
+            user = None
             logger.info(
                 "owner.missing",
                 extra={
@@ -38,7 +36,9 @@ class HerokuReleaseHook(ReleaseHook):
                     "email": email,
                 },
             )
-            self.finish_release(version=request.POST["head_long"], url=request.POST["url"])
+        self.finish_release(
+            version=request.POST.get("head_long"), url=request.POST.get("url"), owner=user
+        )
 
     def set_refs(self, release, **values):
         if not values.get("owner", None):

--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -26,8 +26,10 @@ class HerokuReleaseHook(ReleaseHook):
             user = User.objects.get(
                 email__iexact=email, sentry_orgmember_set__organization__project=self.project
             )
+            self.finish_release(
+                version=request.POST["head_long"], url=request.POST["url"], owner=user
+            )
         except (User.DoesNotExist, User.MultipleObjectsReturned):
-            user = None
             logger.info(
                 "owner.missing",
                 extra={
@@ -36,7 +38,7 @@ class HerokuReleaseHook(ReleaseHook):
                     "email": email,
                 },
             )
-        self.finish_release(version=request.POST["head_long"], url=request.POST["url"], owner=user)
+            self.finish_release(version=request.POST["head_long"], url=request.POST["url"])
 
     def set_refs(self, release, **values):
         if not values.get("owner", None):
@@ -145,4 +147,5 @@ class HerokuPlugin(CorePluginMixin, ReleaseTrackingPlugin):
         )
 
     def get_release_hook(self):
+        print("Heroku")
         return HerokuReleaseHook


### PR DESCRIPTION
## Objective
Heroku release webhook should fail when it cannot find the `head_long` parameter, which we use as the release version.

Fixes SENTRY-FTJ