### PR TITLE
ref(store) Update post_process to use a cache key round 2

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
 
+import random
 import logging
 
-from sentry.utils.services import Service
+from sentry import options
 from sentry.tasks.post_process import post_process_group
+from sentry.utils.services import Service
+from sentry.utils.cache import cache_key_for_event
 
 
 logger = logging.getLogger(__name__)
@@ -43,13 +46,30 @@ class EventStream(Service):
         if skip_consume:
             logger.info("post_process.skip.raw_event", extra={"event_id": event.event_id})
         else:
-            post_process_group.delay(
-                event=event,
-                is_new=is_new,
-                is_regression=is_regression,
-                is_new_group_environment=is_new_group_environment,
-                primary_hash=primary_hash,
+            random_val = random.random()
+            cache_key = cache_key_for_event(
+                {"project": event.project_id, "event_id": event.event_id}
             )
+            if options.get("postprocess.use-cache-key") > random_val:
+                post_process_group.delay(
+                    event=None,
+                    is_new=is_new,
+                    is_regression=is_regression,
+                    is_new_group_environment=is_new_group_environment,
+                    primary_hash=primary_hash,
+                    cache_key=cache_key,
+                    group_id=event.group_id,
+                )
+            else:
+                # Pass the cache key here to ensure that the processing cache is removed.
+                post_process_group.delay(
+                    event=event,
+                    is_new=is_new,
+                    is_regression=is_regression,
+                    is_new_group_environment=is_new_group_environment,
+                    primary_hash=primary_hash,
+                    cache_key=cache_key,
+                )
 
     def insert(
         self,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -116,16 +116,44 @@ def handle_owner_assignment(project, group, event):
 
 
 @instrumented_task(name="sentry.tasks.post_process.post_process_group")
-def post_process_group(event, is_new, is_regression, is_new_group_environment, **kwargs):
+def post_process_group(
+    event, is_new, is_regression, is_new_group_environment, cache_key=None, group_id=None, **kwargs
+):
     """
     Fires post processing hooks for a group.
     """
-    set_current_project(event.project_id)
-
+    from sentry.eventstore.models import Event
+    from sentry.eventstore.processing import event_processing_store
     from sentry.utils import snuba
     from sentry.reprocessing2 import is_reprocessed_event
 
     with snuba.options_override({"consistent": True}):
+        # The event parameter will be removed after transitioning to
+        # event_processing_store is complete.
+        if cache_key and event is None:
+            data = event_processing_store.get(cache_key)
+            if not data:
+                logger.info(
+                    "post_process.skipped",
+                    extra={"cache_key": cache_key, "reason": "missing_cache"},
+                )
+                return
+            event = Event(
+                project_id=data["project"], event_id=data["event_id"], group_id=group_id, data=data
+            )
+        elif check_event_already_post_processed(event):
+            if cache_key:
+                event_processing_store.delete_by_key(cache_key)
+            logger.info(
+                "post_process.skipped",
+                extra={
+                    "project_id": event.project_id,
+                    "event_id": event.event_id,
+                    "reason": "duplicate",
+                },
+            )
+            return
+
         if is_reprocessed_event(event.data):
             logger.info(
                 "post_process.skipped",
@@ -137,16 +165,7 @@ def post_process_group(event, is_new, is_regression, is_new_group_environment, *
             )
             return
 
-        if check_event_already_post_processed(event):
-            logger.info(
-                "post_process.skipped",
-                extra={
-                    "project_id": event.project_id,
-                    "event_id": event.event_id,
-                    "reason": "duplicate",
-                },
-            )
-            return
+        set_current_project(event.project_id)
 
         # NOTE: we must pass through the full Event object, and not an
         # event_id since the Event object may not actually have been stored
@@ -161,13 +180,13 @@ def post_process_group(event, is_new, is_regression, is_new_group_environment, *
         event.data = EventDict(event.data, skip_renormalization=True)
 
         if event.group_id:
-            # Re-bind Group since we're pickling the whole Event object
-            # which may contain a stale Project.
+            # Re-bind Group since we're reading the Event object
+            # from cache, which may contain a stale group and project
             event.group, _ = get_group_with_redirect(event.group_id)
             event.group_id = event.group.id
 
-        # Re-bind Project and Org since we're pickling the whole Event object
-        # which may contain stale parent models.
+        # Re-bind Project and Org since we're reading the Event object
+        # from cache which may contain stale parent models.
         event.project = Project.objects.get_from_cache(id=event.project_id)
         event.project._organization_cache = Organization.objects.get_from_cache(
             id=event.project.organization_id
@@ -232,6 +251,9 @@ def post_process_group(event, is_new, is_regression, is_new_group_environment, *
             event=event,
             primary_hash=kwargs.get("primary_hash"),
         )
+        if cache_key:
+            with metrics.timer("tasks.post_process.delete_event_cache"):
+                event_processing_store.delete_by_key(cache_key)
 
 
 def process_snoozes(group):

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -667,6 +667,7 @@ def create_failed_event(
     # modifications to take place.
     delete_raw_event(project_id, event_id)
     data = event_processing_store.get(cache_key)
+
     if data is None:
         metrics.incr("events.failed", tags={"reason": "cache", "stage": "raw"}, skip_internal=False)
         error_logger.error("process.failed_raw.empty", extra={"cache_key": cache_key})
@@ -690,7 +691,6 @@ def create_failed_event(
             type=issue["type"],
             data=issue["data"],
         )
-
     event_processing_store.delete_by_key(cache_key)
 
     return True
@@ -762,15 +762,18 @@ def _do_save_event(
                 manager.save(
                     project_id, assume_normalized=True, start_time=start_time, cache_key=cache_key
                 )
-
+                # Put the updated event back into the cache so that post_process
+                # has the most recent data.
+                data = manager.get_data()
+                if isinstance(data, CANONICAL_TYPES):
+                    data = dict(data.items())
+                with metrics.timer("tasks.store.do_save_event.write_processing_cache"):
+                    event_processing_store.store(data)
         except HashDiscarded:
             pass
 
         finally:
             if cache_key:
-                with metrics.timer("tasks.store.do_save_event.delete_cache"):
-                    event_processing_store.delete_by_key(cache_key)
-
                 with metrics.timer("tasks.store.do_save_event.delete_attachment_cache"):
                     attachment_cache.delete(cache_key)
 

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 from django.utils import timezone
-from sentry.utils.compat.mock import Mock, patch, ANY
 
+from sentry.eventstore.processing import event_processing_store
 from sentry.models import Group, GroupSnooze, GroupStatus, ProjectOwnership
 from sentry.ownership.grammar import Rule, Matcher, Owner, dump_schema
 from sentry.testutils import TestCase
@@ -13,6 +13,30 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import post_process_group
+from sentry.utils.compat.mock import Mock, patch, ANY
+
+
+class EventMatcher(object):
+    def __init__(self, expected, group=None):
+        self.expected = expected
+        self.expected_group = group
+
+    def __eq__(self, other):
+        matching_id = other.event_id == self.expected.event_id
+        if self.expected_group:
+            return (
+                matching_id
+                and self.expected_group == other.group
+                and self.expected_group.id == other.group_id
+            )
+        return matching_id
+
+
+def get_cache_key(event):
+    cache_data = event.data
+    cache_data["event_id"] = event.event_id
+    cache_data["project"] = event.project_id
+    return event_processing_store.store(cache_data)
 
 
 class PostProcessGroupTest(TestCase):
@@ -37,8 +61,13 @@ class PostProcessGroupTest(TestCase):
             },
             project_id=self.project.id,
         )
+        cache_key = get_cache_key(event)
         post_process_group(
-            event=event, is_new=True, is_regression=False, is_new_group_environment=True
+            event=None,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key=cache_key,
         )
 
         mock_processor.assert_not_called()  # NOQA
@@ -46,11 +75,84 @@ class PostProcessGroupTest(TestCase):
         mock_process_resource_change_bound.assert_not_called()  # NOQA
 
         mock_signal.assert_called_once_with(
-            sender=ANY, project=self.project, event=event, primary_hash=None
+            sender=ANY, project=self.project, event=EventMatcher(event), primary_hash=None
         )
 
     @patch("sentry.rules.processor.RuleProcessor")
-    def test_rule_processor(self, mock_processor):
+    def test_no_cache_abort(self, mock_processor):
+        event = self.store_event(data={}, project_id=self.project.id)
+
+        post_process_group(
+            event=None,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key="total-rubbish",
+            group_id=event.group_id,
+        )
+
+        assert mock_processor.call_count == 0
+
+    def test_processing_cache_cleared(self):
+        event = self.store_event(data={}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
+
+        post_process_group(
+            event=None,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key=cache_key,
+            group_id=event.group_id,
+        )
+        assert event_processing_store.get(cache_key) is None
+
+    def test_processing_cache_cleared_with_event_param(self):
+        event = self.store_event(data={}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
+
+        post_process_group(
+            event=event,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key=cache_key,
+        )
+        assert event_processing_store.get(cache_key) is None
+
+    def test_processing_cache_does_not_error(self):
+        event = self.store_event(data={}, project_id=self.project.id)
+
+        post_process_group(
+            event=event,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key="not-valid",
+        )
+        assert event_processing_store.get("not-valid") is None
+
+    @patch("sentry.rules.processor.RuleProcessor")
+    @patch("sentry.tasks.post_process.check_event_already_post_processed")
+    def test_already_processed_abort(self, mock_check, mock_processor):
+        mock_check.return_value = True
+
+        event = self.store_event(data={}, project_id=self.project.id)
+
+        post_process_group(
+            event=event,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key=None,
+            group_id=event.group_id,
+        )
+
+        assert mock_check.call_count == 1
+        assert mock_processor.call_count == 0, "Should abort early"
+
+    @patch("sentry.rules.processor.RuleProcessor")
+    def test_rule_processor_backwards_compat(self, mock_processor):
         event = self.store_event(data={}, project_id=self.project.id)
 
         mock_callback = Mock()
@@ -59,17 +161,47 @@ class PostProcessGroupTest(TestCase):
         mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
 
         post_process_group(
-            event=event, is_new=True, is_regression=False, is_new_group_environment=True
+            event=event,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            group_id=event.group_id,
         )
 
         mock_processor.assert_called_once_with(event, True, False, True, False)
         mock_processor.return_value.apply.assert_called_once_with()
 
-        mock_callback.assert_called_once_with(event, mock_futures)
+        mock_callback.assert_called_once_with(EventMatcher(event), mock_futures)
+
+    @patch("sentry.rules.processor.RuleProcessor")
+    def test_rule_processor(self, mock_processor):
+        event = self.store_event(data={"message": "testing"}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
+
+        mock_callback = Mock()
+        mock_futures = [Mock()]
+
+        mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
+
+        post_process_group(
+            event=None,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key=cache_key,
+            group_id=event.group_id,
+        )
+
+        mock_processor.assert_called_once_with(EventMatcher(event), True, False, True, False)
+        mock_processor.return_value.apply.assert_called_once_with()
+
+        mock_callback.assert_called_once_with(EventMatcher(event), mock_futures)
 
     @patch("sentry.rules.processor.RuleProcessor")
     def test_group_refresh(self, mock_processor):
-        event = self.store_event(data={}, project_id=self.project.id)
+        event = self.store_event(data={"message": "testing"}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
+
         group1 = event.group
         group2 = self.create_group(project=self.project)
 
@@ -85,31 +217,50 @@ class PostProcessGroupTest(TestCase):
         mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
 
         post_process_group(
-            event=event, is_new=True, is_regression=False, is_new_group_environment=True
+            event=None,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
-
-        assert event.group == group2
-        assert event.group_id == group2.id
+        # Ensure that rule processing sees the merged group.
+        mock_processor.assert_called_with(
+            EventMatcher(event, group=group2), True, False, True, False
+        )
 
     @patch("sentry.rules.processor.RuleProcessor")
     def test_invalidates_snooze(self, mock_processor):
-        event = self.store_event(data={}, project_id=self.project.id)
+        event = self.store_event(data={"message": "testing"}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
+
         group = event.group
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(hours=1))
 
         # Check for has_reappeared=False if is_new=True
         post_process_group(
-            event=event, is_new=True, is_regression=False, is_new_group_environment=True
+            event=None,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
 
-        mock_processor.assert_called_with(event, True, False, True, False)
+        mock_processor.assert_called_with(EventMatcher(event), True, False, True, False)
 
+        cache_key = get_cache_key(event)
         # Check for has_reappeared=True if is_new=False
         post_process_group(
-            event=event, is_new=False, is_regression=False, is_new_group_environment=True
+            event=None,
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
 
-        mock_processor.assert_called_with(event, False, False, True, True)
+        mock_processor.assert_called_with(EventMatcher(event), False, False, True, True)
 
         assert not GroupSnooze.objects.filter(id=snooze.id).exists()
 
@@ -119,14 +270,20 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.rules.processor.RuleProcessor")
     def test_maintains_valid_snooze(self, mock_processor):
         event = self.store_event(data={}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
         group = event.group
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now() + timedelta(hours=1))
 
         post_process_group(
-            event=event, is_new=True, is_regression=False, is_new_group_environment=True
+            event=None,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
 
-        mock_processor.assert_called_with(event, True, False, True, False)
+        mock_processor.assert_called_with(EventMatcher(event), True, False, True, False)
 
         assert GroupSnooze.objects.filter(id=snooze.id).exists()
 
@@ -152,8 +309,14 @@ class PostProcessGroupTest(TestCase):
             },
             project_id=self.project.id,
         )
+        cache_key = get_cache_key(event)
         post_process_group(
-            event=event, is_new=False, is_regression=False, is_new_group_environment=False
+            event=None,
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user is None
@@ -170,7 +333,11 @@ class PostProcessGroupTest(TestCase):
             project_id=self.project.id,
         )
         post_process_group(
-            event=event, is_new=False, is_regression=False, is_new_group_environment=False
+            event=event,
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            group_id=event.group_id,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user == self.user
@@ -185,8 +352,14 @@ class PostProcessGroupTest(TestCase):
             },
             project_id=self.project.id,
         )
+        cache_key = get_cache_key(event)
         post_process_group(
-            event=event, is_new=False, is_regression=False, is_new_group_environment=False
+            event=None,
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
         assert not event.group.assignee_set.exists()
 
@@ -200,9 +373,15 @@ class PostProcessGroupTest(TestCase):
             },
             project_id=self.project.id,
         )
+        cache_key = get_cache_key(event)
         event.group.assignee_set.create(team=self.team, project=self.project)
         post_process_group(
-            event=event, is_new=False, is_regression=False, is_new_group_environment=False
+            event=None,
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user is None
@@ -221,8 +400,14 @@ class PostProcessGroupTest(TestCase):
             },
             project_id=self.project.id,
         )
+        cache_key = get_cache_key(event)
         post_process_group(
-            event=event, is_new=False, is_regression=False, is_new_group_environment=False
+            event=None,
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
         assignee = event.group.assignee_set.first()
         assert assignee is None
@@ -230,6 +415,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.tasks.servicehooks.process_service_hook")
     def test_service_hook_fires_on_new_event(self, mock_process_service_hook):
         event = self.store_event(data={}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
         hook = self.create_service_hook(
             project=self.project,
             organization=self.project.organization,
@@ -239,15 +425,23 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=event, is_new=False, is_regression=False, is_new_group_environment=False
+                event=None,
+                is_new=False,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=cache_key,
+                group_id=event.group_id,
             )
 
-        mock_process_service_hook.delay.assert_called_once_with(servicehook_id=hook.id, event=event)
+        mock_process_service_hook.delay.assert_called_once_with(
+            servicehook_id=hook.id, event=EventMatcher(event)
+        )
 
     @patch("sentry.tasks.servicehooks.process_service_hook")
     @patch("sentry.rules.processor.RuleProcessor")
     def test_service_hook_fires_on_alert(self, mock_processor, mock_process_service_hook):
         event = self.store_event(data={}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
 
         mock_callback = Mock()
         mock_futures = [Mock()]
@@ -263,10 +457,17 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=event, is_new=False, is_regression=False, is_new_group_environment=False
+                event=None,
+                is_new=False,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=cache_key,
+                group_id=event.group_id,
             )
 
-        mock_process_service_hook.delay.assert_called_once_with(servicehook_id=hook.id, event=event)
+        mock_process_service_hook.delay.assert_called_once_with(
+            servicehook_id=hook.id, event=EventMatcher(event)
+        )
 
     @patch("sentry.tasks.servicehooks.process_service_hook")
     @patch("sentry.rules.processor.RuleProcessor")
@@ -274,6 +475,7 @@ class PostProcessGroupTest(TestCase):
         self, mock_processor, mock_process_service_hook
     ):
         event = self.store_event(data={}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
 
         mock_processor.return_value.apply.return_value = []
 
@@ -286,7 +488,12 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=event, is_new=False, is_regression=False, is_new_group_environment=False
+                event=None,
+                is_new=False,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=cache_key,
+                group_id=event.group_id,
             )
 
         assert not mock_process_service_hook.delay.mock_calls
@@ -294,6 +501,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.tasks.servicehooks.process_service_hook")
     def test_service_hook_does_not_fire_without_event(self, mock_process_service_hook):
         event = self.store_event(data={}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
 
         self.create_service_hook(
             project=self.project, organization=self.project.organization, actor=self.user, events=[]
@@ -301,7 +509,12 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=event, is_new=True, is_regression=False, is_new_group_environment=False
+                event=None,
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=False,
+                cache_key=cache_key,
+                group_id=event.group_id,
             )
 
         assert not mock_process_service_hook.delay.mock_calls
@@ -309,9 +522,15 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.tasks.sentry_apps.process_resource_change_bound.delay")
     def test_processes_resource_change_task_on_new_group(self, delay):
         event = self.store_event(data={}, project_id=self.project.id)
+        cache_key = get_cache_key(event)
         group = event.group
         post_process_group(
-            event=event, is_new=True, is_regression=False, is_new_group_environment=False
+            event=None,
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
 
         delay.assert_called_once_with(action="created", sender="Group", instance_id=group.id)
@@ -329,6 +548,7 @@ class PostProcessGroupTest(TestCase):
             project_id=self.project.id,
             assert_no_errors=False,
         )
+        cache_key = get_cache_key(event)
 
         self.create_service_hook(
             project=self.project,
@@ -338,12 +558,19 @@ class PostProcessGroupTest(TestCase):
         )
 
         post_process_group(
-            event=event, is_new=False, is_regression=False, is_new_group_environment=False
+            event=None,
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
 
-        kwargs = {"instance": event}
         delay.assert_called_once_with(
-            action="created", sender="Error", instance_id=event.event_id, **kwargs
+            action="created",
+            sender="Error",
+            instance_id=event.event_id,
+            instance=EventMatcher(event),
         )
 
     @with_feature("organizations:integrations-event-hooks")
@@ -354,9 +581,15 @@ class PostProcessGroupTest(TestCase):
             project_id=self.project.id,
             assert_no_errors=False,
         )
+        cache_key = get_cache_key(event)
 
         post_process_group(
-            event=event, is_new=False, is_regression=False, is_new_group_environment=False
+            event=None,
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
 
         assert not delay.called
@@ -368,9 +601,15 @@ class PostProcessGroupTest(TestCase):
             project_id=self.project.id,
             assert_no_errors=False,
         )
+        cache_key = get_cache_key(event)
 
         post_process_group(
-            event=event, is_new=False, is_regression=False, is_new_group_environment=False
+            event=None,
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
 
         assert not delay.called
@@ -388,13 +627,19 @@ class PostProcessGroupTest(TestCase):
             project_id=self.project.id,
             assert_no_errors=False,
         )
+        cache_key = get_cache_key(event)
 
         self.create_service_hook(
             project=self.project, organization=self.project.organization, actor=self.user, events=[]
         )
 
         post_process_group(
-            event=event, is_new=False, is_regression=False, is_new_group_environment=False
+            event=None,
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=event.group_id,
         )
 
         assert not delay.called


### PR DESCRIPTION
This reverts commit 901868022daf1609f7459a64d8258fa120d4bc4d and restores post_process to using a cache key instead of an AMQP payload.

I've added additional logic to ensure we don't fail when duplicate events are processed and we don't have a cache_key, and included tests for those scenarios. Lastly, I'm always passing cache_key to post_process now to ensure that the processingstore is cleared when the new paths are not run as the delete done during tasks/store has been removed.