### PR TITLE
ref(py3): Fix buffers to coerce redis values from bytes when needed

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -8,7 +8,7 @@ from time import time
 from datetime import datetime
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import force_bytes
+from django.utils.encoding import force_bytes, force_text
 
 from sentry.buffer import Buffer
 from sentry.exceptions import InvalidConfiguration
@@ -139,7 +139,7 @@ class RedisBuffer(Buffer):
     def _load_value(self, payload):
         (type_, value) = payload
         if type_ == "s":
-            return value
+            return force_text(value)
         elif type_ == "d":
             return datetime.fromtimestamp(float(value)).replace(tzinfo=timezone.utc)
         elif type_ == "i":
@@ -230,7 +230,7 @@ class RedisBuffer(Buffer):
                         continue
                     keycount += len(keys)
                     for key in keys:
-                        pending_buffer.append(key)
+                        pending_buffer.append(key.decode("utf-8"))
                         if pending_buffer.full():
                             process_incr.apply_async(kwargs={"batch_keys": pending_buffer.flush()})
                     conn.target([host_id]).zrem(pending_key, *keys)
@@ -273,14 +273,23 @@ class RedisBuffer(Buffer):
             pipe.delete(key)
             values = pipe.execute()[0]
 
+            # XXX(python3): In python2 this isn't as important since redis will
+            # return string tyes (be it, byte strings), but in py3 we get bytes
+            # back, and really we just want to deal with keys as strings.
+            values = {force_text(k): v for k, v in six.iteritems(values)}
+
             if not values:
                 metrics.incr("buffer.revoked", tags={"reason": "empty"}, skip_internal=False)
                 self.logger.debug("buffer.revoked.empty", extra={"redis_key": key})
                 return
 
-            model = import_string(values.pop("m"))
-            if values["f"].startswith("{"):
-                filters = self._load_values(json.loads(values.pop("f")))
+            # XXX(py3): Note that ``import_string`` explicitly wants a str in
+            # python2, so we'll decode (for python3) and then translate back to
+            # a byte string (in python2) for import_string.
+            model = import_string(str(values.pop("m").decode("utf-8")))  # NOQA
+
+            if values["f"].startswith(b"{"):
+                filters = self._load_values(json.loads(values.pop("f").decode("utf-8")))
             else:
                 # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
                 filters = pickle.loads(values.pop("f"))
@@ -292,8 +301,8 @@ class RedisBuffer(Buffer):
                 if k.startswith("i+"):
                     incr_values[k[2:]] = int(v)
                 elif k.startswith("e+"):
-                    if v.startswith("["):
-                        extra_values[k[2:]] = self._load_value(json.loads(v))
+                    if v.startswith(b"["):
+                        extra_values[k[2:]] = self._load_value(json.loads(v.decode("utf-8")))
                     else:
                         # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
                         extra_values[k[2:]] = pickle.loads(v)


### PR DESCRIPTION
This essentially implements the "unicode sandwich" for the redis usage in the redis buffers backend.

Redis will encode keys and values to utf-8 automatically upon any set calls, but will not decode for us. This is important in this case because we do store some pickles in buffer keys, which if decoded would break.

I've handled decoding where we need to

 1. All hget keys are coerced to strings, these will always be strings.
 2. Values are coerced for json decoding just before decoding
 3. In tests I decode keys for ease of readability