### PR TITLE
feat(msteams): adds help card

### DIFF
--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -222,19 +222,43 @@ def build_mentioned_card():
 def build_unrecognized_command_card(command_text):
     instruction = {
         "type": "TextBlock",
-        "text": (u"Sorry, I didn't understand '{}'. Supported commands:".format(command_text)),
+        "text": (u"Sorry, I didn't understand '{}'.".format(command_text)),
         "wrap": True,
     }
 
     commands = {
         "type": "TextBlock",
-        "text": ("**unlink**: unlink your Microsoft Teams identity from your Sentry account."),
+        "text": ("Type **help**: to see the list of available commands"),
         "wrap": True,
     }
 
     return {
         "type": "AdaptiveCard",
         "body": [instruction, commands],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.2",
+    }
+
+
+def build_help_command_card():
+    header = {
+        "type": "TextBlock",
+        "text": ("Please use one of the following commands for Sentry:"),
+        "wrap": True,
+    }
+
+    commands = {
+        "type": "TextBlock",
+        "text": (
+            "- **unlink**: unlink your Microsoft Teams identity from your Sentry account."
+            "\n\n- **help**: view list of all bot commands"
+        ),
+        "wrap": True,
+    }
+
+    return {
+        "type": "AdaptiveCard",
+        "body": [header, commands],
         "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
         "version": "1.2",
     }

--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -250,7 +250,7 @@ def build_help_command_card():
     commands = {
         "type": "TextBlock",
         "text": (
-            "- **unlink**: unlink your Microsoft Teams identity from your Sentry account."
+            "- **unlink**: unlink your Microsoft Teams identity from your Sentry account"
             "\n\n- **help**: view list of all bot commands"
         ),
         "wrap": True,

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -34,6 +34,7 @@ from .card_builder import (
     build_mentioned_card,
     build_unlink_identity_card,
     build_unrecognized_command_card,
+    build_help_command_card,
 )
 from .client import (
     MsTeamsJwtClient,
@@ -442,14 +443,17 @@ class MsTeamsWebhookEndpoint(Endpoint):
     def handle_personal_message(self, request):
         data = request.data
         command_text = data.get("text", "").strip()
+        lowercase_command = command_text.lower()
         conversation_id = data["conversation"]["id"]
 
         # only supporting unlink for now
-        if "unlink" in command_text:
+        if "unlink" in lowercase_command:
             unlink_url = build_unlinking_url(
                 conversation_id, data["serviceUrl"], data["from"]["id"]
             )
             card = build_unlink_identity_card(unlink_url)
+        elif "help" in lowercase_command:
+            card = build_help_command_card()
         else:
             card = build_unrecognized_command_card(command_text)
 

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -356,6 +356,39 @@ class MsTeamsWebhookTest(APITestCase):
     @responses.activate
     @patch("jwt.decode")
     @patch("time.time")
+    def test_help_command(self, mock_time, mock_decode):
+        other_command = deepcopy(EXAMPLE_UNLINK_COMMAND)
+        other_command["text"] = "help"
+        access_json = {"expires_in": 86399, "access_token": "my_token"}
+        responses.add(
+            responses.POST,
+            u"https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
+            json=access_json,
+        )
+        responses.add(
+            responses.POST,
+            u"https://smba.trafficmanager.net/amer/v3/conversations/%s/activities"
+            % other_command["conversation"]["id"],
+            json={},
+        )
+        mock_time.return_value = 1594839999 + 60
+        mock_decode.return_value = DECODED_TOKEN
+        resp = self.client.post(
+            path=webhook_url,
+            data=other_command,
+            format="json",
+            HTTP_AUTHORIZATION=u"Bearer %s" % TOKEN,
+        )
+
+        assert resp.status_code == 204
+        assert "Please use one of the following commands for Sentry" in responses.calls[
+            3
+        ].request.body.decode("utf-8")
+        assert "Bearer my_token" in responses.calls[3].request.headers["Authorization"]
+
+    @responses.activate
+    @patch("jwt.decode")
+    @patch("time.time")
     def test_other_command(self, mock_time, mock_decode):
         other_command = deepcopy(EXAMPLE_UNLINK_COMMAND)
         other_command["text"] = "other"

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -358,7 +358,7 @@ class MsTeamsWebhookTest(APITestCase):
     @patch("time.time")
     def test_help_command(self, mock_time, mock_decode):
         other_command = deepcopy(EXAMPLE_UNLINK_COMMAND)
-        other_command["text"] = "help"
+        other_command["text"] = "Help"
         access_json = {"expires_in": 86399, "access_token": "my_token"}
         responses.add(
             responses.POST,


### PR DESCRIPTION
This PR adds a new command for `help`:

![Screen Shot 2020-09-03 at 3 05 04 PM](https://user-images.githubusercontent.com/8533851/92178781-2a906580-edf8-11ea-89e1-b6dce3d242cc.png)

Also tweaked with the messaging of the unrecognized command card.