### PR TITLE
fix(discover) Fix tag links when there is no query state

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -193,6 +193,7 @@ class Results extends React.Component<Props, State> {
     if (eventView.isValid()) {
       return;
     }
+
     // If the view is not valid, redirect to a known valid state.
     const {location, organization, selection} = this.props;
     const nextEventView = EventView.fromNewQueryWithLocation(
@@ -201,6 +202,9 @@ class Results extends React.Component<Props, State> {
     );
     if (nextEventView.project.length === 0 && selection.projects) {
       nextEventView.project = selection.projects;
+    }
+    if (location.query?.query) {
+      nextEventView.query = decodeScalar(location.query.query) || '';
     }
 
     ReactRouter.browserHistory.replace(

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -138,7 +138,7 @@ describe('EventsV2 > Results', function() {
     const initialData = initializeOrg({
       organization,
       router: {
-        location: {query: {}},
+        location: {query: {query: 'tag:value'}},
       },
     });
 
@@ -157,8 +157,15 @@ describe('EventsV2 > Results', function() {
     // No request as eventview was invalid.
     expect(eventResultsMock).not.toHaveBeenCalled();
 
-    // Should redirect.
-    expect(browserHistory.replace).toHaveBeenCalled();
+    // Should redirect and retain the old query value..
+    expect(browserHistory.replace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/organizations/org-slug/discover/results/',
+        query: expect.objectContaining({
+          query: 'tag:value',
+        }),
+      })
+    );
 
     // Update location simulating a redirect.
     wrapper.setProps({location: {query: {...generateFields()}}});


### PR DESCRIPTION
If you've dropped your query state and click on a tag link you should still go to a result set that applies your new condition.