### PR TITLE
feat(sqs): remove rate limit for SQS

### DIFF
--- a/src/sentry/plugins/bases/data_forwarding.py
+++ b/src/sentry/plugins/bases/data_forwarding.py
@@ -1,10 +1,14 @@
 from __future__ import absolute_import
 
+import logging
+
 from sentry import tsdb, ratelimits
 from sentry.api.serializers import serialize
 from sentry.plugins.base import Plugin
 from sentry.plugins.base.configuration import react_plugin_config
 from sentry.plugins.status import PluginStatus
+
+logger = logging.getLogger(__name__)
 
 
 class DataForwardingPlugin(Plugin):
@@ -37,6 +41,15 @@ class DataForwardingPlugin(Plugin):
         # limit segment to 50 requests/second
         limit, window = self.get_rate_limit()
         if limit and window and ratelimits.is_limited(rl_key, limit=limit, window=window):
+            logger.info(
+                "data_forwarding.skip_rate_limited",
+                extra={
+                    "event_id": event.event_id,
+                    "issue_id": event.group_id,
+                    "project_id": event.project_id,
+                    "organization_id": event.project.organization_id,
+                },
+            )
             return
 
         payload = self.get_event_payload(event)

--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -93,6 +93,10 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
             },
         ]
 
+    def get_rate_limit(self):
+        # no rate limit for SQS
+        return (0, 0)
+
     @track_response_metric
     def forward_event(self, event, payload):
         queue_url = self.get_option("queue_url", event.project)


### PR DESCRIPTION
This PR removes the rate limit for SQS which is impacting some of our larger customers. SQS has no limit of the throughput as long as the queue is not FIFO ([300/s for FIFO](https://aws.amazon.com/sqs/faqs)). I've also added a log statement in case throttle happens so debugging is easier.