### PR TITLE
fix(discover): Allow for not project filters when unselected

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -855,21 +855,22 @@ def format_search_filter(term, params):
         project = None
         try:
             project = Project.objects.get(id__in=params.get("project_id", []), slug=value)
-        except Exception:
-            raise InvalidSearchQuery(
-                u"Invalid query. Project {} does not exist or is not an actively selected project.".format(
-                    value
+        except Exception as e:
+            if not isinstance(e, Project.DoesNotExist) or term.operator != "!=":
+                raise InvalidSearchQuery(
+                    u"Invalid query. Project {} does not exist or is not an actively selected project.".format(
+                        value
+                    )
                 )
-            )
+        else:
+            # Create a new search filter with the correct values
+            term = SearchFilter(SearchKey("project_id"), term.operator, SearchValue(project.id))
+            converted_filter = convert_search_filter_to_snuba_query(term)
+            if converted_filter:
+                if term.operator == "=":
+                    project_to_filter = project.id
 
-        # Create a new search filter with the correct values
-        term = SearchFilter(SearchKey("project_id"), term.operator, SearchValue(project.id))
-        converted_filter = convert_search_filter_to_snuba_query(term)
-        if converted_filter:
-            if term.operator == "=":
-                project_to_filter = project.id
-
-            conditions.append(converted_filter)
+                conditions.append(converted_filter)
     elif name == ISSUE_ID_ALIAS and value != "":
         # A blank term value means that this is a has filter
         group_ids = to_list(value)

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2422,4 +2422,4 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         }
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data["data"] == [{"id": "a" * 32, "project.id": 2}]
+        assert response.data["data"] == [{"id": "a" * 32, "project.id": project2.id}]

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2422,4 +2422,4 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         }
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data["data"] == [{"id": "a" * 32, "project.id": project2.id}]
+        assert response.data["data"] == [{"id": "a" * 32, "project.id": project.id}]

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -271,6 +271,55 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             == "Invalid query. Project morty does not exist or is not an actively selected project."
         )
 
+    def test_not_project_in_query_but_in_header(self):
+        team = self.create_team(organization=self.organization, members=[self.user])
+
+        project = self.create_project(organization=self.organization, teams=[team])
+        project2 = self.create_project(organization=self.organization, teams=[team])
+
+        self.store_event(
+            data={"event_id": "a" * 32, "timestamp": self.min_ago, "fingerprint": ["group1"]},
+            project_id=project.id,
+        )
+        self.store_event(
+            data={"event_id": "b" * 32, "timestamp": self.min_ago, "fingerprint": ["group2"]},
+            project_id=project2.id,
+        )
+
+        query = {
+            "field": ["id", "project.id"],
+            "project": [project.id],
+            "query": "!project:{}".format(project2.slug),
+        }
+        response = self.do_request(query)
+        assert response.status_code == 200
+        assert response.data["data"] == [{"id": "a" * 32, "project.id": project.id}]
+
+    def test_not_project_in_query_with_all_projects(self):
+        team = self.create_team(organization=self.organization, members=[self.user])
+
+        project = self.create_project(organization=self.organization, teams=[team])
+        project2 = self.create_project(organization=self.organization, teams=[team])
+
+        self.store_event(
+            data={"event_id": "a" * 32, "timestamp": self.min_ago, "fingerprint": ["group1"]},
+            project_id=project.id,
+        )
+        self.store_event(
+            data={"event_id": "b" * 32, "timestamp": self.min_ago, "fingerprint": ["group2"]},
+            project_id=project2.id,
+        )
+
+        features = {"organizations:discover-basic": True, "organizations:global-views": True}
+        query = {
+            "field": ["id", "project.id"],
+            "project": [-1],
+            "query": "!project:{}".format(project2.slug),
+        }
+        response = self.do_request(query, features=features)
+        assert response.status_code == 200
+        assert response.data["data"] == [{"id": "a" * 32, "project.id": project.id}]
+
     def test_project_condition_used_for_automatic_filters(self):
         project = self.create_project()
         self.store_event(
@@ -2399,27 +2448,3 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                     response.data["detail"]
                     == "You can view up to 20 fields at a time. Please delete some and try again."
                 )
-
-    def test_allow_not_project_when_project_not_selected(self):
-        team = self.create_team(organization=self.organization, members=[self.user])
-
-        project = self.create_project(organization=self.organization, teams=[team])
-        project2 = self.create_project(organization=self.organization, teams=[team])
-
-        self.store_event(
-            data={"event_id": "a" * 32, "timestamp": self.min_ago, "fingerprint": ["group1"]},
-            project_id=project.id,
-        )
-        self.store_event(
-            data={"event_id": "b" * 32, "timestamp": self.min_ago, "fingerprint": ["group2"]},
-            project_id=project2.id,
-        )
-
-        query = {
-            "field": ["id", "project.id"],
-            "project": [project.id],
-            "query": "!project:{}".format(project2.slug),
-        }
-        response = self.do_request(query)
-        assert response.status_code == 200
-        assert response.data["data"] == [{"id": "a" * 32, "project.id": project.id}]


### PR DESCRIPTION
Currently, when making a query containing `!project:xxx` but the project `xxx`
is not selected, the query results in an error. This change permits such queries
as these conditions are no-op.