### PR TITLE
fix(alert): Alert builder route change fixes and redirects

### DIFF
--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -133,7 +133,7 @@ def build_group_descr(group):
 def build_rule_url(rule, group, project):
     org_slug = group.organization.slug
     project_slug = project.slug
-    rule_url = u"/settings/{}/projects/{}/alerts/rules/{}/".format(org_slug, project_slug, rule.id)
+    rule_url = u"/organizations/{}/alerts/rules/{}/{}/".format(org_slug, project_slug, rule.id)
     return absolute_uri(rule_url)
 
 

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -168,7 +168,7 @@ def build_action_text(group, identity, action):
 def build_rule_url(rule, group, project):
     org_slug = group.organization.slug
     project_slug = project.slug
-    rule_url = u"/settings/{}/projects/{}/alerts/rules/{}/".format(org_slug, project_slug, rule.id)
+    rule_url = u"/organizations/{}/alerts/rules/{}/{}/".format(org_slug, project_slug, rule.id)
     return absolute_uri(rule_url)
 
 

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -304,11 +304,7 @@ class MailAdapter(object):
 
         rules = []
         for rule in notification.rules:
-            rule_link = "/settings/%s/projects/%s/alerts/rules/%s/" % (
-                org.slug,
-                project.slug,
-                rule.id,
-            )
+            rule_link = "/organizations/%s/alerts/rules/%s/%s/" % (org.slug, project.slug, rule.id,)
 
             rules.append((rule.label, rule_link))
 

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -270,6 +270,20 @@ function routes() {
             )
           }
         />
+        <Redirect from="new/" to="/organizations/:orgId/alerts/:projectId/new" />
+        <Redirect from="rules/new/" to="/organizations/:orgId/alerts/:projectId/new" />
+        <Redirect
+          from="metric-rules/new/"
+          to="/organizations/:orgId/alerts/:projectId/new"
+        />
+        <Redirect
+          from="rules/:ruleId/"
+          to="/organizations/:orgId/alerts/rules/:projectId/:ruleId"
+        />
+        <Redirect
+          from="metric-rules/:ruleId/"
+          to="/organizations/:orgId/alerts/metric-rules/:projectId/:ruleId"
+        />
       </Route>
 
       <Route

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -270,19 +270,19 @@ function routes() {
             )
           }
         />
-        <Redirect from="new/" to="/organizations/:orgId/alerts/:projectId/new" />
-        <Redirect from="rules/new/" to="/organizations/:orgId/alerts/:projectId/new" />
+        <Redirect from="new/" to="/organizations/:orgId/alerts/:projectId/new/" />
+        <Redirect from="rules/new/" to="/organizations/:orgId/alerts/:projectId/new/" />
         <Redirect
           from="metric-rules/new/"
-          to="/organizations/:orgId/alerts/:projectId/new"
+          to="/organizations/:orgId/alerts/:projectId/new/"
         />
         <Redirect
           from="rules/:ruleId/"
-          to="/organizations/:orgId/alerts/rules/:projectId/:ruleId"
+          to="/organizations/:orgId/alerts/rules/:projectId/:ruleId/"
         />
         <Redirect
           from="metric-rules/:ruleId/"
-          to="/organizations/:orgId/alerts/metric-rules/:projectId/:ruleId"
+          to="/organizations/:orgId/alerts/metric-rules/:projectId/:ruleId/"
         />
       </Route>
 


### PR DESCRIPTION
In response to the issue alert builder move, some routes are now broken. Fixed the slack integration and email related routes and also added redirects as a fail safe.