### PR TITLE
fix(alert): Populate members list store

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/builder/projectProvider.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/builder/projectProvider.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import {RouteComponentProps} from 'react-router/lib/Router';
 
+import {Client} from 'app/api';
 import {Organization, Project} from 'app/types';
 import {t} from 'app/locale';
+import {fetchOrgMembers} from 'app/actionCreators/members';
 import Alert from 'app/components/alert';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Projects from 'app/utils/projects';
+import withApi from 'app/utils/withApi';
 
 type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
+  api: Client;
   children?: React.ReactNode;
   hasMetricAlerts: boolean;
 };
@@ -18,7 +22,7 @@ type RouteParams = {
 };
 
 function AlertBuilderProjectProvider(props: Props) {
-  const {children, params, organization, ...other} = props;
+  const {children, params, organization, api, ...other} = props;
   const {projectId} = params;
   return (
     <Projects orgId={organization.slug} slugs={[projectId]}>
@@ -35,6 +39,10 @@ function AlertBuilderProjectProvider(props: Props) {
           );
         }
         const project = projects[0] as Project;
+
+        // fetch members list for mail action fields
+        fetchOrgMembers(api, organization.slug, [Number(project.id)]);
+
         return (
           <React.Fragment>
             {children && React.isValidElement(children)
@@ -52,4 +60,4 @@ function AlertBuilderProjectProvider(props: Props) {
   );
 }
 
-export default AlertBuilderProjectProvider;
+export default withApi(AlertBuilderProjectProvider);

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -194,7 +194,6 @@ describe('ProjectAlertsCreate', function() {
         });
 
         expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
-
         selectByValue(wrapper, 'production', {control: true, name: 'environment'});
         selectByValue(wrapper, 'any', {name: 'actionMatch'});
 

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -5,6 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select-new';
 
+import * as memberActionCreators from 'app/actionCreators/members';
 import ProjectAlertsCreate from 'app/views/settings/projectAlerts/create';
 import AlertsContainer from 'app/views/alerts';
 import AlertBuilderProjectProvider from 'app/views/alerts/builder/projectProvider';
@@ -73,6 +74,7 @@ describe('ProjectAlertsCreate', function() {
 
   beforeEach(async function() {
     browserHistory.replace = jest.fn();
+    memberActionCreators.fetchOrgMembers = jest.fn();
     MockApiClient.addMockResponse({
       url:
         '/projects/org-slug/project-slug/rules/configuration/?issue_alerts_targeting=0',
@@ -85,6 +87,10 @@ describe('ProjectAlertsCreate', function() {
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/environments/',
       body: TestStubs.Environments(),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [TestStubs.User()],
     });
   });
 
@@ -137,10 +143,6 @@ describe('ProjectAlertsCreate', function() {
           ],
         });
         MockApiClient.addMockResponse({
-          url: '/organizations/org-slug/users/',
-          body: [TestStubs.User()],
-        });
-        MockApiClient.addMockResponse({
           url: '/organizations/org-slug/events-stats/',
           body: TestStubs.EventsStats(),
         });
@@ -149,6 +151,7 @@ describe('ProjectAlertsCreate', function() {
         const {wrapper} = createWrapper({
           organization: {features: ['incidents']},
         });
+        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
         expect(wrapper.find('IssueEditor')).toHaveLength(0);
         expect(wrapper.find('IncidentRulesCreate')).toHaveLength(0);
 
@@ -172,6 +175,7 @@ describe('ProjectAlertsCreate', function() {
     describe('Without Metric Alerts', function() {
       it('loads default values', function() {
         const {wrapper} = createWrapper();
+        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
         expect(wrapper.find('SelectControl[name="environment"]').prop('value')).toBe(
           '__all_environments__'
         );
@@ -188,6 +192,8 @@ describe('ProjectAlertsCreate', function() {
           method: 'POST',
           body: TestStubs.ProjectAlertRule(),
         });
+
+        expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
 
         selectByValue(wrapper, 'production', {control: true, name: 'environment'});
         selectByValue(wrapper, 'any', {name: 'actionMatch'});


### PR DESCRIPTION
Due to some alert builder route changes, navigating directly to `/organizations/{slug}/alerts/{project}/new` may result in empty mail action fields:

![image](https://user-images.githubusercontent.com/9372512/90830116-171ccf00-e30f-11ea-8005-f630774cae04.png)

Now changed so that we populate the members list store in `projectProvider.tsx` so that the mail action fields can show correctly: 

![image](https://user-images.githubusercontent.com/9372512/90830169-361b6100-e30f-11ea-95fb-8691e3c49b3e.png)
