### PR TITLE
fix(ui) Fix left side alignment in context data

### DIFF
--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -128,7 +128,7 @@ class ContextData extends React.Component {
     withAnnotatedText: false,
   };
 
-  renderValue = value => {
+  renderValue(value) {
     const {preserveQuotes, meta, withAnnotatedText} = this.props;
 
     function getValueWithAnnotatedText(v, meta) {
@@ -230,7 +230,7 @@ class ContextData extends React.Component {
       }
     }
     return walk(value, 0);
-  };
+  }
 
   render() {
     const {
@@ -243,7 +243,7 @@ class ContextData extends React.Component {
     } = this.props;
 
     return (
-      <pre className="val-string" {...other}>
+      <pre {...other}>
         {this.renderValue(data)}
         {children}
       </pre>

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -341,6 +341,11 @@ table.table.key-value {
       word-break: break-word;
       padding: 8px 10px;
       font-size: 12px;
+      color: darken(@purple, 10);
+
+      .val-string:first-child {
+        padding-left: 0;
+      }
     }
   }
 


### PR DESCRIPTION
Fix the left-side alignment of text in context data by removing padding on the first val-string inside a key-value table. I've also normalized the colour used in the table contents between stackframe locals and context data as they were smidge different.

Going to rely on visual diffs to catch regressions elsewhere as less changes can unleash dragons.