### PR TITLE
fix(release): Fix missing projectId in the URL

### DIFF
--- a/src/sentry/static/sentry/app/components/deployBadge.tsx
+++ b/src/sentry/static/sentry/app/components/deployBadge.tsx
@@ -19,7 +19,7 @@ type Props = {
 };
 
 const DeployBadge = ({deploy, orgSlug, projectId, version, className}: Props) => {
-  const shouldLinkToIssues = !!orgSlug && !!version && projectId !== undefined;
+  const shouldLinkToIssues = !!orgSlug && !!version;
 
   const badge = (
     <Badge className={className}>
@@ -37,7 +37,7 @@ const DeployBadge = ({deploy, orgSlug, projectId, version, className}: Props) =>
       to={{
         pathname: `/organizations/${orgSlug}/issues/`,
         query: {
-          project: projectId,
+          project: projectId ?? null,
           environment: deploy.environment,
           query: stringifyQueryObject(new QueryResults([`release:${version!}`])),
         },

--- a/src/sentry/static/sentry/app/components/deployBadge.tsx
+++ b/src/sentry/static/sentry/app/components/deployBadge.tsx
@@ -12,13 +12,14 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 type Props = {
   deploy: Deploy;
+  projectId?: number;
   orgSlug?: string;
   version?: string;
   className?: string;
 };
 
-const DeployBadge = ({deploy, orgSlug, version, className}: Props) => {
-  const shouldLinkToIssues = !!orgSlug && !!version;
+const DeployBadge = ({deploy, orgSlug, projectId, version, className}: Props) => {
+  const shouldLinkToIssues = !!orgSlug && !!version && projectId !== undefined;
 
   const badge = (
     <Badge className={className}>
@@ -36,7 +37,7 @@ const DeployBadge = ({deploy, orgSlug, version, className}: Props) => {
       to={{
         pathname: `/organizations/${orgSlug}/issues/`,
         query: {
-          project: null,
+          project: projectId,
           environment: deploy.environment,
           query: stringifyQueryObject(new QueryResults([`release:${version!}`])),
         },

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/deploys.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/deploys.tsx
@@ -14,16 +14,22 @@ type Props = {
   version: string;
   orgSlug: string;
   deploys: Deploy[];
+  projectId: number;
 };
 
-const Deploys = ({version, orgSlug, deploys}: Props) => {
+const Deploys = ({version, orgSlug, projectId, deploys}: Props) => {
   return (
     <Wrapper>
       <SectionHeading>{t('Deploys')}</SectionHeading>
 
       {deploys.map(deploy => (
         <Row key={deploy.id}>
-          <StyledDeployBadge deploy={deploy} orgSlug={orgSlug} version={version} />
+          <StyledDeployBadge
+            deploy={deploy}
+            orgSlug={orgSlug}
+            version={version}
+            projectId={projectId}
+          />
           <TextOverflow>
             <TimeSince date={deploy.dateFinished} />
           </TextOverflow>

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/index.tsx
@@ -149,6 +149,7 @@ class ReleaseOverview extends AsyncView<Props> {
                         version={version}
                         orgSlug={organization.slug}
                         deploys={deploys}
+                        projectId={project.id}
                       />
                     )}
                   </Side>

--- a/tests/js/spec/components/deployBadge.spec.jsx
+++ b/tests/js/spec/components/deployBadge.spec.jsx
@@ -13,17 +13,17 @@ const deploy = {
   id: '6348842',
 };
 
-const projectId = 1;
-
 describe('DeployBadge', function() {
   it('renders', function() {
-    const wrapper = mountWithTheme(<DeployBadge deploy={deploy} projectId={projectId} />);
+    const wrapper = mountWithTheme(<DeployBadge deploy={deploy} />);
 
     expect(wrapper.find('Badge').text()).toEqual('production');
     expect(wrapper.find('Icon').length).toEqual(0);
   });
 
   it('renders with icon and link', function() {
+    const projectId = 1;
+
     const wrapper = mountWithTheme(
       <DeployBadge
         deploy={deploy}

--- a/tests/js/spec/components/deployBadge.spec.jsx
+++ b/tests/js/spec/components/deployBadge.spec.jsx
@@ -13,9 +13,11 @@ const deploy = {
   id: '6348842',
 };
 
+const projectId = 1;
+
 describe('DeployBadge', function() {
   it('renders', function() {
-    const wrapper = mountWithTheme(<DeployBadge deploy={deploy} />);
+    const wrapper = mountWithTheme(<DeployBadge deploy={deploy} projectId={projectId} />);
 
     expect(wrapper.find('Badge').text()).toEqual('production');
     expect(wrapper.find('Icon').length).toEqual(0);
@@ -23,12 +25,17 @@ describe('DeployBadge', function() {
 
   it('renders with icon and link', function() {
     const wrapper = mountWithTheme(
-      <DeployBadge deploy={deploy} orgSlug="sentry" version="1.2.3" />
+      <DeployBadge
+        deploy={deploy}
+        orgSlug="sentry"
+        version="1.2.3"
+        projectId={projectId}
+      />
     );
 
     expect(wrapper.find('Link').props('to').to).toEqual({
       pathname: '/organizations/sentry/issues/',
-      query: {project: null, environment: 'production', query: 'release:1.2.3'},
+      query: {project: projectId, environment: 'production', query: 'release:1.2.3'},
     });
     expect(wrapper.find('Badge').text()).toEqual('production');
     expect(wrapper.find('Icon').length).toEqual(1);


### PR DESCRIPTION
Description:






closes: https://app.asana.com/0/1158284503473033/1189392458690660

When the user clicks on the "Deploy Button" displayed in some specific releases page:

![image](https://user-images.githubusercontent.com/29228205/90640454-48729d80-e230-11ea-8b98-99e96daf3304.png)

The user will be redirected to a new page, where the project is not being selected in the GlobalSelectionHeader.

The problem was that the generated URL didn't have the `projectId`

This PR fixes this issue.


