### PR TITLE
fix(alerts): Show create alert from discover/performance conditionally

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -10,6 +10,7 @@ import withApi from 'app/utils/withApi';
 import Button from 'app/components/button';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownControl from 'app/components/dropdownControl';
+import Feature from 'app/components/acl/feature';
 import Input from 'app/components/forms/input';
 import space from 'app/styles/space';
 import {IconBookmark, IconDelete} from 'app/icons';
@@ -323,9 +324,12 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
   }
 
   render() {
+    const {organization} = this.props;
     return (
       <ButtonGroup>
-        {this.renderButtonCreateAlert()}
+        <Feature organization={organization} features={['incidents']}>
+          {({hasFeature}) => hasFeature && this.renderButtonCreateAlert()}
+        </Feature>
         {this.renderButtonDelete()}
         {this.renderButtonSaveAs()}
         {this.renderButtonUpdate()}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -9,6 +9,7 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 import space from 'app/styles/space';
 import {generateQueryWithTag} from 'app/utils';
 import EventView from 'app/utils/discover/eventView';
+import Feature from 'app/components/acl/feature';
 import * as Layout from 'app/components/layouts/thirds';
 import Tags from 'app/views/eventsV2/tags';
 import SearchBar from 'app/views/events/searchBar';
@@ -142,7 +143,9 @@ class SummaryContent extends React.Component<Props, State> {
           </Layout.HeaderContent>
           <Layout.HeaderActions>
             <ButtonBar gap={1}>
-              {this.renderCreateAlertButton()}
+              <Feature organization={organization} features={['incidents']}>
+                {({hasFeature}) => hasFeature && this.renderCreateAlertButton()}
+              </Feature>
               {this.renderKeyTransactionButton()}
             </ButtonBar>
           </Layout.HeaderActions>

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -302,7 +302,22 @@ describe('EventsV2 > SaveQueryButtonGroup', function() {
     });
   });
   describe('create alert from discover', () => {
-    it('renders create alert button', () => {
+    it('renders create alert button when metrics alerts is enabled', () => {
+      const metricAlertOrg = {
+        ...organization,
+        features: ['incidents'],
+      };
+      const wrapper = generateWrappedComponent(
+        location,
+        metricAlertOrg,
+        errorsViewModified,
+        savedQuery
+      );
+      const buttonCreateAlert = wrapper.find(SELECTOR_BUTTON_CREATE_ALERT);
+
+      expect(buttonCreateAlert.exists()).toBe(true);
+    });
+    it('does not render create alert button without metric alerts', () => {
       const wrapper = generateWrappedComponent(
         location,
         organization,
@@ -311,7 +326,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function() {
       );
       const buttonCreateAlert = wrapper.find(SELECTOR_BUTTON_CREATE_ALERT);
 
-      expect(buttonCreateAlert.exists()).toBe(true);
+      expect(buttonCreateAlert.exists()).toBe(false);
     });
   });
 });

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -156,6 +156,26 @@ describe('Performance > TransactionSummary', function() {
 
     // Ensure transaction filter button exists
     expect(wrapper.find('[data-test-id="filter-transactions"]')).toHaveLength(1);
+
+    // Ensure create alert from discover is hidden without metric alert
+    expect(wrapper.find('CreateAlertButton')).toHaveLength(0);
+  });
+
+  it('renders feature flagged UI elements', async function() {
+    const initialData = initializeData();
+    initialData.organization.features.push('incidents');
+    const wrapper = mountWithTheme(
+      <TransactionSummary
+        organization={initialData.organization}
+        location={initialData.router.location}
+      />,
+      initialData.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    // Ensure create alert from discover is shown with metric alerts
+    expect(wrapper.find('CreateAlertButton')).toHaveLength(1);
   });
 
   it('triggers a navigation on search', async function() {


### PR DESCRIPTION
We rolled out 'create from discover' to all users, but not all users have metric-alerts which means clicking the create alert button will just bring them to the issue alert creation form. This may confuse the user as an issue alert has no correlation with discover/performance transactions.

Wrapped the button render functions in an 'incidents' (metric-alert) feature check
