### PR TITLE
feat(integrations): Save Sentry Apps to AlertRuleTriggerActions

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -26,13 +26,13 @@ class AlertRuleTriggerActionSerializer(Serializer):
             return "Send a notification via " + action.target_display
 
     def get_identifier_from_action(self, action):
-        target_identifier = (
-            action.target_display if action.target_display is not None else action.target_identifier
-        )
-        if action.type == action.Type.PAGERDUTY.value:
-            target_identifier = int(action.target_identifier)
+        if action.type in [
+            AlertRuleTriggerAction.Type.PAGERDUTY.value,
+            AlertRuleTriggerAction.Type.SENTRY_APP.value,
+        ]:
+            return int(action.target_identifier)
 
-        return target_identifier
+        return action.target_display if action.target_display is not None else action.target_identifier
 
     def serialize(self, obj, attrs, user):
         from sentry.incidents.endpoints.serializers import action_target_type_to_string
@@ -48,6 +48,7 @@ class AlertRuleTriggerActionSerializer(Serializer):
             ],
             "targetIdentifier": self.get_identifier_from_action(obj),
             "integrationId": obj.integration_id,
+            "sentryAppId": obj.sentry_app_id,
             "dateCreated": obj.date_added,
             "desc": self.human_desc(obj),
         }

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -32,7 +32,9 @@ class AlertRuleTriggerActionSerializer(Serializer):
         ]:
             return int(action.target_identifier)
 
-        return action.target_display if action.target_display is not None else action.target_identifier
+        return (
+            action.target_display if action.target_display is not None else action.target_identifier
+        )
 
     def serialize(self, obj, attrs, user):
         from sentry.incidents.endpoints.serializers import action_target_type_to_string

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -84,11 +84,13 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
             "target_type",
             "target_identifier",
             "integration",
+            "sentry_app",
         ]
         extra_kwargs = {
             "target_identifier": {"required": True},
             "target_display": {"required": False},
             "integration": {"required": False, "allow_null": True},
+            "sentry_app": {"required": False, "allow_null": True},
         }
 
     def validate_type(self, type):
@@ -154,6 +156,12 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
             if not attrs.get("integration"):
                 raise serializers.ValidationError(
                     {"integration": "Integration must be provided for slack"}
+                )
+
+        elif attrs.get("type") == AlertRuleTriggerAction.Type.SENTRY_APP:
+            if not attrs.get("sentry_app"):
+                raise serializers.ValidationError(
+                    {"sentry_app": "SentryApp must be provided for sentry_app"}
                 )
 
         return attrs
@@ -231,6 +239,9 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
             for action_data in actions:
                 if "integration_id" in action_data:
                     action_data["integration"] = action_data.pop("integration_id")
+
+                if "sentry_app_id" in action_data:
+                    action_data["sentry_app"] = action_data.pop("sentry_app_id")
 
                 if "id" in action_data:
                     action_instance = AlertRuleTriggerAction.objects.get(

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -345,9 +345,12 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             )
 
     def validate(self, data):
-        """Performs validation on an alert rule's data
-        This includes ensuring there is either 1 or 2 triggers, which each have actions, and have proper thresholds set.
-        The critical trigger should both alert and resolve 'after' the warning trigger (whether that means > or < the value depends on threshold type).
+        """
+        Performs validation on an alert rule's data.
+        This includes ensuring there is either 1 or 2 triggers, which each have
+        actions, and have proper thresholds set. The critical trigger should
+        both alert and resolve 'after' the warning trigger (whether that means
+        > or < the value depends on threshold type).
         """
         data.setdefault("dataset", QueryDatasets.EVENTS)
         project_id = data.get("projects")

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -69,16 +69,16 @@ class InvalidTriggerActionError(Exception):
 
 
 def create_incident(
-    organization,
-    type_,
-    title,
-    date_started,
-    date_detected=None,
-    # TODO: Probably remove detection_uuid?
-    detection_uuid=None,
-    projects=None,
-    user=None,
-    alert_rule=None,
+        organization,
+        type_,
+        title,
+        date_started,
+        date_detected=None,
+        # TODO: Probably remove detection_uuid?
+        detection_uuid=None,
+        projects=None,
+        user=None,
+        alert_rule=None,
 ):
     if date_detected is None:
         date_detected = date_started
@@ -120,12 +120,12 @@ def create_incident(
 
 
 def update_incident_status(
-    incident,
-    status,
-    user=None,
-    comment=None,
-    status_method=IncidentStatusMethod.RULE_TRIGGERED,
-    date_closed=None,
+        incident,
+        status,
+        user=None,
+        comment=None,
+        status_method=IncidentStatusMethod.RULE_TRIGGERED,
+        date_closed=None,
 ):
     """
     Updates the status of an Incident and write an IncidentActivity row to log
@@ -175,8 +175,8 @@ def update_incident_status(
         )
 
         if status == IncidentStatus.CLOSED and (
-            status_method == IncidentStatusMethod.MANUAL
-            or status_method == IncidentStatusMethod.RULE_UPDATED
+                status_method == IncidentStatusMethod.MANUAL
+                or status_method == IncidentStatusMethod.RULE_UPDATED
         ):
             trigger_incident_triggers(incident)
 
@@ -193,7 +193,7 @@ def set_incident_seen(incident, user=None):
     if is_org_member:
         is_project_member = False
         for incident_project in IncidentProject.objects.filter(incident=incident).select_related(
-            "project"
+                "project"
         ):
             if incident_project.project.member_set.filter(user=user).exists():
                 is_project_member = True
@@ -210,14 +210,14 @@ def set_incident_seen(incident, user=None):
 
 @transaction.atomic
 def create_incident_activity(
-    incident,
-    activity_type,
-    user=None,
-    value=None,
-    previous_value=None,
-    comment=None,
-    mentioned_user_ids=None,
-    date_added=None,
+        incident,
+        activity_type,
+        user=None,
+        value=None,
+        previous_value=None,
+        comment=None,
+        mentioned_user_ids=None,
+        date_added=None,
 ):
     if activity_type == IncidentActivityType.COMMENT and user:
         subscribe_to_incident(incident, user)
@@ -468,7 +468,7 @@ def get_incident_event_stats(incident, start=None, end=None, windowed_stats=Fals
 
 
 def get_incident_aggregates(
-    incident, start=None, end=None, windowed_stats=False, use_alert_aggregate=False
+        incident, start=None, end=None, windowed_stats=False, use_alert_aggregate=False
 ):
     """
     Calculates aggregate stats across the life of an incident, or the provided range.
@@ -547,20 +547,20 @@ DEFAULT_ALERT_RULE_RESOLUTION = 1
 
 
 def create_alert_rule(
-    organization,
-    projects,
-    name,
-    query,
-    aggregate,
-    time_window,
-    threshold_type,
-    threshold_period,
-    resolve_threshold=None,
-    environment=None,
-    include_all_projects=False,
-    excluded_projects=None,
-    dataset=QueryDatasets.EVENTS,
-    user=None,
+        organization,
+        projects,
+        name,
+        query,
+        aggregate,
+        time_window,
+        threshold_type,
+        threshold_period,
+        resolve_threshold=None,
+        environment=None,
+        include_all_projects=False,
+        excluded_projects=None,
+        dataset=QueryDatasets.EVENTS,
+        user=None,
 ):
     """
     Creates an alert rule for an organization.
@@ -670,20 +670,20 @@ def snapshot_alert_rule(alert_rule, user=None):
 
 
 def update_alert_rule(
-    alert_rule,
-    dataset=None,
-    projects=None,
-    name=None,
-    query=None,
-    aggregate=None,
-    time_window=None,
-    environment=None,
-    threshold_type=None,
-    threshold_period=None,
-    resolve_threshold=NOT_SET,
-    include_all_projects=None,
-    excluded_projects=None,
-    user=None,
+        alert_rule,
+        dataset=None,
+        projects=None,
+        name=None,
+        query=None,
+        aggregate=None,
+        time_window=None,
+        environment=None,
+        threshold_type=None,
+        threshold_period=None,
+        resolve_threshold=NOT_SET,
+        include_all_projects=None,
+        excluded_projects=None,
+        user=None,
 ):
     """
     Updates an alert rule.
@@ -709,9 +709,9 @@ def update_alert_rule(
     :return: The updated `AlertRule`
     """
     if (
-        name
-        and alert_rule.name != name
-        and AlertRule.objects.filter(organization=alert_rule.organization, name=name).exists()
+            name
+            and alert_rule.name != name
+            and AlertRule.objects.filter(organization=alert_rule.organization, name=name).exists()
     ):
         raise AlertRuleNameAlreadyUsedError()
 
@@ -763,12 +763,12 @@ def update_alert_rule(
 
         existing_subs = []
         if (
-            query is not None
-            or aggregate is not None
-            or time_window is not None
-            or projects is not None
-            or include_all_projects is not None
-            or excluded_projects is not None
+                query is not None
+                or aggregate is not None
+                or time_window is not None
+                or projects is not None
+                or include_all_projects is not None
+                or excluded_projects is not None
         ):
             existing_subs = alert_rule.snuba_query.subscriptions.all().select_related("project")
 
@@ -941,9 +941,9 @@ def update_alert_rule_trigger(trigger, label=None, alert_threshold=None, exclude
     """
 
     if (
-        AlertRuleTrigger.objects.filter(alert_rule=trigger.alert_rule, label=label)
-        .exclude(id=trigger.id)
-        .exists()
+            AlertRuleTrigger.objects.filter(alert_rule=trigger.alert_rule, label=label)
+                    .exclude(id=trigger.id)
+                    .exists()
     ):
         raise AlertRuleTriggerLabelAlreadyUsedError()
 
@@ -1008,7 +1008,7 @@ def trigger_incident_triggers(incident):
             with transaction.atomic():
                 method = "resolve"
                 for action in AlertRuleTriggerAction.objects.filter(
-                    alert_rule_trigger=trigger.alert_rule_trigger
+                        alert_rule_trigger=trigger.alert_rule_trigger
                 ):
                     for project in incident.projects.all():
                         transaction.on_commit(
@@ -1042,7 +1042,7 @@ def get_subscriptions_from_alert_rule(alert_rule, projects):
 
 
 def create_alert_rule_trigger_action(
-    trigger, type, target_type, target_identifier=None, integration=None
+        trigger, type, target_type, target_identifier=None, integration=None
 ):
     """
     Creates an AlertRuleTriggerAction
@@ -1075,7 +1075,12 @@ def create_alert_rule_trigger_action(
 
 
 def update_alert_rule_trigger_action(
-    trigger_action, type=None, target_type=None, target_identifier=None, integration=None
+    trigger_action,
+    type=None,
+    target_type=None,
+    target_identifier=None,
+    integration=None,
+    sentry_app=None
 ):
     """
     Updates values on an AlertRuleTriggerAction
@@ -1085,6 +1090,7 @@ def update_alert_rule_trigger_action(
     :param target_identifier: The identifier of the target
     :param target_display: Human readable name for the target
     :param integration: The Integration related to this action.
+    :param sentry_app: The SentryApp related to this action.
     :return:
     """
     updated_fields = {}
@@ -1094,6 +1100,8 @@ def update_alert_rule_trigger_action(
         updated_fields["target_type"] = target_type.value
     if integration is not None:
         updated_fields["integration"] = integration
+    if sentry_app is not None:
+        updated_fields["sentry_app"] = sentry_app
     if target_identifier is not None:
         type = updated_fields.get("type", trigger_action.type)
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1042,7 +1042,12 @@ def get_subscriptions_from_alert_rule(alert_rule, projects):
 
 
 def create_alert_rule_trigger_action(
-        trigger, type, target_type, target_identifier=None, integration=None
+    trigger,
+    type,
+    target_type,
+    target_identifier=None,
+    integration=None,
+    sentry_app=None
 ):
     """
     Creates an AlertRuleTriggerAction
@@ -1052,6 +1057,7 @@ def create_alert_rule_trigger_action(
     :param target_identifier: (Optional) The identifier of the target
     :param target_display: (Optional) Human readable name for the target
     :param integration: (Optional) The Integration related to this action.
+    :param sentry_app: (Optional) The Sentry App related to this action.
     :return: The created action
     """
 
@@ -1063,6 +1069,10 @@ def create_alert_rule_trigger_action(
         target_identifier, target_display = get_target_identifier_display_for_integration(
             type.value, target_identifier, trigger.alert_rule.organization, integration.id
         )
+    elif type == AlertRuleTriggerAction.Type.SENTRY_APP:
+        target_identifier, target_display = get_alert_rule_trigger_action_sentry_app(
+            trigger.alert_rule.organization, sentry_app.id
+        )
 
     return AlertRuleTriggerAction.objects.create(
         alert_rule_trigger=trigger,
@@ -1071,6 +1081,7 @@ def create_alert_rule_trigger_action(
         target_identifier=target_identifier,
         target_display=target_display,
         integration=integration,
+        sentry_app=sentry_app,
     )
 
 
@@ -1088,9 +1099,8 @@ def update_alert_rule_trigger_action(
     :param type: Which sort of action to take
     :param target_type: Which type of target to send to
     :param target_identifier: The identifier of the target
-    :param target_display: Human readable name for the target
-    :param integration: The Integration related to this action.
-    :param sentry_app: The SentryApp related to this action.
+    :param integration: (Optional) The Integration related to this action.
+    :param sentry_app: (Optional) The SentryApp related to this action.
     :return:
     """
     updated_fields = {}
@@ -1113,6 +1123,16 @@ def update_alert_rule_trigger_action(
                 type, target_identifier, organization, integration.id,
             )
             updated_fields["target_display"] = target_display
+
+        elif type == AlertRuleTriggerAction.Type.SENTRY_APP.value:
+            sentry_app = updated_fields.get("sentry_app", trigger_action.sentry_app)
+            organization = trigger_action.alert_rule_trigger.alert_rule.organization
+
+            target_identifier, target_display = get_alert_rule_trigger_action_sentry_app(
+                organization, sentry_app.id,
+            )
+            updated_fields["target_display"] = target_display
+
         updated_fields["target_identifier"] = target_identifier
     trigger_action.update(**updated_fields)
     return trigger_action
@@ -1187,6 +1207,15 @@ def get_alert_rule_trigger_action_pagerduty_service(target_value, organization, 
         raise InvalidTriggerActionError("No PagerDuty service found.")
 
     return (service.id, service.service_name)
+
+
+def get_alert_rule_trigger_action_sentry_app(organization, sentry_app_id):
+    try:
+        sentry_app = SentryApp.objects.get(id=sentry_app_id, owner=organization)
+    except SentryApp.DoesNotExist:
+        raise InvalidTriggerActionError("No SentryApp found.")
+
+    return sentry_app.id, sentry_app.name
 
 
 def delete_alert_rule_trigger_action(trigger_action):

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -69,16 +69,16 @@ class InvalidTriggerActionError(Exception):
 
 
 def create_incident(
-        organization,
-        type_,
-        title,
-        date_started,
-        date_detected=None,
-        # TODO: Probably remove detection_uuid?
-        detection_uuid=None,
-        projects=None,
-        user=None,
-        alert_rule=None,
+    organization,
+    type_,
+    title,
+    date_started,
+    date_detected=None,
+    # TODO: Probably remove detection_uuid?
+    detection_uuid=None,
+    projects=None,
+    user=None,
+    alert_rule=None,
 ):
     if date_detected is None:
         date_detected = date_started
@@ -120,12 +120,12 @@ def create_incident(
 
 
 def update_incident_status(
-        incident,
-        status,
-        user=None,
-        comment=None,
-        status_method=IncidentStatusMethod.RULE_TRIGGERED,
-        date_closed=None,
+    incident,
+    status,
+    user=None,
+    comment=None,
+    status_method=IncidentStatusMethod.RULE_TRIGGERED,
+    date_closed=None,
 ):
     """
     Updates the status of an Incident and write an IncidentActivity row to log
@@ -175,8 +175,8 @@ def update_incident_status(
         )
 
         if status == IncidentStatus.CLOSED and (
-                status_method == IncidentStatusMethod.MANUAL
-                or status_method == IncidentStatusMethod.RULE_UPDATED
+            status_method == IncidentStatusMethod.MANUAL
+            or status_method == IncidentStatusMethod.RULE_UPDATED
         ):
             trigger_incident_triggers(incident)
 
@@ -193,7 +193,7 @@ def set_incident_seen(incident, user=None):
     if is_org_member:
         is_project_member = False
         for incident_project in IncidentProject.objects.filter(incident=incident).select_related(
-                "project"
+            "project"
         ):
             if incident_project.project.member_set.filter(user=user).exists():
                 is_project_member = True
@@ -210,14 +210,14 @@ def set_incident_seen(incident, user=None):
 
 @transaction.atomic
 def create_incident_activity(
-        incident,
-        activity_type,
-        user=None,
-        value=None,
-        previous_value=None,
-        comment=None,
-        mentioned_user_ids=None,
-        date_added=None,
+    incident,
+    activity_type,
+    user=None,
+    value=None,
+    previous_value=None,
+    comment=None,
+    mentioned_user_ids=None,
+    date_added=None,
 ):
     if activity_type == IncidentActivityType.COMMENT and user:
         subscribe_to_incident(incident, user)
@@ -468,7 +468,7 @@ def get_incident_event_stats(incident, start=None, end=None, windowed_stats=Fals
 
 
 def get_incident_aggregates(
-        incident, start=None, end=None, windowed_stats=False, use_alert_aggregate=False
+    incident, start=None, end=None, windowed_stats=False, use_alert_aggregate=False
 ):
     """
     Calculates aggregate stats across the life of an incident, or the provided range.
@@ -547,20 +547,20 @@ DEFAULT_ALERT_RULE_RESOLUTION = 1
 
 
 def create_alert_rule(
-        organization,
-        projects,
-        name,
-        query,
-        aggregate,
-        time_window,
-        threshold_type,
-        threshold_period,
-        resolve_threshold=None,
-        environment=None,
-        include_all_projects=False,
-        excluded_projects=None,
-        dataset=QueryDatasets.EVENTS,
-        user=None,
+    organization,
+    projects,
+    name,
+    query,
+    aggregate,
+    time_window,
+    threshold_type,
+    threshold_period,
+    resolve_threshold=None,
+    environment=None,
+    include_all_projects=False,
+    excluded_projects=None,
+    dataset=QueryDatasets.EVENTS,
+    user=None,
 ):
     """
     Creates an alert rule for an organization.
@@ -670,20 +670,20 @@ def snapshot_alert_rule(alert_rule, user=None):
 
 
 def update_alert_rule(
-        alert_rule,
-        dataset=None,
-        projects=None,
-        name=None,
-        query=None,
-        aggregate=None,
-        time_window=None,
-        environment=None,
-        threshold_type=None,
-        threshold_period=None,
-        resolve_threshold=NOT_SET,
-        include_all_projects=None,
-        excluded_projects=None,
-        user=None,
+    alert_rule,
+    dataset=None,
+    projects=None,
+    name=None,
+    query=None,
+    aggregate=None,
+    time_window=None,
+    environment=None,
+    threshold_type=None,
+    threshold_period=None,
+    resolve_threshold=NOT_SET,
+    include_all_projects=None,
+    excluded_projects=None,
+    user=None,
 ):
     """
     Updates an alert rule.
@@ -709,9 +709,9 @@ def update_alert_rule(
     :return: The updated `AlertRule`
     """
     if (
-            name
-            and alert_rule.name != name
-            and AlertRule.objects.filter(organization=alert_rule.organization, name=name).exists()
+        name
+        and alert_rule.name != name
+        and AlertRule.objects.filter(organization=alert_rule.organization, name=name).exists()
     ):
         raise AlertRuleNameAlreadyUsedError()
 
@@ -763,12 +763,12 @@ def update_alert_rule(
 
         existing_subs = []
         if (
-                query is not None
-                or aggregate is not None
-                or time_window is not None
-                or projects is not None
-                or include_all_projects is not None
-                or excluded_projects is not None
+            query is not None
+            or aggregate is not None
+            or time_window is not None
+            or projects is not None
+            or include_all_projects is not None
+            or excluded_projects is not None
         ):
             existing_subs = alert_rule.snuba_query.subscriptions.all().select_related("project")
 
@@ -941,9 +941,9 @@ def update_alert_rule_trigger(trigger, label=None, alert_threshold=None, exclude
     """
 
     if (
-            AlertRuleTrigger.objects.filter(alert_rule=trigger.alert_rule, label=label)
-                    .exclude(id=trigger.id)
-                    .exists()
+        AlertRuleTrigger.objects.filter(alert_rule=trigger.alert_rule, label=label)
+        .exclude(id=trigger.id)
+        .exists()
     ):
         raise AlertRuleTriggerLabelAlreadyUsedError()
 
@@ -1008,7 +1008,7 @@ def trigger_incident_triggers(incident):
             with transaction.atomic():
                 method = "resolve"
                 for action in AlertRuleTriggerAction.objects.filter(
-                        alert_rule_trigger=trigger.alert_rule_trigger
+                    alert_rule_trigger=trigger.alert_rule_trigger
                 ):
                     for project in incident.projects.all():
                         transaction.on_commit(
@@ -1042,12 +1042,7 @@ def get_subscriptions_from_alert_rule(alert_rule, projects):
 
 
 def create_alert_rule_trigger_action(
-    trigger,
-    type,
-    target_type,
-    target_identifier=None,
-    integration=None,
-    sentry_app=None
+    trigger, type, target_type, target_identifier=None, integration=None, sentry_app=None
 ):
     """
     Creates an AlertRuleTriggerAction
@@ -1091,7 +1086,7 @@ def update_alert_rule_trigger_action(
     target_type=None,
     target_identifier=None,
     integration=None,
-    sentry_app=None
+    sentry_app=None,
 ):
     """
     Updates values on an AlertRuleTriggerAction

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -13,51 +13,11 @@ from sentry.auth.access import OrganizationGlobalAccess
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer
 from sentry.incidents.models import AlertRule, AlertRuleStatus, Incident, IncidentStatus
 from sentry.testutils import APITestCase
+from tests.sentry.incidents.endpoints.test_organization_alert_rule_index import AlertRuleBase
 
 
-class AlertRuleDetailsBase(object):
+class AlertRuleDetailsBase(AlertRuleBase):
     endpoint = "sentry-api-0-organization-alert-rule-details"
-
-    @fixture
-    def organization(self):
-        return self.create_organization()
-
-    @fixture
-    def project(self):
-        return self.create_project(organization=self.organization)
-
-    @fixture
-    def user(self):
-        return self.create_user()
-
-    @fixture
-    def alert_rule_dict(self):
-        return {
-            "aggregate": "count()",
-            "query": "",
-            "timeWindow": "300",
-            "projects": [self.project.slug],
-            "name": "JustAValidTestRule",
-            "resolveThreshold": 100,
-            "thresholdType": 0,
-            "triggers": [
-                {
-                    "label": "critical",
-                    "alertThreshold": 200,
-                    "actions": [
-                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id}
-                    ],
-                },
-                {
-                    "label": "warning",
-                    "alertThreshold": 150,
-                    "actions": [
-                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id},
-                        {"type": "email", "targetType": "user", "targetIdentifier": self.user.id},
-                    ],
-                },
-            ],
-        }
 
     def new_alert_rule(self, data=None):
         if data is None:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -117,6 +117,37 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data == serialize(alert_rule)
         assert resp.data["name"] == "what"
 
+    def test_sentry_app(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        sentry_app = self.create_sentry_app(
+            name="foo", organization=self.organization, is_alertable=True, verify_install=False
+        )
+        self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization, user=self.user
+        )
+        self.login_as(self.user)
+        alert_rule = self.alert_rule
+        # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
+        serialized_alert_rule = self.get_serialized_alert_rule()
+        serialized_alert_rule["name"] = "ValidSentryAppTestRule"
+        serialized_alert_rule["triggers"][0]["actions"][0] = {
+            "type": "sentry_app",
+            "targetType": "sentry_app",
+            "targetIdentifier": sentry_app.id,
+            "sentryAppId": sentry_app.id,
+        }
+
+        with self.feature(["organizations:incidents", "organizations:integrations-sentry-app-metric-alerts"]):
+            resp = self.get_valid_response(
+                self.organization.slug, alert_rule.id, **serialized_alert_rule
+            )
+
+        alert_rule.name = "ValidSentryAppTestRule"
+        assert resp.data == serialize(alert_rule)
+        assert resp.data["triggers"][0]["actions"][0]["sentryAppId"] == sentry_app.id
+
     def test_not_updated_fields(self):
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -139,7 +139,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             "sentryAppId": sentry_app.id,
         }
 
-        with self.feature(["organizations:incidents", "organizations:integrations-sentry-app-metric-alerts"]):
+        with self.feature(
+            ["organizations:incidents", "organizations:integrations-sentry-app-metric-alerts"]
+        ):
             resp = self.get_valid_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -121,7 +121,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, APITestCase):
             "sentryAppId": sentry_app.id,
         }
 
-        with self.feature(["organizations:incidents", "organizations:integrations-sentry-app-metric-alerts"]):
+        with self.feature(
+            ["organizations:incidents", "organizations:integrations-sentry-app-metric-alerts"]
+        ):
             resp = self.get_valid_response(
                 self.organization.slug, status_code=201, **valid_alert_rule
             )


### PR DESCRIPTION
Set `sentry_app_id` when a user saves an alert rule with a Sentry App trigger action. This involves updating the Serializer and its validators to pass around `sentry_app`.