### PR TITLE
feat(alert): Add new filter for issue occurrences

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -228,6 +228,7 @@ SENTRY_RULES = (
     "sentry.rules.conditions.event_attribute.EventAttributeCondition",
     "sentry.rules.conditions.level.LevelCondition",
     "sentry.rules.filters.age_comparison.AgeComparisonFilter",
+    "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
 )
 
 # methods as defined by http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html + PATCH

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+
+from django import forms
+
+from sentry.rules.filters.base import EventFilter
+
+
+class IssueOccurrencesForm(forms.Form):
+    value = forms.IntegerField()
+
+
+class IssueOccurrencesFilter(EventFilter):
+    form_cls = IssueOccurrencesForm
+    form_fields = {
+        "value": {"type": "number", "placeholder": 10},
+    }
+
+    label = "An issue has happened at least {value} times"
+
+    def passes(self, event, state):
+        try:
+            value = int(self.get_option("value"))
+        except (TypeError, ValueError):
+            return False
+
+        issue_occurrences = event.group.times_seen
+        return issue_occurrences >= value

--- a/tests/sentry/rules/filters/test_issue_occurrences.py
+++ b/tests/sentry/rules/filters/test_issue_occurrences.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.rules.filters.issue_occurrences import IssueOccurrencesFilter
+from sentry.testutils.cases import RuleTestCase
+
+
+class IssueOccurrencesTest(RuleTestCase):
+    rule_cls = IssueOccurrencesFilter
+
+    def test_compares_correctly(self):
+        event = self.get_event()
+        value = 10
+        data = {"value": six.text_type(value)}
+
+        rule = self.get_rule(data=data)
+
+        event.group.times_seen = 11
+        self.assertPasses(rule, event)
+
+        event.group.times_seen = 8
+        self.assertDoesNotPass(rule, event)
+
+    def test_fails_on_bad_data(self):
+        event = self.get_event()
+        data = {"value": "bad data"}
+
+        rule = self.get_rule(data=data)
+
+        event.group.times_seen = 10
+        self.assertDoesNotPass(rule, event)

--- a/tests/sentry/rules/filters/test_issue_occurrences.py
+++ b/tests/sentry/rules/filters/test_issue_occurrences.py
@@ -19,6 +19,9 @@ class IssueOccurrencesTest(RuleTestCase):
         event.group.times_seen = 11
         self.assertPasses(rule, event)
 
+        event.group.times_seen = 10
+        self.assertPasses(rule, event)
+
         event.group.times_seen = 8
         self.assertDoesNotPass(rule, event)
 


### PR DESCRIPTION
Added a `IssueOccurrencesFilter` which will allow a user to filter alerts based on how many times an issue has occurred. Uses the event.group.times_seen attribute to evaluate if the filter passes. Currently is not available to be selected by the user, but is carried through as one of the filters in the backend endpoint.