### PR TITLE
fix(heroku): change order of release check

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -118,9 +118,9 @@ class Release(Model):
     @staticmethod
     def is_valid_version(value):
         return not (
-            any(c in value for c in BAD_RELEASE_CHARS)
+            not value
+            or any(c in value for c in BAD_RELEASE_CHARS)
             or value in (".", "..")
-            or not value
             or value.lower() == "latest"
         )
 

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -628,3 +628,7 @@ class SetRefsTest(SetRefsTestCase):
         self.assert_head_commit(head_commits[0], refs[1]["commit"])
 
         assert len(mock_fetch_commit.method_calls) == 0
+
+    def test_invalid_version(self):
+        release = Release.objects.create(organization=self.org)
+        assert not release.is_valid_version(None)


### PR DESCRIPTION
If the release is `None`, we would get the following error:
```
  File "/usr/src/getsentry/src/sentry/src/sentry/models/release.py", line 121, in <genexpr>
    any(c in value for c in BAD_RELEASE_CHARS)
TypeError: argument of type 'NoneType' is not iterable
```
We just need to change the ordering of the checks for the bad version