### PR TITLE
fix(discover): Allow sorting by user.display

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -45,6 +45,7 @@ class Columns(Enum):
     USER_IP_ADDRESS = Column(
         "events.ip_address", "ip_address", "ip_address", "ip_address", "user.ip"
     )
+    USER_DISPLAY = Column(None, None, None, "user.display", "user.display")
     SDK_NAME = Column("events.sdk_name", "sdk_name", "sdk_name", "sdk_name", "sdk.name")
     SDK_VERSION = Column(
         "events.sdk_version", "sdk_version", "sdk_version", "sdk_version", "sdk.version"

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1615,7 +1615,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(data) == 2
         result = [r["user.display"] for r in data]
         # because we're ordering by `user.display`, we expect the results in sorted order
-        assert result == list(sorted(["catherine", "cathy@example.com"]))
+        assert result == ["catherine", "cathy@example.com"]
 
     def test_has_transaction_status(self):
         project = self.create_project()

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1576,7 +1576,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(data) == 2
         result = [r["user.display"] for r in data]
         # because we're ordering by `-user.display`, we expect the results in reverse sorted order
-        assert result == list(reversed(sorted(["catherine", "cathy@example.com"])))
+        assert result == ['cathy@example.com', 'catherine']
 
     def test_orderby_user_display_with_aggregates(self):
         project1 = self.create_project()

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1576,7 +1576,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(data) == 2
         result = [r["user.display"] for r in data]
         # because we're ordering by `-user.display`, we expect the results in reverse sorted order
-        assert result == ['cathy@example.com', 'catherine']
+        assert result == ["cathy@example.com", "catherine"]
 
     def test_orderby_user_display_with_aggregates(self):
         project1 = self.create_project()


### PR DESCRIPTION
Currently, ordering by `user.display` is parsed to `tags[user.display]`. This
will not error when there are no aggregates, but the resulting order is sorting
on empty strings. When there are aggregates, the ordering by `tags[user.display]`
results in a column that is not in any aggregate/group bys making for an invalid
query. This change will resolve `user.display`  to `user.display` for correct
ordering.