### PR TITLE
ref(features): Enable event attachments by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -808,7 +808,7 @@ SENTRY_FEATURES = {
     # Enable the 'discover' interface.
     "organizations:discover": False,
     # Enable attaching arbitrary files to events.
-    "organizations:event-attachments": False,
+    "organizations:event-attachments": True,
     # Allow organizations to configure built-in symbol sources.
     "organizations:symbol-sources": True,
     # Allow organizations to configure custom external symbol sources.

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -24,6 +24,7 @@ class OrganizationSerializerTest(TestCase):
                 "advanced-search",
                 "shared-issues",
                 "open-membership",
+                "event-attachments",
                 "integrations-issue-basic",
                 "integrations-issue-sync",
                 "integrations-alert-rule",


### PR DESCRIPTION
Enables the event attachments feature by default, which allows to download minidumps from the issue details page and attach custom files to error events.