### PR TITLE
fix(apm): Add min/max fraction digits for human durations

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -250,7 +250,10 @@ export const getHumanDuration = (duration: number): string => {
   // note: duration is assumed to be in seconds
 
   const durationMS = duration * 1000;
-  return `${Number(durationMS.toFixed(2)).toLocaleString()}ms`;
+  return `${Number(durationMS.toFixed(2)).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}ms`;
 };
 
 const getLetterIndex = (letter: string): number => {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -250,7 +250,7 @@ export const getHumanDuration = (duration: number): string => {
   // note: duration is assumed to be in seconds
 
   const durationMS = duration * 1000;
-  return `${Number(durationMS.toFixed(2)).toLocaleString(undefined, {
+  return `${durationMS.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })}ms`;


### PR DESCRIPTION
Use 

```js
foo.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}))
```

as documented here https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString

## Before

<img width="147" alt="Screen Shot 2020-08-18 at 3 17 22 PM" src="https://user-images.githubusercontent.com/139499/90555867-02510780-e166-11ea-80e8-fb0591fc36bb.png">

<img width="252" alt="Screen Shot 2020-08-18 at 3 15 09 PM" src="https://user-images.githubusercontent.com/139499/90555875-067d2500-e166-11ea-90f0-ffdebd312df5.png">

<img width="130" alt="Screen Shot 2020-08-18 at 3 18 21 PM" src="https://user-images.githubusercontent.com/139499/90555923-1ac12200-e166-11ea-8a7a-ba665e9ad866.png">


## After

<img width="188" alt="Screen Shot 2020-08-18 at 3 19 09 PM" src="https://user-images.githubusercontent.com/139499/90555991-2f051f00-e166-11ea-8592-3ddfac3c2650.png">
<img width="213" alt="Screen Shot 2020-08-18 at 3 19 28 PM" src="https://user-images.githubusercontent.com/139499/90556017-39271d80-e166-11ea-9403-394b70913d43.png">
<img width="131" alt="Screen Shot 2020-08-18 at 3 19 46 PM" src="https://user-images.githubusercontent.com/139499/90556059-43491c00-e166-11ea-9415-1028815266a6.png">
