### PR TITLE
fix(py3): http_status passed to spans should be an int

### DIFF
--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -154,7 +154,11 @@ class BaseApiClient(object):
             tags={self.integration_type: self.name, "status": code},
         )
 
-        span.set_http_status(code)
+        try:
+            span.set_http_status(int(code))
+        except ValueError:
+            span.set_status(code)
+
         span.set_tag(self.integration_type, self.name)
 
         extra = {


### PR DESCRIPTION
This fixes a number of py3 tests due to str -> int comparison errors