### PR TITLE
ref(py3): Don't encode text IDs as utf-8 in tests

### DIFF
--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -100,7 +100,7 @@ class TestSentryAppAuthorizations(APITestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION="Bearer {}".format(token))
 
         assert response.status_code == 200
-        assert response.data["id"] == six.text_type(self.org.id).encode("utf-8")
+        assert response.data["id"] == six.text_type(self.org.id)
 
     def test_state(self):
         response = self._run_request(state="abc123")

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -341,7 +341,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
         # And it comes back successfully changed:
         assert resp.data["triggers"][0]["actions"][0]["targetType"] == "user"
-        assert resp.data["triggers"][0]["actions"][0]["targetIdentifier"] == six.binary_type(
+        assert resp.data["triggers"][0]["actions"][0]["targetIdentifier"] == six.text_type(
             self.user.id
         )
 

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -347,7 +347,7 @@ class TestWorkflowNotification(TestCase):
         assert faux(safe_urlopen).kwarg_equals("data.action", "resolved", format="json")
         assert faux(safe_urlopen).kwarg_equals("headers.Sentry-Hook-Resource", "issue")
         assert faux(safe_urlopen).kwarg_equals(
-            "data.data.issue.id", six.text_type(self.issue.id).encode("utf-8"), format="json"
+            "data.data.issue.id", six.text_type(self.issue.id), format="json"
         )
 
     def test_sends_resolved_webhook_as_Sentry_without_user(self, safe_urlopen):


### PR DESCRIPTION
This was changed over incorrectly in 75943c947c73c02e2c5fbddb338bb5a99de678e4, usually we just want these numbers to be strings, not utf-8 encoded bytes