### PR TITLE
fix(redux-state-context): Fix not showing data

### DIFF
--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -7,7 +7,7 @@ from django.utils.encoding import force_text
 
 from sentry.interfaces.base import Interface
 from sentry.utils.json import prune_empty_keys
-from sentry.utils.safe import get_path, trim
+from sentry.utils.safe import get_path
 
 __all__ = ("Contexts",)
 
@@ -37,7 +37,7 @@ class ContextType(object):
     def __init__(self, alias, data):
         self.alias = alias
         ctx_data = {}
-        for key, value in six.iteritems(trim(data)):
+        for key, value in six.iteritems(data):
             # we use simple checks here, rather than ' in set()' to avoid
             # issues with maps/lists
             if value is not None and value != "":

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -201,7 +201,6 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         assert trace["trace_id"] == original_trace["trace_id"]
         assert trace["span_id"] == original_trace["span_id"]
         assert trace["parent_span_id"] == original_trace["parent_span_id"]
-        assert trace["description"].endswith("...")
         assert trace["description"][:-3] in original_trace["description"]
 
     def test_blank_fields(self):


### PR DESCRIPTION
**Problem:** 

Some data coming from the `redux. state` context is not being completely shown in the UI. 

After debugging, I found that the problem was due to the use of the `trim` function. By default, it uses SENTRY_MAX_VARIABLE_SIZE of 512, preventing variables from exceeding this size in characters and now we need more than that.

**Solution:** According to the backend team, we no longer need to use the trim function, as we already filter the data in Relay.

closes: https://app.asana.com/0/1182975495223914/1187751364378701