### PR TITLE
fix(images-loaded): Fix double scrollbar

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/index.tsx
@@ -468,8 +468,7 @@ const StyledEventDataSection = styled(EventDataSection)`
 const DebugImagesPanel = styled(Panel)`
   margin-bottom: ${space(1)};
   max-height: ${PANEL_MAX_HEIGHT}px;
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
 `;
 
 const ToolbarWrapper = styled('div')`


### PR DESCRIPTION
closes: https://app.asana.com/0/1158284503473033/1190508011638977

**Description:** 

Fixes the double scrollbar displayed in the Images Loaded section
![image](https://user-images.githubusercontent.com/29228205/91173046-78f98200-e6dd-11ea-91a4-784a8b85bc65.png)
