### PR TITLE
update handling commands

### DIFF
--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -251,7 +251,8 @@ def build_help_command_card():
     commands = {
         "type": "TextBlock",
         "text": (
-            "- **unlink**: unlink your Microsoft Teams identity from your Sentry account"
+            "- **link**: link your Microsoft Teams identity to your Sentry account"
+            "\n\n- **unlink**: unlink your Microsoft Teams identity from your Sentry account"
             "\n\n- **help**: view list of all bot commands"
         ),
         "wrap": True,

--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -192,6 +192,7 @@ def build_mentioned_card():
         "type": "TextBlock",
         "text": (
             "Sentry for Microsoft Teams does not support any commands in channels, only in direct messages."
+            " To unlink your Microsoft Teams identity from your Sentry account message the personal bot."
         ),
         "wrap": True,
     }
@@ -259,6 +260,23 @@ def build_help_command_card():
     return {
         "type": "AdaptiveCard",
         "body": [header, commands],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.2",
+    }
+
+
+def build_link_identity_command_card():
+    link_identity = {
+        "type": "TextBlock",
+        "text": (
+            "Your Microsoft Teams identity will be linked to your"
+            " Sentry account when you interact with alerts from Sentry."
+        ),
+        "wrap": True,
+    }
+    return {
+        "type": "AdaptiveCard",
+        "body": [link_identity],
         "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
         "version": "1.2",
     }

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -35,6 +35,7 @@ from .card_builder import (
     build_unlink_identity_card,
     build_unrecognized_command_card,
     build_help_command_card,
+    build_link_identity_command_card,
 )
 from .client import (
     MsTeamsJwtClient,
@@ -454,6 +455,8 @@ class MsTeamsWebhookEndpoint(Endpoint):
             card = build_unlink_identity_card(unlink_url)
         elif "help" in lowercase_command:
             card = build_help_command_card()
+        elif "link" == lowercase_command:  # don't to match other types of link commands
+            card = build_link_identity_command_card()
         else:
             card = build_unrecognized_command_card(command_text)
 

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -389,6 +389,41 @@ class MsTeamsWebhookTest(APITestCase):
     @responses.activate
     @patch("jwt.decode")
     @patch("time.time")
+    def test_link_command(self, mock_time, mock_decode):
+        other_command = deepcopy(EXAMPLE_UNLINK_COMMAND)
+        other_command["text"] = "link"
+        access_json = {"expires_in": 86399, "access_token": "my_token"}
+        responses.add(
+            responses.POST,
+            u"https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
+            json=access_json,
+        )
+        responses.add(
+            responses.POST,
+            u"https://smba.trafficmanager.net/amer/v3/conversations/%s/activities"
+            % other_command["conversation"]["id"],
+            json={},
+        )
+        mock_time.return_value = 1594839999 + 60
+        mock_decode.return_value = DECODED_TOKEN
+        resp = self.client.post(
+            path=webhook_url,
+            data=other_command,
+            format="json",
+            HTTP_AUTHORIZATION=u"Bearer %s" % TOKEN,
+        )
+
+        assert resp.status_code == 204
+        assert "Your Microsoft Teams identity will be linked to your Sentry account" in responses.calls[
+            3
+        ].request.body.decode(
+            "utf-8"
+        )
+        assert "Bearer my_token" in responses.calls[3].request.headers["Authorization"]
+
+    @responses.activate
+    @patch("jwt.decode")
+    @patch("time.time")
     def test_other_command(self, mock_time, mock_decode):
         other_command = deepcopy(EXAMPLE_UNLINK_COMMAND)
         other_command["text"] = "other"


### PR DESCRIPTION
This PR adds a new command text for linking identities telling the user they need to interact with a message. It also updates the "help" command for the channel bot saying unlinking needs to be done through private messages with the bot.

Channel help command:
![Screen Shot 2020-09-04 at 10 32 01 AM](https://user-images.githubusercontent.com/8533851/92270347-bf4b9f80-ee9a-11ea-811f-4d8e762d6cb9.png)

PM link command:
![Screen Shot 2020-09-04 at 10 31 28 AM](https://user-images.githubusercontent.com/8533851/92270345-beb30900-ee9a-11ea-8f62-c58e7b3710df.png)
