### PR TITLE
ref(slack): reduce permissions scope

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -98,7 +98,6 @@ class SlackIntegrationProvider(IntegrationProvider):
             "links:read",
             "links:write",
             "team:read",
-            "im:read",
             "chat:write.public",
             "chat:write.customize",
         ]


### PR DESCRIPTION
I couldn't find where the Sentry Slack integration would use `im:read` scope.

Removing this unnecessary and sensitive scope makes it easier for my employer (Square) to upgrade to the new integration.