### PR TITLE
fix(apm): If an org has global-views, querying for related errors or transactions by trace id should be using all projects.

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -15,7 +15,7 @@ import SearchBar from 'app/components/searchBar';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
-import {ALL_PROJECTS} from 'app/constants';
+import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 
 import {ParsedTraceType} from './types';
 import {parseTrace, getTraceDateTimeRange} from './utils';
@@ -124,7 +124,7 @@ class SpansInterface extends React.Component<Props, State> {
       // if an org has no global-views, we make an assumption that errors are collected in the same
       // project as the current transaction event where spans are collected into
       projects: orgFeatures.has('global-views')
-        ? [ALL_PROJECTS]
+        ? [ALL_ACCESS_PROJECTS]
         : [Number(event.projectID)],
       version: 2,
       start,

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -15,6 +15,7 @@ import SearchBar from 'app/components/searchBar';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
+import {ALL_PROJECTS} from 'app/constants';
 
 import {ParsedTraceType} from './types';
 import {parseTrace, getTraceDateTimeRange} from './utils';
@@ -122,7 +123,9 @@ class SpansInterface extends React.Component<Props, State> {
       query: stringifyQueryObject(conditions),
       // if an org has no global-views, we make an assumption that errors are collected in the same
       // project as the current transaction event where spans are collected into
-      projects: orgFeatures.has('global-views') ? [] : [Number(event.projectID)],
+      projects: orgFeatures.has('global-views')
+        ? [ALL_PROJECTS]
+        : [Number(event.projectID)],
       version: 2,
       start,
       end,

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -22,6 +22,7 @@ import space from 'app/styles/space';
 import getDynamicText from 'app/utils/getDynamicText';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
 import withApi from 'app/utils/withApi';
+import {ALL_PROJECTS} from 'app/constants';
 
 import {ProcessedSpanType, RawSpanType, ParsedTraceType, rawSpanKeys} from './types';
 import {isGapSpan, isOrphanSpan, getTraceDateTimeRange} from './utils';
@@ -101,7 +102,7 @@ class SpanDetail extends React.Component<Props, State> {
       sort: ['-id'],
       query: `event.type:transaction trace:${traceID} trace.parent_span:${spanID}`,
       project: organization.features.includes('global-views')
-        ? []
+        ? [ALL_PROJECTS]
         : [Number(event.projectID)],
       start,
       end,
@@ -164,7 +165,9 @@ class SpanDetail extends React.Component<Props, State> {
       ],
       orderby: '-timestamp',
       query: `event.type:transaction trace:${span.trace_id} trace.parent_span:${span.span_id}`,
-      projects: orgFeatures.has('global-views') ? [] : [Number(event.projectID)],
+      projects: orgFeatures.has('global-views')
+        ? [ALL_PROJECTS]
+        : [Number(event.projectID)],
       version: 2,
       start,
       end,
@@ -248,7 +251,9 @@ class SpanDetail extends React.Component<Props, State> {
       ],
       orderby: '-timestamp',
       query: `event.type:transaction trace:${span.trace_id}`,
-      projects: orgFeatures.has('global-views') ? [] : [Number(event.projectID)],
+      projects: orgFeatures.has('global-views')
+        ? [ALL_PROJECTS]
+        : [Number(event.projectID)],
       version: 2,
       start,
       end,
@@ -312,7 +317,9 @@ class SpanDetail extends React.Component<Props, State> {
       fields: ['title', 'project', 'issue', 'timestamp'],
       orderby: '-timestamp',
       query: `event.type:error trace:${span.trace_id} trace.span:${span.span_id}`,
-      projects: orgFeatures.has('global-views') ? [] : [Number(event.projectID)],
+      projects: orgFeatures.has('global-views')
+        ? [ALL_PROJECTS]
+        : [Number(event.projectID)],
       version: 2,
       start,
       end,

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -22,7 +22,7 @@ import space from 'app/styles/space';
 import getDynamicText from 'app/utils/getDynamicText';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
 import withApi from 'app/utils/withApi';
-import {ALL_PROJECTS} from 'app/constants';
+import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 
 import {ProcessedSpanType, RawSpanType, ParsedTraceType, rawSpanKeys} from './types';
 import {isGapSpan, isOrphanSpan, getTraceDateTimeRange} from './utils';
@@ -102,7 +102,7 @@ class SpanDetail extends React.Component<Props, State> {
       sort: ['-id'],
       query: `event.type:transaction trace:${traceID} trace.parent_span:${spanID}`,
       project: organization.features.includes('global-views')
-        ? [ALL_PROJECTS]
+        ? [ALL_ACCESS_PROJECTS]
         : [Number(event.projectID)],
       start,
       end,
@@ -166,7 +166,7 @@ class SpanDetail extends React.Component<Props, State> {
       orderby: '-timestamp',
       query: `event.type:transaction trace:${span.trace_id} trace.parent_span:${span.span_id}`,
       projects: orgFeatures.has('global-views')
-        ? [ALL_PROJECTS]
+        ? [ALL_ACCESS_PROJECTS]
         : [Number(event.projectID)],
       version: 2,
       start,
@@ -252,7 +252,7 @@ class SpanDetail extends React.Component<Props, State> {
       orderby: '-timestamp',
       query: `event.type:transaction trace:${span.trace_id}`,
       projects: orgFeatures.has('global-views')
-        ? [ALL_PROJECTS]
+        ? [ALL_ACCESS_PROJECTS]
         : [Number(event.projectID)],
       version: 2,
       start,
@@ -318,7 +318,7 @@ class SpanDetail extends React.Component<Props, State> {
       orderby: '-timestamp',
       query: `event.type:error trace:${span.trace_id} trace.span:${span.span_id}`,
       projects: orgFeatures.has('global-views')
-        ? [ALL_PROJECTS]
+        ? [ALL_ACCESS_PROJECTS]
         : [Number(event.projectID)],
       version: 2,
       start,

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -254,6 +254,3 @@ export const IS_CI = !!process.env.IS_CI;
 export const NODE_ENV = process.env.NODE_ENV;
 export const DISABLE_RR_WEB = !!process.env.DISABLE_RR_WEB;
 export const SPA_DSN = process.env.SPA_DSN;
-
-// If an organization has global views, this constant refers to an all project selection.
-export const ALL_PROJECTS = -1;

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -254,3 +254,6 @@ export const IS_CI = !!process.env.IS_CI;
 export const NODE_ENV = process.env.NODE_ENV;
 export const DISABLE_RR_WEB = !!process.env.DISABLE_RR_WEB;
 export const SPA_DSN = process.env.SPA_DSN;
+
+// If an organization has global views, this constant refers to an all project selection.
+export const ALL_PROJECTS = -1;


### PR DESCRIPTION
If a user is part of a org with `global-views`, but isn't part of the appropriate team, they should technically still be able to query related transactions and errors by trace id.

- See related errors by trace id.
- Fetch span descendents from another project that the user does not have access to by way of teams.
- Searching by trace id should be using all projects selection by default.