### PR TITLE
Update Error Tracking label to Instrumentation

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
@@ -57,7 +57,7 @@ class ProjectInstallOverview extends AsyncComponent {
 
     return (
       <div>
-        <SentryDocumentTitle title={t('Error Tracking')} objSlug={projectId} />
+        <SentryDocumentTitle title={t('Instrumentation')} objSlug={projectId} />
         <SettingsPageHeader title={t('Configure your application')} />
         <TextBlock>
           {t(

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
@@ -108,7 +108,7 @@ export default function getConfiguration({
       items: [
         {
           path: `${pathPrefix}/install/`,
-          title: t('Error Tracking'),
+          title: t('Instrumentation'),
         },
         {
           path: `${pathPrefix}/keys/`,


### PR DESCRIPTION
Now that we've added Transactions to the project install instructions `Error Tracking` no longer makes sense. 