### PR TITLE
fix(ui): Environment was showing '0' instead of null

### DIFF
--- a/src/sentry/static/sentry/app/components/group/releaseStats.tsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.tsx
@@ -75,7 +75,7 @@ const GroupReleaseStats = ({
             />
             <h6>
               <span>{t('First seen')}</span>
-              {environments.length && <small>({environmentLabel})</small>}
+              {environments.length > 0 && <small>({environmentLabel})</small>}
             </h6>
 
             <SeenInfo
@@ -95,7 +95,7 @@ const GroupReleaseStats = ({
 
             <h6>
               <span>{t('Last seen')}</span>
-              {environments.length && <small>({environmentLabel})</small>}
+              {environments.length > 0 && <small>({environmentLabel})</small>}
             </h6>
             <SeenInfo
               orgSlug={orgSlug}


### PR DESCRIPTION
My bad during TS conversion. The `0` shouldn't be in the title.

<img src="https://user-images.githubusercontent.com/1748388/91365830-e4fbe900-e7b6-11ea-9bbe-a68de2de9659.png" width="333px">