### PR TITLE
fix: Set ALLOWED_HOSTS before starting relay

### DIFF
--- a/src/sentry/testutils/relay.py
+++ b/src/sentry/testutils/relay.py
@@ -36,30 +36,6 @@ def ensure_relay_is_registered():
         pass  # NOQA
 
 
-def adjust_settings_for_relay_tests(settings):
-    """
-    Adjusts the application settings to accept calls from a Relay instance running inside a
-    docker container.
-
-    :param settings: the app settings
-    """
-    settings.ALLOWED_HOSTS = [
-        "localhost",
-        "testserver",
-        "host.docker.internal",
-        "0.0.0.0",
-        "127.0.0.1",
-    ]
-    settings.KAFKA_CLUSTERS = {
-        "default": {
-            "bootstrap.servers": "127.0.0.1:9092",
-            "compression.type": "lz4",
-            "message.max.bytes": 50000000,  # 50MB, default is 1MB
-        }
-    }
-    settings.SENTRY_RELAY_WHITELIST_PK = ["SMSesqan65THCV6M4qs4kBzPai60LzuDn-xNsvYpuP8"]
-
-
 class RelayStoreHelper(object):
     """
     Tests that post to the store entry point should use this helper class
@@ -169,8 +145,6 @@ class RelayStoreHelper(object):
         self.auth_header = get_auth_header(
             "TEST_USER_AGENT/0.0.0", self.projectkey.public_key, self.projectkey.secret_key, "7"
         )
-
-        adjust_settings_for_relay_tests(settings)
 
         self.settings = settings
         self.get_relay_store_url = get_relay_store_url  # noqa

--- a/src/sentry/utils/pytest/relay.py
+++ b/src/sentry/utils/pytest/relay.py
@@ -117,7 +117,7 @@ def relay_server_setup(live_server, tmpdir_factory):
 
 @pytest.fixture(scope="function")
 def relay_server(relay_server_setup, settings):
-    _adjust_settings_for_relay_tests(settings)
+    adjust_settings_for_relay_tests(settings)
     options = relay_server_setup["options"]
     docker_client = get_docker_client()
     container_name = _relay_server_container_name()
@@ -138,7 +138,7 @@ def relay_server(relay_server_setup, settings):
     return {"url": relay_server_setup["url"]}
 
 
-def _adjust_settings_for_relay_tests(settings):
+def adjust_settings_for_relay_tests(settings):
     """
     Adjusts the application settings to accept calls from a Relay instance running inside a
     docker container.

--- a/src/sentry/utils/pytest/relay.py
+++ b/src/sentry/utils/pytest/relay.py
@@ -116,7 +116,8 @@ def relay_server_setup(live_server, tmpdir_factory):
 
 
 @pytest.fixture(scope="function")
-def relay_server(relay_server_setup):
+def relay_server(relay_server_setup, settings):
+    _adjust_settings_for_relay_tests(settings)
     options = relay_server_setup["options"]
     docker_client = get_docker_client()
     container_name = _relay_server_container_name()
@@ -135,6 +136,30 @@ def relay_server(relay_server_setup):
         raise ValueError("relay did not start in time")
 
     return {"url": relay_server_setup["url"]}
+
+
+def _adjust_settings_for_relay_tests(settings):
+    """
+    Adjusts the application settings to accept calls from a Relay instance running inside a
+    docker container.
+
+    :param settings: the app settings
+    """
+    settings.ALLOWED_HOSTS = [
+        "localhost",
+        "testserver",
+        "host.docker.internal",
+        "0.0.0.0",
+        "127.0.0.1",
+    ]
+    settings.KAFKA_CLUSTERS = {
+        "default": {
+            "bootstrap.servers": "127.0.0.1:9092",
+            "compression.type": "lz4",
+            "message.max.bytes": 50000000,  # 50MB, default is 1MB
+        }
+    }
+    settings.SENTRY_RELAY_WHITELIST_PK = ["SMSesqan65THCV6M4qs4kBzPai60LzuDn-xNsvYpuP8"]
 
 
 @pytest.fixture

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -12,7 +12,7 @@ from sentry.utils.compat import mock
 
 from sentry import eventstore
 from sentry.testutils import assert_mock_called_once_with_partial
-from sentry.testutils.relay import adjust_settings_for_relay_tests
+from sentry.utils.pytest.relay import adjust_settings_for_relay_tests
 
 
 @pytest.fixture


### PR DESCRIPTION
Since https://github.com/getsentry/relay/pull/696 relay no longer retries on 400s. We were actually throwing a lot of 400s because we were setting the ALLOWED_HOSTS after relay has started.

cc @jan-auer @RaduW 