### PR TITLE
feat(snetry-apps): use new Teamwork and Linear icons

### DIFF
--- a/src/sentry/static/sentry/app/components/sentryAppIcon.tsx
+++ b/src/sentry/static/sentry/app/components/sentryAppIcon.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 
 import {SentryAppComponent} from 'app/types';
-import {IconClickup, IconClubhouse, IconRookout, IconGeneric} from 'app/icons';
+import {
+  IconClickup,
+  IconClubhouse,
+  IconRookout,
+  IconTeamwork,
+  IconLinear,
+  IconGeneric,
+} from 'app/icons';
 
 type Props = {
   slug: SentryAppComponent['sentryApp']['slug'];
@@ -15,6 +22,10 @@ const SentryAppIcon = ({slug}: Props) => {
       return <IconClubhouse size="md" />;
     case 'rookout':
       return <IconRookout size="md" />;
+    case 'teamwork':
+      return <IconTeamwork size="md" />;
+    case 'linear':
+      return <IconLinear size="md" />;
     default:
       return <IconGeneric size="md" />;
   }

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1027,7 +1027,7 @@ export type SentryAppComponent = {
   schema: SentryAppSchemaStacktraceLink;
   sentryApp: {
     uuid: string;
-    slug: 'clickup' | 'clubhouse' | 'rookout';
+    slug: 'clickup' | 'clubhouse' | 'rookout' | 'teamwork' | 'linear';
     name: string;
   };
 };


### PR DESCRIPTION
Icons for the upcoming Linear and Teamwork integrations:

![Screen Shot 2020-08-14 at 1 24 10 PM](https://user-images.githubusercontent.com/8533851/90289910-b33b6780-de31-11ea-940d-416a8117df89.png)
