### PR TITLE
fix(api):  Check feature before returning custom-inbound-filters.

### DIFF
--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -8,7 +8,7 @@ from sentry_sdk import Hub
 from datetime import datetime
 from pytz import utc
 
-from sentry import quotas, utils
+from sentry import quotas, utils, features
 from sentry.constants import ObjectStatus
 from sentry.grouping.api import get_grouping_config_dict_for_project
 from sentry.interfaces.security import DEFAULT_DISALLOWED_SOURCES
@@ -22,7 +22,6 @@ from sentry.utils.http import get_origins
 from sentry.utils.sdk import configure_scope
 from sentry.relay.utils import to_camel_case_name
 from sentry.datascrubbing import get_pii_config, get_datascrubbing_settings
-from sentry import features
 
 
 def get_project_key_config(project_key):


### PR DESCRIPTION
Check that the project has the correct features before sending
project config to Relay.

In effect this disables the featured filters if the project doesn't
have the required features enabled.