### PR TITLE
ref(py3): Clarify hashlib usage between 2/3

### DIFF
--- a/tests/sentry/utils/hashlib/tests.py
+++ b/tests/sentry/utils/hashlib/tests.py
@@ -17,13 +17,25 @@ HASHLIB_VALUES_TESTS = (
     ("seed", six.binary_type("test".encode("utf-8")), "334e3fd2f66966a5c785d825c5f03494"),
     ("seed", six.text_type("test"), "ce35c0ce0d38976f61a5ca951de74a16"),
     ("seed", (4, 2), "d03b32e798444249d726158594d370f6"),
-    ("seed", {"test": 42}, "c545cf1c4ab09eff4a1e0fa5209f1645"),
+    ("seed", {six.text_type("test"): 42}, "ca094da15d323155e3954cff7ca373c4"),
+    # XXX: It should be noted these cases EXPLICLTY exclude the fact that
+    # python2 and python3 CANNOT hash to the same values whne using the `str`
+    # and not the text_type, since they will map to different cases (py2 will
+    # encode with the 0x06 'byte' marker and py3 will encode using the 0x07
+    # 'unicode' marker).
 )
 
 
 @pytest.mark.parametrize("seed,value,hash", HASHLIB_VALUES_TESTS)
 def test_hash_values(seed, value, hash):
     assert hash_values([value], seed=seed) == hash
+
+
+def test_hashvalues_python23_strings():
+    if six.PY2:
+        assert hash_values(["test"], seed="seed") == "334e3fd2f66966a5c785d825c5f03494"
+    else:
+        assert hash_values(["test"], seed="seed") == "ce35c0ce0d38976f61a5ca951de74a16"
 
 
 class HashlibTest(TestCase):


### PR DESCRIPTION
We use `hash_values` nearly exclusively for cache keys. If we're OK
losing some cache keys across python2 and 3, I think this is our best
solution.