### PR TITLE
fix(deletions): Catch generic ObjectDoesNotExist

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.core.cache import cache
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.utils import timezone
 
@@ -38,7 +39,7 @@ class EventAttachment(Model):
     __repr__ = sane_repr("event_id", "name", "file_id")
 
     def delete(self, *args, **kwargs):
-        super(EventAttachment, self).delete(*args, **kwargs)
+        rv = super(EventAttachment, self).delete(*args, **kwargs)
 
         # Always prune the group cache. Even if there are more crash reports
         # stored than the now configured limit, the cache will be repopulated
@@ -46,10 +47,14 @@ class EventAttachment(Model):
         cache.delete(get_crashreport_key(self.group_id))
 
         try:
-            self.file.delete()
-        except type(self.file).DoesNotExist:
+            file = self.file
+        except ObjectDoesNotExist:
             # It's possible that the File itself was deleted
             # before we were deleted when the object is in memory
             # This seems to be a case that happens during deletion
             # code.
             pass
+        else:
+            file.delete()
+
+        return rv


### PR DESCRIPTION
Doing `self.file` alone will trigger the error, so we can't use that to
get the type, and didn't wanna mess with any potential circular import
from models.File.