### PR TITLE
fix(py3): available-actions API test

### DIFF
--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -66,11 +66,8 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
             organization_integration=integration.organizationintegration_set.first(),
         )
 
-        pagerduty = AlertRuleTriggerAction.get_registered_type(
-            AlertRuleTriggerAction.Type.PAGERDUTY
-        )
         data = build_action_response(
-            pagerduty, integration=integration, organization=self.organization
+            self.pagerduty, integration=integration, organization=self.organization
         )
 
         assert data["type"] == "pagerduty"
@@ -103,12 +100,14 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(self.organization.slug)
 
-        assert resp.data == [
-            build_action_response(self.email),
+        assert len(resp.data) == 2
+        assert build_action_response(self.email) in resp.data
+        assert (
             build_action_response(
                 self.slack, integration=integration, organization=self.organization
-            ),
-        ]
+            )
+            in resp.data
+        )
 
     def test_duplicate_integrations(self):
         integration = Integration.objects.create(external_id="1", provider="slack", name="slack 1")
@@ -121,15 +120,20 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(self.organization.slug)
 
-        assert resp.data == [
-            build_action_response(self.email),
+        assert len(resp.data) == 3
+        assert build_action_response(self.email) in resp.data
+        assert (
             build_action_response(
                 self.slack, integration=integration, organization=self.organization
-            ),
+            )
+            in resp.data
+        )
+        assert (
             build_action_response(
                 self.slack, integration=other_integration, organization=self.organization
-            ),
-        ]
+            )
+            in resp.data
+        )
 
     def test_no_feature(self):
         self.create_team(organization=self.organization, members=[self.user])
@@ -144,13 +148,9 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         ):
             resp = self.get_valid_response(self.organization.slug)
 
-        assert resp.data == [
-            build_action_response(
-                AlertRuleTriggerAction.get_registered_type(AlertRuleTriggerAction.Type.SENTRY_APP),
-                sentry_app=sentry_app,
-            ),
-            build_action_response(self.email),
-        ]
+        assert len(resp.data) == 2
+        assert build_action_response(self.email) in resp.data
+        assert build_action_response(self.sentry_app, sentry_app=sentry_app) in resp.data
 
     def test_blocked_sentry_apps(self):
         internal_sentry_app = self.install_new_sentry_app("internal")
@@ -162,10 +162,6 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         ):
             resp = self.get_valid_response(self.organization.slug)
 
-        assert resp.data == [
-            build_action_response(
-                AlertRuleTriggerAction.get_registered_type(AlertRuleTriggerAction.Type.SENTRY_APP),
-                sentry_app=internal_sentry_app,
-            ),
-            build_action_response(self.email),
-        ]
+        assert len(resp.data) == 2
+        assert build_action_response(self.email) in resp.data
+        assert build_action_response(self.sentry_app, sentry_app=internal_sentry_app) in resp.data


### PR DESCRIPTION
Don't assume array order in available-actions API test.