### PR TITLE
fix(alert): Fix targetType form validation

### DIFF
--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -56,7 +56,7 @@ class MemberTeamForm(forms.Form):
         if targetType != self.teamValue and targetType != self.memberValue:
             return
 
-        if targetIdentifier is None or targetIdentifier == "":
+        if not targetIdentifier:
             msg = forms.ValidationError("You need to specify a Team or Member.")
             self.add_error("targetIdentifier", msg)
             return

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -23,6 +23,7 @@ class MemberTeamForm(forms.Form):
     )
     teamValue = None
     memberValue = None
+    targetTypeEnum = None
 
     def __init__(self, project, *args, **kwargs):
         super(MemberTeamForm, self).__init__(*args, **kwargs)
@@ -43,7 +44,7 @@ class MemberTeamForm(forms.Form):
     def clean(self):
         cleaned_data = super(MemberTeamForm, self).clean()
         try:
-            targetType = ActionTargetType(cleaned_data.get("targetType"))
+            targetType = self.targetTypeEnum(cleaned_data.get("targetType"))
         except ValueError:
             msg = forms.ValidationError("Invalid targetType specified")
             self.add_error("targetType", msg)
@@ -55,7 +56,7 @@ class MemberTeamForm(forms.Form):
         if targetType != self.teamValue and targetType != self.memberValue:
             return
 
-        if targetIdentifier is None:
+        if targetIdentifier is None or targetIdentifier == "":
             msg = forms.ValidationError("You need to specify a Team or Member.")
             self.add_error("targetIdentifier", msg)
             return
@@ -88,6 +89,7 @@ class NotifyEmailForm(MemberTeamForm):
 
     teamValue = ActionTargetType.TEAM
     memberValue = ActionTargetType.MEMBER
+    targetTypeEnum = ActionTargetType
 
 
 class NotifyEmailAction(EventAction):

--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -1,22 +1,23 @@
 from __future__ import absolute_import
 
 from django import forms
+from enum import Enum
 
 from sentry.rules.filters.base import EventFilter
 from sentry.mail.actions import MemberTeamForm
 from sentry.utils.cache import cache
 
 
-class AssigneeTargetType:
+class AssigneeTargetType(Enum):
     UNASSIGNED = "Unassigned"
     TEAM = "Team"
     MEMBER = "Member"
 
 
 CHOICES = [
-    (AssigneeTargetType.UNASSIGNED, "Unassigned"),
-    (AssigneeTargetType.TEAM, "Team"),
-    (AssigneeTargetType.MEMBER, "Member"),
+    (AssigneeTargetType.UNASSIGNED.value, "Unassigned"),
+    (AssigneeTargetType.TEAM.value, "Team"),
+    (AssigneeTargetType.MEMBER.value, "Member"),
 ]
 
 
@@ -25,6 +26,7 @@ class AssignedToForm(MemberTeamForm):
 
     teamValue = AssigneeTargetType.TEAM
     memberValue = AssigneeTargetType.MEMBER
+    targetTypeEnum = AssigneeTargetType
 
 
 class AssignedToFilter(EventFilter):

--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -45,7 +45,7 @@ class AssignedToFilter(EventFilter):
         return assignee_list
 
     def passes(self, event, state):
-        targetType = self.get_option("targetType")
+        targetType = AssigneeTargetType(self.get_option("targetType"))
 
         if targetType == AssigneeTargetType.UNASSIGNED:
             return len(self.get_assignees(event.group)) == 0


### PR DESCRIPTION
The form validation previously only checked for `targetIdentifier is None`, but usually when the frontend sends the targetIdentifier data, if it is unfilled, it will come in as an empty string ''. This caused an `invalid literal for int() with base 10: ''` error in the backend. Added a check for empty string and also unified the new assignee target type filter to use an enum so form validation works properly for that as well.

Fixes: SENTRY-GF5