### PR TITLE
ref(py3): Do not pass ints to six.binary_type

### DIFF
--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -100,7 +100,7 @@ class TestSentryAppAuthorizations(APITestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION="Bearer {}".format(token))
 
         assert response.status_code == 200
-        assert response.data["id"] == six.binary_type(self.org.id)
+        assert response.data["id"] == six.text_type(self.org.id).encode("utf-8")
 
     def test_state(self):
         response = self._run_request(state="abc123")

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -46,7 +46,7 @@ class DataExportTest(APITestCase):
         assert response.data == {
             "id": data_export.id,
             "user": {
-                "id": six.binary_type(self.user.id),
+                "id": six.text_type(self.user.id).encode("utf-8"),
                 "email": self.user.email,
                 "username": self.user.username,
             },
@@ -72,7 +72,7 @@ class DataExportTest(APITestCase):
         assert response2.data == {
             "id": data_export.id,
             "user": {
-                "id": six.binary_type(self.user.id),
+                "id": six.text_type(self.user.id).encode("utf-8"),
                 "email": self.user.email,
                 "username": self.user.username,
             },

--- a/tests/sentry/data_export/endpoints/test_data_export_details.py
+++ b/tests/sentry/data_export/endpoints/test_data_export_details.py
@@ -28,7 +28,7 @@ class DataExportDetailsTest(APITestCase):
             response = self.get_valid_response(self.organization.slug, self.data_export.id)
         assert response.data["id"] == self.data_export.id
         assert response.data["user"] == {
-            "id": six.binary_type(self.user.id),
+            "id": six.text_type(self.user.id).encode("utf-8"),
             "email": self.user.email,
             "username": self.user.username,
         }

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -347,7 +347,7 @@ class TestWorkflowNotification(TestCase):
         assert faux(safe_urlopen).kwarg_equals("data.action", "resolved", format="json")
         assert faux(safe_urlopen).kwarg_equals("headers.Sentry-Hook-Resource", "issue")
         assert faux(safe_urlopen).kwarg_equals(
-            "data.data.issue.id", six.binary_type(self.issue.id), format="json"
+            "data.data.issue.id", six.text_type(self.issue.id).encode("utf-8"), format="json"
         )
 
     def test_sends_resolved_webhook_as_Sentry_without_user(self, safe_urlopen):

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1154,7 +1154,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             event = self.store_event(
                 data={
                     "fingerprint": ["put-me-in-group-1"],
-                    "user": {"id": six.binary_type(i)},
+                    "user": {"id": six.text_type(i).encode("utf-8")},
                     "timestamp": iso_format(self.min_ago + timedelta(seconds=i)),
                 },
                 project_id=self.project.id,
@@ -1518,7 +1518,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             groups.append(
                 self.create_group(
                     project=self.project,
-                    checksum=six.binary_type(i) * 16,
+                    checksum=six.text_type(i).encode("utf-8") * 16,
                     status=GroupStatus.RESOLVED,
                 )
             )

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -985,7 +985,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             event = self.store_event(
                 data={
                     "fingerprint": ["put-me-in-group-1"],
-                    "user": {"id": six.binary_type(i)},
+                    "user": {"id": six.text_type(i).encode("utf-8")},
                     "timestamp": iso_format(self.min_ago + timedelta(seconds=i)),
                 },
                 project_id=self.project.id,
@@ -1384,7 +1384,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             groups.append(
                 self.create_group(
                     project=self.project,
-                    checksum=six.binary_type(i) * 16,
+                    checksum=six.text_type(i).encode("utf-8") * 16,
                     status=GroupStatus.RESOLVED,
                 )
             )


### PR DESCRIPTION
py2

  >>> import six
  >>> six.binary_type(15)
  '15'
  >>> six.text_type(15).encode('utf-8')
  '15'

py3

  >>> import six
  >>> six.binary_type(15)
  b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
  >>> six.text_type(15).encode('utf-8')
  b'15'