### PR TITLE
feat(ui): Add generic state context

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contexts.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts.jsx
@@ -125,6 +125,7 @@ class ContextChunk extends React.Component {
       case 'trace':
         return t('Trace Details');
       case 'default':
+        if (alias === 'state') return t('Application State');
         return toTitleCase(alias);
       default:
         return toTitleCase(type);

--- a/src/sentry/static/sentry/app/components/events/contexts.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts.jsx
@@ -15,7 +15,9 @@ const CONTEXT_TYPES = {
   user: require('app/components/events/contexts/user/user').default,
   gpu: require('app/components/events/contexts/gpu/gpu').default,
   trace: require('app/components/events/contexts/trace/trace').default,
+  // 'redux.state' will be replaced with more generic context called 'state'
   'redux.state': require('app/components/events/contexts/redux').default,
+  state: require('app/components/events/contexts/state').default,
 };
 
 function getContextComponent(type) {

--- a/src/sentry/static/sentry/app/components/events/contexts/state.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/state.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import {t} from 'app/locale';
+import ContextBlock from 'app/components/events/contexts/contextBlock';
+import {KeyValueListData} from 'app/components/events/interfaces/keyValueList/types';
+import ClippedBox from 'app/components/clippedBox';
+
+type Props = {
+  alias: string;
+  data: Record<string, any>;
+};
+
+class StateContextType extends React.Component<Props> {
+  getKnownData(): KeyValueListData[] {
+    return [
+      {
+        key: 'value',
+        subject: t('Latest State'),
+        value: this.props.data.value,
+      },
+    ];
+  }
+
+  render() {
+    return (
+      <ClippedBox clipHeight={250}>
+        <ContextBlock knownData={this.getKnownData()} />
+      </ClippedBox>
+    );
+  }
+}
+
+export default StateContextType;

--- a/src/sentry/static/sentry/app/components/events/contexts/state.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/state.tsx
@@ -1,22 +1,34 @@
 import React from 'react';
+import upperFirst from 'lodash/upperFirst';
 
 import {t} from 'app/locale';
 import ContextBlock from 'app/components/events/contexts/contextBlock';
 import {KeyValueListData} from 'app/components/events/interfaces/keyValueList/types';
 import ClippedBox from 'app/components/clippedBox';
 
+type StateDescription = {
+  type?: string;
+  value: Record<string, any>;
+};
+
 type Props = {
   alias: string;
-  data: Record<string, any>;
+  data: {
+    state: StateDescription;
+    [state: string]: StateDescription;
+  };
 };
 
 class StateContextType extends React.Component<Props> {
   getKnownData(): KeyValueListData[] {
+    const primaryState = this.props.data.state;
+
     return [
       {
-        key: 'value',
-        subject: t('Latest State'),
-        value: this.props.data.value,
+        key: 'state',
+        subject:
+          t('State') + (primaryState.type ? ` (${upperFirst(primaryState.type)})` : ''),
+        value: primaryState.value,
       },
     ];
   }

--- a/tests/js/spec/components/events/contexts/state.spec.jsx
+++ b/tests/js/spec/components/events/contexts/state.spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import {mount} from 'sentry-test/enzyme';
+
+import StateContextType from 'app/components/events/contexts/state';
+
+const STATE_CONTEXT = {
+  type: 'state',
+  state: {
+    type: 'redux',
+    value: {
+      a: 'abc',
+    },
+  },
+  otherState: {
+    value: {
+      b: 'bcd',
+    },
+  },
+};
+
+describe('StateContext', function() {
+  it('renders', () => {
+    const wrapper = mount(<StateContextType alias="state" data={STATE_CONTEXT} />);
+
+    expect(wrapper.find('TableSubject.key').text()).toEqual('State (Redux)');
+    expect(wrapper.find('.val').text()).toEqual('{a: abc}');
+  });
+});


### PR DESCRIPTION
This will later replace `redux.state` context with a more generic one that can be utilized by more libraries/platforms.

We will reflect this in SDKs that currently support states out of the box (vue, redux) and communicate clearly on this page: https://develop.sentry.dev/sdk/event-payloads/contexts/ that if you create this context manually in any other platform you will get the nice rendering too.

![Kapture 2020-08-12 at 16 04 48](https://user-images.githubusercontent.com/9060071/90024924-bd385b80-dcb5-11ea-86d7-3eb2053d47cb.gif)
