### PR TITLE
 fix(sdk_updates): Do not block on empty cache when rendering issue details

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -539,6 +539,7 @@ CELERY_IMPORTS = (
     "sentry.tasks.unmerge",
     "sentry.tasks.update_user_reports",
     "sentry.tasks.relay",
+    "sentry.tasks.release_registry",
 )
 CELERY_QUEUES = [
     Queue("activity.notify", routing_key="activity.notify"),
@@ -689,6 +690,11 @@ CELERYBEAT_SCHEDULE = {
         "task": "sentry.incidents.tasks.process_pending_incident_snapshots",
         "schedule": timedelta(hours=1),
         "options": {"expires": 3600, "queue": "incidents"},
+    },
+    "fetch-release-registry-data": {
+        "task": "sentry.tasks.release_registry.fetch_release_registry_data",
+        "schedule": timedelta(seconds=10),
+        "options": {"expires": 3600},
     },
 }
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -693,7 +693,7 @@ CELERYBEAT_SCHEDULE = {
     },
     "fetch-release-registry-data": {
         "task": "sentry.tasks.release_registry.fetch_release_registry_data",
-        "schedule": timedelta(seconds=10),
+        "schedule": timedelta(minutes=5),
         "options": {"expires": 3600},
     },
 }

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -5,13 +5,11 @@ from distutils.version import LooseVersion
 from django.conf import settings
 from django.core.cache import cache
 
-from sentry.net.http import Session
+from sentry.tasks.release_registry import SDK_INDEX_CACHE_KEY
 from sentry.utils.safe import get_path
 from sentry.utils.compat import zip
 
 logger = logging.getLogger(__name__)
-
-SDK_INDEX_CACHE_KEY = u"sentry:sdk-versions"
 
 
 class SdkSetupState(object):
@@ -329,27 +327,15 @@ SDK_SUPPORTED_MODULES = [
 
 
 def get_sdk_index():
-    value = cache.get(SDK_INDEX_CACHE_KEY)
-    if value is not None:
-        return value
+    """
+    Get the SDK index from cache, if available.
 
-    base_url = settings.SENTRY_RELEASE_REGISTRY_BASEURL
-    if not base_url:
+    The cache is filled by a regular background task (see sentry/tasks/release_registry)
+    """
+    if not settings.SENTRY_RELEASE_REGISTRY_BASEURL:
         return {}
 
-    url = "%s/sdks" % (base_url,)
-
-    try:
-        with Session() as session:
-            response = session.get(url, timeout=1)
-            response.raise_for_status()
-            json = response.json()
-    except Exception:
-        logger.exception("Failed to fetch version index from release registry")
-        json = {}
-
-    cache.set(SDK_INDEX_CACHE_KEY, json, 3600)
-    return json
+    return cache.get(SDK_INDEX_CACHE_KEY) or {}
 
 
 def get_sdk_versions():
@@ -426,6 +412,8 @@ def get_suggested_updates(setup_state, index_state=None, parent_suggestions=None
         parent_suggestions = []
 
     suggestions = list(_get_suggested_updates_step(setup_state, index_state))
+
+    logger.warn(suggestions)
 
     rv = []
     new_setup_states = []

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -413,8 +413,6 @@ def get_suggested_updates(setup_state, index_state=None, parent_suggestions=None
 
     suggestions = list(_get_suggested_updates_step(setup_state, index_state))
 
-    logger.warn(suggestions)
-
     rv = []
     new_setup_states = []
 

--- a/src/sentry/tasks/release_registry.py
+++ b/src/sentry/tasks/release_registry.py
@@ -44,6 +44,11 @@ def _fetch_registry_url(relative_url):
     soft_time_limit=60,
 )
 def fetch_release_registry_data():
+    """
+    Fetch information about the latest SDK version from the release registry.
+
+    More details about the registry: https://github.com/getsentry/sentry-release-registry/
+    """
     if not settings.SENTRY_RELEASE_REGISTRY_BASEURL:
         logger.warn("Release registry URL is not specified, skipping the task.")
         return
@@ -55,5 +60,3 @@ def fetch_release_registry_data():
     # Apps (e.g. sentry-cli)
     app_data = _fetch_registry_url("/apps")
     cache.set(APP_INDEX_CACHE_KEY, app_data, CACHE_TTL)
-
-    logger.warn("--- Done ---")

--- a/src/sentry/tasks/release_registry.py
+++ b/src/sentry/tasks/release_registry.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+
+from sentry.net.http import Session
+from sentry.tasks.base import instrumented_task
+from sentry.utils import metrics
+
+
+logger = logging.getLogger(__name__)
+
+SDK_INDEX_CACHE_KEY = u"sentry:release-registry-sdk-versions"
+APP_INDEX_CACHE_KEY = u"sentry:release-registry-app-versions"
+
+REQUEST_TIMEOUT = 10
+
+CACHE_TTL = 3600
+
+
+def _fetch_registry_url(relative_url):
+    if not settings.SENTRY_RELEASE_REGISTRY_BASEURL:
+        return {}
+
+    base_url = settings.SENTRY_RELEASE_REGISTRY_BASEURL.rstrip("/")
+    relative_url = relative_url.lstrip("/")
+
+    full_url = "%s/%s" % (base_url, relative_url)
+
+    with metrics.timer(
+        "release_registry.fetch.duration", tags={"url": relative_url}, sample_rate=1.0
+    ):
+        with Session() as session:
+            response = session.get(full_url, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+        return response.json()
+
+
+@instrumented_task(
+    name="sentry.tasks.release_registry.fetch_release_registry_data",
+    time_limit=65,
+    soft_time_limit=60,
+)
+def fetch_release_registry_data():
+    if not settings.SENTRY_RELEASE_REGISTRY_BASEURL:
+        logger.warn("Release registry URL is not specified, skipping the task.")
+        return
+
+    # Language SDKs
+    sdk_data = _fetch_registry_url("/sdks")
+    cache.set(SDK_INDEX_CACHE_KEY, sdk_data, CACHE_TTL)
+
+    # Apps (e.g. sentry-cli)
+    app_data = _fetch_registry_url("/apps")
+    cache.set(APP_INDEX_CACHE_KEY, app_data, CACHE_TTL)
+
+    logger.warn("--- Done ---")

--- a/src/sentry/tasks/release_registry.py
+++ b/src/sentry/tasks/release_registry.py
@@ -43,7 +43,7 @@ def _fetch_registry_url(relative_url):
     time_limit=65,
     soft_time_limit=60,
 )
-def fetch_release_registry_data():
+def fetch_release_registry_data(**kwargs):
     """
     Fetch information about the latest SDK version from the release registry.
 


### PR DESCRIPTION
This adds a periodic Celery task that fills/updates the cache, and then we just read from it.