### PR TITLE
fix(discover) Fix user.display in aggregates

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1532,7 +1532,7 @@ def resolve_function(field, match=None, params=None):
         aggregate[0] = aggregate[0].format(**arguments)
         if isinstance(aggregate[1], six.string_types):
             aggregate[1] = aggregate[1].format(**arguments)
-        if isinstance(aggregate[1], ArgValue):
+        elif isinstance(aggregate[1], ArgValue):
             arg = aggregate[1].arg
             aggregate[1] = arguments[arg]
         if aggregate[2] is None:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1188,18 +1188,6 @@ class FunctionArg(object):
         return False
 
 
-class NoColumn(FunctionArg):
-    """
-    Passthrough argument subclass for count()
-    """
-
-    def has_default(self, params):
-        return None
-
-    def normalize(self, value):
-        return value
-
-
 class CountColumn(FunctionArg):
     def has_default(self, params):
         return None
@@ -1400,7 +1388,7 @@ FUNCTIONS = {
     },
     "count": {
         "name": "count",
-        "args": [NoColumn("column")],
+        "args": [CountColumn("column")],
         "aggregate": ["count", None, None],
         "result_type": "integer",
     },

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1188,6 +1188,20 @@ class FunctionArg(object):
         return False
 
 
+class NullColumn(FunctionArg):
+    """
+    Convert the provided column to null so that we
+    can drop it. Used to make count() not have a
+    required argument that we ignore.
+    """
+
+    def has_default(self, params):
+        return None
+
+    def normalize(self, value):
+        return None
+
+
 class CountColumn(FunctionArg):
     def has_default(self, params):
         return None
@@ -1388,7 +1402,7 @@ FUNCTIONS = {
     },
     "count": {
         "name": "count",
-        "args": [CountColumn("column")],
+        "args": [NullColumn("column")],
         "aggregate": ["count", None, None],
         "result_type": "integer",
     },

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1188,13 +1188,25 @@ class FunctionArg(object):
         return False
 
 
+class NoColumn(FunctionArg):
+    """
+    Passthrough argument subclass for count()
+    """
+
+    def has_default(self, params):
+        return None
+
+    def normalize(self, value):
+        return value
+
+
 class CountColumn(FunctionArg):
     def has_default(self, params):
         return None
 
     def normalize(self, value):
         if value is None:
-            return value
+            raise InvalidFunctionArgument("a column is required")
 
         if value not in FIELD_ALIASES:
             return value
@@ -1386,12 +1398,9 @@ FUNCTIONS = {
         "aggregate": ["uniq", ArgValue("column"), None],
         "result_type": "integer",
     },
-    # TODO(evanh) Count doesn't accept parameters in the frontend, but we support it here
-    # for backwards compatibility. Once we've migrated existing queries this should get
-    # changed to accept no parameters.
     "count": {
         "name": "count",
-        "args": [CountColumn("column")],
+        "args": [NoColumn("column")],
         "aggregate": ["count", None, None],
         "result_type": "integer",
     },

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1706,6 +1706,10 @@ def resolve_field_list(fields, snuba_filter, auto_fields=True):
                 if column[0] == "transform":
                     # When there's a project transform, we already group by project_id
                     continue
+                if column[2] == USER_DISPLAY_ALIAS:
+                    # user.display needs to be grouped by its coalesce function
+                    groupby.append(column)
+                    continue
                 groupby.append(column[2])
             else:
                 groupby.append(column)

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1218,7 +1218,7 @@ class CountColumn(FunctionArg):
         if "expression" in alias:
             return alias["expression"]
 
-        return FIELD_ALIASES[value].get("column_alias", value)
+        return alias.get("column_alias", value)
 
 
 class NumericColumn(FunctionArg):

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -330,12 +330,11 @@ enum FieldKey {
   TRANSACTION_DURATION = 'transaction.duration',
   TRANSACTION_OP = 'transaction.op',
   TRANSACTION_STATUS = 'transaction.status',
-  // user.display is intentionally not here as
-  // it isn't stable and ready for customers to use just yet.
   USER_EMAIL = 'user.email',
   USER_ID = 'user.id',
   USER_IP = 'user.ip',
   USER_USERNAME = 'user.username',
+  USER_DISPLAY = 'user.display',
 }
 
 /**
@@ -410,6 +409,7 @@ export const FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
   // Field alises defined in src/sentry/api/event_search.py
   [FieldKey.PROJECT]: 'string',
   [FieldKey.ISSUE]: 'string',
+  [FieldKey.USER_DISPLAY]: 'string',
 };
 
 export type FieldTag = {

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -752,7 +752,11 @@ def nest_groups(data, groups, aggregate_cols):
 
 def resolve_column(dataset):
     def _resolve_column(col):
-        if col is None or col.startswith("tags[") or QUOTED_LITERAL_RE.match(col):
+        if col is None:
+            return col
+        if isinstance(col, six.string_types) and (
+            col.startswith("tags[") or QUOTED_LITERAL_RE.match(col)
+        ):
             return col
 
         # Some dataset specific logic:
@@ -973,7 +977,17 @@ def resolve_snuba_aliases(snuba_filter, resolve_func, function_translations=None
         if isinstance(aggregation[1], six.string_types):
             aggregation[1] = resolve_func(aggregation[1])
         elif isinstance(aggregation[1], (set, tuple, list)):
-            aggregation[1] = [resolve_func(col) for col in aggregation[1]]
+            # The aggregation has another function call as its parameter
+            func_index = get_function_index(aggregation[1])
+            if func_index is not None:
+                # Resolve the columns on the nested function, and add a wrapping
+                # list to become a valid query expression.
+                aggregation[1] = [
+                    [aggregation[1][0], [resolve_func(col) for col in aggregation[1][1]]]
+                ]
+            else:
+                # Parameter is a list of fields.
+                aggregation[1] = [resolve_func(col) for col in aggregation[1]]
     resolved.aggregations = aggregations
 
     conditions = resolved.conditions

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1985,6 +1985,19 @@ class ResolveFieldListTest(unittest.TestCase):
             in six.text_type(err)
         )
 
+    def test_aggregate_function_missing_parameter(self):
+        with pytest.raises(InvalidSearchQuery) as err:
+            fields = ["count_unique()"]
+            resolve_field_list(fields, eventstore.Filter())
+        assert (
+            "InvalidSearchQuery: count_unique(): column argument invalid: a column is required"
+            in six.text_type(err)
+        )
+
+        with pytest.raises(InvalidSearchQuery) as err:
+            fields = ["count_unique(  )"]
+            resolve_field_list(fields, eventstore.Filter())
+
     def test_percentile_function(self):
         fields = ["percentile(transaction.duration, 0.75)"]
         result = resolve_field_list(fields, eventstore.Filter())

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1902,9 +1902,22 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["groupby"] == [
             "title",
             "issue.id",
-            "user.display",
+            ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
             "message",
             "project.id",
+        ]
+
+    def test_field_alias_with_aggregates(self):
+        fields = ["event.type", "user.display", "count_unique(title)"]
+        result = resolve_field_list(fields, eventstore.Filter())
+        assert result["selected_columns"] == [
+            "event.type",
+            ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
+        ]
+        assert result["aggregations"] == [["uniq", "title", "count_unique_title"]]
+        assert result["groupby"] == [
+            "event.type",
+            ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
         ]
 
     def test_aggregate_function_expansion(self):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1932,13 +1932,16 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
         assert result["groupby"] == []
 
-    @pytest.mark.xfail(reason="functions need to handle non string column replacements")
     def test_aggregate_function_complex_field_expansion(self):
         fields = ["count_unique(user.display)"]
         result = resolve_field_list(fields, eventstore.Filter())
         assert result["selected_columns"] == []
         assert result["aggregations"] == [
-            ["uniq", ["coalesce", ["user.email", "user.username", "user.ip"]], "count_unique_user"],
+            [
+                "uniq",
+                ["coalesce", ["user.email", "user.username", "user.ip"]],
+                "count_unique_user_display",
+            ],
         ]
         assert result["groupby"] == []
 


### PR DESCRIPTION
Fix a few issues that have come up around aggregates and the new user.display field.

* The `count_unique()` function requires an argument or it ends up with a None inside that makes snuba very sad.
* The `count_unique(user.display)` expression now does the right thing. I've migrated most of the functions away from string formatting as it makes handling complex fields inside aggregates simpler. I've not removed string formatting of function arguments as @wmak is leaning on it in one of his open pull requests.
