### PR TITLE
feat(sentry-apps): adds docs link for published sentry apps

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -86,7 +86,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get resourceLinks() {
-    //only show links for published apps
+    //only show links for published sentry apps
     if (this.sentryApp.status !== 'published') {
       return [];
     }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -86,8 +86,16 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get resourceLinks() {
-    //sentry apps don't have resources (yet)
-    return [];
+    //only show links for published apps
+    if (this.sentryApp.status !== 'published') {
+      return [];
+    }
+    return [
+      {
+        title: 'Documentation',
+        url: `https://docs.sentry.io/product/integrations/${this.integrationSlug}/`,
+      },
+    ];
   }
 
   get permissions() {


### PR DESCRIPTION
Currently, we don't show any doc links for published Sentry Apps. This PR adds a link for all published apps based on the slug. Since all of the current published apps have doc links, this will work fine. The only caveat is that going forward, when we publish a new app we need to make sure to add the docs .

![Screen Shot 2020-09-01 at 3 07 35 PM](https://user-images.githubusercontent.com/8533851/91911003-08b2a980-ec65-11ea-812d-feaef9024017.png)
