### PR TITLE
ref(py3): Correct casting of incident.identifier in pagerduty.utils

### DIFF
--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -33,7 +33,7 @@ def build_incident_attachment(incident, integration_key, metric_value=None):
         "payload": {
             "summary": incident.alert_rule.name,
             "severity": severity,
-            "source": six.binary_type(incident.identifier),
+            "source": six.text_type(incident.identifier),
             "custom_details": {"details": data["text"]},
         },
         "links": [{"href": data["title_link"], "text": data["title"]}],

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -348,7 +348,7 @@ class PagerDutyActionHandlerBaseTest(object):
         )
         assert data["payload"]["summary"] == alert_rule.name
         assert data["payload"]["severity"] == "critical"
-        assert data["payload"]["source"] == six.binary_type(incident.identifier)
+        assert data["payload"]["source"] == six.text_type(incident.identifier)
         assert data["payload"]["custom_details"] == {
             "details": "1000 events in the last 10 minutes\nFilter: level:error"
         }


### PR DESCRIPTION
Another case fo the linter telling people to use binary_type.