### PR TITLE
ref(alert): Change 'an issue' -> 'the issue' in issue alert form fields

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -103,7 +103,7 @@ class BaseEventFrequencyCondition(EventCondition):
 
 
 class EventFrequencyCondition(BaseEventFrequencyCondition):
-    label = "An issue is seen more than {value} times in {interval}"
+    label = "The issue is seen more than {value} times in {interval}"
 
     def query_hook(self, event, start, end, environment_id):
         return self.tsdb.get_sums(
@@ -116,7 +116,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
 
 
 class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
-    label = "An issue is seen by more than {value} users in {interval}"
+    label = "The issue is seen by more than {value} users in {interval}"
 
     def query_hook(self, event, start, end, environment_id):
         return self.tsdb.get_distinct_counts_totals(

--- a/src/sentry/rules/conditions/first_seen_event.py
+++ b/src/sentry/rules/conditions/first_seen_event.py
@@ -4,7 +4,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class FirstSeenEventCondition(EventCondition):
-    label = "An issue is first seen"
+    label = "The issue is first seen"
 
     def passes(self, event, state):
         if self.rule.environment_id is None:

--- a/src/sentry/rules/conditions/reappeared_event.py
+++ b/src/sentry/rules/conditions/reappeared_event.py
@@ -4,7 +4,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class ReappearedEventCondition(EventCondition):
-    label = "An issue changes state from ignored to unresolved"
+    label = "The issue changes state from ignored to unresolved"
 
     def passes(self, event, state):
         return state.has_reappeared

--- a/src/sentry/rules/conditions/regression_event.py
+++ b/src/sentry/rules/conditions/regression_event.py
@@ -4,7 +4,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class RegressionEventCondition(EventCondition):
-    label = "An issue changes state from resolved to unresolved"
+    label = "The issue changes state from resolved to unresolved"
 
     def passes(self, event, state):
         return state.is_regression

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -321,7 +321,7 @@ class Factories(object):
         condition_data = condition_data or [
             {
                 "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
-                "name": "An issue is first seen",
+                "name": "The issue is first seen",
             },
             {
                 "id": "sentry.rules.conditions.every_event.EveryEventCondition",

--- a/tests/acceptance/test_project_alert_settings.py
+++ b/tests/acceptance/test_project_alert_settings.py
@@ -27,7 +27,7 @@ class ProjectAlertSettingsTest(AcceptanceTestCase):
         condition_data = [
             {
                 "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
-                "name": "An issue is first seen",
+                "name": "The issue is first seen",
             },
             {
                 "id": "sentry.rules.conditions.every_event.EveryEventCondition",

--- a/tests/js/sentry-test/fixtures/projectAlertRuleConfiguration.js
+++ b/tests/js/sentry-test/fixtures/projectAlertRuleConfiguration.js
@@ -9,17 +9,17 @@ export function ProjectAlertRuleConfiguration(params = {}) {
       {
         enabled: true,
         id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
-        label: 'An issue is first seen',
+        label: 'The issue is first seen',
       },
       {
         enabled: true,
         id: 'sentry.rules.conditions.regression_event.RegressionEventCondition',
-        label: 'An issue changes state from resolved to unresolved',
+        label: 'The issue changes state from resolved to unresolved',
       },
       {
         enabled: true,
         id: 'sentry.rules.conditions.reappeared_event.ReappearedEventCondition',
-        label: 'An issue changes state from ignored to unresolved',
+        label: 'The issue changes state from ignored to unresolved',
       },
       {
         formFields: {
@@ -59,7 +59,7 @@ export function ProjectAlertRuleConfiguration(params = {}) {
         },
         enabled: true,
         id: 'sentry.rules.conditions.event_frequency.EventFrequencyCondition',
-        label: 'An issue is seen more than {value} times in {interval}',
+        label: 'The issue is seen more than {value} times in {interval}',
       },
       {
         formFields: {
@@ -77,7 +77,7 @@ export function ProjectAlertRuleConfiguration(params = {}) {
         },
         enabled: true,
         id: 'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition',
-        label: 'An issue is seen by more than {value} users in {interval}',
+        label: 'The issue is seen by more than {value} users in {interval}',
       },
       {
         formFields: {

--- a/tests/js/sentry-test/fixtures/ruleConditions.js
+++ b/tests/js/sentry-test/fixtures/ruleConditions.js
@@ -18,15 +18,15 @@ export const MOCK_RESP_VERBOSE = [
   },
   {
     id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
-    label: 'An issue is first seen',
+    label: 'The issue is first seen',
   },
   {
     id: 'sentry.rules.conditions.regression_event.RegressionEventCondition',
-    label: 'An issue changes state from resolved to unresolved',
+    label: 'The issue changes state from resolved to unresolved',
   },
   {
     id: 'sentry.rules.conditions.reappeared_event.ReappearedEventCondition',
-    label: 'An issue changes state from ignored to unresolved',
+    label: 'The issue changes state from ignored to unresolved',
   },
   {
     formFields: {
@@ -67,7 +67,7 @@ export const MOCK_RESP_VERBOSE = [
       },
     },
     id: EVENT_FREQUENCY_CONDITION,
-    label: 'An issue is seen more than {value} times in {interval}',
+    label: 'The issue is seen more than {value} times in {interval}',
   },
   {
     formFields: {
@@ -81,7 +81,7 @@ export const MOCK_RESP_VERBOSE = [
       },
     },
     id: UNIQUE_USER_FREQUENCY_CONDITION,
-    label: 'An issue is seen by more than {value} users in {interval}',
+    label: 'The issue is seen by more than {value} users in {interval}',
   },
   {
     formFields: {
@@ -167,7 +167,7 @@ export const MOCK_RESP_ONLY_IGNORED_CONDITIONS_INVALID = [
       },
     },
     id: 'cinnamon.rules.conditions.infinite_eclair.A19SeanBanIsabelle',
-    label: 'An issue is seen more than {value} times in {interval}',
+    label: 'The issue is seen more than {value} times in {interval}',
   },
   {
     formFields: {
@@ -185,7 +185,7 @@ export const MOCK_RESP_ONLY_IGNORED_CONDITIONS_INVALID = [
       },
     },
     id: UNIQUE_USER_FREQUENCY_CONDITION,
-    label: 'An issue is seen by more than {value} users in {interval}',
+    label: 'The issue is seen by more than {value} users in {interval}',
   },
 ];
 
@@ -202,7 +202,7 @@ export const MOCK_RESP_INCONSISTENT_PLACEHOLDERS = [
       },
     },
     id: EVENT_FREQUENCY_CONDITION,
-    label: 'An issue is seen more than {value} times in {interval}',
+    label: 'The issue is seen more than {value} times in {interval}',
   },
   {
     formFields: {
@@ -216,7 +216,7 @@ export const MOCK_RESP_INCONSISTENT_PLACEHOLDERS = [
       },
     },
     id: UNIQUE_USER_FREQUENCY_CONDITION,
-    label: 'An issue is seen by more than {value} users in {interval}',
+    label: 'The issue is seen by more than {value} users in {interval}',
   },
 ];
 
@@ -240,7 +240,7 @@ export const MOCK_RESP_INCONSISTENT_INTERVALS = [
       },
     },
     id: EVENT_FREQUENCY_CONDITION,
-    label: 'An issue is seen more than {value} times in {interval}',
+    label: 'The issue is seen more than {value} times in {interval}',
   },
   {
     formFields: {
@@ -254,6 +254,6 @@ export const MOCK_RESP_INCONSISTENT_INTERVALS = [
       },
     },
     id: UNIQUE_USER_FREQUENCY_CONDITION,
-    label: 'An issue is seen by more than {value} users in {interval}',
+    label: 'The issue is seen by more than {value} users in {interval}',
   },
 ];

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -159,7 +159,7 @@ class UpdateProjectRuleTest(APITestCase):
                         "interval": "1h",
                         "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
                         "value": 666,
-                        "name": "An issue is seen more than 30 times in 1m",
+                        "name": "The issue is seen more than 30 times in 1m",
                     }
                 ],
                 "id": rule.id,
@@ -176,7 +176,7 @@ class UpdateProjectRuleTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert (
-            response.data["conditions"][0]["name"] == "An issue is seen more than 666 times in 1h"
+            response.data["conditions"][0]["name"] == "The issue is seen more than 666 times in 1h"
         )
 
         assert RuleActivity.objects.filter(rule=rule, type=RuleActivityType.UPDATED.value).exists()


### PR DESCRIPTION
Changes all conditions which start with 'an issue' to 'the issue' to fit better with the way conditions are worded in the new issue alert builder form.

![image](https://user-images.githubusercontent.com/9372512/91473287-aaea2000-e866-11ea-8e5d-e7eb6b841e8a.png)

Also changed test fixtures to have the same wording for consistency