### PR TITLE
fix(py3): Make RedisTSDB.get_model_key work consistently across py2/py3.

### DIFF
--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 import pytest
@@ -69,6 +70,9 @@ class RedisTSDBTest(TestCase):
 
         result = self.db.get_model_key("foo")
         assert result == "bf4e529197e56a48ae2737505b9736e4"
+
+        result = self.db.get_model_key(u"我爱啤酒")
+        assert result == "26f980fbe1e8a9d3a0123d2049f95f28"
 
     def test_simple(self):
         now = datetime.utcnow().replace(tzinfo=pytz.UTC) - timedelta(hours=4)


### PR DESCRIPTION
This fixes a bug where we get errors when `repr`ing the key before md5ing it - in python 3, repr
returns a unicode string rather than bytes, and so errors when we pass that string to md5.

It also changes how we repr a bytestring - `repr("foo")` will return `"'foo'"` in py2, and
`"b'foo'"` in py3. After messing around with this a while, the safest way to keep these compatible
seems to be to just strip off the `b` from the beginning of the string in py3. This allows repr to
work correctly normal ascii bytestrings, as well as ones that have unicode encoded in them.