### PR TITLE
 fix(apm): Fix visual snapshot for transaction comparison page

### DIFF
--- a/tests/acceptance/test_transaction_comparison.py
+++ b/tests/acceptance/test_transaction_comparison.py
@@ -78,12 +78,12 @@ def regress_spans(original_spans):
         if index % 2 == 0:
             # for every even indexed span, increase its duration.
             # this implies the span was slower.
-            regression_time = timedelta(milliseconds=10)
+            regression_time = timedelta(milliseconds=10 + index)
             span["timestamp"] = timestamp_format(end_datetime + regression_time)
         else:
             # for every odd indexed span, decrease its duration.
             # this implies the span was faster
-            regression_time = timedelta(milliseconds=5)
+            regression_time = timedelta(milliseconds=5 + index)
             span["timestamp"] = timestamp_format(end_datetime - regression_time)
 
         if index == last_index:


### PR DESCRIPTION
Since sorting in JavaScript isn't guaranteed to be stable, we vary the time deltas to make the span sort more predictable:


<img width="1365" alt="Screen Shot 2020-08-12 at 6 58 12 PM" src="https://user-images.githubusercontent.com/139499/90076481-cdf4cb80-dccd-11ea-8b83-b39a62a2cdfd.png">
