### PR TITLE
Test branch that rolls back celery 4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,6 +73,10 @@ RUN set -x \
   && buildDeps="$buildDeps \
   libmaxminddb-dev \
   "\
+  # librabbitmq
+  && buildDeps="$buildDeps \
+  make \
+  " \
   # xmlsec
   && buildDeps="$buildDeps \
   libxmlsec1-dev \
@@ -81,6 +85,10 @@ RUN set -x \
   && apt-get update \
   && apt-get install -y --no-install-recommends $buildDeps \
   && pip install -r /tmp/dist/requirements.txt \
+  # Separate these due to https://git.io/fjyz6
+  # Otherwise librabbitmq will install the latest amqp version,
+  # violating kombu's amqp<2.0 constraint.
+  && pip install librabbitmq==1.6.1 \
   && mkdir /tmp/uwsgi-dogstatsd \
   && wget -O - https://github.com/eventbrite/uwsgi-dogstatsd/archive/filters-and-tags.tar.gz | \
   tar -xzf - -C /tmp/uwsgi-dogstatsd --strip-components=1 \
@@ -111,6 +119,7 @@ RUN set -x \
   \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
+  && python -c 'import librabbitmq' \
   # Fully verify that the C extension is correctly installed, it unfortunately
   # requires a full check into maxminddb.extension.Reader
   && python -c 'import maxminddb.extension; maxminddb.extension.Reader' \

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,7 +1,7 @@
 beautifulsoup4>=4.7.1,<4.8
 boto3>=1.4.1,<1.4.6
 botocore<1.5.71
-celery==4.1.1
+celery>=3.1.25,<4.0.0
 click>=5.0,<7.0
 confluent-kafka==0.11.5
 croniter>=0.3.34,<0.4.0
@@ -24,6 +24,7 @@ google-cloud-storage==1.13.3
 googleapis-common-protos==1.6.0
 ipaddress>=1.0.16,<1.1.0 ; python_version < "3.3"
 jsonschema==3.2.0
+kombu==3.0.37
 lxml>=4.3.3,<4.4.0
 maxminddb==1.5.0
 mistune>0.7,<0.9
@@ -64,10 +65,6 @@ ua-parser>=0.10.0,<0.11.0
 unidiff>=0.5.4
 urllib3==1.24.2
 uwsgi>2.0.0,<2.1.0
-
-# celery
-billiard==3.5.0.5
-kombu==4.2.2.post1
 
 # not directly used, but provides a speedup for redis
 hiredis==0.3.1

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,10 +66,7 @@ urllib3==1.24.2
 uwsgi>2.0.0,<2.1.0
 
 # celery
-# We specifically pin to 3.5.0.4 to avoid the issue in
-# https://github.com/celery/billiard/issues/260. Once we upgrade to Celery 4.3+ we can
-# use a newer version of billiard that has a proper fix.
-billiard==3.5.0.4
+billiard==3.5.0.5
 kombu==4.2.2.post1
 
 # not directly used, but provides a speedup for redis

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     packages=find_packages("src"),
     zip_safe=False,
     install_requires=install_requires,
-    extras_require={"dev": dev_requires, "rabbitmq": ["amqp==2.6.0"]},
+    extras_require={"dev": dev_requires},
     cmdclass=cmdclass,
     license="BSL-1.1",
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     packages=find_packages("src"),
     zip_safe=False,
     install_requires=install_requires,
-    extras_require={"dev": dev_requires, "rabbitmq": ["amqp==2.6.1"]},
+    extras_require={"dev": dev_requires, "rabbitmq": ["amqp==2.6.0"]},
     cmdclass=cmdclass,
     license="BSL-1.1",
     include_package_data=True,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -484,11 +484,6 @@ BROKER_TRANSPORT_OPTIONS = {}
 # though it would cause timeouts/recursions in some cases
 CELERY_ALWAYS_EAGER = False
 
-# We use the old task protocol because during benchmarking we noticed that it's faster
-# than the new protocol. If we ever need to bump this it should be fine, there were no
-# compatibility issues, just need to run benchmarks and do some tests to make sure
-# things run ok.
-CELERY_TASK_PROTOCOL = 1
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 CELERY_IGNORE_RESULT = True
 CELERY_SEND_EVENTS = False

--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -41,7 +41,7 @@ class AmqpBackend(object):
         )
 
     def get_conn(self):
-        from amqp import Connection
+        from librabbitmq import Connection
 
         return Connection(**self.conn_info)
 
@@ -87,7 +87,7 @@ def get_queue_by_name(name):
             return queue
 
 
-backends = {"redis": RedisBackend, "amqp": AmqpBackend}
+backends = {"redis": RedisBackend, "amqp": AmqpBackend, "librabbitmq": AmqpBackend}
 
 try:
     backend = get_backend_for_broker(settings.BROKER_URL)

--- a/src/sentry/utils/retries.py
+++ b/src/sentry/utils/retries.py
@@ -13,12 +13,8 @@ logger = logging.getLogger(__name__)
 
 class RetryException(Exception):
     def __init__(self, message, exception):
-        super(RetryException, self).__init__(message)
         self.message = message
         self.exception = exception
-
-    def __reduce__(self):
-        return RetryException, (self.message, self.exception)
 
     def __str__(self):
         return force_bytes(self.message, errors="replace")


### PR DESCRIPTION
This is a branch so that we can test if Celery 4 is causing the issues we're seeing with workers in on-prem

Test Celery for getsentry/onpremise#629