### PR TITLE
ref: clean up rrweb player ui

### DIFF
--- a/src/sentry/static/sentry/app/components/events/rrwebIntegration.jsx
+++ b/src/sentry/static/sentry/app/components/events/rrwebIntegration.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
-import space from 'app/styles/space';
+import EventDataSection from 'app/components/events/eventDataSection';
 import {Panel} from 'app/components/panels';
 import AsyncComponent from 'app/components/asyncComponent';
 import LazyLoad from 'app/components/lazyLoad';
@@ -42,9 +42,8 @@ export default class RRWebIntegration extends AsyncComponent {
     const url = `/api/0/projects/${orgId}/${projectId}/events/${event.id}/attachments/${attachment.id}/?download`;
 
     return (
-      <ReplayWrapper>
-        <h5>Replay</h5>
-        <Panel>
+      <EventDataSection key="context-replay" title="Replay">
+        <StyledPanel>
           <LazyLoad
             component={() =>
               import(/* webpackChunkName: "rrwebReplayer" */ './rrwebReplayer').then(
@@ -53,13 +52,13 @@ export default class RRWebIntegration extends AsyncComponent {
             }
             url={url}
           />
-        </Panel>
-      </ReplayWrapper>
+        </StyledPanel>
+      </EventDataSection>
     );
   }
 }
 
-const ReplayWrapper = styled('div')`
-  padding-top: ${space(3)};
+const StyledPanel = styled(Panel)`
   overflow: hidden;
+  margin-bottom: 30px;
 `;

--- a/src/sentry/static/sentry/app/components/events/rrwebReplayer.jsx
+++ b/src/sentry/static/sentry/app/components/events/rrwebReplayer.jsx
@@ -32,11 +32,9 @@ class RRWebReplayer extends Component {
 export default styled(RRWebReplayer)`
   .rr-player {
     width: auto !important;
-    height: auto !important;
   }
   .rr-player__frame {
     width: 100% !important;
-    height: 500px !important;
   }
 
   .rr-player iframe {

--- a/src/sentry/static/sentry/app/components/events/rrwebReplayer.jsx
+++ b/src/sentry/static/sentry/app/components/events/rrwebReplayer.jsx
@@ -30,39 +30,53 @@ class RRWebReplayer extends Component {
 }
 
 export default styled(RRWebReplayer)`
-  .rr-player,
-  .rr-player__frame {
+  .rr-player {
     width: auto !important;
-    max-width: 600px;
-    overflow: hidden;
-    margin: 0 auto;
+    height: auto !important;
+  }
+  .rr-player__frame {
+    width: 100% !important;
+    height: 500px !important;
+  }
 
-    @media (min-width: ${theme.breakpoints[3]}) {
-      max-width: 800px;
-    }
+  .rr-player iframe {
+    width: 100% !important;
+    height: 100% !important;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border: 0;
   }
 
   .replayer-wrapper {
-    float: left;
-    clear: both;
+    transform: scale(0.6) translate(0, 0) !important;
     transform-origin: top left;
-    left: 50%;
-    top: 50%;
+    width: 166.66%;
+    height: 166.66%;
+    overflow: hidden;
+    position: relative;
+    box-shadow: inset 0 -1px 3px rgba(0, 0, 0, 0.08);
+  }
+
+  .replayer-mouse,
+  .replayer-mouse:after {
+    z-index: ${theme.zIndex.tooltip};
   }
 
   .rr-controller {
     width: 100%;
-    height: 80px;
+    display: block;
+    padding: ${theme.space[2]}px 0;
     background: #fff;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
-    align-items: center;
     border-radius: 0 0 5px 5px;
+    box-shadow: 0 -1px 3px 0 rgba(0, 0, 0, 0.1);
+    position: relative;
   }
 
   .rr-timeline {
-    width: 80%;
+    width: 100%;
     display: flex;
     align-items: center;
   }


### PR DESCRIPTION
**Before:**

![Screen Recording 2020-07-30 at 11 02 AM](https://user-images.githubusercontent.com/30713/88957868-7299f680-d254-11ea-880e-23661b4fddcd.gif)

**After:**

![Screen Recording 2020-07-29 at 11 24 PM](https://user-images.githubusercontent.com/30713/88957737-39fa1d00-d254-11ea-8ee2-c4492b6f1d61.gif)

**Todos:**

- [x] Confirm that the 60% scale + 166.66% width technique I'm using applies to the mouse events layer
- [x] Figure out a way to set height to 100% when full screen 
