### PR TITLE
feat(ui): Force releases v2 to everyone

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/utils/switchReleasesButton.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/utils/switchReleasesButton.tsx
@@ -1,41 +1,11 @@
-import React from 'react';
-
-import {t} from 'app/locale';
-import Button from 'app/components/button';
-import {IconReleases} from 'app/icons';
-
-import {switchReleasesVersion} from './index';
-
 type Props = {
   orgId: string; // actual id, not slug
   version: '1' | '2';
 };
 
-const SwitchReleasesButton = ({orgId, version}: Props) => {
-  const switchReleases = () => {
-    switchReleasesVersion(version, orgId);
-  };
-
-  if (version === '2') {
-    return (
-      <Button
-        priority="primary"
-        size="small"
-        icon={<IconReleases size="sm" />}
-        onClick={switchReleases}
-      >
-        {t('Go to New Releases')}
-      </Button>
-    );
-  }
-
-  return (
-    <div>
-      <Button priority="link" size="small" onClick={switchReleases}>
-        {t('Go to Legacy Releases')}
-      </Button>
-    </div>
-  );
+const SwitchReleasesButton = (_props: Props) => {
+  // we are forcing everyone to version 2 now, we will delete the codebase behind v1 in a week or so
+  return null;
 };
 
 export default SwitchReleasesButton;


### PR DESCRIPTION
It's been ~5 months since releases v2 came out. 
Until now we allowed users to switch between v1 and v2.

We decided it's time to delete the codebase behind v1 and we are going to do it in two phases.
1. Remove the button to switch between versions and show v2 to everyone by default.
2. Remove the actual codebase behind v1 in a week or so if everything is smooth.

We will give the support team heads up before merging this PR just in case.