### PR TITLE
fix(snuba): Return error/sql again

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -597,7 +597,7 @@ def bulk_raw_query(snuba_param_list, referrer=None):
             with timer("snuba_query"):
                 referrer = headers.get("referer", "<unknown>")
                 if SNUBA_INFO:
-                    logger.info("{}.body: {}".format(referrer, query_params))
+                    logger.info("{}.body: {}".format(referrer, json.dumps(query_params)))
                     query_params["debug"] = True
                 body = json.dumps(query_params)
                 with thread_hub.start_span(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -595,11 +595,11 @@ def bulk_raw_query(snuba_param_list, referrer=None):
         query_params, forward, reverse, thread_hub = params
         try:
             with timer("snuba_query"):
-                body = json.dumps(query_params)
                 referrer = headers.get("referer", "<unknown>")
                 if SNUBA_INFO:
+                    logger.info("{}.body: {}".format(referrer, query_params))
                     query_params["debug"] = True
-                    logger.info("{}.body: {}".format(referrer, body))
+                body = json.dumps(query_params)
                 with thread_hub.start_span(
                     op="snuba", description=u"query {}".format(referrer)
                 ) as span:


### PR DESCRIPTION
- Without debug in the query params snuba won't return the generated sql
- This way debug isn't in the body log too, making it easy to copy to send yourself