### PR TITLE
fix(azure-devops): include full work item in URL

### DIFF
--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -71,7 +71,7 @@ class VstsIssueSync(IssueSyncMixin):
         for item in item_categories:
             for item_type_object in item["workItemTypes"]:
                 # the type is the last part of the url
-                item_type = item_type_object["url"].split(".")[-1]
+                item_type = item_type_object["url"].split("/")[-1]
                 # we can have duplicates so need to dedupe
                 if item_type not in item_type_map:
                     item_type_map[item_type] = item_type_object["name"]

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -78,7 +78,7 @@ class VstsIssueSyncTest(VstsIssueBase):
     def test_create_issue(self):
         responses.add(
             responses.PATCH,
-            "https://fabrikam-fiber-inc.visualstudio.com/0987654321/_apis/wit/workitems/$Task?api-version=3.0",
+            "https://fabrikam-fiber-inc.visualstudio.com/0987654321/_apis/wit/workitems/$Microsoft.VSTS.WorkItemTypes.Task?api-version=3.0",
             body=WORK_ITEM_RESPONSE,
             content_type="application/json",
         )
@@ -87,7 +87,7 @@ class VstsIssueSyncTest(VstsIssueBase):
             "title": "Hello",
             "description": "Fix this.",
             "project": "0987654321",
-            "work_item_type": "Task",
+            "work_item_type": "Microsoft.VSTS.WorkItemTypes.Task",
         }
         assert self.integration.create_issue(form_data) == {
             "key": self.issue_id,
@@ -384,7 +384,7 @@ class VstsIssueFormTest(VstsIssueBase):
                     {
                         "workItemTypes": [
                             {
-                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.Bug".format(
+                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Bug".format(
                                     project
                                 ),
                                 "name": "Bug",
@@ -394,13 +394,13 @@ class VstsIssueFormTest(VstsIssueBase):
                     {
                         "workItemTypes": [
                             {
-                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.Bug".format(
+                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Bug".format(
                                     project
                                 ),
                                 "name": "Issue Bug",
                             },
                             {
-                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.GIssue".format(
+                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Some-Thing.GIssue".format(
                                     project
                                 ),
                                 "name": "G Issue",
@@ -410,7 +410,7 @@ class VstsIssueFormTest(VstsIssueBase):
                     {
                         "workItemTypes": [
                             {
-                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.Task".format(
+                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Task".format(
                                     project
                                 ),
                                 "name": "Task",
@@ -420,7 +420,7 @@ class VstsIssueFormTest(VstsIssueBase):
                     {
                         "workItemTypes": [
                             {
-                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.UserStory".format(
+                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.UserStory".format(
                                     project
                                 ),
                                 "name": "User Story",
@@ -473,7 +473,12 @@ class VstsIssueFormTest(VstsIssueBase):
         self.assert_work_item_type_field(
             fields,
             "Task",
-            [("Bug", "Bug"), ("GIssue", "G Issue"), ("Task", "Task"), ("UserStory", "User Story")],
+            [
+                ("Microsoft.VSTS.WorkItemTypes.Bug", "Bug"),
+                ("Some-Thing.GIssue", "G Issue"),
+                ("Microsoft.VSTS.WorkItemTypes.Task", "Task"),
+                ("Microsoft.VSTS.WorkItemTypes.UserStory", "User Story"),
+            ],
         )
 
     @responses.activate


### PR DESCRIPTION
This fixes the issue with certain kinds of work items that need the full work item type in the URL for creating a ticket. Previously, the default built-in ones worked fine only using the last part of the item name (ex: `Bug` vs `Microsoft.VSTS.WorkItemTypes.Bug`). But for custom ones, we need the full type.