### PR TITLE
fix(onpremise): Skip backfilling event if nodedata is not present

### DIFF
--- a/src/sentry/migrations/0024_auto_20191230_2052.py
+++ b/src/sentry/migrations/0024_auto_20191230_2052.py
@@ -74,8 +74,8 @@ def backfill_eventstream(apps, schema_editor):
             project_id=e.project_id, event_id=e.event_id, group_id=e.group_id, data=e.data.data
         )
         primary_hash = event.get_primary_hash()
-        if event.project is None or event.group is None:
-            print("Skipped {} as group or project information is invalid.\n".format(event))
+        if event.project is None or event.group is None or len(event.data) == 0:
+            print("Skipped {} as group, project or node data information is invalid.\n".format(event))
             continue
 
         try:


### PR DESCRIPTION
We have received reports of nodedata is completely missing for some
onpremise users upgrading from older versions of Sentry. Since the event
is incomplete, we should not migrate it to the new system otherwise
this may cause errors down the line.

This came up in https://github.com/getsentry/sentry/pull/19881
Should fix getsentry/onpremise#468