### PR TITLE
fix(relay): Update sentry_relay and auth endpoints

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -51,7 +51,7 @@ requests[security]>=2.20.0,<2.21.0
 rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
-sentry-relay>=0.5.12,<0.6.0
+sentry-relay>=0.6.0,<0.7.0
 sentry-sdk>=0.16.4,<0.17.0
 simplejson>=3.11.0,<3.12.0
 six>=1.11.0,<1.12.0

--- a/src/sentry/api/endpoints/relay_register.py
+++ b/src/sentry/api/endpoints/relay_register.py
@@ -8,7 +8,7 @@ from rest_framework import serializers, status
 from django.conf import settings
 from django.utils import timezone
 
-from sentry.cache import default_cache
+from sentry import options
 from sentry.utils import json
 from sentry.models import Relay
 from sentry.auth.system import is_internal_ip
@@ -20,9 +20,7 @@ from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
 from sentry_relay import (
     create_register_challenge,
     validate_register_response,
-    get_register_response_relay_id,
     is_version_supported,
-    PublicKey,
 )
 
 
@@ -97,8 +95,10 @@ class RelayRegisterChallengeEndpoint(Endpoint):
                 {"detail": "Missing relay signature"}, status=status.HTTP_400_BAD_REQUEST
             )
 
+        secret = options.get("system.secret-key")
+
         try:
-            challenge = create_register_challenge(request.body, sig)
+            challenge = create_register_challenge(request.body, sig, secret)
         except Exception as exc:
             return Response(
                 {"detail": str(exc).splitlines()[0]}, status=status.HTTP_400_BAD_REQUEST
@@ -116,23 +116,14 @@ class RelayRegisterChallengeEndpoint(Endpoint):
         except Relay.DoesNotExist:
             pass
         else:
-            if relay.public_key != six.text_type(challenge["public_key"]):
+            if relay.public_key != six.text_type(public_key):
                 # This happens if we have an ID collision or someone copies an existing id
                 return Response(
                     {"detail": "Attempted to register agent with a different public key"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-        default_cache.set(
-            "relay-auth:%s" % relay_id,
-            {"token": challenge["token"], "public_key": six.text_type(challenge["public_key"])},
-            60,
-        )
-        return Response(
-            serialize(
-                {"relay_id": six.text_type(challenge["relay_id"]), "token": challenge["token"]}
-            )
-        )
+        return Response(serialize(challenge))
 
 
 class RelayRegisterResponseEndpoint(Endpoint):
@@ -164,37 +155,28 @@ class RelayRegisterResponseEndpoint(Endpoint):
                 {"detail": "Missing relay signature"}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        relay_id = six.text_type(get_register_response_relay_id(request.body))
-        if relay_id != get_header_relay_id(request):
-            return Response(
-                {"detail": "relay_id in payload did not match header"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        params = default_cache.get("relay-auth:%s" % relay_id)
-        if params is None:
-            return Response({"detail": "Challenge expired"}, status=status.HTTP_401_UNAUTHORIZED)
-
-        key = PublicKey.parse(params["public_key"])
+        secret = options.get("system.secret-key")
 
         try:
-            validate_register_response(key, request.body, sig)
+            validated = validate_register_response(request.body, sig, secret)
         except Exception as exc:
             return Response(
                 {"detail": str(exc).splitlines()[0]}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        is_internal = is_internal_relay(request, params["public_key"])
+        relay_id = validated["relay_id"]
+        public_key = validated["public_key"]
+
+        is_internal = is_internal_relay(request, public_key)
         try:
             relay = Relay.objects.get(relay_id=relay_id)
         except Relay.DoesNotExist:
             relay = Relay.objects.create(
-                relay_id=relay_id, public_key=params["public_key"], is_internal=is_internal
+                relay_id=relay_id, public_key=public_key, is_internal=is_internal
             )
         else:
             relay.last_seen = timezone.now()
             relay.is_internal = is_internal
             relay.save()
-        default_cache.delete("relay-auth:%s" % relay_id)
 
         return Response(serialize({"relay_id": relay.relay_id}))

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -201,7 +201,7 @@ class RelayRegisterTest(APITestCase):
 
         assert resp.status_code == 400, resp.content
 
-    def test_expired_challenge(self):
+    def test_public_key_mismatch(self):
         data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)
@@ -241,7 +241,7 @@ class RelayRegisterTest(APITestCase):
             HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
         )
 
-        assert resp.status_code == 401, resp.content
+        assert resp.status_code == 400, resp.content
 
     def test_forge_public_key_on_register(self):
         data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
@@ -369,7 +369,7 @@ class RelayRegisterTest(APITestCase):
 
         assert resp.status_code == 400, resp.content
 
-    def test_relay_id_missmatch_response(self):
+    def test_relay_id_mismatch_response(self):
         data = {"public_key": six.text_type(self.public_key), "relay_id": self.relay_id}
 
         raw_json, signature = self.private_key.pack(data)


### PR DESCRIPTION
Updates the Relay register challenge and response endpoints to use the new stateless authentication mechanism. Instead of relying on a cache between requests, the state is serialized into the challenge token.

See https://github.com/getsentry/relay/pull/743