### PR TITLE
fix(msteams): fix assignee text and non-general channel message

### DIFF
--- a/src/sentry/integrations/msteams/notify_action.py
+++ b/src/sentry/integrations/msteams/notify_action.py
@@ -84,7 +84,7 @@ class MsTeamsNotifyServiceAction(EventAction):
 
         def send_notification(event, futures):
             rules = [f.rule for f in futures]
-            card = build_group_card(event.group, event=event, rules=rules)
+            card = build_group_card(event.group, event, rules, integration)
 
             client = MsTeamsClient(integration)
             client.send_card(channel, card)


### PR DESCRIPTION
This fixes two bugs:
1. Handling messages that aren't on the general channel for Teams
2. Showing the assignee of an issue as just a number

I ended up having to add the `integrationId` to the action payload because we don't get the `teamId` for interactions with direct messages with the Sentry integration.

For the assignee, if the assignee is a user we'll just show the email address. 