### PR TITLE
rfc(perf): Allow sentry.io to measure cdn asset timings

### DIFF
--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -74,6 +74,9 @@ def static_media(request, **kwargs):
 
     # Make sure we Vary: Accept-Encoding for gzipped responses
     response["Vary"] = "Accept-Encoding"
+    
+    # This allows Sentry to record static timings for itself
+    response["Timing-Allow-Origin"] = "https://sentry.io"
 
     # We need CORS for font files
     if path.endswith((".js", ".ttf", ".ttc", ".otf", ".eot", ".woff", ".woff2")):


### PR DESCRIPTION
### Summary
Currently, since our assets are located on a separate domain, we can't retrieve timing information about them. This adds a header to be passed through to sentry-cdn to allow timing solely for ourselves on prod to let us record our own asset timing information.

#### Timing for same origin
![Screen Shot 2020-08-26 at 8 26 35 AM](https://user-images.githubusercontent.com/6111995/91323564-e0631080-e775-11ea-97da-2a89ec3e6ed0.png)

#### Timing for cross origin (without timing-allow-origin specified)
![Screen Shot 2020-08-26 at 8 27 05 AM](https://user-images.githubusercontent.com/6111995/91323610-f1138680-e775-11ea-9d0b-d13742268c48.png)

This is hardcoded to be the most restrictive for now as this will let us test out timing information for our own frontend. Alternatively we could use a wildcard instead, and allow anyone to gather our static asset timings.

Putting it up for rfc to see what people think, ideally it wouldn't be hardcoded and would instead be dynamic to allow timing from our frontends in any environment, so any feedback to that effect would be welcome. 