### PR TITLE
fix(apm): Add status to root transaction span

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -57,6 +57,7 @@ export type ParsedTraceType = {
   childSpans: SpanChildrenLookupType;
   traceID: string;
   rootSpanID: string;
+  rootSpanStatus: string | undefined;
   parentSpanID?: string;
   traceStartTimestamp: number;
   traceEndTimestamp: number;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/types.tsx
@@ -78,6 +78,7 @@ export type TraceContextType = {
   trace_id?: string;
   parent_span_id?: string;
   description?: string;
+  status?: string;
 };
 
 type SpanTreeDepth = number;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -328,6 +328,7 @@ export function generateRootSpan(trace: ParsedTraceType): RawSpanType {
     op: trace.op,
     description: trace.description,
     data: {},
+    status: trace.rootSpanStatus,
   };
 
   return rootSpan;
@@ -427,6 +428,7 @@ export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTrace
   const rootSpanOpName = (traceContext && traceContext.op) || 'transaction';
   const description = traceContext && traceContext.description;
   const parentSpanID = traceContext && traceContext.parent_span_id;
+  const rootSpanStatus = traceContext && traceContext.status;
 
   if (!spanEntry || spans.length <= 0) {
     return {
@@ -436,6 +438,7 @@ export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTrace
       traceEndTimestamp: event.endTimestamp,
       traceID,
       rootSpanID,
+      rootSpanStatus,
       parentSpanID,
       numOfSpans: 0,
       spans: [],
@@ -462,6 +465,7 @@ export function parseTrace(event: Readonly<SentryTransactionEvent>): ParsedTrace
     traceEndTimestamp: event.endTimestamp,
     traceID,
     rootSpanID,
+    rootSpanStatus,
     parentSpanID,
     numOfSpans: spans.length,
     spans,


### PR DESCRIPTION
Propagate any status from the trace context to the root span.

**Before**


<img width="1301" alt="Screen Shot 2020-08-18 at 8 04 37 PM" src="https://user-images.githubusercontent.com/139499/90577250-5cfe5980-e18e-11ea-95ed-70e971f4f4b0.png">


**After**

<img width="1310" alt="Screen Shot 2020-08-18 at 8 04 09 PM" src="https://user-images.githubusercontent.com/139499/90577246-5bcd2c80-e18e-11ea-9f95-ed78cace7e30.png">