### PR TITLE
fix(alerts): Faster incidents page

### DIFF
--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -6,9 +6,9 @@ import six
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.incidents.models import Incident, IncidentProject, IncidentSubscription
+from sentry.models import User
 from sentry.snuba.models import QueryDatasets
 from sentry.utils.db import attach_foreignkey
-from sentry.models import User
 
 
 @register(Incident)

--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -68,19 +68,15 @@ class DetailedIncidentSerializer(IncidentSerializer):
         return results
 
     def _get_incident_seen_list(self, incident, user):
-        incident_seen = list(
+        seen_by_list = list(
             User.objects.filter(incidentseen__incident=incident).order_by(
                 "-incidentseen__last_seen"
             )
         )
 
-        has_seen = False
+        has_seen = any(seen_by for seen_by in seen_by_list if seen_by.id == user.id)
 
-        for seen_by in incident_seen:
-            if seen_by.id == user.id:
-                has_seen = True
-
-        return {"seen_by": serialize(incident_seen), "has_seen": has_seen}
+        return {"seen_by": serialize(seen_by_list), "has_seen": has_seen}
 
     def serialize(self, obj, attrs, user):
         context = super(DetailedIncidentSerializer, self).serialize(obj, attrs, user)

--- a/src/sentry/static/sentry/app/views/alerts/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/header.tsx
@@ -126,8 +126,8 @@ export default class DetailsHeader extends React.Component<Props> {
             <GroupedHeaderItems columns={isErrorDataset ? 5 : 3}>
               <ItemTitle>{t('Environment')}</ItemTitle>
               <ItemTitle>{t('Project')}</ItemTitle>
-              {isErrorDataset && stats && <ItemTitle>{t('Users affected')}</ItemTitle>}
-              {isErrorDataset && stats && <ItemTitle>{t('Total events')}</ItemTitle>}
+              {isErrorDataset && <ItemTitle>{t('Users affected')}</ItemTitle>}
+              {isErrorDataset && <ItemTitle>{t('Total events')}</ItemTitle>}
               <ItemTitle>{t('Active For')}</ItemTitle>
               <ItemValue>{environmentLabel}</ItemValue>
               <ItemValue>
@@ -141,23 +141,23 @@ export default class DetailsHeader extends React.Component<Props> {
                   </Projects>
                 )}
               </ItemValue>
-              {isErrorDataset && stats && (
+              {isErrorDataset && (
                 <ItemValue>
-                  <Count value={stats.uniqueUsers} />
+                  {stats ? <Count value={stats.uniqueUsers} /> : t('Loading')}
                 </ItemValue>
               )}
-              {isErrorDataset && stats && (
+              {isErrorDataset && (
                 <ItemValue>
-                  <Count value={stats.totalEvents} />
+                  {stats ? <Count value={stats.totalEvents} /> : t('Loading')}
                 </ItemValue>
               )}
-              {incident && (
-                <ItemValue>
+              <ItemValue>
+                {incident && (
                   <Duration
                     seconds={getDynamicText({value: duration || 0, fixed: 1200})}
                   />
-                </ItemValue>
-              )}
+                )}
+              </ItemValue>
             </GroupedHeaderItems>
           )}
         </Details>

--- a/src/sentry/static/sentry/app/views/alerts/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/header.tsx
@@ -132,7 +132,7 @@ export default class DetailsHeader extends React.Component<Props> {
               <ItemTitle>{t('Active For')}</ItemTitle>
               <ItemValue>{environmentLabel}</ItemValue>
               <ItemValue>
-                {project && (
+                {project ? (
                   <Projects slugs={[project]} orgId={params.orgId}>
                     {({projects}) =>
                       projects?.length && (
@@ -140,6 +140,8 @@ export default class DetailsHeader extends React.Component<Props> {
                       )
                     }
                   </Projects>
+                ) : (
+                  <Placeholder height="25px" />
                 )}
               </ItemValue>
               {isErrorDataset && (
@@ -161,10 +163,12 @@ export default class DetailsHeader extends React.Component<Props> {
                 </ItemValue>
               )}
               <ItemValue>
-                {incident && (
+                {incident ? (
                   <Duration
                     seconds={getDynamicText({value: duration || 0, fixed: 1200})}
                   />
+                ) : (
+                  <Placeholder height="25px" />
                 )}
               </ItemValue>
             </GroupedHeaderItems>

--- a/src/sentry/static/sentry/app/views/alerts/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/header.tsx
@@ -11,6 +11,7 @@ import Duration from 'app/components/duration';
 import LoadingError from 'app/components/loadingError';
 import MenuItem from 'app/components/menuItem';
 import PageHeading from 'app/components/pageHeading';
+import Placeholder from 'app/components/placeholder';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
 import Projects from 'app/utils/projects';
 import SubscribeButton from 'app/components/subscribeButton';
@@ -143,12 +144,20 @@ export default class DetailsHeader extends React.Component<Props> {
               </ItemValue>
               {isErrorDataset && (
                 <ItemValue>
-                  {stats ? <Count value={stats.uniqueUsers} /> : t('Loading')}
+                  {stats ? (
+                    <Count value={stats.uniqueUsers} />
+                  ) : (
+                    <Placeholder height="25px" />
+                  )}
                 </ItemValue>
               )}
               {isErrorDataset && (
                 <ItemValue>
-                  {stats ? <Count value={stats.totalEvents} /> : t('Loading')}
+                  {stats ? (
+                    <Count value={stats.totalEvents} />
+                  ) : (
+                    <Placeholder height="25px" />
+                  )}
                 </ItemValue>
               )}
               <ItemValue>

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from sentry.utils.compat import mock
 import pytz
 import six
-from django.utils import timezone
 from exam import fixture
 
 from sentry.api.serializers import serialize
@@ -57,7 +56,6 @@ class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest, APITestCase):
         expected = serialize(incident)
 
         user_data = serialize(self.user)
-        user_data["lastSeen"] = timezone.now()
         seen_by = [user_data]
 
         assert resp.data["id"] == expected["id"]


### PR DESCRIPTION
Fixes the incident serializer from making 3 queries per `seen_by` user to 3 for all users. seen here https://sentry.io/organizations/sentry/performance/sentry:974b2a5980724a67ab9ee93d5f8ed18e/ 

On the frontend, don't wait for stats to load before displaying the incident details. Currently, the page feels slow because we wait for both the incident and the stats before displaying anything.