### PR TITLE
fix(ui) Fix colours on breadcrumbs v1

### DIFF
--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -243,10 +243,10 @@ class ContextData extends React.Component {
     } = this.props;
 
     return (
-      <pre {...other}>
+      <ContextValues {...other}>
         {this.renderValue(data)}
         {children}
-      </pre>
+      </ContextValues>
     );
   }
 }
@@ -256,6 +256,11 @@ ContextData.displayName = 'ContextData';
 const StyledIconOpen = styled(IconOpen)`
   position: relative;
   top: 1px;
+`;
+
+const ContextValues = styled('pre')`
+  /* Not using theme to be consistent with less files */
+  color: #4e3fb4;
 `;
 
 export default ContextData;

--- a/src/sentry/static/sentry/app/components/events/eventSdk.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventSdk.tsx
@@ -17,7 +17,7 @@ const EventSdk = ({event: {sdk: data}}: Props) => (
           <td className="key">{t('Name')}</td>
           <td className="value">
             <Annotated object={data} objectKey="name">
-              {value => <pre>{value}</pre>}
+              {value => <pre className="val-string">{value}</pre>}
             </Annotated>
           </td>
         </tr>
@@ -25,7 +25,7 @@ const EventSdk = ({event: {sdk: data}}: Props) => (
           <td className="key">{t('Version')}</td>
           <td className="value">
             <Annotated object={data} objectKey="version">
-              {value => <pre>{value}</pre>}
+              {value => <pre className="val-string">{value}</pre>}
             </Annotated>
           </td>
         </tr>

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -341,7 +341,6 @@ table.table.key-value {
       word-break: break-word;
       padding: 8px 10px;
       font-size: 12px;
-      color: darken(@purple, 10);
 
       .val-string:first-child {
         padding-left: 0;


### PR DESCRIPTION
In my previous change to fix padding I moved a colour definition which caused breacrumbs v1 to become purple. This reverts that change, and retains context data styling by applying val-string to SDK context data.