### PR TITLE
fix(discover) Fix single day daily chart results

### DIFF
--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -129,6 +129,13 @@ def zerofill(data, start, end, rollup):
     end = int(to_timestamp(end))
     rollup_start = (int(to_timestamp(start)) // rollup) * rollup
     rollup_end = (end // rollup) * rollup
+
+    # Fudge the end value when we're only getting a single window.
+    # This ensure that we get both values for a single large window that
+    # straddles two buckets. An example of this is a 1d window that starts
+    # mid day.
+    if rollup_end - rollup_start == rollup:
+        rollup_end += 1
     i = 0
     for key in six.moves.xrange(rollup_start, rollup_end, rollup):
         try:

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -328,7 +328,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             )
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        assert len(data) == 1
+        assert len(data) == 2
 
         assert data[0][1][0]["count"] == sum(event_counts) / (86400.0 / 60.0)
 
@@ -598,6 +598,35 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         assert [attrs for time, attrs in response.data["event_count"]["data"]] == [
             [{"count": 1}],
             [{"count": 2}],
+        ]
+
+    def test_large_interval_no_drop_values(self):
+        self.store_event(
+            data={
+                "event_id": "d" * 32,
+                "message": "not good",
+                "timestamp": iso_format(before_now(minutes=10)),
+                "fingerprint": ["group3"],
+            },
+            project_id=self.project.id,
+        )
+
+        with self.feature("organizations:discover-basic"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "end": iso_format(before_now()),
+                    "start": iso_format(before_now(hours=24)),
+                    "query": 'message:"not good"',
+                    "interval": "1d",
+                    "yAxis": "count()",
+                },
+            )
+        assert response.status_code == 200
+        assert [attrs for time, attrs in response.data["data"]] == [
+            [{"count": 0}],
+            [{"count": 1}],
         ]
 
     @mock.patch("sentry.snuba.discover.timeseries_query", return_value={})


### PR DESCRIPTION
When getting a single day of data grouped by day, we would often return 0 results. This would happen when the results spanned multiple windows, all of the data was in the later window. For example getting 'last 24h' of data and grouping by day will generally return two results for yesterday and today. Due to how xrange() works only the first window would be returned. This lead to inconsistent results with the table views.  When we're only fetching a single window adding a fudge factor ensures that both halves of the window are included.