### PR TITLE
feat: Add SENTRY_METRICS_SET_ORGANIZATION_AND_PROJECT_ID (default false)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1159,6 +1159,7 @@ SENTRY_METRICS_OPTIONS = {}
 SENTRY_METRICS_SAMPLE_RATE = 1.0
 SENTRY_METRICS_PREFIX = "sentry."
 SENTRY_METRICS_SKIP_INTERNAL_PREFIXES = []  # Order this by most frequent prefixes.
+SENTRY_METRICS_SET_ORGANIZATION_AND_PROJECT_ID = False
 
 # URI Prefixes for generating DSN URLs
 # (Defaults to URL_PREFIX by default)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1117,8 +1117,16 @@ def discard_event(job, attachments):
             quantity=attachment_quantity,
         )
 
+    tags = {
+        "platform": job["platform"],
+    }
+
+    if settings.SENTRY_METRICS_SET_ORGANIZATION_AND_PROJECT_ID:
+        tags["organization_id"] = project.organization_id
+        tags["project_id"] = project.project_id
+
     metrics.incr(
-        "events.discarded", skip_internal=True, tags={"platform": job["platform"]},
+        "events.discarded", skip_internal=True, tags=tags,
     )
 
 

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -82,12 +82,16 @@ def track_outcome(
         ),
     )
 
+    tags = {
+        "outcome": outcome.name.lower(),
+        "reason": reason,
+        "category": category.api_name() if category is not None else "null",
+    }
+
+    if settings.SENTRY_METRICS_SET_ORGANIZATION_AND_PROJECT_ID:
+        tags["organization_id"] = org_id
+        tags["project_id"] = project_id
+
     metrics.incr(
-        "events.outcomes",
-        skip_internal=True,
-        tags={
-            "outcome": outcome.name.lower(),
-            "reason": reason,
-            "category": category.api_name() if category is not None else "null",
-        },
+        "events.outcomes", skip_internal=True, tags=tags,
     )


### PR DESCRIPTION
to add org and project id as tags to metrics