### PR TITLE
fix(trends): Small ui tweaks

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -139,7 +139,7 @@ class PerformanceLanding extends React.Component<Props, State> {
       case FilterViews.KEY_TRANSACTIONS:
         return t('By Key Transaction');
       case FilterViews.TRENDS:
-        return t('Trends');
+        return t('By Trends');
       default:
         throw Error(`Unknown view: ${currentView}`);
     }

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -267,7 +267,7 @@ function TrendsListItem(props: TrendsListItemProps) {
         <Tooltip
           title={
             <TooltipContent>
-              <span>{transaction.project}</span>
+              <span>{t('Total Events')}</span>
               <span>
                 <Count value={transaction.count_range_1} />
                 {' → '}
@@ -276,20 +276,45 @@ function TrendsListItem(props: TrendsListItemProps) {
             </TooltipContent>
           }
         >
-          <ItemTransactionPercent>
-            {formatPercentage(
-              transaction.percentage_aggregate_range_2_aggregate_range_1 - 1,
-              0
+          <ItemTransactionPrimary>
+            {currentTrendFunction === TrendFunctionField.USER_MISERY ? (
+              <React.Fragment>
+                {transformValueDelta(
+                  transaction.minus_aggregate_range_2_aggregate_range_1,
+                  trendChangeType,
+                  currentTrendFunction
+                )}
+              </React.Fragment>
+            ) : (
+              <React.Fragment>
+                {trendChangeType === TrendChangeType.REGRESSION ? '+' : ''}
+                {formatPercentage(
+                  transaction.percentage_aggregate_range_2_aggregate_range_1 - 1,
+                  0
+                )}
+              </React.Fragment>
             )}
-          </ItemTransactionPercent>
+          </ItemTransactionPrimary>
         </Tooltip>
-        <ItemTransactionPercentFaster color={color}>
-          {transformValueDelta(
-            transaction.minus_aggregate_range_2_aggregate_range_1,
-            trendChangeType,
-            currentTrendFunction
+        <ItemTransactionSecondary color={color}>
+          {currentTrendFunction === TrendFunctionField.USER_MISERY ? (
+            <React.Fragment>
+              {trendChangeType === TrendChangeType.REGRESSION ? '+' : ''}
+              {formatPercentage(
+                transaction.percentage_aggregate_range_2_aggregate_range_1 - 1,
+                0
+              )}
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              {transformValueDelta(
+                transaction.minus_aggregate_range_2_aggregate_range_1,
+                trendChangeType,
+                currentTrendFunction
+              )}
+            </React.Fragment>
           )}
-        </ItemTransactionPercentFaster>
+        </ItemTransactionSecondary>
       </ItemTransactionPercentContainer>
     </ListItemContainer>
   );
@@ -338,8 +363,8 @@ const ItemTransactionAbsoluteFaster = styled('div')`
   color: ${p => p.theme.gray500};
   font-size: 14px;
 `;
-const ItemTransactionPercent = styled('div')``;
-const ItemTransactionPercentFaster = styled('div')`
+const ItemTransactionPrimary = styled('div')``;
+const ItemTransactionSecondary = styled('div')`
   color: ${p => p.color};
   font-size: 14px;
   white-space: nowrap;

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -28,14 +28,14 @@ import {
 
 export const TRENDS_FUNCTIONS: TrendFunction[] = [
   {
-    label: 'Duration (p50)',
-    field: TrendFunctionField.P50,
-    alias: 'percentile_range',
-  },
-  {
     label: 'Average',
     field: TrendFunctionField.AVG,
     alias: 'avg_range',
+  },
+  {
+    label: 'Duration (p50)',
+    field: TrendFunctionField.P50,
+    alias: 'percentile_range',
   },
   {
     label: 'User Misery',
@@ -141,14 +141,19 @@ export function modifyTrendView(
     kind: 'asc',
   } as Sort;
 
+  if (trendFunction && trendFunction.field === TrendFunctionField.USER_MISERY) {
+    trendSort.field = `minus_${trendFunction.alias}_2_${trendFunction.alias}_1`;
+  }
+
+  if (trendsType === TrendChangeType.REGRESSION) {
+    trendSort.kind = 'desc';
+  }
+
   if (trendFunction) {
     trendView.trendFunction = trendFunction.field;
   }
   const limitTrendResult = getLimitTransactionItems(trendFunction, trendsType);
   trendView.query += ' ' + limitTrendResult;
-  if (trendsType === TrendChangeType.REGRESSION) {
-    trendSort.kind = 'desc';
-  }
 
   trendView.interval = getQueryInterval(location, trendView);
 
@@ -246,7 +251,7 @@ export function getTrendAliasedQueryPercentage(alias: string) {
   return `percentage(${alias}_2,${alias}_1)`;
 }
 
-function getTrendAliasedMinus(alias: string) {
+export function getTrendAliasedMinus(alias: string) {
   return `minus_${alias}_2_${alias}_1`;
 }
 

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -10,6 +10,7 @@ import {
   TRENDS_FUNCTIONS,
   getTrendAliasedFieldPercentage,
   getTrendAliasedQueryPercentage,
+  getTrendAliasedMinus,
 } from 'app/views/performance/trends/utils';
 import {TrendFunctionField} from 'app/views/performance/trends/types';
 
@@ -211,9 +212,8 @@ describe('Performance > Trends', function() {
     expect(firstTransaction.find('ItemTransactionAbsoluteFaster').text()).toMatch(
       '863 → 1.6k miserable users'
     );
-    expect(firstTransaction.find('ItemTransactionPercentFaster').text()).toMatch(
-      '797 less'
-    );
+    expect(firstTransaction.find('ItemTransactionPrimary').text()).toMatch('797 less');
+    expect(firstTransaction.find('ItemTransactionSecondary').text()).toMatch('92%');
   });
 
   it('choosing a trend function changes location', async function() {
@@ -267,6 +267,11 @@ describe('Performance > Trends', function() {
       const aliasedFieldDivide = getTrendAliasedFieldPercentage(trendFunction.alias);
       const aliasedQueryDivide = getTrendAliasedQueryPercentage(trendFunction.alias);
 
+      const sort =
+        trendFunction.field === TrendFunctionField.USER_MISERY
+          ? getTrendAliasedMinus(trendFunction.alias)
+          : aliasedFieldDivide;
+
       const defaultFields = ['transaction', 'project', 'count()'];
       const trendFunctionFields = TRENDS_FUNCTIONS.map(({field}) => field);
 
@@ -281,7 +286,7 @@ describe('Performance > Trends', function() {
         expect.objectContaining({
           query: expect.objectContaining({
             trendFunction: trendFunction.field,
-            sort: aliasedFieldDivide,
+            sort,
             query: expect.stringContaining(aliasedQueryDivide + ':<1'),
             interval: '1h',
             field,
@@ -296,7 +301,7 @@ describe('Performance > Trends', function() {
         expect.objectContaining({
           query: expect.objectContaining({
             trendFunction: trendFunction.field,
-            sort: '-' + aliasedFieldDivide,
+            sort: '-' + sort,
             query: expect.stringContaining(aliasedQueryDivide + ':>1'),
             interval: '1h',
             field,


### PR DESCRIPTION
### Summary
Made a few small ui tweaks to trends

- Switch average to be the first trend function
- Updated tooltip for clarity
- Added '+' for positive % change
- Switch user misery to sort by absolute value instead of %