### PR TITLE
ref(perf-view): Convert transaction summary header into component

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -9,6 +9,7 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 import space from 'app/styles/space';
 import {generateQueryWithTag} from 'app/utils';
 import EventView from 'app/utils/discover/eventView';
+import CreateAlertButton from 'app/components/createAlertButton';
 import * as Layout from 'app/components/layouts/thirds';
 import Tags from 'app/views/eventsV2/tags';
 import SearchBar from 'app/views/events/searchBar';
@@ -65,6 +66,15 @@ class SummaryContent extends React.Component<Props, State> {
       ...location,
       query,
     };
+  };
+
+  handleIncompatibleQuery: React.ComponentProps<
+    typeof CreateAlertButton
+  >['onIncompatibleQuery'] = (incompatibleAlertNoticeFn, _errors) => {
+    const incompatibleAlertNotice = incompatibleAlertNoticeFn(() =>
+      this.setState({incompatibleAlertNotice: null})
+    );
+    this.setState({incompatibleAlertNotice});
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -9,23 +9,18 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 import space from 'app/styles/space';
 import {generateQueryWithTag} from 'app/utils';
 import EventView from 'app/utils/discover/eventView';
-import Feature from 'app/components/acl/feature';
 import * as Layout from 'app/components/layouts/thirds';
 import Tags from 'app/views/eventsV2/tags';
 import SearchBar from 'app/views/events/searchBar';
 import {decodeScalar} from 'app/utils/queryString';
-import CreateAlertButton from 'app/components/createAlertButton';
 import withProjects from 'app/utils/withProjects';
-import ButtonBar from 'app/components/buttonBar';
-import {trackAnalyticsEvent} from 'app/utils/analytics';
 
+import TransactionHeader from './header';
 import TransactionList from './transactionList';
 import UserStats from './userStats';
-import KeyTransactionButton from './keyTransactionButton';
 import TransactionSummaryCharts from './charts';
 import RelatedIssues from './relatedIssues';
 import SidebarCharts from './sidebarCharts';
-import Breadcrumb from '../breadcrumb';
 
 type Props = {
   location: Location;
@@ -72,84 +67,27 @@ class SummaryContent extends React.Component<Props, State> {
     };
   };
 
-  trackAlertClick(errors?: Record<string, boolean>) {
-    const {organization} = this.props;
-    trackAnalyticsEvent({
-      eventKey: 'performance_views.summary.create_alert_clicked',
-      eventName: 'Performance Views: Create alert clicked',
-      organization_id: organization.id,
-      status: errors ? 'error' : 'success',
-      errors,
-      url: window.location.href,
-    });
-  }
-
-  handleIncompatibleQuery: React.ComponentProps<
-    typeof CreateAlertButton
-  >['onIncompatibleQuery'] = (incompatibleAlertNoticeFn, errors) => {
-    this.trackAlertClick(errors);
-    const incompatibleAlertNotice = incompatibleAlertNoticeFn(() =>
-      this.setState({incompatibleAlertNotice: null})
-    );
-    this.setState({incompatibleAlertNotice});
-  };
-
-  handleCreateAlertSuccess = () => {
-    this.trackAlertClick();
-  };
-
-  renderCreateAlertButton() {
-    const {eventView, organization, projects} = this.props;
-
-    return (
-      <CreateAlertButton
-        eventView={eventView}
-        organization={organization}
-        projects={projects}
-        onIncompatibleQuery={this.handleIncompatibleQuery}
-        onSuccess={this.handleCreateAlertSuccess}
-        referrer="performance"
-      />
-    );
-  }
-
-  renderKeyTransactionButton() {
-    const {eventView, organization, transactionName} = this.props;
-
-    return (
-      <KeyTransactionButton
-        transactionName={transactionName}
-        eventView={eventView}
-        organization={organization}
-      />
-    );
-  }
-
   render() {
-    const {transactionName, location, eventView, organization, totalValues} = this.props;
+    const {
+      transactionName,
+      location,
+      eventView,
+      organization,
+      projects,
+      totalValues,
+    } = this.props;
     const {incompatibleAlertNotice} = this.state;
     const query = decodeScalar(location.query.query) || '';
 
     return (
       <React.Fragment>
-        <Layout.Header>
-          <Layout.HeaderContent>
-            <Breadcrumb
-              organization={organization}
-              location={location}
-              transactionName={transactionName}
-            />
-            <Layout.Title>{transactionName}</Layout.Title>
-          </Layout.HeaderContent>
-          <Layout.HeaderActions>
-            <ButtonBar gap={1}>
-              <Feature organization={organization} features={['incidents']}>
-                {({hasFeature}) => hasFeature && this.renderCreateAlertButton()}
-              </Feature>
-              {this.renderKeyTransactionButton()}
-            </ButtonBar>
-          </Layout.HeaderActions>
-        </Layout.Header>
+        <TransactionHeader
+          eventView={eventView}
+          location={location}
+          organization={organization}
+          projects={projects}
+          transactionName={transactionName}
+        />
         <Layout.Body>
           {incompatibleAlertNotice && (
             <Layout.Main fullWidth>{incompatibleAlertNotice}</Layout.Main>

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -97,6 +97,7 @@ class SummaryContent extends React.Component<Props, State> {
           organization={organization}
           projects={projects}
           transactionName={transactionName}
+          handleIncompatibleQuery={this.handleIncompatibleQuery}
         />
         <Layout.Body>
           {incompatibleAlertNotice && (

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/header.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/header.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import {Location} from 'history';
+
+import {Organization, Project} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import Feature from 'app/components/acl/feature';
+import CreateAlertButton from 'app/components/createAlertButton';
+import * as Layout from 'app/components/layouts/thirds';
+import ButtonBar from 'app/components/buttonBar';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
+import Breadcrumb from 'app/views/performance/breadcrumb';
+
+import KeyTransactionButton from './keyTransactionButton';
+
+type Props = {
+  eventView: EventView;
+  location: Location;
+  organization: Organization;
+  projects: Project[];
+  transactionName: string;
+};
+
+class TransactionHeader extends React.Component<Props> {
+  trackAlertClick(errors?: Record<string, boolean>) {
+    const {organization} = this.props;
+    trackAnalyticsEvent({
+      eventKey: 'performance_views.summary.create_alert_clicked',
+      eventName: 'Performance Views: Create alert clicked',
+      organization_id: organization.id,
+      status: errors ? 'error' : 'success',
+      errors,
+      url: window.location.href,
+    });
+  }
+
+  handleIncompatibleQuery: React.ComponentProps<
+    typeof CreateAlertButton
+  >['onIncompatibleQuery'] = (incompatibleAlertNoticeFn, errors) => {
+    this.trackAlertClick(errors);
+    const incompatibleAlertNotice = incompatibleAlertNoticeFn(() =>
+      this.setState({incompatibleAlertNotice: null})
+    );
+    this.setState({incompatibleAlertNotice});
+  };
+
+  handleCreateAlertSuccess = () => {
+    this.trackAlertClick();
+  };
+
+  renderCreateAlertButton() {
+    const {eventView, organization, projects} = this.props;
+
+    return (
+      <CreateAlertButton
+        eventView={eventView}
+        organization={organization}
+        projects={projects}
+        onIncompatibleQuery={this.handleIncompatibleQuery}
+        onSuccess={this.handleCreateAlertSuccess}
+        referrer="performance"
+      />
+    );
+  }
+
+  renderKeyTransactionButton() {
+    const {eventView, organization, transactionName} = this.props;
+
+    return (
+      <KeyTransactionButton
+        transactionName={transactionName}
+        eventView={eventView}
+        organization={organization}
+      />
+    );
+  }
+
+  render() {
+    const {organization, location, transactionName} = this.props;
+
+    return (
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Breadcrumb
+            organization={organization}
+            location={location}
+            transactionName={transactionName}
+          />
+          <Layout.Title>{transactionName}</Layout.Title>
+        </Layout.HeaderContent>
+        <Layout.HeaderActions>
+          <ButtonBar gap={1}>
+            <Feature organization={organization} features={['incidents']}>
+              {({hasFeature}) => hasFeature && this.renderCreateAlertButton()}
+            </Feature>
+            {this.renderKeyTransactionButton()}
+          </ButtonBar>
+        </Layout.HeaderActions>
+      </Layout.Header>
+    );
+  }
+}
+
+export default TransactionHeader;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/header.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/header.tsx
@@ -18,7 +18,7 @@ type Props = {
   organization: Organization;
   projects: Project[];
   transactionName: string;
-  handleIncompatibleQuery?: React.ComponentProps<
+  handleIncompatibleQuery: React.ComponentProps<
     typeof CreateAlertButton
   >['onIncompatibleQuery'];
 };

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/header.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/header.tsx
@@ -18,6 +18,9 @@ type Props = {
   organization: Organization;
   projects: Project[];
   transactionName: string;
+  handleIncompatibleQuery?: React.ComponentProps<
+    typeof CreateAlertButton
+  >['onIncompatibleQuery'];
 };
 
 class TransactionHeader extends React.Component<Props> {
@@ -37,10 +40,7 @@ class TransactionHeader extends React.Component<Props> {
     typeof CreateAlertButton
   >['onIncompatibleQuery'] = (incompatibleAlertNoticeFn, errors) => {
     this.trackAlertClick(errors);
-    const incompatibleAlertNotice = incompatibleAlertNoticeFn(() =>
-      this.setState({incompatibleAlertNotice: null})
-    );
-    this.setState({incompatibleAlertNotice});
+    this.props.handleIncompatibleQuery?.(incompatibleAlertNoticeFn, errors);
   };
 
   handleCreateAlertSuccess = () => {


### PR DESCRIPTION
Extract the header of the transaction summary page into its own component.
This is in preparation for the upcoming rum page.