### PR TITLE
feat(grouping): More comprehensive fingerprinting support

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -14,7 +14,7 @@ from sentry.grouping.variants import (
 )
 from sentry.grouping.enhancer import Enhancements, InvalidEnhancerConfig, ENHANCEMENT_BASES
 from sentry.grouping.utils import (
-    DEFAULT_FINGERPRINT_VALUES,
+    is_default_fingerprint_var,
     hash_from_values,
     resolve_fingerprint_values,
 )
@@ -194,7 +194,7 @@ def get_grouping_variants_for_event(event, config=None):
 
     # Otherwise we go to the various forms of fingerprint handling.
     fingerprint = event.data.get("fingerprint") or ["{{ default }}"]
-    defaults_referenced = sum(1 if d in DEFAULT_FINGERPRINT_VALUES else 0 for d in fingerprint)
+    defaults_referenced = sum(1 if is_default_fingerprint_var(d) else 0 for d in fingerprint)
 
     if config is None:
         config = load_default_grouping_config()

--- a/src/sentry/grouping/enhancer.py
+++ b/src/sentry/grouping/enhancer.py
@@ -33,8 +33,11 @@ line = _ (comment / rule / empty) newline?
 rule = _ matchers actions
 
 matchers         = matcher+
-matcher          = _ matcher_type sep argument
-matcher_type     = "path" / "function" / "module" / "family" / "package" / "app"
+matcher          = _ negation? matcher_type sep argument
+matcher_type     = key / quoted_key
+
+key              = ~r"[a-zA-Z0-9_\.-]+"
+quoted_key       = ~r"\"([a-zA-Z0-9_\.:-]+)\""
 
 actions          = action+
 action           = flag_action / var_action
@@ -53,11 +56,12 @@ argument         = quoted / unquoted
 quoted           = ~r'"([^"\\]*(?:\\.[^"\\]*)*)"'
 unquoted         = ~r"\S+"
 
-sep     = ":"
-space   = " "
-empty   = ""
-newline = ~r"[\r\n]"
-_       = space*
+sep      = ":"
+space    = " "
+empty    = ""
+negation = "!"
+newline  = ~r"[\r\n]"
+_        = space*
 
 """
 )
@@ -89,14 +93,35 @@ ACTION_FLAGS = {
 REVERSE_ACTION_FLAGS = dict((v, k) for k, v in six.iteritems(ACTION_FLAGS))
 
 
+MATCHERS = {
+    # discover field names
+    "stack.module": "module",
+    "stack.abs_path": "path",
+    "stack.package": "package",
+    "stack.function": "function",
+    # fingerprinting shortened fields
+    "module": "module",
+    "path": "path",
+    "package": "package",
+    "function": "function",
+    # fingerprinting specific fields
+    "family": "family",
+    "app": "app",
+}
+
+
 class InvalidEnhancerConfig(Exception):
     pass
 
 
 class Match(object):
-    def __init__(self, key, pattern):
-        self.key = key
+    def __init__(self, key, pattern, negated=False):
+        try:
+            self.key = MATCHERS[key]
+        except KeyError:
+            raise InvalidEnhancerConfig("Unknown matcher '%s'" % key)
         self.pattern = pattern
+        self.negated = negated
 
     @property
     def description(self):
@@ -154,16 +179,22 @@ class Match(object):
             arg = {True: "1", False: "0"}.get(get_rule_bool(self.pattern), "")
         else:
             arg = self.pattern
-        return MATCH_KEYS[self.key] + arg
+        return ("!" if self.negated else "") + MATCH_KEYS[self.key] + arg
 
     @classmethod
     def _from_config_structure(cls, obj):
-        key = SHORT_MATCH_KEYS[obj[0]]
-        if key == "family":
-            arg = ",".join([_f for _f in [REVERSE_FAMILIES.get(x) for x in obj[1:]] if _f])
+        val = obj
+        if val.startswith("!"):
+            negated = True
+            val = val[1:]
         else:
-            arg = obj[1:]
-        return cls(key, arg)
+            negated = False
+        key = SHORT_MATCH_KEYS[val[0]]
+        if key == "family":
+            arg = ",".join([_f for _f in [REVERSE_FAMILIES.get(x) for x in val[1:]] if _f])
+        else:
+            arg = val[1:]
+        return cls(key, arg, negated)
 
 
 class Action(object):
@@ -520,8 +551,8 @@ class EnhancmentsVisitor(NodeVisitor):
         return Rule(matcher, actions)
 
     def visit_matcher(self, node, children):
-        _, ty, _, argument = children
-        return Match(ty, argument)
+        _, negation, ty, _, argument = children
+        return Match(ty, argument, bool(negation))
 
     def visit_matcher_type(self, node, children):
         return node.text
@@ -572,6 +603,13 @@ class EnhancmentsVisitor(NodeVisitor):
 
     def generic_visit(self, node, children):
         return children
+
+    def visit_key(self, node, children):
+        return node.text
+
+    def visit_quoted_key(self, node, children):
+        # leading ! are used to indicate negation. make sure they don't appear.
+        return node.match.groups()[0].lstrip("!")
 
 
 def _load_configs():

--- a/src/sentry/grouping/fingerprinting.py
+++ b/src/sentry/grouping/fingerprinting.py
@@ -41,7 +41,7 @@ comment        = ~r"#[^\r\n]*"
 
 quoted         = ~r'"([^"\\]*(?:\\.[^"\\]*)*)"'
 unquoted       = ~r"\S+"
-unquoted_no_comma = ~r"((?:\{\{\s*\S+\s*\}\})|(?:[^\s,]+))"
+unquoted_no_comma = ~r"((?:\{\{\s*\S+\s*\}\})|(?:[^\s\{,]+))"
 
 follow   = "->"
 sep      = ":"

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -42,6 +42,8 @@ def get_rule_bool(value):
 def resolve_fingerprint_values(values, event):
     def get_fingerprint_value(value):
         var = parse_fingerprint_var(value)
+        if var is None:
+            return value
         if var == "transaction":
             return event.data.get("transaction") or "<no-transaction>"
         elif var in ("type", "error.type"):
@@ -61,6 +63,12 @@ def resolve_fingerprint_values(values, event):
             if pkg:
                 pkg = pkg.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
             return pkg or "<no-package>"
+        elif var.startswith("tags."):
+            tag = var[5:]
+            for t, value in event.data.get("tags") or ():
+                if t == tag:
+                    return value
+            return "<no-value-for-tag-%s>" % tag
         return value
 
     return [get_fingerprint_value(x) for x in values]

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -63,6 +63,10 @@ def resolve_fingerprint_values(values, event):
             if pkg:
                 pkg = pkg.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
             return pkg or "<no-package>"
+        elif var == "level":
+            return event.data.get("level") or "<no-level>"
+        elif var == "logger":
+            return event.data.get("logger") or "<no-logger>"
         elif var.startswith("tags."):
             tag = var[5:]
             for t, value in event.data.get("tags") or ():

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import re
+
 from hashlib import md5
 
 from django.utils.encoding import force_bytes
@@ -8,12 +10,17 @@ from sentry.utils.safe import get_path
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
 
 
-DEFAULT_FINGERPRINT_VALUES = frozenset(["{{ default }}", "{{default}}"])
-TRANSACTION_FINGERPRINT_VALUES = frozenset(["{{ transaction }}", "{{transaction}}"])
-EXCEPTION_TYPE_FINGERPRINT_VALUES = frozenset(["{{ type }}", "{{type}}"])
-FUNCTION_FINGERPRINT_VALUES = frozenset(["{{ function }}", "{{function}}"])
-MODULE_FINGERPRINT_VALUES = frozenset(["{{ module }}", "{{module}}"])
-PACKAGE_FINGERPRINT_VALUES = frozenset(["{{ package }}", "{{package}}"])
+_fingerprint_var_re = re.compile(r"^\{\{\s*(\S+)\s*\}\}$")
+
+
+def parse_fingerprint_var(value):
+    match = _fingerprint_var_re.match(value)
+    if match is not None:
+        return match.group(1)
+
+
+def is_default_fingerprint_var(value):
+    return parse_fingerprint_var(value) == "default"
 
 
 def hash_from_values(values):
@@ -34,20 +41,21 @@ def get_rule_bool(value):
 
 def resolve_fingerprint_values(values, event):
     def get_fingerprint_value(value):
-        if value in TRANSACTION_FINGERPRINT_VALUES:
+        var = parse_fingerprint_var(value)
+        if var == "transaction":
             return event.data.get("transaction") or "<no-transaction>"
-        elif value in EXCEPTION_TYPE_FINGERPRINT_VALUES:
+        elif var in ("type", "error.type"):
             ty = get_path(event.data, "exception", "values", -1, "type")
             return ty or "<no-type>"
-        elif value in FUNCTION_FINGERPRINT_VALUES:
+        elif var in ("function", "stack.function"):
             frame = get_crash_frame_from_event_data(event.data)
             func = frame.get("function") if frame else None
             return func or "<no-function>"
-        elif value in MODULE_FINGERPRINT_VALUES:
+        elif var in ("module", "stack.module"):
             frame = get_crash_frame_from_event_data(event.data)
             mod = frame.get("module") if frame else None
             return mod or "<no-module>"
-        elif value in PACKAGE_FINGERPRINT_VALUES:
+        elif var in ("package", "stack.package"):
             frame = get_crash_frame_from_event_data(event.data)
             pkg = frame.get("package") if frame else None
             if pkg:

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from sentry.grouping.utils import hash_from_values, DEFAULT_FINGERPRINT_VALUES
+from sentry.grouping.utils import hash_from_values, is_default_fingerprint_var
 
 
 class BaseVariant(object):
@@ -135,7 +135,7 @@ class SaltedComponentVariant(ComponentVariant):
             return None
         final_values = []
         for value in self.values:
-            if value in DEFAULT_FINGERPRINT_VALUES:
+            if is_default_fingerprint_var(value):
                 final_values.extend(self.component.iter_values())
             else:
                 final_values.append(value)
@@ -146,7 +146,7 @@ class SaltedComponentVariant(ComponentVariant):
             yield x
 
         for value in self.values:
-            if value not in DEFAULT_FINGERPRINT_VALUES:
+            if not is_default_fingerprint_var(value):
                 yield ("fingerprint", "ident-shingle"), [value]
 
     def _get_metadata_as_dict(self):

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-message-on-value.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-message-on-value.json
@@ -1,0 +1,39 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [
+        [
+          "message",
+          "*love*"
+        ]
+      ],
+      "fingerprint": [
+        "what-is-love"
+      ]
+    }
+  ],
+  "fingerprint": [
+    "{{ default }}"
+  ],
+  "exception": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "main",
+              "abs_path": "Application.java",
+              "module": "io.sentry.example.Application",
+              "filename": "Application.java",
+              "lineno": 13,
+              "in_app": false
+            }
+          ]
+        },
+        "type": "NoLove",
+        "value": "something has no love."
+      }
+    ]
+  },
+  "platform": "java"
+}

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-on-log-info.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-on-log-info.json
@@ -1,0 +1,27 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [
+        [
+          "logger",
+          "sentry.*"
+        ],
+        [
+          "level",
+          "ERROR"
+        ]
+      ],
+      "fingerprint": [
+        "log-",
+        "{{ logger }}",
+        "-",
+        "{{ level }}"
+      ]
+    }
+  ],
+  "logentry": {
+    "formatted": "Love not found."
+  },
+  "logger": "sentry.example.love",
+  "level": "error"
+}

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-on-tags.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-on-tags.json
@@ -1,0 +1,23 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [
+        [
+          "tags.foobar",
+          "*stuff*"
+        ]
+      ],
+      "fingerprint": [
+        "foobar-matched-stuff-",
+        "{{ tags.barfoo }}"
+      ]
+    }
+  ],
+  "logentry": {
+    "formatted": "Hello my sweet Love"
+  },
+  "tags": {
+    "foobar": "my-stuff-other-stuff",
+    "barfoo": "amazing"
+  }
+}

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_message_on_value.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_message_on_value.pysnap
@@ -1,0 +1,26 @@
+---
+created: '2020-09-01T22:02:02.030304Z'
+creator: sentry
+source: tests/sentry/grouping/similarity/test_features.py
+---
+similarity:2020-07-23:fingerprint:ident-shingle: "what-is-love"
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","application.java"],["function","main"],["module","io.sentry.example.Application"]]
+similarity:2020-07-23:type:ident-shingle: "NoLove"
+similarity:2020-07-23:value:character-5-shingle: " has "
+similarity:2020-07-23:value:character-5-shingle: " love"
+similarity:2020-07-23:value:character-5-shingle: " no l"
+similarity:2020-07-23:value:character-5-shingle: "as no"
+similarity:2020-07-23:value:character-5-shingle: "ethin"
+similarity:2020-07-23:value:character-5-shingle: "g has"
+similarity:2020-07-23:value:character-5-shingle: "has n"
+similarity:2020-07-23:value:character-5-shingle: "hing "
+similarity:2020-07-23:value:character-5-shingle: "ing h"
+similarity:2020-07-23:value:character-5-shingle: "love."
+similarity:2020-07-23:value:character-5-shingle: "methi"
+similarity:2020-07-23:value:character-5-shingle: "ng ha"
+similarity:2020-07-23:value:character-5-shingle: "no lo"
+similarity:2020-07-23:value:character-5-shingle: "o lov"
+similarity:2020-07-23:value:character-5-shingle: "ometh"
+similarity:2020-07-23:value:character-5-shingle: "s no "
+similarity:2020-07-23:value:character-5-shingle: "somet"
+similarity:2020-07-23:value:character-5-shingle: "thing"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_on_log_info.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_on_log_info.pysnap
@@ -1,0 +1,20 @@
+---
+created: '2020-09-02T08:18:16.673126Z'
+creator: sentry
+source: tests/sentry/grouping/similarity/test_features.py
+---
+similarity:2020-07-23:fingerprint:ident-shingle: "-"
+similarity:2020-07-23:fingerprint:ident-shingle: "error"
+similarity:2020-07-23:fingerprint:ident-shingle: "log-"
+similarity:2020-07-23:fingerprint:ident-shingle: "sentry.example.love"
+similarity:2020-07-23:message:character-5-shingle: " foun"
+similarity:2020-07-23:message:character-5-shingle: " not "
+similarity:2020-07-23:message:character-5-shingle: "Love "
+similarity:2020-07-23:message:character-5-shingle: "e not"
+similarity:2020-07-23:message:character-5-shingle: "found"
+similarity:2020-07-23:message:character-5-shingle: "not f"
+similarity:2020-07-23:message:character-5-shingle: "ot fo"
+similarity:2020-07-23:message:character-5-shingle: "ound."
+similarity:2020-07-23:message:character-5-shingle: "ove n"
+similarity:2020-07-23:message:character-5-shingle: "t fou"
+similarity:2020-07-23:message:character-5-shingle: "ve no"

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_on_tags.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_fingerprinting/fingerprint_on_tags.pysnap
@@ -1,0 +1,22 @@
+---
+created: '2020-09-01T22:31:58.123867Z'
+creator: sentry
+source: tests/sentry/grouping/similarity/test_features.py
+---
+similarity:2020-07-23:fingerprint:ident-shingle: "amazing"
+similarity:2020-07-23:fingerprint:ident-shingle: "foobar-matched-stuff-"
+similarity:2020-07-23:message:character-5-shingle: " Love"
+similarity:2020-07-23:message:character-5-shingle: " my s"
+similarity:2020-07-23:message:character-5-shingle: " swee"
+similarity:2020-07-23:message:character-5-shingle: "Hello"
+similarity:2020-07-23:message:character-5-shingle: "eet L"
+similarity:2020-07-23:message:character-5-shingle: "ello "
+similarity:2020-07-23:message:character-5-shingle: "et Lo"
+similarity:2020-07-23:message:character-5-shingle: "llo m"
+similarity:2020-07-23:message:character-5-shingle: "lo my"
+similarity:2020-07-23:message:character-5-shingle: "my sw"
+similarity:2020-07-23:message:character-5-shingle: "o my "
+similarity:2020-07-23:message:character-5-shingle: "sweet"
+similarity:2020-07-23:message:character-5-shingle: "t Lov"
+similarity:2020-07-23:message:character-5-shingle: "weet "
+similarity:2020-07-23:message:character-5-shingle: "y swe"

--- a/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing.pysnap
+++ b/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-16T11:57:20.348479Z'
+created: '2020-09-01T22:01:36.949231Z'
 creator: sentry
 source: tests/sentry/grouping/test_enhancer.py
 ---
@@ -14,6 +14,7 @@ rules:
     range: null
   matchers:
   - key: path
+    negated: false
     pattern: '*/code/game/whatever/*'
 - actions:
   - flag: false
@@ -24,6 +25,7 @@ rules:
     range: null
   matchers:
   - key: function
+    negated: false
     pattern: panic_handler
 - actions:
   - flag: false
@@ -31,6 +33,7 @@ rules:
     range: down
   matchers:
   - key: function
+    negated: false
     pattern: ThreadStartWin32
 - actions:
   - flag: false
@@ -38,6 +41,7 @@ rules:
     range: down
   matchers:
   - key: function
+    negated: false
     pattern: ThreadStartLinux
 - actions:
   - flag: false
@@ -45,6 +49,7 @@ rules:
     range: down
   matchers:
   - key: function
+    negated: false
     pattern: ThreadStartMac
 - actions:
   - flag: false
@@ -52,8 +57,10 @@ rules:
     range: null
   matchers:
   - key: family
+    negated: false
     pattern: native
   - key: module
+    negated: false
     pattern: std::*
 - actions:
   - flag: false
@@ -61,6 +68,7 @@ rules:
     range: null
   matchers:
   - key: module
+    negated: false
     pattern: core::*
 - actions:
   - flag: false
@@ -68,8 +76,10 @@ rules:
     range: null
   matchers:
   - key: family
+    negated: false
     pattern: javascript
   - key: path
+    negated: false
     pattern: '*/test.js'
 - actions:
   - flag: false
@@ -77,15 +87,19 @@ rules:
     range: null
   matchers:
   - key: family
+    negated: false
     pattern: javascript
   - key: app
+    negated: false
     pattern: '1'
   - key: path
+    negated: false
     pattern: '*/test.js'
 - actions:
   - value: 3
     var: max-frames
   matchers:
   - key: family
+    negated: false
     pattern: native
 version: 1

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
@@ -1,0 +1,32 @@
+---
+created: '2020-09-01T15:34:37.668131Z'
+creator: sentry
+source: tests/sentry/grouping/test_fingerprinting.py
+---
+config:
+  rules:
+  - fingerprint:
+    - what-is-love
+    matchers:
+    - - message
+      - '*love*'
+  version: 1
+fingerprint:
+- what-is-love
+variants:
+  app:
+    component:
+      contributes: false
+      contributes_to_similarity: true
+      hint: custom fingerprint takes precedence
+    type: component
+  custom-fingerprint:
+    type: custom-fingerprint
+    values:
+    - what-is-love
+  system:
+    component:
+      contributes: false
+      contributes_to_similarity: true
+      hint: custom fingerprint takes precedence
+    type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
@@ -1,0 +1,37 @@
+---
+created: '2020-09-02T08:17:26.393018Z'
+creator: sentry
+source: tests/sentry/grouping/test_fingerprinting.py
+---
+config:
+  rules:
+  - fingerprint:
+    - log-
+    - '{{ logger }}'
+    - '-'
+    - '{{ level }}'
+    matchers:
+    - - logger
+      - sentry.*
+    - - level
+      - ERROR
+  version: 1
+fingerprint:
+- log-
+- '{{ logger }}'
+- '-'
+- '{{ level }}'
+variants:
+  custom-fingerprint:
+    type: custom-fingerprint
+    values:
+    - log-
+    - sentry.example.love
+    - '-'
+    - error
+  default:
+    component:
+      contributes: false
+      contributes_to_similarity: true
+      hint: custom fingerprint takes precedence
+    type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
@@ -1,0 +1,29 @@
+---
+created: '2020-09-01T22:31:12.397048Z'
+creator: sentry
+source: tests/sentry/grouping/test_fingerprinting.py
+---
+config:
+  rules:
+  - fingerprint:
+    - foobar-matched-stuff-
+    - '{{ tags.barfoo }}'
+    matchers:
+    - - tags.foobar
+      - '*stuff*'
+  version: 1
+fingerprint:
+- foobar-matched-stuff-
+- '{{ tags.barfoo }}'
+variants:
+  custom-fingerprint:
+    type: custom-fingerprint
+    values:
+    - foobar-matched-stuff-
+    - amazing
+  default:
+    component:
+      contributes: false
+      contributes_to_similarity: true
+      hint: custom fingerprint takes precedence
+    type: component

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -15,6 +15,41 @@ type:DatabaseUnavailable                        -> DatabaseUnavailable
 function:assertion_failed module:foo            -> AssertionFailed, foo
 app:true                                        -> aha
 app:true                                        -> {{ default }}
+!path:**/foo/**                                 -> everything
+!"path":**/foo/**                               -> everything
+"""
+    )
+    assert rules._to_config_structure() == {
+        "rules": [
+            {"matchers": [["type", "DatabaseUnavailable"]], "fingerprint": ["DatabaseUnavailable"]},
+            {
+                "matchers": [["function", "assertion_failed"], ["module", "foo"]],
+                "fingerprint": ["AssertionFailed", "foo"],
+            },
+            {"matchers": [["app", "true"]], "fingerprint": ["aha"]},
+            {"matchers": [["app", "true"]], "fingerprint": ["{{ default }}"]},
+            {"matchers": [["!path", "**/foo/**"]], "fingerprint": ["everything"]},
+            {"matchers": [["!path", "**/foo/**"]], "fingerprint": ["everything"]},
+        ],
+        "version": 1,
+    }
+
+    assert (
+        FingerprintingRules._from_config_structure(
+            rules._to_config_structure()
+        )._to_config_structure()
+        == rules._to_config_structure()
+    )
+
+
+def test_discover_field_parsing(insta_snapshot):
+    rules = FingerprintingRules.from_config_string(
+        """
+# This is a config
+error.type:DatabaseUnavailable                        -> DatabaseUnavailable
+stack.function:assertion_failed stack.module:foo      -> AssertionFailed, foo
+app:true                                        -> aha
+app:true                                        -> {{ default }}
 """
     )
     assert rules._to_config_structure() == {

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -17,6 +17,7 @@ app:true                                        -> aha
 app:true                                        -> {{ default }}
 !path:**/foo/**                                 -> everything
 !"path":**/foo/**                               -> everything
+logger:sentry.*                                 -> logger-, {{ logger }}
 """
     )
     assert rules._to_config_structure() == {
@@ -30,6 +31,7 @@ app:true                                        -> {{ default }}
             {"matchers": [["app", "true"]], "fingerprint": ["{{ default }}"]},
             {"matchers": [["!path", "**/foo/**"]], "fingerprint": ["everything"]},
             {"matchers": [["!path", "**/foo/**"]], "fingerprint": ["everything"]},
+            {"matchers": [["logger", "sentry.*"]], "fingerprint": ["logger-", "{{ logger }}"]},
         ],
         "version": 1,
     }

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -44,6 +44,32 @@ logger:sentry.*                                 -> logger-, {{ logger }}
     )
 
 
+def test_automatic_argument_splitting():
+    rules = FingerprintingRules.from_config_string(
+        """
+logger:test -> logger-{{ logger }}
+logger:test -> logger-, {{ logger }}
+logger:test2 -> logger-{{ logger }}-{{ level }}
+logger:test2 -> logger-, {{ logger }}, -, {{ level }}
+"""
+    )
+    assert rules._to_config_structure() == {
+        "rules": [
+            {"matchers": [["logger", "test"]], "fingerprint": ["logger-", "{{ logger }}"]},
+            {"matchers": [["logger", "test"]], "fingerprint": ["logger-", "{{ logger }}"]},
+            {
+                "matchers": [["logger", "test2"]],
+                "fingerprint": ["logger-", "{{ logger }}", "-", "{{ level }}"],
+            },
+            {
+                "matchers": [["logger", "test2"]],
+                "fingerprint": ["logger-", "{{ logger }}", "-", "{{ level }}"],
+            },
+        ],
+        "version": 1,
+    }
+
+
 def test_discover_field_parsing(insta_snapshot):
     rules = FingerprintingRules.from_config_string(
         """


### PR DESCRIPTION
This adds significant improvements to our fingerprinting system.  It's work in progress
as some of those changes also need to be reflected by the grouping enhancement system.

Changes so far:

* [x] added discover style aliases (`error.type` instead of `type`) etc.
* [x] added negations (`!path:**/foo/**`) like in discover
* [x] improved way fingerprint values are handled in replacements
* [x] message now also tests against exception value, but value does not test against message. This change is in line with what appears to be user expectations.
* [x] add discover aliases to grouping enhancements
* [x] add ability to match on tags like in ownership
* [x] add ability to use tags on the right hand side of fingerprinting
* [x] add ability to match on log level and logger name
* [x] improve user experience when variables in fingerprints are used. `foo-{{ logger }}` now is the same as `foo-, {{ logger }}` which was less obvious to users