### PR TITLE
ref(slack): Allow users to pass in channel_id

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import random
+import logging
 import six
 
 import sentry_sdk
@@ -24,6 +25,7 @@ from .utils import (
 
 # 30% of messages for workspace apps will get the upgrade CTA
 UPGRADE_MESSAGE_FREQUENCY = 0.30
+logger = logging.getLogger("sentry.rules")
 
 
 class SlackNotifyServiceForm(forms.Form):
@@ -53,6 +55,13 @@ class SlackNotifyServiceForm(forms.Form):
     def clean(self):
         channel_id = None
         if self.data.get("channel_id"):
+            logger.info(
+                "rule.slack.provide_channel_id",
+                extra={
+                    "slack_integration_id": self.data.get("workspace"),
+                    "channel_id": self.data.get("channel_id"),
+                },
+            )
             # default to "#" if they have the channel name without the prefix
             channel_prefix = self.data["channel"][0] if self.data["channel"][0] == "@" else "#"
             channel_id = self.data["channel_id"]

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -4,7 +4,7 @@ import six
 
 from django.core.urlresolvers import reverse
 
-from sentry.models import Environment, Rule, RuleActivity, RuleActivityType, RuleStatus
+from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType, RuleStatus
 from sentry.testutils import APITestCase
 
 
@@ -260,6 +260,58 @@ class UpdateProjectRuleTest(APITestCase):
         rule = Rule.objects.get(id=rule.id)
         assert rule.label == "hello world"
         assert rule.environment_id is None
+
+    def test_slack_channel_id_saved(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+
+        rule = Rule.objects.create(
+            project=project,
+            environment_id=Environment.get_or_create(project, "production").id,
+            label="foo",
+        )
+        integration = Integration.objects.create(
+            provider="slack",
+            name="Awesome Team",
+            external_id="TXXXXXXX1",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
+        integration.add_organization(project.organization, self.user)
+
+        url = reverse(
+            "sentry-api-0-project-rule-details",
+            kwargs={
+                "organization_slug": project.organization.slug,
+                "project_slug": project.slug,
+                "rule_id": rule.id,
+            },
+        )
+        response = self.client.put(
+            url,
+            data={
+                "name": "hello world",
+                "environment": None,
+                "actionMatch": "any",
+                "actions": [
+                    {
+                        "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+                        "name": "Send a notification to the funinthesun Slack workspace to #team-team-team and show tags [] in notification",
+                        "workspace": integration.id,
+                        "channel": "#team-team-team",
+                        "channel_id": "CSVK0921",
+                    }
+                ],
+                "conditions": [
+                    {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
+                ],
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == six.text_type(rule.id)
+        assert response.data["actions"][0]["channel_id"] == "CSVK0921"
 
     def test_invalid_rule_node_type(self):
         self.login_as(user=self.user)

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -329,3 +329,16 @@ class SlackNotifyActionTest(RuleTestCase):
 
         assert not form.is_valid()
         assert len(form.errors) == 1
+
+    def test_channel_id_provided(self):
+        rule = self.get_rule(
+            data={
+                "workspace": self.integration.id,
+                "channel": "#my-channel",
+                "channel_id": "C2349874",
+                "tags": "",
+            }
+        )
+
+        form = rule.get_form_instance()
+        assert form.is_valid()


### PR DESCRIPTION
**Context**
Some users have an automated script that runs to create alert rules when spinning up a new Sentry project. When doing so, Slack timeouts due to the number of channels the user has. We handle this case in the UI by doing an async lookup for the channel id (related PR [here](https://github.com/getsentry/sentry/pull/16738)). 

In order to avoid the timeouts all together, we can allow the user to supply us with the channel id in the request. This way we don't need to make any API calls to Slack.

**assumptions**
* The user is passing in a valid `channel_id`
* The `channel_id` is correct for the `channel` (channel name) that is also supplied in the request