### PR TITLE
ci: upgrade clickhouse 19.17.4.11 -> 20.3.9.70

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ start_snuba: &start_snuba |-
     --name sentry_clickhouse \
     -d --network host \
     --ulimit nofile=262144:262144 \
-    yandex/clickhouse-server:19.11 \
+    yandex/clickhouse-server:20.3.9.70 \
 
   docker run \
     --name sentry_snuba \

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1476,7 +1476,7 @@ SENTRY_DEVSERVICES = {
         ),
     },
     "clickhouse": {
-        "image": "yandex/clickhouse-server:19.17.4.11",
+        "image": "yandex/clickhouse-server:20.3.9.70",
         "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
         "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],
         "volumes": {"clickhouse": {"bind": "/var/lib/clickhouse"}},


### PR DESCRIPTION
See https://github.com/getsentry/snuba/pull/1210.