### PR TITLE
ref(py3): Fix range usage in reports

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -136,7 +136,12 @@ def merge_sequences(target, other, function=operator.add):
     sequences must be equal.
     """
     assert len(target) == len(other), "sequence lengths must match"
-    return type(target)([function(x, y) for x, y in zip(target, other)])
+
+    rt_type = type(target)
+    if rt_type == range:
+        rt_type = list
+
+    return rt_type([function(x, y) for x, y in zip(target, other)])
 
 
 def merge_mappings(target, other, function=lambda x, y: x + y):

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -39,7 +39,6 @@ from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.utils.dates import to_datetime, to_timestamp, floor_to_utc_day
 from sentry.testutils.helpers.datetime import iso_format
 
-from six.moves import xrange
 from sentry.utils.compat import map
 
 
@@ -86,42 +85,42 @@ def test_merge_mapping_different_keys():
 
 
 def test_merge_sequences():
-    assert merge_sequences(range(0, 4), range(0, 4)) == [i * 2 for i in xrange(0, 4)]
+    assert merge_sequences(range(0, 4), range(0, 4)) == [i * 2 for i in range(0, 4)]
 
 
 def test_merge_sequences_custom_operator():
     assert merge_sequences(
-        [{chr(65 + i): i} for i in xrange(0, 26)],
-        [{chr(65 + i): i} for i in xrange(0, 26)],
+        [{chr(65 + i): i} for i in range(0, 26)],
+        [{chr(65 + i): i} for i in range(0, 26)],
         merge_mappings,
-    ) == [{chr(65 + i): i * 2} for i in xrange(0, 26)]
+    ) == [{chr(65 + i): i * 2} for i in range(0, 26)]
 
 
 def test_merge_series():
-    assert merge_series([(i, i) for i in xrange(0, 10)], [(i, i) for i in xrange(0, 10)]) == [
-        (i, i * 2) for i in xrange(0, 10)
+    assert merge_series([(i, i) for i in range(0, 10)], [(i, i) for i in range(0, 10)]) == [
+        (i, i * 2) for i in range(0, 10)
     ]
 
 
 def test_merge_series_custom_operator():
     assert merge_series(
-        [(i, {chr(65 + i): i}) for i in xrange(0, 26)],
-        [(i, {chr(65 + i): i}) for i in xrange(0, 26)],
+        [(i, {chr(65 + i): i}) for i in range(0, 26)],
+        [(i, {chr(65 + i): i}) for i in range(0, 26)],
         merge_mappings,
-    ) == [(i, {chr(65 + i): i * 2}) for i in xrange(0, 26)]
+    ) == [(i, {chr(65 + i): i * 2}) for i in range(0, 26)]
 
 
 def test_merge_series_offset_timestamps():
     with pytest.raises(AssertionError):
-        merge_series([(i, i) for i in xrange(0, 10)], [(i + 1, i) for i in xrange(0, 10)])
+        merge_series([(i, i) for i in range(0, 10)], [(i + 1, i) for i in range(0, 10)])
 
 
 def test_merge_series_different_lengths():
     with pytest.raises(AssertionError):
-        merge_series([(i, i) for i in xrange(0, 1)], [(i, i) for i in xrange(0, 10)])
+        merge_series([(i, i) for i in range(0, 1)], [(i, i) for i in range(0, 10)])
 
     with pytest.raises(AssertionError):
-        merge_series([(i, i) for i in xrange(0, 10)], [(i, i) for i in xrange(0, 1)])
+        merge_series([(i, i) for i in range(0, 10)], [(i, i) for i in range(0, 1)])
 
 
 def test_clean_series():
@@ -129,7 +128,7 @@ def test_clean_series():
     n = 5
     start = to_datetime(rollup * 0)
     stop = to_datetime(rollup * n)
-    series = [(rollup * i, i) for i in xrange(0, n)]
+    series = [(rollup * i, i) for i in range(0, n)]
     assert clean_series(start, stop, rollup, series) == series
 
 
@@ -138,7 +137,7 @@ def test_clean_series_trims_extra():
     n = 5
     start = to_datetime(rollup * 0)
     stop = to_datetime(rollup * n)
-    series = [(rollup * i, i) for i in xrange(0, n + 1)]
+    series = [(rollup * i, i) for i in range(0, n + 1)]
     assert clean_series(start, stop, rollup, series) == series[:n]
 
 
@@ -147,7 +146,7 @@ def test_clean_series_rejects_offset_timestamp():
     n = 5
     start = to_datetime(rollup * 0)
     stop = to_datetime(rollup * n)
-    series = [(rollup * (i * 1.1), i) for i in xrange(0, n)]
+    series = [(rollup * (i * 1.1), i) for i in range(0, n)]
     with pytest.raises(AssertionError):
         clean_series(start, stop, rollup, series)
 


### PR DESCRIPTION
Stop using xrange in these tests and just use range, the values are not large, so there's no need to ensure we're dealing with an iterator.

In py3 we ensure we don't try to cast back to a range type