### PR TITLE
Open discover query docs in new tab

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
@@ -82,7 +82,7 @@ class ColumnEditModal extends React.Component<Props, State> {
         </Body>
         <Footer>
           <ButtonBar gap={1}>
-            <Button priority="default" href={DISCOVER2_DOCS_URL}>
+            <Button priority="default" href={DISCOVER2_DOCS_URL} external>
               {t('Read the Docs')}
             </Button>
             <Button label={t('Apply')} priority="primary" onClick={this.handleApply}>


### PR DESCRIPTION
When modifying columns for a discovery query clicking on "Read the docs" opened the docs over top of your work. 