### PR TITLE
test(jest): Fix flakey jest snapshots not saving

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -46,7 +46,7 @@ jobs:
             path: .artifacts/visual-snapshots/jest
 
         - name: Create Images from HTML
-          uses: getsentry/action-html-to-image@master
+          uses: getsentry/action-html-to-image@main
           with:
             base-path: .artifacts/visual-snapshots/jest
             css-path: src/sentry/static/sentry/dist/sentry.css

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -9,7 +9,7 @@ jobs:
     jest:
       runs-on: ubuntu-latest
       env:
-        VISUAL_SNAPSHOT_ENABLE: 1
+        VISUAL_HTML_ENABLE: 1
       steps:
         # Checkout codebase
         - uses: actions/checkout@v2
@@ -39,9 +39,21 @@ jobs:
             NODE_ENV=production yarn build-css
             yarn test-ci --forceExit
 
+        - name: Save HTML artifacts
+          uses: actions/upload-artifact@v2
+          with:
+            name: jest-html
+            path: .artifacts/visual-snapshots/jest
+
+        - name: Create Images from HTML
+          uses: getsentry/action-html-to-image@master
+          with:
+            base-path: .artifacts/visual-snapshots/jest
+            css-path: src/sentry/static/sentry/dist/sentry.css
+
         - name: Save snapshots
           if: always()
-          uses: getsentry/action-visual-snapshot@v2
+          uses: getsentry/action-visual-snapshot@v2-dev
           with:
             save-only: true
             snapshot-path: .artifacts/visual-snapshots

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -53,7 +53,7 @@ jobs:
 
         - name: Save snapshots
           if: always()
-          uses: getsentry/action-visual-snapshot@v2-dev
+          uses: getsentry/action-visual-snapshot@v2
           with:
             save-only: true
             snapshot-path: .artifacts/visual-snapshots

--- a/config/webpack.css.config.js
+++ b/config/webpack.css.config.js
@@ -17,6 +17,10 @@ config.module = {
       use: [
         {
           loader: 'url-loader',
+          options: {
+            esModule: false,
+            limit: true,
+          },
         },
       ],
     },

--- a/config/webpack.css.config.js
+++ b/config/webpack.css.config.js
@@ -5,5 +5,18 @@ const config = require('../webpack.config');
 config.entry = {
   sentry: 'less/jest-ci.less',
 };
+config.module = {
+  ...config.module,
+  rules: [
+    ...config.module.rules.filter(({test}) =>
+      ['/\\.css/', '/\\.less$/'].includes(test.toString())
+    ),
+
+    {
+      test: /\.(jpe?g|png|gif|ttf|eot|svg|woff(2)?)(\?[a-z0-9=&.]+)?$/,
+      use: 'base64-inline-loader?limit=10000&name=[name].[ext]',
+    },
+  ],
+};
 
 module.exports = config;

--- a/config/webpack.css.config.js
+++ b/config/webpack.css.config.js
@@ -14,7 +14,11 @@ config.module = {
 
     {
       test: /\.(jpe?g|png|gif|ttf|eot|svg|woff(2)?)(\?[a-z0-9=&.]+)?$/,
-      use: 'base64-inline-loader?limit=10000&name=[name].[ext]',
+      use: [
+        {
+          loader: 'url-loader',
+        },
+      ],
     },
   ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -53,14 +53,5 @@ module.exports = {
 
   testEnvironmentOptions: {
     output: path.resolve(__dirname, '.artifacts', 'visual-snapshots', 'jest'),
-    includeCss: path.resolve(
-      __dirname,
-      'src',
-      'sentry',
-      'static',
-      'sentry',
-      'dist',
-      'sentry.css'
-    ),
   },
 };

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@storybook/addon-storysource": "^5.3.3",
     "@storybook/addons": "^5.3.3",
     "@storybook/react": "^5.3.3",
-    "@visual-snapshot/jest": "1.0.14-alpha.1",
+    "@visual-snapshot/jest": "1.0.14-alpha.2",
     "babel-eslint": "^10.0.3",
     "babel-gettext-extractor": "^4.1.3",
     "babel-jest": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@storybook/addon-storysource": "^5.3.3",
     "@storybook/addons": "^5.3.3",
     "@storybook/react": "^5.3.3",
-    "@visual-snapshot/jest": "^1.0.13",
+    "@visual-snapshot/jest": "1.0.14-alpha.1",
     "babel-eslint": "^10.0.3",
     "babel-gettext-extractor": "^4.1.3",
     "babel-jest": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@storybook/addon-storysource": "^5.3.3",
     "@storybook/addons": "^5.3.3",
     "@storybook/react": "^5.3.3",
-    "@visual-snapshot/jest": "1.0.14-alpha.2",
+    "@visual-snapshot/jest": "1.0.14-alpha.3",
     "babel-eslint": "^10.0.3",
     "babel-gettext-extractor": "^4.1.3",
     "babel-jest": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "babel-gettext-extractor": "^4.1.3",
     "babel-jest": "24.9.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
+    "base64-inline-loader": "^1.1.1",
     "csstype": "^2.6.8",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.1",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@storybook/addon-storysource": "^5.3.3",
     "@storybook/addons": "^5.3.3",
     "@storybook/react": "^5.3.3",
-    "@visual-snapshot/jest": "1.0.14-alpha.3",
+    "@visual-snapshot/jest": "^1.0.14",
     "babel-eslint": "^10.0.3",
     "babel-gettext-extractor": "^4.1.3",
     "babel-jest": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "babel-gettext-extractor": "^4.1.3",
     "babel-jest": "24.9.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
-    "base64-inline-loader": "^1.1.1",
     "csstype": "^2.6.8",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.1",
@@ -176,6 +175,7 @@
     "stylelint-processor-styled-components": "^1.10.0",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
     "typescript-styled-plugin": "^0.15.0",
+    "url-loader": "^4.1.0",
     "webpack-dev-server": "3.10.3"
   },
   "optionalDependencies": {

--- a/src/sentry/static/sentry/less/jest-ci.less
+++ b/src/sentry/static/sentry/less/jest-ci.less
@@ -1,5 +1,6 @@
 /* This is only used for CI, specifically for jest snapshots */
 @import url('./sentry.less');
+@import '~platformicons/platformicons/platformicons.css';
 
 /* Disable animations */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4639,15 +4639,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-inline-loader@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/base64-inline-loader/-/base64-inline-loader-1.1.1.tgz#2b8b2841e7848292519ea3a3d8dfc6a6c141791a"
-  integrity sha512-v/bHvXQ8sW28t9ZwBsFGgyqZw2bpT49/dtPTtlmixoSM/s9wnOngOKFVQLRH8BfMTy6jTl5m5CdvqpZt8y5d6g==
-  dependencies:
-    file-loader "^1.1.11"
-    loader-utils "^1.1.0"
-    mime-types "^2.1.18"
-
 base64-js@^1.0.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
@@ -7624,14 +7615,6 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
-
-file-loader@^1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.11.tgz#6fe886449b0f2a936e43cabaac0cdbfb369506f8"
-  integrity sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==
-  dependencies:
-    loader-utils "^1.0.2"
-    schema-utils "^0.4.5"
 
 file-loader@^3.0.1:
   version "3.0.1"
@@ -11001,7 +10984,7 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   dependencies:
     mime-db "1.43.0"
 
-mime-types@^2.1.18:
+mime-types@^2.1.26:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
@@ -13152,24 +13135,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer-core@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-5.2.1.tgz#0d21b5bbb30c82db9b439d255a459f3538cc7235"
-  integrity sha512-gLjEOrzwgcnwRH+sm4hS1TBqe2/DN248nRb2hYB7+lZ9kCuLuACNvuzlXILlPAznU3Ob+mEvVEBDcLuFa0zq3g==
-  dependencies:
-    debug "^4.1.0"
-    devtools-protocol "0.0.781568"
-    extract-zip "^2.0.0"
-    https-proxy-agent "^4.0.0"
-    mime "^2.0.3"
-    pkg-dir "^4.2.0"
-    progress "^2.0.1"
-    proxy-from-env "^1.0.0"
-    rimraf "^3.0.2"
-    tar-fs "^2.0.0"
-    unbzip2-stream "^1.3.3"
-    ws "^7.2.3"
-
 puppeteer@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.2.1.tgz#7f0564f0a5384f352a38c8cc42af875cd87f4ea6"
@@ -14569,14 +14534,6 @@ scheduler@^0.18.0:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-schema-utils@^0.4.5:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
-  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
-  dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
 
 schema-utils@^1.0.0:
   version "1.0.0"
@@ -16518,6 +16475,15 @@ url-loader@^2.0.1:
     loader-utils "^1.2.3"
     mime "^2.4.4"
     schema-utils "^2.5.0"
+
+url-loader@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.0.tgz#c7d6b0d6b0fccd51ab3ffc58a78d32b8d89a7be2"
+  integrity sha512-IzgAAIC8wRrg6NYkFIJY09vtktQcsvU8V6HhtQj9PTefbYImzLB1hufqo4m+RyM5N3mLx5BqJKccgxJS+W3kqw==
+  dependencies:
+    loader-utils "^2.0.0"
+    mime-types "^2.1.26"
+    schema-utils "^2.6.5"
 
 url-parse@^1.4.3:
   version "1.4.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3327,10 +3327,10 @@
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-"@visual-snapshot/jest-environment@^1.0.14-alpha.3":
-  version "1.0.14-alpha.3"
-  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest-environment/-/jest-environment-1.0.14-alpha.3.tgz#7ea1ddf75307ec192a1e469d8b9d5974a1b4d617"
-  integrity sha512-AA00/RyMNjuVHc9u0Wo2bmpLYZjhEdCcNd/22GZs3aGvc1aDqWrD9BgtM8QLYBe5wWI0T9tr+DkpCBJeo4YAqg==
+"@visual-snapshot/jest-environment@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest-environment/-/jest-environment-1.0.14.tgz#8ac219d9c3ede073a6411dc89011b0cc9cf9ecea"
+  integrity sha512-katKsy1hEmwb/csN64wIZkzLBpt/91xf34UvB7BrC0PrasMGY7ereFeI8SZqv1ZAsZNBNqK7vyOVgHzLSqVYJw==
   dependencies:
     "@jest/environment" "^26.1.0"
     "@jest/types" "^24.9"
@@ -3342,12 +3342,12 @@
   optionalDependencies:
     fsevents "^2.1.3"
 
-"@visual-snapshot/jest@1.0.14-alpha.3":
-  version "1.0.14-alpha.3"
-  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest/-/jest-1.0.14-alpha.3.tgz#e4afb0329442b2f5c9df30740095968ddfb91695"
-  integrity sha512-mqt2WERE4k8sa3wE0bmK0uggM1uF6/11vqa283yh/RLJcCMGb4bMfWn+wwqLXR34bopaL7ZjV6EAceTRJiOUkQ==
+"@visual-snapshot/jest@^1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest/-/jest-1.0.14.tgz#a789c095e41c5121aacff0706ded421be6868032"
+  integrity sha512-I7K7/Wg9Sj6+UnnWqqXhZxrde8ulnVa0b/s01dU/xqn6O3Z7r8Z5EypezI/Pb3EA/qCrfGOcQzz1Of1/KblCkA==
   dependencies:
-    "@visual-snapshot/jest-environment" "^1.0.14-alpha.3"
+    "@visual-snapshot/jest-environment" "^1.0.14"
     typescript "^3.9.6"
 
 "@webassemblyjs/ast@1.8.5":

--- a/yarn.lock
+++ b/yarn.lock
@@ -4639,6 +4639,15 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-inline-loader@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/base64-inline-loader/-/base64-inline-loader-1.1.1.tgz#2b8b2841e7848292519ea3a3d8dfc6a6c141791a"
+  integrity sha512-v/bHvXQ8sW28t9ZwBsFGgyqZw2bpT49/dtPTtlmixoSM/s9wnOngOKFVQLRH8BfMTy6jTl5m5CdvqpZt8y5d6g==
+  dependencies:
+    file-loader "^1.1.11"
+    loader-utils "^1.1.0"
+    mime-types "^2.1.18"
+
 base64-js@^1.0.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
@@ -7615,6 +7624,14 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+file-loader@^1.1.11:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.11.tgz#6fe886449b0f2a936e43cabaac0cdbfb369506f8"
+  integrity sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==
+  dependencies:
+    loader-utils "^1.0.2"
+    schema-utils "^0.4.5"
 
 file-loader@^3.0.1:
   version "3.0.1"
@@ -10972,12 +10989,24 @@ mime-db@1.43.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
   integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
+mime-db@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
+  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.26"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
   integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
   dependencies:
     mime-db "1.43.0"
+
+mime-types@^2.1.18:
+  version "2.1.27"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
+  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  dependencies:
+    mime-db "1.44.0"
 
 mime@1.6.0, mime@^1.4.1:
   version "1.6.0"
@@ -14540,6 +14569,14 @@ scheduler@^0.18.0:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+schema-utils@^0.4.5:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
+  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
 
 schema-utils@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3327,10 +3327,10 @@
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-"@visual-snapshot/jest-environment@^1.0.14-alpha.2":
-  version "1.0.14-alpha.2"
-  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest-environment/-/jest-environment-1.0.14-alpha.2.tgz#ef2d9f3237164cf16e0f52286a5749c354722900"
-  integrity sha512-UeszSUTn6RttjqCe1i3hqIeCuZuyDBNg5a35+Ghx+Wy1C6VVuhDRoQpPsYYxXeEJzghE3+nXokmAkfFbQN5N1w==
+"@visual-snapshot/jest-environment@^1.0.14-alpha.3":
+  version "1.0.14-alpha.3"
+  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest-environment/-/jest-environment-1.0.14-alpha.3.tgz#7ea1ddf75307ec192a1e469d8b9d5974a1b4d617"
+  integrity sha512-AA00/RyMNjuVHc9u0Wo2bmpLYZjhEdCcNd/22GZs3aGvc1aDqWrD9BgtM8QLYBe5wWI0T9tr+DkpCBJeo4YAqg==
   dependencies:
     "@jest/environment" "^26.1.0"
     "@jest/types" "^24.9"
@@ -3342,12 +3342,12 @@
   optionalDependencies:
     fsevents "^2.1.3"
 
-"@visual-snapshot/jest@1.0.14-alpha.2":
-  version "1.0.14-alpha.2"
-  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest/-/jest-1.0.14-alpha.2.tgz#cfcda936739443b6b1be6dbf4b1ebd8f390b4c75"
-  integrity sha512-Ns6gwVHS+4KDZdYcV8dhR/FHYEteMZq/rDjDOa5f/zeZQGgiYn2Eqx+SqxGwnhETO7Ssf18nF6zANaCoR0dhIw==
+"@visual-snapshot/jest@1.0.14-alpha.3":
+  version "1.0.14-alpha.3"
+  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest/-/jest-1.0.14-alpha.3.tgz#e4afb0329442b2f5c9df30740095968ddfb91695"
+  integrity sha512-mqt2WERE4k8sa3wE0bmK0uggM1uF6/11vqa283yh/RLJcCMGb4bMfWn+wwqLXR34bopaL7ZjV6EAceTRJiOUkQ==
   dependencies:
-    "@visual-snapshot/jest-environment" "^1.0.14-alpha.2"
+    "@visual-snapshot/jest-environment" "^1.0.14-alpha.3"
     typescript "^3.9.6"
 
 "@webassemblyjs/ast@1.8.5":

--- a/yarn.lock
+++ b/yarn.lock
@@ -3002,7 +3002,14 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/puppeteer@^3.0.1":
+"@types/puppeteer-core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer-core/-/puppeteer-core-2.0.0.tgz#3b7fbbac53d56b566f5ef096116e1d60d504aa45"
+  integrity sha512-JvoEb7KgEkUet009ZDrtpUER3hheXoHgQByuYpJZ5WWT7LWwMH+0NTqGQXGgoOKzs+G5NA1T4DZwXK79Bhnejw==
+  dependencies:
+    "@types/puppeteer" "*"
+
+"@types/puppeteer@*", "@types/puppeteer@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-3.0.1.tgz#053ec20facc162b25a64785affccaa3e5817c607"
   integrity sha512-t03eNKCvWJXhQ8wkc5C6GYuSqMEdKLOX0GLMGtks25YZr38wKZlKTwGM/BoAPVtdysX7Bb9tdwrDS1+NrW3RRA==
@@ -3327,27 +3334,28 @@
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-"@visual-snapshot/jest-environment@^1.0.13":
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest-environment/-/jest-environment-1.0.13.tgz#ca79c69c238c9df420e5a6d346b2af0f0f714077"
-  integrity sha512-1dD4g974VAONaFtHl5vOo0o9zt+q4e5VXYL6oWgNF7bkt0QKD5JDzrT9P6nGuA86EwsZyM75IM7DwQWCLK1goA==
+"@visual-snapshot/jest-environment@^1.0.14-alpha.1":
+  version "1.0.14-alpha.1"
+  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest-environment/-/jest-environment-1.0.14-alpha.1.tgz#939576d12f067baf055e81245a9623db45d8ed4c"
+  integrity sha512-vQ0KAMJkgg7IV/JVJxAX8M6p7VjUzzl+FULjrzi3GG0nI14/RWoMPIDzqD/c9hNRwzkRYJI03muQzL2+C8we7w==
   dependencies:
     "@jest/environment" "^26.1.0"
     "@jest/types" "^24.9"
     "@sindresorhus/slugify" "^1.0.0"
     "@types/puppeteer" "^3.0.1"
+    "@types/puppeteer-core" "^2.0.0"
     jest-environment-jsdom "^24.9"
-    puppeteer "^5.0.0"
+    puppeteer-core "^5.2.1"
     typescript "^3.9.6"
   optionalDependencies:
     fsevents "^2.1.3"
 
-"@visual-snapshot/jest@^1.0.13":
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest/-/jest-1.0.13.tgz#83990426e7c2a66f8def5290a29fe2a2e10f58af"
-  integrity sha512-aV+iDgCFce/Bq3iXzfQ5v++1F0f9CRo28bzIwIASp8Ww1ve+yCQHqJv9bGml1yrkouIenTBDH2Cx21zfdj07Tw==
+"@visual-snapshot/jest@1.0.14-alpha.1":
+  version "1.0.14-alpha.1"
+  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest/-/jest-1.0.14-alpha.1.tgz#69b6a4e6a3e75ee40d665295f2a91d67b66f8c8e"
+  integrity sha512-ZQOqZ+Z7kmp+4aeurnWbg8nOPG5QJiPX+IdkUIAjkctcECYmDBQZplR/WX8QorDpRdwbT3IuRRp3yLyuXsleqQ==
   dependencies:
-    "@visual-snapshot/jest-environment" "^1.0.13"
+    "@visual-snapshot/jest-environment" "^1.0.14-alpha.1"
     typescript "^3.9.6"
 
 "@webassemblyjs/ast@1.8.5":
@@ -6397,10 +6405,10 @@ detect-port@^1.3.0:
     address "^1.0.1"
     debug "^2.6.0"
 
-devtools-protocol@0.0.767361:
-  version "0.0.767361"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.767361.tgz#5977f2558b84f9df36f62501bdddb82f3ae7b66b"
-  integrity sha512-ziRTdhEVQ9jEwedaUaXZ7kl9w9TF/7A3SXQ0XuqrJB+hMS62POHZUWTbumDN2ehRTfvWqTPc2Jw4gUl/jggmHA==
+devtools-protocol@0.0.781568:
+  version "0.0.781568"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.781568.tgz#4cdca90a952d2c77831096ff6cd32695d8715a04"
+  integrity sha512-9Uqnzy6m6zEStluH9iyJ3iHyaQziFnMnLeC8vK0eN6smiJmIx7+yB64d67C2lH/LZra+5cGscJAJsNXO+MdPMg==
 
 diff-sequences@^24.9.0:
   version "24.9.0"
@@ -11129,11 +11137,6 @@ mitt@^1.1.3:
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-1.2.0.tgz#cb24e6569c806e31bd4e3995787fe38a04fdf90d"
   integrity sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==
 
-mitt@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mitt/-/mitt-2.0.1.tgz#9e8a075b4daae82dd91aac155a0ece40ca7cb393"
-  integrity sha512-FhuJY+tYHLnPcBHQhbUFzscD5512HumCPE4URXZUgPi3IvOJi4Xva5IIgy3xX56GqCmw++MAm5UURG6kDBYTdg==
-
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -13128,17 +13131,16 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.1.0.tgz#e7bae2caa6e3a13a622755e4c27689d9812c38ca"
-  integrity sha512-IZBFG8XcA+oHxYo5rEpJI/HQignUis2XPijPoFpNxla2O+WufonGsUsSqrhRXgBKOME5zNfhRdUY2LvxAiKlhw==
+puppeteer-core@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-5.2.1.tgz#0d21b5bbb30c82db9b439d255a459f3538cc7235"
+  integrity sha512-gLjEOrzwgcnwRH+sm4hS1TBqe2/DN248nRb2hYB7+lZ9kCuLuACNvuzlXILlPAznU3Ob+mEvVEBDcLuFa0zq3g==
   dependencies:
     debug "^4.1.0"
-    devtools-protocol "0.0.767361"
+    devtools-protocol "0.0.781568"
     extract-zip "^2.0.0"
     https-proxy-agent "^4.0.0"
     mime "^2.0.3"
-    mitt "^2.0.1"
     pkg-dir "^4.2.0"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3002,14 +3002,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/puppeteer-core@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/puppeteer-core/-/puppeteer-core-2.0.0.tgz#3b7fbbac53d56b566f5ef096116e1d60d504aa45"
-  integrity sha512-JvoEb7KgEkUet009ZDrtpUER3hheXoHgQByuYpJZ5WWT7LWwMH+0NTqGQXGgoOKzs+G5NA1T4DZwXK79Bhnejw==
-  dependencies:
-    "@types/puppeteer" "*"
-
-"@types/puppeteer@*", "@types/puppeteer@^3.0.1":
+"@types/puppeteer@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-3.0.1.tgz#053ec20facc162b25a64785affccaa3e5817c607"
   integrity sha512-t03eNKCvWJXhQ8wkc5C6GYuSqMEdKLOX0GLMGtks25YZr38wKZlKTwGM/BoAPVtdysX7Bb9tdwrDS1+NrW3RRA==
@@ -3334,28 +3327,27 @@
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-"@visual-snapshot/jest-environment@^1.0.14-alpha.1":
-  version "1.0.14-alpha.1"
-  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest-environment/-/jest-environment-1.0.14-alpha.1.tgz#939576d12f067baf055e81245a9623db45d8ed4c"
-  integrity sha512-vQ0KAMJkgg7IV/JVJxAX8M6p7VjUzzl+FULjrzi3GG0nI14/RWoMPIDzqD/c9hNRwzkRYJI03muQzL2+C8we7w==
+"@visual-snapshot/jest-environment@^1.0.14-alpha.2":
+  version "1.0.14-alpha.2"
+  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest-environment/-/jest-environment-1.0.14-alpha.2.tgz#ef2d9f3237164cf16e0f52286a5749c354722900"
+  integrity sha512-UeszSUTn6RttjqCe1i3hqIeCuZuyDBNg5a35+Ghx+Wy1C6VVuhDRoQpPsYYxXeEJzghE3+nXokmAkfFbQN5N1w==
   dependencies:
     "@jest/environment" "^26.1.0"
     "@jest/types" "^24.9"
     "@sindresorhus/slugify" "^1.0.0"
     "@types/puppeteer" "^3.0.1"
-    "@types/puppeteer-core" "^2.0.0"
     jest-environment-jsdom "^24.9"
-    puppeteer-core "^5.2.1"
+    puppeteer "^5.0.0"
     typescript "^3.9.6"
   optionalDependencies:
     fsevents "^2.1.3"
 
-"@visual-snapshot/jest@1.0.14-alpha.1":
-  version "1.0.14-alpha.1"
-  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest/-/jest-1.0.14-alpha.1.tgz#69b6a4e6a3e75ee40d665295f2a91d67b66f8c8e"
-  integrity sha512-ZQOqZ+Z7kmp+4aeurnWbg8nOPG5QJiPX+IdkUIAjkctcECYmDBQZplR/WX8QorDpRdwbT3IuRRp3yLyuXsleqQ==
+"@visual-snapshot/jest@1.0.14-alpha.2":
+  version "1.0.14-alpha.2"
+  resolved "https://registry.yarnpkg.com/@visual-snapshot/jest/-/jest-1.0.14-alpha.2.tgz#cfcda936739443b6b1be6dbf4b1ebd8f390b4c75"
+  integrity sha512-Ns6gwVHS+4KDZdYcV8dhR/FHYEteMZq/rDjDOa5f/zeZQGgiYn2Eqx+SqxGwnhETO7Ssf18nF6zANaCoR0dhIw==
   dependencies:
-    "@visual-snapshot/jest-environment" "^1.0.14-alpha.1"
+    "@visual-snapshot/jest-environment" "^1.0.14-alpha.2"
     typescript "^3.9.6"
 
 "@webassemblyjs/ast@1.8.5":
@@ -13135,6 +13127,24 @@ puppeteer-core@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-5.2.1.tgz#0d21b5bbb30c82db9b439d255a459f3538cc7235"
   integrity sha512-gLjEOrzwgcnwRH+sm4hS1TBqe2/DN248nRb2hYB7+lZ9kCuLuACNvuzlXILlPAznU3Ob+mEvVEBDcLuFa0zq3g==
+  dependencies:
+    debug "^4.1.0"
+    devtools-protocol "0.0.781568"
+    extract-zip "^2.0.0"
+    https-proxy-agent "^4.0.0"
+    mime "^2.0.3"
+    pkg-dir "^4.2.0"
+    progress "^2.0.1"
+    proxy-from-env "^1.0.0"
+    rimraf "^3.0.2"
+    tar-fs "^2.0.0"
+    unbzip2-stream "^1.3.3"
+    ws "^7.2.3"
+
+puppeteer@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.2.1.tgz#7f0564f0a5384f352a38c8cc42af875cd87f4ea6"
+  integrity sha512-PZoZG7u+T6N1GFWBQmGVG162Ak5MAy8nYSVpeeQrwJK2oYUlDWpHEJPcd/zopyuEMTv7DiztS1blgny1txR2qw==
   dependencies:
     debug "^4.1.0"
     devtools-protocol "0.0.781568"


### PR DESCRIPTION
Change the `visual-snapshot` environment so that it does not run `puppeteer`, instead created a GitHub action container that runs puppeteer and renders the image from html. See https://github.com/getsentry/action-html-to-image. I believe previously, the jest env was closing puppeteer before it could finish screenshots.

Also fixed platformicons and css/icons inlined as base64 so that it can be properly rendered inside of docker container.