### PR TITLE
feat(metric alerts): Send PagerDuty metric alerts

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -143,8 +143,9 @@ class PagerDutyActionHandler(ActionHandler):
         self.send_alert(metric_value)
 
     def send_alert(self, metric_value):
-        # TODO: finish
-        pass
+        from sentry.integrations.pagerduty.utils import send_incident_alert_notification
+
+        send_incident_alert_notification(self.action, self.incident, metric_value)
 
 
 def format_duration(minutes):

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -31,6 +31,7 @@ class PagerDutyClient(ApiClient):
     def send_trigger(self, data):
         # expected payload: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
         # for now, only construct the payload if data is an event
+
         if isinstance(data, Event):
             source = data.transaction or data.culprit or "<unknown>"
             group = data.group
@@ -57,6 +58,9 @@ class PagerDutyClient(ApiClient):
                     }
                 ],
             }
+        else:
+            payload = data
+
         return self.post("/", data=payload)
 
     def send_acknowledge(self, data):

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -31,7 +31,6 @@ class PagerDutyClient(ApiClient):
     def send_trigger(self, data):
         # expected payload: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
         # for now, only construct the payload if data is an event
-
         if isinstance(data, Event):
             source = data.transaction or data.culprit or "<unknown>"
             group = data.group
@@ -59,6 +58,7 @@ class PagerDutyClient(ApiClient):
                 ],
             }
         else:
+            # this is a metric alert
             payload = data
 
         return self.post("/", data=payload)

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -30,7 +30,6 @@ class PagerDutyClient(ApiClient):
 
     def send_trigger(self, data):
         # expected payload: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
-        # for now, only construct the payload if data is an event
         if isinstance(data, Event):
             source = data.transaction or data.culprit or "<unknown>"
             group = data.group
@@ -58,7 +57,7 @@ class PagerDutyClient(ApiClient):
                 ],
             }
         else:
-            # this is a metric alert
+            # the payload is for a metric alert
             payload = data
 
         return self.post("/", data=payload)

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import
+
+import logging
+import six
+
+from sentry.incidents.models import IncidentStatus
+from sentry.integrations.metric_alerts import incident_attachment_info
+from sentry.models import PagerDutyService
+from sentry.shared_integrations.exceptions import ApiError
+
+from .client import PagerDutyClient
+
+logger = logging.getLogger("sentry.integrations.pagerduty")
+
+
+def build_incident_attachment(incident, integration_key, metric_value=None):
+    data = incident_attachment_info(incident, metric_value)
+    if incident.status == IncidentStatus.CRITICAL.value:
+        severity = "critical"
+    elif incident.status == IncidentStatus.WARNING.value:
+        severity = "warning"
+    elif incident.status == IncidentStatus.CLOSED.value:
+        severity = "info"
+
+    footer_text = "Sentry Incident | {}".format(data["ts"].strftime("%b %d"))
+
+    return {
+        "routing_key": integration_key,
+        "event_action": "trigger"
+        if incident.status in [IncidentStatus.WARNING.value, IncidentStatus.CRITICAL.value]
+        else "resolve",
+        "dedup_key": "incident_{}".format(incident.identifier),
+        "payload": {
+            "summary": data["text"],
+            "severity": severity,
+            "source": incident.identifier,
+            "custom_details": footer_text,
+        },
+        "links": [{"href": data["title_link"], "text": data["title"]}],
+    }
+
+
+def send_incident_alert_notification(action, incident, metric_value):
+    integration = action.integration
+    service = PagerDutyService.objects.get(organization_integration__integration=integration)
+    integration_key = service.integration_key
+    client = PagerDutyClient(integration_key=integration_key)
+    attachment = build_incident_attachment(incident, integration_key, metric_value)
+
+    try:
+        client.send_trigger(attachment)
+    except ApiError as e:
+        logger.info(
+            "rule.fail.pagerduty_trigger",
+            extra={
+                "error": six.text_type(e),
+                "service_name": service.service_name,
+                "service_id": service.id,
+            },
+        )
+        raise e

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -307,7 +307,7 @@ class MsTeamsActionHandlerFireTest(MsTeamsActionHandlerBaseTest, TestCase):
 class PagerDutyActionHandlerBaseTest(object):
     def setUp(self):
 
-        SERVICES = [
+        service = [
             {
                 "type": "service",
                 "integration_key": "pfc73e8cb4s44d519f3d63d45b5q77g9",
@@ -319,13 +319,13 @@ class PagerDutyActionHandlerBaseTest(object):
             provider="pagerduty",
             name="Example PagerDuty",
             external_id="example-pagerduty",
-            metadata={"services": SERVICES},
+            metadata={"service": service},
         )
         self.integration.add_organization(self.organization, self.user)
 
         self.service = PagerDutyService.objects.create(
-            service_name=SERVICES[0]["service_name"],
-            integration_key=SERVICES[0]["integration_key"],
+            service_name=service[0]["service_name"],
+            integration_key=service[0]["integration_key"],
             organization_integration=self.integration.organizationintegration_set.first(),
         )
 
@@ -392,7 +392,7 @@ class PagerDutyActionHandlerFireTest(PagerDutyActionHandlerBaseTest, TestCase):
         self.run_test(self.create_incident(status=2, alert_rule=alert_rule), "fire")
 
     def test_fire_metric_alert_multiple_services(self):
-        SERVICES = [
+        service = [
             {
                 "type": "service",
                 "integration_key": "afc73e8cb4s44d519f3d63d45b5q77g9",
@@ -401,8 +401,8 @@ class PagerDutyActionHandlerFireTest(PagerDutyActionHandlerBaseTest, TestCase):
             },
         ]
         PagerDutyService.objects.create(
-            service_name=SERVICES[0]["service_name"],
-            integration_key=SERVICES[0]["integration_key"],
+            service_name=service[0]["service_name"],
+            integration_key=service[0]["integration_key"],
             organization_integration=self.integration.organizationintegration_set.first(),
         )
         alert_rule = self.create_alert_rule()

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1490,14 +1490,14 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             metadata={"services": SERVICES},
         )
         integration.add_organization(self.organization, self.user)
-        PagerDutyService.objects.create(
+        service = PagerDutyService.objects.create(
             service_name=SERVICES[0]["service_name"],
             integration_key=SERVICES[0]["integration_key"],
             organization_integration=integration.organizationintegration_set.first(),
         )
         type = AlertRuleTriggerAction.Type.PAGERDUTY
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
-        target_identifier = 2
+        target_identifier = service.id
         action = update_alert_rule_trigger_action(
             self.action,
             type,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1321,14 +1321,14 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
             metadata={"services": SERVICES},
         )
         integration.add_organization(self.organization, self.user)
-        PagerDutyService.objects.create(
+        service = PagerDutyService.objects.create(
             service_name=SERVICES[0]["service_name"],
             integration_key=SERVICES[0]["integration_key"],
             organization_integration=integration.organizationintegration_set.first(),
         )
         type = AlertRuleTriggerAction.Type.PAGERDUTY
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
-        target_identifier = 1
+        target_identifier = service.id
         action = create_alert_rule_trigger_action(
             self.trigger,
             type,


### PR DESCRIPTION
This is the follow up to https://github.com/getsentry/sentry/pull/20077 wherein sending and resolving PagerDuty metric alerts is implemented. 

### Triggered Incident

![pd_metric_alert_triggered](https://user-images.githubusercontent.com/29959063/90699777-04d06180-e239-11ea-93b4-88727b1e798d.png)


### Resolved Incident

![pd_metric_alert_resolved](https://user-images.githubusercontent.com/29959063/90699787-0863e880-e239-11ea-893e-4ba9d6e8e137.png)


### Test Plan

Following https://github.com/getsentry/sentry/pull/20182 you must run this in `sentry shell`:

```
from sentry.incidents.models import (
    AlertRuleTriggerAction,
    Incident,
    AlertRule
)
from sentry.models import (
    Organization,
    Project
)
alert_rule = AlertRule.objects.get(id=1L)
org = Organization.objects.get(id=1L)
project = Project.objects.get(id=1L)
Incident.objects.create(
    organization=org,
    title="It's Lit",
    alert_rule=alert_rule,
    type=2,
    status=20,
)
incident = Incident.objects.all()[0]
trigger = AlertRuleTriggerAction.objects.get(id=1L)
trigger.fire(incident, project, 123)
```

and then `trigger.resolve(incident, project, 123)` can be used to resolve the incident. 

### Example Payload

```
{
'event_action': 'trigger', 
'payload': {
    'custom_details': 'Sentry Incident | Aug 19', 
    'source': 30, 
    'severity': 'critical', 
    'summary': '123 events in the last 1 minutes'
}, 
'routing_key': u'12345678', 
'links': [{
    'text': u'Critical: Things are Bad', 
    'href': u'https://sentry.io/organizations/sentry/alerts/30/'}], 
'dedup_key': 'incident_30'
}
```