### PR TITLE
ref(py3): Remove old im_func attributes

### DIFF
--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -193,14 +193,18 @@ class AuthenticatorInterface(object):
         """If the interface has an activation method that needs to be
         called this returns `True`.
         """
-        return self.activate.im_func is not AuthenticatorInterface.activate.im_func
+        return self.activate.__func__ is not six.get_unbound_function(
+            AuthenticatorInterface.activate
+        )
 
     @property
     def can_validate_otp(self):
         """If the interface is able to validate OTP codes then this returns
         `True`.
         """
-        return self.validate_otp.im_func is not AuthenticatorInterface.validate_otp.im_func
+        return self.validate_otp.__func__ is not six.get_unbound_function(
+            AuthenticatorInterface.validate_otp
+        )
 
     @property
     def config(self):

--- a/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
@@ -41,6 +41,9 @@ class UserAuthenticatorEnrollTest(APITestCase):
     @mock.patch("sentry.utils.email.logger")
     @mock.patch("sentry.models.TotpInterface.validate_otp", return_value=True)
     def test_totp_can_enroll(self, validate_otp, email_log):
+        # XXX: Pretend an unbound function exists.
+        validate_otp.__func__ = None
+
         url = reverse(
             "sentry-api-0-user-authenticator-enroll",
             kwargs={"user_id": "me", "interface_id": "totp"},
@@ -80,6 +83,9 @@ class UserAuthenticatorEnrollTest(APITestCase):
     @mock.patch("sentry.utils.email.logger")
     @mock.patch("sentry.models.TotpInterface.validate_otp", return_value=False)
     def test_invalid_otp(self, validate_otp, email_log):
+        # XXX: Pretend an unbound function exists.
+        validate_otp.__func__ = None
+
         url = reverse(
             "sentry-api-0-user-authenticator-enroll",
             kwargs={"user_id": "me", "interface_id": "totp"},
@@ -96,6 +102,9 @@ class UserAuthenticatorEnrollTest(APITestCase):
     @mock.patch("sentry.models.SmsInterface.validate_otp", return_value=True)
     @mock.patch("sentry.models.SmsInterface.send_text", return_value=True)
     def test_sms_can_enroll(self, send_text, validate_otp, email_log):
+        # XXX: Pretend an unbound function exists.
+        validate_otp.__func__ = None
+
         new_options = settings.SENTRY_OPTIONS.copy()
         new_options["sms.twilio-account"] = "twilio-account"
 
@@ -265,6 +274,9 @@ class AcceptOrganizationInviteTest(APITestCase):
     @mock.patch("sentry.models.SmsInterface.validate_otp", return_value=True)
     @mock.patch("sentry.models.SmsInterface.send_text", return_value=True)
     def test_accept_pending_invite__sms_enroll(self, send_text, validate_otp):
+        # XXX: Pretend an unbound function exists.
+        validate_otp.__func__ = None
+
         om = self.get_om_and_init_invite()
 
         # setup sms
@@ -300,6 +312,9 @@ class AcceptOrganizationInviteTest(APITestCase):
 
     @mock.patch("sentry.models.TotpInterface.validate_otp", return_value=True)
     def test_accept_pending_invite__totp_enroll(self, validate_otp):
+        # XXX: Pretend an unbound function exists.
+        validate_otp.__func__ = None
+
         om = self.get_om_and_init_invite()
 
         # setup totp


### PR DESCRIPTION
These were removed in python3 in favor of `__func__`.

Python3 also removed the concept of an unbound method, so we use the six.get_unbound_function to get the method from the base class for comparison.

```py
# python 2 land
>>> class Test(object):
...     def whatever(self):
...             pass
...
>>>
>>> Test.whatever
<unbound method Test.whatever>
>>> Test.whatever.__func__
<function whatever at 0x10d1c4b18>
>>> test = Test()
>>> test.whatever
<bound method Test.whatever of <__main__.Test object at 0x10d1c32d0>>
>>> test.whatever.__func__
<function whatever at 0x10d1c4b18>
>>> import six
>>> six.get_unbound_function(Test.whatever)
<function whatever at 0x10d1c4b18>

# python 3 land
>>> class Test(object):
...     def whatever(self):
...             pass
...
>>> Test.whatever
<function Test.whatever at 0x10bc36620>
>>> test = Test()
>>> test.whatever
<bound method Test.whatever of <__main__.Test object at 0x10bc40eb8>>
>>> test.whatever.__func__
<function Test.whatever at 0x10bc36620>
>>> import six
>>> six.get_unbound_function(Test.whatever)
<function Test.whatever at 0x10bc36620>

```