### PR TITLE
fix(ui) Fix commit email warning icon.

### DIFF
--- a/src/sentry/static/sentry/app/components/commitRow.tsx
+++ b/src/sentry/static/sentry/app/components/commitRow.tsx
@@ -9,7 +9,7 @@ import {t, tct} from 'app/locale';
 import UserAvatar from 'app/components/avatar/userAvatar';
 import CommitLink from 'app/components/commitLink';
 import Hovercard from 'app/components/hovercard';
-import {IconFlag} from 'app/icons';
+import {IconWarning} from 'app/icons';
 import Link from 'app/components/links/link';
 import TextOverflow from 'app/components/textOverflow';
 import TimeSince from 'app/components/timeSince';
@@ -78,7 +78,9 @@ class CommitRow extends React.Component<Props> {
           <AvatarWrapper>
             <Hovercard body={this.renderHovercardBody(author)}>
               <UserAvatar size={36} user={author} />
-              <EmailWarningIcon />
+              <EmailWarningIcon>
+                <IconWarning size="xs" />
+              </EmailWarningIcon>
             </Hovercard>
           </AvatarWrapper>
         ) : (
@@ -125,13 +127,16 @@ const StyledLink = styled(Link)`
   }
 `;
 
-const EmailWarningIcon = styled(IconFlag)`
+const EmailWarningIcon = styled('span')`
   position: relative;
-  margin-left: -11px;
-  border-radius: 11px;
-  margin-bottom: -25px;
+  top: 15px;
+  left: -11px;
+  display: inline-block;
+  line-height: 12px;
+  border-radius: 50%;
   border: 1px solid ${p => p.theme.white};
   background: ${p => p.theme.yellow300};
+  padding: 1px 2px 3px 2px;
 `;
 
 const CommitMessage = styled('div')`

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/releaseNoCommitData.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/releaseNoCommitData.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 const ReleaseNoCommitData = ({orgId}: Props) => (
   <StyledWell centered>
-    <IconCommit size="xl" />
+    <IconCommit size="54px" />
     <h4>{t('Releases are better with commit data!')}</h4>
     <p>
       {t(
@@ -30,6 +30,10 @@ const StyledWell = styled(Well)`
   background-color: ${p => p.theme.white};
   padding-top: ${space(2)};
   padding-bottom: ${space(4)};
+
+  svg {
+    fill: ${p => p.theme.gray400};
+  }
 `;
 
 export default ReleaseNoCommitData;


### PR DESCRIPTION
Use a better icon and align with the avatar contents more.

## Before 
![Screen Shot 2020-09-03 at 3 41 41 PM](https://user-images.githubusercontent.com/24086/92159805-fe76e380-edfb-11ea-91a3-011c90b8e483.png)


## Now
![Screen Shot 2020-09-03 at 3 39 38 PM](https://user-images.githubusercontent.com/24086/92159740-ddae8e00-edfb-11ea-9e97-c8d51f2b11e9.png)
