### PR TITLE
fix(perf): Fix statsPeriod tag value to be rounded

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/utils.tsx
@@ -52,7 +52,7 @@ export function addRoutePerformanceContext(selection: GlobalSelection) {
     selection.datetime.start,
     selection.datetime.end
   );
-  const seconds = days * 86400;
+  const seconds = Math.floor(days * 86400);
 
   transaction?.setTag('statsPeriod', seconds.toString());
 }


### PR DESCRIPTION
### Summary 
The value wasn't rounded and was (very rarely) not an integer, which will make it hard to compare to `query.period` on the backend.