### PR TITLE
ref(py3): Fix template tag escaping tests

### DIFF
--- a/tests/sentry/templatetags/test_sentry_api.py
+++ b/tests/sentry/templatetags/test_sentry_api.py
@@ -18,4 +18,4 @@ class SerializeDetailedOrgTest(TestCase):
         result = self.TEMPLATE.render(context={"org": org})
 
         assert "<script>" not in result
-        assert "\u003cscript\u003ealert(1);\u003c/script\u003e" in result
+        assert "\\u003cscript\\u003ealert(1);\\u003c/script\\u003e" in result


### PR DESCRIPTION
Would like to have this one expalined to me.. not really sure why this
double escaping works, and why it didn't break py2 tests.