### PR TITLE
fix(acceptance): Fix tooltips visual diff for breadcrumb time

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumbTime.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumbTime.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 const BreadcrumbTime = ({timestamp}: Props) =>
   defined(timestamp) ? (
-    <Tooltip title={getBreadcrumbTimeTooltipTitle(timestamp)}>
+    <Tooltip title={getBreadcrumbTimeTooltipTitle(timestamp)} disableForVisualTest>
       <Time>
         {getDynamicText({
           value: moment(timestamp).format('HH:mm:ss'),


### PR DESCRIPTION
The time tooltip on breadcrumbs also needs to be disabled for visual diff, trying out the non v2 version of breadcrumb interface.