### PR TITLE
feat(integrations): Update toggle copy

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
@@ -57,7 +57,7 @@ const getPublicFormFields = (): Field[] => [
     disabled: ({webhookDisabled}) => webhookDisabled,
     disabledReason: 'Cannot enable alert rule action without a webhook url',
     help: tct(
-      'If enabled, this integration will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions [learn_more:here].',
+      'If enabled, this integration will be available in Issue Alert rules and Metric Alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions [learn_more:here].',
       {
         learn_more: (
           <ExternalLink href="https://docs.sentry.io/product/notifications/#actions" />


### PR DESCRIPTION
Make it clear that the toggle will also let this Sentry App work with Metric Alerts (even if the organization doesn't have them enabled.

Before: 
```
If enabled, this integration will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions here.
```

After: 
```
If enabled, this integration will be available in Issue Alert rules and Metric Alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions here.
```