### PR TITLE
fix(msteams): change how we handle expired signature

### DIFF
--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import logging
-import time
 
 from django.utils.translation import ugettext_lazy as _
 
@@ -14,7 +13,6 @@ from sentry.integrations import (
     FeatureDescription,
 )
 from sentry.pipeline import PipelineView
-from sentry.shared_integrations.exceptions import IntegrationError
 from .client import get_token_data
 
 logger = logging.getLogger("sentry.integrations.msteams")
@@ -100,8 +98,4 @@ class MsTeamsIntegrationProvider(IntegrationProvider):
 
 class MsTeamsPipelineView(PipelineView):
     def dispatch(self, request, pipeline):
-        data = pipeline.fetch_state("msteams")
-        # check the expiration time of the link
-        if int(time.time()) > data["expiration_time"]:
-            return pipeline.error(IntegrationError("Installation link expired"))
         return pipeline.next_step()

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -35,9 +35,6 @@ from .utils import build_welcome_card, build_linking_card
 
 logger = logging.getLogger("sentry.integrations.msteams.webhooks")
 
-# 24 hours to finish installation
-INSTALL_EXPIRATION_TIME = 60 * 60 * 24
-
 
 def verify_signature(request):
     # docs for jwt authentication here: https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0#bot-to-connector
@@ -147,7 +144,6 @@ class MsTeamsWebhookEndpoint(Endpoint):
             "team_id": team["id"],
             "team_name": team["name"],
             "service_url": data["serviceUrl"],
-            "expiration_time": int(time.time()) + INSTALL_EXPIRATION_TIME,
         }
 
         # sign the params so this can't be forged

--- a/src/sentry/web/frontend/msteams_extension_configuration.py
+++ b/src/sentry/web/frontend/msteams_extension_configuration.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import
 
-
 from sentry import features
 from sentry.utils.signing import unsign
 
 from .integration_extension_configuration import IntegrationExtensionConfigurationView
+
+
+# 24 hours to finish installation
+INSTALL_EXPIRATION_TIME = 60 * 60 * 24
 
 
 class MsTeamsExtensionConfigurationView(IntegrationExtensionConfigurationView):
@@ -19,5 +22,7 @@ class MsTeamsExtensionConfigurationView(IntegrationExtensionConfigurationView):
         params = params.copy()
         signed_params = params["signed_params"]
         del params["signed_params"]
-        params.update(unsign(signed_params.encode("ascii", errors="ignore")))
+        params.update(
+            unsign(signed_params.encode("ascii", errors="ignore"), max_age=INSTALL_EXPIRATION_TIME)
+        )
         return params

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -26,7 +26,6 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
             "team_id": team_id,
             "service_url": "https://smba.trafficmanager.net/amer/",
             "team_name": "my_team",
-            "expiration_time": self.start_time + 60 * 60 * 24,
         }
 
     def assert_setup_flow(self):
@@ -76,15 +75,3 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
     @responses.activate
     def test_installation(self):
         self.assert_setup_flow()
-
-    def test_expired(self):
-        with patch("time.time") as mock_time:
-            mock_time.return_value = self.start_time
-            self.pipeline_state["expiration_time"] = self.start_time - 1
-            params = {"signed_params": sign(**self.pipeline_state)}
-
-            self.pipeline.bind_state(self.provider.key, self.pipeline_state)
-            resp = self.client.get(self.setup_path, params)
-
-            assert resp.status_code == 200
-            assert "Installation link expired" in resp.content

--- a/tests/sentry/web/frontend/test_msteams_extension.py
+++ b/tests/sentry/web/frontend/test_msteams_extension.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import
 
+from django.core.signing import SignatureExpired
 
+from sentry.models import OrganizationMember
 from sentry.testutils import TestCase
 from sentry.web.frontend.msteams_extension_configuration import MsTeamsExtensionConfigurationView
+from sentry.utils.compat.mock import patch
 from sentry.utils.signing import sign
 
 
@@ -13,3 +16,14 @@ class MsTeamsExtensionConfigurationTest(TestCase):
         signed_data = sign(**data)
         params = {"signed_params": signed_data}
         assert data == config_view.map_params_to_state(params)
+
+    @patch("sentry.web.frontend.msteams_extension_configuration.unsign")
+    def test_expired_signature(self, mock_unsign):
+        with self.feature({"organizations:integrations-msteams": True}):
+            mock_unsign.side_effect = SignatureExpired()
+            self.login_as(self.user)
+            org = self.create_organization()
+            OrganizationMember.objects.create(user=self.user, organization=org)
+            path = u"/extensions/msteams/configure/"
+            resp = self.client.get(path, {"signed_params": "test"})
+            assert "Installation link expired" in resp.content


### PR DESCRIPTION
Previously, I added some code to check if the signature was expired. However, unsigning the parameters that we encode in the URL already checks the date and you'll get a nasty error message. I have therefore added a case for the `SignatureExpired` case and set the expiration time to 24 hours. Here's what the error looks like now:

![Screen Shot 2020-08-11 at 3 54 50 PM](https://user-images.githubusercontent.com/8533851/89956925-040d4f00-dbeb-11ea-8154-44bd042ac350.png)
