### PR TITLE
ref(issues-details-page): Replace some anchor tags with ExternalLink component

### DIFF
--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -257,7 +257,7 @@ ContextData.displayName = 'ContextData';
 
 const StyledIconOpen = styled(IconOpen)`
   position: relative;
-  top: -1px;
+  top: 1px;
 `;
 
 const ToggleIcon = styled('a')`

--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -8,6 +8,7 @@ import styled from '@emotion/styled';
 import AnnotatedText from 'app/components/events/meta/annotatedText';
 import {IconOpen, IconAdd, IconSubtract} from 'app/icons';
 import {isUrl} from 'app/utils';
+import ExternalLink from 'app/components/links/externalLink';
 
 function looksLikeObjectRepr(value) {
   const a = value[0];
@@ -166,9 +167,9 @@ class ContextData extends React.Component {
 
         if (valueInfo.isString && isUrl(value)) {
           out.push(
-            <a key="external" href={value} className="external-icon">
+            <ExternalLink key="external" href={value} className="external-icon">
               <StyledIconOpen size="xs" />
-            </a>
+            </ExternalLink>
           );
         }
 
@@ -256,7 +257,7 @@ ContextData.displayName = 'ContextData';
 
 const StyledIconOpen = styled(IconOpen)`
   position: relative;
-  top: 1px;
+  top: -1px;
 `;
 
 const ToggleIcon = styled('a')`

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
@@ -13,6 +13,7 @@ import VersionHoverCard from 'app/components/versionHoverCard';
 import TraceHoverCard from 'app/utils/discover/traceHoverCard';
 import Version from 'app/components/version';
 import {IconOpen, IconInfo} from 'app/icons';
+import ExternalLink from 'app/components/links/externalLink';
 
 type Props = {
   tag: EventTag;
@@ -57,9 +58,9 @@ const EventTagsPill = ({
         )}
       </Link>
       {isUrl(tag.value) && (
-        <a href={tag.value} className="external-icon">
+        <ExternalLink href={tag.value} className="external-icon">
           <StyledIconOpen size="xs" />
-        </a>
+        </ExternalLink>
       )}
       {isRelease && (
         <div className="pill-icon">

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
@@ -59,7 +59,7 @@ const EventTagsPill = ({
       </Link>
       {isUrl(tag.value) && (
         <ExternalLink href={tag.value} className="external-icon">
-          <StyledIconOpen size="xs" />
+          <IconOpen size="xs" />
         </ExternalLink>
       )}
       {isRelease && (

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPill.tsx
@@ -59,7 +59,7 @@ const EventTagsPill = ({
       </Link>
       {isUrl(tag.value) && (
         <ExternalLink href={tag.value} className="external-icon">
-          <IconOpen size="xs" />
+          <StyledIconOpen size="xs" />
         </ExternalLink>
       )}
       {isRelease && (

--- a/src/sentry/static/sentry/app/components/events/interfaces/cspHelp.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/cspHelp.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {t} from 'app/locale';
 import {IconOpen} from 'app/icons';
+import ExternalLink from 'app/components/links/externalLink';
 
 const help = {
   'base-uri': t(
@@ -132,10 +133,10 @@ function getLink(key) {
 
   return (
     <span>
-      <a href={href}>developer.mozilla.org</a>
-      <a href={href} className="external-icon">
+      <ExternalLink href={href}>developer.mozilla.org</ExternalLink>
+      <ExternalLink href={href} className="external-icon">
         <IconOpen size="xs" />
-      </a>
+      </ExternalLink>
     </span>
   );
 }

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionMechanism.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionMechanism.jsx
@@ -4,10 +4,12 @@ import isObject from 'lodash/isObject';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
+import {css} from '@emotion/core';
 
 import space from 'app/styles/space';
 import Pills from 'app/components/pills';
 import Pill from 'app/components/pill';
+import ExternalLink from 'app/components/links/externalLink';
 import Hovercard from 'app/components/hovercard';
 import {t} from 'app/locale';
 import {IconInfo, IconOpen} from 'app/icons';
@@ -48,22 +50,21 @@ class ExceptionMechanism extends React.Component {
     const {errno, signal, mach_exception} = meta;
 
     const linkElement = help_link && isUrl(help_link) && (
-      <a href={help_link} className="external-icon">
+      <StyledExternalLink href={help_link}>
         <IconOpen size="xs" />
-      </a>
+      </StyledExternalLink>
     );
 
     const descriptionElement = description && (
       <Hovercard
         header={
           <span>
-            {t('Details')} {linkElement}
+            <Details>{t('Details')}</Details> {linkElement}
           </span>
         }
         body={description}
-        containerClassName="pill-icon"
       >
-        <IconInfo size="14px" />
+        <StyledIconInfo size="14px" />
       </Hovercard>
     );
 
@@ -112,4 +113,26 @@ export default ExceptionMechanism;
 
 const Wrapper = styled('div')`
   margin: ${space(2)} 0;
+`;
+
+const iconStyle = p => css`
+  transition: 0.1s linear color;
+  color: ${p.theme.gray500};
+  :hover {
+    color: ${p.theme.gray700};
+  }
+`;
+
+const StyledExternalLink = styled(ExternalLink)`
+  display: inline-flex !important;
+  ${iconStyle};
+`;
+
+const Details = styled('span')`
+  margin-right: ${space(1)};
+`;
+
+const StyledIconInfo = styled(IconInfo)`
+  display: flex;
+  ${iconStyle};
 `;


### PR DESCRIPTION
closes: https://app.asana.com/0/1182975495223914/1190508011638981

. Through the use of component `ExternalLink`, some urls that are displayed as tags will open in a new tab.

ps: I still didn't want to remove the external-icon class, but I am planning to do it in some another PR