### PR TITLE
feat(performance): Be able to filter spans by operation name

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -1,0 +1,342 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {t, tn} from 'app/locale';
+import space from 'app/styles/space';
+import {IconFilter} from 'app/icons';
+import DropdownControl from 'app/components/dropdownControl';
+import DropdownButton from 'app/components/dropdownButton';
+import CheckboxFancy from 'app/components/checkboxFancy/checkboxFancy';
+import {pickSpanBarColour} from 'app/components/events/interfaces/spans/utils';
+
+import {ParsedTraceType} from './types';
+
+type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
+
+type NoFilter = {
+  type: 'no_filter';
+};
+
+type ActiveFilter = {
+  type: 'active_filter';
+  operationNames: Set<string>;
+};
+
+export const noFilter: NoFilter = {
+  type: 'no_filter',
+};
+
+export type ActiveOperationFilter = NoFilter | ActiveFilter;
+
+type Props = {
+  parsedTrace: ParsedTraceType;
+  operationNameFilters: ActiveOperationFilter;
+  toggleOperationNameFilter: (operationName: string) => void;
+  toggleAllOperationNameFilters: (operationNames: string[]) => void;
+};
+
+class Filter extends React.Component<Props> {
+  getOperationNames(): string[] {
+    const {parsedTrace} = this.props;
+
+    const result = parsedTrace.spans.reduce(
+      (operationNames: string[], span) => {
+        const operationName = span.op;
+
+        if (typeof operationName === 'string' && operationName.length > 0) {
+          if (!operationNames.includes(operationName)) {
+            operationNames.push(operationName);
+          }
+        }
+
+        return operationNames;
+      },
+      [parsedTrace.op]
+    );
+
+    // sort alphabetically
+    result.sort();
+
+    return result;
+  }
+
+  isOperationNameActive(operationName: string): boolean {
+    const {operationNameFilters} = this.props;
+
+    if (operationNameFilters.type === 'no_filter') {
+      return false;
+    }
+
+    // invariant: operationNameFilters.type === 'active_filter'
+
+    return operationNameFilters.operationNames.has(operationName);
+  }
+
+  getNumberOfActiveFilters(): number {
+    const {operationNameFilters} = this.props;
+
+    if (operationNameFilters.type === 'no_filter') {
+      return 0;
+    }
+
+    return operationNameFilters.operationNames.size;
+  }
+
+  render() {
+    const operationNames = this.getOperationNames();
+
+    if (operationNames.length === 0) {
+      return null;
+    }
+
+    const checkedQuantity = this.getNumberOfActiveFilters();
+
+    const buttonProps = {
+      label: (
+        <React.Fragment>
+          <IconFilter size="xs" />
+          <FilterLabel>{t('Filter')}</FilterLabel>
+        </React.Fragment>
+      ),
+      priority: 'default',
+      hasDarkBorderBottomColor: false,
+    };
+
+    if (checkedQuantity > 0) {
+      buttonProps.label = (
+        <span>{tn('%s Active Filter', '%s Active Filters', checkedQuantity)}</span>
+      );
+      buttonProps.priority = 'primary';
+      buttonProps.hasDarkBorderBottomColor = true;
+    }
+
+    return (
+      <Wrapper>
+        <DropdownControl
+          menuWidth="240px"
+          blendWithActor
+          button={({isOpen, getActorProps}) => (
+            <StyledDropdownButton
+              {...getActorProps()}
+              showChevron={false}
+              isOpen={isOpen}
+              hasDarkBorderBottomColor={buttonProps.hasDarkBorderBottomColor}
+              priority={buttonProps.priority as DropdownButtonProps['priority']}
+            >
+              {buttonProps.label}
+            </StyledDropdownButton>
+          )}
+        >
+          <MenuContent
+            onClick={event => {
+              // propagated clicks will dismiss the menu; we stop this here
+              event.stopPropagation();
+            }}
+          >
+            <Header>
+              <span>{t('Operation')}</span>
+              <CheckboxFancy
+                isChecked={checkedQuantity > 0}
+                isIndeterminate={
+                  checkedQuantity > 0 && checkedQuantity !== operationNames.length
+                }
+                onClick={event => {
+                  event.stopPropagation();
+                  this.props.toggleAllOperationNameFilters(operationNames);
+                }}
+              />
+            </Header>
+            <List>
+              {operationNames.map((operationName: string) => {
+                const isActive = this.isOperationNameActive(operationName);
+
+                return (
+                  <ListItem key={operationName} isChecked={isActive}>
+                    <OperationDot
+                      style={{backgroundColor: pickSpanBarColour(operationName)}}
+                    />
+                    <OperationName>{operationName}</OperationName>
+                    <CheckboxFancy
+                      isChecked={isActive}
+                      onClick={event => {
+                        event.stopPropagation();
+                        this.props.toggleOperationNameFilter(operationName);
+                      }}
+                    />
+                  </ListItem>
+                );
+              })}
+            </List>
+          </MenuContent>
+        </DropdownControl>
+      </Wrapper>
+    );
+  }
+}
+
+const FilterLabel = styled('span')`
+  margin-left: ${space(1)};
+`;
+
+const Wrapper = styled('div')`
+  position: relative;
+  display: flex;
+
+  margin-right: ${space(1)};
+`;
+
+const StyledDropdownButton = styled(DropdownButton)<{hasDarkBorderBottomColor?: boolean}>`
+  white-space: nowrap;
+  max-width: 200px;
+
+  z-index: ${p => p.theme.zIndex.dropdown};
+
+  &:hover,
+  &:active {
+    ${p =>
+      !p.isOpen &&
+      p.hasDarkBorderBottomColor &&
+      `
+          border-bottom-color: ${p.theme.button.primary.border};
+        `}
+  }
+
+  ${p =>
+    !p.isOpen &&
+    p.hasDarkBorderBottomColor &&
+    `
+      border-bottom-color: ${p.theme.button.primary.border};
+    `}
+`;
+
+const MenuContent = styled('div')`
+  max-height: 250px;
+  overflow-y: auto;
+  border-top: 1px solid ${p => p.theme.gray400};
+`;
+
+const Header = styled('div')`
+  display: grid;
+  grid-template-columns: auto min-content;
+  grid-column-gap: ${space(1)};
+  align-items: center;
+
+  margin: 0;
+  background-color: ${p => p.theme.gray100};
+  color: ${p => p.theme.gray500};
+  font-weight: normal;
+  font-size: ${p => p.theme.fontSizeMedium};
+  padding: ${space(1)} ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.borderDark};
+`;
+
+const List = styled('ul')`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const ListItem = styled('li')<{isChecked?: boolean}>`
+  display: grid;
+  grid-template-columns: max-content 1fr max-content;
+  grid-column-gap: ${space(1)};
+  align-items: center;
+  padding: ${space(1)} ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.borderDark};
+  :hover {
+    background-color: ${p => p.theme.gray100};
+  }
+  ${CheckboxFancy} {
+    opacity: ${p => (p.isChecked ? 1 : 0.3)};
+  }
+
+  &:hover ${CheckboxFancy} {
+    opacity: 1;
+  }
+
+  &:hover span {
+    color: ${p => p.theme.blue400};
+    text-decoration: underline;
+  }
+`;
+
+const OperationDot = styled('div')`
+  content: '';
+  display: block;
+  width: 8px;
+  min-width: 8px;
+  height: 8px;
+  margin-right: ${space(1)};
+  border-radius: 100%;
+`;
+
+const OperationName = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+`;
+
+export function toggleFilter(
+  previousState: ActiveOperationFilter,
+  operationName: string
+): ActiveOperationFilter {
+  if (previousState.type === 'no_filter') {
+    return {
+      type: 'active_filter',
+      operationNames: new Set([operationName]),
+    };
+  }
+
+  // invariant: previousState.type === 'active_filter'
+  // invariant: previousState.operationNames.size >= 1
+
+  const {operationNames} = previousState;
+
+  if (operationNames.has(operationName)) {
+    operationNames.delete(operationName);
+  } else {
+    operationNames.add(operationName);
+  }
+
+  if (operationNames.size >= 1) {
+    return {
+      type: 'active_filter',
+      operationNames,
+    };
+  }
+
+  return {
+    type: 'no_filter',
+  };
+}
+
+export function toggleAllFilters(
+  previousState: ActiveOperationFilter,
+  operationNames: string[]
+): ActiveOperationFilter {
+  if (previousState.type === 'no_filter') {
+    return {
+      type: 'active_filter',
+      operationNames: new Set(operationNames),
+    };
+  }
+
+  // invariant: previousState.type === 'active_filter'
+
+  if (previousState.operationNames.size === operationNames.length) {
+    // all filters were selected, so the next state should un-select all filters
+    return {
+      type: 'no_filter',
+    };
+  }
+
+  // not all filters were selected, so the next state is to select all the remaining filters
+
+  return {
+    type: 'active_filter',
+    operationNames: new Set(operationNames),
+  };
+}
+
+export default Filter;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -301,7 +301,7 @@ export function toggleFilter(
     operationNames.add(operationName);
   }
 
-  if (operationNames.size >= 1) {
+  if (operationNames.size > 0) {
     return {
       type: 'active_filter',
       operationNames,

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -331,7 +331,6 @@ export function toggleAllFilters(
   }
 
   // not all filters were selected, so the next state is to select all the remaining filters
-
   return {
     type: 'active_filter',
     operationNames: new Set(operationNames),

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -114,7 +114,7 @@ class Filter extends React.Component<Props> {
     }
 
     return (
-      <Wrapper>
+      <Wrapper data-test-id="op-filter-dropdown">
         <DropdownControl
           menuWidth="240px"
           blendWithActor
@@ -125,6 +125,7 @@ class Filter extends React.Component<Props> {
               isOpen={isOpen}
               hasDarkBorderBottomColor={dropDownButtonProps.hasDarkBorderBottomColor}
               priority={dropDownButtonProps.priority as DropdownButtonProps['priority']}
+              data-test-id="filter-button"
             >
               {dropDownButtonProps.children}
             </StyledDropdownButton>

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -54,8 +54,8 @@ class Filter extends React.Component<Props> {
       [parsedTrace.op]
     );
 
-    // sort alphabetically
-    result.sort();
+    // sort alphabetically using case insensitive comparison
+    result.sort((a, b) => a.localeCompare(b, undefined, {sensitivity: 'base'}));
 
     return result;
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -152,9 +152,7 @@ class Filter extends React.Component<Props> {
 
                 return (
                   <ListItem key={operationName} isChecked={isActive}>
-                    <OperationDot
-                      style={{backgroundColor: pickSpanBarColour(operationName)}}
-                    />
+                    <OperationDot backgroundColor={pickSpanBarColour(operationName)} />
                     <OperationName>{operationName}</OperationName>
                     <CheckboxFancy
                       isChecked={isActive}
@@ -260,7 +258,7 @@ const ListItem = styled('li')<{isChecked?: boolean}>`
   }
 `;
 
-const OperationDot = styled('div')`
+const OperationDot = styled('div')<{backgroundColor: string}>`
   content: '';
   display: block;
   width: 8px;
@@ -268,6 +266,8 @@ const OperationDot = styled('div')`
   height: 8px;
   margin-right: ${space(1)};
   border-radius: 100%;
+
+  background-color: ${p => p.backgroundColor};
 `;
 
 const OperationName = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -60,7 +60,7 @@ class Filter extends React.Component<Props> {
     return result;
   }
 
-  isOperationNameActive(operationName: string): boolean {
+  isOperationNameActive(operationName: string) {
     const {operationNameFilters} = this.props;
 
     if (operationNameFilters.type === 'no_filter') {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -92,8 +92,10 @@ class Filter extends React.Component<Props> {
 
     const checkedQuantity = this.getNumberOfActiveFilters();
 
-    const buttonProps = {
-      label: (
+    const dropDownButtonProps: Pick<DropdownButtonProps, 'children' | 'priority'> & {
+      hasDarkBorderBottomColor: boolean;
+    } = {
+      children: (
         <React.Fragment>
           <IconFilter size="xs" />
           <FilterLabel>{t('Filter')}</FilterLabel>
@@ -104,11 +106,11 @@ class Filter extends React.Component<Props> {
     };
 
     if (checkedQuantity > 0) {
-      buttonProps.label = (
+      dropDownButtonProps.children = (
         <span>{tn('%s Active Filter', '%s Active Filters', checkedQuantity)}</span>
       );
-      buttonProps.priority = 'primary';
-      buttonProps.hasDarkBorderBottomColor = true;
+      dropDownButtonProps.priority = 'primary';
+      dropDownButtonProps.hasDarkBorderBottomColor = true;
     }
 
     return (
@@ -121,10 +123,10 @@ class Filter extends React.Component<Props> {
               {...getActorProps()}
               showChevron={false}
               isOpen={isOpen}
-              hasDarkBorderBottomColor={buttonProps.hasDarkBorderBottomColor}
-              priority={buttonProps.priority as DropdownButtonProps['priority']}
+              hasDarkBorderBottomColor={dropDownButtonProps.hasDarkBorderBottomColor}
+              priority={dropDownButtonProps.priority as DropdownButtonProps['priority']}
             >
-              {buttonProps.label}
+              {dropDownButtonProps.children}
             </StyledDropdownButton>
           )}
         >

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -31,7 +31,7 @@ export type ActiveOperationFilter = NoFilter | ActiveFilter;
 
 type Props = {
   parsedTrace: ParsedTraceType;
-  operationNameFilters: ActiveOperationFilter;
+  operationNameFilter: ActiveOperationFilter;
   toggleOperationNameFilter: (operationName: string) => void;
   toggleAllOperationNameFilters: (operationNames: string[]) => void;
 };
@@ -62,25 +62,25 @@ class Filter extends React.Component<Props> {
   }
 
   isOperationNameActive(operationName: string) {
-    const {operationNameFilters} = this.props;
+    const {operationNameFilter} = this.props;
 
-    if (operationNameFilters.type === 'no_filter') {
+    if (operationNameFilter.type === 'no_filter') {
       return false;
     }
 
-    // invariant: operationNameFilters.type === 'active_filter'
+    // invariant: operationNameFilter.type === 'active_filter'
 
-    return operationNameFilters.operationNames.has(operationName);
+    return operationNameFilter.operationNames.has(operationName);
   }
 
   getNumberOfActiveFilters(): number {
-    const {operationNameFilters} = this.props;
+    const {operationNameFilter} = this.props;
 
-    if (operationNameFilters.type === 'no_filter') {
+    if (operationNameFilter.type === 'no_filter') {
       return 0;
     }
 
-    return operationNameFilters.operationNames.size;
+    return operationNameFilter.operationNames.size;
   }
 
   render() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -8,6 +8,7 @@ import DropdownControl from 'app/components/dropdownControl';
 import DropdownButton from 'app/components/dropdownButton';
 import CheckboxFancy from 'app/components/checkboxFancy/checkboxFancy';
 import {pickSpanBarColour} from 'app/components/events/interfaces/spans/utils';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 import {ParsedTraceType} from './types';
 
@@ -272,9 +273,7 @@ const OperationDot = styled('div')<{backgroundColor: string}>`
 
 const OperationName = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+  ${overflowEllipsis};
 `;
 
 export function toggleFilter(

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -95,11 +95,9 @@ class SpansInterface extends React.Component<Props, State> {
   }
 
   toggleOperationNameFilter = (operationName: string) => {
-    this.setState(prevState => {
-      return {
-        operationNameFilters: toggleFilter(prevState.operationNameFilters, operationName),
-      };
-    });
+    this.setState(prevState => ({
+      operationNameFilters: toggleFilter(prevState.operationNameFilters, operationName),
+    }));
   };
 
   toggleAllOperationNameFilters = (operationNames: string[]) => {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -215,7 +215,7 @@ const Search = styled('div')`
 `;
 
 const StyledSearchBar = styled(SearchBar)`
-  width: 100%;
+  flex-grow: 1;
 `;
 
 const AlertContainer = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -20,6 +20,12 @@ import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import {ParsedTraceType} from './types';
 import {parseTrace, getTraceDateTimeRange} from './utils';
 import TraceView from './traceView';
+import Filter, {
+  ActiveOperationFilter,
+  noFilter,
+  toggleFilter,
+  toggleAllFilters,
+} from './filter';
 
 type Props = {
   orgId: string;
@@ -30,6 +36,7 @@ type Props = {
 type State = {
   parsedTrace: ParsedTraceType;
   searchQuery: string | undefined;
+  operationNameFilters: ActiveOperationFilter;
 };
 
 class SpansInterface extends React.Component<Props, State> {
@@ -41,6 +48,7 @@ class SpansInterface extends React.Component<Props, State> {
   state: State = {
     searchQuery: undefined,
     parsedTrace: parseTrace(this.props.event),
+    operationNameFilters: noFilter,
   };
 
   static getDerivedStateFromProps(props: Props, state: State): State {
@@ -85,6 +93,25 @@ class SpansInterface extends React.Component<Props, State> {
       </AlertContainer>
     );
   }
+
+  toggleOperationNameFilter = (operationName: string) => {
+    this.setState(prevState => {
+      return {
+        operationNameFilters: toggleFilter(prevState.operationNameFilters, operationName),
+      };
+    });
+  };
+
+  toggleAllOperationNameFilters = (operationNames: string[]) => {
+    this.setState(prevState => {
+      return {
+        operationNameFilters: toggleAllFilters(
+          prevState.operationNameFilters,
+          operationNames
+        ),
+      };
+    });
+  };
 
   render() {
     const {event, orgId, location, organization} = this.props;
@@ -149,12 +176,20 @@ class SpansInterface extends React.Component<Props, State> {
                   isLoading,
                   numOfErrors,
                 })}
-                <StyledSearchBar
-                  defaultQuery=""
-                  query={this.state.searchQuery || ''}
-                  placeholder={t('Search for spans')}
-                  onSearch={this.handleSpanFilter}
-                />
+                <Search>
+                  <Filter
+                    parsedTrace={parsedTrace}
+                    operationNameFilters={this.state.operationNameFilters}
+                    toggleOperationNameFilter={this.toggleOperationNameFilter}
+                    toggleAllOperationNameFilters={this.toggleAllOperationNameFilters}
+                  />
+                  <StyledSearchBar
+                    defaultQuery=""
+                    query={this.state.searchQuery || ''}
+                    placeholder={t('Search for spans')}
+                    onSearch={this.handleSpanFilter}
+                  />
+                </Search>
                 <Panel>
                   <TraceView
                     event={event}
@@ -163,6 +198,7 @@ class SpansInterface extends React.Component<Props, State> {
                     organization={organization}
                     parsedTrace={parsedTrace}
                     spansWithErrors={spansWithErrors}
+                    operationNameFilters={this.state.operationNameFilters}
                   />
                 </Panel>
               </React.Fragment>
@@ -174,8 +210,14 @@ class SpansInterface extends React.Component<Props, State> {
   }
 }
 
-const StyledSearchBar = styled(SearchBar)`
+const Search = styled('div')`
+  display: flex;
+  width: 100%;
   margin-bottom: ${space(1)};
+`;
+
+const StyledSearchBar = styled(SearchBar)`
+  width: 100%;
 `;
 
 const AlertContainer = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -177,7 +177,7 @@ class SpansInterface extends React.Component<Props, State> {
                 <Search>
                   <Filter
                     parsedTrace={parsedTrace}
-                    operationNameFilters={this.state.operationNameFilters}
+                    operationNameFilter={this.state.operationNameFilters}
                     toggleOperationNameFilter={this.toggleOperationNameFilter}
                     toggleAllOperationNameFilters={this.toggleAllOperationNameFilters}
                   />

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -32,6 +32,7 @@ import SpanGroup from './spanGroup';
 import {SpanRowMessage} from './styles';
 import * as DividerHandlerManager from './dividerHandlerManager';
 import {FilterSpans} from './traceView';
+import {ActiveOperationFilter} from './filter';
 
 type RenderedSpanTree = {
   spanTree: JSX.Element | null;
@@ -48,6 +49,7 @@ type PropType = {
   filterSpans: FilterSpans | undefined;
   event: SentryTransactionEvent;
   spansWithErrors: TableData | null | undefined;
+  operationNameFilters: ActiveOperationFilter;
 };
 
 class SpanTree extends React.Component<PropType> {
@@ -107,7 +109,18 @@ class SpanTree extends React.Component<PropType> {
   }
 
   isSpanFilteredOut(span: Readonly<RawSpanType>): boolean {
-    const {filterSpans} = this.props;
+    const {filterSpans, operationNameFilters} = this.props;
+
+    if (operationNameFilters.type === 'active_filter') {
+      const operationName = getSpanOperation(span);
+
+      if (
+        typeof operationName === 'string' &&
+        !operationNameFilters.operationNames.has(operationName)
+      ) {
+        return true;
+      }
+    }
 
     if (!filterSpans) {
       return false;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -95,7 +95,8 @@ class SpanTree extends React.Component<PropType> {
       if (!isCurrentSpanHidden) {
         messages.push(
           <span key="spans-filtered">
-            <strong>{numOfFilteredSpansAbove}</strong> {t('spans filtered out')}
+            <strong>{numOfFilteredSpansAbove}</strong>{' '}
+            {numOfFilteredSpansAbove === 1 ? t('hidden span') : t('hidden spans')}
           </span>
         );
       }

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {SentryTransactionEvent, Organization} from 'app/types';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import {TableData} from 'app/utils/discover/discoverQuery';
 
 import {
@@ -93,12 +93,23 @@ class SpanTree extends React.Component<PropType> {
 
     if (showFilteredSpansMessage) {
       if (!isCurrentSpanHidden) {
-        messages.push(
-          <span key="spans-filtered">
-            <strong>{numOfFilteredSpansAbove}</strong>{' '}
-            {numOfFilteredSpansAbove === 1 ? t('hidden span') : t('hidden spans')}
-          </span>
-        );
+        if (numOfFilteredSpansAbove === 1) {
+          messages.push(
+            <span key="spans-filtered">
+              {tct('[numOfSpans] hidden span', {
+                numOfSpans: <strong>{numOfFilteredSpansAbove}</strong>,
+              })}
+            </span>
+          );
+        } else {
+          messages.push(
+            <span key="spans-filtered">
+              {tct('[numOfSpans] hidden spans', {
+                numOfSpans: <strong>{numOfFilteredSpansAbove}</strong>,
+              })}
+            </span>
+          );
+        }
       }
     }
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -13,6 +13,7 @@ import {RawSpanType, ParsedTraceType} from './types';
 import {generateRootSpan, getSpanID, getTraceContext} from './utils';
 import TraceViewHeader from './header';
 import * as CursorGuideHandler from './cursorGuideHandler';
+import {ActiveOperationFilter} from './filter';
 
 type IndexedFusedSpan = {
   span: RawSpanType;
@@ -40,6 +41,7 @@ type Props = {
   parsedTrace: ParsedTraceType;
   searchQuery: string | undefined;
   spansWithErrors: TableData | null | undefined;
+  operationNameFilters: ActiveOperationFilter;
 };
 
 type State = {
@@ -183,7 +185,7 @@ class TraceView extends React.PureComponent<Props, State> {
       );
     }
 
-    const {orgId, organization, spansWithErrors} = this.props;
+    const {orgId, organization, spansWithErrors, operationNameFilters} = this.props;
 
     return (
       <DragManager interactiveLayerRef={this.minimapInteractiveRef}>
@@ -202,6 +204,7 @@ class TraceView extends React.PureComponent<Props, State> {
               orgId={orgId}
               organization={organization}
               spansWithErrors={spansWithErrors}
+              operationNameFilters={operationNameFilters}
             />
           </CursorGuideHandler.Provider>
         )}


### PR DESCRIPTION

Add controls to filter spans by operation name; similar to how breadcrumbs are filtered.

----

**Filtering on one operation name:**

![Kapture 2020-09-02 at 05 48 35](https://user-images.githubusercontent.com/139499/91967056-b020f200-ece0-11ea-891d-2b077658befb.gif)

**Multiple filters + select all + clear all:**

![Kapture 2020-09-02 at 05 51 34](https://user-images.githubusercontent.com/139499/91967084-b911c380-ece0-11ea-98ed-859e5a60db8f.gif)
