### PR TITLE
ref(store) Increase TTL for event processing store

### DIFF
--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from sentry.utils.cache import cache_key_for_event
 
-DEFAULT_TIMEOUT = 3600
+DEFAULT_TIMEOUT = 60 * 60 * 24
 
 
 class BaseEventProcessingStore(object):


### PR DESCRIPTION
We'll be using the event processing store for post process soon. In order to reduce the chances of blobs going missing during a temporary outage. I want to increase the processing store TTL to 24 hours. This will help ensure that all events are still in the cache when post_process runs.

I checked getsentry and it doesn't appear to set this option anywhere.