### PR TITLE
ref(py3): Do not use deprecated e.message

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -8,6 +8,7 @@ from rest_framework import serializers
 
 from django.db import transaction
 from django.utils import timezone
+from django.utils.encoding import force_text
 
 from sentry.api.event_search import InvalidSearchQuery
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
@@ -162,7 +163,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                 trigger=self.context["trigger"], **validated_data
             )
         except InvalidTriggerActionError as e:
-            raise serializers.ValidationError(e.message)
+            raise serializers.ValidationError(force_text(e))
 
     def update(self, instance, validated_data):
         if "id" in validated_data:
@@ -170,7 +171,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
         try:
             return update_alert_rule_trigger_action(instance, **validated_data)
         except InvalidTriggerActionError as e:
-            raise serializers.ValidationError(e.message)
+            raise serializers.ValidationError(force_text(e))
 
 
 class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
@@ -311,7 +312,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                     "Invalid Metric: We do not currently support this field."
                 )
         except InvalidSearchQuery as e:
-            raise serializers.ValidationError("Invalid Metric: {}".format(e.message))
+            raise serializers.ValidationError("Invalid Metric: {}".format(force_text(e)))
         return translate_aggregate_field(aggregate)
 
     def validate_dataset(self, dataset):
@@ -356,7 +357,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 },
             )
         except (InvalidSearchQuery, ValueError) as e:
-            raise serializers.ValidationError("Invalid Query or Metric: {}".format(e.message))
+            raise serializers.ValidationError("Invalid Query or Metric: {}".format(force_text(e)))
         else:
             if not snuba_filter.aggregations:
                 raise serializers.ValidationError(


### PR DESCRIPTION
I think this was the last bit of usage