### PR TITLE
fix(integrations): don't query projects that aren't visible

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -16,6 +16,7 @@ from sentry.integrations import (
     FeatureDescription,
 )
 from sentry import options
+from sentry.constants import ObjectStatus
 from sentry.pipeline import NestedPipelineView
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.utils.http import absolute_uri
@@ -147,7 +148,9 @@ class VercelIntegration(IntegrationInstallation):
         sentry_projects = map(
             lambda proj: {key: proj[key] for key in proj_fields},
             (
-                Project.objects.filter(organization_id=self.organization_id)
+                Project.objects.filter(
+                    organization_id=self.organization_id, status=ObjectStatus.VISIBLE
+                )
                 .order_by("slug")
                 .values(*proj_fields)
             ),

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -93,6 +93,14 @@ class OrganizationPluginsTest(APITestCase):
             }
         ]
 
+    def test_disabled_proejct(self):
+        plugins.get("trello").enable(self.projectA)
+        plugins.get("trello").set_option("key", "some_value", self.projectA)
+        self.projectA.status = 1
+        self.projectA.save()
+        response = self.client.get(self.url)
+        assert filter(lambda x: x["slug"] == "trello", response.data)[0]["projectList"] == []
+
     def test_configured_multiple_projects(self):
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         plugins.get("trello").set_option("key", "another_value", self.projectB)


### PR DESCRIPTION
This PR fixes two bugs with the same underlying root cause: not checking the status of the project when making a query. This fixes it where we list projects for Vercel and where we list projects for plugin configurations.

Fixes https://github.com/getsentry/sentry/issues/20132