### PR TITLE
feat(net): Add option to ensure user-supplied DNS lookups are always FQDN

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -78,6 +78,11 @@ INTERNAL_IPS = ()
 # List of IP subnets which should not be accessible
 SENTRY_DISALLOWED_IPS = ()
 
+# When resolving DNS for external sources (source map fetching, webhooks, etc),
+# ensure that domains are fully resolved first to avoid poking internal
+# search domains.
+SENTRY_ENSURE_FQDN = False
+
 # Hosts that are allowed to use system token authentication.
 # http://en.wikipedia.org/wiki/Reserved_IP_addresses
 INTERNAL_SYSTEM_IPS = (

--- a/tests/sentry/net/test_socket.py
+++ b/tests/sentry/net/test_socket.py
@@ -3,11 +3,17 @@ from __future__ import absolute_import
 import pytest
 from sentry.utils.compat.mock import patch
 from django.core.exceptions import SuspiciousOperation
+from django.test import override_settings
 
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import override_blacklist
 
-from sentry.net.socket import is_ipaddress_allowed, is_safe_hostname, safe_socket_connect
+from sentry.net.socket import (
+    is_ipaddress_allowed,
+    is_safe_hostname,
+    safe_socket_connect,
+    ensure_fqdn,
+)
 
 
 class SocketTest(TestCase):
@@ -32,3 +38,9 @@ class SocketTest(TestCase):
     def test_safe_socket_connect(self):
         with pytest.raises(SuspiciousOperation):
             safe_socket_connect(("127.0.0.1", 80))
+
+    @override_settings(SENTRY_ENSURE_FQDN=True)
+    def test_ensure_fqdn(self):
+        assert ensure_fqdn("example.com") == "example.com."
+        assert ensure_fqdn("127.0.0.1") == "127.0.0.1"
+        assert ensure_fqdn("example.com.") == "example.com."


### PR DESCRIPTION
This is purely an internal safety/performance feature, and doesn't have
any visual outward changes and shouldn't affect any legit uses.

This just makes sure all of our "safe" network paths don't try to
resolve using an /etc/resolv.conf's search domains.

If we're assuming anything through this path is configured by a
customer/user, we're already attempting to avoid resolving to any
internal DNS by restricting IP address. This prevents also crawling the
resolver search domains, since these are very typically configured for
internal DNS lookups. This also has the side effect of being slightly
more performant on DNS resolution since the resolver doesn't need to
check the search domains first. Depending on /etc/resolv.conf
configuration, this could be a lot of extra DNS lookups.

For us, this is mostly in preparation for Kubernetes since it's default
DNS resolver is not good, and rather than changing it in Kube side, it's
a gain anyways to avoid the behavior.

https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html
for some context.