### PR TITLE
fix(charts): Release series should respect selected environments

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -390,6 +390,7 @@ class EventsChart extends React.Component<Props> {
           start={start}
           end={end}
           projects={projects}
+          environments={environments}
         >
           {({releaseSeries}) => previousChart({...chartProps, releaseSeries})}
         </ReleaseSeries>

--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -40,6 +40,7 @@ class ReleaseSeries extends React.Component {
     router: PropTypes.object,
     organization: SentryTypes.Organization,
     projects: PropTypes.arrayOf(PropTypes.number),
+    environments: PropTypes.arrayOf(PropTypes.string),
 
     period: PropTypes.string,
     start: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
@@ -70,6 +71,7 @@ class ReleaseSeries extends React.Component {
   componentDidUpdate(prevProps) {
     if (
       !isEqual(prevProps.projects, this.props.projects) ||
+      !isEqual(prevProps.environments, this.props.environments) ||
       !isEqual(prevProps.start, this.props.start) ||
       !isEqual(prevProps.end, this.props.end) ||
       !isEqual(prevProps.period, this.props.period)
@@ -79,8 +81,14 @@ class ReleaseSeries extends React.Component {
   }
 
   fetchData() {
-    const {api, organization, projects, period, start, end} = this.props;
-    const conditions = {start, end, project: projects, statsPeriod: period};
+    const {api, organization, projects, environments, period, start, end} = this.props;
+    const conditions = {
+      start,
+      end,
+      project: projects,
+      environment: environments,
+      statsPeriod: period,
+    };
     getOrganizationReleases(api, organization, conditions)
       .then(releases => {
         this.setReleasesWithSeries(releases);

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -209,6 +209,7 @@ class DurationChart extends React.Component<Props> {
                     period={statsPeriod}
                     utc={utc}
                     projects={project}
+                    environments={environment}
                   >
                     {({releaseSeries}) => (
                       <TransitionChart loading={loading} reloading={reloading}>

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -255,6 +255,7 @@ class Chart extends React.Component<Props> {
                 period={statsPeriod}
                 utc={utc}
                 projects={project}
+                environments={environment}
               >
                 {({releaseSeries}) => (
                   <TransitionChart loading={loading} reloading={reloading}>

--- a/tests/js/spec/components/charts/releaseSeries.spec.jsx
+++ b/tests/js/spec/components/charts/releaseSeries.spec.jsx
@@ -62,6 +62,23 @@ describe('ReleaseSeries', function() {
     );
   });
 
+  it('fetches releases with environment conditions', async function() {
+    const wrapper = mount(
+      <ReleaseSeries environments={['dev', 'test']}>{renderFunc}</ReleaseSeries>,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(releasesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {environment: ['dev', 'test']},
+      })
+    );
+  });
+
   it('fetches releases with start and end date strings', async function() {
     const wrapper = mount(
       <ReleaseSeries start="2020-01-01" end="2020-01-31">


### PR DESCRIPTION
Currently the release series do not account for the selected environments at
all. This change ensures that they are checked if needed.