### PR TITLE
fix(ui): Fix warning for nested <a> elements

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
@@ -159,7 +159,7 @@ const SectionHeader = styled('div')<{isCentered?: boolean}>`
 
     text-transform: none;
   }
-  & small a {
+  & small > span {
     color: ${p => p.theme.gray700};
     border-bottom: 1px dotted ${p => p.theme.borderDark};
     font-weight: normal;

--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -102,16 +102,16 @@ class CrashHeader extends React.Component {
       >
         <GuideAnchor target="exception" disabled={hideGuide} position="bottom">
           {title}
+        </GuideAnchor>
+        <Tooltip title={t('Toggle stacktrace order')}>
           <small>
             (
-            <Tooltip title={t('Toggle stacktrace order')}>
-              <a onClick={this.handleToggleOrder}>
-                {newestFirst ? t('most recent call first') : t('most recent call last')}
-              </a>
-            </Tooltip>
+            <span onClick={this.handleToggleOrder}>
+              {newestFirst ? t('most recent call first') : t('most recent call last')}
+            </span>
             )
           </small>
-        </GuideAnchor>
+        </Tooltip>
       </h3>
     );
 

--- a/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
@@ -588,7 +588,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                     isCentered={false}
                                   >
                                     <div
-                                      className="css-8d8cxx-SectionHeader e1fbjd862"
+                                      className="css-52rdwg-SectionHeader e1fbjd862"
                                       id="message"
                                     >
                                       <Permalink


### PR DESCRIPTION
```
Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
    in a (at crashHeader.jsx:109)
    in InnerReference (created by Context.Consumer)
```

This error is caused by `<EventDataSection/>` wrapping the title of each section with a `<Permalink/>`, which is implemented with `<a>`. 

Switched to a `<span>` to fix it, and because it's still wrapped by the permalink's anchor, the cursor is still a pointer on hover.