### PR TITLE
feat(integrations): Add Sentry apps to available-actions

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -22,6 +22,8 @@ class AlertRuleTriggerActionSerializer(Serializer):
             return "Send a Slack notification to " + action.target_display
         elif action.type == action.Type.MSTEAMS.value:
             return "Send a Microsoft Teams notification to " + action.target_display
+        elif action.type == action.Type.SENTRY_APP.value:
+            return "Send a notification via " + action.target_display
 
     def get_identifier_from_action(self, action):
         target_identifier = (

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -856,6 +856,8 @@ SENTRY_FEATURES = {
     "organizations:integrations-msteams": False,
     # Allow orgs to install AzureDevops with limited scopes
     "organizations:integrations-vsts-limited-scopes": False,
+    # Use Sentry Apps with Metric Alerts
+    "organizations:integrations-sentry-app-metric-alerts": False,
     # Enable data forwarding functionality for organizations.
     "organizations:data-forwarding": True,
     # Enable experimental performance improvements.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -79,6 +79,7 @@ default_manager.add("organizations:integrations-chat-unfurl", OrganizationFeatur
 default_manager.add("organizations:integrations-incident-management", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-msteams", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-vsts-limited-scopes", OrganizationFeature)  # NOQA
+default_manager.add("organizations:integrations-sentry-app-metric-alerts", OrganizationFeature)  # NOQA
 default_manager.add("organizations:internal-catchall", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA
 default_manager.add("organizations:large-debug-files", OrganizationFeature)  # NOQA

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -79,7 +79,9 @@ default_manager.add("organizations:integrations-chat-unfurl", OrganizationFeatur
 default_manager.add("organizations:integrations-incident-management", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-msteams", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-vsts-limited-scopes", OrganizationFeature)  # NOQA
-default_manager.add("organizations:integrations-sentry-app-metric-alerts", OrganizationFeature)  # NOQA
+default_manager.add(
+    "organizations:integrations-sentry-app-metric-alerts", OrganizationFeature  # NOQA
+)
 default_manager.add("organizations:internal-catchall", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA
 default_manager.add("organizations:large-debug-files", OrganizationFeature)  # NOQA

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -148,6 +148,23 @@ class PagerDutyActionHandler(ActionHandler):
         send_incident_alert_notification(self.action, self.incident, metric_value)
 
 
+@AlertRuleTriggerAction.register_type(
+    "sentry_app",
+    AlertRuleTriggerAction.Type.SENTRY_APP,
+    [AlertRuleTriggerAction.TargetType.SENTRY_APP],
+)
+class IntegrationActionHandler(ActionHandler):
+    def fire(self, metric_value):
+        self.send_alert(metric_value)
+
+    def resolve(self, metric_value):
+        self.send_alert(metric_value)
+
+    def send_alert(self, metric_value):
+        # TODO: finish
+        pass
+
+
 def format_duration(minutes):
     """
     Format minutes into a duration string

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -7,22 +7,25 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.constants import SentryAppStatus
 from sentry.incidents.endpoints.bases import OrganizationEndpoint
 from sentry.incidents.endpoints.serializers import action_target_type_to_string
 from sentry.incidents.logic import (
+    get_alertable_sentry_apps,
     get_available_action_integrations_for_org,
     get_pagerduty_services,
 )
 from sentry.incidents.models import AlertRuleTriggerAction
 
 
-def build_action_response(registered_type, integration=None, organization=None):
+def build_action_response(registered_type, integration=None, organization=None, sentry_app=None):
     """
     Build the "available action" objects for the API. Each one can have different fields.
 
     :param registered_type: One of the registered AlertRuleTriggerAction types.
     :param integration: Optional. The Integration if this action uses a one.
     :param organization: Optional. If this is a PagerDuty action, we need the organization to look up services.
+    :param sentry_app: Optional. The SentryApp if this action uses a one.
     :return: The available action object.
     """
 
@@ -43,6 +46,11 @@ def build_action_response(registered_type, integration=None, organization=None):
                 {"value": service["id"], "label": service["service_name"]}
                 for service in get_pagerduty_services(organization, integration.id)
             ]
+
+    elif sentry_app:
+        action_response["sentryAppName"] = sentry_app.name
+        action_response["sentryAppId"] = sentry_app.id
+        action_response["status"] = SentryAppStatus.as_str(sentry_app.status)
 
     return action_response
 
@@ -71,6 +79,18 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
                     )
                     for integration in provider_integrations[registered_type.integration_provider]
                 ]
+
+            # Add all alertable SentryApps to the list.
+            elif registered_type.type == AlertRuleTriggerAction.Type.SENTRY_APP:
+                if features.has(
+                    "organizations:integrations-sentry-app-metric-alerts",
+                    organization,
+                    actor=request.user,
+                ):
+                    actions += [
+                        build_action_response(registered_type, sentry_app=app)
+                        for app in get_alertable_sentry_apps(organization.id)
+                    ]
 
             else:
                 actions.append(build_action_response(registered_type))

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -55,6 +55,7 @@ action_target_type_to_string = {
     AlertRuleTriggerAction.TargetType.USER: "user",
     AlertRuleTriggerAction.TargetType.TEAM: "team",
     AlertRuleTriggerAction.TargetType.SPECIFIC: "specific",
+    AlertRuleTriggerAction.TargetType.SENTRY_APP: "sentry_app",
 }
 string_to_action_target_type = {v: k for (k, v) in action_target_type_to_string.items()}
 

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -539,6 +539,7 @@ class AlertRuleTriggerAction(Model):
         PAGERDUTY = 1
         SLACK = 2
         MSTEAMS = 3
+        SENTRY_APP = 4
 
     INTEGRATION_TYPES = frozenset((Type.PAGERDUTY.value, Type.SLACK.value, Type.MSTEAMS.value))
 
@@ -550,6 +551,8 @@ class AlertRuleTriggerAction(Model):
         # A specific team. This could be used to send an email to everyone associated
         # with a team.
         TEAM = 2
+        # A Sentry App instead of any of the above.
+        SENTRY_APP = 3
 
     TypeRegistration = namedtuple(
         "TypeRegistration",

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -66,8 +66,9 @@ const getCleanAction = (actionConfig): Action => {
       actionConfig.allowedTargetTypes.length > 0
         ? actionConfig.allowedTargetTypes[0]
         : null,
-    targetIdentifier: '',
+    targetIdentifier: actionConfig.sentryAppId || '',
     integrationId: actionConfig.integrationId,
+    sentryAppId: actionConfig.sentryAppId,
     options: actionConfig.options || null,
   };
 };
@@ -81,9 +82,12 @@ const getCleanAction = (actionConfig): Action => {
 const getActionUniqueKey = ({
   type,
   integrationId,
-}: Pick<Action, 'type' | 'integrationId'>) => {
+  sentryAppId,
+}: Pick<Action, 'type' | 'integrationId' | 'sentryAppId'>) => {
   if (integrationId) {
     return `${type}-${integrationId}`;
+  } else if (sentryAppId) {
+    return `${type}-${sentryAppId}`;
   }
   return type;
 };
@@ -97,7 +101,19 @@ const getActionUniqueKey = ({
 const getFullActionTitle = ({
   type,
   integrationName,
-}: Pick<MetricActionTemplate, 'type' | 'integrationName'>) => {
+  sentryAppName,
+  status,
+}: Pick<
+  MetricActionTemplate,
+  'type' | 'integrationName' | 'sentryAppName' | 'status'
+>) => {
+  if (sentryAppName) {
+    if (status === 'internal') {
+      return `${sentryAppName} (${status})`;
+    }
+    return `${sentryAppName}`;
+  }
+
   const label = ActionLabel[type];
   if (integrationName) {
     return `${label} - ${integrationName}`;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -108,7 +108,7 @@ const getFullActionTitle = ({
   'type' | 'integrationName' | 'sentryAppName' | 'status'
 >) => {
   if (sentryAppName) {
-    if (status === 'internal') {
+    if (status) {
       return `${sentryAppName} (${status})`;
     }
     return `${sentryAppName}`;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -82,6 +82,7 @@ export enum ActionType {
   SLACK = 'slack',
   PAGERDUTY = 'pagerduty',
   MSTEAMS = 'msteams',
+  SENTRY_APP = 'sentry_app',
 }
 
 export enum TargetType {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -86,18 +86,22 @@ export enum ActionType {
 }
 
 export enum TargetType {
-  // The name can be customized for each integration. Email for email, channel for Slack, service for PagerDuty). We probably won't support this for email at first, since we need to be careful not to enable spam
+  // A direct reference, like an email address, Slack channel, or PagerDuty service
   SPECIFIC = 'specific',
 
-  // Just works with email for now, grabs given user's email address
+  // A specific user. This could be used to grab the user's email address.
   USER = 'user',
 
-  // Just works with email for now, grabs the emails for all team members
+  // A specific team. This could be used to send an email to everyone associated with a team.
   TEAM = 'team',
+
+  // A Sentry App instead of any of the above.
+  SENTRY_APP = 'sentry_app',
 }
 
 /**
- * This is an available action template that is associated to a Trigger in a Metric Alert Rule
+ * This is an available action template that is associated to a Trigger in a
+ * Metric Alert Rule. They are defined by the available-actions API.
  */
 export type MetricActionTemplate = {
   /**
@@ -113,27 +117,27 @@ export type MetricActionTemplate = {
   /**
    * Name of the integration. This is a text field that differentiates integrations from the same provider from each other
    */
-  integrationName: string;
+  integrationName?: string;
 
   /**
    * Integration id for this `type`, should be passed to backend as `integrationId` when creating an action
    */
-  integrationId: number;
+  integrationId?: number;
 
   /**
    * Name of the SentryApp. Like `integrationName`, this differentiates SentryApps from each other.
    */
-  sentryAppName: string;
+  sentryAppName?: string;
 
   /**
    * SentryApp id for this `type`, should be passed to backend as `sentryAppId` when creating an action.
    */
-  sentryAppId: number;
+  sentryAppId?: number;
 
   /**
    * For some available actions, we pass in the list of available targets.
    */
-  options: Array<{label: string; value: any}> | null;
+  options?: Array<{label: string; value: any}>;
 
   /**
    * If this is a `sentry_app` action, this is the Sentry App's status.

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -121,9 +121,24 @@ export type MetricActionTemplate = {
   integrationId: number;
 
   /**
+   * Name of the SentryApp. Like `integrationName`, this differentiates SentryApps from each other.
+   */
+  sentryAppName: string;
+
+  /**
+   * SentryApp id for this `type`, should be passed to backend as `sentryAppId` when creating an action.
+   */
+  sentryAppId: number;
+
+  /**
    * For some available actions, we pass in the list of available targets.
    */
   options: Array<{label: string; value: any}> | null;
+
+  /**
+   * If this is a `sentry_app` action, this is the Sentry App's status.
+   */
+  status?: 'unpublished' | 'published' | 'internal';
 };
 
 /**
@@ -161,7 +176,7 @@ export type UnsavedAction = {
 
   /**
    * How to identify the target. Can be email, slack channel, pagerduty service,
-   * user_id, team_id, etc
+   * user_id, team_id, SentryApp id, etc
    */
   targetIdentifier: string | null;
 
@@ -171,7 +186,17 @@ export type UnsavedAction = {
   integrationId?: number | null;
 
   /**
+   * The id of the SentryApp, can be null (e.g. email) or undefined (server errors when posting w/ null value)
+   */
+  sentryAppId?: number | null;
+
+  /**
    * For some available actions, we pass in the list of available targets.
    */
   options: Array<{label: string; value: any}> | null;
+
+  /**
+   * If this is a `sentry_app` action, this is the Sentry App's status.
+   */
+  status?: 'unpublished' | 'published' | 'internal';
 };


### PR DESCRIPTION
Update `OrganizationAlertRuleAvailableActionIndexEndpoint` to include all `is_alertable` Sentry Apps.
The API change is behind a new feature flag `organizations:integrations-metric-alerts-support` so it should be safe to deploy. 
Refactor commits moved to https://github.com/getsentry/sentry/pull/20405