### PR TITLE
fix(metric_alerts): Fix float validation when creating a metric alert

### DIFF
--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -154,6 +154,15 @@ class TestAlertRuleSerializer(TestCase):
             {"resolve_threshold": 500},
             {"nonFieldErrors": ["critical alert threshold must be above resolution threshold"]},
         )
+        base_params = self.valid_params.copy()
+        base_params["resolve_threshold"] = 0.5
+        base_params["triggers"].pop()
+        base_params["triggers"][0]["alertThreshold"] = 0.3
+        serializer = AlertRuleSerializer(context=self.context, data=base_params)
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "nonFieldErrors": ["critical alert threshold must be above resolution threshold"]
+        }
 
     def test_transaction_dataset(self):
         serializer = AlertRuleSerializer(context=self.context, data=self.valid_transaction_params)


### PR DESCRIPTION
Floats validation was completely busted, and allowed people to create invalid rules that would keep
flapping, such as alert 0.5, resolve < 1. This fixes the float validation to work as expected.

This won't work for the case we have with ints, where you have a rule like alert > 0, resolve < 1. I
think we should look into having resolve thresholds be gte/lte so that we can remove this hackiness
around validation.