### PR TITLE
ref(ts) Convert create organization and routeerror to typescript

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -444,10 +444,8 @@ export default class AsyncComponent<
     return (
       <RouteError
         error={error}
-        component={this}
         disableLogSentry={!shouldLogSentry}
         disableReport={disableReport}
-        onRetry={this.remountComponent}
       />
     );
   }

--- a/src/sentry/static/sentry/app/components/forms/inputField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/inputField.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import FormField from 'app/components/forms/formField';
 
 type InputFieldProps = FormField['props'] & {
-  placeholder: string;
+  placeholder?: string;
   inputStyle?: object;
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   onKeyPress?: (event: React.KeyboardEvent<HTMLInputElement>) => void;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -45,6 +45,11 @@ declare global {
      */
     SentryRenderApp: () => void;
     sentryEmbedCallback?: ((embed: any) => void) | null;
+    /**
+     * Set to true if adblock could be installed.
+     * See sentry/js/ads.js for how this global is disabled.
+     */
+    adblockSuspected?: boolean;
   }
 }
 

--- a/src/sentry/static/sentry/app/utils/errorHandler.tsx
+++ b/src/sentry/static/sentry/app/utils/errorHandler.tsx
@@ -4,7 +4,7 @@ import RouteError from 'app/views/routeError';
 
 type State = {
   hasError: boolean;
-  error: Error | null;
+  error: Error | undefined;
 };
 
 export default function errorHandler<P>(Component: React.ComponentType<P>) {
@@ -21,7 +21,7 @@ export default function errorHandler<P>(Component: React.ComponentType<P>) {
       // we are explicit if an error has been thrown since errors thrown are not guaranteed
       // to be truthy (e.g. throw null).
       hasError: false,
-      error: null,
+      error: undefined,
     };
 
     componentDidCatch(_error: Error, info: React.ErrorInfo) {

--- a/src/sentry/static/sentry/app/views/organizationCreate.tsx
+++ b/src/sentry/static/sentry/app/views/organizationCreate.tsx
@@ -18,7 +18,7 @@ export default class OrganizationCreate extends AsyncView {
   }
 
   getTitle() {
-    return 'Create Organization';
+    return t('Create Organization');
   }
 
   renderBody() {

--- a/src/sentry/static/sentry/app/views/routeError.tsx
+++ b/src/sentry/static/sentry/app/views/routeError.tsx
@@ -1,21 +1,29 @@
-import {withRouter} from 'react-router';
+import {withRouter, WithRouterProps} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import * as Sentry from '@sentry/react';
 import styled from '@emotion/styled';
 
+import Alert from 'app/components/alert';
+import {t, tct} from 'app/locale';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import {IconWarning} from 'app/icons';
 import space from 'app/styles/space';
 
-class RouteError extends React.Component {
+type Props = WithRouterProps & {
+  disableLogSentry?: boolean;
+  disableReport?: boolean;
+  error: Error;
+};
+
+class RouteError extends React.Component<Props> {
   static propTypes = {
     /**
      * Disable logging to Sentry
      */
     disableLogSentry: PropTypes.bool,
     disableReport: PropTypes.bool,
-    error: PropTypes.object.isRequired,
+    error: PropTypes.instanceOf(Error).isRequired,
     routes: PropTypes.array,
   };
 
@@ -82,44 +90,48 @@ class RouteError extends React.Component {
     document.querySelector('.sentry-error-embed-wrapper')?.remove();
   }
 
+  private _timeout: undefined | number;
+
   render() {
     // TODO(dcramer): show additional resource links
     return (
-      <div className="alert alert-block alert-error">
+      <Alert icon={<IconWarning size="md" />} type="error">
         <Heading>
-          <StyledIconWarning size="md" />
-          <span>Oops! Something went wrong</span>
+          <span>{t('Oops! Something went wrong')}</span>
         </Heading>
         <p>
+          {t(`
           It looks like you've hit an issue in our client application. Don't worry though!
           We use Sentry to monitor Sentry and it's likely we're already looking into this!
+          `)}
         </p>
-        <p>If you're daring, you may want to try the following:</p>
+        <p>{t("If you're daring, you may want to try the following:")}</p>
         <ul>
           {window && window.adblockSuspected && (
             <li>
-              We detected something AdBlock-like. Try disabling it, as it's known to cause
-              issues.
+              {t(
+                "We detected something AdBlock-like. Try disabling it, as it's known to cause issues."
+              )}
             </li>
           )}
           <li>
-            Give it a few seconds and{' '}
-            <a
-              onClick={() => {
-                window.location.href = window.location.href;
-              }}
-            >
-              reload the page
-            </a>
-            .
+            {tct(`Give it a few seconds and [link:reload the page].`, {
+              link: (
+                <a
+                  onClick={() => {
+                    window.location.href = window.location.href;
+                  }}
+                />
+              ),
+            })}
           </li>
           <li>
-            If all else fails,{' '}
-            <a href="http://github.com/getsentry/sentry/issues">create an issue</a> with
-            more details.
+            {tct(`If all else fails, [link:create an issue] with more details.`, {
+              link: <a href="http://github.com/getsentry/sentry/issues" />,
+            })}
           </li>
         </ul>
-      </div>
+      </Alert>
     );
   }
 }
@@ -132,10 +144,6 @@ const Heading = styled('h3')`
   font-weight: normal;
 
   margin-bottom: ${space(1.5)};
-`;
-
-const StyledIconWarning = styled(IconWarning)`
-  margin-right: ${space(1)};
 `;
 
 export default withRouter(RouteError);

--- a/src/sentry/static/sentry/app/views/routeError.tsx
+++ b/src/sentry/static/sentry/app/views/routeError.tsx
@@ -11,20 +11,19 @@ import {IconWarning} from 'app/icons';
 import space from 'app/styles/space';
 
 type Props = WithRouterProps & {
+  error: Error | undefined;
+  /**
+   * Disable logging to Sentry
+   */
   disableLogSentry?: boolean;
   disableReport?: boolean;
-  error: Error;
 };
 
 class RouteError extends React.Component<Props> {
   static propTypes = {
-    /**
-     * Disable logging to Sentry
-     */
     disableLogSentry: PropTypes.bool,
     disableReport: PropTypes.bool,
-    error: PropTypes.instanceOf(Error).isRequired,
-    routes: PropTypes.array,
+    error: PropTypes.instanceOf(Error),
   };
 
   static contextTypes = {

--- a/tests/js/spec/views/routeError.spec.jsx
+++ b/tests/js/spec/views/routeError.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as Sentry from '@sentry/react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {RouteError} from 'app/views/routeError';
 
@@ -16,7 +16,10 @@ describe('RouteError', function() {
   it('captures errors with raven', async function() {
     const error = new Error('Big Bad Error');
     const routes = TestStubs.routes();
-    mount(<RouteError routes={routes} error={error} />, TestStubs.routerContext());
+    mountWithTheme(
+      <RouteError routes={routes} error={error} />,
+      TestStubs.routerContext()
+    );
 
     await tick();
 


### PR DESCRIPTION
I've aligned RouteError with our newer Alert component styles as well.

![Screen Shot 2020-08-07 at 1 43 07 PM](https://user-images.githubusercontent.com/24086/89674655-81b52000-d8b6-11ea-9aff-ae09e0790d0b.png)
