### PR TITLE
ref(alert): Text changes on issue alert builder

### DIFF
--- a/src/sentry/rules/conditions/every_event.py
+++ b/src/sentry/rules/conditions/every_event.py
@@ -4,7 +4,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class EveryEventCondition(EventCondition):
-    label = "An event is seen"
+    label = "An event occurs"
 
     def passes(self, event, state):
         return True

--- a/src/sentry/rules/filters/age_comparison.py
+++ b/src/sentry/rules/filters/age_comparison.py
@@ -49,7 +49,8 @@ class AgeComparisonFilter(EventFilter):
     }
 
     # An issue is newer/older than X minutes/hours/days/weeks
-    label = "An issue is {comparison_type} than {value} {time}"
+    label = "The issue is {comparison_type} than {value} {time}"
+    prompt = "The issue is older or newer than..."
 
     def passes(self, event, state):
         comparison_type = self.get_option("comparison_type")

--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -32,7 +32,7 @@ class AssignedToForm(MemberTeamForm):
 class AssignedToFilter(EventFilter):
     form_cls = AssignedToForm
     label = "The issue is assigned to {targetType}"
-    prompt = "The issue is assigned to {No One/Team/Member}"
+    prompt = "The issue is assigned to {no one/team/member}"
 
     form_fields = {"targetType": {"type": "assignee", "choices": CHOICES}}
 

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -15,7 +15,8 @@ class IssueOccurrencesFilter(EventFilter):
         "value": {"type": "number", "placeholder": 10},
     }
 
-    label = "An issue has happened at least {value} times"
+    label = "The issue has happened at least {value} times"
+    prompt = "The issue has happened at least {x} times (Note: this is approximate)"
 
     def passes(self, event, state):
         try:

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -505,34 +505,37 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
                     <StepContent>
                       <StepLead>
-                        {tct('[when:When] an issue matches [selector] of the following', {
-                          when: <Badge />,
-                          selector: (
-                            <EmbeddedWrapper>
-                              <EmbeddedSelectField
-                                className={classNames({
-                                  error: this.hasError('actionMatch'),
-                                })}
-                                inline={false}
-                                styles={{
-                                  control: provided => ({
-                                    ...provided,
-                                    minHeight: '20px',
-                                    height: '20px',
-                                  }),
-                                }}
-                                isSearchable={false}
-                                isClearable={false}
-                                name="actionMatch"
-                                required
-                                flexibleControlStateSize
-                                choices={ACTION_MATCH_CHOICES}
-                                onChange={val => this.handleChange('actionMatch', val)}
-                                disabled={!hasAccess}
-                              />
-                            </EmbeddedWrapper>
-                          ),
-                        })}
+                        {tct(
+                          '[when:When] an issue meets [selector] of the following conditions',
+                          {
+                            when: <Badge />,
+                            selector: (
+                              <EmbeddedWrapper>
+                                <EmbeddedSelectField
+                                  className={classNames({
+                                    error: this.hasError('actionMatch'),
+                                  })}
+                                  inline={false}
+                                  styles={{
+                                    control: provided => ({
+                                      ...provided,
+                                      minHeight: '20px',
+                                      height: '20px',
+                                    }),
+                                  }}
+                                  isSearchable={false}
+                                  isClearable={false}
+                                  name="actionMatch"
+                                  required
+                                  flexibleControlStateSize
+                                  choices={ACTION_MATCH_CHOICES}
+                                  onChange={val => this.handleChange('actionMatch', val)}
+                                  disabled={!hasAccess}
+                                />
+                              </EmbeddedWrapper>
+                            ),
+                          }
+                        )}
                       </StepLead>
                       <RuleNodeList
                         nodes={this.state.configs?.conditions ?? null}

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -325,7 +325,7 @@ class Factories(object):
             },
             {
                 "id": "sentry.rules.conditions.every_event.EveryEventCondition",
-                "name": "An event is seen",
+                "name": "An event occurs",
             },
         ]
         return Rule.objects.create(

--- a/tests/acceptance/test_project_alert_settings.py
+++ b/tests/acceptance/test_project_alert_settings.py
@@ -31,7 +31,7 @@ class ProjectAlertSettingsTest(AcceptanceTestCase):
             },
             {
                 "id": "sentry.rules.conditions.every_event.EveryEventCondition",
-                "name": "An event is seen",
+                "name": "An event occurs",
             },
         ]
 

--- a/tests/js/sentry-test/fixtures/projectAlertRuleConfiguration.js
+++ b/tests/js/sentry-test/fixtures/projectAlertRuleConfiguration.js
@@ -4,7 +4,7 @@ export function ProjectAlertRuleConfiguration(params = {}) {
       {
         enabled: true,
         id: 'sentry.rules.conditions.every_event.EveryEventCondition',
-        label: 'An event is seen',
+        label: 'An event occurs',
       },
       {
         enabled: true,

--- a/tests/js/sentry-test/fixtures/ruleConditions.js
+++ b/tests/js/sentry-test/fixtures/ruleConditions.js
@@ -14,7 +14,7 @@ const UNIQUE_USER_FREQUENCY_CONDITION =
 export const MOCK_RESP_VERBOSE = [
   {
     id: 'sentry.rules.conditions.every_event.EveryEventCondition',
-    label: 'An event is seen',
+    label: 'An event occurs',
   },
   {
     id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',


### PR DESCRIPTION
Some text changes to make certain things more readable/clear:

- Replace “An” with “The” in filters (I accidently left this out of #20444)
- age filter dropdown text should read “The issue is older or newer than….” (including the ellipsis)
- “at least {X} times” filter: add “(Note: this is approximate)” to the end
- “When an issue meets {all} of the following conditions”
- “An event is seen” -> “An event occurs”

**Old:**
<img width="1172" alt="Screen Shot 2020-09-02 at 3 49 46 PM" src="https://user-images.githubusercontent.com/9372512/92030266-c9ec2480-ed34-11ea-8277-0ebb1b3dea76.png">


**New:**
![image](https://user-images.githubusercontent.com/9372512/92030205-b6d95480-ed34-11ea-98d6-a204c28957bf.png)
