### PR TITLE
feat(perf): Add period as a transaction tag for performance views

### DIFF
--- a/src/sentry/static/sentry/app/utils/dates.tsx
+++ b/src/sentry/static/sentry/app/utils/dates.tsx
@@ -2,6 +2,7 @@ import moment from 'moment';
 
 import ConfigStore from 'app/stores/configStore';
 import {parseStatsPeriod} from 'app/components/organizations/globalSelectionHeader/getParams';
+import {DateString} from 'app/types';
 
 // TODO(billy): Move to TimeRangeSelector specific utils
 export const DEFAULT_DAY_START_TIME = '00:00:00';
@@ -209,6 +210,21 @@ export function parsePeriodToHours(str: string): number {
     default:
       return -1;
   }
+}
+
+export function statsPeriodToDays(
+  statsPeriod: string | undefined,
+  start: DateString | undefined,
+  end: DateString | undefined
+) {
+  if (statsPeriod && statsPeriod.endsWith('d')) {
+    return parseInt(statsPeriod.slice(0, -1), 10);
+  } else if (statsPeriod && statsPeriod.endsWith('h')) {
+    return parseInt(statsPeriod.slice(0, -1), 10) / 24;
+  } else if (start && end) {
+    return (new Date(end).getTime() - new Date(start).getTime()) / (24 * 60 * 60 * 1000);
+  }
+  return 0;
 }
 
 export const use24Hours = () => ConfigStore.get('user')?.options?.clock24Hours;

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -32,6 +32,7 @@ import {
   DISPLAY_MODE_OPTIONS,
   DISPLAY_MODE_FALLBACK_OPTIONS,
 } from './types';
+import {statsPeriodToDays} from '../dates';
 
 // Metadata mapping for discover results.
 export type MetaType = Record<string, ColumnType>;
@@ -560,18 +561,7 @@ class EventView {
 
   getDays(): number {
     const statsPeriod = decodeScalar(this.statsPeriod);
-
-    if (statsPeriod && statsPeriod.endsWith('d')) {
-      return parseInt(statsPeriod.slice(0, -1), 10);
-    } else if (statsPeriod && statsPeriod.endsWith('h')) {
-      return parseInt(statsPeriod.slice(0, -1), 10) / 24;
-    } else if (this.start && this.end) {
-      return (
-        (new Date(this.end).getTime() - new Date(this.start).getTime()) /
-        (24 * 60 * 60 * 1000)
-      );
-    }
-    return 0;
+    return statsPeriodToDays(statsPeriod, this.start, this.end);
   }
 
   clone(): EventView {

--- a/src/sentry/static/sentry/app/utils/getCurrentSentryReactTransaction.tsx
+++ b/src/sentry/static/sentry/app/utils/getCurrentSentryReactTransaction.tsx
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/react';
+
+/**
+ * Gets the current transaction, if one exists.
+ */
+export default function getCurrentSentryReactTransaction() {
+  return Sentry?.getCurrentHub()
+    ?.getScope()
+    ?.getTransaction();
+}

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -39,6 +39,7 @@ import Tags from './tags';
 import ResultsHeader from './resultsHeader';
 import ResultsChart from './resultsChart';
 import {generateTitle} from './utils';
+import {addRoutePerformanceContext} from '../performance/utils';
 
 type Props = {
   api: Client;
@@ -85,6 +86,7 @@ class Results extends React.Component<Props, State> {
   componentDidMount() {
     const {api, organization, selection} = this.props;
     loadOrganizationTags(api, organization.slug, selection);
+    addRoutePerformanceContext(selection);
     this.checkEventView();
     this.canLoadEvents();
   }
@@ -105,6 +107,7 @@ class Results extends React.Component<Props, State> {
       !isEqual(prevProps.selection.projects, selection.projects)
     ) {
       loadOrganizationTags(api, organization.slug, selection);
+      addRoutePerformanceContext(selection);
     }
 
     if (prevState.confirmedQuery !== confirmedQuery) this.fetchTotalCount();

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -32,6 +32,7 @@ import {generatePerformanceEventView, DEFAULT_STATS_PERIOD} from './data';
 import Table from './table';
 import Charts from './charts/index';
 import Onboarding from './onboarding';
+import {addRoutePerformanceContext} from './utils';
 
 enum FilterViews {
   ALL_TRANSACTIONS = 'ALL_TRANSACTIONS',
@@ -72,6 +73,7 @@ class PerformanceLanding extends React.Component<Props, State> {
   componentDidMount() {
     const {api, organization, selection} = this.props;
     loadOrganizationTags(api, organization.slug, selection);
+    addRoutePerformanceContext(selection);
     trackAnalyticsEvent({
       eventKey: 'performance_views.overview.view',
       eventName: 'Performance Views: Transaction overview view',
@@ -86,6 +88,7 @@ class PerformanceLanding extends React.Component<Props, State> {
       !isEqual(prevProps.selection.datetime, selection.datetime)
     ) {
       loadOrganizationTags(api, organization.slug, selection);
+      addRoutePerformanceContext(selection);
     }
   }
 

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -25,6 +25,7 @@ import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
 
 import SummaryContent from './content';
+import {addRoutePerformanceContext} from '../utils';
 
 type Props = {
   api: Client;
@@ -64,6 +65,7 @@ class TransactionSummary extends React.Component<Props, State> {
     const {api, organization, selection} = this.props;
     this.fetchTotalCount();
     loadOrganizationTags(api, organization.slug, selection);
+    addRoutePerformanceContext(selection);
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
@@ -83,6 +85,7 @@ class TransactionSummary extends React.Component<Props, State> {
       !isEqual(prevProps.selection.datetime, selection.datetime)
     ) {
       loadOrganizationTags(api, organization.slug, selection);
+      addRoutePerformanceContext(selection);
     }
   }
 

--- a/src/sentry/static/sentry/app/views/performance/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/utils.tsx
@@ -1,6 +1,8 @@
 import {LocationDescriptor, Query} from 'history';
 
-import {OrganizationSummary} from 'app/types';
+import {OrganizationSummary, GlobalSelection} from 'app/types';
+import getCurrentSentryReactTransaction from 'app/utils/getCurrentSentryReactTransaction';
+import {statsPeriodToDays} from 'app/utils/dates';
 
 export function getPerformanceLandingUrl(organization: OrganizationSummary): string {
   return `/organizations/${organization.slug}/performance/`;
@@ -41,4 +43,16 @@ export function getTransactionComparisonUrl({
       transaction,
     },
   };
+}
+
+export function addRoutePerformanceContext(selection: GlobalSelection) {
+  const transaction = getCurrentSentryReactTransaction();
+  const days = statsPeriodToDays(
+    selection.datetime.period,
+    selection.datetime.start,
+    selection.datetime.end
+  );
+  const seconds = days * 86400;
+
+  transaction?.setTag('statsPeriod', seconds.toString());
 }


### PR DESCRIPTION
### Summary
This will add statsPeriod (in seconds) as a tag to all performance/discover views that rely on it to perform queries. This will help discern the difference between performance grouped by period, and can be compared against the `query.period` we collect on the backend.
