### PR TITLE
ref(ui) Crisp up the expand/collapse icons

### DIFF
--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -6,7 +6,7 @@ import isArray from 'lodash/isArray';
 import styled from '@emotion/styled';
 
 import AnnotatedText from 'app/components/events/meta/annotatedText';
-import {IconOpen} from 'app/icons';
+import {IconOpen, IconAdd, IconSubtract} from 'app/icons';
 import {isUrl} from 'app/utils';
 
 function looksLikeObjectRepr(value) {
@@ -94,22 +94,23 @@ class ToggleWrap extends React.Component {
       return wrappedChildren;
     }
 
-    const classes = ['val-toggle'];
-    if (this.state.toggled) {
-      classes.push('val-toggle-open');
-    }
-
     return (
-      <span className={classes.join(' ')}>
-        <a
+      <span>
+        <ToggleIcon
+          isOpen={this.state.toggled}
           href="#"
-          className="val-toggle-link"
           onClick={evt => {
             this.setState(state => ({toggled: !state.toggled}));
             evt.preventDefault();
           }}
-        />
-        {wrappedChildren}
+        >
+          {this.state.toggled ? (
+            <IconSubtract size="9px" color="white" />
+          ) : (
+            <IconAdd size="9px" color="white" />
+          )}
+        </ToggleIcon>
+        {this.state.toggled && wrappedChildren}
       </span>
     );
   }
@@ -256,6 +257,23 @@ ContextData.displayName = 'ContextData';
 const StyledIconOpen = styled(IconOpen)`
   position: relative;
   top: 1px;
+`;
+
+const ToggleIcon = styled('a')`
+  display: inline-block;
+  position: relative;
+  top: 1px;
+  height: 11px;
+  width: 11px;
+  line-height: 1;
+  padding-left: 1px;
+  margin-left: 1px;
+  border-radius: 2px;
+
+  background: ${p => (p.isOpen ? p.theme.gray500 : p.theme.blue400)};
+  &:hover {
+    background: ${p => (p.isOpen ? p.theme.gray600 : p.theme.blue500)};
+  }
 `;
 
 const ContextValues = styled('pre')`

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1421,53 +1421,6 @@ span.val {
   }
 }
 
-.val-toggle {
-  > a.val-toggle-link:before {
-    content: '+';
-  }
-
-  > .val-array-items,
-  > .val-dict-items {
-    display: none;
-  }
-
-  &.val-toggle-open {
-    > a.val-toggle-link:before {
-      content: '-';
-    }
-
-    > .val-array-items,
-    > .val-dict-items {
-      display: block;
-    }
-  }
-
-  a.val-toggle-link {
-    background: @link-color;
-    border-radius: 2px;
-    color: white;
-    font-weight: bold;
-    font-size: 10px;
-    line-height: 11px;
-    text-align: center;
-    height: 11px;
-    width: 11px;
-    display: inline-block;
-
-    &:hover {
-      background: @link-color-hover;
-    }
-  }
-
-  &.val-toggle-open > a.val-toggle-link {
-    background: @gray-light;
-  }
-
-  &.val-toggle-open > a.val-toggle-link:hover {
-    background: @gray;
-  }
-}
-
 /**
 * Exceptions and Threads
 * ============================================================================


### PR DESCRIPTION
Use the new SVG icons for the context collapse/expand icons and align everything onto the pixel grid so we don't have any subpixel aliasing.

### Before

![Screen Shot 2020-08-10 at 12 23 26 PM](https://user-images.githubusercontent.com/24086/89806758-8e7b8300-db05-11ea-947f-341fb4068343.png)
![Screen Shot 2020-08-10 at 12 23 38 PM](https://user-images.githubusercontent.com/24086/89806759-8e7b8300-db05-11ea-9295-886bb1fee646.png)

### After

![Screen Shot 2020-08-10 at 12 27 42 PM](https://user-images.githubusercontent.com/24086/89806804-99ceae80-db05-11ea-8206-16da709eba81.png)
![Screen Shot 2020-08-10 at 12 28 14 PM](https://user-images.githubusercontent.com/24086/89806807-9a674500-db05-11ea-9b93-074e7d0679d9.png)

