### PR TITLE
ref(alert): Refactor validation error message

### DIFF
--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -49,9 +49,7 @@ class RuleNodeField(serializers.Field):
             if first_error != "This field is required.":
                 raise ValidationError(first_error)
 
-            raise ValidationError(
-                "Ensure at least one action is enabled and all required fields are filled in."
-            )
+            raise ValidationError("Ensure all required fields are filled in.")
 
         # Update data from cleaned form values
         data.update(form.cleaned_data)
@@ -90,12 +88,12 @@ class RuleSerializer(serializers.Serializer):
 
     def validate_conditions(self, value):
         if not value:
-            raise serializers.ValidationError(u"Must select a condition")
+            raise serializers.ValidationError(u"Must select a condition.")
         return value
 
     def validate_actions(self, value):
         if not value:
-            raise serializers.ValidationError(u"Must select an action")
+            raise serializers.ValidationError(u"Must select an action.")
         return value
 
     def validate(self, attrs):


### PR DESCRIPTION
The error message for unfilled fields in the issue alert builder is a little redundant as there is a separate error for when an action is not selected. Got rid of the part mentioning an action and added punctuation to the other validation errors for consistency. Comparison below:

Old:
![image](https://user-images.githubusercontent.com/9372512/91604561-e6571e00-e93c-11ea-8a7f-996b561301aa.png)


New:
![image](https://user-images.githubusercontent.com/9372512/91604310-6cbf3000-e93c-11ea-86a4-58fcf5e231f6.png)
