### PR TITLE
bug(ui): fix platform docs padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "parseurl": "^1.3.2",
     "platformicons": "2.1.1",
     "po-catalog-loader": "2.0.0",
+    "prismjs": "^1.21.0",
     "prop-types": "^15.6.0",
     "query-string": "6.6.0",
     "react": "16.12.0",

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
+import 'prismjs/themes/prism-tomorrow.css';
 
 import {Panel, PanelAlert, PanelBody, PanelHeader} from 'app/components/panels';
 import {loadDocs} from 'app/actionCreators/projects';
@@ -16,8 +17,6 @@ import platforms from 'app/data/platforms';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
-
-const PrismaTheme = require('prismjs/themes/prism-tomorrow.css').toString();
 
 class ProjectInstallPlatform extends React.Component {
   static propTypes = {
@@ -166,7 +165,7 @@ class ProjectInstallPlatform extends React.Component {
 
 const DocumentationWrapper = styled('div')`
   .gatsby-highlight {
-    margin-bottom: 20px;
+    margin-bottom: ${space(3)};
 
     &:last-child {
       margin-bottom: 0;
@@ -174,11 +173,9 @@ const DocumentationWrapper = styled('div')`
   }
 
   .alert {
-    margin-bottom: 20px;
-    border-radius: 3px;
+    margin-bottom: ${space(3)};
+    border-radius: ${p => p.theme.borderRadius};
   }
-
-  ${PrismaTheme}
 
   p {
     line-height: 1.5;

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -17,6 +17,8 @@ import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 
+const PrismaTheme = require('prismjs/themes/prism-tomorrow.css').toString();
+
 class ProjectInstallPlatform extends React.Component {
   static propTypes = {
     api: PropTypes.object,
@@ -163,6 +165,21 @@ class ProjectInstallPlatform extends React.Component {
 }
 
 const DocumentationWrapper = styled('div')`
+  .gatsby-highlight {
+    margin-bottom: 20px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .alert {
+    margin-bottom: 20px;
+    border-radius: 3px;
+  }
+
+  ${PrismaTheme}
+
   p {
     line-height: 1.5;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12827,6 +12827,13 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
+prismjs@^1.21.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.21.0.tgz#36c086ec36b45319ec4218ee164c110f9fc015a3"
+  integrity sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==
+  optionalDependencies:
+    clipboard "^2.0.0"
+
 prismjs@^1.8.4:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.19.0.tgz#713afbd45c3baca4b321569f2df39e17e729d4dc"


### PR DESCRIPTION
Quick fix to improve the look of the in-app onboarding docs.

**Before:**

<img width="1592" alt="Screen Shot 2020-08-22 at 10 59 27 PM" src="https://user-images.githubusercontent.com/30713/90972122-2b0d3000-e4cb-11ea-91bc-7ea05aaf2920.png">

**After:**

<img width="1592" alt="Screen Shot 2020-08-22 at 10 43 23 PM" src="https://user-images.githubusercontent.com/30713/90972077-eda8a280-e4ca-11ea-9b55-861ba1c71f73.png">

Note: This uses the theme we're using on the docs site (prism-tomorrow), but it feels a little out of place here. I'd like to follow up next week with something that matches our colors a bit better.

cc @benvinegar 