### PR TITLE
ref(alert): Add comment to issue occurrences filter

### DIFF
--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -23,6 +23,7 @@ class IssueOccurrencesFilter(EventFilter):
         except (TypeError, ValueError):
             return False
 
-        # this value is slightly delayed due to us batching writes to times_seen. This can cause the filter to be delayed or occasionally not work as expected.
+        # This value is slightly delayed due to us batching writes to times_seen,
+        # which can cause the filter to be delayed or occasionally not work as expected.
         issue_occurrences = event.group.times_seen
         return issue_occurrences >= value

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -23,7 +23,7 @@ class IssueOccurrencesFilter(EventFilter):
         except (TypeError, ValueError):
             return False
 
-        # This value is slightly delayed due to us batching writes to times_seen,
+        # This value is slightly delayed due to us batching writes to times_seen
         # which can cause the filter to be delayed or occasionally not work as expected.
         issue_occurrences = event.group.times_seen
         return issue_occurrences >= value

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -23,5 +23,6 @@ class IssueOccurrencesFilter(EventFilter):
         except (TypeError, ValueError):
             return False
 
+        # this value is slightly delayed due to us batching writes to times_seen. This can cause the filter to be delayed or occasionally not work as expected.
         issue_occurrences = event.group.times_seen
         return issue_occurrences >= value


### PR DESCRIPTION
Because of batch writes to `times_seen` of a group, this filter may be delayed. Added a comment to bring awareness to this potential limitation.