### PR TITLE
build(github): Temp remove getsentry/acceptance

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -6,33 +6,6 @@ on:
   pull_request:
 
 jobs:
-    getsentry:
-      if: ${{ github.ref != 'refs/heads/master' }}
-      runs-on: ubuntu-16.04
-      steps:
-        - name: getsentry token
-          id: getsentry
-          uses: getsentry/action-github-app-token@v1
-          with:
-            app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
-            private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
-
-        # Notify getsentry
-        - name: Dispatch getsentry tests
-          uses: actions/github-script@v3
-          with:
-            github-token: ${{ steps.getsentry.outputs.token }}
-            script: |
-              github.actions.createWorkflowDispatch({
-                owner: 'getsentry',
-                repo: 'getsentry',
-                workflow_id: 'acceptance.yml',
-                ref: 'master',
-                inputs: {
-                  sha: '${{ github.event.pull_request.head.sha }}',
-                }
-              })
-
     jest:
       runs-on: ubuntu-latest
       env:


### PR DESCRIPTION
Going to temporarily remove this for two reasons:

1) The expression we are using to update the sentry check: [needs.jobid.result](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions\#needs-context) is always returning "success". I think because we are trying to always save snapshots regardless of the acceptance test run (e.g using `if: always()`)

2) There are two tests in getsentry that are failing at a very high rate only on GHA

Given that these actions are gonna cost us a bit of money, Im going to temporarily disable this.