### PR TITLE
ref(py3): Conditionally use set_exception_info in subclassed Future

### DIFF
--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import logging
 import sys
 import threading
+import six
+
 from six.moves.queue import Full, PriorityQueue
 from concurrent.futures import Future
 from concurrent.futures._base import RUNNING, FINISHED
@@ -23,8 +25,11 @@ def execute(function, daemon=True):
 
         try:
             result = function()
-        except Exception:
-            future.set_exception_info(*sys.exc_info()[1:])
+        except Exception as e:
+            if six.PY3:
+                future.set_exception(e)
+            else:
+                future.set_exception_info(*sys.exc_info()[1:])
         else:
             future.set_result(result)
 
@@ -49,7 +54,7 @@ class TimedFuture(Future):
         a timestamp or ``None`` (if the future has not been either completed or
         cancelled.)
 
-        There are some idiosyncracies with the way the timings are recorded:
+        There are some idiosyncrasies with the way the timings are recorded:
 
         - The ``started`` value will generally not be ``None`` if the
           ``finished`` value is also not ``None``. However, for a future that
@@ -92,14 +97,24 @@ class TimedFuture(Future):
             self.__timing[1] = time()
             return super(TimedFuture, self).set_result(*args, **kwargs)
 
-    def set_exception_info(self, *args, **kwargs):
-        # XXX: This makes the potentially unsafe assumption that
-        # ``set_exception`` will always continue to call this function.
-        with self._condition:
-            # This method always overwrites the result, so we always overwrite
-            # the timing, even if another timing was already recorded.
-            self.__timing[1] = time()
-            return super(TimedFuture, self).set_exception_info(*args, **kwargs)
+    # XXX: In python2 land we use pythonfutures library, which implements the
+    # set_exception_info method, we want to override that here instead of
+    # set_exception if we can.
+    if six.PY3:
+
+        def set_exception(self, *args, **kwargs):
+            with self._condition:
+                self.__timing[1] = time()
+                return super(TimedFuture, self).set_exception(*args, **kwargs)
+
+    else:
+
+        def set_exception_info(self, *args, **kwargs):
+            # XXX: This makes the potentially unsafe assumption that
+            # ``set_exception`` will always continue to call this function.
+            with self._condition:
+                self.__timing[1] = time()
+                return super(TimedFuture, self).set_exception_info(*args, **kwargs)
 
 
 class Executor(object):
@@ -146,8 +161,11 @@ class SynchronousExecutor(Executor):
         assert future.set_running_or_notify_cancel()
         try:
             result = callable()
-        except Exception:
-            future.set_exception_info(*sys.exc_info()[1:])
+        except Exception as e:
+            if six.PY3:
+                future.set_exception(e)
+            else:
+                future.set_exception_info(*sys.exc_info()[1:])
         else:
             future.set_result(result)
         return future
@@ -179,8 +197,11 @@ class ThreadedExecutor(Executor):
                 continue
             try:
                 result = function()
-            except Exception:
-                future.set_exception_info(*sys.exc_info()[1:])
+            except Exception as e:
+                if six.PY3:
+                    future.set_exception(e)
+                else:
+                    future.set_exception_info(*sys.exc_info()[1:])
             else:
                 future.set_result(result)
             queue.task_done()

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -160,13 +160,13 @@ def test_synchronous_executor():
     assert executor.submit(lambda: mock.sentinel.RESULT).result() is mock.sentinel.RESULT
 
     def callable():
-        raise Exception(mock.sentinel.MESSAGE)
+        raise Exception(mock.sentinel.EXCEPTION)
 
     future = executor.submit(callable)
     try:
         future.result()
     except Exception as e:
-        assert e.message is mock.sentinel.MESSAGE
+        assert e.args[0] == mock.sentinel.EXCEPTION
     else:
         assert False, "expected future to raise"
 


### PR DESCRIPTION
Our requirements file loads the backported pythonfutures library ONLY in python2. In python3 this is part of the standard library.

Unfortunately the python3 implementation does NOT have a `set_exception_info` method on the `Future` object, only `set_exception` which does not keep track of the traceback.

In fact, this was never part of PEP-3148 [0], however was added into the backport library in [1], which we implemented in our subclassed futures.

[0]: https://www.python.org/dev/peps/pep-3148/
[1]: https://github.com/agronholm/pythonfutures/commit/6342a77a56fa04ac9c9b28cbf4d1ac26be3f0476

The implication of this is that futures which raise exceptions will now unfortunately lose the traceback.