### PR TITLE
ref(py3): Correct usage of body content in responses

### DIFF
--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -369,7 +369,7 @@ class PagerDutyActionHandlerBaseTest(object):
         responses.add(
             method=responses.POST,
             url="https://events.pagerduty.com/v2/enqueue/",
-            body={},
+            json={},
             status=202,
             content_type="application/json",
         )

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -49,7 +49,7 @@ class PagerDutyNotifyActionTest(RuleTestCase):
         responses.add(
             method=responses.POST,
             url="https://events.pagerduty.com/v2/enqueue/",
-            body={},
+            json={},
             status=202,
             content_type="application/json",
         )
@@ -139,7 +139,7 @@ class PagerDutyNotifyActionTest(RuleTestCase):
         responses.add(
             method=responses.POST,
             url="https://events.pagerduty.com/v2/enqueue/",
-            body={},
+            json={},
             status=202,
             content_type="application/json",
         )

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -242,7 +242,7 @@ class VercelReleasesTest(APITestCase):
         def request_callback(request):
             payload = json.loads(request.body)
             status_code = 400 if payload.get("refs") else 200
-            return (status_code, {}, {})
+            return (status_code, {}, json.dumps({}))
 
         responses.add_callback(
             responses.POST,


### PR DESCRIPTION
You cannot pass a dict as a body, it must be a string or use the `json`
kwarg

This was https://github.com/getsentry/sentry/pull/20377 but it was accidentally automatically closed when I pushed an already merged commit to it.