### PR TITLE
fix(ratelimiter): Actually produce hexdigests for keys

### DIFF
--- a/src/sentry/utils/ratelimits.py
+++ b/src/sentry/utils/ratelimits.py
@@ -6,39 +6,47 @@ from sentry import features
 from sentry.app import ratelimiter
 from sentry.utils.hashlib import md5_text
 
+DEFAULT_CONFIG = {
+    # 100 invites from a user per day
+    "members:invite-by-user": {"limit": 100, "window": 3600 * 24},
+    # 100 invites from an org per day
+    "members:invite-by-org": {"limit": 100, "window": 3600 * 24},
+    # 10 invites per email per org per day
+    "members:org-invite-to-email": {"limit": 10, "window": 3600 * 24},
+}
 
-def for_organization_member_invite(organization, email, user=None, auth=None):
+
+def for_organization_member_invite(organization, email, user=None, auth=None, config=None):
     """
     Rate limit logic for triggering a user invite email, which should also be applied for generating
     a brand new member invite when possible.
     """
+    if config is None:
+        config = DEFAULT_CONFIG
+
     if not features.has("organizations:invite-members-rate-limits", organization, actor=user):
         return False
 
     limits = (
         ratelimiter.is_limited(
             u"members:invite-by-user:{}".format(
-                md5_text(user.id if user and user.is_authenticated() else six.text_type(auth))
+                md5_text(
+                    user.id if user and user.is_authenticated() else six.text_type(auth)
+                ).hexdigest()
             ),
-            # 100 invites from a user per day
-            limit=100,
-            window=3600 * 24,
+            **config["members:invite-by-user"]
         )
         if (user or auth)
         else None,
         ratelimiter.is_limited(
-            u"members:invite-by-org:{}".format(md5_text(organization.id)),
-            # 100 invites from an org per day
-            limit=100,
-            window=3600 * 24,
+            u"members:invite-by-org:{}".format(md5_text(organization.id).hexdigest()),
+            **config["members:invite-by-org"]
         ),
         ratelimiter.is_limited(
             u"members:org-invite-to-email:{}-{}".format(
                 organization.id, md5_text(email.lower()).hexdigest()
             ),
-            # 10 invites per email per org per day
-            limit=10,
-            window=3600 * 24,
+            **config["members:org-invite-to-email"]
         ),
     )
     return any(limits)

--- a/tests/sentry/utils/test_ratelimits.py
+++ b/tests/sentry/utils/test_ratelimits.py
@@ -6,43 +6,60 @@ from sentry.models import ApiToken, Organization, User
 from sentry.testutils import TestCase
 from sentry.utils import ratelimits
 
+# Produce faster tests by reducing the limits so we don't have to generate so amny
+RELAXED_CONFIG = {
+    "members:invite-by-user": {"limit": 5, "window": 3600 * 24},
+    "members:invite-by-org": {"limit": 5, "window": 3600 * 24},
+    "members:org-invite-to-email": {"limit": 2, "window": 3600 * 24},
+}
+
 
 class ForOrganizationMemberTestCase(TestCase):
     def test_by_email(self):
         organization = Organization(id=1)
         email = "foo@example.com"
-        for n in range(10):
-            assert not ratelimits.for_organization_member_invite(organization, email)
+        for n in range(2):
+            assert not ratelimits.for_organization_member_invite(
+                organization, email, config=RELAXED_CONFIG
+            )
 
-        assert ratelimits.for_organization_member_invite(organization, email)
+        assert ratelimits.for_organization_member_invite(organization, email, config=RELAXED_CONFIG)
 
     def test_by_organization(self):
         organization = Organization(id=1)
-        for n in range(100):
+        for n in range(5):
             assert not ratelimits.for_organization_member_invite(
-                organization, "{}@example.com".format(randint(0, 1000000))
+                organization, "{}@example.com".format(randint(0, 1000000)), config=RELAXED_CONFIG
             )
 
-        assert ratelimits.for_organization_member_invite(organization, "anything@example.com")
+        assert ratelimits.for_organization_member_invite(
+            organization, "anything@example.com", config=RELAXED_CONFIG
+        )
 
     def test_by_api_token(self):
-        token = ApiToken()
-        for n in range(100):
+        token = ApiToken(id=1)
+        for n in range(5):
             assert not ratelimits.for_organization_member_invite(
                 Organization(id=randint(0, 100000)),
                 "{}@example.com".format(randint(0, 1000000)),
                 auth=token,
+                config=RELAXED_CONFIG,
             )
 
-        assert ratelimits.for_organization_member_invite(Organization(id=1), "anything@example.com")
+        assert ratelimits.for_organization_member_invite(
+            Organization(id=1), "anything@example.com", auth=token, config=RELAXED_CONFIG
+        )
 
     def test_by_user(self):
         user = User(email="biz@example.com")
-        for n in range(100):
+        for n in range(5):
             assert not ratelimits.for_organization_member_invite(
                 Organization(id=randint(0, 100000)),
                 "{}@example.com".format(randint(0, 1000000)),
                 user=user,
+                config=RELAXED_CONFIG,
             )
 
-        assert ratelimits.for_organization_member_invite(Organization(id=1), "anything@example.com")
+        assert ratelimits.for_organization_member_invite(
+            Organization(id=1), "anything@example.com", user=user, config=RELAXED_CONFIG
+        )


### PR DESCRIPTION
We weren't actually producing a string version of the md5 hash without
`hexdigest`, so this was actually just encoding the repr of the md5 hash
object.

This seems to have worked OK inadvertantly in python2, but not in
python3.