### PR TITLE
ref(py3): Fix quotas tests

### DIFF
--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -50,10 +50,10 @@ def test_is_rate_limited_script():
         )
     ) == [True, False]
 
-    assert client.get("foo") == "1"
+    assert client.get("foo") == b"1"
     assert 59 <= client.ttl("foo") <= 60
 
-    assert client.get("bar") == "1"
+    assert client.get("bar") == b"1"
     assert 119 <= client.ttl("bar") <= 120
 
     # make sure "refund/negative" keys haven't been incremented
@@ -246,7 +246,7 @@ class RedisQuotaTest(TestCase):
         assert len(error_keys) == 2
 
         for key in error_keys:
-            assert client.get(key) == "1"
+            assert client.get(key) == b"1"
 
         attachment_keys = client.keys("r:quota:a:*")
         assert len(attachment_keys) == 0
@@ -300,7 +300,7 @@ class RedisQuotaTest(TestCase):
         assert len(attachment_keys) == 1
 
         for key in attachment_keys:
-            assert client.get(key) == "100"
+            assert client.get(key) == b"100"
 
     def test_get_usage_uses_refund(self):
         timestamp = time.time()


### PR DESCRIPTION
Since most of quotas happens in a lua script, the only thing to fix are the tests that inspect what it's doing