### PR TITLE
build(deps): Bump simplejson

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -53,7 +53,7 @@ rfc3986-validator==0.1.1
 # [end] jsonschema format validators
 sentry-relay>=0.5.12,<0.6.0
 sentry-sdk>=0.16.0,<0.17.0
-simplejson>=3.2.0,<3.9.0
+simplejson>=3.11.0,<3.12.0
 six>=1.11.0,<1.12.0
 sqlparse>=0.2.0,<0.3.0
 statsd>=3.1.0,<3.2.0


### PR DESCRIPTION
We're bumping so that simplejson is on a version that is tested against 3.6, our target py3 version.

The migration from 3.8.2 -> 3.11 is trivial, here is a summarized changelog, not including meta changes in the package:

**Version 3.11.0 released 2017-06-18**
* Call PyObject_IsTrue() only once for the strict argument of scanner https://github.com/simplejson/simplejson/pull/170
* Fix a crash with unencodable encoding in the encoder https://github.com/simplejson/simplejson/pull/171
* Remove remnants of Python 2.4 support https://github.com/simplejson/simplejson/pull/168
* Fix argument checking errors in _speedups.c https://github.com/simplejson/simplejson/pull/169
* Remove the `__init__` methods in extension classes https://github.com/simplejson/simplejson/pull/166
* Add Python 3.6 to testing matrix and PyPI metadata https://github.com/simplejson/simplejson/pull/153 https://github.com/simplejson/simplejson/pull/152

**Version 3.10.0 released 2016-10-28**
* Add RawJSON class to allow a faster path for already encoded JSON. https://github.com/simplejson/simplejson/pull/143

**Version 3.9.0 released 2016-10-21**
* Workaround for bad behavior in string subclasses https://github.com/simplejson/simplejson/issues/144
* Fix warnings flagged by -3 https://github.com/simplejson/simplejson/pull/146