### PR TITLE
build(gha): Allow acceptance test snapshot dir to be configurable

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -119,6 +119,7 @@ jobs:
             echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
             echo "::set-output name=python-version::2.7"
             echo "::set-output name=matrix-instance-number::$(($MATRIX_INSTANCE+1))"
+            echo "::set-output name=acceptance-dir::.artifacts/visual-snapshots/acceptance"
 
 
         # yarn cache
@@ -191,10 +192,11 @@ jobs:
         - name: Run acceptance tests (#${{ steps.config.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
           if: always()
           run: |
-            mkdir -p .artifacts/visual-snapshots/acceptance
-            mkdir -p .artifacts/visual-snapshots/acceptance-mobile
+            mkdir -p ${{ steps.config.outputs.acceptance-dir }}
+            mkdir -p ${{ steps.config.outputs.acceptance-dir }}-mobile
             make run-acceptance
           env:
+            PYTEST_SNAPSHOTS_DIR: ${{ steps.config.outputs.acceptance-dir }}
             USE_SNUBA: 1
             TEST_GROUP: ${{ matrix.instance }}
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -315,19 +315,22 @@ class Browser(object):
             self.wait_for_images_loaded()
             self.wait_for_fonts_loaded()
 
+            snapshot_dir = os.environ.get(
+                "PYTEST_SNAPSHOTS_DIR", ".artifacts/visual-snapshots/acceptance"
+            )
             # Note: below will fail if these directories do not exist
 
             if not mobile_only:
                 # This will make sure we resize viewport height to fit contents
                 with self.full_viewport():
                     self.driver.find_element_by_tag_name("body").screenshot(
-                        u".artifacts/visual-snapshots/acceptance/{}.png".format(slugify(name))
+                        u"{}/{}.png".format(snapshot_dir, slugify(name))
                     )
 
             with self.mobile_viewport():
                 # switch to a mobile sized viewport
                 self.driver.find_element_by_tag_name("body").screenshot(
-                    u".artifacts/visual-snapshots/acceptance-mobile/{}.png".format(slugify(name))
+                    u"{}-mobile/{}.png".format(snapshot_dir, slugify(name))
                 )
 
         return self


### PR DESCRIPTION
This allows configuration of the snapshot dir for acceptance tests. This will allow us to add more snapshot groups easily (e.g. diff resolutions, or diff media queries)