### PR TITLE
fix(grouping): Show hidden strategies in grouping debugger

### DIFF
--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingConfigSelect.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingConfigSelect.tsx
@@ -40,14 +40,14 @@ class GroupingConfigSelect extends AsyncComponent<Props, State> {
     const {configId, eventConfigId, onSelect} = this.props;
     const {configs} = this.state;
 
-    const options = configs
-      .filter(config => !config.hidden || config.id === eventConfigId)
-      .map(({id}) => ({
-        value: id,
-        label: (
-          <GroupingConfigItem isActive={id === eventConfigId}>{id}</GroupingConfigItem>
-        ),
-      }));
+    const options = configs.map(({id, hidden}) => ({
+      value: id,
+      label: (
+        <GroupingConfigItem isHidden={hidden} isActive={id === eventConfigId}>
+          {id}
+        </GroupingConfigItem>
+      ),
+    }));
 
     return (
       <DropdownAutoComplete


### PR DESCRIPTION
Those strategies are still excluded from the upgrade flow and none of
those appear for users (only customer support)