### PR TITLE
fix(ui) Don't close nested menus when items are clicked

### DIFF
--- a/docs-ui/components/dropdownLink.stories.js
+++ b/docs-ui/components/dropdownLink.stories.js
@@ -31,3 +31,21 @@ export const AnchorRight = withInfo('Anchors to right side')(() => (
 AnchorRight.story = {
   name: 'anchor right',
 };
+
+export const NestedDropdown = withInfo('Nested dropdowns')(() => (
+  <div className="clearfix">
+    <DropdownLink title="Nested Menu">
+      <li className="dropdown-submenu">
+        <DropdownLink title="submenu" caret={false} isNestedDropdown alwaysRenderMenu>
+          <MenuItem href="">Sub Item 1</MenuItem>
+          <MenuItem href="">Sub Item 2</MenuItem>
+        </DropdownLink>
+      </li>
+      <MenuItem href="">Item 2</MenuItem>
+    </DropdownLink>
+  </div>
+));
+
+NestedDropdown.story = {
+  name: 'nested dropdowns',
+};

--- a/src/sentry/static/sentry/app/components/dropdownMenu.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownMenu.tsx
@@ -372,8 +372,14 @@ class DropdownMenu extends React.Component<Props, State> {
       },
 
       onClick: (e: React.MouseEvent<Element>) => {
-        // Note: clicking on an actor that has a nested menu will close the dropdown menus
-        // This is because we currently do not try to find the deepest non-nested dropdown menu
+        // If we are a nested dropdown, clicking the actor
+        // should be a no-op so that the menu doesn't close.
+        if (isNestedDropdown) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
+
         this.handleToggle(e);
 
         if (typeof onClick === 'function') {
@@ -414,8 +420,6 @@ class DropdownMenu extends React.Component<Props, State> {
         this.handleMouseLeave(e);
       },
       onClick: (e: React.MouseEvent<Element>) => {
-        // Note: clicking on an actor that has a nested menu will close the dropdown menus
-        // This is because we currently do not try to find the deepest non-nested dropdown menu
         this.handleDropdownMenuClick(e);
 
         if (typeof onClick === 'function') {

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -250,12 +250,12 @@ describe('DropdownLink', function() {
       expect(wrapper.find('.dropdown-menu')).toHaveLength(0);
     });
 
-    it('closes when second level nested actor is clicked', function() {
+    it('does not close when second level nested actor is clicked', function() {
       wrapper.find('a.nested-menu').simulate('mouseEnter');
       jest.runAllTimers();
       wrapper.update();
       wrapper.find('a.nested-menu-2 span').simulate('click');
-      expect(wrapper.find('.dropdown-menu')).toHaveLength(0);
+      expect(wrapper.find('.dropdown-menu')).toHaveLength(2);
     });
 
     it('closes when third level nested actor is clicked', function() {

--- a/tests/js/spec/components/dropdownMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownMenu.spec.jsx
@@ -218,4 +218,27 @@ describe('DropdownMenu', function() {
     addSpy.mockRestore();
     removeSpy.mockRestore();
   });
+
+  it('does not close nested dropdown on actor clicks', function() {
+    wrapper = mount(
+      <DropdownMenu isNestedDropdown>
+        {({getRootProps, getActorProps, getMenuProps}) => (
+          <span {...getRootProps({})}>
+            <button {...getActorProps({})}>Open Dropdown</button>
+            {
+              <ul {...getMenuProps({})}>
+                <li data-test-id="menu-item">Dropdown Menu Item 1</li>
+              </ul>
+            }
+          </span>
+        )}
+      </DropdownMenu>
+    );
+    wrapper.find('button').simulate('mouseEnter');
+    expect(wrapper.find('[data-test-id="menu-item"]')).toHaveLength(1);
+
+    wrapper.find('button').simulate('click');
+    //Should still be visible.
+    expect(wrapper.find('[data-test-id="menu-item"]')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
When nested items receive clicks the menus closing makes nested menus like the ignore actions hard to use.

Fixes #19826