### PR TITLE
ref(py3): py3 assert_called_with requires ordered kwargs

### DIFF
--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -409,11 +409,11 @@ class PostSentryAppsTest(SentryAppsTest):
 
         record.assert_called_with(
             "sentry_app.schema_validation_error",
-            user_id=self.user.id,
-            organization_id=self.org.id,
-            sentry_app_name="MyApp",
-            error_message="['#general'] is too short for element of type 'alert-rule-action'",
             schema='{"elements":[{"required_fields":[{"label":"Channel","type":"select","options":[["#general"]],"name":"channel"}],"type":"alert-rule-action"}]}',
+            user_id=self.user.id,
+            sentry_app_name="MyApp",
+            organization_id=self.org.id,
+            error_message="['#general'] is too short for element of type 'alert-rule-action'",
         )
 
     @with_feature("organizations:integrations-event-hooks")


### PR DESCRIPTION
There's probably more of these.