### PR TITLE
fix(Vercel): ignore 404s for vercel delete

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import logging
 
 from sentry.integrations.client import ApiClient
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.integrations.vercel.api")
@@ -89,9 +90,15 @@ class VercelClient(ApiClient):
         return response
 
     def update_env_variable(self, vercel_project_id, key, value):
-        self.delete(
-            self.DELETE_ENV_VAR_URL % (vercel_project_id, key),
-            allow_text=True,
-            params={"target": "production"},
-        )
+        try:
+            self.delete(
+                self.DELETE_ENV_VAR_URL % (vercel_project_id, key),
+                allow_text=True,
+                params={"target": "production"},
+            )
+        except ApiError as e:
+            # we can ignore 404 errors here since we are just trying to delete
+            if e.code != 404:
+                raise
+
         return self.create_env_variable(vercel_project_id, key, value)

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -263,9 +263,9 @@ class VercelIntegration(IntegrationInstallation):
     def create_env_var(self, client, vercel_project_id, key, value):
         if not self.env_var_already_exists(client, vercel_project_id, key):
             return client.create_env_variable(vercel_project_id, key, value)
-        self.delete_env_variable(client, vercel_project_id, key, value)
+        self.update_env_variable(client, vercel_project_id, key, value)
 
-    def delete_env_variable(self, client, vercel_project_id, key, value):
+    def update_env_variable(self, client, vercel_project_id, key, value):
         return client.update_env_variable(vercel_project_id, key, value)
 
 


### PR DESCRIPTION
We sometimes get 404 errors when deleting secrets. It's unclear why this is happening but we can safely ignore these.

Fixes: SENTRY-H1Q