### PR TITLE
ref(py3): Decode test bodies in msteams integration tests

### DIFF
--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -43,7 +43,7 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
             access_json = {"expires_in": 86399, "access_token": "my_token"}
             responses.add(
                 responses.POST,
-                u"https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
+                "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
                 json=access_json,
             )
 
@@ -78,9 +78,9 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
                 integration=integration, organization=self.organization
             )
 
-            integration_url = "organizations/{}/rules/".format(self.organization.slug)
-            assert integration_url in responses.calls[1].request.body
-            assert self.organization.name in responses.calls[1].request.body
+            integration_url = u"organizations/{}/rules/".format(self.organization.slug)
+            assert integration_url in responses.calls[1].request.body.decode("utf-8")
+            assert self.organization.name in responses.calls[1].request.body.decode("utf-8")
 
     @responses.activate
     def test_installation(self):

--- a/tests/sentry/integrations/msteams/test_unlink_identity.py
+++ b/tests/sentry/integrations/msteams/test_unlink_identity.py
@@ -91,9 +91,10 @@ class MsTeamsIntegrationUnlinkIdentityTest(TestCase):
         identity = Identity.objects.filter(external_id=teams_user_id, user=self.user1)
 
         assert len(identity) == 0
-        assert (
-            "Your Microsoft Teams identity has been unlinked to your Sentry account."
-            in responses.calls[1].request.body
+        assert "Your Microsoft Teams identity has been unlinked to your Sentry account." in responses.calls[
+            1
+        ].request.body.decode(
+            "utf-8"
         )
         assert len(responses.calls) == 2
 

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -268,7 +268,7 @@ class MsTeamsWebhookTest(APITestCase):
         )
 
         assert resp.status_code == 204
-        assert "Personal Installation of Sentry" in responses.calls[3].request.body
+        assert "Personal Installation of Sentry" in responses.calls[3].request.body.decode("utf-8")
         assert "Bearer my_token" in responses.calls[3].request.headers["Authorization"]
 
     @responses.activate
@@ -297,10 +297,9 @@ class MsTeamsWebhookTest(APITestCase):
         )
 
         assert resp.status_code == 204
-        assert (
-            "Sentry for Microsoft Teams does not support any commands"
-            in responses.calls[3].request.body
-        )
+        assert "Sentry for Microsoft Teams does not support any commands" in responses.calls[
+            3
+        ].request.body.decode("utf-8")
         assert "Bearer my_token" in responses.calls[3].request.headers["Authorization"]
 
     @responses.activate
@@ -349,7 +348,9 @@ class MsTeamsWebhookTest(APITestCase):
         )
 
         assert resp.status_code == 204
-        assert "Click below to unlink your identity" in responses.calls[3].request.body
+        assert "Click below to unlink your identity" in responses.calls[3].request.body.decode(
+            "utf-8"
+        )
         assert "Bearer my_token" in responses.calls[3].request.headers["Authorization"]
 
     @responses.activate
@@ -380,5 +381,7 @@ class MsTeamsWebhookTest(APITestCase):
         )
 
         assert resp.status_code == 204
-        assert "Sorry, I didn't understand 'other'" in responses.calls[3].request.body
+        assert "Sorry, I didn't understand 'other'" in responses.calls[3].request.body.decode(
+            "utf-8"
+        )
         assert "Bearer my_token" in responses.calls[3].request.headers["Authorization"]


### PR DESCRIPTION
Looks like these are recent introductions.

In py3 land request bodies are typically going to be byte strings, thus to do string comparisons in py3 you'll have to decode them first.