### PR TITLE
test(jest): Disable CSS animations in jest snapshots

### DIFF
--- a/config/webpack.css.config.js
+++ b/config/webpack.css.config.js
@@ -3,7 +3,7 @@
 const config = require('../webpack.config');
 
 config.entry = {
-  sentry: config.entry.sentry,
+  sentry: 'less/jest-ci.less',
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
   "scripts": {
     "test": "node scripts/test.js",
     "test-precommit": "yarn test --bail --findRelatedTests -u",
-    "test-ci": "IS_CI=1 yarn test --ci --coverage",
+    "test-ci": "yarn test --ci --coverage",
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
     "lint": "yarn eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx,.ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
   "scripts": {
     "test": "node scripts/test.js",
     "test-precommit": "yarn test --bail --findRelatedTests -u",
-    "test-ci": "yarn test --ci --coverage",
+    "test-ci": "IS_CI=1 yarn test --ci --coverage",
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
     "lint": "yarn eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx,.ts,.tsx",

--- a/src/sentry/static/sentry/less/jest-ci.less
+++ b/src/sentry/static/sentry/less/jest-ci.less
@@ -1,0 +1,16 @@
+/* This is only used for CI, specifically for jest snapshots */
+@import url('./sentry.less');
+
+/* Disable animations */
+
+*,
+::before,
+::after {
+  animation-delay: -1ms !important;
+  animation-duration: 0ms !important;
+  animation-iteration-count: 1 !important;
+  background-attachment: initial !important;
+  scroll-behavior: auto !important;
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}


### PR DESCRIPTION
This disables CSS animations in jest snapshots by using a CI specific LESS file that imports sentry CSS and disabling animations via CSS.