### PR TITLE
fix(deletions): Don't fail deleting EventAttachment on missing File

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -45,4 +45,11 @@ class EventAttachment(Model):
         # with the next incoming crash report.
         cache.delete(get_crashreport_key(self.group_id))
 
-        self.file.delete()
+        try:
+            self.file.delete()
+        except type(self.file).DoesNotExist:
+            # It's possible that the File itself was deleted
+            # before we were deleted when the object is in memory
+            # This seems to be a case that happens during deletion
+            # code.
+            pass


### PR DESCRIPTION
This seems odd since File itself is a foreign key, so it's not
technically possible for this to exist in the database. But it happens.

In theory this can happen when the EventAttachment is sitting in memory,
then somethign else comes along and deletes the File. The File and the
EventAttachment are both gone at that point, but the EventAttachment in
memory doesn't know that.

This prevents that issue entirely.