### PR TITLE
feat(PagerDuty): Add logging when service doesn't exist

### DIFF
--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -47,7 +47,11 @@ def send_incident_alert_notification(action, incident, metric_value):
     except PagerDutyService.DoesNotExist:
         logger.info(
             "fetch.fail.pagerduty_metric_alert",
-            extra={"integration_id": integration.id, "organization_id": incident.organization_id},
+            extra={
+                "integration_id": integration.id,
+                "organization_id": incident.organization_id,
+                "target_identifier": action.target_identifier,
+            },
         )
     integration_key = service.integration_key
     client = PagerDutyClient(integration_key=integration_key)

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -42,7 +42,13 @@ def build_incident_attachment(incident, integration_key, metric_value=None):
 
 def send_incident_alert_notification(action, incident, metric_value):
     integration = action.integration
-    service = PagerDutyService.objects.get(id=action.target_identifier)
+    try:
+        service = PagerDutyService.objects.get(id=action.target_identifier)
+    except PagerDutyService.DoesNotExist:
+        logger.info(
+            "fetch.fail.pagerduty_metric_alert",
+            extra={"integration_id": integration.id, "organization_id": incident.organization_id},
+        )
     integration_key = service.integration_key
     client = PagerDutyClient(integration_key=integration_key)
     attachment = build_incident_attachment(incident, integration_key, metric_value)


### PR DESCRIPTION
If retrieving a `PagerDutyService` fails, log to Kibana. Fixes [SENTRY-HKG](https://sentry.io/organizations/sentry/issues/1860958041/?project=1&referrer=slack) and [SENTRY-HKH](https://sentry.io/organizations/sentry/issues/1860961200/?project=1&referrer=slack)