### PR TITLE
build: Bump sentry-flake8 for json import lints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       files: \.py$
       log_file: '.artifacts/flake8.pycodestyle.log'
       additional_dependencies:
-      - sentry-flake8==0.3.1
+      - sentry-flake8==0.4.0
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0
     hooks:


### PR DESCRIPTION
Following https://github.com/getsentry/sentry/pull/20090 and https://github.com/getsentry/sentry-flake8/pull/15