### PR TITLE
ref(py3): Correct hmac signature generation / comp in slack request

### DIFF
--- a/src/sentry/integrations/slack/requests.py
+++ b/src/sentry/integrations/slack/requests.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import hmac
-import six
 from hashlib import sha256
 
 from sentry import options
@@ -119,9 +118,9 @@ class SlackRequest(object):
         signature = self.request.META["HTTP_X_SLACK_SIGNATURE"]
         timestamp = self.request.META["HTTP_X_SLACK_REQUEST_TIMESTAMP"]
 
-        req = six.binary_type("v0:%s:%s" % (timestamp, self.request.body))
-        request_hash = "v0=" + hmac.new(six.binary_type(signing_secret), req, sha256).hexdigest()
-        return hmac.compare_digest(six.binary_type(request_hash), six.binary_type(signature))
+        req = b"v0:%s:%s" % (timestamp.encode("utf-8"), self.request.body)
+        request_hash = "v0=" + hmac.new(signing_secret.encode("utf-8"), req, sha256).hexdigest()
+        return hmac.compare_digest(request_hash.encode("utf-8"), signature.encode("utf-8"))
 
     def _check_verification_token(self, verification_token):
         return self.data.get("token") == verification_token

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -111,9 +111,9 @@ class SlackEventRequestTest(TestCase):
 
     def set_signature(self, secret, data):
         timestamp = six.text_type(int(time.mktime(datetime.utcnow().timetuple())))
-        req = six.binary_type("v0:%s:%s" % (timestamp, six.binary_type(data)))
+        req = b"v0:%s:%s" % (timestamp.encode("utf-8"), data)
 
-        signature = "v0=" + hmac.new(six.binary_type(secret), req, sha256).hexdigest()
+        signature = "v0=" + hmac.new(secret.encode("utf-8"), req, sha256).hexdigest()
         self.request.META["HTTP_X_SLACK_REQUEST_TIMESTAMP"] = timestamp
         self.request.META["HTTP_X_SLACK_SIGNATURE"] = signature
 
@@ -161,7 +161,7 @@ class SlackEventRequestTest(TestCase):
             self.request.data = {"challenge": "abc123", "type": "url_verification"}
 
             # we get a url encoded body with Slack
-            self.request.body = urlencode(self.request.data)
+            self.request.body = urlencode(self.request.data).encode("utf-8")
 
             self.set_signature(options.get("slack.signing-secret"), self.request.body)
             self.slack_request.validate()
@@ -171,7 +171,7 @@ class SlackEventRequestTest(TestCase):
             self.request.data = {"challenge": "abc123", "type": "url_verification"}
 
             # we get a url encoded body with Slack
-            self.request.body = urlencode(self.request.data)
+            self.request.body = urlencode(self.request.data).encode("utf-8")
 
             self.set_signature(options.get("slack-v2.signing-secret"), self.request.body)
             self.slack_request.validate()
@@ -184,7 +184,7 @@ class SlackEventRequestTest(TestCase):
                 "challenge": "abc123",
                 "type": "url_verification",
             }
-            self.request.body = urlencode(self.request.data)
+            self.request.body = urlencode(self.request.data).encode("utf-8")
 
             self.set_signature("bad_key", self.request.body)
             with self.assertRaises(SlackRequestError) as e:
@@ -197,7 +197,7 @@ class SlackEventRequestTest(TestCase):
             "challenge": "abc123",
             "type": "url_verification",
         }
-        self.request.body = json.dumps(self.request.data)
+        self.request.body = json.dumps(self.request.data).encode("utf-8")
 
         self.slack_request.validate()
 


### PR DESCRIPTION
Would like more eyes on this to make sure I didn't do this incorrectly
and tests are false positives now