### PR TITLE
fix(metric_alerts): Fix bug where alert rules don't auto resolve in some cases.

### DIFF
--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -419,6 +419,43 @@ class ProcessUpdateTest(TestCase):
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.RESOLVED)
         self.assert_actions_resolved_for_incident(incident, [self.action])
 
+    def test_auto_resolve_percent_boundary(self):
+        # Verify that we resolve an alert rule automatically even if no resolve
+        # threshold is set
+        rule = self.rule
+        rule.update(resolve_threshold=None)
+        trigger = self.trigger
+        trigger.update(alert_threshold=0.5)
+        processor = self.send_update(rule, trigger.alert_threshold + 0.1, timedelta(minutes=-2))
+        self.assert_trigger_counts(processor, trigger, 0, 0)
+        incident = self.assert_active_incident(rule)
+        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
+        self.assert_actions_fired_for_incident(incident, [self.action])
+
+        processor = self.send_update(rule, trigger.alert_threshold, timedelta(minutes=-1))
+        self.assert_trigger_counts(processor, trigger, 0, 0)
+        self.assert_no_active_incident(rule)
+        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.RESOLVED)
+        self.assert_actions_resolved_for_incident(incident, [self.action])
+
+    def test_auto_resolve_boundary(self):
+        # Verify that we resolve an alert rule automatically if the value hits the
+        # original alert trigger value
+        rule = self.rule
+        rule.update(resolve_threshold=None)
+        trigger = self.trigger
+        processor = self.send_update(rule, trigger.alert_threshold + 1, timedelta(minutes=-2))
+        self.assert_trigger_counts(processor, trigger, 0, 0)
+        incident = self.assert_active_incident(rule)
+        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
+        self.assert_actions_fired_for_incident(incident, [self.action])
+
+        processor = self.send_update(rule, trigger.alert_threshold, timedelta(minutes=-1))
+        self.assert_trigger_counts(processor, trigger, 0, 0)
+        self.assert_no_active_incident(rule)
+        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.RESOLVED)
+        self.assert_actions_resolved_for_incident(incident, [self.action])
+
     def test_auto_resolve_reversed(self):
         # Test auto resolving works correctly when threshold is reversed
         rule = self.rule


### PR DESCRIPTION
When we have a rule that has an alert threshold of > 0 it should resolve when a value of 0 comes in.
This fails, because we only support lt/gt comparisons.

This pr adds in a small hack so that this behaviour will work. It might be worth considering adding
in lte/gte support at some point.