### PR TITLE
feat(msteams): adds app id and deep link

### DIFF
--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -5,6 +5,7 @@ import logging
 from django.utils.translation import ugettext_lazy as _
 
 
+from sentry import options
 from sentry.integrations import (
     IntegrationInstallation,
     IntegrationFeatures,
@@ -38,10 +39,13 @@ FEATURES = [
 ]
 
 
-INSTALL_NOTICE_TEXT = "INSTALL TEXT"
+INSTALL_NOTICE_TEXT = (
+    "Visit the Teams Marketplace to install this integration. After adding the integration"
+    " to your team, you will get a message in the General channel to complete installation."
+)
 
 external_install = {
-    "url": u"https://google.com",  # TODO: set correct URL
+    "url": u"https://teams.microsoft.com/l/app/%s" % options.get("msteams.app-id"),
     "buttonText": _("Teams Marketplace"),
     "noticeText": _(INSTALL_NOTICE_TEXT),
 }
@@ -52,7 +56,7 @@ metadata = IntegrationMetadata(
     features=FEATURES,
     author="The Sentry Team",
     noun=_("Installation"),
-    issue_url="https://github.com/getsentry/sentry/issues/new",
+    issue_url="https://github.com/getsentry/sentry/issues/new?title=Microsoft%20Teams%20Integration:%20&labels=Component%3A%20Integrations",
     source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/msteams",
     aspects={"externalInstall": external_install},
 )

--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -45,7 +45,7 @@ INSTALL_NOTICE_TEXT = (
 )
 
 external_install = {
-    "url": u"https://teams.microsoft.com/l/app/%s" % options.get("msteams.app-id"),
+    "url": u"https://teams.microsoft.com/l/app/{}".format(options.get("msteams.app-id")),
     "buttonText": _("Teams Marketplace"),
     "noticeText": _(INSTALL_NOTICE_TEXT),
 }

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -155,6 +155,7 @@ register("vercel.integration-slug", default="sentry")
 # MsTeams Integration
 register("msteams.client-id", flags=FLAG_PRIORITIZE_DISK)
 register("msteams.client-secret", flags=FLAG_PRIORITIZE_DISK)
+register("msteams.app-id")
 
 # Snuba
 register("snuba.search.pre-snuba-candidates-optimizer", type=Bool, default=False)


### PR DESCRIPTION
This PR adds a deep link to install the Microsoft Teams integration at `https://teams.microsoft.com/l/app/{app_id}`. However, this link won't work until the app is actually published. I also updated a few other things with the integration like the installation text and the create issue link.

![Screen Shot 2020-08-18 at 11 01 56 AM](https://user-images.githubusercontent.com/8533851/90549326-2fd88980-e143-11ea-92cf-bb78fac68399.png)

