### PR TITLE
fix(alert): Fix filter_match in slack celery task

### DIFF
--- a/src/sentry/integrations/slack/tasks.py
+++ b/src/sentry/integrations/slack/tasks.py
@@ -59,7 +59,16 @@ class RedisRuleStatus(object):
 
 @instrumented_task(name="sentry.integrations.slack.search_channel_id", queue="integrations")
 def find_channel_id_for_rule(
-    name, environment, project, action_match, conditions, actions, frequency, uuid, rule_id=None
+    name,
+    environment,
+    project,
+    action_match,
+    filter_match,
+    conditions,
+    actions,
+    frequency,
+    uuid,
+    rule_id=None,
 ):
     redis_rule_status = RedisRuleStatus(uuid)
 
@@ -114,6 +123,7 @@ def find_channel_id_for_rule(
             "environment": environment,
             "project": project,
             "action_match": action_match,
+            "filter_match": filter_match,
             "conditions": conditions,
             "actions": actions,
             "frequency": frequency,

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -42,6 +42,7 @@ class SlackTasksTest(TestCase):
             "environment": None,
             "project": self.project1,
             "action_match": "all",
+            "filter_match": "all",
             "conditions": [
                 {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
             ],
@@ -90,6 +91,7 @@ class SlackTasksTest(TestCase):
             "environment": None,
             "project": self.project1,
             "action_match": "all",
+            "filter_match": "all",
             "conditions": [condition_data],
             "actions": [
                 {
@@ -149,6 +151,7 @@ class SlackTasksTest(TestCase):
             "environment": None,
             "project": self.project1,
             "action_match": "all",
+            "filter_match": "all",
             "conditions": [{"id": "sentry.rules.conditions.every_event.EveryEventCondition"}],
             "actions": [
                 {


### PR DESCRIPTION
After recent changes from https://github.com/getsentry/sentry/pull/20412, this celery task is now broken as it is called with an extra `filter_match` parameter. Fixed by adding it in.

Ref: SENTRY-HKX