### PR TITLE
fix(ui): Prevent error boundary setting state after unmount

### DIFF
--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -63,9 +63,7 @@ class ErrorBoundary extends React.Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     const {errorTag} = this.props;
 
-    if (this._isMounted) {
-      this.setState({error});
-    }
+    this.setState({error});
     Sentry.withScope(scope => {
       if (errorTag) {
         Object.keys(errorTag).forEach(tag => scope.setTag(tag, errorTag[tag]));
@@ -83,8 +81,8 @@ class ErrorBoundary extends React.Component<Props, State> {
     }
   }
 
-  unlistenBrowserHistory: ReturnType<typeof browserHistory.listen> | undefined;
-  _isMounted: boolean | undefined;
+  private unlistenBrowserHistory?: ReturnType<typeof browserHistory.listen>;
+  private _isMounted: boolean = false;
 
   render() {
     const {error} = this.state;

--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -82,7 +82,7 @@ class ErrorBoundary extends React.Component<Props, State> {
   }
 
   private unlistenBrowserHistory?: ReturnType<typeof browserHistory.listen>;
-  private _isMounted: boolean = false;
+  private _isMounted = false;
 
   render() {
     const {error} = this.state;

--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -81,8 +81,8 @@ class ErrorBoundary extends React.Component<Props, State> {
     }
   }
 
-  unlistenBrowserHistory?: ReturnType<typeof browserHistory.listen>;
-  _isMounted = false;
+  private unlistenBrowserHistory?: ReturnType<typeof browserHistory.listen>;
+  private _isMounted = false;
 
   render() {
     const {error} = this.state;

--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -81,8 +81,8 @@ class ErrorBoundary extends React.Component<Props, State> {
     }
   }
 
-  private unlistenBrowserHistory?: ReturnType<typeof browserHistory.listen>;
-  private _isMounted = false;
+  unlistenBrowserHistory?: ReturnType<typeof browserHistory.listen>;
+  _isMounted = false;
 
   render() {
     const {error} = this.state;


### PR DESCRIPTION
Sometimes during development the error boundary component errors when changing pages.

The browserHistory listener is still triggered sometimes after `unlistenBrowserHistory` is called and tries to set state to null even though it is being destroyed.

![image](https://user-images.githubusercontent.com/1400464/90543621-d2d8d580-e13a-11ea-976a-08cc5d2c2541.png)
