### PR TITLE
fix(py3): Use text_type for enum value in msteams integration

### DIFF
--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -14,12 +14,9 @@ MSTEAMS_MAX_ITERS = 100
 ME = "ME"
 
 
-# MS Teams will convert integers into strings
-# in value inputs sent in adaptive cards,
-# may as well just do that here first.
-# Subclasses six.binary_type to appease
-# json loader for testing.
-class ACTION_TYPE(six.binary_type, enum.Enum):
+# MS Teams will convert integers into strings in value inputs sent in adaptive
+# cards, may as well just do that here first.
+class ACTION_TYPE(six.text_type, enum.Enum):
     RESOLVE = "1"
     IGNORE = "2"
     ASSIGN = "3"


### PR DESCRIPTION
This should just be `text_type`, not bytes