### PR TITLE
feat(metric alerts): Update PagerDuty payload

### DIFF
--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -26,17 +26,15 @@ def build_incident_attachment(incident, integration_key, metric_value=None):
     if incident.status in [IncidentStatus.WARNING.value, IncidentStatus.CRITICAL.value]:
         event_action = "trigger"
 
-    footer_text = "Sentry Incident | {}".format(data["ts"].strftime("%b %d"))
-
     return {
         "routing_key": integration_key,
         "event_action": event_action,
         "dedup_key": "incident_{}_{}".format(incident.organization_id, incident.identifier),
         "payload": {
-            "summary": data["text"],
+            "summary": data["title"],
             "severity": severity,
             "source": incident.identifier,
-            "custom_details": footer_text,
+            "custom_details": {"details": data["text"]},
         },
         "links": [{"href": data["title_link"], "text": data["title"]}],
     }

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -33,7 +33,7 @@ def build_incident_attachment(incident, integration_key, metric_value=None):
         "payload": {
             "summary": data["title"],
             "severity": severity,
-            "source": incident.identifier,
+            "source": six.binary_type(incident.identifier),
             "custom_details": {"details": data["text"]},
         },
         "links": [{"href": data["title_link"], "text": data["title"]}],

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -346,14 +346,12 @@ class PagerDutyActionHandlerBaseTest(object):
         assert data["dedup_key"] == "incident_{}_{}".format(
             incident.organization_id, incident.identifier
         )
-        assert (
-            data["payload"]["summary"] == "1000 events in the last 10 minutes\nFilter: level:error"
-        )
+        assert data["payload"]["summary"] == "Critical: {}".format(alert_rule.name)
         assert data["payload"]["severity"] == "critical"
         assert data["payload"]["source"] == incident.identifier
-        assert data["payload"]["custom_details"] == "Sentry Incident | {}".format(
-            incident.date_started.strftime("%b %d")
-        )
+        assert data["payload"]["custom_details"] == {
+            "details": "1000 events in the last 10 minutes\nFilter: level:error"
+        }
         assert data["links"][0]["text"] == "Critical: {}".format(alert_rule.name)
         assert data["links"][0]["href"] == "http://testserver/organizations/baz/alerts/1/"
 

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -348,7 +348,7 @@ class PagerDutyActionHandlerBaseTest(object):
         )
         assert data["payload"]["summary"] == "Critical: {}".format(alert_rule.name)
         assert data["payload"]["severity"] == "critical"
-        assert data["payload"]["source"] == incident.identifier
+        assert data["payload"]["source"] == six.binary_type(incident.identifier)
         assert data["payload"]["custom_details"] == {
             "details": "1000 events in the last 10 minutes\nFilter: level:error"
         }


### PR DESCRIPTION
This PR changes the PagerDuty metric alert payload slightly

**summary**: num events / time period >> status: metric alert rule name
**custom details**: Sentry Incident | Date >> num events / time period

This also turns custom details into a dictionary for easy future expansion if needed. 

### Before
![pd_metric_alert_triggered](https://user-images.githubusercontent.com/29959063/91101135-5141e580-e61b-11ea-9b6b-11f55de33a66.png)


### After
![Screen Shot 2020-08-24 at 3 01 18 PM](https://user-images.githubusercontent.com/29959063/91100987-0a53f000-e61b-11ea-90a5-f4a780aa972d.png)

**Note**: Sorry if this is a little confusing, my metic alert rule name is "bloop2: the electric bloopaloo" so the summary is "Critical: Name of My Metric Alert"

### Example Payload

```
{
    'event_action': 'trigger', 
    'payload': {
        'custom_details': {
            'details': '1000 events in the last 10 minutes'
        }, 
        'source': 1, 
        'severity': 'critical', 
        'summary': u'Critical: Emerging Rodent'
    }, 
    'routing_key': '12345678', 
    'links': [{
        'text': u'Critical: Emerging Rodent', 
        'href': u'http://testserver/organizations/baz/alerts/1/'
    }], 
    'dedup_key': 'incident_13_1'
}
```
