### PR TITLE
fix(metrics): Rename region to source_region tag for synthetic monitoring

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -797,7 +797,11 @@ def time_synthetic_monitoring_event(data, project_id, start_time):
         return False
 
     now = time()
-    tags = {"target": extra["target"], "region": extra["region"], "source": extra["source"]}
+    tags = {
+        "target": extra["target"],
+        "source_region": extra["source_region"],
+        "source": extra["source"],
+    }
 
     metrics.timing(
         "events.synthetic-monitoring.time-to-ingest-total",

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -396,7 +396,7 @@ def test_time_synthetic_monitoring_event_in_save_event_missing_extra(mock_metric
 
 def test_time_synthetic_monitoring_event_in_save_event(mock_metrics_timing):
     tags = {
-        "region": "region-1",
+        "source_region": "region-1",
         "target": "target.io",
         "source": "source-1",
     }


### PR DESCRIPTION

This is to prevent veneur/dd agent to override the region tag attached here to
the actual region where the task is running.