### PR TITLE
feat(score-reason): Add filenames and line numbers to score reason

### DIFF
--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -89,7 +89,10 @@ def _match_commits_path(commit_file_changes, path, lineno=None):
 
     for i, file_change in enumerate(commit_file_changes):
         score = score_path_match_length(file_change.filename, path)
-        score_reason = "Commit file changes match the run time path."
+        score_reason = "Commited file `%s` matches the run time path `%s`." % (
+            file_change.filename,
+            path,
+        )
 
         if score > 0:
             # Raise the score if the line range changed in this commit
@@ -114,10 +117,20 @@ def _match_commits_path(commit_file_changes, path, lineno=None):
                     best_line_score += line_score
                     score += best_line_score + exact_line_score
                     if exact_line_score:
-                        score_reason = "Commit modified the exact line contained the runtime path."
+                        score_reason = (
+                            "Commit modified `%s` on line %d which matches the run time path `%s:%d`."
+                            % (file_change.filename, lineno, path, lineno)
+                        )
                     else:
                         score_reason = (
-                            "Commit modified the line range contained in the runtime path."
+                            "Commit modified `%s` from lines %d-%d which matches the run time path `%s:%d`."
+                            % (
+                                file_change.filename,
+                                file_line_change.line_start,
+                                file_line_change.line_end,
+                                path,
+                                lineno,
+                            )
                         )
 
         if score > best_score:

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -183,7 +183,7 @@ class MatchCommitsPathTestCase(CommitTestCase):
             "hello/app.py",
             "hello/app.py",
         )
-        assert [(file_change.commit, 2, score_reason)] == _match_commits_path(
+        assert [(file_change.commit, 2, score_reason, "Low")] == _match_commits_path(
             file_changes, "hello/app.py"
         )
 
@@ -205,7 +205,7 @@ class MatchCommitsPathTestCase(CommitTestCase):
         score_reason = "Commited file `%s` matches the run time path `hello/app.py`."
 
         commits = sorted(
-            [(fc.commit, 2, score_reason % fc.filename) for fc in file_changes],
+            [(fc.commit, 2, score_reason % fc.filename, "Low") for fc in file_changes],
             key=lambda fc: fc[0].id,
         )
         assert commits == sorted(
@@ -244,7 +244,8 @@ class MatchCommitsPathTestCase(CommitTestCase):
         )
 
         commits = sorted(
-            [(fc.commit, 3, score_reason) for fc in file_changes[-1:]], key=lambda fc: fc[0].id,
+            [(fc.commit, 3, score_reason, "Medium") for fc in file_changes[-1:]],
+            key=lambda fc: fc[0].id,
         )
         assert commits == sorted(
             _match_commits_path(file_changes, "hello/app.py", lineno=6), key=lambda fc: fc[0].id
@@ -286,7 +287,8 @@ class MatchCommitsPathTestCase(CommitTestCase):
         )
 
         commits = sorted(
-            [(fc.commit, 8, score_reason) for fc in file_changes[-4:-3]], key=lambda fc: fc[0].id,
+            [(fc.commit, 8, score_reason, "High") for fc in file_changes[-4:-3]],
+            key=lambda fc: fc[0].id,
         )
 
         assert commits == sorted(
@@ -301,7 +303,8 @@ class MatchCommitsPathTestCase(CommitTestCase):
         self.create_commitfilelinechange(6, 6, commitfilechange=file_changes[-1])
 
         commits = sorted(
-            [(fc.commit, 13, score_reason) for fc in file_changes[-1:]], key=lambda fc: fc[0].id,
+            [(fc.commit, 13, score_reason, "High") for fc in file_changes[-1:]],
+            key=lambda fc: fc[0].id,
         )
 
         assert commits == sorted(
@@ -643,6 +646,7 @@ class GetEventFileCommitters(CommitTestCase):
                 % ("src/sentry/models/release.py", 38, 40, "sentry/models/release.py", 39)
             )
         )
+        assert result[0]["commits"][0]["scoreConfidence"] == six.binary_type("Medium")
 
     def test_matching_case_insensitive(self):
         event = self.store_event(

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -179,9 +179,13 @@ class MatchCommitsPathTestCase(CommitTestCase):
             file_change,
             self.create_commitfilechange(filename="goodbye/app.js", type="A"),
         ]
-        assert [
-            (file_change.commit, 2, "Commit file changes match the run time path.")
-        ] == _match_commits_path(file_changes, "hello/app.py")
+        score_reason = "Commited file `%s` matches the run time path `%s`." % (
+            "hello/app.py",
+            "hello/app.py",
+        )
+        assert [(file_change.commit, 2, score_reason)] == _match_commits_path(
+            file_changes, "hello/app.py"
+        )
 
     def test_skip_one_score_match_longer_than_one_token(self):
         file_changes = [
@@ -198,8 +202,10 @@ class MatchCommitsPathTestCase(CommitTestCase):
             self.create_commitfilechange(filename="template/hello/app.py", type="A"),
         ]
 
+        score_reason = "Commited file `%s` matches the run time path `hello/app.py`."
+
         commits = sorted(
-            [(fc.commit, 2, "Commit file changes match the run time path.") for fc in file_changes],
+            [(fc.commit, 2, score_reason % fc.filename) for fc in file_changes],
             key=lambda fc: fc[0].id,
         )
         assert commits == sorted(
@@ -232,12 +238,13 @@ class MatchCommitsPathTestCase(CommitTestCase):
 
         self.create_commitfilelinechange(5, 10, commitfilechange=file_changes[-1])
 
+        score_reason = (
+            "Commit modified `%s` from lines %d-%d which matches the run time path `%s:%d`."
+            % ("hello/app.py", 5, 10, "hello/app.py", 6,)
+        )
+
         commits = sorted(
-            [
-                (fc.commit, 3, "Commit modified the line range contained in the runtime path.")
-                for fc in file_changes[-1:]
-            ],
-            key=lambda fc: fc[0].id,
+            [(fc.commit, 3, score_reason) for fc in file_changes[-1:]], key=lambda fc: fc[0].id,
         )
         assert commits == sorted(
             _match_commits_path(file_changes, "hello/app.py", lineno=6), key=lambda fc: fc[0].id
@@ -273,12 +280,13 @@ class MatchCommitsPathTestCase(CommitTestCase):
         self.create_commitfilelinechange(5, 10, commitfilechange=file_changes[-3])
         self.create_commitfilelinechange(6, 6, commitfilechange=file_changes[-4])
 
+        score_reason = (
+            "Commit modified `%s` on line %d which matches the run time path `%s:%d`."
+            % ("hello/app.py", 6, "hello/app.py", 6,)
+        )
+
         commits = sorted(
-            [
-                (fc.commit, 8, "Commit modified the exact line contained the runtime path.")
-                for fc in file_changes[-4:-3]
-            ],
-            key=lambda fc: fc[0].id,
+            [(fc.commit, 8, score_reason) for fc in file_changes[-4:-3]], key=lambda fc: fc[0].id,
         )
 
         assert commits == sorted(
@@ -293,11 +301,7 @@ class MatchCommitsPathTestCase(CommitTestCase):
         self.create_commitfilelinechange(6, 6, commitfilechange=file_changes[-1])
 
         commits = sorted(
-            [
-                (fc.commit, 13, "Commit modified the exact line contained the runtime path.")
-                for fc in file_changes[-1:]
-            ],
-            key=lambda fc: fc[0].id,
+            [(fc.commit, 13, score_reason) for fc in file_changes[-1:]], key=lambda fc: fc[0].id,
         )
 
         assert commits == sorted(
@@ -634,7 +638,10 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "b" * 40
         assert result[0]["commits"][0]["scoreReason"] == (
-            six.binary_type("Commit modified the line range contained in the runtime path.")
+            six.binary_type(
+                "Commit modified `%s` from lines %d-%d which matches the run time path `%s:%d`."
+                % ("src/sentry/models/release.py", 38, 40, "sentry/models/release.py", 39)
+            )
         )
 
     def test_matching_case_insensitive(self):


### PR DESCRIPTION
Adds more information to `scoreReason` as well as provides a matching `scoreConfidence`:

- Low - filename matches path in the frame
- Medium - filename matches path and the line range change contains the line number in the frame
- High - filename matches path and line range is exactly the line number in the frame