### PR TITLE
feat(integrations): Block published SentryApps from dropdown

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -89,7 +89,9 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
                 ):
                     actions += [
                         build_action_response(registered_type, sentry_app=app)
-                        for app in get_alertable_sentry_apps(organization.id)
+                        for app in get_alertable_sentry_apps(
+                            organization.id, with_metric_alerts=True
+                        )
                     ]
 
             else:

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 from sentry import analytics
 from sentry.api.event_search import get_filter, resolve_field
-from sentry.constants import SentryAppInstallationStatus
+from sentry.constants import SentryAppInstallationStatus, SentryAppStatus
 from sentry.incidents import tasks
 from sentry.incidents.models import (
     AlertRule,
@@ -1206,12 +1206,16 @@ def get_available_action_integrations_for_org(organization):
     return Integration.objects.filter(organizations=organization, provider__in=providers)
 
 
-def get_alertable_sentry_apps(organization_id):
-    return SentryApp.objects.filter(
+def get_alertable_sentry_apps(organization_id, with_metric_alerts=False):
+    query = SentryApp.objects.filter(
         installations__organization_id=organization_id,
         is_alertable=True,
         installations__status=SentryAppInstallationStatus.INSTALLED,
-    ).distinct()
+    )
+
+    if with_metric_alerts:
+        query = query.exclude(status=SentryAppStatus.PUBLISHED)
+    return query.distinct()
 
 
 def get_pagerduty_services(organization, integration_id):


### PR DESCRIPTION
When we turn on Metric Alert Integrations, we don't want to surprise anyone with new webhook types. To prevent this, temporarily block public SentryApps from showing up in the dropdown. Rather than blocking the one app by DB ID, we're excluding it by `status`. Once we have an established metric alerts webhook format, then we can unblock them.