### PR TITLE
ref(py3): Fix dict key order differences between py2/3 in tests

### DIFF
--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -46,6 +46,7 @@ class ProjectOwnershipSerializer(serializers.Serializer):
                     bad_actors.append(u"#{}".format(owner.identifier))
 
         if bad_actors:
+            bad_actors.sort()
             raise serializers.ValidationError(
                 {"raw": u"Invalid rule owners: {}".format(", ".join(bad_actors))}
             )

--- a/tests/sentry/api/endpoints/test_organization_auth_providers.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_providers.py
@@ -33,5 +33,4 @@ class OrganizationAuthProviders(APITestCase):
             resp = self.client.get(path)
 
         assert resp.status_code == 200
-
-        assert resp.data[0]["key"] == "dummy"
+        assert any(d["key"] == "dummy" for d in resp.data)

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -89,4 +89,4 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             self.path, {"raw": "*.js idont@exist.com admin@localhost #faketeam #tiger-team"}
         )
         assert resp.status_code == 400
-        assert resp.data == {"raw": ["Invalid rule owners: idont@exist.com, #faketeam"]}
+        assert resp.data == {"raw": ["Invalid rule owners: #faketeam, idont@exist.com"]}

--- a/tests/sentry/api/endpoints/test_project_servicehooks.py
+++ b/tests/sentry/api/endpoints/test_project_servicehooks.py
@@ -39,7 +39,7 @@ class CreateProjectServiceHookTest(APITestCase):
         assert hook.url == "http://example.com"
         assert hook.project_id == self.project.id
         assert hook.actor_id == self.user.id
-        assert hook.events == ["event.alert", "event.created"]
+        assert sorted(hook.events) == ["event.alert", "event.created"]
         assert hook.version == 0
 
         hook_project = ServiceHookProject.objects.get(project_id=self.project.id)

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -407,9 +407,13 @@ class PostSentryAppsTest(SentryAppsTest):
             "schema": ["['#general'] is too short for element of type 'alert-rule-action'"]
         }
 
+        # XXX: Compare schema as an object instead of json to avoid key
+        # ordering issues
+        record.call_args.kwargs["schema"] = json.loads(record.call_args.kwargs["schema"])
+
         record.assert_called_with(
             "sentry_app.schema_validation_error",
-            schema='{"elements":[{"required_fields":[{"label":"Channel","type":"select","options":[["#general"]],"name":"channel"}],"type":"alert-rule-action"}]}',
+            schema=kwargs["schema"],
             user_id=self.user.id,
             sentry_app_name="MyApp",
             organization_id=self.org.id,

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -280,9 +280,9 @@ class VstsIssueSyncTest(VstsIssueBase):
             == "https://fabrikam-fiber-inc.visualstudio.com/_apis/wit/workitems/%d"
             % vsts_work_item_id
         )
-        assert (
-            req.body == '[{"path": "/fields/System.State", "value": "Resolved", "op": "replace"}]'
-        )
+        assert json.loads(req.body) == [
+            {"path": "/fields/System.State", "value": "Resolved", "op": "replace"}
+        ]
         assert responses.calls[2].response.status_code == 200
 
     def test_get_issue_url(self):

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -50,22 +50,20 @@ class TestInstallationNotifier(TestCase):
 
         data = faux(safe_urlopen).kwargs["data"]
 
-        assert data == json.dumps(
-            {
-                "action": "created",
-                "installation": {"uuid": self.install.uuid},
-                "data": {
-                    "installation": {
-                        "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
-                        "organization": {"slug": self.org.slug},
-                        "uuid": self.install.uuid,
-                        "code": self.install.api_grant.code,
-                        "status": "installed",
-                    }
-                },
-                "actor": {"id": self.user.id, "name": self.user.name, "type": "user"},
-            }
-        )
+        assert json.loads(data) == {
+            "action": "created",
+            "installation": {"uuid": self.install.uuid},
+            "data": {
+                "installation": {
+                    "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
+                    "organization": {"slug": self.org.slug},
+                    "uuid": self.install.uuid,
+                    "code": self.install.api_grant.code,
+                    "status": "installed",
+                }
+            },
+            "actor": {"id": self.user.id, "name": self.user.name, "type": "user"},
+        }
 
         assert faux(safe_urlopen).kwarg_equals(
             "headers",
@@ -84,22 +82,20 @@ class TestInstallationNotifier(TestCase):
 
         data = faux(safe_urlopen).kwargs["data"]
 
-        assert data == json.dumps(
-            {
-                "action": "deleted",
-                "installation": {"uuid": self.install.uuid},
-                "data": {
-                    "installation": {
-                        "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
-                        "organization": {"slug": self.org.slug},
-                        "uuid": self.install.uuid,
-                        "code": self.install.api_grant.code,
-                        "status": "installed",
-                    }
-                },
-                "actor": {"id": self.user.id, "name": self.user.name, "type": "user"},
-            }
-        )
+        assert json.loads(data) == {
+            "action": "deleted",
+            "installation": {"uuid": self.install.uuid},
+            "data": {
+                "installation": {
+                    "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
+                    "organization": {"slug": self.org.slug},
+                    "uuid": self.install.uuid,
+                    "code": self.install.api_grant.code,
+                    "status": "installed",
+                }
+            },
+            "actor": {"id": self.user.id, "name": self.user.name, "type": "user"},
+        }
 
         assert faux(safe_urlopen).kwarg_equals(
             "headers",

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from exam import fixture
-from six.moves.urllib.parse import parse_qs
+from six.moves.urllib.parse import parse_qs, urlparse
 
 from sentry.models import ApiApplication, ApiAuthorization, ApiGrant, ApiToken
 from sentry.testutils import TestCase
@@ -142,7 +142,12 @@ class OAuthAuthorizeCodeTest(TestCase):
         assert grant.get_scopes() == ["org:read"]
 
         assert resp.status_code == 302
-        assert resp["Location"] == u"https://example.com?state=foo&code={}".format(grant.code)
+
+        # XXX: Compare parsed query strings to avoid ordering differences
+        # between py2/3
+        assert parse_qs(urlparse(resp["Location"]).query) == parse_qs(
+            u"state=foo&code={}".format(grant.code)
+        )
 
         assert not ApiToken.objects.filter(user=self.user).exists()
 

--- a/tests/sentry/web/frontend/test_vsts_extension_configuration.py
+++ b/tests/sentry/web/frontend/test_vsts_extension_configuration.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from six.moves.urllib.parse import parse_qsl, urlparse
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import TestCase
@@ -48,11 +49,14 @@ class VstsExtensionConfigurationTest(TestCase):
         assert resp.url.startswith("https://app.vssps.visualstudio.com/oauth2/authorize")
 
     def test_logged_out(self):
-        resp = self.client.get(self.path, {"targetId": "1", "targetName": "foo"})
+        query = {"targetId": "1", "targetName": "foo"}
+        resp = self.client.get(self.path, query)
 
         assert resp.status_code == 302
         assert "/auth/login/" in resp.url
-        # URL encoded post-login redirect URL
-        assert (
-            "next=%2Fextensions%2Fvsts%2Fconfigure%2F%3FtargetName%3Dfoo%26targetId%3D1" in resp.url
-        )
+
+        # Verify URL encoded post-login redirect URL
+        next_parts = urlparse(dict(parse_qsl(urlparse(resp.url).query))["next"])
+
+        assert next_parts.path == "/extensions/vsts/configure/"
+        assert dict(parse_qsl(next_parts.query)) == query


### PR DESCRIPTION
Mostly fixed by either:

1. sorting
2. comparing objects instead of strings