### PR TITLE
feat(flutter): Platformicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "papaparse": "^5.2.0",
     "parseurl": "^1.3.2",
-    "platformicons": "2.0.3",
+    "platformicons": "2.1.1",
     "po-catalog-loader": "2.0.0",
     "prop-types": "^15.6.0",
     "query-string": "6.6.0",

--- a/src/sentry/static/sentry/app/components/platformIcon.tsx
+++ b/src/sentry/static/sentry/app/components/platformIcon.tsx
@@ -74,7 +74,7 @@ type Props = {
   height?: string;
 };
 
-const PlatformIcon = ({ platform, size, ...props }: Props) => {
+const PlatformIcon = ({platform, size, ...props}: Props) => {
   const width = props.width || size || '1em';
   const height = props.height || size || '1em';
 
@@ -107,7 +107,7 @@ export default PlatformIcon;
 // TODO(color): theme doesn't have the color #625471
 const StyledPlatformIconTile = styled(PlatformIconTile, {
   shouldForwardProp: prop => prop !== 'width' && prop !== 'height',
-}) <{ width: string; height: string }>`
+})<{width: string; height: string}>`
   width: ${p => p.width};
   height: ${p => p.height};
   position: relative;

--- a/src/sentry/static/sentry/app/components/platformIcon.tsx
+++ b/src/sentry/static/sentry/app/components/platformIcon.tsx
@@ -51,6 +51,8 @@ const PLATFORM_TO_ICON = {
   'react-native': 'react-native',
   rust: 'rust',
   swift: 'swift',
+  flutter: 'flutter',
+  dart: 'dart',
   // TODO: AWS used to be python-awslambda but the displayed generic icon
   // We need to figure out what is causing it to be python-pythonawslambda
 };
@@ -72,7 +74,7 @@ type Props = {
   height?: string;
 };
 
-const PlatformIcon = ({platform, size, ...props}: Props) => {
+const PlatformIcon = ({ platform, size, ...props }: Props) => {
   const width = props.width || size || '1em';
   const height = props.height || size || '1em';
 
@@ -105,7 +107,7 @@ export default PlatformIcon;
 // TODO(color): theme doesn't have the color #625471
 const StyledPlatformIconTile = styled(PlatformIconTile, {
   shouldForwardProp: prop => prop !== 'width' && prop !== 'height',
-})<{width: string; height: string}>`
+}) <{ width: string; height: string }>`
   width: ${p => p.width};
   height: ${p => p.height};
   position: relative;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12170,10 +12170,10 @@ pkg-up@2.0.0, pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-platformicons@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-2.0.3.tgz#a7cf8074059639373061a4c00cf69d49800e7d01"
-  integrity sha512-x89ncc/HFL4reW0+2qHOxd9b/qHtUSWq54qBXYBScFO7kE5wGhSadsfRq9AmZweMPSnO4qbxKM432EorA5EtKA==
+platformicons@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-2.1.1.tgz#ab8c04c465ec3fbbcd0d5485d0c543e014a7f8a4"
+  integrity sha512-zfAgpUzIdbrXgHdhyO5ld2gvgS+HA5E/KrVavPRnYRNBeCDnX6DBprHXs6ipeyo/0+OKKoGeMejjXnoFApGdtA==
 
 pluralize@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1633368/90824297-33b40980-e305-11ea-89d2-a3f0a1707b43.png)


The `platformicons` repo [received Dart and Flutter](https://github.com/getsentry/platformicons/commit/dac162cbcd3e89c59522b4055a1edf8f7061ef8f).
It's [published with version 2.1.1](https://www.npmjs.com/package/platformicons) (thanks @ckj )

Thanks @matejminar for following it up