### PR TITLE
fix(discover): Do not prepend extra id column if already present

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -551,6 +551,10 @@ class EventView {
     return this.fields.some(field => isAggregateField(field.field));
   }
 
+  hasIdField() {
+    return this.fields.some(field => field.field === 'id');
+  }
+
   numOfColumns(): number {
     return this.fields.length;
   }


### PR DESCRIPTION
In discover, when there isn't an aggregate, it automatically prepends an ID
column. This is noisy when there is already a ID column selected. This change
removes the prepended ID column if it already exists.
