### PR TITLE
fix(search): Disallow suggestions for id and timestamp

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -705,7 +705,8 @@ class SnubaTagStorage(TagStorage):
         #               generate a time range to bound where they are searching. e.g. if a user
         #               enters 2020-07 we can generate the following conditions:
         #               >= 2020-07-01T00:00:00 AND <= 2020-07-31T23:59:59
-        if snuba_key in {"event_id", "timestamp"}:
+        # time:         This is a column computed from timestamp so it suffers the same issues
+        if snuba_key in {"event_id", "timestamp", "time"}:
             return SequencePaginator([])
 
         conditions = []

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -200,21 +200,17 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
     def test_no_projects(self):
         self.run_test("fruit", expected=[])
 
-    def test_id(self):
+    def test_disabled_tag_keys(self):
         self.store_event(
             data={"timestamp": iso_format(self.day_ago), "tags": {"fruit": "apple"}},
             project_id=self.project.id,
         )
         self.run_test("id", expected=[])
         self.run_test("id", qs_params={"query": "z"}, expected=[])
-
-    def test_timstamp(self):
-        self.store_event(
-            data={"timestamp": iso_format(self.day_ago), "tags": {"fruit": "apple"}},
-            project_id=self.project.id,
-        )
         self.run_test("timestamp", expected=[])
         self.run_test("timestamp", qs_params={"query": "z"}, expected=[])
+        self.run_test("time", expected=[])
+        self.run_test("time", qs_params={"query": "z"}, expected=[])
 
 
 class TransactionTagKeyValues(OrganizationTagKeyTestCase):

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -200,6 +200,22 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
     def test_no_projects(self):
         self.run_test("fruit", expected=[])
 
+    def test_id(self):
+        self.store_event(
+            data={"timestamp": iso_format(self.day_ago), "tags": {"fruit": "apple"}},
+            project_id=self.project.id,
+        )
+        self.run_test("id", expected=[])
+        self.run_test("id", qs_params={"query": "z"}, expected=[])
+
+    def test_timstamp(self):
+        self.store_event(
+            data={"timestamp": iso_format(self.day_ago), "tags": {"fruit": "apple"}},
+            project_id=self.project.id,
+        )
+        self.run_test("timestamp", expected=[])
+        self.run_test("timestamp", qs_params={"query": "z"}, expected=[])
+
 
 class TransactionTagKeyValues(OrganizationTagKeyTestCase):
     def setUp(self):


### PR DESCRIPTION
In Snuba, event_id is a FixedString and timestamp is a DateTime which are
incompatible with like and != that we use to filter values. Furthermore,
filtering suggesting ids and timestamps is often not useful so we opt to
disable them instead.