### PR TITLE
fix(grouping): Fixes precedence hint for grouping

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -147,10 +147,14 @@ def _get_calculated_grouping_variants_for_event(event, config):
             if winning_strategy is None:
                 if component.contributes:
                     winning_strategy = strategy.name
-                    precedence_hint = "%s takes precedence" % (
-                        "%s of %s" % (strategy.name, variant)
+                    variants_hint = "/".join(
+                        sorted(k for k, v in six.iteritems(rv) if v.contributes)
+                    )
+                    precedence_hint = "%s take%s precedence" % (
+                        "%s of %s" % (strategy.name, variants_hint)
                         if variant != "default"
-                        else strategy.name
+                        else strategy.name,
+                        "" if strategy.name.endswith("s") else "s",
                     )
             elif component.contributes and winning_strategy != strategy.name:
                 component.update(

--- a/src/sentry/grouping/enhancer.py
+++ b/src/sentry/grouping/enhancer.py
@@ -421,7 +421,7 @@ class Enhancements(object):
         padded = data + b"=" * (4 - (len(data) % 4))
         try:
             return cls._from_config_structure(
-                msgpack.loads(zlib.decompress(base64.urlsafe_b64decode(padded)))
+                msgpack.loads(zlib.decompress(base64.urlsafe_b64decode(padded)), raw=False)
             )
         except (LookupError, AttributeError, TypeError, ValueError) as e:
             raise ValueError("invalid grouping enhancement config: %s" % e)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:52:17.939418Z'
+created: '2020-08-25T09:17:18.130483Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -138,8 +138,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:24.513814Z'
+created: '2020-08-25T09:17:17.962011Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -496,8 +496,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "Failed to start connector [Connector[HTTP/1.1-8080]]"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:25.450820Z'
+created: '2020-08-25T09:17:18.164316Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -50,8 +50,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/threads_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2020-02-26T19:54:25.931779Z'
+created: '2020-08-25T09:17:18.865561Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (threads of system takes precedence)
+    app (threads of system take precedence)
       threads (ignored because hash matches system variant)
         stacktrace*
           frame* (frame considered in-app because no frame is in-app)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:26.416957Z'
+created: '2020-08-25T09:17:10.213133Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -138,8 +138,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:27.224451Z'
+created: '2020-08-25T09:17:10.052466Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -496,8 +496,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "Failed to start connector [Connector[HTTP/1.1-8080]]"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:28.601685Z'
+created: '2020-08-25T09:17:10.249624Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -50,8 +50,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/threads_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2020-02-26T19:54:29.234297Z'
+created: '2020-08-25T09:17:10.922310Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (threads of system takes precedence)
+    app (threads of system take precedence)
       threads (ignored because hash matches system variant)
         stacktrace*
           frame* (frame considered in-app because no frame is in-app)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:29.774186Z'
+created: '2020-08-25T09:17:13.182419Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -172,8 +172,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "An unhandled exception has occurred while executing the request."
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:29.799133Z'
+created: '2020-08-25T09:17:14.071215Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -92,8 +92,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:30.919728Z'
+created: '2020-08-25T09:17:13.909441Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -388,8 +388,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "Failed to start connector [Connector[HTTP/1.1-8080]]"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:32.306466Z'
+created: '2020-08-25T09:17:14.105981Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -36,8 +36,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/threads_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2020-02-26T19:54:32.774204Z'
+created: '2020-08-25T09:17:14.769045Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (threads of system takes precedence)
+    app (threads of system take precedence)
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:33.594397Z'
+created: '2020-08-25T09:17:11.244403Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -174,8 +174,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "An unhandled exception has occurred while executing the request."
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:33.623832Z'
+created: '2020-08-25T09:17:12.117575Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -94,8 +94,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:34.930429Z'
+created: '2020-08-25T09:17:11.949819Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -394,8 +394,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "Failed to start connector [Connector[HTTP/<float><int>]]"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:36.273690Z'
+created: '2020-08-25T09:17:12.150312Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -38,8 +38,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/threads_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2020-02-26T19:54:36.876767Z'
+created: '2020-08-25T09:17:12.844476Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (threads of system takes precedence)
+    app (threads of system take precedence)
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.424317Z'
+created: '2020-08-25T09:17:19.194245Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -174,8 +174,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "An unhandled exception has occurred while executing the request."
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.450121Z'
+created: '2020-08-25T09:17:20.100596Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -116,8 +116,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:38.338250Z'
+created: '2020-08-25T09:17:19.930253Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -394,8 +394,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "Failed to start connector [Connector[HTTP/<float><int>]]"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:39.709423Z'
+created: '2020-08-25T09:17:20.134951Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -44,8 +44,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2020-02-26T19:54:40.300879Z'
+created: '2020-08-25T09:17:20.859593Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (threads of system takes precedence)
+    app (threads of system take precedence)
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:40.917238Z'
+created: '2020-08-25T09:17:15.093586Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -174,8 +174,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "An unhandled exception has occurred while executing the request."
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:40.940477Z'
+created: '2020-08-25T09:17:16.087810Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -116,8 +116,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.945780Z'
+created: '2020-08-25T09:17:15.905761Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -394,8 +394,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "Failed to start connector [Connector[HTTP/<float><int>]]"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:43.084483Z'
+created: '2020-08-25T09:17:16.122350Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -44,8 +44,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/threads_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2020-02-26T19:54:43.612839Z'
+created: '2020-08-25T09:17:16.852190Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (threads of system takes precedence)
+    app (threads of system take precedence)
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T17:38:20.630238Z'
+created: '2020-08-25T09:17:06.951020Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -174,8 +174,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "An unhandled exception has occurred while executing the request."
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T17:38:22.236194Z'
+created: '2020-08-25T09:17:08.237675Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -116,8 +116,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T17:38:21.991258Z'
+created: '2020-08-25T09:17:08.056973Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -394,8 +394,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "Failed to start connector [Connector[HTTP/<float><int>]]"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T17:38:22.284656Z'
+created: '2020-08-25T09:17:08.273305Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -44,8 +44,8 @@ app:
 default:
   hash: null
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of app/system takes precedence)
+      message (exception of app/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/threads_compute_hashes.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2020-07-23T17:38:23.157043Z'
+created: '2020-08-25T09:17:08.996865Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (threads of system takes precedence)
+    app (threads of system take precedence)
       threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace
           frame (non app frame)


### PR DESCRIPTION
The grouping explanation hint did not produce the correct output for when more than
one variant was contributing.  This does not affect the grouping but would incorrectly
display a slightly incorrect hint.  It now correctly will show all variants that
contributed. Also fixes a grammatical mistake.

Replaces #20349