### PR TITLE
fix(ui) Format duration percentile yAxis as time

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -132,7 +132,7 @@ class DurationChart extends React.Component<Props> {
       yAxis: {
         axisLabel: {
           color: theme.gray400,
-          // p50 coerces the axis to be time based
+          // p50() coerces the axis to be time based
           formatter: (value: number) => axisLabelFormatter(value, 'p50()'),
         },
       },

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
@@ -12,6 +12,7 @@ import QuestionTooltip from 'app/components/questionTooltip';
 import AsyncComponent from 'app/components/asyncComponent';
 import {OrganizationSummary} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
+import {axisLabelFormatter} from 'app/utils/discover/charts';
 import theme from 'app/utils/theme';
 import {getDuration} from 'app/utils/formatters';
 
@@ -137,6 +138,14 @@ class DurationPercentileChart extends AsyncComponent<Props, State> {
         alignWithLabel: true,
       },
     };
+    const yAxis = {
+      type: 'value',
+      axisLabel: {
+        color: theme.gray400,
+        // Use p50() to force time formatting.
+        formatter: (value: number) => axisLabelFormatter(value, 'p50()'),
+      },
+    };
     const tooltip = {
       valueFormatter(value) {
         return getDuration(value / 1000, 2);
@@ -148,7 +157,7 @@ class DurationPercentileChart extends AsyncComponent<Props, State> {
       <AreaChart
         grid={{left: '10px', right: '10px', top: '40px', bottom: '0px'}}
         xAxis={xAxis}
-        yAxis={{type: 'value'}}
+        yAxis={yAxis}
         series={transformData(chartData.data)}
         tooltip={tooltip}
         colors={colors}


### PR DESCRIPTION
Use the duration formatting functions to render the yAxis as time
instead of number of ms.

### Before
![Screen Shot 2020-09-01 at 3 14 17 PM](https://user-images.githubusercontent.com/24086/91896048-3cda9a00-ec66-11ea-827a-71ff0cae8e01.png)

### After
![Screen Shot 2020-09-01 at 3 10 18 PM](https://user-images.githubusercontent.com/24086/91896073-45cb6b80-ec66-11ea-929c-336145e52528.png)
