### PR TITLE
fix(workflow): Use empty as default when query string is undefined

### DIFF
--- a/src/sentry/static/sentry/app/utils/stream.tsx
+++ b/src/sentry/static/sentry/app/utils/stream.tsx
@@ -17,10 +17,10 @@ type QueryObj = {
   [key: string]: string;
 };
 
-export function queryToObj(queryStr: string): QueryObj {
+export function queryToObj(queryStr = ''): QueryObj {
   const text: string[] = [];
 
-  const queryItems = (queryStr || '').match(/\S+:"[^"]*"?|\S+/g);
+  const queryItems = queryStr.match(/\S+:"[^"]*"?|\S+/g);
   const queryObj: QueryObj = (queryItems || []).reduce((obj, item) => {
     const index = item.indexOf(':');
     if (index === -1) {

--- a/src/sentry/static/sentry/app/utils/stream.tsx
+++ b/src/sentry/static/sentry/app/utils/stream.tsx
@@ -20,7 +20,7 @@ type QueryObj = {
 export function queryToObj(queryStr: string): QueryObj {
   const text: string[] = [];
 
-  const queryItems = queryStr.match(/\S+:"[^"]*"?|\S+/g);
+  const queryItems = (queryStr || '').match(/\S+:"[^"]*"?|\S+/g);
   const queryObj: QueryObj = (queryItems || []).reduce((obj, item) => {
     const index = item.indexOf(':');
     if (index === -1) {

--- a/tests/js/spec/utils/stream.spec.jsx
+++ b/tests/js/spec/utils/stream.spec.jsx
@@ -32,6 +32,12 @@ describe('utils/stream', function() {
         is: 'unresolved',
       });
     });
+
+    it('should use empty string as __text and not fail if query is undefined', function() {
+      expect(queryToObj()).toEqual({
+        __text: '',
+      });
+    });
   });
 
   describe('objToQuery()', function() {


### PR DESCRIPTION
Added a `||` default for query strings in `queryToObj` converter.

Saw similar errors before like this. They sometime happen when app crashes due to another error and before all the props of this functions caller get initialized, so query string is undefined. Defaulting the query string is a good practice regardless and will fix the sentry issue.

fixes: https://sentry.io/organizations/sentry/issues/1449915175