### PR TITLE
ref(py3): Fix handling of null bytes in postgres driver

### DIFF
--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from six import string_types
+from six import string_types, binary_type
 import psycopg2 as Database
 
 # Some of these imports are unused, but they are inherited from other engines
@@ -29,6 +29,8 @@ def remove_null(value):
     # somewhat legible rather than error. Considering this is better
     # behavior than the database truncating, seems good to do this
     # rather than attempting to sanitize all data inputs now manually.
+    if type(value) is bytes:
+        return value.replace(b"\x00", b"")
     return value.replace("\x00", "")
 
 
@@ -47,7 +49,7 @@ def remove_surrogates(value):
 def clean_bad_params(params):
     params = list(params)
     for idx, param in enumerate(params):
-        if isinstance(param, string_types):
+        if isinstance(param, (string_types, binary_type)):
             params[idx] = remove_null(remove_surrogates(param))
     return params
 

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import pytest
 from sentry.testutils import TestCase
 from sentry.constants import MAX_CULPRIT_LENGTH
-from django.utils.encoding import force_text
+from django.utils.encoding import force_text, force_bytes
 from sentry.utils.compat import map
 
 
@@ -22,7 +22,8 @@ class CursorWrapperTestCase(TestCase):
 
         cursor = connection.cursor()
         cursor.execute("SELECT %s", [b"Ma\x00tt"])
-        assert cursor.fetchone()[0] == b"Matt"
+        assert force_bytes(cursor.fetchone()[0]) == b"Matt"
+
         cursor.execute("SELECT %s", [u"Ma\x00tt"])
         assert cursor.fetchone()[0] == u"Matt"
 
@@ -35,7 +36,7 @@ class CursorWrapperTestCase(TestCase):
         assert len(long_str) <= MAX_CULPRIT_LENGTH
 
         cursor.execute("SELECT %s", [long_str])
-        long_str_from_db = cursor.fetchone()[0]
+        long_str_from_db = force_bytes(cursor.fetchone()[0])
         assert long_str_from_db == (b"a" * (MAX_CULPRIT_LENGTH - 1))
         assert len(long_str_from_db) <= MAX_CULPRIT_LENGTH
 


### PR DESCRIPTION
Fixes two issues here:

 * In python3 we get back a memory view from selecting bytes, so we coerce that to bytes for comparison

 * Explicitly handle removal of the null byte in byte objects, which don't exist in python2.