### PR TITLE
Allow users to copy global-views instruction

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.tsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.tsx
@@ -124,7 +124,7 @@ class FeatureDisabled extends React.Component<Props, State> {
                   e.preventDefault();
                 }}
               >
-                <StyledIconCopy /> Copy to Clipboard
+                <StyledIconCopy /> {t('Copy to Clipboard')}
               </Button>
             </Clipboard>
             <pre onClick={e => selectText(e.target as HTMLElement)}>

--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.tsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.tsx
@@ -123,8 +123,9 @@ class FeatureDisabled extends React.Component<Props, State> {
                   e.stopPropagation();
                   e.preventDefault();
                 }}
+                icon={<IconCopy />}
               >
-                <StyledIconCopy /> {t('Copy to Clipboard')}
+                {t('Copy to Clipboard')}
               </Button>
             </Clipboard>
             <pre onClick={e => selectText(e.target as HTMLElement)}>
@@ -189,10 +190,6 @@ const AlertWrapper = styled('div')`
   code {
     background: #fbf7e0;
   }
-`;
-
-const StyledIconCopy = styled(IconCopy)`
-  margin-right: ${space(1)};
 `;
 
 export default FeatureDisabled;

--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.tsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {selectText} from 'app/utils/selectText';
-import {IconInfo, IconChevron, IconLock} from 'app/icons';
+import {IconInfo, IconChevron, IconLock, IconCopy} from 'app/icons';
 import {t, tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
+import Clipboard from 'app/components/clipboard';
 import ExternalLink from 'app/components/links/externalLink';
 import space from 'app/styles/space';
 import {CONFIG_DOCS_URL} from 'app/constants';
@@ -96,7 +97,12 @@ class FeatureDisabled extends React.Component<Props, State> {
           )}
         </FeatureDisabledMessage>
         {showDescription && (
-          <HelpDescription>
+          <HelpDescription
+            onClick={e => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+          >
             <p>
               {tct(
                 `Enable this feature on your sentry installation by adding the
@@ -109,6 +115,18 @@ class FeatureDisabled extends React.Component<Props, State> {
                 }
               )}
             </p>
+            <Clipboard hideUnsupported value={installText(features, featureName)}>
+              <Button
+                borderless
+                size="xsmall"
+                onClick={e => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }}
+              >
+                <StyledIconCopy /> Copy to Clipboard
+              </Button>
+            </Clipboard>
             <pre onClick={e => selectText(e.target as HTMLElement)}>
               <code>{installText(features, featureName)}</code>
             </pre>
@@ -171,6 +189,10 @@ const AlertWrapper = styled('div')`
   code {
     background: #fbf7e0;
   }
+`;
+
+const StyledIconCopy = styled(IconCopy)`
+  margin-right: ${space(1)};
 `;
 
 export default FeatureDisabled;


### PR DESCRIPTION
This also fixes a bug where clicking on the popup would select a project

Before:
![Screen Recording 2020-09-04 at 03 26 51 PM](https://user-images.githubusercontent.com/155016/92282365-6f390100-eecb-11ea-8806-7689baea77ad.gif)

After:
![Screen Recording 2020-09-04 at 04 18 44 PM](https://user-images.githubusercontent.com/155016/92282372-73fdb500-eecb-11ea-86a0-4ff7fcee41d7.gif)
