### PR TITLE
feat(trends): Test switching trends item link to comparison view

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -18,6 +18,11 @@ import {formatPercentage} from 'app/utils/formatters';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {t} from 'app/locale';
 import withProjects from 'app/utils/withProjects';
+import {IconEllipsis} from 'app/icons';
+import MenuItem from 'app/components/menuItem';
+import DropdownLink from 'app/components/dropdownLink';
+import withApi from 'app/utils/withApi';
+import {Client} from 'app/api';
 
 import Chart from './chart';
 import {
@@ -26,6 +31,7 @@ import {
   TrendsData,
   NormalizedTrendsTransaction,
   TrendFunctionField,
+  TrendsStats,
 } from './types';
 import {
   trendToColor,
@@ -35,11 +41,14 @@ import {
   normalizeTrendsTransactions,
   getSelectedQueryKey,
   getCurrentTrendFunction,
+  getTrendBaselinesForTransaction,
+  getIntervalRatio,
 } from './utils';
 import {transactionSummaryRouteWithQuery} from '../transactionSummary/utils';
 import {HeaderTitleLegend} from '../styles';
 
 type Props = {
+  api: Client;
   organization: Organization;
   trendChangeType: TrendChangeType;
   previousTrendFunction?: TrendFunctionField;
@@ -113,6 +122,7 @@ function handleChangeSelected(
 
 function ChangedTransactions(props: Props) {
   const {
+    api,
     location,
     trendChangeType,
     previousTrendFunction,
@@ -145,7 +155,7 @@ function ChangedTransactions(props: Props) {
             events
           );
 
-          const results = eventsTrendsData && eventsTrendsData.stats;
+          const statsData = eventsTrendsData && eventsTrendsData.stats;
           const transactionsList = events && events.slice ? events.slice(0, 5) : [];
 
           const trendFunction = getCurrentTrendFunction(location);
@@ -163,7 +173,7 @@ function ChangedTransactions(props: Props) {
                 <React.Fragment>
                   <ChartContainer>
                     <Chart
-                      statsData={results}
+                      statsData={statsData}
                       query={trendView.query}
                       project={trendView.project}
                       environment={trendView.environment}
@@ -178,6 +188,7 @@ function ChangedTransactions(props: Props) {
                   <TransactionsList>
                     {transactionsList.map((transaction, index) => (
                       <TrendsListItem
+                        api={api}
                         currentTrendFunction={currentTrendFunction}
                         trendView={props.trendView}
                         organization={organization}
@@ -188,6 +199,7 @@ function ChangedTransactions(props: Props) {
                         transactions={transactionsList}
                         location={location}
                         projects={projects}
+                        statsData={statsData}
                         handleSelectTransaction={handleChangeSelected(
                           location,
                           trendChangeType,
@@ -211,6 +223,7 @@ function ChangedTransactions(props: Props) {
 }
 
 type TrendsListItemProps = {
+  api: Client;
   trendView: TrendView;
   organization: Organization;
   transaction: NormalizedTrendsTransaction;
@@ -220,6 +233,7 @@ type TrendsListItemProps = {
   projects: Project[];
   location: Location;
   index: number;
+  statsData: TrendsStats;
   handleSelectTransaction: (transaction: NormalizedTrendsTransaction) => void;
 };
 
@@ -255,6 +269,24 @@ function TrendsListItem(props: TrendsListItemProps) {
       <ItemTransactionNameContainer>
         <ItemTransactionName>
           <TransactionLink {...props} />
+          <TransactionMenuContainer>
+            <DropdownLink
+              caret={false}
+              title={
+                <TransactionMenuButton>
+                  <IconEllipsis
+                    size="sm"
+                    data-test-id="trends-item-action"
+                    color="gray600"
+                  />
+                </TransactionMenuButton>
+              }
+            >
+              <MenuItem>
+                <TransactionSummaryLink {...props} />
+              </MenuItem>
+            </DropdownLink>
+          </TransactionMenuContainer>
         </ItemTransactionName>
         <ItemTransactionAbsoluteFaster>
           {transformDeltaSpread(
@@ -324,6 +356,45 @@ function TrendsListItem(props: TrendsListItemProps) {
 type TransactionLinkProps = TrendsListItemProps & {};
 
 const TransactionLink = (props: TransactionLinkProps) => {
+  const {
+    organization,
+    trendView: eventView,
+    transaction,
+    api,
+    statsData,
+    location,
+  } = props;
+  const summaryView = eventView.clone();
+  const intervalRatio = getIntervalRatio(location);
+
+  async function onLinkClick() {
+    const baselines = await getTrendBaselinesForTransaction(
+      api,
+      organization,
+      eventView,
+      statsData,
+      intervalRatio,
+      transaction
+    );
+    if (baselines) {
+      const {previousPeriod, currentPeriod} = baselines;
+      const comparisonString = `${previousPeriod.project}:${previousPeriod.id}/${currentPeriod.project}:${currentPeriod.id}`;
+      browserHistory.push({
+        pathname: `/organizations/${organization.slug}/performance/compare/${comparisonString}/`,
+        query: {
+          ...summaryView.generateQueryStringObject(),
+          transaction: String(transaction.transaction),
+        },
+      });
+    }
+  }
+
+  return <StyledLink onClick={onLinkClick}>{transaction.transaction}</StyledLink>;
+};
+
+type TransactionSummaryLinkProps = TrendsListItemProps & {};
+
+const TransactionSummaryLink = (props: TransactionSummaryLinkProps) => {
   const {organization, trendView: eventView, transaction, projects} = props;
 
   const summaryView = eventView.clone();
@@ -335,11 +406,38 @@ const TransactionLink = (props: TransactionLinkProps) => {
     projectID,
   });
 
-  return <StyledLink to={target}>{transaction.transaction}</StyledLink>;
+  return <StyledSummaryLink to={target}>{t('View Summary')}</StyledSummaryLink>;
 };
 
-const StyledLink = styled(Link)`
+const StyledLink = styled('a')`
   word-break: break-all;
+`;
+
+const StyledSummaryLink = styled(Link)`
+  color: ${p => p.theme.textColor};
+  :hover {
+    color: ${p => p.theme.textColor};
+  }
+`;
+
+const TransactionMenuButton = styled('button')`
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  padding: 0 ${space(1)};
+
+  border: 0;
+  background: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  outline: none;
+`;
+const TransactionMenuContainer = styled('div')`
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 const TransactionsList = styled('div')``;
@@ -359,7 +457,11 @@ const ItemRadioContainer = styled('div')`
 const ItemTransactionNameContainer = styled('div')`
   flex-grow: 1;
 `;
-const ItemTransactionName = styled('div')``;
+const ItemTransactionName = styled('div')`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+`;
 const ItemTransactionAbsoluteFaster = styled('div')`
   color: ${p => p.theme.gray500};
   font-size: 14px;
@@ -397,4 +499,4 @@ const EmptyStateContainer = styled('div')`
 
 const StyledPanel = styled(Panel)``;
 
-export default withProjects(withOrganization(ChangedTransactions));
+export default withApi(withProjects(withOrganization(ChangedTransactions)));

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -16,6 +16,10 @@ import Duration from 'app/components/duration';
 import {Sort, Field} from 'app/utils/discover/fields';
 import {t} from 'app/locale';
 import Count from 'app/components/count';
+import {Organization} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import {Client} from 'app/api';
+import {getUtcDateString} from 'app/utils/dates';
 
 import {
   TrendFunction,
@@ -24,7 +28,9 @@ import {
   TrendsTransaction,
   NormalizedTrendsTransaction,
   TrendFunctionField,
+  TrendsStats,
 } from './types';
+import {BaselineQueryResults} from '../transactionSummary/baselineQuery';
 
 export const TRENDS_FUNCTIONS: TrendFunction[] = [
   {
@@ -159,6 +165,62 @@ export function modifyTrendView(
 
   trendView.sorts = [trendSort];
   trendView.fields = fields;
+}
+
+export async function getTrendBaselinesForTransaction(
+  api: Client,
+  organization: Organization,
+  eventView: EventView,
+  statsData: TrendsStats,
+  intervalRatio: number,
+  transaction: NormalizedTrendsTransaction
+) {
+  const orgSlug = organization.slug;
+  const url = `/organizations/${orgSlug}/event-baseline/`;
+
+  const scopeQueryToTransaction = ` transaction:${transaction.transaction}`;
+
+  const globalSelectionQuery = eventView.getGlobalSelectionQuery();
+  delete globalSelectionQuery.statsPeriod;
+  const baseApiPayload = {
+    ...globalSelectionQuery,
+    query: eventView.query + scopeQueryToTransaction,
+  };
+
+  const stats = Object.values(statsData)[0].data;
+
+  const seriesStart = stats[0][0] * 1000;
+  const seriesEnd = stats.slice(-1)[0][0] * 1000;
+  const seriesSplit = seriesStart + (seriesEnd - seriesStart) * intervalRatio;
+
+  const previousPeriodPayload = {
+    ...baseApiPayload,
+    start: getUtcDateString(seriesStart),
+    end: getUtcDateString(seriesSplit),
+    baselineValue: transaction.aggregate_range_1,
+  };
+  const currentPeriodPayload = {
+    ...baseApiPayload,
+    start: getUtcDateString(seriesSplit),
+    end: getUtcDateString(seriesEnd),
+    baselineValue: transaction.aggregate_range_2,
+  };
+
+  const dataPreviousPeriodPromise = api.requestPromise(url, {
+    method: 'GET',
+    query: previousPeriodPayload,
+  });
+  const dataCurrentPeriodPromise = api.requestPromise(url, {
+    method: 'GET',
+    query: currentPeriodPayload,
+  });
+
+  const previousPeriod = (await dataPreviousPeriodPromise) as BaselineQueryResults;
+  const currentPeriod = (await dataCurrentPeriodPromise) as BaselineQueryResults;
+  return {
+    currentPeriod,
+    previousPeriod,
+  };
 }
 
 function getQueryInterval(location: Location, eventView: TrendView) {

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -50,6 +50,7 @@ function initializeData(projects, query) {
 
 describe('Performance > Trends', function() {
   let trendsMock;
+  let baselineMock;
   beforeEach(function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
@@ -125,6 +126,13 @@ describe('Performance > Trends', function() {
         },
       },
     });
+    baselineMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/event-baseline/',
+      body: {
+        project: 'sentry',
+        id: '66877921c6ff440b8b891d3734f074e7',
+      },
+    });
   });
 
   afterEach(function() {
@@ -168,7 +176,38 @@ describe('Performance > Trends', function() {
     expect(wrapper.find('TrendsListItem')).toHaveLength(4);
   });
 
-  it('clicking transaction link links to the correct view', async function() {
+  it('view summary menu action links to the correct view', async function() {
+    const projects = [TestStubs.Project({id: 1, slug: 'internal'}), TestStubs.Project()];
+    const data = initializeData(projects, {project: ['1']});
+
+    const wrapper = mountWithTheme(
+      <PerformanceLanding
+        organization={data.organization}
+        location={data.router.location}
+      />,
+      data.routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    wrapper
+      .find('TransactionMenuButton')
+      .first()
+      .simulate('click');
+
+    const firstTransaction = wrapper.find('TrendsListItem').first();
+    const summaryLink = firstTransaction.find('StyledSummaryLink');
+    expect(summaryLink).toHaveLength(1);
+
+    expect(summaryLink.text()).toEqual('View Summary');
+    expect(summaryLink.props().to.pathname).toEqual(
+      '/organizations/org-slug/performance/summary/'
+    );
+    expect(summaryLink.props().to.query.project).toEqual(1);
+  });
+
+  it('transaction link calls comparison view', async function() {
     const projects = [TestStubs.Project({id: 1, slug: 'internal'}), TestStubs.Project()];
     const data = initializeData(projects, {project: ['1']});
 
@@ -184,14 +223,18 @@ describe('Performance > Trends', function() {
     wrapper.update();
 
     const firstTransaction = wrapper.find('TrendsListItem').first();
-    const transactionLink = firstTransaction.find('StyledLink');
-    expect(transactionLink).toHaveLength(1);
+    const transactionLink = firstTransaction.find('StyledLink').first();
+    transactionLink.simulate('click');
 
-    expect(transactionLink.text()).toEqual('/organizations/:orgId/performance/');
-    expect(transactionLink.props().to.pathname).toEqual(
-      '/organizations/org-slug/performance/summary/'
-    );
-    expect(transactionLink.props().to.query.project).toEqual(1);
+    await tick();
+    wrapper.update();
+
+    expect(baselineMock).toHaveBeenCalledTimes(2);
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname:
+        '/organizations/org-slug/performance/compare/sentry:66877921c6ff440b8b891d3734f074e7/sentry:66877921c6ff440b8b891d3734f074e7/',
+      query: expect.anything(),
+    });
   });
 
   it('transaction list renders user misery', async function() {


### PR DESCRIPTION
### Summary
This switching the transaction link for trends items to push the user to a comparison view to test it for internal. The summary link has been moved into a dropdown for now.

Currently this pulls baselines only on click (and doesn't have a load animation), but we can refine this in the future if we want to move forward with this.