### PR TITLE
build(travis): Explicitly run Snuba migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,8 @@ start_snuba: &start_snuba |-
     -e CLICKHOUSE_PORT=9000 \
     getsentry/snuba
 
+  docker exec sentry_snuba snuba migrate
+
 script:
   # certain commands require sentry init to be run, but this is only true for
   # running things within Travis


### PR DESCRIPTION
We currently rely on Snuba to automatically detect and run migrations every time any of the Snuba APIs are called.
We should remove this behavior and just explicitly migrate Snuba before running the tests instead.