### PR TITLE
fix: Prevent celery from printing out vegetables to the terminal

### DIFF
--- a/src/sentry/monkey/__init__.py
+++ b/src/sentry/monkey/__init__.py
@@ -84,5 +84,18 @@ def patch_django_views_debug():
     debug.get_safe_settings = lambda: {}
 
 
-for patch in (patch_parse_cookie, patch_httprequest_repr, patch_django_views_debug):
+def patch_celery_imgcat():
+    # Remove Celery's attempt to display an rgb image in iTerm 2, as that
+    # attempt just prints out base64 trash in tmux.
+    from celery.utils import term
+
+    term.imgcat = lambda *a, **kw: b""
+
+
+for patch in (
+    patch_parse_cookie,
+    patch_httprequest_repr,
+    patch_django_views_debug,
+    patch_celery_imgcat,
+):
     patch()

--- a/src/sentry/monkey/__init__.py
+++ b/src/sentry/monkey/__init__.py
@@ -87,7 +87,10 @@ def patch_django_views_debug():
 def patch_celery_imgcat():
     # Remove Celery's attempt to display an rgb image in iTerm 2, as that
     # attempt just prints out base64 trash in tmux.
-    from celery.utils import term
+    try:
+        from celery.utils import term
+    except ImportError:
+        return
 
     term.imgcat = lambda *a, **kw: b""
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/837573/89066815-61450d00-d36e-11ea-8c36-dd317c8381bf.png)

when it works it's ok, when it doesn't it's base64