### PR TITLE
fix(ui) Fix spacing between processing errors and spans

### DIFF
--- a/src/sentry/static/sentry/app/components/events/errors.jsx
+++ b/src/sentry/static/sentry/app/components/events/errors.jsx
@@ -80,14 +80,6 @@ const StyledBanner = styled(BannerContainer)`
       color: ${p => p.theme.gray700};
     }
   }
-
-  /*
-  Remove border on adjacent context summary box.
-  Once that component uses emotion this will be harder.
-  */
-  & + .context-summary {
-    border-top: none;
-  }
 `;
 
 const StyledIconWarning = styled(IconWarning)`

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
 import {analytics} from 'app/utils/analytics';
@@ -193,7 +193,11 @@ class EventEntries extends React.Component {
 
     return (
       <div className={className} data-test-id="event-entries">
-        {!objectIsEmpty(event.errors) && <EventErrors event={event} />}{' '}
+        {!objectIsEmpty(event.errors) && (
+          <ErrorContainer>
+            <EventErrors event={event} />
+          </ErrorContainer>
+        )}
         {!isShare &&
           (showExampleCommit ? (
             <EventCauseEmpty organization={organization} project={project} />
@@ -257,6 +261,8 @@ class EventEntries extends React.Component {
   }
 }
 
+const ErrorContainer = styled('div')``;
+
 const BorderlessEventEntries = styled(EventEntries)`
   & ${/* sc-selector */ DataSection} {
     padding: ${space(3)} 0 0 0;
@@ -264,6 +270,9 @@ const BorderlessEventEntries = styled(EventEntries)`
   & ${/* sc-selector */ DataSection}:first-child {
     padding-top: 0;
     border-top: 0;
+  }
+  & ${/* sc-selector */ ErrorContainer} {
+    margin-bottom: ${space(2)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -261,7 +261,15 @@ class EventEntries extends React.Component {
   }
 }
 
-const ErrorContainer = styled('div')``;
+const ErrorContainer = styled('div')`
+  /*
+  Remove border on adjacent context summary box.
+  Once that component uses emotion this will be harder.
+  */
+  & + .context-summary {
+    border-top: none;
+  }
+`;
 
 const BorderlessEventEntries = styled(EventEntries)`
   & ${/* sc-selector */ DataSection} {

--- a/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
@@ -347,7 +347,7 @@ exports[`SharedGroupDetails renders 1`] = `
                       showTagSummary={true}
                     >
                       <EventEntries
-                        className="css-1pvkuk1-BorderlessEventEntries enep45q0"
+                        className="css-u7sqso-BorderlessEventEntries enep45q1"
                         event={
                           Object {
                             "dateCreated": "2019-05-21T18:01:48.762Z",
@@ -488,10 +488,9 @@ exports[`SharedGroupDetails renders 1`] = `
                         showTagSummary={true}
                       >
                         <div
-                          className="css-1pvkuk1-BorderlessEventEntries enep45q0"
+                          className="css-u7sqso-BorderlessEventEntries enep45q1"
                           data-test-id="event-entries"
                         >
-                           
                           <EventTags
                             event={
                               Object {


### PR DESCRIPTION
On event details in performance and discover add some spacing so the layout is less sad.

### Before 

![Screen Shot 2020-08-11 at 12 19 18 PM](https://user-images.githubusercontent.com/24086/89938789-0371ba00-dbe5-11ea-9122-03649919297f.png)

### Now

![Screen Shot 2020-08-11 at 3 03 21 PM](https://user-images.githubusercontent.com/24086/89938719-e5a45500-dbe4-11ea-8d6e-8f470c43a905.png)