### PR TITLE
Feat(trends) Adding absolute correlation as a column

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -84,7 +84,7 @@ class OrganizationEventsTrendsEndpoint(OrganizationEventsV2EndpointBase):
                     count_column["format"].format(start=start, end=middle, index="1"),
                     count_column["format"].format(start=middle, end=end, index="2"),
                     percentage_column["format"].format(alias=count_column["alias"]),
-                    "absolute_corr()",
+                    "absolute_correlation()",
                 ],
                 query=query,
                 params=params,

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -84,6 +84,7 @@ class OrganizationEventsTrendsEndpoint(OrganizationEventsV2EndpointBase):
                     count_column["format"].format(start=start, end=middle, index="1"),
                     count_column["format"].format(start=middle, end=end, index="2"),
                     percentage_column["format"].format(alias=count_column["alias"]),
+                    "absolute_corr()",
                 ],
                 query=query,
                 params=params,

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1562,6 +1562,12 @@ FUNCTIONS = {
         "aggregate": [u"minus", [ArgValue("minuend"), ArgValue("subtrahend")], None],
         "result_type": "duration",
     },
+    "absolute_corr": {
+        "name": "absolute_corr",
+        "args": [],
+        "aggregate": [u"abs(corr(toUnixTimestamp(finish_ts),duration))", None, None],
+        "result_type": "number",
+    },
 }
 
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1562,10 +1562,10 @@ FUNCTIONS = {
         "aggregate": [u"minus", [ArgValue("minuend"), ArgValue("subtrahend")], None],
         "result_type": "duration",
     },
-    "absolute_corr": {
-        "name": "absolute_corr",
+    "absolute_correlation": {
+        "name": "absolute_correlation",
         "args": [],
-        "aggregate": [u"abs(corr(toUnixTimestamp(finish_ts),duration))", None, None],
+        "aggregate": ["abs", [["corr", ["toUnixTimestamp", ["timestamp"], "duration"]]], None],
         "result_type": "number",
     },
 }

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1029,7 +1029,9 @@ def resolve_snuba_aliases(snuba_filter, resolve_func, function_translations=None
             else:
                 # Parameter is a list of fields.
                 aggregation[1] = [
-                    resolve_func(col) if col not in derived_columns else col
+                    resolve_func(col)
+                    if not isinstance(col, (set, tuple, list)) and col not in derived_columns
+                    else col
                     for col in aggregation[1]
                 ]
     resolved.aggregations = aggregations

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2141,6 +2141,17 @@ class ResolveFieldListTest(unittest.TestCase):
             resolve_field_list(fields, eventstore.Filter())
         assert "start argument invalid: today is in the wrong format" in six.text_type(err)
 
+    def test_absolute_correlation(self):
+        fields = ["absolute_correlation()"]
+        result = resolve_field_list(fields, eventstore.Filter())
+        assert result["aggregations"] == [
+            [
+                "abs",
+                [["corr", ["toUnixTimestamp", ["timestamp"], "duration"]]],
+                u"absolute_correlation",
+            ]
+        ]
+
     def test_percentage(self):
         fields = [
             "user_misery_range(300, 2020-05-01T01:12:34, 2020-05-03T06:48:57, 1)",

--- a/tests/snuba/api/endpoints/test_organization_events_trends.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trends.py
@@ -59,6 +59,8 @@ class OrganizationEventsTrendsEndpointTest(APITestCase, SnubaTestCase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
+        # Shouldn't do an exact match here because we aren't using the stable correlation function
+        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_1": 1,
             "count_range_2": 3,
@@ -101,6 +103,8 @@ class OrganizationEventsTrendsEndpointTest(APITestCase, SnubaTestCase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
+        # Shouldn't do an exact match here because we aren't using the stable correlation function
+        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_2": 3,
             "count_range_1": 1,
@@ -143,6 +147,8 @@ class OrganizationEventsTrendsEndpointTest(APITestCase, SnubaTestCase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
+        # Shouldn't do an exact match here because we aren't using the stable correlation function
+        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_2": 3,
             "count_range_1": 1,
@@ -205,6 +211,8 @@ class OrganizationEventsTrendsEndpointTest(APITestCase, SnubaTestCase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
+        # Shouldn't do an exact match here because we aren't using the stable correlation function
+        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_2": 4,
             "count_range_1": 0,


### PR DESCRIPTION
-  This is to evaluate correlation as a potential function
  to reduce noise on the trends page, the idea being that transactions
  that don't have a trend would have a very low correlation
- eg.
```
┌─count─┬─transaction_name─┬─────────────────corr─┐
│  6374 │ just_noise       │ 0.000795355262310444 │
│  6374 │ just_noise2      │  0.01764134880616409 │
│  6374 │ spike            │ 0.059511697018921055 │
│  6375 │ one_step         │   0.5783087192166589 │
│  6373 │ multiple_step    │   0.9872211392127279 │
│  6373 │ linear           │    0.993622240550848 │
└───────┴──────────────────┴──────────────────────┘
```
<img width="808" alt="image" src="https://user-images.githubusercontent.com/4205004/92277864-eec1d280-eec1-11ea-8080-bf6ff24efa6c.png">

- the two noise transactions are endpoints that sleep for a random duration and do nothing else, and should have low correlation so they can be easily excluded