### PR TITLE
test(py3): Fix missing point version in GHA

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -153,7 +153,7 @@ jobs:
           MATRIX_INSTANCE: ${{ matrix.instance }}
         run: |
           # XXX(py3): Minors that aren't latest seem to not be available.
-          echo "::set-output name=python-version::3.6.11"
+          echo "::set-output name=python-version::3.6.12"
           echo "::set-output name=matrix-instance-number::$(($MATRIX_INSTANCE+1))"
 
       - name: Set up Python ${{ steps.config.outputs.python-version }}


### PR DESCRIPTION
Apparently 3.6.11 can't be installed anymore in GHA :shrug: