### PR TITLE
fix(search): Adding a check for invalid sort key

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -181,6 +181,10 @@ class SnubaSearchBackendBase(SearchBackend):
             date_to=date_to,
         )
 
+        # ensure sort strategy is supported by executor
+        if not query_executor.has_sort_strategy(sort_by):
+            raise InvalidSearchQuery(u"Sort key '{}' not supported.".format(sort_by))
+
         return query_executor.query(
             projects=projects,
             retention_window_start=retention_window_start,

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -211,6 +211,9 @@ class AbstractQueryExecutor:
         """
         return converted_filter
 
+    def has_sort_strategy(self, sort_by):
+        return sort_by in self.sort_strategies.keys()
+
 
 class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
     ISSUE_FIELD_NAME = "group_id"

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -145,6 +145,14 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400
         assert "Invalid format for numeric search" in response.data["detail"]
 
+    def test_invalid_sort_key(self):
+        now = timezone.now()
+        self.create_group(checksum="a" * 32, last_seen=now - timedelta(seconds=1))
+        self.login_as(user=self.user)
+
+        response = self.get_response(sort="meow", query="is:unresolved")
+        assert response.status_code == 400
+
     def test_simple_pagination(self):
         event1 = self.store_event(
             data={"timestamp": iso_format(before_now(seconds=2)), "fingerprint": ["group-1"]},


### PR DESCRIPTION
It seems we were able to pass some invalid sort keys to the executor. The easiest way I know is by just typing a new value in the URL. This caused some errors, so I added a check for this to prevent it in the future.

Fixes https://sentry.io/organizations/sentry/issues/1658771022/