### PR TITLE
feat(msteams): adds user scope and handles mentions

### DIFF
--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -14,6 +14,11 @@ from sentry.utils.http import absolute_uri
 from .utils import ACTION_TYPE
 
 ME = "ME"
+logo = {
+    "type": "Image",
+    "url": absolute_uri(get_asset_url("sentry", "images/sentry-glyph-black.png")),
+    "size": "Medium",
+}
 
 
 def generate_action_payload(action_type, event, rules, integration):
@@ -52,11 +57,6 @@ def get_assignee_string(group):
 
 def build_welcome_card(signed_params):
     url = u"%s?signed_params=%s" % (absolute_uri("/extensions/msteams/configure/"), signed_params,)
-    logo = {
-        "type": "Image",
-        "url": absolute_uri(get_asset_url("sentry", "images/sentry-glyph-black.png")),
-        "size": "Medium",
-    }
     welcome = {
         "type": "TextBlock",
         "weight": "Bolder",
@@ -107,11 +107,6 @@ def build_welcome_card(signed_params):
 
 
 def build_installation_confirmation_message(organization):
-    logo = {
-        "type": "Image",
-        "url": absolute_uri(get_asset_url("sentry", "images/sentry-glyph-black.png")),
-        "size": "Medium",
-    }
     welcome = {
         "type": "TextBlock",
         "weight": "Bolder",
@@ -148,6 +143,76 @@ def build_installation_confirmation_message(organization):
             alert_rule_instructions,
         ],
         "actions": [alert_rule_button],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.2",
+    }
+
+
+def build_personal_installation_message():
+    welcome = {
+        "type": "TextBlock",
+        "weight": "Bolder",
+        "size": "Large",
+        "text": "Personal Installation of Sentry",
+        "wrap": True,
+    }
+    instruction = {
+        "type": "TextBlock",
+        "text": (
+            "It looks like you have installed Sentry as a personal app."
+            " Sentry for Microsoft Teams needs to be added to a team. Please add"
+            ' Sentry again, and select "Add to a team" from the "Add" button\'s list arrow'
+        ),
+        "wrap": True,
+    }
+    return {
+        "type": "AdaptiveCard",
+        "body": [
+            {
+                "type": "ColumnSet",
+                "columns": [
+                    {"type": "Column", "items": [logo], "width": "auto"},
+                    {
+                        "type": "Column",
+                        "items": [welcome],
+                        "width": "stretch",
+                        "verticalContentAlignment": "Center",
+                    },
+                ],
+            },
+            instruction,
+        ],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.2",
+    }
+
+
+def build_mentioned_card():
+
+    instruction = {
+        "type": "TextBlock",
+        "text": ("Sentry for Microsoft Teams does not support any commands."),
+        "wrap": True,
+    }
+
+    alert_instruction = {
+        "type": "TextBlock",
+        "text": (
+            "Want to learn more about configuring alerts in Sentry? Check out our documentation."
+        ),
+        "wrap": True,
+    }
+
+    button = {
+        "type": "Action.OpenUrl",
+        "title": "Docs",
+        "url": "https://docs.sentry.io/product/alerts-notifications/alerts/",
+    }
+
+    return {
+        "type": "AdaptiveCard",
+        "body": [instruction, alert_instruction],
+        "actions": [button],
         "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
         "version": "1.2",
     }

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -26,7 +26,13 @@ from sentry.utils.compat import filter
 from sentry.utils.signing import sign
 from sentry.web.decorators import transaction_start
 
-from .card_builder import build_welcome_card, build_linking_card, build_group_card
+from .card_builder import (
+    build_welcome_card,
+    build_linking_card,
+    build_group_card,
+    build_personal_installation_message,
+    build_mentioned_card,
+)
 from .client import (
     MsTeamsPreInstallClient,
     MsTeamsJwtClient,
@@ -132,6 +138,11 @@ class MsTeamsWebhookEndpoint(Endpoint):
     permission_classes = ()
     provider = "msteams"
 
+    def get_preinstall_client(self, service_url):
+        # may want try/catch here since this makes an external API call
+        access_token = get_token_data()["access_token"]
+        return MsTeamsPreInstallClient(access_token, service_url)
+
     @csrf_exempt
     def dispatch(self, request, *args, **kwargs):
         return super(MsTeamsWebhookEndpoint, self).dispatch(request, *args, **kwargs)
@@ -147,22 +158,42 @@ class MsTeamsWebhookEndpoint(Endpoint):
             # the only message events we care about are those which
             # are from a user submitting an option on a card, which
             # will always contain an "payload.actionType" in the data.
-            if not data.get("value", {}).get("payload", {}).get("actionType"):
-                return self.respond(status=204)
-            return self.handle_action_submitted(request)
+            if data.get("value", {}).get("payload", {}).get("actionType"):
+                return self.handle_action_submitted(request)
+            else:
+                return self.handle_other_message(request)
         elif data["type"] == "conversationUpdate":
             channel_data = data["channelData"]
             event = channel_data.get("eventType")
+            conversation_type = data.get("conversation", {}).get("conversationType")
 
             # TODO: Handle other events
             if event == "teamMemberAdded":
-                return self.handle_member_added(request)
+                return self.handle_team_member_added(request)
             elif event == "teamMemberRemoved":
-                return self.handle_member_removed(request)
+                return self.handle_team_member_removed(request)
+            elif (
+                data.get("membersAdded") and conversation_type == "personal"
+            ):  # no explicit event for user adding app unfortunately
+                return self.handle_personal_member_add(request)
 
         return self.respond(status=204)
 
-    def handle_member_added(self, request):
+    def handle_personal_member_add(self, request):
+        data = request.data
+        # only care if our bot is the new member added
+        matches = filter(lambda x: x["id"] == data["recipient"]["id"], data["membersAdded"])
+        if not matches:
+            return self.respond(status=204)
+
+        client = self.get_preinstall_client(data["serviceUrl"])
+
+        user_conversation_id = data["conversation"]["id"]
+        card = build_personal_installation_message()
+        client.send_card(user_conversation_id, card)
+        return self.respond(status=204)
+
+    def handle_team_member_added(self, request):
         data = request.data
         channel_data = data["channelData"]
         # only care if our bot is the new member added
@@ -171,9 +202,6 @@ class MsTeamsWebhookEndpoint(Endpoint):
             return self.respond(status=204)
 
         team = channel_data["team"]
-
-        # TODO: add try/except for request exceptions
-        access_token = get_token_data()["access_token"]
 
         # need to keep track of the service url since we won't get it later
         signed_data = {
@@ -186,12 +214,12 @@ class MsTeamsWebhookEndpoint(Endpoint):
         signed_params = sign(**signed_data)
 
         # send welcome message to the team
-        client = MsTeamsPreInstallClient(access_token, data["serviceUrl"])
+        client = self.get_preinstall_client(data["serviceUrl"])
         card = build_welcome_card(signed_params)
         client.send_card(team["id"], card)
         return self.respond(status=201)
 
-    def handle_member_removed(self, request):
+    def handle_team_member_removed(self, request):
         data = request.data
         channel_data = data["channelData"]
         # only care if our bot is the new member removed
@@ -388,3 +416,26 @@ class MsTeamsWebhookEndpoint(Endpoint):
         client.update_card(conversation_id, activity_id, card)
 
         return issue_change_response
+
+    def handle_other_message(self, request):
+        data = request.data
+        # check to see if we are mentioned
+        recipient_id = data.get("recipient", {}).get("id")
+        if recipient_id:
+            # check the ids of the mentiokns in the entities
+            mentioned = (
+                len(
+                    filter(
+                        lambda x: x.get("mentioned", {}).get("id") == recipient_id,
+                        data.get("entities", []),
+                    )
+                )
+                > 0
+            )
+            if mentioned:
+                client = self.get_preinstall_client(data["serviceUrl"])
+                card = build_mentioned_card()
+                conversation_id = data["conversation"]["id"]
+                client.send_card(conversation_id, card)
+
+        return self.respond(status=204)

--- a/tests/sentry/integrations/msteams/test_helpers.py
+++ b/tests/sentry/integrations/msteams/test_helpers.py
@@ -6,7 +6,7 @@ GENERIC_EVENT = {
     "type": "conversationUpdate",
 }
 
-EXAMPLE_MEMBER_ADDED = {
+EXAMPLE_TEAM_MEMBER_ADDED = {
     "recipient": {"id": "28:5710acff-f313-453f-8b75-44fff54bab14", "name": "Steve-Bot-5"},
     "from": {
         "aadObjectId": "a6de2a64-9501-4e16-9e50-74df223570a3",
@@ -35,7 +35,7 @@ EXAMPLE_MEMBER_ADDED = {
     "id": "f:8e005ef8-f848-156f-55b1-0a5bb3207225",
 }
 
-EXAMPLE_MEMBER_REMOVED = {
+EXAMPLE_TEAM_MEMBER_REMOVED = {
     "membersRemoved": [{"id": "28:5710acff-f313-453f-8b75-44fff54bab14"}],
     "type": "conversationUpdate",
     "timestamp": "2020-07-16T23:47:29.7965243Z",
@@ -63,6 +63,63 @@ EXAMPLE_MEMBER_REMOVED = {
         "tenant": {"id": "f5ffd8cf-a1aa-4242-adad-86509faa3be5"},
     },
 }
+
+EXAMPLE_PERSONAL_MEMBER_ADDED = {
+    "recipient": {"id": "28:5710acff-f313-453f-8b75-44fff54bab14", "name": "Steve-Bot-5"},
+    "from": {
+        "aadObjectId": "a6de2a64-9501-4e16-9e50-74df223570a3",
+        "id": "29:1Q2o9Y0pyxOhK7QU6o7DatYWMy4MFapyiHoA1r_xB2s5XsGTSxIrKOH_JGmxDXpex30trbSo3Oyh3pkXF8RnlVQ",
+    },
+    "conversation": {
+        "id": "a:1rLdrbRhx8Pc7Y6HNUmkI6QHZ4vUe1dECseFMsjCLUs61NUCtDKvf_iXhzX96AJlIFs7WgQUzTrjV3iMjbON0UfMV_gNh2tUNgHj_iY5hQoYdFu_t-hTt-uDl7m6_X4-Z",
+        "conversationType": "personal",
+        "tenantId": "f5ffd8cf-a1aa-4242-adad-86509faa3be5",
+    },
+    "timestamp": "2020-07-13T19:54:30.8044041Z",
+    "channelId": "msteams",
+    "membersAdded": [
+        {"id": "28:5710acff-f313-453f-8b75-44fff54bab14"},
+        {"id": "28:5710acff-f313-453f-8b75-44fff54bab14"},
+    ],
+    "serviceUrl": "https://smba.trafficmanager.net/amer/",
+    "channelData": {"tenant": {"id": "f5ffd8cf-a1aa-4242-adad-86509faa3be5"}},
+    "type": "conversationUpdate",
+    "id": "f:d4414f98-25be-6cc7-b8c7-f01d51e3afd0",
+}
+
+
+EXAMPLE_MENTIONED = {
+    "text": "<at>SentryTest</at> help\n",
+    "recipient": {"id": "28:5710acff-f313-453f-8b75-44fff54bab14", "name": "Steve-Bot-5"},
+    "from": {
+        "aadObjectId": "a6de2a64-9501-4e16-9e50-74df223570a3",
+        "id": "29:1Q2o9Y0pyxOhK7QU6o7DatYWMy4MFapyiHoA1r_xB2s5XsGTSxIrKOH_JGmxDXpex30trbSo3Oyh3pkXF8RnlVQ",
+    },
+    "conversation": {
+        "id": "a:1rLdrbRhx8Pc7Y6HNUmkI6QHZ4vUe1dECseFMsjCLUs61NUCtDKvf_iXhzX96AJlIFs7WgQUzTrjV3iMjbON0UfMV_gNh2tUNgHj_iY5hQoYdFu_t-hTt-uDl7m6_X4-Z",
+        "conversationType": "channel",
+        "isGroup": True,
+        "tenantId": "f5ffd8cf-a1aa-4242-adad-86509faa3be5",
+    },
+    "timestamp": "2020-07-13T19:54:30.8044041Z",
+    "channelId": "msteams",
+    "serviceUrl": "https://smba.trafficmanager.net/amer/",
+    "channelData": {
+        "tenant": {"id": "f5ffd8cf-a1aa-4242-adad-86509faa3be5"},
+        "team": {"id": "19:8d46058cda57449380517cc374727f2a@thread.tacv2"},
+    },
+    "entities": [
+        {
+            "mentioned": {"id": "28:5710acff-f313-453f-8b75-44fff54bab14", "name": "Steve-Bot-5"},
+            "text": "<at>Steve-Bot-5</at>",
+            "type": "mention",
+        },
+        {"locale": "en-US", "country": "US", "platform": "Web", "type": "clientInfo"},
+    ],
+    "type": "message",
+    "id": "1598889368164",
+}
+
 
 DECODED_TOKEN = {
     "iss": "https://api.botframework.com",


### PR DESCRIPTION
This PR adds two capabilities:
1. Handles the user scope by responding to the `memberAdded` event for a personal installation. Since the personal bot doesn't do anything, we just give instructions on doing the team installation.
 
![Screen Shot 2020-08-31 at 11 08 10 AM](https://user-images.githubusercontent.com/8533851/91751879-51416880-eb7a-11ea-8aff-7f70a58c4248.png)

2. Handles mentions of our bot (`@Sentry`) with a message saying we don't support any command and linking the user to the docs.

![Screen Shot 2020-08-31 at 11 09 37 AM](https://user-images.githubusercontent.com/8533851/91752019-8b126f00-eb7a-11ea-99d9-5dd82e25ac90.png)
