### PR TITLE
feat(alerts): Add `maxBuckets` parameter to event stats endpoint.

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -242,7 +242,13 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_query"):
                 result = get_event_stats(query_columns, query, params, rollup, reference_event)
 
-        serializer = SnubaTSResultSerializer(organization, None, request.user)
+        max_buckets = request.GET.get("maxBuckets")
+        if max_buckets is not None:
+            max_buckets = int(max_buckets)
+
+        serializer = SnubaTSResultSerializer(
+            organization, None, request.user, max_buckets=max_buckets
+        )
 
         with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_serialization"):
             if top_events:

--- a/tests/sentry/api/serializers/test_snuba.py
+++ b/tests/sentry/api/serializers/test_snuba.py
@@ -3,10 +3,14 @@ from __future__ import absolute_import
 import unittest
 from datetime import timedelta
 
+import pytz
 from django.utils import timezone
 
-from sentry.api.serializers.snuba import zerofill
+from sentry.api.serializers.snuba import SnubaTSResultSerializer, zerofill
+from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.dates import to_timestamp
+from sentry.utils.snuba import SnubaTSResult
 
 
 class ZeroFillTest(unittest.TestCase):
@@ -50,4 +54,52 @@ class ZeroFillTest(unittest.TestCase):
             end=start + timedelta(minutes=60),
             rollup=rollup,
             zerofilled_buckets=[2, 3, 4, 5],
+        )
+
+
+class SnubaTSResultSerializerTest(TestCase):
+    def run_test(self, start, values, rollup, expected, max_buckets=None):
+        start = start.replace(tzinfo=pytz.utc, microsecond=0, second=0)
+        end = start + (rollup * len(values))
+
+        data = []
+        for i, value in enumerate(values):
+            row = {}
+            row["time"] = int(to_timestamp(start + (rollup * i)))
+            if value is not None:
+                row["count"] = value
+            data.append(row)
+
+        result = SnubaTSResult({"data": data}, start, end, int(rollup.total_seconds()))
+        serializer = SnubaTSResultSerializer(
+            self.organization, None, self.user, max_buckets=max_buckets
+        )
+        assert [item[1][0] for item in serializer.serialize(result)["data"]] == expected
+
+    def test(self):
+        self.run_test(
+            before_now(days=1),
+            [None, 2, 1, None],
+            timedelta(minutes=1),
+            [{"count": 0}, {"count": 2}, {"count": 1}, {"count": 0}],
+        )
+
+    def test_max_buckets(self):
+        self.run_test(
+            before_now(days=1),
+            [None, 2, 1, None],
+            timedelta(minutes=1),
+            [{"max": 2, "avg": 1.0, "min": 0}, {"max": 1, "avg": 0.5, "min": 0}],
+            max_buckets=2,
+        )
+        self.run_test(
+            before_now(days=1),
+            [500, 267, 354, 350, 324, 600, 235],
+            timedelta(minutes=1),
+            [
+                {"max": 500, "avg": 373.6666666666667, "min": 267},
+                {"max": 600, "avg": 424.6666666666667, "min": 324},
+                {"max": 235, "avg": 235.0, "min": 235},
+            ],
+            max_buckets=3,
         )


### PR DESCRIPTION
When in the alert rule builder we want to allow users to specify time ranges to view for the rule
that they're building. At the moment this is difficult for smaller time windows, because a large
number of points get returned and can't be rendered effectively in the graph.

We want the ability to summarize a set of datapoints of a specific time window, so that the user can
get a general idea of how their rule will behave. To enable this, I've added the `maxBuckets`
parameter to the event stats api. If the number of results returned from snuba exceeds this number,
then we'll aggregate the values into a smaller number of buckets to make it easier to render the
graph. For each aggregate bucket we provide the min/max/average of the datapoints involved.