### PR TITLE
ref(api): Use queryset.exists() instead of .count()>0

### DIFF
--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -36,4 +36,4 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         if project_ids:
             queryset = queryset.filter(id__in=project_ids)
 
-        return Response(serialize({"sentFirstEvent": queryset.count() > 0}, request.user))
+        return Response(serialize({"sentFirstEvent": queryset.exists()}, request.user))


### PR DESCRIPTION
Since we don't care about the actual count, let the database perform a
simpler and faster query instead.

https://docs.djangoproject.com/en/1.11/ref/models/querysets/#exists