### PR TITLE
ref(slack): Enable messages tab

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -164,6 +164,14 @@ class SlackActionEndpoint(Endpoint):
             return self.respond(status=e.status)
 
         data = slack_request.data
+
+        # if a user is just clicking our auto response in the messages tab we just return a 200
+        if (
+            data.get("actions")
+            and data["actions"][0].get("value", "") == "sentry_docs_link_clicked"
+        ):
+            return self.respond()
+
         channel_id = data.get("channel", {}).get("id")
         user_id = data.get("user", {}).get("id")
         response_url = data.get("response_url")

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -93,6 +93,50 @@ class SlackEventEndpoint(Endpoint):
     def on_url_verification(self, request, data):
         return self.respond({"challenge": data["challenge"]})
 
+    def on_message(self, request, integration, token, data):
+        channel = data["channel"]
+        # if it's a message posted by our bot, we don't want to respond since
+        # that will cause an infinite loop of messages
+        if data.get("bot_id"):
+            return self.respond()
+
+        access_token = integration.metadata.get("user_access_token")
+        if not access_token:
+            access_token = integration.metadata["access_token"]
+
+        headers = {"Authorization": "Bearer %s" % access_token}
+        payload = {
+            "channel": channel,
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "Want to set up or edit an alert rule? Check out our documentation.",
+                    },
+                },
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "Sentry Docs"},
+                            "url": "https://docs.sentry.io/product/alerts-notifications/alerts/",
+                            "value": "sentry_docs_link_clicked",
+                        }
+                    ],
+                },
+            ],
+        }
+
+        client = SlackClient()
+        try:
+            client.post("/chat.postMessage", headers=headers, data=payload, json=True)
+        except ApiError as e:
+            logger.error("slack.event.on-message-error", extra={"error": six.text_type(e)})
+
+        return self.respond()
+
     def on_link_shared(self, request, integration, token, data):
         parsed_events = defaultdict(dict)
         for item in data["links"]:
@@ -147,6 +191,17 @@ class SlackEventEndpoint(Endpoint):
 
         if slack_request.type == "link_shared":
             resp = self.on_link_shared(
+                request,
+                slack_request.integration,
+                slack_request.data.get("token"),
+                slack_request.data.get("event"),
+            )
+
+            if resp:
+                return resp
+
+        if slack_request.type == "message":
+            resp = self.on_message(
                 request,
                 slack_request.integration,
                 slack_request.data.get("token"),

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -99,6 +99,7 @@ class SlackIntegrationProvider(IntegrationProvider):
             "links:write",
             "team:read",
             "im:read",
+            "im:history",
             "chat:write.public",
             "chat:write.customize",
         ]

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -414,3 +414,16 @@ class StatusActionTest(BaseEventTest):
     def test_slack_bad_payload(self):
         resp = self.client.post("/extensions/slack/action/", data={"nopayload": 0})
         assert resp.status_code == 400
+
+    def test_sentry_docs_link_clicked(self):
+        payload = {
+            "token": options.get("slack.verification-token"),
+            "team": {"id": "TXXXXXXX1", "domain": "example.com"},
+            "user": {"id": self.identity.external_id, "domain": "example"},
+            "type": "block_actions",
+            "actions": [{"value": "sentry_docs_link_clicked"}],
+        }
+        payload = {"payload": json.dumps(payload)}
+
+        resp = self.client.post("/extensions/slack/action/", data=payload)
+        assert resp.status_code == 200

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -8,6 +8,7 @@ from sentry.utils import json
 from sentry.integrations.slack.utils import build_group_attachment, build_incident_attachment
 from sentry.models import Integration, OrganizationIntegration
 from sentry.testutils import APITestCase
+from sentry.utils.compat import filter
 
 UNSET = object()
 
@@ -43,6 +44,23 @@ LINK_SHARED_EVENT = """{
             "url": "https://yet.another-example.com/v/abcde"
         }
     ]
+}"""
+
+MESSAGE_IM_EVENT = """{
+    "type": "message",
+    "channel": "DOxxxxxx",
+    "user": "Uxxxxxxx",
+    "text": "helloo",
+    "message_ts": "123456789.9875"
+}"""
+
+MESSAGE_IM_BOT_EVENT = """{
+    "type": "message",
+    "channel": "DOxxxxxx",
+    "user": "Uxxxxxxx",
+    "text": "helloo",
+    "bot_id": "bot_id",
+    "message_ts": "123456789.9875"
 }"""
 
 
@@ -179,3 +197,31 @@ class LinkSharedEventTest(BaseEventTest):
         assert resp.status_code == 200, resp.content
         data = dict(parse_qsl(responses.calls[0].request.body))
         assert data["token"] == "xoxt-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+
+
+def get_block_type_text(block_type, data):
+    block = filter(lambda x: x["type"] == block_type, data["blocks"])[0]
+    if block_type == "section":
+        return block["text"]["text"]
+
+    return block["elements"][0]["text"]["text"]
+
+
+class MessageIMEventTest(BaseEventTest):
+    @responses.activate
+    def test_user_message_im(self):
+        responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
+        resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_EVENT))
+        assert resp.status_code == 200, resp.content
+        request = responses.calls[0].request
+        assert request.headers["Authorization"] == "Bearer xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+        data = json.loads(request.body)
+        assert (
+            get_block_type_text("section", data)
+            == "Want to learn more about configuring alerts in Sentry? Check out our documentation."
+        )
+        assert get_block_type_text("actions", data) == "Sentry Docs"
+
+    def test_bot_message_im(self):
+        resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_BOT_EVENT))
+        assert resp.status_code == 200, resp.content


### PR DESCRIPTION
**Current problem:**
In the workspace app days, when you had an alert rule set up with slack that sent alerts to a specific person, it would send it in a DM. 

Now, with bot apps, the alert will get sent to the 'Messages' tab in the App home page. 
> ![Screen Shot 2020-08-13 at 11 25 10 AM](https://user-images.githubusercontent.com/15368179/90172329-b2ce9e00-dd57-11ea-9b16-3be52438296e.png)

The problem is that we didn't have this 'Messages' tab turned on when the new Slack App went live, and although alerts can still be sent, once you view the message you cannot return to it because Slack hides the 'Messages' tab.

There is a simple toggle to turn this on, but in order to get the app re-approved we have to meet some requirements that state we must respond to users who type in the messages tab.

**Responding to users:**
In conversations with Slack, the easiest way to meet this requirement is to subscribe to the `message.im` event (which requires the `im:history` scope, and have a canned response:

>![Screen Shot 2020-08-13 at 11 21 01 AM](https://user-images.githubusercontent.com/15368179/90171981-2fad4800-dd57-11ea-8416-f609d4928c03.png)

The button links to [these docs](https://docs.sentry.io/product/alerts-notifications/alerts/).