### PR TITLE
fix(celery): Pin amqp to 2.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     packages=find_packages("src"),
     zip_safe=False,
     install_requires=install_requires,
-    extras_require={"dev": dev_requires, "rabbitmq": ["amqp==2.6.0"]},
+    extras_require={"dev": dev_requires, "rabbitmq": ["amqp==2.6.1"]},
     cmdclass=cmdclass,
     license="BSL-1.1",
     include_package_data=True,


### PR DESCRIPTION
amqp released a new version with the fix for the buffer overflow issue we were experiencing, so
bumping to this version.