### PR TITLE
fix(acceptance): Fix tooltip visual acceptance tests

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/time/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/time/index.tsx
@@ -38,6 +38,7 @@ const Time = React.memo(
             </div>
           }
           containerDisplayMode="inline-flex"
+          disableForVisualTest
         >
           <TextOverflow>
             {getDynamicText({

--- a/src/sentry/static/sentry/app/components/group/seenInfo.jsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.jsx
@@ -80,7 +80,7 @@ class SeenInfo extends React.Component {
         <dt key={0}>{t('When')}:</dt>
         {date ? (
           <dd key={1}>
-            <Tooltip title={this.getTooltipTitle()}>
+            <Tooltip title={this.getTooltipTitle()} disableForVisualTest>
               <TimeSince className="dotted-underline" date={date} />
             </Tooltip>
             <br />
@@ -90,7 +90,7 @@ class SeenInfo extends React.Component {
           </dd>
         ) : dateGlobal && environment === '' ? (
           <dd key={1}>
-            <Tooltip title={this.getTooltipTitle()}>
+            <Tooltip title={this.getTooltipTitle()} disableForVisualTest>
               <TimeSince date={dateGlobal} />
             </Tooltip>
             <br />

--- a/src/sentry/static/sentry/app/components/stackedBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.tsx
@@ -272,7 +272,7 @@ class StackedBarChart extends React.Component<Props, State> {
         viewBox="0 0 10 10"
         size={10}
       >
-        <Tooltip title={title} position="bottom">
+        <Tooltip title={title} position="bottom" disableForVisualTest>
           <circle
             data-test-id="chart-column"
             r="4"

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -59,12 +59,6 @@ type Props = DefaultProps & {
    * If child node supports ref forwarding, you can skip apply a wrapper
    */
   skipWrapper?: boolean;
-
-  /**
-   * Stops tooltip from being opened during tooltip visual acceptance.
-   * Should be set to true if tooltip contains unisolated data (eg. dates)
-   */
-  disableForVisualTest?: boolean;
 };
 
 type State = {

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -59,6 +59,12 @@ type Props = DefaultProps & {
    * If child node supports ref forwarding, you can skip apply a wrapper
    */
   skipWrapper?: boolean;
+
+  /**
+   * Stops tooltip from being opened during tooltip visual acceptance.
+   * Should be set to true if tooltip contains unisolated data (eg. dates)
+   */
+  disableForVisualTest?: boolean;
 };
 
 type State = {

--- a/src/sentry/static/sentry/app/stores/tooltipStore.tsx
+++ b/src/sentry/static/sentry/app/stores/tooltipStore.tsx
@@ -17,7 +17,9 @@ const TooltipStore: TooltipStoreInterface = {
     return this.tooltips.filter(tooltip => {
       // Filtering out disabled tooltips and lists of tooltips (which cause rendering issues for snapshots) using the internal 'key'
       return (
-        !(tooltip.props as any).disabled && !(tooltip as any)._reactInternalFiber.key
+        !(tooltip.props as any).disabled &&
+        !(tooltip as any)._reactInternalFiber.key &&
+        !(tooltip.props as any).disableForVisualTest
       );
     });
   },

--- a/src/sentry/static/sentry/app/stores/tooltipStore.tsx
+++ b/src/sentry/static/sentry/app/stores/tooltipStore.tsx
@@ -17,9 +17,7 @@ const TooltipStore: TooltipStoreInterface = {
     return this.tooltips.filter(tooltip => {
       // Filtering out disabled tooltips and lists of tooltips (which cause rendering issues for snapshots) using the internal 'key'
       return (
-        !(tooltip.props as any).disabled &&
-        !(tooltip as any)._reactInternalFiber.key &&
-        !(tooltip.props as any).disableForVisualTest
+        !(tooltip.props as any).disabled && !(tooltip as any)._reactInternalFiber.key
       );
     });
   },

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
@@ -152,9 +152,7 @@ class GroupEventToolbar extends React.Component {
           </Link>
         </h4>
         <span>
-          <Tooltip
-            title={getDynamicText({value: this.getDateTooltip(), fixed: 'Dummy title'})}
-          >
+          <Tooltip title={this.getDateTooltip()} disableForVisualTest>
             <DateTime
               date={getDynamicText({value: evt.dateCreated, fixed: 'Dummy timestamp'})}
               style={style}

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
@@ -152,7 +152,9 @@ class GroupEventToolbar extends React.Component {
           </Link>
         </h4>
         <span>
-          <Tooltip title={this.getDateTooltip()} disableForVisualTest>
+          <Tooltip
+            title={getDynamicText({value: this.getDateTooltip(), fixed: 'Dummy title'})}
+          >
             <DateTime
               date={getDynamicText({value: evt.dateCreated, fixed: 'Dummy timestamp'})}
               style={style}

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
@@ -152,7 +152,7 @@ class GroupEventToolbar extends React.Component {
           </Link>
         </h4>
         <span>
-          <Tooltip title={this.getDateTooltip()}>
+          <Tooltip title={this.getDateTooltip()} disableForVisualTest>
             <DateTime
               date={getDynamicText({value: evt.dateCreated, fixed: 'Dummy timestamp'})}
               style={style}


### PR DESCRIPTION
### Summary
This adds a prop to tooltips to disable them from opening during tooltip visual tests if they contain ephemeral data.