### PR TITLE
feat(relay): Check version during authentication

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -51,7 +51,7 @@ requests[security]>=2.20.0,<2.21.0
 rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
-sentry-relay>=0.5.11,<0.6.0
+sentry-relay>=0.5.12,<0.6.0
 sentry-sdk>=0.16.0,<0.17.0
 simplejson>=3.2.0,<3.9.0
 six>=1.11.0,<1.12.0


### PR DESCRIPTION
In the authentication challenge endpoint, verify that Relay's version is still supported. Compatibility is supplied by the `sentry_relay` crate and can be checked with `is_version_supported`.

Initially, all Relay versions are supported. In the future, breaking changes in Relay may drop support for older versions and then update the minimum supported version in the package.

Requires https://github.com/getsentry/relay/pull/697
Requires new version of `sentry_relay`