### PR TITLE
feat(trends): Improve trends graph

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -50,26 +50,26 @@ export const TRENDS_FUNCTIONS: TrendFunction[] = [
 export function chartIntervalFunction(dateTimeSelection: DateTimeObject) {
   const diffInMinutes = getDiffInMinutes(dateTimeSelection);
   if (diffInMinutes >= THIRTY_DAYS) {
-    return '48h';
-  }
-
-  if (diffInMinutes >= TWO_WEEKS) {
     return '24h';
   }
 
-  if (diffInMinutes >= ONE_WEEK) {
+  if (diffInMinutes >= TWO_WEEKS) {
     return '12h';
   }
 
+  if (diffInMinutes >= ONE_WEEK) {
+    return '6h';
+  }
+
   if (diffInMinutes >= TWENTY_FOUR_HOURS) {
-    return '1h';
+    return '30m';
   }
 
   if (diffInMinutes <= ONE_HOUR) {
-    return '180s';
+    return '90s';
   }
 
-  return '2m';
+  return '60s';
 }
 
 export const trendToColor = {

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -288,7 +288,7 @@ describe('Performance > Trends', function() {
             trendFunction: trendFunction.field,
             sort,
             query: expect.stringContaining(aliasedQueryDivide + ':<1'),
-            interval: '1h',
+            interval: '30m',
             field,
           }),
         })
@@ -303,7 +303,7 @@ describe('Performance > Trends', function() {
             trendFunction: trendFunction.field,
             sort: '-' + sort,
             query: expect.stringContaining(aliasedQueryDivide + ':>1'),
-            interval: '1h',
+            interval: '30m',
             field,
           }),
         })


### PR DESCRIPTION
### Summary
This adds additional marklines to the trend graph to show values being compared across periods, along with tweaks to the legend to support toggling the display of these marklines as well as releases.

Other: Also reduced interval being passed to the backend to show more resolution on the graphs