### PR TITLE
build: Move sentry-flake8 to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,8 @@ repos:
       language: python
       files: \.py$
       log_file: '.artifacts/flake8.pycodestyle.log'
+      additional_dependencies:
+      - sentry-flake8==0.3.1
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -181,8 +181,6 @@ matrix:
     - python: 3.7
       name: 'pre-commit hooks (includes python linting + format check)'
       install:
-        # XXX: this must be synced with requirements-dev.txt
-        - pip install 'sentry-flake8==0.3.0'
         - SENTRY_NO_VIRTUALENV_CREATION=1 make setup-git
       script:
         # Run pre-commit to lint and format check files that were changed (but not deleted) compared to master.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,4 @@ pytest-html==1.22.0
 pytest-sentry==0.1.1
 pytest-rerunfailures==8.0
 responses>=0.8.1,<0.9.0
-sentry-flake8==0.3.1
 werkzeug==0.15.5


### PR DESCRIPTION
This makes a bit more sense since flake8 is run by precommit.