### PR TITLE
fix(trends): Fixes project id missing from summary link

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/discoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/discoverQuery.tsx
@@ -120,8 +120,7 @@ class DiscoverQuery extends React.Component<Props, State> {
       trendChangeType,
     } = this.props;
 
-    // The check for trendChangeType here is due to the fact that the event view will never be valid with trends as they don't send any fields.
-    if (!eventView.isValid() && !trendChangeType) {
+    if (!eventView.isValid()) {
       return;
     }
 

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -171,9 +171,22 @@ class PerformanceLanding extends React.Component<Props, State> {
   handleViewChange(viewKey: FilterViews) {
     const {location} = this.props;
 
+    const newQuery = {
+      ...location.query,
+    };
+
+    // This is a temporary change for trends to test adding a default count to increase relevancy
+    if (viewKey === FilterViews.TRENDS) {
+      if (!newQuery.query) {
+        newQuery.query = 'count():>1000';
+      } else if (!newQuery.query.includes('count()')) {
+        newQuery.query += 'count():>1000';
+      }
+    }
+
     ReactRouter.browserHistory.push({
       pathname: location.pathname,
-      query: {...location.query, view: viewKey},
+      query: {...newQuery, view: viewKey},
     });
   }
 

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -6,7 +6,7 @@ import {browserHistory} from 'react-router';
 import {Panel} from 'app/components/panels';
 import withOrganization from 'app/utils/withOrganization';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
-import {Organization} from 'app/types';
+import {Organization, Project} from 'app/types';
 import {decodeScalar} from 'app/utils/queryString';
 import space from 'app/styles/space';
 import {RadioLineItem} from 'app/views/settings/components/forms/controls/radioGroup';
@@ -17,6 +17,7 @@ import Count from 'app/components/count';
 import {formatPercentage} from 'app/utils/formatters';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {t} from 'app/locale';
+import withProjects from 'app/utils/withProjects';
 
 import Chart from './chart';
 import {
@@ -44,7 +45,21 @@ type Props = {
   previousTrendFunction?: TrendFunctionField;
   trendView: TrendView;
   location: Location;
+  projects: Project[];
 };
+
+function getTransactionProjectId(
+  transaction: NormalizedTrendsTransaction,
+  projects?: Project[]
+): string | undefined {
+  if (!transaction.project || !projects) {
+    return undefined;
+  }
+  const transactionProject = projects.find(
+    project => project.slug === transaction.project
+  );
+  return transactionProject?.id;
+}
 
 function getChartTitle(trendChangeType: TrendChangeType): string {
   switch (trendChangeType) {
@@ -61,7 +76,7 @@ function getSelectedTransaction(
   location: Location,
   trendChangeType: TrendChangeType,
   transactions?: NormalizedTrendsTransaction[]
-): string | undefined {
+): NormalizedTrendsTransaction | undefined {
   const queryKey = getSelectedQueryKey(trendChangeType);
   const offsetString = decodeScalar(location.query[queryKey]);
   const offset = offsetString ? parseInt(offsetString, 10) : 0;
@@ -69,7 +84,7 @@ function getSelectedTransaction(
     return undefined;
   }
 
-  const transaction = transactions[offset].transaction;
+  const transaction = transactions[offset];
   return transaction;
 }
 
@@ -97,7 +112,13 @@ function handleChangeSelected(
 }
 
 function ChangedTransactions(props: Props) {
-  const {location, trendChangeType, previousTrendFunction, organization} = props;
+  const {
+    location,
+    trendChangeType,
+    previousTrendFunction,
+    organization,
+    projects,
+  } = props;
   const trendView = props.trendView.clone();
   const chartTitle = getChartTitle(trendChangeType);
   modifyTrendView(trendView, location, trendChangeType);
@@ -165,6 +186,7 @@ function ChangedTransactions(props: Props) {
                         trendChangeType={trendChangeType}
                         transactions={transactionsList}
                         location={location}
+                        projects={projects}
                         handleSelectTransaction={handleChangeSelected(
                           location,
                           trendChangeType,
@@ -194,6 +216,7 @@ type TrendsListItemProps = {
   trendChangeType: TrendChangeType;
   currentTrendFunction: TrendFunctionField;
   transactions: NormalizedTrendsTransaction[];
+  projects: Project[];
   location: Location;
   index: number;
   handleSelectTransaction: (transaction: NormalizedTrendsTransaction) => void;
@@ -216,7 +239,7 @@ function TrendsListItem(props: TrendsListItemProps) {
     trendChangeType,
     transactions
   );
-  const isSelected = selectedTransaction === transaction.transaction;
+  const isSelected = selectedTransaction === transaction;
 
   return (
     <ListItemContainer>
@@ -272,13 +295,15 @@ function TrendsListItem(props: TrendsListItemProps) {
 type TransactionLinkProps = TrendsListItemProps & {};
 
 const TransactionLink = (props: TransactionLinkProps) => {
-  const {organization, trendView: eventView, transaction} = props;
+  const {organization, trendView: eventView, transaction, projects} = props;
 
   const summaryView = eventView.clone();
+  const projectID = getTransactionProjectId(transaction, projects);
   const target = transactionSummaryRouteWithQuery({
     orgSlug: organization.slug,
     transaction: String(transaction.transaction),
     query: summaryView.generateQueryStringObject(),
+    projectID,
   });
 
   return <StyledLink to={target}>{transaction.transaction}</StyledLink>;
@@ -343,4 +368,4 @@ const EmptyStateContainer = styled('div')`
 
 const StyledPanel = styled(Panel)``;
 
-export default withOrganization(ChangedTransactions);
+export default withProjects(withOrganization(ChangedTransactions));

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -18,7 +18,7 @@ import {Series} from 'app/types/echarts';
 import theme from 'app/utils/theme';
 
 import {trendToColor, getIntervalRatio, getCurrentTrendFunction} from './utils';
-import {TrendChangeType, TrendsStats} from './types';
+import {TrendChangeType, TrendsStats, NormalizedTrendsTransaction} from './types';
 
 const QUERY_KEYS = [
   'environment',
@@ -37,7 +37,7 @@ type Props = WithRouterProps &
     location: Location;
     organization: OrganizationSummary;
     trendChangeType: TrendChangeType;
-    transaction?: string;
+    transaction?: NormalizedTrendsTransaction;
     isLoading: boolean;
     statsData: TrendsStats;
   };
@@ -135,7 +135,10 @@ class Chart extends React.Component<Props> {
     } = props;
     const lineColor = trendToColor[trendChangeType];
 
-    const events = statsData && statsData[transaction || ''];
+    const events =
+      statsData && transaction?.project && transaction?.transaction
+        ? statsData[[transaction.project, transaction.transaction].join(',')]
+        : undefined;
     const data = events?.data ?? [];
 
     const trendFunction = getCurrentTrendFunction(location);

--- a/src/sentry/static/sentry/app/views/performance/trends/types.ts
+++ b/src/sentry/static/sentry/app/views/performance/trends/types.ts
@@ -44,7 +44,8 @@ export type TrendsData = {
 
 type BaseTrendsTransaction = {
   transaction: string;
-  project?: string; // TODO: Fix allowing project as field
+  project?: string;
+  count: number;
 
   count_range_1: number;
   count_range_2: number;

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -128,7 +128,7 @@ export function modifyTrendView(
   trendsType: TrendChangeType
 ) {
   const trendFunction = getCurrentTrendFunction(location);
-  const fields = ['transaction'].map(field => ({
+  const fields = ['transaction', 'project', 'count()'].map(field => ({
     field,
   })) as Field[];
 

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -79,7 +79,7 @@ describe('Performance > Trends', function() {
       url: '/organizations/org-slug/events-trends/',
       body: {
         stats: {
-          '/organizations/:orgId/performance/': {
+          'internal,/organizations/:orgId/performance/': {
             data: [[123, []]],
           },
           order: 0,
@@ -97,6 +97,8 @@ describe('Performance > Trends', function() {
           },
           data: [
             {
+              count: 8,
+              project: 'internal',
               count_range_1: 2,
               count_range_2: 6,
               divide_count_range_2_count_range_1: 3,
@@ -107,6 +109,8 @@ describe('Performance > Trends', function() {
               transaction: '/organizations/:orgId/performance/',
             },
             {
+              count: 60,
+              project: 'internal',
               count_range_1: 20,
               count_range_2: 40,
               divide_count_range_2_count_range_1: 2,
@@ -161,6 +165,32 @@ describe('Performance > Trends', function() {
     wrapper.update();
 
     expect(wrapper.find('TrendsListItem')).toHaveLength(4);
+  });
+
+  it('clicking transaction link links to the correct view', async function() {
+    const projects = [TestStubs.Project({id: 1, slug: 'internal'}), TestStubs.Project()];
+    const data = initializeData(projects, {project: ['1']});
+
+    const wrapper = mountWithTheme(
+      <PerformanceLanding
+        organization={data.organization}
+        location={data.router.location}
+      />,
+      data.routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    const firstTransaction = wrapper.find('TrendsListItem').first();
+    const transactionLink = firstTransaction.find('StyledLink');
+    expect(transactionLink).toHaveLength(1);
+
+    expect(transactionLink.text()).toEqual('/organizations/:orgId/performance/');
+    expect(transactionLink.props().to.pathname).toEqual(
+      '/organizations/org-slug/performance/summary/'
+    );
+    expect(transactionLink.props().to.query.project).toEqual(1);
   });
 
   it('transaction list renders user misery', async function() {


### PR DESCRIPTION
### Summary
This fixes the transaction links on trends taking you to a transaction summary with the wrong project, which would show nothing.

Other:
- Added count() as a field to allow filtering, and added a default count to the query when navigating to trends as a temporary measure for finding relevant trends