### PR TITLE
ref(similar-issues): Remove 'Similar issues by trace ID' feature

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -286,7 +286,7 @@ class GroupDetails extends React.Component<Props, State> {
     }
 
     if (currentTab === TAB.SIMILAR_ISSUES) {
-      childProps = {...childProps, event};
+      childProps = {...childProps};
     }
 
     return (

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -285,10 +285,6 @@ class GroupDetails extends React.Component<Props, State> {
       childProps = {...childProps, event, baseUrl};
     }
 
-    if (currentTab === TAB.SIMILAR_ISSUES) {
-      childProps = {...childProps};
-    }
-
     return (
       <React.Fragment>
         <GroupHeader

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import Feature from 'app/components/acl/feature';
 import {Project, Group} from 'app/types';
-import withOrganization from 'app/utils/withOrganization';
 
 import SimilarStackTrace from './similarStackTrace';
 import SimilarTraceID from './similarTraceID';
@@ -12,33 +11,16 @@ type Props = React.ComponentProps<typeof SimilarTraceID> & {
   group: Group;
 };
 
-const GroupSimilarIssues = ({
-  event,
-  organization,
-  location,
-  project,
-  group,
-  ...props
-}: Props) => (
-  <React.Fragment>
-    <Feature features={['similarity-view']} project={project}>
-      <SimilarStackTrace
-        project={project}
-        location={location}
-        group={group}
-        query={location.query}
-        {...props}
-      />
-    </Feature>
-    <Feature features={['related-events']} organization={organization}>
-      <Feature
-        features={['discover-basic', 'performance-view']}
-        organization={organization}
-      >
-        <SimilarTraceID event={event} organization={organization} location={location} />
-      </Feature>
-    </Feature>
-  </React.Fragment>
+const GroupSimilarIssues = ({location, project, group, ...props}: Props) => (
+  <Feature features={['similarity-view']} project={project}>
+    <SimilarStackTrace
+      project={project}
+      location={location}
+      group={group}
+      query={location.query}
+      {...props}
+    />
+  </Feature>
 );
 
-export default withOrganization(GroupSimilarIssues);
+export default GroupSimilarIssues;


### PR DESCRIPTION
After an internal discussion, we concluded that "Similar Events (Issues) by Trace Id"  shouldn't be in the "Similar Issues" Tab.

This feature will still be used elsewhere (it will only be moved), so I'm just removing it from the main view of Similar Issues for now.