### PR TITLE
fix(breadcrumbv2): Fix border bottom when there are active filters

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/filter/dropdownButton.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/filter/dropdownButton.tsx
@@ -46,6 +46,12 @@ const StyledDropdownButton = styled(DropdownButton)<{hasDarkBorderBottomColor?: 
   &:hover,
   &:active {
     border-right: 0;
+    ${p =>
+      !p.isOpen &&
+      p.hasDarkBorderBottomColor &&
+      `
+        border-bottom-color: ${p.theme.button.primary.border};
+      `}
   }
   z-index: ${p => p.theme.zIndex.dropdown};
   border-radius: ${p =>


### PR DESCRIPTION
Fix border bottom of the hover state when there are active filters for breadcrumbs.

**Before:**

![Kapture 2020-08-31 at 16 30 15](https://user-images.githubusercontent.com/139499/91765930-c2e3db80-eba7-11ea-912c-25ba2006b2b0.gif)


**After:**

![Kapture 2020-08-31 at 16 29 11](https://user-images.githubusercontent.com/139499/91765933-c4150880-eba7-11ea-8ca6-89b3f99a5da2.gif)