### PR TITLE
fix(discover) Format y-axis and tooltips consistently

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/charts.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/charts.tsx
@@ -1,0 +1,39 @@
+import {getDuration, formatPercentage} from 'app/utils/formatters';
+import {aggregateOutputType} from 'app/utils/discover/fields';
+
+/**
+ * Formatter for chart tooltips that handle a variety of discover result values
+ */
+export function tooltipFormatter(value: number, seriesName: string): string {
+  switch (aggregateOutputType(seriesName)) {
+    case 'number':
+      return value.toLocaleString();
+    case 'percentage':
+      return formatPercentage(value, 2);
+    case 'duration':
+      return getDuration(value / 1000, 2, true);
+    default:
+      return value.toString();
+  }
+}
+
+/**
+ * Formatter for chart axis labels that handle a variety of discover result values
+ * This function is *very similar* to tootipFormatter but outputs data with less precision.
+ */
+export function axisLabelFormatter(value: number, seriesName: string): string {
+  switch (aggregateOutputType(seriesName)) {
+    case 'integer':
+    case 'number':
+      return value.toLocaleString();
+    case 'percentage':
+      return formatPercentage(value, 1);
+    case 'duration':
+      if (value === 0) {
+        return '0';
+      }
+      return getDuration(value / 1000, 0, true);
+    default:
+      return value.toString();
+  }
+}

--- a/src/sentry/static/sentry/app/utils/discover/charts.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/charts.tsx
@@ -6,6 +6,7 @@ import {aggregateOutputType} from 'app/utils/discover/fields';
  */
 export function tooltipFormatter(value: number, seriesName: string): string {
   switch (aggregateOutputType(seriesName)) {
+    case 'integer':
     case 'number':
       return value.toLocaleString();
     case 'percentage':

--- a/src/sentry/static/sentry/app/utils/discover/charts.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/charts.tsx
@@ -28,7 +28,7 @@ export function axisLabelFormatter(value: number, seriesName: string): string {
     case 'number':
       return value.toLocaleString();
     case 'percentage':
-      return formatPercentage(value, 1);
+      return formatPercentage(value, 0);
     case 'duration':
       if (value === 0) {
         return '0';

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -7,6 +7,7 @@ import {Series} from 'app/types/echarts';
 import AreaChart from 'app/components/charts/areaChart';
 import ChartZoom from 'app/components/charts/chartZoom';
 import {aggregateOutputType} from 'app/utils/discover/fields';
+import {tooltipFormatter, axisLabelFormatter} from 'app/utils/discover/charts';
 import theme from 'app/utils/theme';
 
 type Props = {
@@ -98,11 +99,23 @@ class Chart extends React.Component<Props> {
           gridIndex: 0,
           scale: true,
           max: dataMax,
+          axisLabel: {
+            color: theme.gray400,
+            formatter(value: number) {
+              return axisLabelFormatter(value, data[0].seriesName);
+            },
+          },
         },
         {
           gridIndex: 1,
           scale: true,
           max: dataMax,
+          axisLabel: {
+            color: theme.gray400,
+            formatter(value: number) {
+              return axisLabelFormatter(value, data[1].seriesName);
+            },
+          },
         },
       ],
       utc,
@@ -110,7 +123,8 @@ class Chart extends React.Component<Props> {
       showTimeInTooltip: true,
       colors: [colors[0], colors[1]],
       tooltip: {
-        nameFormatter(value) {
+        valueFormatter: tooltipFormatter,
+        nameFormatter(value: string) {
           return value === 'epm()' ? 'tpm()' : value;
         },
       },

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -21,7 +21,7 @@ import EventView from 'app/utils/discover/eventView';
 import withApi from 'app/utils/withApi';
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
-import {getDuration} from 'app/utils/formatters';
+import {tooltipFormatter, axisLabelFormatter} from 'app/utils/discover/charts';
 import getDynamicText from 'app/utils/getDynamicText';
 
 import {HeaderTitleLegend} from '../styles';
@@ -110,16 +110,32 @@ class DurationChart extends React.Component<Props> {
       selected: seriesSelection,
     };
 
-    const tooltip = {
-      valueFormatter(value: number) {
-        return getDuration(value / 1000, 2);
-      },
-    };
-
     const datetimeSelection = {
       start: start || null,
       end: end || null,
       period: statsPeriod,
+    };
+
+    const chartOptions = {
+      grid: {
+        left: '10px',
+        right: '10px',
+        top: '40px',
+        bottom: '0px',
+      },
+      seriesOptions: {
+        showSymbol: false,
+      },
+      tooltip: {
+        valueFormatter: tooltipFormatter,
+      },
+      yAxis: {
+        axisLabel: {
+          color: theme.gray400,
+          // p50 coerces the axis to be time based
+          formatter: (value: number) => axisLabelFormatter(value, 'p50()'),
+        },
+      },
     };
 
     return (
@@ -201,19 +217,10 @@ class DurationChart extends React.Component<Props> {
                           value: (
                             <AreaChart
                               {...zoomRenderProps}
+                              {...chartOptions}
                               legend={legend}
                               onLegendSelectChanged={this.handleLegendSelectChanged}
                               series={[...series, ...releaseSeries]}
-                              seriesOptions={{
-                                showSymbol: false,
-                              }}
-                              tooltip={tooltip}
-                              grid={{
-                                left: '10px',
-                                right: '10px',
-                                top: '40px',
-                                bottom: '0px',
-                              }}
                             />
                           ),
                           fixed: 'Duration Chart',

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -91,7 +91,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
         // apdex
         gridIndex: 0,
         axisLabel: {
-          formatter: (value: number) => formatFloat(value, 2),
+          formatter: (value: number) => formatFloat(value, 1),
           color: theme.gray400,
         },
         ...axisLineConfig,
@@ -109,7 +109,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
         // failure rate
         gridIndex: 2,
         axisLabel: {
-          formatter: (value: number) => formatPercentage(value, 2),
+          formatter: (value: number) => formatPercentage(value, 0),
           color: theme.gray400,
         },
         ...axisLineConfig,

--- a/tests/js/spec/utils/discover/charts.spec.jsx
+++ b/tests/js/spec/utils/discover/charts.spec.jsx
@@ -1,0 +1,36 @@
+import {tooltipFormatter, axisLabelFormatter} from 'app/utils/discover/charts';
+
+describe('tooltipFormatter()', function() {
+  it('formats values', function() {
+    const cases = [
+      // function, input, expected
+      ['count()', 0.1, '0.1'],
+      ['avg(thing)', 0.125126, '0.125'],
+      ['failure_rate()', 0.66123, '66.12%'],
+      ['p50()', 100, '100.00ms'],
+      ['p50()', 100.23, '100.23ms'],
+      ['p50()', 1200, '1.20s'],
+      ['p50()', 86400000, '24.00hr'],
+    ];
+    for (const scenario of cases) {
+      expect(tooltipFormatter(scenario[1], scenario[0])).toEqual(scenario[2]);
+    }
+  });
+});
+
+describe('axisLabelFormatter()', function() {
+  it('formats values', function() {
+    const cases = [
+      // type, input, expected
+      ['count()', 0.1, '0.1'],
+      ['avg(thing)', 0.125126, '0.125'],
+      ['failure_rate()', 0.66123, '66.1%'],
+      ['p50()', 100, '100ms'],
+      ['p50()', 1200, '1s'],
+      ['p50()', 86400000, '24hr'],
+    ];
+    for (const scenario of cases) {
+      expect(axisLabelFormatter(scenario[1], scenario[0])).toEqual(scenario[2]);
+    }
+  });
+});

--- a/tests/js/spec/utils/discover/charts.spec.jsx
+++ b/tests/js/spec/utils/discover/charts.spec.jsx
@@ -24,7 +24,7 @@ describe('axisLabelFormatter()', function() {
       // type, input, expected
       ['count()', 0.1, '0.1'],
       ['avg(thing)', 0.125126, '0.125'],
-      ['failure_rate()', 0.66123, '66.1%'],
+      ['failure_rate()', 0.66123, '66%'],
       ['p50()', 100, '100ms'],
       ['p50()', 1200, '1s'],
       ['p50()', 86400000, '24hr'],

--- a/tests/js/spec/utils/formatters.spec.jsx
+++ b/tests/js/spec/utils/formatters.spec.jsx
@@ -2,7 +2,38 @@ import {
   formatFloat,
   formatAbbreviatedNumber,
   formatPercentage,
+  getDuration,
 } from 'app/utils/formatters';
+
+describe('getDuration()', function() {
+  it('should format durations', function() {
+    expect(getDuration(0, 2)).toBe('0.00ms');
+    expect(getDuration(0.1)).toBe('100ms');
+    expect(getDuration(0.1, 2)).toBe('100.00ms');
+    expect(getDuration(1)).toBe('1 second');
+    expect(getDuration(2)).toBe('2 seconds');
+    expect(getDuration(65)).toBe('65 seconds');
+    expect(getDuration(122)).toBe('2 minutes');
+    expect(getDuration(3720)).toBe('62 minutes');
+    expect(getDuration(36000)).toBe('10 hours');
+    expect(getDuration(86400)).toBe('24 hours');
+    expect(getDuration(86400 * 2)).toBe('2 days');
+    expect(getDuration(604800)).toBe('1 week');
+  });
+
+  it('should format numbers and abbreviate units', function() {
+    expect(getDuration(0, 2, true)).toBe('0.00ms');
+    expect(getDuration(0, 0, true)).toBe('0ms');
+    expect(getDuration(0.1, 0, true)).toBe('100ms');
+    expect(getDuration(0.1, 2, true)).toBe('100.00ms');
+    expect(getDuration(1, 2, true)).toBe('1.00s');
+    expect(getDuration(122, 0, true)).toBe('2min');
+    expect(getDuration(3600, 0, true)).toBe('60min');
+    expect(getDuration(86400, 0, true)).toBe('24hr');
+    expect(getDuration(86400 * 2, 0, true)).toBe('2d');
+    expect(getDuration(604800, 0, true)).toBe('1wk');
+  });
+});
 
 describe('formatAbbreviatedNumber()', function() {
   it('should abbreviate numbers', function() {


### PR DESCRIPTION
Update discover and performance views to format durations as s/ms consistently across all charts. Also use short forms for time units in tooltips and axis labels as they consume less space and are more consistent with how we show these values elsewhere.

#### failure rate as %
![Screen Shot 2020-07-30 at 9 22 20 PM](https://user-images.githubusercontent.com/24086/88990388-ce439e80-d2ab-11ea-9dda-082895c51d59.png)

#### discover with durations
![Screen Shot 2020-07-30 at 5 53 09 PM](https://user-images.githubusercontent.com/24086/88990413-e5828c00-d2ab-11ea-84a7-913e14e4f4de.png)

#### Performance overview
![Screen Shot 2020-07-30 at 5 34 44 PM](https://user-images.githubusercontent.com/24086/88990480-09de6880-d2ac-11ea-9e76-157e3c654d63.png)

#### Performance summary
![Screen Shot 2020-07-30 at 5 22 23 PM](https://user-images.githubusercontent.com/24086/88990500-1d89cf00-d2ac-11ea-9c1a-1fee0875e16c.png)


