### PR TITLE
feat(perf-views): Adding pagination to the trends endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -1,15 +1,12 @@
 from __future__ import absolute_import
 
 import logging
-import six
 import sentry_sdk
 
 from functools import partial
-from django.utils.http import urlquote
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
-from sentry.api.base import LINK_HEADER
 from sentry.api.bases import (
     OrganizationEventsEndpointBase,
     OrganizationEventsV2EndpointBase,
@@ -21,7 +18,6 @@ from sentry.api.serializers import EventSerializer, serialize, SimpleEventSerial
 from sentry import eventstore, features
 from sentry.snuba import discover
 from sentry.utils.snuba import MAX_FIELDS
-from sentry.utils.http import absolute_uri
 from sentry.models.project import Project
 
 logger = logging.getLogger(__name__)
@@ -91,29 +87,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
 
 class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
-    def build_cursor_link(self, request, name, cursor):
-        # The base API function only uses the last query parameter, but this endpoint
-        # needs all the parameters, particularly for the "field" query param.
-        querystring = u"&".join(
-            u"{0}={1}".format(urlquote(query[0]), urlquote(value))
-            for query in request.GET.lists()
-            if query[0] != "cursor"
-            for value in query[1]
-        )
-
-        base_url = absolute_uri(urlquote(request.path))
-        if querystring:
-            base_url = u"{0}?{1}".format(base_url, querystring)
-        else:
-            base_url = base_url + "?"
-
-        return LINK_HEADER.format(
-            uri=base_url,
-            cursor=six.text_type(cursor),
-            name=name,
-            has_results="true" if bool(cursor) else "false",
-        )
-
     def get(self, request, organization):
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -9,6 +9,7 @@ from rest_framework.exceptions import ParseError
 from sentry import features
 from sentry.api.bases import OrganizationEventsV2EndpointBase, NoProjects
 from sentry.api.event_search import DateArg, parse_function
+from sentry.api.paginator import GenericOffsetPaginator
 from sentry.snuba import discover
 
 
@@ -27,6 +28,7 @@ class OrganizationEventsTrendsEndpoint(OrganizationEventsV2EndpointBase):
             "alias": "user_misery_range_",
         },
         "count_range": {"format": "count_range({start}, {end}, {index})", "alias": "count_range_"},
+        "percentage": {"format": "percentage({alias}2, {alias}1)"},
     }
 
     def has_feature(self, organization, request):
@@ -66,54 +68,72 @@ class OrganizationEventsTrendsEndpoint(OrganizationEventsV2EndpointBase):
             raise ParseError(detail=u"{} is not a supported trend function".format(trend_function))
 
         count_column = self.trend_columns.get("count_range")
+        percentage_column = self.trend_columns["percentage"]
         selected_columns = request.GET.getlist("field")[:]
         query = request.GET.get("query")
         orderby = self.get_orderby(request)
 
-        with self.handle_query_errors():
-            events_results = discover.query(
+        def data_fn(offset, limit):
+            return discover.query(
                 selected_columns=selected_columns
                 + [
                     trend_column["format"].format(*columns, start=start, end=middle, index="1"),
                     trend_column["format"].format(*columns, start=middle, end=end, index="2"),
-                    "percentage({alias}2,{alias}1)".format(alias=trend_column["alias"]),
+                    percentage_column["format"].format(alias=trend_column["alias"]),
                     "minus({alias}2,{alias}1)".format(alias=trend_column["alias"]),
                     count_column["format"].format(start=start, end=middle, index="1"),
                     count_column["format"].format(start=middle, end=end, index="2"),
-                    "percentage({alias}2,{alias}1)".format(alias=count_column["alias"]),
+                    percentage_column["format"].format(alias=count_column["alias"]),
                 ],
                 query=query,
                 params=params,
                 orderby=orderby,
-                limit=5,
+                offset=offset,
+                limit=limit,
                 referrer="api.trends.get-percentage-change",
                 auto_fields=True,
                 use_aggregate_conditions=True,
             )
 
-        def get_event_stats(query_columns, query, params, rollup, reference_event):
-            return discover.top_events_timeseries(
-                query_columns,
-                selected_columns,
-                query,
-                params,
-                orderby,
-                rollup,
-                5,
-                organization,
-                top_events=events_results,
-                referrer="api.trends.get-event-stats",
+        def on_results(events_results):
+            def get_event_stats(query_columns, query, params, rollup, reference_event):
+                return discover.top_events_timeseries(
+                    query_columns,
+                    selected_columns,
+                    query,
+                    params,
+                    orderby,
+                    rollup,
+                    min(5, len(events_results["data"])),
+                    organization,
+                    top_events=events_results,
+                    referrer="api.trends.get-event-stats",
+                )
+
+            stats_results = (
+                self.get_event_stats_data(
+                    request,
+                    organization,
+                    get_event_stats,
+                    top_events=True,
+                    query_column=trend_function,
+                )
+                if len(events_results["data"]) > 0
+                else {}
             )
 
-        stats_results = self.get_event_stats_data(
-            request, organization, get_event_stats, top_events=True, query_column=trend_function
-        )
-
-        return Response(
-            {
+            return {
                 "events": self.handle_results_with_meta(
                     request, organization, params["project_id"], events_results
                 ),
                 "stats": stats_results,
             }
-        )
+
+        with self.handle_query_errors():
+            return self.paginate(
+                request=request,
+                paginator=GenericOffsetPaginator(data_fn=data_fn),
+                on_results=on_results,
+                default_per_page=5,
+                max_per_page=5,
+            )

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -129,6 +129,7 @@ function ChangedTransactions(props: Props) {
         orgSlug={organization.slug}
         location={location}
         trendChangeType={trendChangeType}
+        limit={5}
       >
         {({isLoading, tableData}) => {
           const eventsTrendsData = (tableData as unknown) as TrendsData;


### PR DESCRIPTION
- Also fixing some minor issues I noticed
 - Limiting stats to match event results, and not even running stats if
   there aren't any events
 - Moving percentage to `trend_columns`
- Moving build_cursor_link to the base so that it's reusable by trends