### PR TITLE
feat(sentry-apps): adds default text for async fields

### DIFF
--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.tsx
@@ -261,7 +261,7 @@ export class SentryAppExternalIssueForm extends React.Component<Props, State> {
     };
 
     //async only used for select components
-    const isAsync = typeof field.async === 'undefined' ? true : field.async; //default to true
+    const isAsync = typeof field.async === 'undefined' ? true : !!field.async; //default to true
 
     if (fieldToPass.type === 'select') {
       // find the options from state to pass down

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.tsx
@@ -260,6 +260,9 @@ export class SentryAppExternalIssueForm extends React.Component<Props, State> {
       required,
     };
 
+    //async only used for select components
+    const isAsync = typeof field.async === 'undefined' ? true : field.async; //default to true
+
     if (fieldToPass.type === 'select') {
       // find the options from state to pass down
       const defaultOptions = (field.choices || []).map(([value, label]) => ({
@@ -275,6 +278,10 @@ export class SentryAppExternalIssueForm extends React.Component<Props, State> {
         defaultOptions,
         filterOption,
       };
+      //default message for async select fields
+      if (isAsync) {
+        fieldToPass.noOptionsMessage = () => 'Type to search';
+      }
     } else if (['text', 'textarea'].includes(fieldToPass.type || '') && field.default) {
       fieldToPass = {...fieldToPass, defaultValue: this.getFieldDefault(field)};
     }
@@ -293,7 +300,7 @@ export class SentryAppExternalIssueForm extends React.Component<Props, State> {
     const extraProps = field.uri
       ? {
           loadOptions: (input: string) => this.getOptions(field, input),
-          async: typeof field.async === 'undefined' ? true : field.async, //default to true
+          async: isAsync,
           cache: false,
           onSelectResetsInput: false,
           onCloseResetsInput: false,

--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
@@ -30,6 +30,7 @@ type Props = {
   onBlur?: (value, event) => void;
   access?: Set<Scope>;
   deprecatedSelectControl?: boolean;
+  noOptionsMessage?: () => string;
 };
 
 export default class FieldFromConfig extends React.Component<Props> {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -107,6 +107,7 @@ type SelectControlType = {type: 'choice' | 'select'} & {
   options?: Array<{label: string; value: any}>; //for new select
   defaultOptions?: Array<{label: string; value: any}> | boolean;
   filterOption?: ReturnType<typeof createFilter>;
+  noOptionsMessage?: () => string;
 };
 
 type TextareaType = {type: 'textarea'} & {


### PR DESCRIPTION
This PR adds a default text for async components if they have no options loaded telling the user to type. This was requested by an integration partner.

![Screen Shot 2020-08-18 at 11 20 32 AM](https://user-images.githubusercontent.com/8533851/90551263-e9385e80-e145-11ea-828d-ea50d6eac1a2.png)
