### PR TITLE
Change PagerDuty metric alert summary

### DIFF
--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -31,7 +31,7 @@ def build_incident_attachment(incident, integration_key, metric_value=None):
         "event_action": event_action,
         "dedup_key": "incident_{}_{}".format(incident.organization_id, incident.identifier),
         "payload": {
-            "summary": data["title"],
+            "summary": incident.alert_rule.name,
             "severity": severity,
             "source": six.binary_type(incident.identifier),
             "custom_details": {"details": data["text"]},

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -346,7 +346,7 @@ class PagerDutyActionHandlerBaseTest(object):
         assert data["dedup_key"] == "incident_{}_{}".format(
             incident.organization_id, incident.identifier
         )
-        assert data["payload"]["summary"] == "Critical: {}".format(alert_rule.name)
+        assert data["payload"]["summary"] == alert_rule.name
         assert data["payload"]["severity"] == "critical"
         assert data["payload"]["source"] == six.binary_type(incident.identifier)
         assert data["payload"]["custom_details"] == {


### PR DESCRIPTION
This PR changes the summary to be the name of the metric alert, rather than the status + the name of the metric alert.