### PR TITLE
fix(cell-actions): Do note quote search terms with colons

### DIFF
--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -88,7 +88,7 @@ export class QueryResults {
         case TokenType.TAG:
           if (token.value === '' || token.value === null) {
             formattedTokens.push(`${token.key}:""`);
-          } else if (/[\s:\(\)\\"]/g.test(token.value)) {
+          } else if (/[\s\(\)\\"]/g.test(token.value)) {
             formattedTokens.push(`${token.key}:"${escapeDoubleQuotes(token.value)}"`);
           } else {
             formattedTokens.push(`${token.key}:${token.value}`);

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -328,9 +328,12 @@ describe('utils/tokenizeSearch', function() {
         string: 'bad things repository_id:"UUID(\'long-value\')"',
       },
       {
-        name: 'should quote tags with colon',
+        // values with quotes do not need to be quoted
+        // furthermore, timestamps contain colons
+        // but the backend currently does not support quoted date formats
+        name: 'should not quote tags with colon',
         object: new QueryResults(['bad', 'things', 'user:"id:123"']),
-        string: 'bad things user:"id:123"',
+        string: 'bad things user:id:123',
       },
       {
         name: 'should escape quote tags with double quotes',

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -263,9 +263,9 @@ describe('getExpandedResults()', function() {
 
     // handles user tag values.
     result = getExpandedResults(view, {user: 'id:12735'}, {});
-    expect(result.query).toEqual('event.type:error user:"id:12735"');
+    expect(result.query).toEqual('event.type:error user:id:12735');
     result = getExpandedResults(view, {user: 'name:uhoh'}, {});
-    expect(result.query).toEqual('event.type:error user:"name:uhoh"');
+    expect(result.query).toEqual('event.type:error user:name:uhoh');
 
     // quotes value
     result = getExpandedResults(view, {extra: 'has space'}, {});
@@ -364,7 +364,7 @@ describe('getExpandedResults()', function() {
       tags: [{key: 'user', value: 'id:1234'}],
     };
     let result = getExpandedResults(view, {}, event);
-    expect(result.query).toEqual('event.type:error user:"id:1234" title:"something bad"');
+    expect(result.query).toEqual('event.type:error user:id:1234 title:"something bad"');
 
     event = {
       title: 'something bad',
@@ -384,7 +384,7 @@ describe('getExpandedResults()', function() {
       user: 'id:1234',
     };
     const result = getExpandedResults(view, {}, event);
-    expect(result.query).toEqual('event.type:error user:"id:1234" title:"something bad"');
+    expect(result.query).toEqual('event.type:error user:id:1234 title:"something bad"');
   });
 
   it('normalizes the timestamp field', () => {
@@ -398,7 +398,7 @@ describe('getExpandedResults()', function() {
       timestamp: '2020-02-13T17:05:46+00:00',
     };
     const result = getExpandedResults(view, {}, event);
-    expect(result.query).toEqual('event.type:error timestamp:"2020-02-13T17:05:46"');
+    expect(result.query).toEqual('event.type:error timestamp:2020-02-13T17:05:46');
   });
 
   it('does not duplicate conditions', () => {


### PR DESCRIPTION
Colons in timestamps where causing cell actions to quote the timestamp when
using cell actions. This is causing issues with the existing grammar which does
not support quoted date formats. By removing the quotes here, we will minimize
the number of invalid queries in the short term. This change also removes quotes
when searching for a user which can contain colons. This change does not impact
this use case as the quotes are not necessary (e.g. `user:id:1`)