### PR TITLE
fix(vercel): handle case with no name

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -316,8 +316,7 @@ class VercelIntegrationProvider(IntegrationProvider):
             external_id = data["user_id"]
             installation_type = "user"
             user = client.get_user()
-            name = user["name"]
-
+            name = user.get("name") or user["username"]
         try:
             webhook = client.create_deploy_webhook()
         except ApiError as err:


### PR DESCRIPTION
The name of the user is not required in Vercel. If there is no name, then we default to the username.

Fixes SENTRY-H86 and https://github.com/getsentry/sentry/issues/20116