### PR TITLE
feat(alerts): View issue alert rules without project write

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import
 
-from sentry.api.bases.project import ProjectEndpoint, StrictProjectPermission
+from sentry.api.bases.project import ProjectEndpoint
 from sentry.rules import rules
 from rest_framework.response import Response
 
 
 class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
-    permission_classes = (StrictProjectPermission,)
-
     def get(self, request, project):
         """
         Retrieve the list of configuration options for a given project.

--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -14,6 +14,7 @@ import ButtonBar from 'app/components/buttonBar';
 import Confirm from 'app/components/confirm';
 import ErrorBoundary from 'app/components/errorBoundary';
 import IdBadge from 'app/components/idBadge';
+import Link from 'app/components/links/link';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 
@@ -42,13 +43,18 @@ class RuleListRow extends React.Component<Props, State> {
     const {rule, projectsLoaded, projects, orgId, onDelete} = this.props;
     const dateCreated = moment(rule.dateCreated).format('ll');
     const slug = rule.projects[0];
+    const link = `/organizations/${orgId}/alerts/${
+      isIssueAlert(rule) ? 'rules' : 'metric-rules'
+    }/${slug}/${rule.id}/`;
 
     return (
       <ErrorBoundary>
         <AlertRulesPanelItem>
           <TableLayout>
             <RuleType>{isIssueAlert(rule) ? t('Issue') : t('Metric')}</RuleType>
-            <Title>{rule.name}</Title>
+            <Title>
+              <Link to={link}>{rule.name}</Link>
+            </Title>
             <ProjectBadge
               avatarSize={18}
               project={!projectsLoaded ? {slug} : this.getProject(slug, projects)}
@@ -79,13 +85,10 @@ class RuleListRow extends React.Component<Props, State> {
                     />
                   </Confirm>
                   <Button
-                    disabled={!hasAccess}
                     size="small"
                     icon={<IconSettings />}
                     title={t('Edit')}
-                    to={`/organizations/${orgId}/alerts/${
-                      isIssueAlert(rule) ? 'rules' : 'metric-rules'
-                    }/${slug}/${rule.id}/`}
+                    to={link}
                   />
                 </ButtonBar>
               )}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -32,6 +32,7 @@ type Props = {
   data?: IssueAlertRuleAction | IssueAlertRuleCondition;
   project: Project;
   organization: Organization;
+  disabled: boolean;
   onDelete: (rowIndex: number) => void;
   onPropertyChange: (rowIndex: number, name: string, value: string) => void;
 };
@@ -51,7 +52,7 @@ class RuleNode extends React.Component<Props> {
   getChoiceField = (name: string, fieldConfig: FormField) => {
     // Select the first item on this list
     // If it's not yet defined, call onPropertyChange to make sure the value is set on state
-    const {data, index, onPropertyChange} = this.props;
+    const {data, index, onPropertyChange, disabled} = this.props;
     let initialVal;
 
     if (data) {
@@ -86,6 +87,7 @@ class RuleNode extends React.Component<Props> {
             height: '28px',
           }),
         }}
+        disabled={disabled}
         choices={choices}
         onChange={({value}) => onPropertyChange(index, name, value)}
       />
@@ -93,7 +95,7 @@ class RuleNode extends React.Component<Props> {
   };
 
   getTextField = (name: string, fieldConfig: FormField) => {
-    const {data, index, onPropertyChange} = this.props;
+    const {data, index, onPropertyChange, disabled} = this.props;
 
     return (
       <InlineInput
@@ -101,6 +103,7 @@ class RuleNode extends React.Component<Props> {
         name={name}
         value={(data && data[name]) ?? ''}
         placeholder={`${fieldConfig.placeholder}`}
+        disabled={disabled}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
           onPropertyChange(index, name, e.target.value)
         }
@@ -125,12 +128,12 @@ class RuleNode extends React.Component<Props> {
   };
 
   getMailActionFields = (_: string, __: FormField) => {
-    const {data, organization, project} = this.props;
+    const {data, organization, project, disabled} = this.props;
     const isInitialized =
       data?.targetType !== undefined && `${data.targetType}`.length > 0;
     return (
       <MailActionFields
-        disabled={false}
+        disabled={disabled}
         project={project}
         organization={organization}
         loading={!isInitialized}
@@ -247,7 +250,7 @@ class RuleNode extends React.Component<Props> {
   }
 
   render() {
-    const {data} = this.props;
+    const {data, disabled} = this.props;
 
     return (
       <RuleRowContainer>
@@ -255,6 +258,7 @@ class RuleNode extends React.Component<Props> {
           {data && <input type="hidden" name="id" value={data.id} />}
           {this.renderRow()}
           <DeleteButton
+            disabled={disabled}
             label={t('Delete Node')}
             onClick={this.handleDelete}
             type="button"

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -112,7 +112,7 @@ class RuleNode extends React.Component<Props> {
   };
 
   getNumberField = (name: string, fieldConfig: FormField) => {
-    const {data, index, onPropertyChange} = this.props;
+    const {data, index, onPropertyChange, disabled} = this.props;
 
     return (
       <InlineInput
@@ -120,6 +120,7 @@ class RuleNode extends React.Component<Props> {
         name={name}
         value={(data && data[name]) ?? ''}
         placeholder={`${fieldConfig.placeholder}`}
+        disabled={disabled}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
           onPropertyChange(index, name, e.target.value)
         }

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -28,6 +28,7 @@ type Props = {
    * Placeholder for select control
    */
   placeholder: string;
+  disabled: boolean;
   onPropertyChange: (ruleIndex: number, prop: string, val: string) => void;
   onAddRow: (value: string) => void;
   onDeleteRow: (ruleIndex: number) => void;
@@ -55,6 +56,7 @@ class RuleNodeList extends React.Component<Props> {
       items,
       organization,
       project,
+      disabled,
     } = this.props;
 
     const shouldUsePrompt = project.features?.includes?.('issue-alerts-targeting');
@@ -81,6 +83,7 @@ class RuleNodeList extends React.Component<Props> {
                 onPropertyChange={onPropertyChange}
                 organization={organization}
                 project={project}
+                disabled={disabled}
               />
             ))}
           </RuleNodes>
@@ -90,6 +93,7 @@ class RuleNodeList extends React.Component<Props> {
           value={null}
           onChange={obj => onAddRow(obj ? obj.value : obj)}
           options={options}
+          disabled={disabled}
         />
       </React.Fragment>
     );


### PR DESCRIPTION
**Warning**: Lowers permissions on `GET /projects/:orgId/:projectId/rules/configuration/` route to `project:read` from `project:write`

Disables issue rule form fields when the user does not have `project:write`. Previously users could not view issue alerts unless they had `project:write`
![image](https://user-images.githubusercontent.com/1400464/90680311-85ca3180-e216-11ea-96df-d3daa50a6c9b.png)

Makes rule names links on rules list page and removes disabled flag on "Edit"
![image](https://user-images.githubusercontent.com/1400464/90680403-a4c8c380-e216-11ea-83bc-d0a9b9c1b1d4.png)
