### PR TITLE
fix(discover): Include project when id is present

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1810,7 +1810,7 @@ def resolve_field_list(fields, snuba_filter, auto_fields=True):
         # would be aggregated away.
         if not aggregations and "id" not in columns:
             columns.append("id")
-        if not aggregations and "project.id" not in columns:
+        if "id" in columns and "project.id" not in columns:
             columns.append("project.id")
             project_key = PROJECT_NAME_ALIAS
 


### PR DESCRIPTION
The project is included in the results by default when id is a selected field,
but only when there are no aggregates. This change ensures that when id is a
selected field, we include project even when there are aggregates present.