### PR TITLE
fix(sample-event): Increase wait between requests

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/createSampleEventButton.tsx
+++ b/src/sentry/static/sentry/app/views/onboarding/createSampleEventButton.tsx
@@ -11,7 +11,7 @@ import {
   clearIndicators,
 } from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
-import {trackAdhocEvent} from 'app/utils/analytics';
+import {trackAdhocEvent, trackAnalyticsEvent} from 'app/utils/analytics';
 import Button from 'app/components/button';
 import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
@@ -29,20 +29,23 @@ type State = {
 };
 
 const EVENT_POLL_RETRIES = 6;
-const EVENT_POLL_INTERVAL = 500;
+const EVENT_POLL_INTERVAL = 800;
 
-async function latestEventAvailable(api: Client, groupID: string) {
+async function latestEventAvailable(
+  api: Client,
+  groupID: string
+): Promise<{eventCreated: boolean; retries: number}> {
   let retries = 0;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
     if (retries > EVENT_POLL_RETRIES) {
-      return false;
+      return {eventCreated: false, retries: retries - 1};
     }
     await new Promise(resolve => setTimeout(resolve, EVENT_POLL_INTERVAL));
     try {
       await api.requestPromise(`/issues/${groupID}/events/latest/`);
-      return true;
+      return {eventCreated: true, retries};
     } catch {
       ++retries;
     }
@@ -104,21 +107,35 @@ class CreateSampleEventButton extends React.Component<Props, State> {
 
     // Wait for the event to be fully processed and available on the group
     // before redirecting.
-    const eventCreated = await latestEventAvailable(api, eventData.groupID);
+    const {eventCreated, retries} = await latestEventAvailable(api, eventData.groupID);
     clearIndicators();
     this.setState({creating: false});
 
+    trackAnalyticsEvent({
+      eventKey: `sample_event.${eventCreated ? 'created' : 'failed'}`,
+      eventName: `Sample Event ${eventCreated ? 'Created' : 'Failed'}`,
+      organization_id: organization.id,
+      project_id: project.id,
+      platform: project.platform || '',
+      interval: EVENT_POLL_INTERVAL,
+      source,
+      retries,
+    });
+
     if (!eventCreated) {
       addErrorMessage(t('Failed to load sample event'));
+
+      Sentry.withScope(scope => {
+        scope.setTag('groupID', eventData.groupID);
+        scope.setTag('platform', project.platform || '');
+        scope.setTag('interval', EVENT_POLL_INTERVAL.toString());
+        scope.setTag('retries', retries.toString());
+
+        scope.setLevel(Sentry.Severity.Warning);
+        Sentry.captureMessage('Failed to load sample event');
+      });
       return;
     }
-
-    trackAdhocEvent({
-      eventKey: 'sample_event.created',
-      org_id: organization.id,
-      project_id: project.id,
-      source,
-    });
 
     browserHistory.push(
       `/organizations/${organization.slug}/issues/${eventData.groupID}/`

--- a/tests/js/spec/components/createSampleEventButton.spec.jsx
+++ b/tests/js/spec/components/createSampleEventButton.spec.jsx
@@ -1,19 +1,25 @@
 import {browserHistory} from 'react-router';
 import React from 'react';
+import * as Sentry from '@sentry/react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import CreateSampleEventButton from 'app/views/onboarding/createSampleEventButton';
 
 jest.useFakeTimers();
+jest.mock('app/utils/analytics');
 
 describe('CreateSampleEventButton', function() {
   const {org, project, routerContext} = initializeOrg();
   const groupID = '123';
 
   const wrapper = mountWithTheme(
-    <CreateSampleEventButton source="test" project={project} />,
+    <CreateSampleEventButton
+      source="test"
+      project={{...project, platform: 'javascript'}}
+    />,
     routerContext
   );
 
@@ -124,5 +130,18 @@ describe('CreateSampleEventButton', function() {
     expect(browserHistory.push).toHaveBeenCalledWith(
       `/organizations/${org.slug}/issues/${groupID}/`
     );
+
+    expect(trackAnalyticsEvent).toHaveBeenCalledWith({
+      eventKey: 'sample_event.created',
+      eventName: 'Sample Event Created',
+      organization_id: org.id,
+      project_id: project.id,
+      interval: 800,
+      retries: 1,
+      source: 'test',
+      platform: 'javascript',
+    });
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 });

--- a/tests/js/spec/components/createSampleEventButton.spec.jsx
+++ b/tests/js/spec/components/createSampleEventButton.spec.jsx
@@ -131,16 +131,18 @@ describe('CreateSampleEventButton', function() {
       `/organizations/${org.slug}/issues/${groupID}/`
     );
 
-    expect(trackAnalyticsEvent).toHaveBeenCalledWith({
-      eventKey: 'sample_event.created',
-      eventName: 'Sample Event Created',
-      organization_id: org.id,
-      project_id: project.id,
-      interval: 800,
-      retries: 1,
-      source: 'test',
-      platform: 'javascript',
-    });
+    expect(trackAnalyticsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventKey: 'sample_event.created',
+        eventName: 'Sample Event Created',
+        organization_id: org.id,
+        project_id: project.id,
+        interval: 800,
+        retries: 1,
+        source: 'test',
+        platform: 'javascript',
+      })
+    );
 
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
We currently wait 500ms per request for a sample event to be created, though increased latency in the event pipeline could be causing the loading of sample events to be failing more often. This adds analytics tracking and a Sentry warning around sample events so we can track how often this is happening and potentially its impact on onboarding. This also increases the interval to 800ms.