### PR TITLE
build(github): Dispatch a  `getsentry` build for sentry PRs

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
     getsentry:
+      if: ${{ github.ref != 'refs/heads/master' }}
       runs-on: ubuntu-16.04
       steps:
         - name: getsentry token
@@ -121,24 +122,6 @@ jobs:
         VISUAL_SNAPSHOT_ENABLE: 1
 
       steps:
-        # Notify getsentry
-        - name: Start getsentry tests
-          if: ${{ github.ref != 'refs/heads/master' }}
-          uses: actions/github-script@v3
-          with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            script: |
-              github.actions.createWorkflowDispatch({
-                owner: 'getsentry',
-                repo: 'getsentry',
-                workflow_id: 'acceptance.yml',
-                ref: 'master',
-                inputs: {
-                  sha: '${{ github.event.pull_request.base.sha }}',
-                  pull_request: '${{ github.event.pull_request.id }}'
-                }
-              })
-
         - name: Install System Dependencies
           run: |
             sudo apt-get update

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -27,8 +27,8 @@ jobs:
                 workflow_id: 'acceptance.yml',
                 ref: 'build/gha/add-workflow-dispatch-for-tests',
                 inputs: {
-                  sha: ${{ github.event.pull_request.base.sha }},
-                  pull_request: ${{ github.event.pull_request.id }}
+                  sha: '${{ github.event.pull_request.base.sha }}',
+                  pull_request: '${{ github.event.pull_request.id }}'
                 }
               })
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -27,7 +27,7 @@ jobs:
                 workflow_id: 'acceptance.yml',
                 ref: 'build/gha/add-workflow-dispatch-for-tests',
                 inputs: {
-                  sha: '${{ github.event.pull_request.base.sha }}',
+                  sha: '${{ github.event.pull_request.head.sha }}',
                   pull_request: '${{ github.event.pull_request.id }}'
                 }
               })

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -14,6 +14,7 @@ jobs:
           id: getsentry
           uses: getsentry/action-github-app-token@v1
           with:
+            app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
             private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
         # Notify getsentry

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -6,6 +6,35 @@ on:
   pull_request:
 
 jobs:
+<<<<<<< HEAD
+=======
+    getsentry:
+      runs-on: ubuntu-16.04
+      steps:
+        - name: getsentry token
+          id: getsentry
+          uses: getsentry/action-github-app-token@v1
+          with:
+            private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
+        # Notify getsentry
+        - name: Dispatch getsentry tests
+          uses: actions/github-script@v3
+          with:
+            github-token: ${{ steps.getsentry.outputs.token }}
+            script: |
+              github.actions.createWorkflowDispatch({
+                owner: 'getsentry',
+                repo: 'getsentry',
+                workflow_id: 'acceptance.yml',
+                ref: 'build/gha/add-workflow-dispatch-for-tests',
+                inputs: {
+                  sha: ${{ github.event.pull_request.base.sha }},
+                  pull_request: ${{ github.event.pull_request.id }}
+                }
+              })
+
+>>>>>>> a6213ebe80... [skip ci] github token
     jest:
       runs-on: ubuntu-latest
       env:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
 
 jobs:
-<<<<<<< HEAD
-=======
     getsentry:
       runs-on: ubuntu-16.04
       steps:
@@ -34,7 +32,6 @@ jobs:
                 }
               })
 
->>>>>>> a6213ebe80... [skip ci] github token
     jest:
       runs-on: ubuntu-latest
       env:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -96,6 +96,24 @@ jobs:
         VISUAL_SNAPSHOT_ENABLE: 1
 
       steps:
+        # Notify getsentry
+        - name: Start getsentry tests
+          if: ${{ github.ref != 'refs/heads/master' }}
+          uses: actions/github-script@v3
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            script: |
+              octokit.actions.createWorkflowDispatch({
+                owner: 'getsentry',
+                repo: 'getsentry',
+                workflow_id: 'acceptance.yml',
+                ref: 'master',
+                inputs: {
+                  sha: '${{ github.event.pull_request.base.sha }}',
+                  pull_request: '${{ github.event.pull_request.id }}'
+                }
+              })
+
         - name: Install System Dependencies
           run: |
             sudo apt-get update

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -103,7 +103,7 @@ jobs:
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             script: |
-              octokit.actions.createWorkflowDispatch({
+              github.actions.createWorkflowDispatch({
                 owner: 'getsentry',
                 repo: 'getsentry',
                 workflow_id: 'acceptance.yml',

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -25,10 +25,9 @@ jobs:
                 owner: 'getsentry',
                 repo: 'getsentry',
                 workflow_id: 'acceptance.yml',
-                ref: 'build/gha/add-workflow-dispatch-for-tests',
+                ref: 'master',
                 inputs: {
                   sha: '${{ github.event.pull_request.head.sha }}',
-                  pull_request: '${{ github.event.pull_request.id }}'
                 }
               })
 


### PR DESCRIPTION
This uses [Github Actions' `workflow_dispatch`](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) to [trigger](https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event) a `getsentry` build that will report back to the PR w/ build status.