### PR TITLE
ref(ui): Update organization, team, and project terminology for slug/name to be consistent

### DIFF
--- a/src/sentry/static/sentry/app/components/teams/createTeamForm.tsx
+++ b/src/sentry/static/sentry/app/components/teams/createTeamForm.tsx
@@ -35,7 +35,7 @@ export default class CreateTeamForm extends React.Component<Props> {
       <React.Fragment>
         <p>
           {t(
-            "Teams group members' access to a specific focus, e.g. a major product or application that may have sub-projects."
+            'Members of a team have access to specific areas, such as a new release or a new application feature.'
           )}
         </p>
 

--- a/src/sentry/static/sentry/app/components/teams/createTeamForm.tsx
+++ b/src/sentry/static/sentry/app/components/teams/createTeamForm.tsx
@@ -51,7 +51,7 @@ export default class CreateTeamForm extends React.Component<Props> {
         >
           <TextField
             name="slug"
-            label={t('Team Slug')}
+            label={t('Team Name')}
             placeholder={t('e.g. operations, web-frontend, desktop')}
             help={t('May contain lowercase letters, numbers, dashes and underscores.')}
             required

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.tsx
@@ -15,10 +15,9 @@ const formGroups: JsonFormObject[] = [
         name: 'slug',
         type: 'string',
         required: true,
-        label: t('Name'),
+        label: t('Organization Slug'),
         help: t('A unique ID used to identify this organization'),
         transformInput: slugify,
-
         saveOnBlur: false,
         saveMessageAlertType: 'info',
         saveMessage: t(
@@ -29,9 +28,8 @@ const formGroups: JsonFormObject[] = [
         name: 'name',
         type: 'string',
         required: true,
-
         label: t('Display Name'),
-        help: t('This is the name that users will see for the organization'),
+        help: t('A human-friendly name for the organization'),
       },
       {
         name: 'isEarlyAdopter',

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.jsx
@@ -23,6 +23,7 @@ import withOrganization from 'app/utils/withOrganization';
 import withTeams from 'app/utils/withTeams';
 import IssueAlertOptions from 'app/views/projectInstall/issueAlertOptions';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
+import slugify from 'app/utils/slugify';
 import {IconAdd} from 'app/icons';
 
 class CreateProject extends React.Component {
@@ -75,7 +76,7 @@ class CreateProject extends React.Component {
               placeholder={t('Project name')}
               autoComplete="off"
               value={projectName}
-              onChange={e => this.setState({projectName: e.target.value})}
+              onChange={e => this.setState({projectName: slugify(e.target.value)})}
             />
           </ProjectNameInput>
         </div>


### PR DESCRIPTION
### For organizations
In the settings for organizations, we have 2 fields: "name` and "display name". It's not immediately obvious on the difference between them. This is not great as we refer to the unique ID as "slug" in docs.

Currently: 
* During organization creation, we take a "organization name" from the user (e.g "Empower Plant" and automatically
  1. save the string as a "display name": `Empower Plant`
  1. slugify the string and save it as "slug": `empower-plant`, or `empower-plant-s8f2v` if there is a collision
* In settings, we have "name" and "display name".

During creation, if there are collisions for the unique slug, we append a random string. IMO this is a good flow because we want them to move quickly to the next step during onboarding.

The change is
* During organization creation, nothing changes.
* In settings, we have "**organization slug**" and "display name"


<br>

### For projects/teams
There isn't a distinction between name or slug, which eliminates confusion. They are just called "name" and when you set a name for them, the input is automatically "slugified" in the form by converting spaces to dashes, lowercasing, etc.

Currently:

* During project creation, the form is called "project name" and input allows strings with spaces.
* During team creation, the form is called "team slug" and input is immediately slugified
* In settings, we use "name" for both project and team

I decided to make that consistent and change it to:

* During project creation, the form is called "project name" and input is **immediately slugified**
* During team creation, the form is called "**team name**" and input is immediately slugified
* In settings, nothing changes.