### PR TITLE
ci: Update GCB check name for Craft for human-readable names

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -9,7 +9,9 @@ statusProvider:
   name: github
   config:
     contexts:
-      - 'Trigger: 7973c658-e248-4a14-8552-7a66caa7fc0c'
+      - 'onpremise-builder (sentryio)'
+      - 'continuous-integration/travis-ci/push'
+      - 'acceptance'
 targets:
   - name: github
   - name: pypi


### PR DESCRIPTION
See https://cloud.google.com/cloud-build/docs/automating-builds/create-github-app-triggers?#data_sharing and this Slack thread: https://sentry.slack.com/archives/CJ3CW08F9/p1598481307017600

This also adds Travis CI and GHA acceptance tests as required.
