### PR TITLE
ref(slack): Increase CTA to 50%

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -23,8 +23,8 @@ from .utils import (
     get_integration_type,
 )
 
-# 30% of messages for workspace apps will get the upgrade CTA
-UPGRADE_MESSAGE_FREQUENCY = 0.30
+# 50% of messages for workspace apps will get the upgrade CTA
+UPGRADE_MESSAGE_FREQUENCY = 0.50
 logger = logging.getLogger("sentry.rules")
 
 

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -118,7 +118,7 @@ class SlackNotifyActionTest(RuleTestCase):
         mock_uniform.assert_called_with(0, 1)
 
     @responses.activate
-    @patch("random.uniform", return_value=0.51)
+    @patch("random.uniform", return_value=0.49)
     def test_upgrade_notice_bot_app(self, mock_uniform):
         self.integration.metadata.update(
             {

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -118,7 +118,7 @@ class SlackNotifyActionTest(RuleTestCase):
         mock_uniform.assert_called_with(0, 1)
 
     @responses.activate
-    @patch("random.uniform", return_value=0.049)
+    @patch("random.uniform", return_value=0.51)
     def test_upgrade_notice_bot_app(self, mock_uniform):
         self.integration.metadata.update(
             {


### PR DESCRIPTION
Let's blast em. Just kidding, only going up to 50%.  They have less than a month to upgrade so seems reasonable. 