### PR TITLE
fix(alerts): Expect null on error when loading alert rules

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -643,7 +643,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
                       <RuleNodeList
                         nodes={this.state.configs?.actions ?? null}
-                        items={actions || []}
+                        items={actions ?? []}
                         placeholder={t('Add an action...')}
                         onPropertyChange={this.handleChangeActionProperty}
                         onAddRow={this.handleAddAction}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -86,11 +86,11 @@ type Props = {
 } & RouteComponentProps<{orgId: string; projectId: string; ruleId?: string}, {}>;
 
 type State = AsyncView['state'] & {
-  rule: UnsavedIssueAlertRule | IssueAlertRule;
+  rule: UnsavedIssueAlertRule | IssueAlertRule | null;
   detailedError: null | {
     [key: string]: string[];
   };
-  environments: Environment[];
+  environments: Environment[] | null;
   configs: {
     actions: IssueAlertRuleActionTemplate[];
     filters: IssueAlertRuleConditionTemplate[];
@@ -99,10 +99,8 @@ type State = AsyncView['state'] & {
   uuid: null | string;
 };
 
-function isSavedAlertRule(
-  rule: UnsavedIssueAlertRule | IssueAlertRule
-): rule is IssueAlertRule {
-  return rule?.hasOwnProperty('id');
+function isSavedAlertRule(rule: State['rule']): rule is IssueAlertRule {
+  return rule?.hasOwnProperty('id') ?? false;
 }
 
 class IssueRuleEditor extends AsyncView<Props, State> {
@@ -538,7 +536,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                       </StepLead>
                       <RuleNodeList
                         nodes={this.state.configs?.conditions ?? null}
-                        items={conditions}
+                        items={conditions ?? []}
                         placeholder={t('Add a condition...')}
                         onPropertyChange={this.handleChangeConditionProperty}
                         onAddRow={this.handleAddCondition}


### PR DESCRIPTION
Mental note to make sure props being loaded by AsyncComponent should be `| null` when they error.

Fixes SENTRY-G9X