### PR TITLE
Revert "fix(py3): Be consistent with encoding in sourcemap processor…(#20276)"

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -9,7 +9,6 @@ import base64
 import six
 import zlib
 
-from django.utils.encoding import force_bytes
 from django.conf import settings
 from os.path import splitext
 from requests.utils import get_encoding_from_headers
@@ -154,7 +153,7 @@ def discover_sourcemap(result):
     sourcemap = result.headers.get("sourcemap", result.headers.get("x-sourcemap"))
 
     if not sourcemap:
-        parsed_body = result.body.decode(result.encoding or "utf-8").split("\n")
+        parsed_body = result.body.split("\n")
         # Source maps are only going to exist at either the top or bottom of the document.
         # Technically, there isn't anything indicating *where* it should exist, so we
         # are generous and assume it's somewhere either in the first or last 5 lines.
@@ -181,7 +180,6 @@ def discover_sourcemap(result):
             # not very long.
             search_space = possibilities[-1][-300:].rstrip()
             match = SOURCE_MAPPING_URL_RE.search(search_space)
-
             if match:
                 sourcemap = match.group(1)
 
@@ -419,8 +417,7 @@ def fetch_sourcemap(url, project=None, release=None, dist=None, allow_scraping=T
     if is_data_uri(url):
         try:
             body = base64.b64decode(
-                force_bytes(url[BASE64_PREAMBLE_LENGTH:])
-                + (b"=" * (-(len(url) - BASE64_PREAMBLE_LENGTH) % 4))
+                url[BASE64_PREAMBLE_LENGTH:] + (b"=" * (-(len(url) - BASE64_PREAMBLE_LENGTH) % 4))
             )
         except TypeError as e:
             raise UnparseableSourcemap({"url": "<base64>", "reason": six.text_type(e)})

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -133,7 +133,7 @@ class FetchReleaseFileTest(TestCase):
 
         assert isinstance(foo_result.body, six.binary_type)
         assert foo_result == http.UrlResult(
-            "file.min.js", {"content-type": "application/json; charset=utf-8"}, b"foo", 200, "utf-8"
+            "file.min.js", {"content-type": "application/json; charset=utf-8"}, "foo", 200, "utf-8"
         )
 
         # test that cache pays attention to dist value as well as name
@@ -142,7 +142,7 @@ class FetchReleaseFileTest(TestCase):
         # result is cached, but that's not what we should find
         assert bar_result != foo_result
         assert bar_result == http.UrlResult(
-            "file.min.js", {"content-type": "application/json; charset=utf-8"}, b"bar", 200, "utf-8"
+            "file.min.js", {"content-type": "application/json; charset=utf-8"}, "bar", 200, "utf-8"
         )
 
     def test_tilde(self):
@@ -293,7 +293,7 @@ class FetchFileTest(TestCase):
     @patch("sentry.lang.javascript.processor.fetch_release_file")
     def test_non_url_with_release(self, mock_fetch_release_file):
         mock_fetch_release_file.return_value = http.UrlResult(
-            "/example.js", {"content-type": "application/json"}, b"foo", 200, None
+            "/example.js", {"content-type": "application/json"}, "foo", 200, None
         )
 
         release = Release.objects.create(version="1", organization_id=self.project.organization_id)
@@ -396,36 +396,23 @@ class CacheControlTest(unittest.TestCase):
 class DiscoverSourcemapTest(unittest.TestCase):
     # discover_sourcemap(result)
     def test_simple(self):
-        result = http.UrlResult("http://example.com", {}, b"", 200, None)
+        result = http.UrlResult("http://example.com", {}, "", 200, None)
         assert discover_sourcemap(result) is None
 
         result = http.UrlResult(
-            "http://example.com",
-            {"x-sourcemap": "http://example.com/source.map.js"},
-            b"",
-            200,
-            None,
+            "http://example.com", {"x-sourcemap": "http://example.com/source.map.js"}, "", 200, None
         )
         assert discover_sourcemap(result) == "http://example.com/source.map.js"
 
         result = http.UrlResult(
-            "http://example.com", {"sourcemap": "http://example.com/source.map.js"}, b"", 200, None
-        )
-        assert discover_sourcemap(result) == "http://example.com/source.map.js"
-
-        result = http.UrlResult(
-            "http://example.com",
-            {},
-            b"//@ sourceMappingURL=http://example.com/source.map.js\nconsole.log(true)",
-            200,
-            None,
+            "http://example.com", {"sourcemap": "http://example.com/source.map.js"}, "", 200, None
         )
         assert discover_sourcemap(result) == "http://example.com/source.map.js"
 
         result = http.UrlResult(
             "http://example.com",
             {},
-            b"//# sourceMappingURL=http://example.com/source.map.js\nconsole.log(true)",
+            "//@ sourceMappingURL=http://example.com/source.map.js\nconsole.log(true)",
             200,
             None,
         )
@@ -434,7 +421,7 @@ class DiscoverSourcemapTest(unittest.TestCase):
         result = http.UrlResult(
             "http://example.com",
             {},
-            b"console.log(true)\n//@ sourceMappingURL=http://example.com/source.map.js",
+            "//# sourceMappingURL=http://example.com/source.map.js\nconsole.log(true)",
             200,
             None,
         )
@@ -443,7 +430,7 @@ class DiscoverSourcemapTest(unittest.TestCase):
         result = http.UrlResult(
             "http://example.com",
             {},
-            b"console.log(true)\n//# sourceMappingURL=http://example.com/source.map.js",
+            "console.log(true)\n//@ sourceMappingURL=http://example.com/source.map.js",
             200,
             None,
         )
@@ -452,7 +439,16 @@ class DiscoverSourcemapTest(unittest.TestCase):
         result = http.UrlResult(
             "http://example.com",
             {},
-            b"console.log(true)\n//# sourceMappingURL=http://example.com/source.map.js\n//# sourceMappingURL=http://example.com/source2.map.js",
+            "console.log(true)\n//# sourceMappingURL=http://example.com/source.map.js",
+            200,
+            None,
+        )
+        assert discover_sourcemap(result) == "http://example.com/source.map.js"
+
+        result = http.UrlResult(
+            "http://example.com",
+            {},
+            "console.log(true)\n//# sourceMappingURL=http://example.com/source.map.js\n//# sourceMappingURL=http://example.com/source2.map.js",
             200,
             None,
         )
@@ -462,20 +458,18 @@ class DiscoverSourcemapTest(unittest.TestCase):
         result = http.UrlResult(
             "http://example.com",
             {},
-            b"console.log(true);//# sourceMappingURL=http://example.com/source.map.js",
+            "console.log(true);//# sourceMappingURL=http://example.com/source.map.js",
             200,
             None,
         )
         assert discover_sourcemap(result) == "http://example.com/source.map.js"
 
         result = http.UrlResult(
-            "http://example.com", {}, b"//# sourceMappingURL=app.map.js/*ascii:lol*/", 200, None
+            "http://example.com", {}, "//# sourceMappingURL=app.map.js/*ascii:lol*/", 200, None
         )
         assert discover_sourcemap(result) == "http://example.com/app.map.js"
 
-        result = http.UrlResult(
-            "http://example.com", {}, b"//# sourceMappingURL=/*lol*/", 200, None
-        )
+        result = http.UrlResult("http://example.com", {}, "//# sourceMappingURL=/*lol*/", 200, None)
         with self.assertRaises(AssertionError):
             discover_sourcemap(result)
 


### PR DESCRIPTION
This reverts commit 37b45b7b10edc79c97a98cc0419d32b7daa54326.