### PR TITLE
fix(py3): Don't test api base request encoding with unicode marker

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -40,7 +40,7 @@ ONE_MINUTE = 60
 ONE_HOUR = ONE_MINUTE * 60
 ONE_DAY = ONE_HOUR * 24
 
-LINK_HEADER = '<{uri}&cursor={cursor}>; rel="{name}"; results="{has_results}"; cursor="{cursor}"'
+LINK_HEADER = u'<{uri}&cursor={cursor}>; rel="{name}"; results="{has_results}"; cursor="{cursor}"'
 
 DEFAULT_AUTHENTICATION = (TokenAuthentication, ApiKeyAuthentication, SessionAuthentication)
 

--- a/tests/sentry/api/bases/test_endpoint.py
+++ b/tests/sentry/api/bases/test_endpoint.py
@@ -11,28 +11,26 @@ from sentry.api.base import Endpoint
 class EndpointTest(TestCase):
     def test_simple(self):
         request = Mock()
-        request.GET = {u"member": [u"1"]}
+        request.GET = {"member": ["1"]}
         request.method = "GET"
         request.path = "/api/0/organizations/"
         endpoint = Endpoint()
         result = endpoint.build_cursor_link(request, "next", "1492107369532:0:0")
 
         assert result == (
-            "<http://testserver/api/0/organizations/?"
-            "member=%5Bu%271%27%5D&cursor=1492107369532:0:0>;"
+            "<http://testserver/api/0/organizations/?member=%5B%271%27%5D&cursor=1492107369532:0:0>;"
             ' rel="next"; results="true"; cursor="1492107369532:0:0"'
         )
 
     def test_unicode_path(self):
         request = Mock()
-        request.GET = {u"member": [u"1"]}
+        request.GET = {"member": ["1"]}
         request.method = "GET"
         request.path = "/api/0/organizations/üuuuu/"
         endpoint = Endpoint()
         result = endpoint.build_cursor_link(request, "next", "1492107369532:0:0")
 
         assert result == (
-            "<http://testserver/api/0/organizations/%C3%BCuuuu/?"
-            "member=%5Bu%271%27%5D&cursor=1492107369532:0:0>;"
+            "<http://testserver/api/0/organizations/%C3%BCuuuu/?member=%5B%271%27%5D&cursor=1492107369532:0:0>;"
             ' rel="next"; results="true"; cursor="1492107369532:0:0"'
         )


### PR DESCRIPTION
For whatever reason djangos urlquote will just take the repr of a passed value and turn that into the quoted value..

python2

>>> urlquote([u'test'])
u'%5Bu%27test%27%5D'

python3

>>> urlquote([u'test'])
'%5B%27test%27%5D'

If you look closely you'll see the `u` was dropped.

To fix this test we just drop the unicode literal. I would be very surprised if we relied on this behavior.