### PR TITLE
meta(): Run `webpack-profile` with `NO_TS_FORK`

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "dev-acceptance": "NO_DEV_SERVER=1 NODE_ENV=development yarn webpack --watch",
     "storybook": "SENTRY_UI_HOT_RELOAD='' start-storybook -p 9001 -c .storybook",
     "storybook-build": "build-storybook -c .storybook -o docs-ui/.storybook-out --quiet",
-    "webpack-profile": "yarn -s webpack --profile --json > stats.json",
+    "webpack-profile": "NO_TS_FORK=1 yarn -s webpack --profile --json > stats.json",
     "build-css": "NODE_ENV=production yarn webpack --config=config/webpack.css.config.js",
     "build": "NODE_ENV=production yarn webpack --mode production --display errors-only --output-path=public"
   },


### PR DESCRIPTION
Otherwise TS Fork plugin will output to stdout and `webpack-profile` redirects stdout to a file that expects JSON.