### PR TITLE
feat(integrations): Handle Trigger Actions

### DIFF
--- a/src/sentry/api/serializers/models/app_platform_event.py
+++ b/src/sentry/api/serializers/models/app_platform_event.py
@@ -7,6 +7,10 @@ from sentry.utils import json
 
 
 class AppPlatformEvent(object):
+    """
+    This data structure encapsulates the payload sent to a SentryApp's webhook.
+    """
+
     def __init__(self, resource, action, install, data, actor=None):
         self.resource = resource
         self.action = action

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -186,14 +186,6 @@ def format_duration(minutes):
     return "{:d} second{}".format(seconds, pluralize(seconds))
 
 
-INCIDENT_STATUS_KEY = {
-    IncidentStatus.OPEN: "open",
-    IncidentStatus.CLOSED: "resolved",
-    IncidentStatus.CRITICAL: "critical",
-    IncidentStatus.WARNING: "warning",
-}
-
-
 def generate_incident_trigger_email_context(project, incident, alert_rule_trigger, status):
     trigger = alert_rule_trigger
     incident_trigger = IncidentTrigger.objects.get(incident=incident, alert_rule_trigger=trigger)
@@ -241,7 +233,7 @@ def generate_incident_trigger_email_context(project, incident, alert_rule_trigge
         # if resolve threshold and threshold type is *BELOW* then show '>'
         "threshold_direction_string": ">" if show_greater_than_string else "<",
         "status": INCIDENT_STATUS[IncidentStatus(incident.status)],
-        "status_key": INCIDENT_STATUS_KEY[IncidentStatus(incident.status)],
+        "status_key": INCIDENT_STATUS[IncidentStatus(incident.status)].lower(),
         "is_critical": incident.status == IncidentStatus.CRITICAL,
         "is_warning": incident.status == IncidentStatus.WARNING,
         "unsubscribe_link": None,

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -153,7 +153,7 @@ class PagerDutyActionHandler(ActionHandler):
     AlertRuleTriggerAction.Type.SENTRY_APP,
     [AlertRuleTriggerAction.TargetType.SENTRY_APP],
 )
-class IntegrationActionHandler(ActionHandler):
+class SentryAppActionHandler(ActionHandler):
     def fire(self, metric_value):
         self.send_alert(metric_value)
 
@@ -161,8 +161,9 @@ class IntegrationActionHandler(ActionHandler):
         self.send_alert(metric_value)
 
     def send_alert(self, metric_value):
-        # TODO: finish
-        pass
+        from sentry.rules.actions.notify_event_service import send_incident_alert_notification
+
+        send_incident_alert_notification(self.action, self.incident, metric_value)
 
 
 def format_duration(minutes):

--- a/src/sentry/mediators/sentry_app_installations/installation_notifier.py
+++ b/src/sentry/mediators/sentry_app_installations/installation_notifier.py
@@ -24,11 +24,7 @@ class InstallationNotifier(Mediator):
             raise APIUnauthorized(u"Invalid action '{}'".format(self.action))
 
     def _send_webhook(self):
-        safe_urlread(
-            send_and_save_webhook_request(
-                self.sentry_app.webhook_url, self.sentry_app, self.request
-            )
-        )
+        safe_urlread(send_and_save_webhook_request(self.sentry_app, self.request))
 
     @property
     def request(self):

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -36,9 +36,9 @@ def build_incident_attachment(incident, metric_value=None):
         "metric_alert": convert_dict_key_case(
             serialize(incident, serializer=IncidentSerializer()), camel_to_snake_case
         ),
-        "text": data["text"],
-        "title": data["title"],
-        "url": data["title_link"],
+        "description_text": data["text"],
+        "description_title": data["title"],
+        "web_url": data["title_link"],
     }
 
 

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -6,13 +6,13 @@ from __future__ import absolute_import
 from django import forms
 
 from sentry.incidents.logic import get_alertable_sentry_apps
+from sentry.models import SentryApp
 from sentry.plugins.base import plugins
 from sentry.rules.actions.base import EventAction
 from sentry.rules.actions.services import PluginService, SentryAppService
-from sentry.models import SentryApp
-from sentry.utils.safe import safe_execute
-from sentry.utils import metrics
 from sentry.tasks.sentry_apps import notify_sentry_app
+from sentry.utils import metrics
+from sentry.utils.safe import safe_execute
 
 
 class NotifyEventServiceForm(forms.Form):

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -23,11 +23,18 @@ logger = logging.getLogger("sentry.integrations.sentry_app")
 
 
 def send_incident_alert_notification(action, incident, metric_value=None):
+    """
+    When a metric alert is triggered, send incident data to the SentryApp's webhook.
+    :param action: The triggered `AlertRuleTriggerAction`.
+    :param incident: The `Incident` for which to build a payload.
+    :param metric_value: The value of the metric that triggered this alert to
+    fire. If not provided we'll attempt to calculate this ourselves.
+    :return:
+    """
     sentry_app = action.sentry_app
     organization = incident.organization
     metrics.incr("notifications.sent", instance=sentry_app.slug, skip_internal=False)
 
-    # TODO we might NOT need to fetch this.
     try:
         install = SentryAppInstallation.objects.get(
             organization=organization.id,

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -26,9 +26,16 @@ logger = logging.getLogger("sentry.integrations.sentry_app")
 
 
 def build_incident_attachment(incident, metric_value=None):
+    from sentry.api.serializers.rest_framework.base import (
+        camel_to_snake_case,
+        convert_dict_key_case,
+    )
+
     data = incident_attachment_info(incident, metric_value)
     return {
-        "metric_alert": serialize(incident, serializer=IncidentSerializer()),
+        "metric_alert": convert_dict_key_case(
+            serialize(incident, serializer=IncidentSerializer()), camel_to_snake_case
+        ),
         "text": data["text"],
         "title": data["title"],
         "url": data["title_link"],

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -54,7 +54,6 @@ def send_incident_alert_notification(action, incident, metric_value=None):
         return
 
     send_and_save_webhook_request(
-        sentry_app.webhook_url,
         sentry_app,
         AppPlatformEvent(
             resource="metric_alert",

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -43,12 +43,12 @@ def send_incident_alert_notification(action, incident, metric_value=None):
         )
     except SentryAppInstallation.DoesNotExist:
         logger.info(
-            "event_alert_webhook.missing_installation",
+            "metric_alert_webhook.missing_installation",
             extra={
-                "sentry_app_id": sentry_app.id,
+                "action": action.id,
+                "incident": incident.id,
                 "organization": organization.slug,
-                "organization_id": incident.organization_id,
-                "target_identifier": sentry_app.id,
+                "sentry_app_id": sentry_app.id,
             }
         )
         return

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -6,35 +6,36 @@ from celery.task import current
 from django.core.urlresolvers import reverse
 from requests.exceptions import (
     ConnectionError,
-    Timeout,
     RequestException,
+    Timeout,
 )
 
+from sentry.api.serializers import serialize, AppPlatformEvent
+from sentry.constants import SentryAppInstallationStatus
 from sentry.eventstore.models import Event
 from sentry.http import safe_urlopen
-from sentry.tasks.base import instrumented_task, retry
-from sentry.utils import metrics
-from sentry.utils.http import absolute_uri
-from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
-from sentry.api.serializers import serialize, AppPlatformEvent
 from sentry.models import (
-    SentryAppInstallation,
     Group,
-    Project,
     Organization,
-    User,
+    Project,
+    SentryApp,
+    SentryAppInstallation,
     ServiceHook,
     ServiceHookProject,
-    SentryApp,
-)
-from sentry.shared_integrations.exceptions import (
-    IgnorableSentryAppError,
-    ApiHostError,
-    ApiTimeoutError,
+    User,
 )
 from sentry.models.sentryapp import VALID_EVENTS, track_response_code
+from sentry.shared_integrations.exceptions import (
+    ApiHostError,
+    ApiTimeoutError,
+    IgnorableSentryAppError,
+)
+from sentry.tasks.base import instrumented_task, retry
+from sentry.utils import metrics
 from sentry.utils.compat import filter
-from sentry.constants import SentryAppInstallationStatus
+from sentry.utils.http import absolute_uri
+from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
+
 
 logger = logging.getLogger("sentry.tasks.sentry_apps")
 
@@ -46,7 +47,7 @@ TASK_OPTIONS = {
 
 RETRY_OPTIONS = {
     "on": (RequestException, ApiHostError, ApiTimeoutError),
-    "ignore": (IgnorableSentryAppError),
+    "ignore": (IgnorableSentryAppError,),
 }
 
 # We call some models by a different name, publicly, than their class name.

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -924,7 +924,8 @@ class Factories(object):
         target_type=AlertRuleTriggerAction.TargetType.USER,
         target_identifier=None,
         integration=None,
+        sentry_app=None,
     ):
         return create_alert_rule_trigger_action(
-            trigger, type, target_type, target_identifier, integration
+            trigger, type, target_type, target_identifier, integration, sentry_app
         )

--- a/src/sentry/utils/sentryappwebhookrequests.py
+++ b/src/sentry/utils/sentryappwebhookrequests.py
@@ -6,9 +6,8 @@ from dateutil.parser import parse as parse_date
 from django.conf import settings
 from django.utils import timezone
 
-from sentry.utils import redis
 from sentry.models.sentryapp import VALID_EVENTS
-from sentry.utils import json
+from sentry.utils import json, redis
 
 
 BUFFER_SIZE = 100
@@ -16,11 +15,11 @@ KEY_EXPIRY = 60 * 60 * 24 * 30  # 30 days
 
 EXTENDED_VALID_EVENTS = VALID_EVENTS + (
     "event_alert.triggered",
+    "external_issue.created",
+    "external_issue.linked",
     "installation.created",
     "installation.deleted",
     "select_options.requested",
-    "external_issue.created",
-    "external_issue.linked",
 )
 
 

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -17,7 +17,6 @@ from sentry.incidents.action_handlers import (
     MsTeamsActionHandler,
     PagerDutyActionHandler,
     generate_incident_trigger_email_context,
-    INCIDENT_STATUS_KEY,
 )
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models import (
@@ -118,7 +117,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             "query": action.alert_rule_trigger.alert_rule.snuba_query.query,
             "threshold": action.alert_rule_trigger.alert_threshold,
             "status": INCIDENT_STATUS[IncidentStatus(incident.status)],
-            "status_key": INCIDENT_STATUS_KEY[IncidentStatus(incident.status)],
+            "status_key": INCIDENT_STATUS[IncidentStatus(incident.status)].lower(),
             "environment": "All",
             "is_critical": False,
             "is_warning": False,
@@ -306,7 +305,6 @@ class MsTeamsActionHandlerFireTest(MsTeamsActionHandlerBaseTest, TestCase):
 @freeze_time()
 class PagerDutyActionHandlerBaseTest(object):
     def setUp(self):
-
         service = [
             {
                 "type": "service",

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -27,7 +27,6 @@ from sentry.incidents.models import (
     TriggerStatus,
     INCIDENT_STATUS,
 )
-from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.models import Integration, PagerDutyService, UserOption
 from sentry.testutils import TestCase
 from sentry.utils import json
@@ -411,6 +410,8 @@ class SentryAppActionHandlerTest(FireTest, TestCase):
 
     @responses.activate
     def run_test(self, incident, method):
+        from sentry.rules.actions.notify_event_service import build_incident_attachment
+
         action = self.create_alert_rule_trigger_action(
             target_identifier=self.sentry_app.id,
             type=AlertRuleTriggerAction.Type.SENTRY_APP,
@@ -432,7 +433,7 @@ class SentryAppActionHandlerTest(FireTest, TestCase):
             getattr(handler, method)(metric_value)
         data = responses.calls[0].request.body
 
-        assert json.dumps(incident_attachment_info(incident, metric_value)) in data
+        assert json.dumps(build_incident_attachment(incident, metric_value)) in data
 
     def test_fire_metric_alert(self):
         self.run_fire_test()


### PR DESCRIPTION
In this PR, I implement `send_incident_alert_notification` for `SentryAppActionHandler`. All we needed to do was put the data from `incident_attachment_info` and send it via `send_and_save_webhook_request`.
Other changes:
 - clean up some string stuff for `IncidentStatus`
 - clean up `test_action_handlers.py`
 - add docstrings to some functions

Docs changes: https://github.com/getsentry/sentry-docs/pull/2216