### PR TITLE
feat(metric_alerts): Bump `MAX_ROLLUP_POINTS` to 10k to support wider date ranges.

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -82,7 +82,7 @@ SENTRY_APP_SLUG_MAX_LENGTH = 64
 
 # Maximum number of results we are willing to fetch when calculating rollup
 # Clients should adapt the interval width based on their display width.
-MAX_ROLLUP_POINTS = 4500
+MAX_ROLLUP_POINTS = 10000
 
 
 # Team slugs which may not be used. Generally these are top level URL patterns


### PR DESCRIPTION
Alternative to https://github.com/getsentry/sentry/pull/20434. It looks like it's not a huge problem
to just render 10k points in the metric alerts rule builder, so we'd like to just bump this value so
that we can fetch more datapoints. This means that we can fetch (almost) a week worth of 1 minute
datapoints, and that should be enough for our requirements.