### PR TITLE
fix(alert): Change "add alert rule" link from integrations

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationAlertRules.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationAlertRules.jsx
@@ -36,7 +36,7 @@ class IntegrationAlertRules extends React.Component {
             <ProjectItem key={project.slug}>
               <ProjectBadge project={project} avatarSize={16} />
               <Button
-                to={`/settings/${orgId}/projects/${project.slug}/alerts/rules/new/`}
+                to={`/organizations/${orgId}/alerts/projects/${project.slug}/alerts/new/`}
                 size="xsmall"
               >
                 {t('Add Alert Rule')}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationAlertRules.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationAlertRules.jsx
@@ -36,7 +36,7 @@ class IntegrationAlertRules extends React.Component {
             <ProjectItem key={project.slug}>
               <ProjectBadge project={project} avatarSize={16} />
               <Button
-                to={`/organizations/${orgId}/alerts/projects/${project.slug}/alerts/new/`}
+                to={`/organizations/${orgId}/alerts/${project.slug}/new/`}
                 size="xsmall"
               >
                 {t('Add Alert Rule')}


### PR DESCRIPTION
Found another alert builder route we didn't change from this issue https://sentry.io/organizations/sentry/issues/496412334/events/89d634f942e043c3be4b3b270c3282d5/?project=11276&query=is%3Aunresolved+assigned%3A%23workflow&statsPeriod=14d

I did a search for other routes and hopefully this is the last one, but will continue to monitor.