### PR TITLE
ref(py3): Normalize signing byte / string usage

### DIFF
--- a/src/sentry/integrations/msteams/link_identity.py
+++ b/src/sentry/integrations/msteams/link_identity.py
@@ -35,7 +35,7 @@ class MsTeamsLinkIdentityView(BaseView):
     @transaction_start("MsTeamsLinkIdentityView")
     @never_cache
     def handle(self, request, signed_params):
-        params = unsign(signed_params.encode("ascii", errors="ignore"))
+        params = unsign(signed_params)
 
         organization, integration, idp = get_identity(
             request.user, params["organization_id"], params["integration_id"]

--- a/src/sentry/integrations/msteams/unlink_identity.py
+++ b/src/sentry/integrations/msteams/unlink_identity.py
@@ -31,7 +31,7 @@ class MsTeamsUnlinkIdentityView(BaseView):
     @transaction_start("MsTeamsUnlinkIdentityView")
     @never_cache
     def handle(self, request, signed_params):
-        params = unsign(signed_params.encode("ascii", errors="ignore"))
+        params = unsign(signed_params)
 
         if request.method != "POST":
             return render_to_response(

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -37,7 +37,7 @@ class SlackLinkIdentityView(BaseView):
     @transaction_start("SlackLinkIdentityView")
     @never_cache
     def handle(self, request, signed_params):
-        params = unsign(signed_params.encode("ascii", errors="ignore"))
+        params = unsign(signed_params)
 
         organization, integration, idp = get_identity(
             request.user, params["organization_id"], params["integration_id"]

--- a/src/sentry/integrations/slack/unlink_identity.py
+++ b/src/sentry/integrations/slack/unlink_identity.py
@@ -37,7 +37,7 @@ class SlackUnlinkIdentityView(BaseView):
     @transaction_start("SlackUnlinkIdentityView")
     @never_cache
     def handle(self, request, signed_params):
-        params = unsign(signed_params.encode("ascii", errors="ignore"))
+        params = unsign(signed_params)
 
         organization, integration, idp = get_identity(
             request.user, params["organization_id"], params["integration_id"]

--- a/src/sentry/utils/signing.py
+++ b/src/sentry/utils/signing.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import base64
 
+from django.utils.encoding import force_bytes, force_text
 from django.core.signing import TimestampSigner
 from sentry.utils.json import dumps, loads
 
@@ -12,13 +13,27 @@ SALT = "sentry-generic-signing"
 
 
 def sign(**kwargs):
-    return base64.urlsafe_b64encode(TimestampSigner(salt=SALT).sign(dumps(kwargs))).rstrip("=")
+    """
+    Signs all passed kwargs and produces a base64 string which may be passed to
+    unsign which will verify the string has not been tampered with.
+    """
+    return force_text(
+        base64.urlsafe_b64encode(
+            TimestampSigner(salt=SALT).sign(dumps(kwargs)).encode("utf-8")
+        ).rstrip(b"=")
+    )
 
 
 def unsign(data, max_age=60 * 60 * 24 * 2):
-    return loads(TimestampSigner(salt=SALT).unsign(urlsafe_b64decode(data), max_age=max_age))
+    """
+    Unsign a signed base64 string. Accepts the base64 value as a string or bytes
+    """
+    return loads(
+        TimestampSigner(salt=SALT).unsign(urlsafe_b64decode(data).decode("utf-8"), max_age=max_age)
+    )
 
 
 def urlsafe_b64decode(b64string):
+    b64string = force_bytes(b64string)
     padded = b64string + b"=" * (4 - len(b64string) % 4)
     return base64.urlsafe_b64decode(padded)

--- a/src/sentry/web/frontend/msteams_extension_configuration.py
+++ b/src/sentry/web/frontend/msteams_extension_configuration.py
@@ -22,7 +22,5 @@ class MsTeamsExtensionConfigurationView(IntegrationExtensionConfigurationView):
         params = params.copy()
         signed_params = params["signed_params"]
         del params["signed_params"]
-        params.update(
-            unsign(signed_params.encode("ascii", errors="ignore"), max_age=INSTALL_EXPIRATION_TIME)
-        )
+        params.update(unsign(signed_params, max_age=INSTALL_EXPIRATION_TIME,))
         return params

--- a/tests/sentry/integrations/msteams/test_unlink_identity.py
+++ b/tests/sentry/integrations/msteams/test_unlink_identity.py
@@ -70,7 +70,7 @@ class MsTeamsIntegrationUnlinkIdentityTest(TestCase):
         )
 
         signed_params = unlink_url.split("/")[-2]
-        params = unsign(signed_params.encode("ascii", errors="ignore"))
+        params = unsign(signed_params)
         assert params == {
             "conversation_id": self.conversation_id,
             "service_url": "https://smba.trafficmanager.net/amer",


### PR DESCRIPTION
This gives the signing utils a consistent interface.

Signing will always produce a string, and unsigning will take either a
string or bytes, but it will ensure we're dealing with the byte
value of the base64 representation.