### PR TITLE
fix(ui) Increase space for charts

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/charts.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/charts.tsx
@@ -1,4 +1,13 @@
-import {getDuration, formatPercentage} from 'app/utils/formatters';
+import {
+  WEEK,
+  DAY,
+  HOUR,
+  MINUTE,
+  SECOND,
+  getDuration,
+  formatPercentage,
+} from 'app/utils/formatters';
+import {t} from 'app/locale';
 import {aggregateOutputType} from 'app/utils/discover/fields';
 
 /**
@@ -30,11 +39,43 @@ export function axisLabelFormatter(value: number, seriesName: string): string {
     case 'percentage':
       return formatPercentage(value, 0);
     case 'duration':
-      if (value === 0) {
-        return '0';
-      }
-      return getDuration(value / 1000, 0, true);
+      return axisDuration(value);
     default:
       return value.toString();
   }
+}
+
+/**
+ * Specialized duration formatting for axis labels.
+ * In that context we are ok sacrificing accuracy for more
+ * consistent sizing.
+ *
+ * @param value Number of milliseconds to format.
+ */
+function axisDuration(value: number): string {
+  if (value === 0) {
+    return '0';
+  }
+  if (value >= WEEK) {
+    const label = (value / WEEK).toFixed(0);
+    return t('%swk', label);
+  }
+  if (value >= DAY) {
+    const label = (value / DAY).toFixed(0);
+    return t('%sd', label);
+  }
+  if (value >= HOUR) {
+    const label = (value / HOUR).toFixed(0);
+    return t('%shr', label);
+  }
+  if (value >= MINUTE) {
+    const label = (value / MINUTE).toFixed(0);
+    return t('%smin', label);
+  }
+  if (value >= SECOND) {
+    const label = (value / SECOND).toFixed(0);
+    return t('%ss', label);
+  }
+  const label = (value / SECOND).toFixed(1);
+  return t('%ss', label);
 }

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -47,11 +47,11 @@ function roundWithFixed(
 }
 
 // in milliseconds
-const WEEK = 604800000;
-const DAY = 86400000;
-const HOUR = 3600000;
-const MINUTE = 60000;
-const SECOND = 1000;
+export const WEEK = 604800000;
+export const DAY = 86400000;
+export const HOUR = 3600000;
+export const MINUTE = 60000;
+export const SECOND = 1000;
 
 export function getDuration(
   seconds: number,

--- a/tests/js/spec/utils/discover/charts.spec.jsx
+++ b/tests/js/spec/utils/discover/charts.spec.jsx
@@ -25,9 +25,13 @@ describe('axisLabelFormatter()', function() {
       ['count()', 0.1, '0.1'],
       ['avg(thing)', 0.125126, '0.125'],
       ['failure_rate()', 0.66123, '66%'],
-      ['p50()', 100, '100ms'],
+      ['p50()', 100, '0.1s'],
+      ['p50()', 541, '0.5s'],
       ['p50()', 1200, '1s'],
-      ['p50()', 86400000, '24hr'],
+      ['p50()', 60000, '1min'],
+      ['p50()', 120000, '2min'],
+      ['p50()', 3600000, '1hr'],
+      ['p50()', 86400000, '1d'],
     ];
     for (const scenario of cases) {
       expect(axisLabelFormatter(scenario[1], scenario[0])).toEqual(scenario[2]);


### PR DESCRIPTION
Minimize the amount of pixels we use to render yaxis values so that we have more pixels for the chart data.

### Before

![Screen Shot 2020-08-11 at 1 04 46 PM](https://user-images.githubusercontent.com/24086/89926760-4cb90e00-dbd3-11ea-876b-e1e642f54a3b.png)

### After

![Screen Shot 2020-08-11 at 12 41 26 PM](https://user-images.githubusercontent.com/24086/89926782-55114900-dbd3-11ea-8e96-152af41cb11e.png)
