### PR TITLE
ref(py3): Workaround difference in urljoin

### DIFF
--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -32,7 +32,7 @@ def test_system_origin():
         # String substitution with variable
         ("{% absolute_uri '/{}/' who %}", "http://testserver/matt/"),
         # String substitution with missing variable
-        ("{% absolute_uri '/foo/{}/' xxx %}", "http://testserver/foo//"),
+        ("{% absolute_uri '/foo/x{}/' xxx %}", "http://testserver/foo/x/"),
         # String substitution with multiple vars
         ("{% absolute_uri '/{}/{}/' who desc %}", "http://testserver/matt/awesome/"),
         # Empty tag, as other var
@@ -48,8 +48,8 @@ def test_system_origin():
         ("{% absolute_uri '/{}/' who as uri %}hello {{ uri }}!", "hello http://testserver/matt/!"),
         # Mix it all up
         (
-            "{% absolute_uri '/{}/{}/{}/{}/' who 'xxx' nope desc as uri %}hello {{ uri }}!",
-            "hello http://testserver/matt/xxx//awesome/!",
+            "{% absolute_uri '/{}/{}/x{}/{}/' who 'xxx' nope desc as uri %}hello {{ uri }}!",
+            "hello http://testserver/matt/xxx/x/awesome/!",
         ),
     ),
 )


### PR DESCRIPTION
In python3 land urljoin will filter out double slashes [0], which python2 does not do. We can just work around this one failing test, which doesn't really test for this, by inserting text before the empty variable to ensure the slash does not collapse, making things consistent between 2 and 3.

[0]: https://bugs.python.org/issue40594