### PR TITLE
fix(discover): Removing xfail on test that was failing

### DIFF
--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -8,6 +8,7 @@ from sentry.utils.compat.mock import patch
 from datetime import timedelta
 
 from six.moves.urllib.parse import urlencode
+from selenium.webdriver.common.keys import Keys
 
 from sentry.discover.models import DiscoverSavedQuery
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
@@ -413,7 +414,6 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         # Saved query should exist.
         assert DiscoverSavedQuery.objects.filter(name=query_name).exists()
 
-    @pytest.mark.skip(reason="Skipping this to unblock master")
     def test_view_and_rename_saved_query(self):
         # Create saved query to rename
         query = DiscoverSavedQuery.objects.create(
@@ -433,7 +433,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
             input = self.browser.element('div[name="discover2-query-name"]')
             input.click()
-            input.send_keys("updated!")
+            input.send_keys(Keys.END + "updated!")
 
             # Move focus somewhere else to trigger a blur and update the query
             self.browser.element("table").click()


### PR DESCRIPTION
- Current guess is something changed with how click interacts with the
  input boxes, so updated ended up after `Custom` instead of at the end
  of the input
- Adding a press of `end` so the input goes to the end instead