### PR TITLE
test(acceptance): Run headless Chrome with `disable-dev-shm`

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -459,6 +459,7 @@ def browser(request, live_server):
         options = webdriver.ChromeOptions()
         options.add_argument("no-sandbox")
         options.add_argument("disable-gpu")
+        options.add_argument("disable-dev-shm-usage")
         options.add_argument(u"window-size={}".format(window_size))
         if headless:
             options.add_argument("headless")


### PR DESCRIPTION
This seems to help getsentrys docker test image when running in GHA (no idea why Travis wasn't affected)

From
https://docs.cypress.io/guides/guides/continuous-integration.html#In-Docker:

> In a Docker container, the default size of the /dev/shm shared memory space is 64MB. This is not typically enough to run Chrome and can cause the browser to crash. You can fix this by passing the --disable-dev-shm-usage flag to Chrome