### PR TITLE
ref(py3): Fix string casting in relay tests

### DIFF
--- a/src/sentry/relay/utils.py
+++ b/src/sentry/relay/utils.py
@@ -3,12 +3,10 @@ from __future__ import absolute_import
 import six
 import uuid
 
-from django.utils.encoding import force_text
-
 
 def get_header_relay_id(request):
     try:
-        return six.text_type(uuid.UUID(force_text(request.META["HTTP_X_SENTRY_RELAY_ID"])))
+        return six.text_type(uuid.UUID(request.META["HTTP_X_SENTRY_RELAY_ID"]))
     except (LookupError, ValueError, TypeError):
         pass
 

--- a/src/sentry/relay/utils.py
+++ b/src/sentry/relay/utils.py
@@ -3,10 +3,12 @@ from __future__ import absolute_import
 import six
 import uuid
 
+from django.utils.encoding import force_text
+
 
 def get_header_relay_id(request):
     try:
-        return six.text_type(uuid.UUID(request.META["HTTP_X_SENTRY_RELAY_ID"]))
+        return six.text_type(uuid.UUID(force_text(request.META["HTTP_X_SENTRY_RELAY_ID"])))
     except (LookupError, ValueError, TypeError):
         pass
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -45,13 +45,13 @@ def private_key(key_pair):
 
 @pytest.fixture
 def relay_id():
-    return six.binary_type(six.text_type(uuid4()).encode("ascii"))
+    return six.text_type(uuid4())
 
 
 @pytest.fixture
 def relay(relay_id, public_key):
     return Relay.objects.create(
-        relay_id=relay_id, public_key=six.binary_type(public_key), is_internal=True
+        relay_id=relay_id, public_key=six.text_type(public_key), is_internal=True
     )
 
 
@@ -79,7 +79,7 @@ def call_endpoint(client, relay, private_key, default_project):
             path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=relay.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=relay.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -79,7 +79,7 @@ def call_endpoint(client, relay, private_key, default_project):
             path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=relay.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=relay.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 

--- a/tests/sentry/api/endpoints/test_relay_projectids.py
+++ b/tests/sentry/api/endpoints/test_relay_projectids.py
@@ -57,7 +57,7 @@ class RelayProjectIdsEndpointTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 

--- a/tests/sentry/api/endpoints/test_relay_projectids.py
+++ b/tests/sentry/api/endpoints/test_relay_projectids.py
@@ -30,12 +30,10 @@ class RelayProjectIdsEndpointTest(APITestCase):
 
         self.public_key = self.key_pair[1]
         self.private_key = self.key_pair[0]
-        self.relay_id = six.binary_type(six.text_type(uuid4()).encode("ascii"))
+        self.relay_id = six.text_type(uuid4())
 
         self.relay = Relay.objects.create(
-            relay_id=self.relay_id,
-            public_key=six.binary_type(self.public_key),
-            is_internal=internal,
+            relay_id=self.relay_id, public_key=self.public_key, is_internal=internal,
         )
 
         self.project = self.create_project()
@@ -49,7 +47,7 @@ class RelayProjectIdsEndpointTest(APITestCase):
         if add_org_key:
             org.update_option(
                 "sentry:trusted-relays",
-                [{"public_key": self.relay.public_key, "name": "main-relay"}],
+                [{"public_key": six.text_type(self.relay.public_key), "name": "main-relay"}],
             )
 
     def _call_endpoint(self, public_key):
@@ -59,7 +57,7 @@ class RelayProjectIdsEndpointTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 

--- a/tests/sentry/api/endpoints/test_relay_publickeys.py
+++ b/tests/sentry/api/endpoints/test_relay_publickeys.py
@@ -107,7 +107,7 @@ class RelayPublicKeysConfigTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=calling_relay.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=calling_relay.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 

--- a/tests/sentry/api/endpoints/test_relay_publickeys.py
+++ b/tests/sentry/api/endpoints/test_relay_publickeys.py
@@ -26,23 +26,23 @@ class RelayPublicKeysConfigTest(APITestCase):
 
         self.internal_relay = Relay.objects.create(
             relay_id=six.text_type(uuid4()),
-            public_key=six.binary_type(self.public_key),
+            public_key=six.text_type(self.public_key),
             is_internal=True,
         )
 
         self.external_relay = Relay.objects.create(
             relay_id=six.text_type(uuid4()),
-            public_key=six.binary_type(self.public_key),
+            public_key=six.text_type(self.public_key),
             is_internal=False,
         )
         self.relay_a = Relay.objects.create(
             relay_id=six.text_type(uuid4()),
-            public_key=six.binary_type(self.public_key),
+            public_key=six.text_type(self.public_key),
             is_internal=False,
         )
         self.relay_b = Relay.objects.create(
             relay_id=six.text_type(uuid4()),
-            public_key=six.binary_type(self.public_key),
+            public_key=six.text_type(self.public_key),
             is_internal=True,
         )
 
@@ -107,7 +107,7 @@ class RelayPublicKeysConfigTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=calling_relay.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=calling_relay.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -37,7 +37,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -52,7 +52,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -67,7 +67,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -78,7 +78,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data="a",
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
         )
 
         assert resp.status_code == 400, resp.content
@@ -92,7 +92,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
         )
 
         assert resp.status_code == 400, resp.content
@@ -120,7 +120,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature + "a",
         )
 
@@ -135,7 +135,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -148,7 +148,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -166,7 +166,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -179,7 +179,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -195,7 +195,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -210,7 +210,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -223,7 +223,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -237,7 +237,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -252,7 +252,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -262,7 +262,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -278,7 +278,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -293,7 +293,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -306,7 +306,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data="a",
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -321,7 +321,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -336,7 +336,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -351,7 +351,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -364,7 +364,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
         )
 
         assert resp.status_code == 400, resp.content
@@ -378,7 +378,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -391,7 +391,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=six.text_type(uuid4()).encode("ascii"),
+            HTTP_X_SENTRY_RELAY_ID=six.text_type(uuid4()),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -21,15 +21,15 @@ class RelayRegisterTest(APITestCase):
         self.key_pair = generate_key_pair()
 
         self.public_key = self.key_pair[1]
-        settings.SENTRY_RELAY_WHITELIST_PK.append(six.binary_type(self.public_key))
+        settings.SENTRY_RELAY_WHITELIST_PK.append(six.text_type(self.public_key))
 
         self.private_key = self.key_pair[0]
-        self.relay_id = six.binary_type(six.text_type(uuid4()).encode("ascii"))
+        self.relay_id = six.text_type(uuid4())
 
         self.path = reverse("sentry-api-0-relay-register-challenge")
 
     def test_valid_register(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -37,14 +37,14 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
         assert resp.status_code == 200, resp.content
 
     def test_register_missing_relay_id(self):
-        data = {"public_key": six.binary_type(self.public_key)}
+        data = {"public_key": six.text_type(self.public_key)}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -52,7 +52,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -67,7 +67,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -78,13 +78,13 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data="a",
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
         )
 
         assert resp.status_code == 400, resp.content
 
     def test_register_missing_header(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -92,13 +92,13 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
         )
 
         assert resp.status_code == 400, resp.content
 
     def test_register_missing_header2(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -112,7 +112,7 @@ class RelayRegisterTest(APITestCase):
         assert resp.status_code == 400, resp.content
 
     def test_register_wrong_sig(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -120,14 +120,14 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature + "a",
         )
 
         assert resp.status_code == 400, resp.content
 
     def test_valid_register_response(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -135,7 +135,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -148,7 +148,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -158,7 +158,7 @@ class RelayRegisterTest(APITestCase):
         assert relay.relay_id == self.relay_id
 
     def test_forge_public_key(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -166,7 +166,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -179,15 +179,15 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
         keys = generate_key_pair()
 
-        settings.SENTRY_RELAY_WHITELIST_PK.append(six.binary_type(keys[1]))
+        settings.SENTRY_RELAY_WHITELIST_PK.append(six.text_type(keys[1]))
 
-        data = {"public_key": six.binary_type(keys[1]), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(keys[1]), "relay_id": self.relay_id}
 
         raw_json, signature = keys[0].pack(data)
 
@@ -195,14 +195,14 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
         assert resp.status_code == 400, resp.content
 
     def test_expired_challenge(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -210,7 +210,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -223,13 +223,13 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
         keys = generate_key_pair()
 
-        data = {"token": six.binary_type(result.get("token")), "relay_id": self.relay_id}
+        data = {"token": six.text_type(result.get("token")), "relay_id": self.relay_id}
 
         raw_json, signature = keys[0].pack(data)
 
@@ -237,14 +237,14 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
         assert resp.status_code == 401, resp.content
 
     def test_forge_public_key_on_register(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -252,7 +252,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -262,7 +262,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -270,7 +270,7 @@ class RelayRegisterTest(APITestCase):
 
         keys = generate_key_pair()
 
-        data = {"token": six.binary_type(result.get("token")), "relay_id": self.relay_id}
+        data = {"token": six.text_type(result.get("token")), "relay_id": self.relay_id}
 
         raw_json, signature = keys[0].pack(data)
 
@@ -278,14 +278,14 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
         assert resp.status_code == 400, resp.content
 
     def test_invalid_json_response(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -293,7 +293,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -306,14 +306,14 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data="a",
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
         assert resp.status_code == 400, resp.content
 
     def test_missing_token_response(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -321,7 +321,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -336,14 +336,14 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
         assert resp.status_code == 400, resp.content
 
     def test_missing_sig_response(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -351,7 +351,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -364,13 +364,13 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
         )
 
         assert resp.status_code == 400, resp.content
 
     def test_relay_id_missmatch_response(self):
-        data = {"public_key": six.binary_type(self.public_key), "relay_id": self.relay_id}
+        data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
 
@@ -378,7 +378,7 @@ class RelayRegisterTest(APITestCase):
             self.path,
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id.encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
@@ -391,7 +391,7 @@ class RelayRegisterTest(APITestCase):
             reverse("sentry-api-0-relay-register-response"),
             data=raw_json,
             content_type="application/json",
-            HTTP_X_SENTRY_RELAY_ID=six.binary_type(six.text_type(uuid4()).encode("ascii")),
+            HTTP_X_SENTRY_RELAY_ID=six.text_type(uuid4()).encode("ascii"),
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 


### PR DESCRIPTION
This is another instance of the linter likely suggesting binary type, when really we want string type to cast these objects to strings.