### PR TITLE
fix(celery): Fix error with pickling `RetryException`

### DIFF
--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -13,8 +13,12 @@ logger = logging.getLogger(__name__)
 
 class RetryException(Exception):
     def __init__(self, message, exception):
+        super(RetryException, self).__init__(message)
         self.message = message
         self.exception = exception
+
+    def __reduce__(self):
+        return RetryException, (self.message, self.exception)
 
     def __str__(self):
         return force_bytes(self.message, errors="replace")


### PR DESCRIPTION
This fixes a bug with pickling our `RetryException` class. There are a couple of problems with the
exception:
 - https://github.com/celery/celery/issues/3623: Doesn't call `super()` which causes issues.
 - `Exception` implements `__reduce__` and only passes a single arg, so pickling will fail anyway.
   We needed to implement `__reduce__` on our exception and have it handle passing both args that
are required to construct the exception. (https://stackoverflow.com/a/36342588,
https://docs.python.org/2/library/pickle.html#object.__reduce__)

Fixes SENTRY-H9Z