### PR TITLE
feat(vercel): adds user agent for vercel releases

### DIFF
--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -8,7 +8,7 @@ import six
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.crypto import constant_time_compare
 from requests.exceptions import RequestException
-from sentry import http, options
+from sentry import http, options, VERSION
 from sentry.api.base import Endpoint
 from sentry.models import (
     OrganizationIntegration,
@@ -172,7 +172,8 @@ class VercelWebhookEndpoint(Endpoint):
                 url = absolute_uri("/api/0/organizations/%s/releases/" % organization.slug)
                 headers = {
                     "Accept": "application/json",
-                    "Authorization": "Bearer %s" % token,
+                    "Authorization": u"Bearer %s" % token,
+                    "User-Agent": u"sentry_vercel/{}".format(VERSION),
                 }
                 json_error = None
 

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -5,6 +5,7 @@ import hmac
 import responses
 import six
 
+from sentry import VERSION
 from sentry.models import (
     Integration,
     OrganizationIntegration,
@@ -92,7 +93,8 @@ class VercelReleasesTest(APITestCase):
             assert response.status_code == 201
 
             assert len(responses.calls) == 2
-            release_body = json.loads(responses.calls[0].request.body)
+            release_request = responses.calls[0].request
+            release_body = json.loads(release_request.body)
             set_refs_body = json.loads(responses.calls[1].request.body)
             assert release_body == {
                 "projects": [self.project.slug],
@@ -108,6 +110,7 @@ class VercelReleasesTest(APITestCase):
                     }
                 ],
             }
+            assert release_request.headers["User-Agent"] == u"sentry_vercel/{}".format(VERSION)
 
     @responses.activate
     def test_no_match(self):


### PR DESCRIPTION
We add a user agent for Vercel releases which is `sentry_vercel/${VERSION}` where `VERSION` is the current version of Sentry. This way, we can track how many releases are coming from the Vercel integration.