### PR TITLE
fix(trends): Add current trend function field to request

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -128,7 +128,9 @@ export function modifyTrendView(
   trendsType: TrendChangeType
 ) {
   const trendFunction = getCurrentTrendFunction(location);
-  const fields = [trendFunction.field, 'transaction', 'project', 'count()'].map(
+
+  const trendFunctionFields = TRENDS_FUNCTIONS.map(({field}) => field);
+  const fields = [...trendFunctionFields, 'transaction', 'project', 'count()'].map(
     field => ({
       field,
     })

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -128,9 +128,11 @@ export function modifyTrendView(
   trendsType: TrendChangeType
 ) {
   const trendFunction = getCurrentTrendFunction(location);
-  const fields = ['transaction', 'project', 'count()'].map(field => ({
-    field,
-  })) as Field[];
+  const fields = [trendFunction.field, 'transaction', 'project', 'count()'].map(
+    field => ({
+      field,
+    })
+  ) as Field[];
 
   const trendSort = {
     field: `percentage_${trendFunction.alias}_2_${trendFunction.alias}_1`,

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -267,6 +267,8 @@ describe('Performance > Trends', function() {
       const aliasedFieldDivide = getTrendAliasedFieldPercentage(trendFunction.alias);
       const aliasedQueryDivide = getTrendAliasedQueryPercentage(trendFunction.alias);
 
+      const defaultFields = ['transaction', 'project', 'count()'];
+
       // Improved trends call
       expect(trendsMock).toHaveBeenNthCalledWith(
         1,
@@ -277,6 +279,7 @@ describe('Performance > Trends', function() {
             sort: aliasedFieldDivide,
             query: expect.stringContaining(aliasedQueryDivide + ':<1'),
             interval: '1h',
+            field: [trendFunction.field, ...defaultFields],
           }),
         })
       );
@@ -291,6 +294,7 @@ describe('Performance > Trends', function() {
             sort: '-' + aliasedFieldDivide,
             query: expect.stringContaining(aliasedQueryDivide + ':>1'),
             interval: '1h',
+            field: [trendFunction.field, ...defaultFields],
           }),
         })
       );

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -268,6 +268,11 @@ describe('Performance > Trends', function() {
       const aliasedQueryDivide = getTrendAliasedQueryPercentage(trendFunction.alias);
 
       const defaultFields = ['transaction', 'project', 'count()'];
+      const trendFunctionFields = TRENDS_FUNCTIONS.map(({field}) => field);
+
+      const field = [...trendFunctionFields, ...defaultFields];
+
+      expect(field).toHaveLength(6);
 
       // Improved trends call
       expect(trendsMock).toHaveBeenNthCalledWith(
@@ -279,7 +284,7 @@ describe('Performance > Trends', function() {
             sort: aliasedFieldDivide,
             query: expect.stringContaining(aliasedQueryDivide + ':<1'),
             interval: '1h',
-            field: [trendFunction.field, ...defaultFields],
+            field,
           }),
         })
       );
@@ -294,7 +299,7 @@ describe('Performance > Trends', function() {
             sort: '-' + aliasedFieldDivide,
             query: expect.stringContaining(aliasedQueryDivide + ':>1'),
             interval: '1h',
-            field: [trendFunction.field, ...defaultFields],
+            field,
           }),
         })
       );


### PR DESCRIPTION
### Summary

This will add the current trend function field to the request to allow filtering to work via that field (eg. user_misery(300) will be filterable)