### PR TITLE
fix: Document why we  delay API responses by default and slightly improve logic

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -207,11 +207,7 @@ class Endpoint(APIView):
         request._metric_tags = {}
 
         if settings.SENTRY_API_RESPONSE_DELAY:
-            with sentry_sdk.start_span(
-                op="base.dispatch.sleep", description=type(self).__name__,
-            ) as span:
-                span.set_data("SENTRY_API_RESPONSE_DELAY", settings.SENTRY_API_RESPONSE_DELAY)
-                time.sleep(settings.SENTRY_API_RESPONSE_DELAY / 1000.0)
+            start_time = time.time()
 
         origin = request.META.get("HTTP_ORIGIN", "null")
         # A "null" value should be treated as no Origin for us.
@@ -257,6 +253,16 @@ class Endpoint(APIView):
             self.add_cors_headers(request, response)
 
         self.response = self.finalize_response(request, response, *args, **kwargs)
+
+        if settings.SENTRY_API_RESPONSE_DELAY:
+            duration = time.time() - start_time
+
+            if duration < (settings.SENTRY_API_RESPONSE_DELAY / 1000.0):
+                with sentry_sdk.start_span(
+                    op="base.dispatch.sleep", description=type(self).__name__,
+                ) as span:
+                    span.set_data("SENTRY_API_RESPONSE_DELAY", settings.SENTRY_API_RESPONSE_DELAY)
+                    time.sleep(settings.SENTRY_API_RESPONSE_DELAY / 1000.0 - duration)
 
         return self.response
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1369,6 +1369,14 @@ SENTRY_ENCRYPTION_SCHEMES = (
 )
 
 # Delay (in ms) to induce on API responses
+#
+# Simulates a small amount of lag which helps uncover more obvious race
+# conditions in UI interactions. It's also needed to test (or implement) any
+# kind of loading scenarios. Without this we will just implicitly lower the
+# overall quality of software we ship because we will not experience it in the
+# same way we would in production.
+#
+# See discussion on https://github.com/getsentry/sentry/pull/20187
 SENTRY_API_RESPONSE_DELAY = 150 if IS_DEV else None
 
 # Watchers for various application purposes (such as compiling static media)


### PR DESCRIPTION
Not really sure why this was set to non-0 in the first place.