### PR TITLE
ref(py3): Fix __bool__ compatability on cursors

### DIFF
--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -29,8 +29,11 @@ class Cursor(object):
             int(self.is_prev),
         )
 
-    def __nonzero__(self):
-        return self.has_results
+    def __bool__(self):
+        return bool(self.has_results)
+
+    # python2 compatability
+    __nonzero__ = __bool__
 
     @classmethod
     def from_string(cls, value):


### PR DESCRIPTION
Didn't see any other usage of __nonzero__