### PR TITLE
feat(store) Add option to transition post_process to cache keys

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -256,3 +256,7 @@ register("processing.can-use-scrubbers", default=True)
 #
 # Note: A value that is neither 0 nor 1 is regarded as 0
 register("store.use-relay-dsn-sample-rate", default=1)
+
+# Runtime switch for transitioning post_process to using a cache key
+# instead of passing the entire event in the celery parameters.
+register("postprocess.use-cache-key", default=0.0, flags=FLAG_PRIORITIZE_DISK)


### PR DESCRIPTION
The store post_process task currently takes the entire event as a parameter to the task. This puts a lot of weight into RabbitMQ messages. The other steps of processing pass a cache key around and fetch the actual data out of the eventprocessing store backed by redis.

This option will be used to cutover to only sending the cache_key instead of sending both the cache_key and the event in the celery task parameters. Stages of this transition would be:

1. Update the eventprocessing TTL to 24 hours. This will help remove the need to update TTLs when forwarding events to post processing after processing has completed. It also us handle outages better. Lastly it should obviate the need to have a [post processing lock key](https://github.com/getsentry/sentry/blob/ed479c5dbc29c9552dd06183f96c3ecff5484e58/src/sentry/tasks/post_process.py#L84-L95) as the eventprocessing store cache can be used as the 'lock'.
2. Add cache_key parameter to post_process task. The value would be None.
3. Pass both the cache_key and event parameter to post_process. If the event is None, fetch the event from the processing store. If the cache key has expired we can infer that we are running on an old event, or the task has been in the queue for more than 24hrs and something really terrible has happened. At this point eventprocessing store would be cleared at the *end* of post_process instead of during store_event.
4. When the option is enabled, the event parameter would no longer be sent to post_process and only the cache path would be used based on the rate defined in the option.
5. Once the option is at 1.0 we would remove the event parameter an option checking path entirely.

Related to https://www.notion.so/sentry/Sending-Events-to-Redis-for-Post-Processing-96ab185cf3084a5ab3a7b90c94669ced