### PR TITLE
ref(py3): Pass id at User init time to fix relation setup in tests

### DIFF
--- a/tests/sentry/plugins/bases/issue/tests.py
+++ b/tests/sentry/plugins/bases/issue/tests.py
@@ -13,8 +13,7 @@ from sentry.testutils import TestCase
 
 class GetAuthForUserTest(TestCase):
     def _get_mock_user(self):
-        user = mock.Mock(spec=User())
-        user.id = 1
+        user = mock.Mock(spec=User(id=1))
         user.is_authenticated.return_value = False
         return user
 


### PR DESCRIPTION
Otherwise you'll end up with the following error:

ValueError: "<User at 0x116018080: id=None>" needs to have a value for field "id" before this many-to-many relationship can be used.