### PR TITLE
ref(py3): Sort similarity snapshot values from dicts in tests

### DIFF
--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_exception_type.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_exception_type.pysnap
@@ -1,9 +1,11 @@
 ---
-created: '2020-08-19T12:18:50.734616Z'
+created: '2020-08-21T21:07:53.331900Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "database-unavailable"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -38,5 +40,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_exception_type_and_module.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_exception_type_and_module.pysnap
@@ -1,9 +1,11 @@
 ---
-created: '2020-08-19T12:18:50.995804Z'
+created: '2020-08-21T21:07:53.542741Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "database-unavailable"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -38,5 +40,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_exception_type_and_module2.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_exception_type_and_module2.pysnap
@@ -1,9 +1,11 @@
 ---
-created: '2020-08-19T12:18:50.349777Z'
+created: '2020-08-21T21:07:53.030501Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "my-route"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -38,5 +40,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_exception_value.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_exception_value.pysnap
@@ -1,9 +1,11 @@
 ---
-created: '2020-08-19T12:18:50.964803Z'
+created: '2020-08-21T21:07:53.517004Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "something-went-wrong"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "EndOfWorld"
 similarity:2020-07-23:value:character-5-shingle: " went"
 similarity:2020-07-23:value:character-5-shingle: " wron"
 similarity:2020-07-23:value:character-5-shingle: "ent w"
@@ -20,5 +22,3 @@ similarity:2020-07-23:value:character-5-shingle: "t wro"
 similarity:2020-07-23:value:character-5-shingle: "thing"
 similarity:2020-07-23:value:character-5-shingle: "went "
 similarity:2020-07-23:value:character-5-shingle: "wrong"
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "EndOfWorld"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_function.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_function.pysnap
@@ -1,10 +1,12 @@
 ---
-created: '2020-08-19T12:18:50.322395Z'
+created: '2020-08-21T21:07:53.008788Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "database-unavailable"
 similarity:2020-07-23:fingerprint:ident-shingle: "main"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -39,5 +41,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_message.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_message.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2020-08-19T12:18:50.936124Z'
+created: '2020-08-21T21:07:53.493107Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:fingerprint:ident-shingle: "what-is-love"
 similarity:2020-07-23:message:character-5-shingle: " Love"
 similarity:2020-07-23:message:character-5-shingle: " my s"
 similarity:2020-07-23:message:character-5-shingle: " swee"
@@ -18,4 +19,3 @@ similarity:2020-07-23:message:character-5-shingle: "sweet"
 similarity:2020-07-23:message:character-5-shingle: "t Lov"
 similarity:2020-07-23:message:character-5-shingle: "weet "
 similarity:2020-07-23:message:character-5-shingle: "y swe"
-similarity:2020-07-23:fingerprint:ident-shingle: "what-is-love"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_native.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:50.894070Z'
+created: '2020-08-21T21:07:53.458907Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -39,6 +39,8 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["function","tokio_current_thre
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","tokio_current_thread::Entered<T>::tick"]],[["function","tokio_current_thread::scheduler::Scheduler<T>::tick"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","tokio_current_thread::scheduler::Scheduler<T>::tick"]],[["function","tokio_current_thread::CurrentRunner::set_spawn"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","unknown"]],[["function","_start"]]]
+similarity:2020-07-23:type:ident-shingle: "Custom"
+similarity:2020-07-23:type:ident-shingle: "SymCacheError"
 similarity:2020-07-23:value:character-5-shingle: " head"
 similarity:2020-07-23:value:character-5-shingle: " of r"
 similarity:2020-07-23:value:character-5-shingle: " pars"
@@ -81,5 +83,3 @@ similarity:2020-07-23:value:character-5-shingle: "to pa"
 similarity:2020-07-23:value:character-5-shingle: "ut of"
 similarity:2020-07-23:value:character-5-shingle: "valid"
 similarity:2020-07-23:value:character-5-shingle: "ymcac"
-similarity:2020-07-23:type:ident-shingle: "Custom"
-similarity:2020-07-23:type:ident-shingle: "SymCacheError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_native_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:50.565703Z'
+created: '2020-08-21T21:07:53.192427Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -39,6 +39,8 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["function","tokio_current_thre
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","tokio_current_thread::Entered<T>::tick"]],[["function","tokio_current_thread::scheduler::Scheduler<T>::tick"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","tokio_current_thread::scheduler::Scheduler<T>::tick"]],[["function","tokio_current_thread::CurrentRunner::set_spawn"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","unknown"]],[["function","_start"]]]
+similarity:2020-07-23:type:ident-shingle: "Custom"
+similarity:2020-07-23:type:ident-shingle: "SymCacheError"
 similarity:2020-07-23:value:character-5-shingle: " head"
 similarity:2020-07-23:value:character-5-shingle: " of r"
 similarity:2020-07-23:value:character-5-shingle: " pars"
@@ -81,5 +83,3 @@ similarity:2020-07-23:value:character-5-shingle: "to pa"
 similarity:2020-07-23:value:character-5-shingle: "ut of"
 similarity:2020-07-23:value:character-5-shingle: "valid"
 similarity:2020-07-23:value:character-5-shingle: "ymcac"
-similarity:2020-07-23:type:ident-shingle: "Custom"
-similarity:2020-07-23:type:ident-shingle: "SymCacheError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_native_non_app.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_native_non_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:50.719253Z'
+created: '2020-08-21T21:07:53.321111Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -38,6 +38,8 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["function","tokio_current_thre
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","tokio_current_thread::Entered<T>::tick"]],[["function","tokio_current_thread::scheduler::Scheduler<T>::tick"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","tokio_current_thread::scheduler::Scheduler<T>::tick"]],[["function","tokio_current_thread::CurrentRunner::set_spawn"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","unknown"]],[["function","_start"]]]
+similarity:2020-07-23:type:ident-shingle: "Custom"
+similarity:2020-07-23:type:ident-shingle: "SymCacheError"
 similarity:2020-07-23:value:character-5-shingle: " head"
 similarity:2020-07-23:value:character-5-shingle: " of r"
 similarity:2020-07-23:value:character-5-shingle: " pars"
@@ -80,5 +82,3 @@ similarity:2020-07-23:value:character-5-shingle: "to pa"
 similarity:2020-07-23:value:character-5-shingle: "ut of"
 similarity:2020-07-23:value:character-5-shingle: "valid"
 similarity:2020-07-23:value:character-5-shingle: "ymcac"
-similarity:2020-07-23:type:ident-shingle: "Custom"
-similarity:2020-07-23:type:ident-shingle: "SymCacheError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_no_function.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_no_function.pysnap
@@ -1,10 +1,12 @@
 ---
-created: '2020-08-19T12:18:51.011101Z'
+created: '2020-08-21T21:07:53.553282Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "<no-function>"
 similarity:2020-07-23:fingerprint:ident-shingle: "database-unavailable"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -39,5 +41,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_no_match.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_no_match.pysnap
@@ -1,9 +1,11 @@
 ---
-created: '2020-08-19T12:18:50.980864Z'
+created: '2020-08-21T21:07:53.529260Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "my-route"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -38,5 +40,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_no_package.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_no_package.pysnap
@@ -1,9 +1,11 @@
 ---
-created: '2020-08-19T12:18:50.369435Z'
+created: '2020-08-21T21:07:53.046289Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "<no-package>"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.cpp"],["function","main"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -38,5 +40,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.cpp"],["function","main"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_no_transaction.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_no_transaction.pysnap
@@ -1,10 +1,12 @@
 ---
-created: '2020-08-19T12:18:50.384627Z'
+created: '2020-08-21T21:07:53.059548Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "<no-transaction>"
 similarity:2020-07-23:fingerprint:ident-shingle: "database-unavailable"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -39,5 +41,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_override_client.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_override_client.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2020-08-19T12:18:50.335198Z'
+created: '2020-08-21T21:07:53.018371Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:fingerprint:ident-shingle: "what-is-love"
 similarity:2020-07-23:message:character-5-shingle: " Love"
 similarity:2020-07-23:message:character-5-shingle: " my s"
 similarity:2020-07-23:message:character-5-shingle: " swee"
@@ -18,4 +19,3 @@ similarity:2020-07-23:message:character-5-shingle: "sweet"
 similarity:2020-07-23:message:character-5-shingle: "t Lov"
 similarity:2020-07-23:message:character-5-shingle: "weet "
 similarity:2020-07-23:message:character-5-shingle: "y swe"
-similarity:2020-07-23:fingerprint:ident-shingle: "what-is-love"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_package.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_package.pysnap
@@ -1,9 +1,11 @@
 ---
-created: '2020-08-19T12:18:50.907967Z'
+created: '2020-08-21T21:07:53.471721Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "foo.dylib"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.cpp"],["function","main"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -38,5 +40,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.cpp"],["function","main"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_python.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_python.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:50.308155Z'
+created: '2020-08-21T21:07:52.997178Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -13,6 +13,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","resp = self.se
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","response = _Session.request(self, *args, **kwargs)"],["filename","http.py"],["function","request"],["module","sentry.net.http"]],[["context-line","resp = self.send(prep, **send_kwargs)"],["filename","sessions.py"],["function","request"],["module","requests.sessions"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","result = func(*args, **kwargs)"],["filename","safe.py"],["function","safe_execute"],["module","sentry.utils.safe"]],[["context-line","self.notify(notification)"],["filename","notify.py"],["function","rule_notify"],["module","sentry.plugins.bases.notify"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","self.notify(notification)"],["filename","notify.py"],["function","rule_notify"],["module","sentry.plugins.bases.notify"]],[["context-line","r.label for r in notification.rules])"],["filename","notify.py"],["function","notify"],["module","sentry.plugins.bases.notify"]]]
+similarity:2020-07-23:type:ident-shingle: "ReadTimeout"
 similarity:2020-07-23:value:character-5-shingle: " (rea"
 similarity:2020-07-23:value:character-5-shingle: " Read"
 similarity:2020-07-23:value:character-5-shingle: " out."
@@ -99,4 +100,3 @@ similarity:2020-07-23:value:character-5-shingle: "timeo"
 similarity:2020-07-23:value:character-5-shingle: "tionP"
 similarity:2020-07-23:value:character-5-shingle: "ut. ("
 similarity:2020-07-23:value:character-5-shingle: "ut=<i"
-similarity:2020-07-23:type:ident-shingle: "ReadTimeout"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_transaction.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_transaction.pysnap
@@ -1,10 +1,12 @@
 ---
-created: '2020-08-19T12:18:50.950186Z'
+created: '2020-08-21T21:07:53.506412Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "database-unavailable"
 similarity:2020-07-23:fingerprint:ident-shingle: "my-transaction"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -39,5 +41,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_type_module.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_type_module.pysnap
@@ -1,10 +1,12 @@
 ---
-created: '2020-08-19T12:18:50.923714Z'
+created: '2020-08-21T21:07:53.482071Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:fingerprint:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:fingerprint:ident-shingle: "io.sentry.example.Application"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"
 similarity:2020-07-23:value:character-5-shingle: " away"
 similarity:2020-07-23:value:character-5-shingle: " data"
 similarity:2020-07-23:value:character-5-shingle: " reas"
@@ -39,5 +41,3 @@ similarity:2020-07-23:value:character-5-shingle: "t awa"
 similarity:2020-07-23:value:character-5-shingle: "tabas"
 similarity:2020-07-23:value:character-5-shingle: "the d"
 similarity:2020-07-23:value:character-5-shingle: "went "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "DatabaseUnavailable"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/actix.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:48.695442Z'
+created: '2020-08-21T21:07:51.828140Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -81,6 +81,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","thread.rs"],["func
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","__pthread_body"]],[["filename","lib.rs"],["function","___rust_maybe_catch_panic"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","__pthread_body"]],[["filename","thread.rs"],["function","std::sys::unix::thread::Thread::new::thread_start"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","__pthread_start"]],[["function","__pthread_body"]]]
+similarity:2020-07-23:type:ident-shingle: "actix_web::pipeline"
 similarity:2020-07-23:value:character-5-shingle: " <int"
 similarity:2020-07-23:value:character-5-shingle: " Erro"
 similarity:2020-07-23:value:character-5-shingle: " Inte"
@@ -183,4 +184,3 @@ similarity:2020-07-23:value:character-5-shingle: "ver E"
 similarity:2020-07-23:value:character-5-shingle: "went "
 similarity:2020-07-23:value:character-5-shingle: "wrong"
 similarity:2020-07-23:value:character-5-shingle: "y wro"
-similarity:2020-07-23:type:ident-shingle: "actix_web::pipeline"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/aspnetcore.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:48.044548Z'
+created: '2020-08-21T21:07:51.105494Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -28,6 +28,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["function","Throw"],["module",
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","Throw"],["module","System.Runtime.ExceptionServices.ExceptionDispatchInfo"]],[["function","InvokeNextActionFilterAsync"],["module","Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","Throw"],["module","System.Runtime.ExceptionServices.ExceptionDispatchInfo"]],[["function","InvokeNextResourceFilter"],["module","Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","lambda_method"],["module","(unknown)"]],[["filename","valuescontroller.cs"],["function","Get"],["module","SentryTest2.Controllers.ValuesController"]]]
+similarity:2020-07-23:type:ident-shingle: "System.Exception"
 similarity:2020-07-23:value:character-5-shingle: " exce"
 similarity:2020-07-23:value:character-5-shingle: "c exc"
 similarity:2020-07-23:value:character-5-shingle: "cepti"
@@ -38,4 +39,3 @@ similarity:2020-07-23:value:character-5-shingle: "ption"
 similarity:2020-07-23:value:character-5-shingle: "sync "
 similarity:2020-07-23:value:character-5-shingle: "xcept"
 similarity:2020-07-23:value:character-5-shingle: "ync e"
-similarity:2020-07-23:type:ident-shingle: "System.Exception"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/connection_error.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:49.029504Z'
+created: '2020-08-21T21:07:52.050172Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -13,6 +13,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","return script(
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"],["filename","client.py"],["function","evalsha"],["module","redis.client"]],[["context-line","return self.parse_response(connection, command_name, **options)"],["filename","client.py"],["function","execute_command"],["module","redis.client"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","return self.parse_response(connection, command_name, **options)"],["filename","client.py"],["function","execute_command"],["module","redis.client"]],[["context-line","response = connection.read_response()"],["filename","client.py"],["function","parse_response"],["module","redis.client"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","return super(SubscriptionQuota, self).is_rate_limited(project, key=key)"],["filename","quotas.py"],["function","is_rate_limited"],["module","getsentry.quotas"]],[["context-line","rejections = is_rate_limited(client, keys, args)"],["filename","redis.py"],["function","is_rate_limited"],["module","sentry.quotas.redis"]]]
+similarity:2020-07-23:type:ident-shingle: "ConnectionError"
 similarity:2020-07-23:value:character-5-shingle: " ('Co"
 similarity:2020-07-23:value:character-5-shingle: " by s"
 similarity:2020-07-23:value:character-5-shingle: " clos"
@@ -75,4 +76,3 @@ similarity:2020-07-23:value:character-5-shingle: "tion "
 similarity:2020-07-23:value:character-5-shingle: "ver.'"
 similarity:2020-07-23:value:character-5-shingle: "while"
 similarity:2020-07-23:value:character-5-shingle: "y ser"
-similarity:2020-07-23:type:ident-shingle: "ConnectionError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/custom_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:49.054931Z'
+created: '2020-08-21T21:07:52.067482Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -22,6 +22,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","self.shutdown(
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"],["filename","debugfile.py"],["function","get_symcaches"],["module","sentry.models.debugfile"]],[["context-line","model.cache_file.save_to(cachefile_path)"],["filename","debugfile.py"],["function","_load_cachefiles_via_fs"],["module","sentry.models.debugfile"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","t.join(sys.maxint)"],["filename","thread.py"],["function","shutdown"],["module","concurrent.futures.thread"]],[["context-line","self.__block.wait(delay)"],["filename","threading.py"],["function","join"],["module","threading"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","with_conversion_errors=True)"],["filename","symbolizer.py"],["function","__init__"],["module","sentry.lang.native.symbolizer"]],[["context-line","symcaches = self._load_cachefiles_via_fs(project, cachefiles, SymCache)"],["filename","debugfile.py"],["function","get_symcaches"],["module","sentry.models.debugfile"]]]
+similarity:2020-07-23:type:ident-shingle: "SoftTimeLimitExceeded"
 similarity:2020-07-23:value:character-5-shingle: "Excee"
 similarity:2020-07-23:value:character-5-shingle: "Limit"
 similarity:2020-07-23:value:character-5-shingle: "SoftT"
@@ -41,4 +42,3 @@ similarity:2020-07-23:value:character-5-shingle: "oftTi"
 similarity:2020-07-23:value:character-5-shingle: "tExce"
 similarity:2020-07-23:value:character-5-shingle: "tTime"
 similarity:2020-07-23:value:character-5-shingle: "xceed"
-similarity:2020-07-23:type:ident-shingle: "SoftTimeLimitExceeded"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_comput_hashes.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_comput_hashes.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2020-07-23T16:57:25.135074Z'
+created: '2020-08-21T21:07:51.164088Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:type:ident-shingle: "ValueError"
 similarity:2020-07-23:value:character-5-shingle: " worl"
 similarity:2020-07-23:value:character-5-shingle: "ello "
 similarity:2020-07-23:value:character-5-shingle: "hello"
@@ -10,4 +11,3 @@ similarity:2020-07-23:value:character-5-shingle: "llo w"
 similarity:2020-07-23:value:character-5-shingle: "lo wo"
 similarity:2020-07-23:value:character-5-shingle: "o wor"
 similarity:2020-07-23:value:character-5-shingle: "world"
-similarity:2020-07-23:type:ident-shingle: "ValueError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_compute_hashes.pysnap
@@ -1,8 +1,10 @@
 ---
-created: '2020-08-19T12:18:49.712611Z'
+created: '2020-08-21T21:07:52.568395Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","baz.py"]]
+similarity:2020-07-23:type:ident-shingle: "ValueError"
 similarity:2020-07-23:value:character-5-shingle: " worl"
 similarity:2020-07-23:value:character-5-shingle: "ello "
 similarity:2020-07-23:value:character-5-shingle: "hello"
@@ -10,5 +12,3 @@ similarity:2020-07-23:value:character-5-shingle: "llo w"
 similarity:2020-07-23:value:character-5-shingle: "lo wo"
 similarity:2020-07-23:value:character-5-shingle: "o wor"
 similarity:2020-07-23:value:character-5-shingle: "world"
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","baz.py"]]
-similarity:2020-07-23:type:ident-shingle: "ValueError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_compute_hashes_2.pysnap
@@ -1,8 +1,10 @@
 ---
-created: '2020-08-19T12:18:49.176131Z'
+created: '2020-08-21T21:07:52.151572Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","baz.py"]]
+similarity:2020-07-23:type:ident-shingle: "ValueError"
 similarity:2020-07-23:value:character-5-shingle: " worl"
 similarity:2020-07-23:value:character-5-shingle: "ello "
 similarity:2020-07-23:value:character-5-shingle: "hello"
@@ -10,5 +12,3 @@ similarity:2020-07-23:value:character-5-shingle: "llo w"
 similarity:2020-07-23:value:character-5-shingle: "lo wo"
 similarity:2020-07-23:value:character-5-shingle: "o wor"
 similarity:2020-07-23:value:character-5-shingle: "world"
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","baz.py"]]
-similarity:2020-07-23:type:ident-shingle: "ValueError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_compute_hashes_3.pysnap
@@ -1,8 +1,10 @@
 ---
-created: '2020-08-11T11:59:10.248756Z'
+created: '2020-08-21T21:07:51.994551Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","baz.py"]]
+similarity:2020-07-23:type:ident-shingle: "ValueError"
 similarity:2020-07-23:value:character-5-shingle: " worl"
 similarity:2020-07-23:value:character-5-shingle: "ello "
 similarity:2020-07-23:value:character-5-shingle: "hello"
@@ -10,5 +12,3 @@ similarity:2020-07-23:value:character-5-shingle: "llo w"
 similarity:2020-07-23:value:character-5-shingle: "lo wo"
 similarity:2020-07-23:value:character-5-shingle: "o wor"
 similarity:2020-07-23:value:character-5-shingle: "world"
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","baz.py"]]
-similarity:2020-07-23:type:ident-shingle: "ValueError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_javascript_no_in_app.pysnap
@@ -1,9 +1,10 @@
 ---
-created: '2020-08-19T12:18:49.088260Z'
+created: '2020-08-21T21:07:52.090676Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","onError(err);"],["filename","createteammodal.jsx"],["module","app/components/modals/createTeamModal"]],[["context-line","this.model.submitError(error);"],["filename","form.jsx"],["function","onError"],["module","app/views/settings/components/forms/form"]]]
+similarity:2020-07-23:type:ident-shingle: "TypeError"
 similarity:2020-07-23:value:character-5-shingle: " 'sub"
 similarity:2020-07-23:value:character-5-shingle: " null"
 similarity:2020-07-23:value:character-5-shingle: " of n"
@@ -42,4 +43,3 @@ similarity:2020-07-23:value:character-5-shingle: "tErro"
 similarity:2020-07-23:value:character-5-shingle: "ty 's"
 similarity:2020-07-23:value:character-5-shingle: "ubmit"
 similarity:2020-07-23:value:character-5-shingle: "y 'su"
-similarity:2020-07-23:type:ident-shingle: "TypeError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/java_chained.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/java_chained.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2020-08-19T12:18:48.812904Z'
+created: '2020-08-21T21:07:51.909217Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","abstractapplicationcontext.java"],["function","refresh"],["module","org.springframework.context.support.AbstractApplicationContext"]],[["filename","embeddedwebapplicationcontext.java"],["function","finishRefresh"],["module","org.springframework.boot.context.embedded.EmbeddedWebApplicationContext"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","abstractendpoint.java"],["function","start"],["module","org.apache.tomcat.util.net.AbstractEndpoint"]],[["filename","nioendpoint.java"],["function","bind"],["module","org.apache.tomcat.util.net.NioEndpoint"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","abstractprotocol.java"],["function","start"],["module","org.apache.coyote.AbstractProtocol"]],[["filename","abstractendpoint.java"],["function","start"],["module","org.apache.tomcat.util.net.AbstractEndpoint"]]]
@@ -24,10 +25,12 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","springapplication.
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","standardservice.java"],["function","addConnector"],["module","org.apache.catalina.core.StandardService"]],[["filename","lifecyclebase.java"],["function","start"],["module","org.apache.catalina.util.LifecycleBase"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","tomcatembeddedservletcontainer.java"],["function","addPreviouslyRemovedConnectors"],["module","org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"]],[["filename","standardservice.java"],["function","addConnector"],["module","org.apache.catalina.core.StandardService"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","tomcatembeddedservletcontainer.java"],["function","start"],["module","org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"]],[["filename","tomcatembeddedservletcontainer.java"],["function","addPreviouslyRemovedConnectors"],["module","org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer"]]]
+similarity:2020-07-23:type:ident-shingle: "BindException"
+similarity:2020-07-23:type:ident-shingle: "LifecycleException"
 similarity:2020-07-23:value:character-5-shingle: "  Pro"
-similarity:2020-07-23:value:character-5-shingle: " \"Tom"
 similarity:2020-07-23:value:character-5-shingle: " Prot"
 similarity:2020-07-23:value:character-5-shingle: " [Con"
+similarity:2020-07-23:value:character-5-shingle: " \"Tom"
 similarity:2020-07-23:value:character-5-shingle: " alre"
 similarity:2020-07-23:value:character-5-shingle: " comp"
 similarity:2020-07-23:value:character-5-shingle: " fail"
@@ -35,8 +38,6 @@ similarity:2020-07-23:value:character-5-shingle: " hand"
 similarity:2020-07-23:value:character-5-shingle: " in u"
 similarity:2020-07-23:value:character-5-shingle: " star"
 similarity:2020-07-23:value:character-5-shingle: " to s"
-similarity:2020-07-23:value:character-5-shingle: "\";  P"
-similarity:2020-07-23:value:character-5-shingle: "\"Tomc"
 similarity:2020-07-23:value:character-5-shingle: "(): \""
 similarity:2020-07-23:value:character-5-shingle: "): \"T"
 similarity:2020-07-23:value:character-5-shingle: ".getN"
@@ -58,6 +59,8 @@ similarity:2020-07-23:value:character-5-shingle: "TTP/<"
 similarity:2020-07-23:value:character-5-shingle: "Tomca"
 similarity:2020-07-23:value:character-5-shingle: "[Conn"
 similarity:2020-07-23:value:character-5-shingle: "[HTTP"
+similarity:2020-07-23:value:character-5-shingle: "\";  P"
+similarity:2020-07-23:value:character-5-shingle: "\"Tomc"
 similarity:2020-07-23:value:character-5-shingle: "ady i"
 similarity:2020-07-23:value:character-5-shingle: "ailed"
 similarity:2020-07-23:value:character-5-shingle: "alrea"
@@ -65,8 +68,8 @@ similarity:2020-07-23:value:character-5-shingle: "ame()"
 similarity:2020-07-23:value:character-5-shingle: "andle"
 similarity:2020-07-23:value:character-5-shingle: "art c"
 similarity:2020-07-23:value:character-5-shingle: "art f"
-similarity:2020-07-23:value:character-5-shingle: "at\"; "
 similarity:2020-07-23:value:character-5-shingle: "at><i"
+similarity:2020-07-23:value:character-5-shingle: "at\"; "
 similarity:2020-07-23:value:character-5-shingle: "cat\";"
 similarity:2020-07-23:value:character-5-shingle: "ce.ge"
 similarity:2020-07-23:value:character-5-shingle: "col h"
@@ -136,15 +139,12 @@ similarity:2020-07-23:value:character-5-shingle: "start"
 similarity:2020-07-23:value:character-5-shingle: "t [Co"
 similarity:2020-07-23:value:character-5-shingle: "t com"
 similarity:2020-07-23:value:character-5-shingle: "t fai"
-similarity:2020-07-23:value:character-5-shingle: "t\";  "
 similarity:2020-07-23:value:character-5-shingle: "t><in"
 similarity:2020-07-23:value:character-5-shingle: "tName"
+similarity:2020-07-23:value:character-5-shingle: "t\";  "
 similarity:2020-07-23:value:character-5-shingle: "tart "
 similarity:2020-07-23:value:character-5-shingle: "to st"
 similarity:2020-07-23:value:character-5-shingle: "tocol"
 similarity:2020-07-23:value:character-5-shingle: "tor[H"
 similarity:2020-07-23:value:character-5-shingle: "vice."
 similarity:2020-07-23:value:character-5-shingle: "y in "
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
-similarity:2020-07-23:type:ident-shingle: "BindException"
-similarity:2020-07-23:type:ident-shingle: "LifecycleException"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/java_minimal.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:48.294294Z'
+created: '2020-08-21T21:07:51.269604Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -49,9 +49,9 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","thread.java"],["fu
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","threadpoolexecutor.java"],["function","run"],["module","java.util.concurrent.ThreadPoolExecutor$Worker"]],[["filename","threadpoolexecutor.java"],["function","runWorker"],["module","java.util.concurrent.ThreadPoolExecutor"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","threadpoolexecutor.java"],["function","runWorker"],["module","java.util.concurrent.ThreadPoolExecutor"]],[["filename","socketprocessorbase.java"],["function","run"],["module","org.apache.tomcat.util.net.SocketProcessorBase"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","wsfilter.java"],["function","doFilter"],["module","org.apache.tomcat.websocket.server.WsFilter"]],[["filename","applicationfilterchain.java"],["function","doFilter"],["module","org.apache.catalina.core.ApplicationFilterChain"]]]
+similarity:2020-07-23:type:ident-shingle: "ArithmeticException"
 similarity:2020-07-23:value:character-5-shingle: " by z"
 similarity:2020-07-23:value:character-5-shingle: " zero"
 similarity:2020-07-23:value:character-5-shingle: "/ by "
 similarity:2020-07-23:value:character-5-shingle: "by ze"
 similarity:2020-07-23:value:character-5-shingle: "y zer"
-similarity:2020-07-23:type:ident-shingle: "ArithmeticException"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_exception_fallback_to_message.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_exception_fallback_to_message.pysnap
@@ -1,9 +1,9 @@
 ---
-created: '2020-07-23T16:57:26.424066Z'
+created: '2020-08-21T21:07:52.099614Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:value:character-5-shingle: "\n(tim"
+similarity:2020-07-23:type:ident-shingle: "Error"
 similarity:2020-07-23:value:character-5-shingle: " <int"
 similarity:2020-07-23:value:character-5-shingle: " <url"
 similarity:2020-07-23:value:character-5-shingle: " chun"
@@ -15,6 +15,7 @@ similarity:2020-07-23:value:character-5-shingle: "<int>"
 similarity:2020-07-23:value:character-5-shingle: "<url>"
 similarity:2020-07-23:value:character-5-shingle: "> fai"
 similarity:2020-07-23:value:character-5-shingle: "Loadi"
+similarity:2020-07-23:value:character-5-shingle: "\n(tim"
 similarity:2020-07-23:value:character-5-shingle: "ading"
 similarity:2020-07-23:value:character-5-shingle: "ailed"
 similarity:2020-07-23:value:character-5-shingle: "chunk"
@@ -42,4 +43,3 @@ similarity:2020-07-23:value:character-5-shingle: "t> fa"
 similarity:2020-07-23:value:character-5-shingle: "timeo"
 similarity:2020-07-23:value:character-5-shingle: "unk <"
 similarity:2020-07-23:value:character-5-shingle: "ut: <"
-similarity:2020-07-23:type:ident-shingle: "Error"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2020-07-23T16:57:27.503007Z'
+created: '2020-08-21T21:07:52.965081Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:type:ident-shingle: "Error"
 similarity:2020-07-23:value:character-5-shingle: " (err"
 similarity:2020-07-23:value:character-5-shingle: " (md5"
 similarity:2020-07-23:value:character-5-shingle: " (sub"
@@ -181,4 +182,3 @@ similarity:2020-07-23:value:character-5-shingle: "um <s"
 similarity:2020-07-23:value:character-5-shingle: "uuid>"
 similarity:2020-07-23:value:character-5-shingle: "via <"
 similarity:2020-07-23:value:character-5-shingle: "yload"
-similarity:2020-07-23:type:ident-shingle: "Error"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:50.056216Z'
+created: '2020-08-21T21:07:52.819355Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -14,6 +14,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react-dom.developm
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react-dom.development.js"],["function","performWorkOnRoot"]],[["filename","react-dom.development.js"],["function","renderRoot"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react-dom.development.js"],["function","renderRoot"]],[["filename","react-dom.development.js"],["function","replayUnitOfWork"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react-dom.development.js"],["function","replayUnitOfWork"]],[["filename","react-dom.development.js"],["function","invokeGuardedCallback"]]]
+similarity:2020-07-23:type:ident-shingle: "ReferenceError"
 similarity:2020-07-23:value:character-5-shingle: " defi"
 similarity:2020-07-23:value:character-5-shingle: " is n"
 similarity:2020-07-23:value:character-5-shingle: " not "
@@ -31,4 +32,3 @@ similarity:2020-07-23:value:character-5-shingle: "s not"
 similarity:2020-07-23:value:character-5-shingle: "t def"
 similarity:2020-07-23:value:character-5-shingle: "t is "
 similarity:2020-07-23:value:character-5-shingle: "varan"
-similarity:2020-07-23:type:ident-shingle: "ReferenceError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_chrome.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2020-08-11T11:59:09.400303Z'
+created: '2020-08-21T21:07:51.322534Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","callback"]]]
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","testMethod"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","aha"]],[["filename","test.html"],["function","test"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","callAnotherThing"]],[["filename","test.html"],["function","aha"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","callback"]],[["filename","test.html"],["function","callAnotherThing"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","test"]],[["filename","test.html"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","testMethod"]],[["filename","test.html"],["function","aha"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","callback"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","testMethod"]]]
 similarity:2020-07-23:type:ident-shingle: "Error"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_edge.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2020-08-11T11:59:10.957945Z'
+created: '2020-08-21T21:07:52.534984Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","callback"]]]
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","testMethod"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","aha"]],[["filename","test.html"],["function","test"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","callAnotherThing"]],[["filename","test.html"],["function","aha"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","callback"]],[["filename","test.html"],["function","callAnotherThing"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","test"]],[["filename","test.html"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","testMethod"]],[["filename","test.html"],["function","aha"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","callback"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","testMethod"]]]
 similarity:2020-07-23:type:ident-shingle: "Error"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_firefox.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2020-08-11T11:59:09.379829Z'
+created: '2020-08-21T21:07:51.309432Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","callback"]]]
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","testMethod"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","aha"]],[["filename","test.html"],["function","test"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","callAnotherThing"]],[["filename","test.html"],["function","aha"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","callback"]],[["filename","test.html"],["function","callAnotherThing"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","test"]],[["filename","test.html"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","testMethod"]],[["filename","test.html"],["function","aha"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","callback"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","testMethod"]]]
 similarity:2020-07-23:type:ident-shingle: "Error"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_safari.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2020-08-11T11:59:10.192424Z'
+created: '2020-08-21T21:07:51.956589Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","callback"]]]
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","testMethod"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","aha"]],[["filename","test.html"],["function","test"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","callAnotherThing"]],[["filename","test.html"],["function","aha"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","callback"]],[["filename","test.html"],["function","callAnotherThing"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","test"]],[["filename","test.html"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"],["function","testMethod"]],[["filename","test.html"],["function","aha"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","callback"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","test.html"]],[["filename","test.html"],["function","testMethod"]]]
 similarity:2020-07-23:type:ident-shingle: "Error"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:49.651021Z'
+created: '2020-08-21T21:07:52.520807Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -21,6 +21,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react-dom.producti
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react-dom.production.min.js"],["function","rh"],["module","usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"]],[["context-line","this.fetchData();"],["filename","groupeventdetails.jsx"],["function","X"],["module","app/views/groupDetails/shared/groupEventDetails"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react-dom.production.min.js"],["function","this"],["module","usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"]],[["filename","react-dom.production.min.js"],["function","If"],["module","usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react.production.min.js"],["function","this"],["module","usr/src/getsentry/src/sentry/node_modules/react/cjs/react.production"]],[["filename","react-dom.production.min.js"],["function","this"],["module","usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"]]]
+similarity:2020-07-23:type:ident-shingle: "NotFoundError"
 similarity:2020-07-23:value:character-5-shingle: " /iss"
 similarity:2020-07-23:value:character-5-shingle: " <int"
 similarity:2020-07-23:value:character-5-shingle: "/ <in"
@@ -54,4 +55,3 @@ similarity:2020-07-23:value:character-5-shingle: "test/"
 similarity:2020-07-23:value:character-5-shingle: "ts/la"
 similarity:2020-07-23:value:character-5-shingle: "ues/<"
 similarity:2020-07-23:value:character-5-shingle: "vents"
-similarity:2020-07-23:type:ident-shingle: "NotFoundError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:50.180562Z'
+created: '2020-08-21T21:07:52.909691Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -17,6 +17,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react-dom.producti
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react-dom.production.min.js"],["function","ih"],["module","usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"]],[["context-line","this.fetchData();"],["filename","groupeventdetails.jsx"],["function","q"],["module","app/views/groupDetails/shared/groupEventDetails"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react-dom.production.min.js"],["function","tag"],["module","usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"]],[["filename","react-dom.production.min.js"],["function","Yg"],["module","usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","react.production.min.js"],["function","setState"],["module","usr/src/getsentry/src/sentry/node_modules/react/cjs/react.production"]],[["filename","react-dom.production.min.js"],["function","enqueueSetState"],["module","usr/src/getsentry/src/sentry/node_modules/react-dom/cjs/react-dom.production"]]]
+similarity:2020-07-23:type:ident-shingle: "NotFoundError"
 similarity:2020-07-23:value:character-5-shingle: " /iss"
 similarity:2020-07-23:value:character-5-shingle: " <int"
 similarity:2020-07-23:value:character-5-shingle: "/ <in"
@@ -50,4 +51,3 @@ similarity:2020-07-23:value:character-5-shingle: "test/"
 similarity:2020-07-23:value:character-5-shingle: "ts/la"
 similarity:2020-07-23:value:character-5-shingle: "ues/<"
 similarity:2020-07-23:value:character-5-shingle: "vents"
-similarity:2020-07-23:type:ident-shingle: "NotFoundError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/laravel.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:49.234071Z'
+created: '2020-08-21T21:07:52.200107Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -40,6 +40,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","return $this->
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","return $this->runRoute($request, $this->findRoute($request));"],["filename","router.php"],["function","Illuminate\\Routing\\Router::dispatchToRoute"]],[["context-line","$this->runRouteWithinStack($route, $request)"],["filename","router.php"],["function","Illuminate\\Routing\\Router::runRoute"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","return tap($next($request), function ($response) use ($request) {"],["filename","verifycsrftoken.php"],["function","Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::handle"]],[["context-line","return $callable($passable);"],["filename","pipeline.php"],["function","Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","});"],["filename","router.php"],["function","Illuminate\\Routing\\Router::runRouteWithinStack"]],[["context-line","return $pipeline($this->passable);"],["filename","pipeline.php"],["function","Illuminate\\Pipeline\\Pipeline::then"]]]
+similarity:2020-07-23:type:ident-shingle: "Exception"
 similarity:2020-07-23:value:character-5-shingle: " TEST"
 similarity:2020-07-23:value:character-5-shingle: "ARAVE"
 similarity:2020-07-23:value:character-5-shingle: "AVEL "
@@ -48,4 +49,3 @@ similarity:2020-07-23:value:character-5-shingle: "L TES"
 similarity:2020-07-23:value:character-5-shingle: "LARAV"
 similarity:2020-07-23:value:character-5-shingle: "RAVEL"
 similarity:2020-07-23:value:character-5-shingle: "VEL T"
-similarity:2020-07-23:type:ident-shingle: "Exception"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/laravel_anonymous.pysnap
@@ -1,10 +1,12 @@
 ---
-created: '2020-08-19T12:18:49.131609Z'
+created: '2020-08-21T21:07:52.119152Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:stacktrace:frames-ident: [["context-line","require_once __DIR__.'/public/index.php';"],["filename","server.php"]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","require_once __DIR__.'/public/index.php';"],["filename","server.php"]],[["context-line","return $callable($passable);"],["filename","pipeline.php"],["function","run"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","return $callable($passable);"],["filename","pipeline.php"],["function","run"]],[["context-line","? $pipe->{$this->method}(...$parameters)"],["filename","pipeline.php"],["function","Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"]]]
+similarity:2020-07-23:type:ident-shingle: "Exception"
 similarity:2020-07-23:value:character-5-shingle: " TEST"
 similarity:2020-07-23:value:character-5-shingle: "ARAVE"
 similarity:2020-07-23:value:character-5-shingle: "AVEL "
@@ -13,5 +15,3 @@ similarity:2020-07-23:value:character-5-shingle: "L TES"
 similarity:2020-07-23:value:character-5-shingle: "LARAV"
 similarity:2020-07-23:value:character-5-shingle: "RAVEL"
 similarity:2020-07-23:value:character-5-shingle: "VEL T"
-similarity:2020-07-23:stacktrace:frames-ident: [["context-line","require_once __DIR__.'/public/index.php';"],["filename","server.php"]]
-similarity:2020-07-23:type:ident-shingle: "Exception"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/native_limit_frames.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2020-08-19T12:18:49.533464Z'
+created: '2020-08-21T21:07:52.437256Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:stacktrace:frames-ident: [["function","<lambda>::operator()"]]
 similarity:2020-07-23:value:character-5-shingle: " ever"
 similarity:2020-07-23:value:character-5-shingle: " fire"
 similarity:2020-07-23:value:character-5-shingle: " is o"
@@ -31,4 +32,3 @@ similarity:2020-07-23:value:character-5-shingle: "thing"
 similarity:2020-07-23:value:character-5-shingle: "veryt"
 similarity:2020-07-23:value:character-5-shingle: "y shi"
 similarity:2020-07-23:value:character-5-shingle: "ythin"
-similarity:2020-07-23:stacktrace:frames-ident: [["function","<lambda>::operator()"]]

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/python_exception_base.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/python_exception_base.pysnap
@@ -1,8 +1,10 @@
 ---
-created: '2020-08-11T11:59:10.842565Z'
+created: '2020-08-21T21:07:52.448162Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","baz.py"]]
+similarity:2020-07-23:type:ident-shingle: "ValueError"
 similarity:2020-07-23:value:character-5-shingle: " worl"
 similarity:2020-07-23:value:character-5-shingle: "ello "
 similarity:2020-07-23:value:character-5-shingle: "hello"
@@ -10,5 +12,3 @@ similarity:2020-07-23:value:character-5-shingle: "llo w"
 similarity:2020-07-23:value:character-5-shingle: "lo wo"
 similarity:2020-07-23:value:character-5-shingle: "o wor"
 similarity:2020-07-23:value:character-5-shingle: "world"
-similarity:2020-07-23:stacktrace:frames-ident: [["filename","baz.py"]]
-similarity:2020-07-23:type:ident-shingle: "ValueError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2020-08-19T12:18:50.019676Z'
+created: '2020-08-21T21:07:52.790416Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","email = request.POST['user']"],["filename","plugin.py"],["function","handle"],["module","sentry_plugins.heroku.plugin"]],[["context-line","raise MultiValueDictKeyError(repr(key))"],["filename","datastructures.py"],["function","__getitem__"],["module","django.utils.datastructures"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","hook.handle(request)"],["filename","release_webhook.py"],["function","post"],["module","sentry.web.frontend.release_webhook"]],[["context-line","email = request.POST['user']"],["filename","plugin.py"],["function","handle"],["module","sentry_plugins.heroku.plugin"]]]
-similarity:2020-07-23:value:character-5-shingle: "\"'use"
+similarity:2020-07-23:type:ident-shingle: "MultiValueDictKeyError"
 similarity:2020-07-23:value:character-5-shingle: "'user"
+similarity:2020-07-23:value:character-5-shingle: "\"'use"
 similarity:2020-07-23:value:character-5-shingle: "ser'\""
 similarity:2020-07-23:value:character-5-shingle: "user'"
-similarity:2020-07-23:type:ident-shingle: "MultiValueDictKeyError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/python_grouping_enhancer_towards_crash.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2020-08-19T12:18:49.253791Z'
+created: '2020-08-21T21:07:52.216110Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","response = wrapped_callback(request, *callback_args, **callback_kwargs)"],["filename","base.py"],["function","get_response"],["module","django.core.handlers.base"]],[["context-line","return self.dispatch(request, *args, **kwargs)"],["filename","base.py"],["function","view"],["module","django.views.generic.base"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","return self.dispatch(request, *args, **kwargs)"],["filename","base.py"],["function","view"],["module","django.views.generic.base"]],[["context-line","return bound_func(*args, **kwargs)"],["filename","decorators.py"],["function","_wrapper"],["module","django.utils.decorators"]]]
-similarity:2020-07-23:value:character-5-shingle: "\"'use"
+similarity:2020-07-23:type:ident-shingle: "MultiValueDictKeyError"
 similarity:2020-07-23:value:character-5-shingle: "'user"
+similarity:2020-07-23:value:character-5-shingle: "\"'use"
 similarity:2020-07-23:value:character-5-shingle: "ser'\""
 similarity:2020-07-23:value:character-5-shingle: "user'"
-similarity:2020-07-23:type:ident-shingle: "MultiValueDictKeyError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/python_http_error.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/python_http_error.pysnap
@@ -1,10 +1,11 @@
 ---
-created: '2020-08-19T12:18:49.072460Z'
+created: '2020-08-21T21:07:52.079156Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","resp.raise_for_status()"],["filename","notify_action.py"],["function","send_notification"],["module","sentry.integrations.slack.notify_action"]],[["context-line","raise HTTPError(http_error_msg, response=self)"],["filename","models.py"],["function","raise_for_status"],["module","requests.models"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","result = func(*args, **kwargs)"],["filename","safe.py"],["function","safe_execute"],["module","sentry.utils.safe"]],[["context-line","resp.raise_for_status()"],["filename","notify_action.py"],["function","send_notification"],["module","sentry.integrations.slack.notify_action"]]]
+similarity:2020-07-23:type:ident-shingle: "HTTPError"
 similarity:2020-07-23:value:character-5-shingle: " <url"
 similarity:2020-07-23:value:character-5-shingle: " Clie"
 similarity:2020-07-23:value:character-5-shingle: " Erro"
@@ -53,4 +54,3 @@ similarity:2020-07-23:value:character-5-shingle: "ts fo"
 similarity:2020-07-23:value:character-5-shingle: "uests"
 similarity:2020-07-23:value:character-5-shingle: "url: "
 similarity:2020-07-23:value:character-5-shingle: "y Req"
-similarity:2020-07-23:type:ident-shingle: "HTTPError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/react_native.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:49.588735Z'
+created: '2020-08-21T21:07:52.479586Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -24,6 +24,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","this.touchable
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","touchableHandleResponderRelease: function(e) {"],["filename","touchable.js"],["function","arguments"],["module","react-native/Libraries/Components/Touchable/Touchable"]],[["context-line","this._performSideEffectsForTransition(curState, nextState, signal, e);"],["filename","touchable.js"],["function","_receiveSignal"],["module","react-native/Libraries/Components/Touchable/Touchable"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","var funcArgs = Array.prototype.slice.call(arguments, 3);"],["filename","reactnativerenderer-prod.js"],["function","apply"],["module","react-native/Libraries/Renderer/ReactNativeRenderer-prod"]],[["context-line","touchableHandleResponderRelease: function(e) {"],["filename","touchable.js"],["function","arguments"],["module","react-native/Libraries/Components/Touchable/Touchable"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","[native code] forEach"]],[["context-line","executeDispatch(e, !1, dispatchListeners, dispatchInstances);"],["filename","reactnativerenderer-prod.js"],["function","D"],["module","react-native/Libraries/Renderer/ReactNativeRenderer-prod"]]]
+similarity:2020-07-23:type:ident-shingle: "TypeError"
 similarity:2020-07-23:value:character-5-shingle: " '({}"
 similarity:2020-07-23:value:character-5-shingle: " (eva"
 similarity:2020-07-23:value:character-5-shingle: " a fu"
@@ -82,4 +83,3 @@ similarity:2020-07-23:value:character-5-shingle: "valid"
 similarity:2020-07-23:value:character-5-shingle: "valua"
 similarity:2020-07-23:value:character-5-shingle: "{}).i"
 similarity:2020-07-23:value:character-5-shingle: "}).in"
-similarity:2020-07-23:type:ident-shingle: "TypeError"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_cocoa.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2020-08-11T11:59:09.048097Z'
+created: '2020-08-21T21:07:51.123416Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","bar.m"]],[["filename","baz.m"]]]
 similarity:2020-07-23:stacktrace:frames-ident: [["filename","bar.m"]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","bar.m"]],[["filename","baz.m"]]]

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_compute_hashes.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2020-08-11T11:59:10.984036Z'
+created: '2020-08-21T21:07:52.557247Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","foo.py"]],[["filename","bar.py"]]]
 similarity:2020-07-23:stacktrace:frames-ident: [["filename","foo.py"]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","foo.py"]],[["filename","bar.py"]]]

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-19T12:18:49.009584Z'
+created: '2020-08-21T21:07:52.034898Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
@@ -9,6 +9,7 @@ similarity:2020-07-23:stacktrace:frames-pairs: [[["function","log_demo::main"]],
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","std::panicking::try::do_call"]],[["function","std::rt::lang_start::{{closure}}"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","std::rt::lang_start::{{closure}}"]],[["function","log_demo::main"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","std::rt::lang_start_internal"]],[["function","___rust_maybe_catch_panic"]]]
+similarity:2020-07-23:type:ident-shingle: "log_demo"
 similarity:2020-07-23:value:character-5-shingle: " ever"
 similarity:2020-07-23:value:character-5-shingle: " fire"
 similarity:2020-07-23:value:character-5-shingle: " is o"
@@ -37,4 +38,3 @@ similarity:2020-07-23:value:character-5-shingle: "thing"
 similarity:2020-07-23:value:character-5-shingle: "veryt"
 similarity:2020-07-23:value:character-5-shingle: "y shi"
 similarity:2020-07-23:value:character-5-shingle: "ythin"
-similarity:2020-07-23:type:ident-shingle: "log_demo"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_hash_without_system_frames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2020-08-11T11:59:11.341176Z'
+created: '2020-08-21T21:07:52.830567Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","foo.py"]],[["filename","bar.py"]]]
 similarity:2020-07-23:stacktrace:frames-ident: [["filename","foo.py"]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","foo.py"]],[["filename","bar.py"]]]

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_rust.pysnap
@@ -1,14 +1,16 @@
 ---
-created: '2020-08-19T12:18:49.410780Z'
+created: '2020-08-21T21:07:52.337444Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:stacktrace:frames-ident: [["function","log_demo::main"]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","___rust_maybe_catch_panic"]],[["function","std::panicking::try::do_call"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","_main"]],[["function","std::rt::lang_start_internal"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","log_demo::main"]],[["function","log::__private_api_log"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","std::panicking::try::do_call"]],[["function","std::rt::lang_start::{{closure}}"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","std::rt::lang_start::{{closure}}"]],[["function","log_demo::main"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","std::rt::lang_start_internal"]],[["function","___rust_maybe_catch_panic"]]]
+similarity:2020-07-23:type:ident-shingle: "log_demo"
 similarity:2020-07-23:value:character-5-shingle: " ever"
 similarity:2020-07-23:value:character-5-shingle: " fire"
 similarity:2020-07-23:value:character-5-shingle: " is o"
@@ -37,5 +39,3 @@ similarity:2020-07-23:value:character-5-shingle: "thing"
 similarity:2020-07-23:value:character-5-shingle: "veryt"
 similarity:2020-07-23:value:character-5-shingle: "y shi"
 similarity:2020-07-23:value:character-5-shingle: "ythin"
-similarity:2020-07-23:stacktrace:frames-ident: [["function","log_demo::main"]]
-similarity:2020-07-23:type:ident-shingle: "log_demo"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_rust2.pysnap
@@ -1,12 +1,14 @@
 ---
-created: '2020-08-19T12:18:49.859280Z'
+created: '2020-08-21T21:07:52.674605Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:stacktrace:frames-ident: [["function","log_demo::main"]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","_main"]],[["function","std::rt::lang_start_internal"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","std::panicking::try::do_call"]],[["function","std::rt::lang_start::{{closure}}"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","std::rt::lang_start::{{closure}}"]],[["function","log_demo::main"]]]
 similarity:2020-07-23:stacktrace:frames-pairs: [[["function","std::rt::lang_start_internal"]],[["function","std::panicking::try::do_call"]]]
+similarity:2020-07-23:type:ident-shingle: "log_demo"
 similarity:2020-07-23:value:character-5-shingle: " ever"
 similarity:2020-07-23:value:character-5-shingle: " fire"
 similarity:2020-07-23:value:character-5-shingle: " is o"
@@ -35,5 +37,3 @@ similarity:2020-07-23:value:character-5-shingle: "thing"
 similarity:2020-07-23:value:character-5-shingle: "veryt"
 similarity:2020-07-23:value:character-5-shingle: "y shi"
 similarity:2020-07-23:value:character-5-shingle: "ythin"
-similarity:2020-07-23:stacktrace:frames-ident: [["function","log_demo::main"]]
-similarity:2020-07-23:type:ident-shingle: "log_demo"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/stacktrace_with_minimal_app_frames.pysnap
@@ -1,7 +1,7 @@
 ---
-created: '2020-08-11T11:59:11.248786Z'
+created: '2020-08-21T21:07:52.757001Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","foo.py"]],[["filename","bar.py"]]]
 similarity:2020-07-23:stacktrace:frames-ident: [["filename","foo.py"]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","foo.py"]],[["filename","bar.py"]]]

--- a/tests/sentry/grouping/similarity/test_features.py
+++ b/tests/sentry/grouping/similarity/test_features.py
@@ -70,7 +70,7 @@ def test_similarity_extract_grouping_input(grouping_input, insta_snapshot):
         for feature in features:
             snapshot.append("{}: {}".format(":".join(label), json.dumps(feature, sort_keys=True)))
 
-    insta_snapshot("\n".join(snapshot))
+    insta_snapshot("\n".join(sorted(snapshot)))
 
 
 @with_fingerprint_input("fingerprint_input")
@@ -86,7 +86,7 @@ def test_similarity_extract_fingerprinting(fingerprint_input, insta_snapshot):
         for feature in features:
             snapshot.append("{}: {}".format(":".join(label), json.dumps(feature, sort_keys=True)))
 
-    insta_snapshot("\n".join(snapshot))
+    insta_snapshot("\n".join(sorted(snapshot)))
 
 
 def _get_configurations():


### PR DESCRIPTION
This avoids ordering differences of dictionary values between python 2 and 3.