### PR TITLE
chore(json): Always use sentry.utils.json

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -17,7 +17,6 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from simplejson import JSONDecodeError
 
 from sentry import tsdb
 from sentry.auth import access
@@ -167,7 +166,7 @@ class Endpoint(APIView):
 
         try:
             request.json_body = json.loads(request.body)
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             return
 
     def initialize_request(self, request, *args, **kwargs):

--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
 
 import logging
-import json
 
 from jsonschema import Draft7Validator
 from jsonschema.exceptions import best_match
 from jsonschema.exceptions import ValidationError as SchemaValidationError
+
+from sentry.utils import json
 
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/conf/locale.py
+++ b/src/sentry/conf/locale.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
 import os
-import json
 import sentry
+
+from sentry.utils import json
 
 
 # change locale file dir name to locale code

--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import logging
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -15,6 +14,7 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
+from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
 from .base import ExportQueryType, ExportStatus, DEFAULT_EXPIRATION

--- a/src/sentry/db/models/fields/jsonfield.py
+++ b/src/sentry/db/models/fields/jsonfield.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, unicode_literals
-import json
+
 import datetime
 import six
 
@@ -11,6 +11,7 @@ from django.db import models
 from django.db.models.lookups import Exact, IExact, In, Contains, IContains
 from django.utils.translation import ugettext_lazy as _
 
+from sentry.utils import json
 from sentry.db.models.utils import Creator
 
 

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -7,7 +7,6 @@ from six.moves.urllib.parse import parse_qsl, urlencode
 from uuid import uuid4
 from time import time
 from requests.exceptions import SSLError
-from simplejson import JSONDecodeError
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry.auth.exceptions import IdentityNotValid
@@ -292,7 +291,7 @@ class OAuth2CallbackView(PipelineView):
                 "error": "Could not verify SSL certificate",
                 "error_description": u"Ensure that {} has a valid SSL certificate".format(url),
             }
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             logger.info("identity.oauth2.json-error", extra={"url": self.access_token_url})
             return {
                 "error": "Could not decode a JSON Response",

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -13,7 +13,6 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from django.utils import timezone
-from simplejson import JSONDecodeError
 from sentry.models import Commit, CommitAuthor, Organization, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.utils import json
@@ -191,7 +190,7 @@ class BitbucketWebhookEndpoint(View):
 
         try:
             event = json.loads(body.decode("utf-8"))
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             logger.error(
                 PROVIDER_NAME + ".webhook.invalid-json",
                 extra={"organization_id": organization.id},

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -11,7 +11,6 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import View
-from simplejson import JSONDecodeError
 from sentry.models import Commit, CommitAuthor, Organization, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.utils import json
@@ -139,7 +138,7 @@ class BitbucketServerWebhookEndpoint(View):
 
         try:
             event = json.loads(body.decode("utf-8"))
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             logger.error(
                 PROVIDER_NAME + ".webhook.invalid-json",
                 extra={"organization_id": organization.id, "integration_id": integration_id},

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -14,7 +14,6 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from django.utils import timezone
-from simplejson import JSONDecodeError
 from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.models import (
@@ -440,7 +439,7 @@ class GitHubWebhookBase(View):
 
         try:
             event = json.loads(body.decode("utf-8"))
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             logger.error(
                 "github.webhook.invalid-json", extra=self.get_logging_data(), exc_info=True
             )

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -11,7 +11,6 @@ from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
-from simplejson import JSONDecodeError
 from sentry.models import Integration
 from sentry.utils import json
 from sentry.integrations.github.webhook import (
@@ -128,7 +127,7 @@ class GitHubEnterpriseWebhookBase(View):
 
         try:
             event = json.loads(body.decode("utf-8"))
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             logger.warning(
                 "github_enterprise.webhook.invalid-json",
                 extra=self.get_logging_data(),

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -11,7 +11,6 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
-from simplejson import JSONDecodeError
 
 from sentry.models import Commit, CommitAuthor, Integration, PullRequest, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
@@ -241,7 +240,7 @@ class GitlabWebhookEndpoint(View):
 
         try:
             event = json.loads(request.body.decode("utf-8"))
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             logger.info(
                 "gitlab.webhook.invalid-json", extra={"external_id": integration.external_id}
             )

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import logging
 import jwt
-import json
 import time
 
 from django.views.decorators.csrf import csrf_exempt
@@ -18,6 +17,7 @@ from sentry.models import (
     Group,
     Project,
 )
+from sentry.utils import json
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.compat import filter
 from sentry.utils.signing import sign

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import re
 import six
 from collections import defaultdict
@@ -12,6 +11,7 @@ from sentry.incidents.models import Incident
 from sentry.models import Group, Project
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.web.decorators import transaction_start
+from sentry.utils import json
 
 from .client import SlackClient
 from .requests import SlackEventRequest, SlackRequestError

--- a/src/sentry/integrations/vercel/uihook.py
+++ b/src/sentry/integrations/vercel/uihook.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import logging
 
 from django.http import HttpResponse
@@ -11,6 +10,7 @@ from six.moves.urllib.parse import urlencode
 from sentry.api.base import Endpoint, allow_cors_options
 from sentry.constants import ObjectStatus
 from sentry.models import Integration, Organization, OrganizationIntegration, OrganizationStatus
+from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
 

--- a/src/sentry/lang/javascript/errormapping.py
+++ b/src/sentry/lang/javascript/errormapping.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import re
-import json
 import time
 import logging
 import random
@@ -12,6 +11,7 @@ from django.core.cache import cache
 from six.moves.urllib.parse import parse_qsl
 
 from sentry import http
+from sentry.utils import json
 from sentry.utils.safe import get_path
 from sentry.utils.strings import count_sprintf_parameters
 

--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -9,11 +9,13 @@ python stdlib to prevent the need to install the world just to run eslint.
 """
 from __future__ import absolute_import
 
-
 import os
 import sys
 import subprocess
-import json
+
+# Import the stdlib json instead of sentry.utils.json, since this command is
+# run in setup.py
+import json  # NOQA
 
 from subprocess import check_output, Popen
 

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import os
 import re
 import logging
-import json
 import six
 
 from pkg_resources import parse_version
@@ -12,6 +11,7 @@ from sentry.utils.compat import functools
 import sentry
 
 from django.conf import settings
+from sentry.utils import json
 from sentry.utils.compat import map
 
 logger = logging.getLogger("sentry")

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -5,13 +5,12 @@ import re
 import six
 
 from django.utils.timezone import now
-from simplejson import JSONEncoder
 from structlog import get_logger
 from structlog.processors import _json_fallback_handler
 
-from sentry.utils import metrics
+from sentry.utils import metrics, json
 
-_default_encoder = JSONEncoder(
+_default_encoder = json.JSONEncoder(
     separators=(",", ":"),
     ignore_nan=True,
     skipkeys=False,

--- a/src/sentry/management/commands/serve_normalize.py
+++ b/src/sentry/management/commands/serve_normalize.py
@@ -7,13 +7,14 @@ import stat
 import sys
 import time
 import traceback
-import json
 import resource
 from optparse import make_option
 
 import six
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.encoding import force_str
+
+from sentry.utils import json
 
 
 class ForkingUnixStreamServer(SocketServer.ForkingMixIn, SocketServer.UnixStreamServer):

--- a/src/sentry/nodestore/bigtable/backend.py
+++ b/src/sentry/nodestore/bigtable/backend.py
@@ -7,14 +7,14 @@ from zlib import compress as zlib_compress, decompress as zlib_decompress
 
 from google.cloud import bigtable
 from google.cloud.bigtable.row_set import RowSet
-from simplejson import JSONEncoder, _default_decoder
 from django.utils import timezone
 
+from sentry.utils import json
 from sentry.nodestore.base import NodeStorage
 
 
 # Cache an instance of the encoder we want to use
-json_dumps = JSONEncoder(
+json_dumps = json.JSONEncoder(
     separators=(",", ":"),
     skipkeys=False,
     ensure_ascii=True,
@@ -25,7 +25,7 @@ json_dumps = JSONEncoder(
     default=None,
 ).encode
 
-json_loads = _default_decoder.decode
+json_loads = json._default_decoder.decode
 
 
 _connection_lock = Lock()

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import logging
-import json
 import requests
 import sentry_sdk
 import six
@@ -13,7 +12,7 @@ from bs4 import BeautifulSoup
 from django.utils.functional import cached_property
 from requests.exceptions import ConnectionError, Timeout, HTTPError
 from sentry.http import build_session
-from sentry.utils import metrics
+from sentry.utils import metrics, json
 from sentry.utils.hashlib import md5_text
 from sentry.utils.decorators import classproperty
 

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import logging
-from json import loads
 
 import jsonschema
 import pytz
@@ -13,7 +12,7 @@ from django.conf import settings
 from sentry.snuba.json_schemas import SUBSCRIPTION_PAYLOAD_VERSIONS, SUBSCRIPTION_WRAPPER_SCHEMA
 from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.snuba.tasks import _delete_from_snuba
-from sentry.utils import metrics
+from sentry.utils import metrics, json
 
 logger = logging.getLogger(__name__)
 
@@ -262,7 +261,7 @@ class QuerySubscriptionConsumer(object):
         :return: A dict with the parsed message
         """
         with metrics.timer("snuba_query_subscriber.parse_message_value.json_parse"):
-            wrapper = loads(value)
+            wrapper = json.loads(value)
 
         with metrics.timer("snuba_query_subscriber.parse_message_value.json_validate_wrapper"):
             try:

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import
 
-import json
-
 from sentry.api.event_search import get_filter, resolve_field_list
 from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.tasks.base import instrumented_task
-from sentry.utils import metrics
+from sentry.utils import metrics, json
 from sentry.utils.snuba import (
     _snuba_pool,
     Dataset,

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import json
 import logging
 import sentry
 
@@ -11,6 +10,7 @@ from hashlib import sha1
 from uuid import uuid4
 
 from sentry.app import locks, tsdb
+from sentry.utils import json
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.tasks.base import instrumented_task
 from sentry.debug.utils.packages import get_all_package_versions

--- a/src/sentry/utils/apidocs.py
+++ b/src/sentry/utils/apidocs.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import os
 import re
-import json
 import inspect
 import requests
 import mimetypes
@@ -20,6 +19,7 @@ from pytz import utc
 from random import randint
 from six import StringIO
 from sentry.utils.compat import map
+from sentry.utils import json
 
 # Do not import from sentry here!  Bad things will happen
 

--- a/src/sentry/utils/distutils/commands/build_assets.py
+++ b/src/sentry/utils/distutils/commands/build_assets.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import
 
-import json
 import datetime
 import os
 import os.path
 import sys
 import traceback
+
+# Import the stdlib json instead of sentry.utils.json, since this command is
+# run in setup.py
+import json  # NOQA
 
 from distutils import log
 

--- a/src/sentry/utils/distutils/commands/build_js_sdk_registry.py
+++ b/src/sentry/utils/distutils/commands/build_js_sdk_registry.py
@@ -2,10 +2,13 @@
 # process.  Thus we do not want to import non stdlib things here.
 from __future__ import absolute_import
 
+# Import the stdlib json instead of sentry.utils.json, since this command is
+# run in setup.py
+import json  # NOQA
+
 import io
 import os
 import sys
-import json
 from distutils import log
 
 import sentry

--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -7,9 +7,12 @@ import multiprocessing
 import multiprocessing.dummy
 import os
 import sys
-import json
 import logging
 import time
+
+# Import the stdlib json instead of sentry.utils.json, since this command is
+# run at build time
+import json  # NOQA
 
 import sentry
 

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -1,8 +1,11 @@
 # Avoid shadowing the standard library json module
 from __future__ import absolute_import
 
+# XXX(epurkhiser): We import JSONDecodeError just to have it be exported as
+# part of this module. We don't use it directly within the module, but moudles
+# that import it from here will. Do not remove.
+from simplejson import JSONEncoder, JSONDecodeError, _default_decoder  # NOQA
 from enum import Enum
-from simplejson import JSONEncoder, _default_decoder
 import datetime
 import uuid
 import six

--- a/src/sentry/utils/sentryappwebhookrequests.py
+++ b/src/sentry/utils/sentryappwebhookrequests.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import six
-import json
 
 from dateutil.parser import parse as parse_date
 from django.conf import settings
@@ -9,6 +8,7 @@ from django.utils import timezone
 
 from sentry.utils import redis
 from sentry.models.sentryapp import VALID_EVENTS
+from sentry.utils import json
 
 
 BUFFER_SIZE = 100

--- a/src/sentry/web/frontend/release_webhook.py
+++ b/src/sentry/web/frontend/release_webhook.py
@@ -4,7 +4,6 @@ from hashlib import sha256
 import hmac
 import logging
 import six
-from simplejson import JSONDecodeError
 
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
@@ -41,7 +40,7 @@ class ReleaseWebhookView(View):
 
         try:
             data = json.loads(request.body)
-        except JSONDecodeError as exc:
+        except json.JSONDecodeError as exc:
             return HttpResponse(
                 status=400,
                 content=json.dumps({"error": six.text_type(exc)}),

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -13,7 +13,6 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from django.utils import timezone
-from simplejson import JSONDecodeError
 from sentry.models import Commit, CommitAuthor, Organization, Repository
 from sentry.plugins.providers import RepositoryProvider
 from sentry.utils import json
@@ -163,7 +162,7 @@ class BitbucketWebhookEndpoint(View):
 
         try:
             event = json.loads(body.decode("utf-8"))
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             logger.error(
                 "bitbucket.webhook.invalid-json",
                 extra={"organization_id": organization.id},

--- a/src/sentry_plugins/freight/plugin.py
+++ b/src/sentry_plugins/freight/plugin.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
-import json
-
 import sentry
+from sentry.utils import json
 from sentry.plugins.bases import ReleaseTrackingPlugin
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 

--- a/src/sentry_plugins/github/endpoints/webhook.py
+++ b/src/sentry_plugins/github/endpoints/webhook.py
@@ -14,7 +14,6 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from django.utils import timezone
-from simplejson import JSONDecodeError
 from sentry import options
 from sentry.models import (
     Commit,
@@ -411,7 +410,7 @@ class GithubWebhookBase(View):
 
         try:
             event = json.loads(body.decode("utf-8"))
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             logger.error(
                 "github.webhook.invalid-json",
                 extra=self.get_logging_data(organization),

--- a/src/sentry_plugins/jira_ac/views.py
+++ b/src/sentry_plugins/jira_ac/views.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import json
-
 from six.moves.urllib.parse import urlparse
 
 from django.forms.utils import ErrorList
@@ -11,6 +9,7 @@ from django.views.generic import View
 from django.core.urlresolvers import reverse
 from django.utils.decorators import method_decorator
 
+from sentry.utils import json
 from sentry.models import Organization
 from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response

--- a/src/sentry_plugins/phabricator/plugin.py
+++ b/src/sentry_plugins/phabricator/plugin.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
-import json
-
 from django.conf.urls import url
 from rest_framework.response import Response
 
 from sentry.exceptions import PluginError
 from sentry.plugins.bases.issue2 import IssuePlugin2, IssueGroupActionEndpoint
+from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry.integrations import FeatureDescription, IntegrationFeatures
 from six.moves.urllib.parse import urljoin

--- a/src/sentry_plugins/redmine/forms.py
+++ b/src/sentry_plugins/redmine/forms.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
-import json
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _
+
+from sentry.utils import json
 
 from .client import RedmineClient
 

--- a/src/sentry_plugins/redmine/plugin.py
+++ b/src/sentry_plugins/redmine/plugin.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import json
 import six
 
 from django.utils.translation import ugettext_lazy as _
@@ -7,6 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 from sentry.exceptions import PluginError
 from sentry.plugins.bases.issue import IssuePlugin
 from sentry_plugins.base import CorePluginMixin
+from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry.integrations import FeatureDescription, IntegrationFeatures
 import sentry

--- a/src/sentry_plugins/sessionstack/client.py
+++ b/src/sentry_plugins/sessionstack/client.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-import json
 import requests
 
+from sentry.utils import json
 from sentry.http import safe_urlopen
 
 from .utils import get_basic_auth, remove_trailing_slashes, add_query_params

--- a/src/social_auth/backends/bitbucket.py
+++ b/src/social_auth/backends/bitbucket.py
@@ -12,10 +12,10 @@ extend it.
 """
 from __future__ import absolute_import
 
-import simplejson
-
 from social_auth.backends import BaseOAuth1, OAuthBackend
 from social_auth.utils import dsa_urlopen
+
+from sentry.utils import json
 
 # Bitbucket configuration
 BITBUCKET_SERVER = "bitbucket.org/api/1.0"
@@ -88,7 +88,7 @@ class BitbucketAuth(BaseOAuth1):
         response = self.fetch_response(request)
         try:
             # Then retrieve the user's primary email address or the top email
-            email_addresses = simplejson.loads(response)
+            email_addresses = json.loads(response)
             for email_address in reversed(email_addresses):
                 if email_address["active"]:
                     email = email_address["email"]
@@ -97,7 +97,7 @@ class BitbucketAuth(BaseOAuth1):
             # Then return the user data using a normal GET with the
             # BITBUCKET_USER_DATA_URL and the user's email
             response = dsa_urlopen(BITBUCKET_USER_DATA_URL + email)
-            user_details = simplejson.load(response)["user"]
+            user_details = json.load(response)["user"]
             user_details["email"] = email
             return user_details
         except ValueError:

--- a/src/social_auth/backends/github.py
+++ b/src/social_auth/backends/github.py
@@ -12,14 +12,14 @@ field, check OAuthBackend class for details on how to extend it.
 """
 from __future__ import absolute_import
 
-import simplejson
-
 from django.conf import settings
 from six.moves.urllib.error import HTTPError
 from six.moves.urllib.request import Request
 from social_auth.utils import dsa_urlopen
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.exceptions import AuthFailed
+
+from sentry.utils import json
 
 
 # GitHub configuration
@@ -47,7 +47,7 @@ class GithubBackend(OAuthBackend):
         )
 
         try:
-            data = simplejson.load(dsa_urlopen(req))
+            data = json.load(dsa_urlopen(req))
         except (ValueError, HTTPError):
             data = []
         return data
@@ -94,7 +94,7 @@ class GithubAuth(BaseOAuth2):
         req = Request(GITHUB_USER_DATA_URL, headers={"Authorization": "token %s" % access_token})
 
         try:
-            data = simplejson.load(dsa_urlopen(req))
+            data = json.load(dsa_urlopen(req))
         except ValueError:
             data = None
 

--- a/src/social_auth/fields.py
+++ b/src/social_auth/fields.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import simplejson
 import six
 
 from django.core.exceptions import ValidationError
@@ -8,6 +7,7 @@ from django.db.models import TextField
 from django.utils.encoding import smart_text
 
 from sentry.db.models.utils import Creator
+from sentry.utils import json
 
 
 class JSONField(TextField):
@@ -32,7 +32,7 @@ class JSONField(TextField):
             return None
         if isinstance(value, six.string_types):
             try:
-                return simplejson.loads(value)
+                return json.loads(value)
             except Exception as e:
                 raise ValidationError(six.text_type(e))
         else:
@@ -44,14 +44,14 @@ class JSONField(TextField):
         if isinstance(value, six.string_types):
             super(JSONField, self).validate(value, model_instance)
             try:
-                simplejson.loads(value)
+                json.loads(value)
             except Exception as e:
                 raise ValidationError(six.text_type(e))
 
     def get_prep_value(self, value):
         """Convert value to JSON string before save"""
         try:
-            return simplejson.dumps(value)
+            return json.dumps(value)
         except Exception as e:
             raise ValidationError(six.text_type(e))
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, print_function
 
 import os
-import json
 import subprocess
 import time
+
+from sentry.utils import json
 
 
 def pytest_configure(config):

--- a/tests/relay_integration/lang/javascript/test_example.py
+++ b/tests/relay_integration/lang/javascript/test_example.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
 import os
-import json
 import responses
 
+from sentry.utils import json
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -3,17 +3,17 @@ from __future__ import absolute_import
 from datetime import datetime
 
 import dateutil
-from pytz import UTC
 import six
-
+from pytz import UTC
 from base64 import b64encode
-from django.core.urlresolvers import reverse
-from django.core import mail
-from sentry.utils.compat.mock import patch
 from exam import fixture
 from pprint import pprint
-import json
 
+from django.core.urlresolvers import reverse
+from django.core import mail
+
+from sentry.utils import json
+from sentry.utils.compat.mock import patch
 from sentry.api.endpoints.organization_details import ERR_NO_2FA, ERR_SSO_ENABLED
 from sentry.constants import APDEX_THRESHOLD_DEFAULT, RESERVED_ORGANIZATION_SLUGS
 from sentry.models import (

--- a/tests/sentry/api/endpoints/test_organization_release_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_release_meta.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-import json
 from django.core.urlresolvers import reverse
 
+from sentry.utils import json
 from sentry.models import (
     File,
     Release,

--- a/tests/sentry/api/endpoints/test_project_create_sample.py
+++ b/tests/sentry/api/endpoints/test_project_create_sample.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
-import json
 
+from sentry.utils import json
 from sentry.testutils import APITestCase
 
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import pytest
-import json
 import six
 import re
 
@@ -11,7 +10,7 @@ from django.core.urlresolvers import reverse
 
 from sentry import quotas
 from sentry.constants import ObjectStatus
-from sentry.utils import safe
+from sentry.utils import safe, json
 from sentry.models.relay import Relay
 from sentry.models import Project
 

--- a/tests/sentry/api/endpoints/test_relay_projectids.py
+++ b/tests/sentry/api/endpoints/test_relay_projectids.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import six
 import re
 
@@ -8,7 +7,7 @@ from uuid import uuid4
 
 from django.core.urlresolvers import reverse
 
-from sentry.utils import safe
+from sentry.utils import safe, json
 from sentry.models.relay import Relay
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_relay_publickeys.py
+++ b/tests/sentry/api/endpoints/test_relay_publickeys.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
-import json
 import six
 
 from uuid import uuid4
 
 from django.core.urlresolvers import reverse
 
+from sentry.utils import json
 from sentry.models import Relay
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import six
 
 from uuid import uuid4
@@ -8,6 +7,7 @@ from uuid import uuid4
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
+from sentry.utils import json
 from sentry.models import Relay
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import io
 import os
-import json
 
 from six.moves.urllib.parse import parse_qsl
 from django.core.urlresolvers import reverse
@@ -16,6 +15,7 @@ from sentry.models import (
     Organization,
     OrganizationMember,
 )
+from sentry.utils import json
 from sentry.utils.compat import mock
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/data_export/test_models.py
+++ b/tests/sentry/data_export/test_models.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import six
 import tempfile
 from datetime import timedelta
@@ -12,6 +11,7 @@ from sentry.data_export.base import ExportQueryType, ExportStatus, DEFAULT_EXPIR
 from sentry.data_export.models import ExportedData
 from sentry.models import File
 from sentry.testutils import TestCase
+from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry.utils.compat.mock import patch
 

--- a/tests/sentry/db/models/fields/test_jsonfield.py
+++ b/tests/sentry/db/models/fields/test_jsonfield.py
@@ -74,7 +74,7 @@ class JSONFieldTest(TestCase):
         field.set_attributes_from_name("json")
         self.assertEqual(None, field.get_db_prep_save(None, connection=None))
         self.assertEqual(
-            '{"spam": "eggs"}', field.get_db_prep_save({"spam": "eggs"}, connection=None)
+            '{"spam":"eggs"}', field.get_db_prep_save({"spam": "eggs"}, connection=None)
         )
 
     def test_formfield(self):

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/custom_fingerprint.pysnap
@@ -5,4 +5,4 @@ source: tests/sentry/grouping/test_variants.py
 ---
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  values: ["celery", "SoftTimeLimitExceeded", "sentry.tasks.store.process_event"]
+  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint.pysnap
@@ -5,4 +5,4 @@ source: tests/sentry/grouping/test_variants.py
 ---
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  values: ["celery", "SoftTimeLimitExceeded", "sentry.tasks.store.process_event"]
+  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/custom_fingerprint.pysnap
@@ -5,4 +5,4 @@ source: tests/sentry/grouping/test_variants.py
 ---
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  values: ["celery", "SoftTimeLimitExceeded", "sentry.tasks.store.process_event"]
+  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/custom_fingerprint.pysnap
@@ -5,4 +5,4 @@ source: tests/sentry/grouping/test_variants.py
 ---
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  values: ["celery", "SoftTimeLimitExceeded", "sentry.tasks.store.process_event"]
+  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint.pysnap
@@ -5,4 +5,4 @@ source: tests/sentry/grouping/test_variants.py
 ---
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  values: ["celery", "SoftTimeLimitExceeded", "sentry.tasks.store.process_event"]
+  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint.pysnap
@@ -5,4 +5,4 @@ source: tests/sentry/grouping/test_variants.py
 ---
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
-  values: ["celery", "SoftTimeLimitExceeded", "sentry.tasks.store.process_event"]
+  values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -3,13 +3,13 @@
 from __future__ import absolute_import
 
 import os
-import json
 import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
 from sentry.grouping.api import apply_server_fingerprinting
 from sentry.grouping.fingerprinting import FingerprintingRules
+from sentry.utils import json
 
 
 def test_basic_parsing(insta_snapshot):

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function
 
 import os
-import json
 import pytest
 
 from sentry import eventstore
@@ -11,6 +10,7 @@ from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.api import get_default_grouping_config_dict, load_grouping_config
+from sentry.utils import json
 
 
 def dump_variant(variant, lines=None, indent=0):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import pytz
 import requests
 import six
@@ -8,6 +7,7 @@ import six
 from exam import fixture
 from freezegun import freeze_time
 
+from sentry.utils import json
 from sentry.api.serializers import serialize
 from sentry.incidents.models import AlertRule, AlertRuleThresholdType
 from sentry.snuba.models import QueryDatasets

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
 import six
-import json
 import requests
 import pytz
 
 from exam import fixture
 from freezegun import freeze_time
 
+from sentry.utils import json
 from sentry.api.serializers import serialize
 from sentry.incidents.models import AlertRule
 from sentry.testutils.helpers.datetime import before_now

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 
 import responses
 import six
@@ -28,6 +27,7 @@ from sentry.incidents.models import (
 from sentry.integrations.slack.utils import build_incident_attachment
 from sentry.models import Integration, UserOption
 from sentry.testutils import TestCase
+from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-import json
+
 import pytest
 from uuid import uuid4
 import responses
@@ -79,6 +79,7 @@ from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.models.integration import Integration
 from sentry.testutils import TestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
+from sentry.utils import json
 from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import
 
 import copy
+import responses
+import six
 
 from sentry.integrations.bitbucket.issues import ISSUE_TYPES, PRIORITIES
 from sentry.models import ExternalIssue, Integration
 from sentry.testutils import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import iso_format, before_now
-
-import json
-import responses
-import six
+from sentry.utils import json
 
 
 class BitbucketIssueTest(APITestCase):

--- a/tests/sentry/integrations/cloudflare/test_webhook.py
+++ b/tests/sentry/integrations/cloudflare/test_webhook.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 
 from hashlib import sha256
 import hmac
-import json
 import six
 
 from sentry import options
+from sentry.utils import json
 from sentry.models import ApiToken, ProjectKey
 from sentry.testutils import TestCase
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 from sentry.utils.compat import mock
 import responses
 import six
@@ -20,6 +19,7 @@ from sentry.models import (
     OrganizationIntegration,
 )
 from sentry.testutils import APITestCase
+from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import iso_format, before_now

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import responses
 
 from sentry.utils.compat.mock import patch
@@ -11,6 +10,7 @@ from django.core.urlresolvers import reverse
 from sentry.integrations.issues import IssueSyncMixin
 from sentry.models import Integration
 from sentry.testutils import APITestCase
+from sentry.utils import json
 
 
 SAMPLE_EDIT_ISSUE_PAYLOAD_NO_ASSIGNEE = """

--- a/tests/sentry/integrations/msteams/test_link_identity.py
+++ b/tests/sentry/integrations/msteams/test_link_identity.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 
 import responses
 import time
-import json
 
+from sentry.utils import json
 from sentry.utils.compat.mock import patch
 
 from sentry.models import (

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 
-import json
-
 import responses
 from six.moves.urllib.parse import parse_qsl
 
 from sentry import options
+from sentry.utils import json
 from sentry.integrations.slack.utils import build_group_attachment, build_incident_attachment
 from sentry.models import Integration, OrganizationIntegration
 from sentry.testutils import APITestCase

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import hmac
 import time
 import six
@@ -8,9 +7,9 @@ from datetime import datetime
 from hashlib import sha256
 from six.moves.urllib.parse import urlencode
 
-from sentry.utils.compat import mock
-
 from sentry import options
+from sentry.utils import json
+from sentry.utils.compat import mock
 from sentry.utils.cache import memoize
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import override_options

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import responses
 import six
 
@@ -19,6 +18,7 @@ from sentry.models import (
     SentryAppInstallation,
 )
 from sentry.testutils import IntegrationTestCase
+from sentry.utils import json
 from sentry.utils.compat.mock import patch
 from sentry.utils.http import absolute_uri
 

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -2,8 +2,6 @@
 
 from __future__ import absolute_import
 
-import json
-from sentry.utils.compat import mock
 
 from social_auth.models import UserSocialAuth
 
@@ -12,6 +10,8 @@ from sentry.plugins.base import plugins
 from sentry.plugins.bases import IssueTrackingPlugin2
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
+from sentry.utils import json
+from sentry.utils.compat import mock
 
 
 class PluginWithFields(IssueTrackingPlugin2):

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 
-import json
 import pytest
 import responses
 
@@ -13,6 +12,7 @@ from sentry.models import Rule
 from sentry.plugins.base import Notification
 from sentry.plugins.sentry_webhooks.plugin import validate_urls, WebHooksPlugin, WebHooksOptionsForm
 from sentry.testutils import TestCase
+from sentry.utils import json
 
 
 class WebHooksPluginTest(TestCase):

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import unittest
 from copy import deepcopy
 from datetime import timedelta
@@ -12,6 +11,7 @@ from dateutil.parser import parse as parse_date
 from django.conf import settings
 from exam import fixture, patcher
 
+from sentry.utils import json
 from sentry.utils.compat.mock import Mock
 from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.snuba.query_subscription_consumer import (

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import abc
-import json
 from uuid import uuid4
 
 import responses
@@ -16,6 +15,7 @@ from sentry.snuba.tasks import (
     update_subscription_in_snuba,
     delete_subscription_from_snuba,
 )
+from sentry.utils import json
 from sentry.testutils import TestCase
 
 

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import json
 import responses
 import sentry
 
@@ -11,6 +10,7 @@ from sentry import options
 from sentry.models import Broadcast
 from sentry.testutils import TestCase
 from sentry.tasks.beacon import BEACON_URL, send_beacon
+from sentry.utils import json
 
 
 class SendBeaconTest(TestCase):

--- a/tests/sentry/web/frontend/test_group_event_json.py
+++ b/tests/sentry/web/frontend/test_group_event_json.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
-import json
 
 from exam import fixture
 
+from sentry.utils import json
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 import six
 from datetime import timedelta
 from uuid import uuid4
@@ -30,6 +29,7 @@ from sentry.models import (
     UserOption,
     Release,
 )
+from sentry.utils import json
 from sentry.utils.compat.mock import patch, Mock
 
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 
-import json
 from datetime import timedelta
 from uuid import uuid4
 
 import six
+from six.moves.urllib.parse import quote
+
 from django.conf import settings
 from django.utils import timezone
 from exam import fixture
@@ -34,7 +35,7 @@ from sentry.models import (
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import iso_format, before_now
-from six.moves.urllib.parse import quote
+from sentry.utils import json
 
 
 class GroupListTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 from copy import deepcopy
 from uuid import uuid4
 
@@ -26,6 +25,7 @@ from sentry.incidents.models import (
 )
 from sentry.incidents.tasks import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.snuba.query_subscription_consumer import QuerySubscriptionConsumer, subscriber_registry
+from sentry.utils import json
 
 from sentry.testutils import TestCase
 

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import json
 from copy import deepcopy
 from datetime import timedelta
 from uuid import uuid4
@@ -11,8 +10,8 @@ from dateutil.parser import parse as parse_date
 from django.conf import settings
 from django.test.utils import override_settings
 from exam import fixture
-from sentry.utils.compat.mock import call, Mock
 
+from sentry.utils.compat.mock import call, Mock
 from sentry.snuba.models import QueryDatasets
 from sentry.snuba.query_subscription_consumer import (
     QuerySubscriptionConsumer,
@@ -21,6 +20,7 @@ from sentry.snuba.query_subscription_consumer import (
 )
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import SnubaTestCase, TestCase
+from sentry.utils import json
 
 
 class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import calendar
 from datetime import timedelta
-import json
 import pytest
 import requests
 import six
@@ -19,6 +18,7 @@ from sentry.tagstore.exceptions import (
 )
 from sentry.tagstore.snuba.backend import SnubaTagStorage
 from sentry.testutils import SnubaTestCase, TestCase
+from sentry.utils import json
 
 
 class TagStorageTest(TestCase, SnubaTestCase):

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import calendar
 from datetime import datetime, timedelta
-import json
 import pytz
 import requests
 import six
@@ -10,6 +9,7 @@ import six
 from django.conf import settings
 from sentry.utils.compat.mock import patch
 
+from sentry.utils import json
 from sentry.models import GroupHash, GroupRelease, Release
 from sentry.tsdb.base import TSDBModel
 from sentry.tsdb.snuba import SnubaTSDB


### PR DESCRIPTION
This will be enforced by a lint rule (https://github.com/getsentry/sentry-flake8/pull/15).

Ensures we always use our json interface. This allows us to control compatability for python3 (though really all we want there is to use `simplejson`, which is what `sentry.utils.json` uses).

I did this manually with the help of the lint errors.