### PR TITLE
ref(py3): Decode msgpack enhancement config as unicode

### DIFF
--- a/src/sentry/grouping/enhancer.py
+++ b/src/sentry/grouping/enhancer.py
@@ -421,7 +421,7 @@ class Enhancements(object):
         padded = data + b"=" * (4 - (len(data) % 4))
         try:
             return cls._from_config_structure(
-                msgpack.loads(zlib.decompress(base64.urlsafe_b64decode(padded)))
+                msgpack.loads(zlib.decompress(base64.urlsafe_b64decode(padded)), raw=False)
             )
         except (LookupError, AttributeError, TypeError, ValueError) as e:
             raise ValueError("invalid grouping enhancement config: %s" % e)


### PR DESCRIPTION
Without `raw` this will return a byte string for the groupping enhancement key, which will fail to lookup the configuration