### PR TITLE
feat(onboarding) Add component for new tour designs

### DIFF
--- a/docs-ui/components/featureTourModal.stories.js
+++ b/docs-ui/components/featureTourModal.stories.js
@@ -1,21 +1,56 @@
 import React from 'react';
 import {withInfo} from '@storybook/addon-info';
+import {action} from '@storybook/addon-actions';
 
 import Button from 'app/components/button';
+import {IconEdit} from 'app/icons';
+import GlobalModal from 'app/components/globalModal';
 import FeatureTourModal from 'app/components/modals/featureTourModal';
 
 export default {
   title: 'UI/Modals',
 };
 
-export const Basics = withInfo('A feature tour with multiple steps')(() => (
-  <div className="section">
-    <FeatureTourModal>
-      {({handleShow}) => <Button onClick={handleShow}>Show tour</Button>}
-    </FeatureTourModal>
-  </div>
-));
+const steps = [
+  {
+    title: 'How to draw an owl',
+    body: (
+      <React.Fragment>
+        <p>First get all your sketchbook and pencil.</p>
+      </React.Fragment>
+    ),
+  },
+  {
+    title: 'Draw two circles',
+    body: 'Next, draw a circle for the head, and another for the body.',
+    actions: <Button>Read docs</Button>,
+  },
+  {
+    image: <IconEdit size="xl" />,
+    title: 'Draw the rest of the owl',
+    body: 'Finish off the drawing by adding eyes, feathers and talons.',
+  },
+  {
+    title: 'All done!',
+    body: 'Great job on drawing your owl.',
+  },
+];
 
-Basics.story = {
-  name: 'Basics',
+export const FeatureTourModalBasics = withInfo('A feature tour with multiple steps')(
+  () => (
+    <div className="section">
+      <GlobalModal />
+      <FeatureTourModal
+        steps={steps}
+        onAdvance={action('onAdvance')}
+        onCloseModal={action('onCloseModal')}
+      >
+        {({handleShow}) => <Button onClick={handleShow}>Show tour</Button>}
+      </FeatureTourModal>
+    </div>
+  )
+);
+
+FeatureTourModalBasics.story = {
+  name: 'FeatureTourModal',
 };

--- a/docs-ui/components/featureTourModal.stories.js
+++ b/docs-ui/components/featureTourModal.stories.js
@@ -41,7 +41,7 @@ export const FeatureTourModalBasics = withInfo('A feature tour with multiple ste
         onAdvance={action('onAdvance')}
         onCloseModal={action('onCloseModal')}
       >
-        {({handleShow}) => <Button onClick={handleShow}>Show tour</Button>}
+        {({showModal}) => <Button onClick={showModal}>Show tour</Button>}
       </FeatureTourModal>
     </div>
   )

--- a/docs-ui/components/featureTourModal.stories.js
+++ b/docs-ui/components/featureTourModal.stories.js
@@ -14,11 +14,7 @@ export default {
 const steps = [
   {
     title: 'How to draw an owl',
-    body: (
-      <React.Fragment>
-        <p>First get all your sketchbook and pencil.</p>
-      </React.Fragment>
-    ),
+    body: <p>First get all your sketchbook and pencil.</p>,
   },
   {
     title: 'Draw two circles',

--- a/docs-ui/components/featureTourModal.stories.js
+++ b/docs-ui/components/featureTourModal.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import {withInfo} from '@storybook/addon-info';
+
+import Button from 'app/components/button';
+import FeatureTourModal from 'app/components/modals/featureTourModal';
+
+export default {
+  title: 'UI/Modals',
+};
+
+export const Basics = withInfo('A feature tour with multiple steps')(() => (
+  <div className="section">
+    <FeatureTourModal>
+      {({handleShow}) => <Button onClick={handleShow}>Show tour</Button>}
+    </FeatureTourModal>
+  </div>
+));
+
+Basics.story = {
+  name: 'Basics',
+};

--- a/docs-ui/components/repoLabel.stories.js
+++ b/docs-ui/components/repoLabel.stories.js
@@ -4,7 +4,7 @@ import {withInfo} from '@storybook/addon-info';
 import RepoLabel from 'app/components/repoLabel';
 
 export default {
-  title: 'RepoLabel',
+  title: 'UI/RepoLabel',
 };
 
 export const Default = withInfo('A badge to use for repo names')(() => {

--- a/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
@@ -28,9 +28,21 @@ type ContentsProps = ModalRenderProps & {
    */
   onAdvance?: (currentIndex: number, durationOpen: number) => void;
   /**
-   * Triggered when the tour is closed by completion or x
+   * Triggered when the tour is closed by completion or IconClose
    */
   onCloseModal?: (currentIndex: number, durationOpen: number) => void;
+  /**
+   * Customize the text shown on the done button.
+   */
+  doneText?: string;
+  /**
+   * Provide a URL for the done state to open in a new tab.
+   */
+  doneUrl?: string;
+};
+
+const defaultProps = {
+  doneText: t('Done'),
 };
 
 type ContentsState = {
@@ -47,6 +59,8 @@ type ContentsState = {
 };
 
 class ModalContents extends React.Component<ContentsProps, ContentsState> {
+  static defaultProps = defaultProps;
+
   state: ContentsState = {
     openedAt: Date.now(),
     current: 0,
@@ -74,7 +88,7 @@ class ModalContents extends React.Component<ContentsProps, ContentsState> {
   };
 
   render() {
-    const {Body, steps} = this.props;
+    const {Body, steps, doneText, doneUrl} = this.props;
     const {current} = this.state;
     const step = steps[current] !== undefined ? steps[current] : steps[steps.length - 1];
     const hasNext = steps[current + 1] !== undefined;
@@ -105,8 +119,13 @@ class ModalContents extends React.Component<ContentsProps, ContentsState> {
               </Button>
             )}
             {!hasNext && (
-              <Button data-test-id="complete-tour" onClick={this.handleClose}>
-                {t('All Done')}
+              <Button
+                external
+                href={doneUrl}
+                data-test-id="complete-tour"
+                onClick={this.handleClose}
+              >
+                {doneText}
               </Button>
             )}
           </ButtonBar>
@@ -122,15 +141,15 @@ type ChildProps = {
 };
 
 type Props = {
-  children: (childProps: ChildProps) => React.ReactNode;
-} & Pick<ContentsProps, 'steps' | 'onCloseModal' | 'onAdvance'>;
+  children: (props: ChildProps) => React.ReactNode;
+} & Pick<ContentsProps, 'steps' | 'onCloseModal' | 'onAdvance' | 'doneText' | 'doneUrl'>;
 
 function FeatureTourModal(props: Props) {
   const handleShow = () => {
     const modalProps = omit(props, ['children']);
     openModal(deps => <ModalContents {...deps} {...modalProps} />);
   };
-  return props.children({handleShow});
+  return <React.Fragment>{props.children({handleShow})}</React.Fragment>;
 }
 
 export default FeatureTourModal;
@@ -153,4 +172,18 @@ const StepCounter = styled(TourContent)`
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.gray400};
   margin-bottom: 0;
+`;
+
+// Styled components that can be used to build tour content.
+export const TourText = styled('p')`
+  text-align: center;
+  margin: 0 ${space(3)};
+`;
+
+export const TourImage = styled('img')`
+  margin-top: ${space(4)};
+  /** override styles in less files */
+  box-shadow: none !important;
+  border: 0 !important;
+  border-radius: 0 !important;
 `;

--- a/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
@@ -54,7 +54,7 @@ class ModalContents extends React.Component<ContentsProps, ContentsState> {
 
   handleAdvance = () => {
     const {onAdvance} = this.props;
-    this.setState({current: this.state.current + 1}, () => {
+    this.setState(prevState => ({current: prevState.current + 1}, () => {
       const duration = Date.now() - this.state.openedAt;
       callIfFunction(onAdvance, this.state.current, duration);
     });

--- a/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
@@ -12,9 +12,9 @@ import space from 'app/styles/space';
 
 type TourStep = {
   title: string;
-  image?: React.ReactNode;
   body: React.ReactNode;
-  actions: React.ReactNode;
+  actions: React.ReactElement;
+  image?: React.ReactElement;
 };
 
 type ContentsProps = ModalRenderProps & {
@@ -54,10 +54,13 @@ class ModalContents extends React.Component<ContentsProps, ContentsState> {
 
   handleAdvance = () => {
     const {onAdvance} = this.props;
-    this.setState(prevState => ({current: prevState.current + 1}, () => {
-      const duration = Date.now() - this.state.openedAt;
-      callIfFunction(onAdvance, this.state.current, duration);
-    });
+    this.setState(
+      prevState => ({current: prevState.current + 1}),
+      () => {
+        const duration = Date.now() - this.state.openedAt;
+        callIfFunction(onAdvance, this.state.current, duration);
+      }
+    );
   };
 
   handleClose = () => {

--- a/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
@@ -13,7 +13,7 @@ import space from 'app/styles/space';
 type TourStep = {
   title: string;
   body: React.ReactNode;
-  actions: React.ReactElement;
+  actions?: React.ReactElement;
   image?: React.ReactElement;
 };
 

--- a/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
@@ -1,4 +1,110 @@
 import React from 'react';
+import omit from 'lodash/omit';
+import styled from '@emotion/styled';
+
+import {openModal, ModalRenderProps} from 'app/actionCreators/modal';
+import Button from 'app/components/button';
+import ButtonBar from 'app/components/buttonBar';
+import {t} from 'app/locale';
+import {IconClose} from 'app/icons';
+import {callIfFunction} from 'app/utils/callIfFunction';
+import space from 'app/styles/space';
+
+type TourStep = {
+  title: string;
+  image?: React.ReactNode;
+  body: React.ReactNode;
+  actions: React.ReactNode;
+};
+
+type ContentsProps = ModalRenderProps & {
+  /**
+   * The list of tour steps.
+   * The FeatureTourModal will manage state on the active step.
+   */
+  steps: TourStep[];
+  /**
+   * Triggered when the tour is advanced.
+   */
+  onAdvance?: (currentIndex: number, durationOpen: number) => void;
+  /**
+   * Triggered when the tour is closed by completion or x
+   */
+  onCloseModal?: (currentIndex: number, durationOpen: number) => void;
+};
+
+type ContentsState = {
+  /**
+   * The current step offset to show
+   */
+  current: number;
+
+  /**
+   * The timestamp with ms the tour was opened,
+   * used to track duration on each step.
+   */
+  openedAt: number;
+};
+
+class ModalContents extends React.Component<ContentsProps, ContentsState> {
+  state: ContentsState = {
+    openedAt: Date.now(),
+    current: 0,
+  };
+
+  handleAdvance = () => {
+    const {onAdvance} = this.props;
+    this.setState({current: this.state.current + 1}, () => {
+      const duration = Date.now() - this.state.openedAt;
+      callIfFunction(onAdvance, this.state.current, duration);
+    });
+  };
+
+  handleClose = () => {
+    const {closeModal, onCloseModal} = this.props;
+
+    const duration = Date.now() - this.state.openedAt;
+    callIfFunction(onCloseModal, this.state.current, duration);
+
+    // Call the modal close.
+    closeModal();
+  };
+
+  render() {
+    const {Body, steps} = this.props;
+    const {current} = this.state;
+    const step = steps[current] !== undefined ? steps[current] : steps[steps.length - 1];
+    const hasNext = steps[current + 1] !== undefined;
+
+    return (
+      <Body>
+        <CloseButton
+          borderless
+          size="zero"
+          onClick={this.handleClose}
+          icon={<IconClose />}
+        />
+        {step.image && <TourContent>{step.image}</TourContent>}
+        <TourContent>
+          <h3>{step.title}</h3>
+          {step.body}
+        </TourContent>
+        <TourContent>
+          <ButtonBar gap={1}>
+            {step.actions && step.actions}
+            {hasNext && (
+              <Button priority="primary" onClick={this.handleAdvance}>
+                {t('Next')}
+              </Button>
+            )}
+            {!hasNext && <Button onClick={this.handleClose}>{t('All Done')}</Button>}
+          </ButtonBar>
+        </TourContent>
+        <StepCounter>{t('%s of %s', current + 1, steps.length)}</StepCounter>
+      </Body>
+    );
+  }
+}
 
 type ChildProps = {
   handleShow: () => void;
@@ -6,33 +112,34 @@ type ChildProps = {
 
 type Props = {
   children: (childProps: ChildProps) => React.ReactNode;
-};
+} & Pick<ContentsProps, 'steps' | 'onCloseModal' | 'onAdvance'>;
 
-type State = {
-  isShowing: boolean;
-};
-
-class FeatureTourModal extends React.Component<Props> {
-  state: State = {
-    isShowing: false,
+function FeatureTourModal(props: Props) {
+  const handleShow = () => {
+    const modalProps = omit(props, ['children']);
+    openModal(deps => <ModalContents {...deps} {...modalProps} />);
   };
-
-  handleShow = () => {
-    this.setState({isShowing: true});
-  };
-
-  render() {
-    const {children} = this.props;
-    const {isShowing} = this.state;
-
-    const childProps = {
-      handleShow: this.handleShow,
-    };
-    if (isShowing) {
-      return <div>I am showing!</div>;
-    }
-    return children(childProps);
-  }
+  return props.children({handleShow});
 }
 
 export default FeatureTourModal;
+
+const CloseButton = styled(Button)`
+  position: absolute;
+  top: -${space(2)};
+  right: -${space(2)};
+`;
+
+const TourContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: ${space(2)};
+`;
+
+const StepCounter = styled(TourContent)`
+  text-transform: uppercase;
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.gray400};
+  margin-bottom: 0;
+`;

--- a/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
@@ -96,11 +96,19 @@ class ModalContents extends React.Component<ContentsProps, ContentsState> {
           <ButtonBar gap={1}>
             {step.actions && step.actions}
             {hasNext && (
-              <Button priority="primary" onClick={this.handleAdvance}>
+              <Button
+                data-test-id="next-step"
+                priority="primary"
+                onClick={this.handleAdvance}
+              >
                 {t('Next')}
               </Button>
             )}
-            {!hasNext && <Button onClick={this.handleClose}>{t('All Done')}</Button>}
+            {!hasNext && (
+              <Button data-test-id="complete-tour" onClick={this.handleClose}>
+                {t('All Done')}
+              </Button>
+            )}
           </ButtonBar>
         </TourContent>
         <StepCounter>{t('%s of %s', current + 1, steps.length)}</StepCounter>

--- a/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+type ChildProps = {
+  handleShow: () => void;
+};
+
+type Props = {
+  children: (childProps: ChildProps) => React.ReactNode;
+};
+
+type State = {
+  isShowing: boolean;
+};
+
+class FeatureTourModal extends React.Component<Props> {
+  state: State = {
+    isShowing: false,
+  };
+
+  handleShow = () => {
+    this.setState({isShowing: true});
+  };
+
+  render() {
+    const {children} = this.props;
+    const {isShowing} = this.state;
+
+    const childProps = {
+      handleShow: this.handleShow,
+    };
+    if (isShowing) {
+      return <div>I am showing!</div>;
+    }
+    return children(childProps);
+  }
+}
+
+export default FeatureTourModal;

--- a/tests/js/spec/components/featureTourModal.spec.jsx
+++ b/tests/js/spec/components/featureTourModal.spec.jsx
@@ -22,11 +22,16 @@ const steps = [
 describe('FeatureTourModal', function() {
   let onAdvance, onCloseModal;
 
-  const createWrapper = () =>
+  const createWrapper = (props = {}) =>
     mountWithTheme(
       <React.Fragment>
         <GlobalModal />
-        <FeatureTourModal steps={steps} onAdvance={onAdvance} onCloseModal={onCloseModal}>
+        <FeatureTourModal
+          steps={steps}
+          onAdvance={onAdvance}
+          onCloseModal={onCloseModal}
+          {...props}
+        >
           {({handleShow}) => (
             <a href="#" onClick={handleShow} data-test-id="reveal">
               Open
@@ -39,7 +44,7 @@ describe('FeatureTourModal', function() {
   const showModal = async wrapper => {
     wrapper.find('[data-test-id="reveal"]').simulate('click');
     await tick();
-    await wrapper.update();
+    wrapper.update();
   };
 
   beforeEach(function() {
@@ -98,6 +103,21 @@ describe('FeatureTourModal', function() {
     wrapper.find('Button[data-test-id="complete-tour"]').simulate('click');
     expect(onAdvance).toHaveBeenCalledTimes(1);
     expect(onCloseModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('last step shows doneText and uses doneUrl', async function() {
+    const props = {doneText: 'Finished', doneUrl: 'http://example.org'};
+    const wrapper = createWrapper(props);
+
+    await showModal(wrapper);
+
+    // Advance to the the last step.
+    wrapper.find('Button[data-test-id="next-step"]').simulate('click');
+
+    // Ensure button looks right
+    const button = wrapper.find('Button[data-test-id="complete-tour"]');
+    expect(button.text()).toEqual(props.doneText);
+    expect(button.props().href).toEqual(props.doneUrl);
   });
 
   it('close button dismisses modal', async function() {

--- a/tests/js/spec/components/featureTourModal.spec.jsx
+++ b/tests/js/spec/components/featureTourModal.spec.jsx
@@ -32,8 +32,8 @@ describe('FeatureTourModal', function() {
           onCloseModal={onCloseModal}
           {...props}
         >
-          {({handleShow}) => (
-            <a href="#" onClick={handleShow} data-test-id="reveal">
+          {({showModal}) => (
+            <a href="#" onClick={showModal} data-test-id="reveal">
               Open
             </a>
           )}
@@ -101,6 +101,9 @@ describe('FeatureTourModal', function() {
 
     // Click the done
     wrapper.find('Button[data-test-id="complete-tour"]').simulate('click');
+
+    // Wait for the ModalStore action to propagate.
+    await tick();
     expect(onAdvance).toHaveBeenCalledTimes(1);
     expect(onCloseModal).toHaveBeenCalledTimes(1);
   });
@@ -126,6 +129,9 @@ describe('FeatureTourModal', function() {
     await showModal(wrapper);
 
     wrapper.find('CloseButton').simulate('click');
+
+    // Wait for the ModalStore action to propagate.
+    await tick();
     expect(onCloseModal).toHaveBeenCalled();
   });
 });

--- a/tests/js/spec/components/featureTourModal.spec.jsx
+++ b/tests/js/spec/components/featureTourModal.spec.jsx
@@ -121,6 +121,12 @@ describe('FeatureTourModal', function() {
     const button = wrapper.find('Button[data-test-id="complete-tour"]');
     expect(button.text()).toEqual(props.doneText);
     expect(button.props().href).toEqual(props.doneUrl);
+
+    // Click the done
+    button.simulate('click');
+    // Wait for the ModalStore action to propagate.
+    await tick();
+    expect(onCloseModal).toHaveBeenCalledTimes(1);
   });
 
   it('close button dismisses modal', async function() {

--- a/tests/js/spec/components/featureTourModal.spec.jsx
+++ b/tests/js/spec/components/featureTourModal.spec.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import FeatureTourModal from 'app/components/modals/featureTourModal';
+import GlobalModal from 'app/components/globalModal';
+
+const steps = [
+  {
+    title: 'First',
+    body: 'First step',
+    image: <em data-test-id="step-image">Image</em>,
+    actions: (
+      <a href="#" data-test-id="step-action">
+        additional action
+      </a>
+    ),
+  },
+  {title: 'Second', body: 'Second step'},
+];
+
+describe('FeatureTourModal', function() {
+  let onAdvance, onCloseModal;
+
+  const createWrapper = () =>
+    mountWithTheme(
+      <React.Fragment>
+        <GlobalModal />
+        <FeatureTourModal steps={steps} onAdvance={onAdvance} onCloseModal={onCloseModal}>
+          {({handleShow}) => (
+            <a href="#" onClick={handleShow} data-test-id="reveal">
+              Open
+            </a>
+          )}
+        </FeatureTourModal>
+      </React.Fragment>
+    );
+
+  const showModal = async wrapper => {
+    wrapper.find('[data-test-id="reveal"]').simulate('click');
+    await tick();
+    await wrapper.update();
+  };
+
+  beforeEach(function() {
+    onAdvance = jest.fn();
+    onCloseModal = jest.fn();
+  });
+
+  it('shows the modal on click', async function() {
+    const wrapper = createWrapper();
+
+    // No modal showing
+    expect(wrapper.find('GlobalModal').props().visible).toEqual(false);
+    await showModal(wrapper);
+
+    // Modal is now showing
+    expect(wrapper.find('GlobalModal').props().visible).toEqual(true);
+  });
+
+  it('advances on click', async function() {
+    const wrapper = createWrapper();
+
+    await showModal(wrapper);
+
+    // Should start on the first step.
+    expect(wrapper.find('TourContent h3').text()).toEqual(steps[0].title);
+
+    // Advance to the next step.
+    wrapper.find('Button[data-test-id="next-step"]').simulate('click');
+
+    // Should move to next step.
+    expect(wrapper.find('TourContent h3').text()).toEqual(steps[1].title);
+    expect(onAdvance).toHaveBeenCalled();
+  });
+
+  it('shows step content', async function() {
+    const wrapper = createWrapper();
+
+    await showModal(wrapper);
+
+    // Should show title, image and actions
+    expect(wrapper.find('TourContent h3').text()).toEqual(steps[0].title);
+    expect(wrapper.find('TourContent em[data-test-id="step-image"]')).toHaveLength(1);
+    expect(wrapper.find('TourContent a[data-test-id="step-action"]')).toHaveLength(1);
+    expect(wrapper.find('StepCounter').text()).toEqual('1 of 2');
+  });
+
+  it('last step shows done', async function() {
+    const wrapper = createWrapper();
+
+    await showModal(wrapper);
+
+    // Advance to the the last step.
+    wrapper.find('Button[data-test-id="next-step"]').simulate('click');
+
+    // Click the done
+    wrapper.find('Button[data-test-id="complete-tour"]').simulate('click');
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+    expect(onCloseModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('close button dismisses modal', async function() {
+    const wrapper = createWrapper();
+
+    await showModal(wrapper);
+
+    wrapper.find('CloseButton').simulate('click');
+    expect(onCloseModal).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
For performance and discover we'd like to trial out a new re-startable tour. If successful this would replace the guide anchor onboarding used in issues and the slide show tour used in releases.

The component exposes two callbacks:

- `onAdvance` lets a page know that the tour has advanced and gives it an opportunity to track metrics as required. The index and duration are included so that we know how long it takes users to get through a tour and where they are spending their time.
- `onCloseModal` lets the page know that the tour has concluded and that the modal has been closed.

If people are generally happy with the API I'll add tests.

## Demo

![tourmodal](https://user-images.githubusercontent.com/24086/90567074-8c559c00-e177-11ea-9da8-ea1f75fd6ed0.gif)

## Related figma doc

https://www.figma.com/file/2IFuCbGFCQ7KKui9ef8qi7/Empty-State?node-id=475%3A27