### PR TITLE
fix(trends): Small usability improvements for trends

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -178,9 +178,14 @@ class PerformanceLanding extends React.Component<Props, State> {
     // This is a temporary change for trends to test adding a default count to increase relevancy
     if (viewKey === FilterViews.TRENDS) {
       if (!newQuery.query) {
-        newQuery.query = 'count():>1000';
-      } else if (!newQuery.query.includes('count()')) {
+        newQuery.query =
+          'count():>1000 transaction.duration:>0 p50():>0 avg(transaction.duration):>0';
+      }
+      if (!newQuery.query.includes('count()')) {
         newQuery.query += 'count():>1000';
+      }
+      if (!newQuery.query.includes('transaction.duration')) {
+        newQuery.query += ' transaction.duration:>0';
       }
     }
 

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -16,6 +16,7 @@ import LineChart from 'app/components/charts/lineChart';
 import ChartZoom from 'app/components/charts/chartZoom';
 import {Series} from 'app/types/echarts';
 import theme from 'app/utils/theme';
+import {axisLabelFormatter, tooltipFormatter} from 'app/utils/discover/charts';
 
 import {trendToColor, getIntervalRatio, getCurrentTrendFunction} from './utils';
 import {TrendChangeType, TrendsStats, NormalizedTrendsTransaction} from './types';
@@ -62,12 +63,17 @@ function getLegend() {
     align: 'left',
     textStyle: {
       verticalAlign: 'top',
-      fontSize: 12,
+      fontSize: 11,
       fontFamily: 'Rubik',
     },
     data: [
       {
-        name: 'Baseline',
+        name: 'Present Baseline',
+        icon:
+          'path://M180 1000 l0 -40 200 0 200 0 0 40 0 40 -200 0 -200 0 0 -40z, M810 1000 l0 -40 200 0 200 0 0 40 0 40 -200 0 -200 0 0 -40zm, M1440 1000 l0 -40 200 0 200 0 0 40 0 40 -200 0 -200 0 0 -40z',
+      },
+      {
+        name: 'Past Baseline',
         icon:
           'path://M180 1000 l0 -40 200 0 200 0 0 40 0 40 -200 0 -200 0 0 -40z, M810 1000 l0 -40 200 0 200 0 0 40 0 40 -200 0 -200 0 0 -40zm, M1440 1000 l0 -40 200 0 200 0 0 40 0 40 -200 0 -200 0 0 -40z',
       },
@@ -118,21 +124,24 @@ function getIntervalLine(
   };
 
   const periodLineLabel = {
-    fontSize: 10,
+    fontSize: 11,
     show: true,
   };
 
   const previousPeriod = {
     ...periodLine,
     markLine: {...periodLine.markLine},
+    seriesName: 'Past Baseline',
   };
   const currentPeriod = {
     ...periodLine,
     markLine: {...periodLine.markLine},
+    seriesName: 'Present Baseline',
   };
   const periodDividingLine = {
     ...periodLine,
     markLine: {...periodLine.markLine},
+    seriesName: 'Period split',
   };
 
   const seriesDiff = seriesEnd - seriesStart;
@@ -140,13 +149,13 @@ function getIntervalLine(
 
   previousPeriod.markLine.data = [
     [
-      {value: 'Previous Period', coord: [seriesStart, transaction.aggregate_range_1]},
+      {value: 'Past', coord: [seriesStart, transaction.aggregate_range_1]},
       {coord: [seriesLine, transaction.aggregate_range_1]},
     ],
   ];
   currentPeriod.markLine.data = [
     [
-      {value: 'Current Period', coord: [seriesLine, transaction.aggregate_range_2]},
+      {value: 'Present', coord: [seriesLine, transaction.aggregate_range_2]},
       {coord: [seriesEnd, transaction.aggregate_range_2]},
     ],
   ];
@@ -173,12 +182,12 @@ function getIntervalLine(
 
   previousPeriod.markLine.label = {
     ...periodLineLabel,
-    formatter: 'Previous Period',
+    formatter: 'Past',
     position: 'insideStartBottom',
   };
   currentPeriod.markLine.label = {
     ...periodLineLabel,
-    formatter: 'Current Period',
+    formatter: 'Present',
     position: 'insideEndBottom',
   };
 
@@ -210,7 +219,7 @@ class Chart extends React.Component<Props> {
     const data = events?.data ?? [];
 
     const trendFunction = getCurrentTrendFunction(location);
-    const results = transformEventStats(data, trendFunction.label);
+    const results = transformEventStats(data, trendFunction.chartLabel);
 
     const start = props.start ? getUtcToLocalDateObject(props.start) : undefined;
 
@@ -222,6 +231,19 @@ class Chart extends React.Component<Props> {
 
     const loading = isLoading;
     const reloading = isLoading;
+
+    const chartOptions = {
+      tooltip: {
+        valueFormatter: tooltipFormatter,
+      },
+      yAxis: {
+        axisLabel: {
+          color: theme.gray400,
+          // p50() coerces the axis to be time based
+          formatter: (value: number) => axisLabelFormatter(value, 'p50()'),
+        },
+      },
+    };
 
     return (
       <React.Fragment>
@@ -264,6 +286,7 @@ class Chart extends React.Component<Props> {
                       value: (
                         <LineChart
                           {...zoomRenderProps}
+                          {...chartOptions}
                           series={[...series, ...releaseSeries, ...intervalSeries]}
                           seriesOptions={{
                             showSymbol: false,

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -84,7 +84,7 @@ class TrendsContent extends React.Component<Props, State> {
           />
           <TrendsDropdown>
             <DropdownControl
-              buttonProps={{prefix: t('Filter')}}
+              buttonProps={{prefix: t('Display')}}
               label={currentTrendFunction.label}
             >
               {TRENDS_FUNCTIONS.map(({label, field}) => (

--- a/src/sentry/static/sentry/app/views/performance/trends/types.ts
+++ b/src/sentry/static/sentry/app/views/performance/trends/types.ts
@@ -10,6 +10,8 @@ export type TrendFunction = {
   label: string;
   field: TrendFunctionField;
   alias: string;
+  chartLabel: string;
+  legendLabel: string;
 };
 
 export enum TrendChangeType {

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -34,19 +34,18 @@ import {BaselineQueryResults} from '../transactionSummary/baselineQuery';
 
 export const TRENDS_FUNCTIONS: TrendFunction[] = [
   {
-    label: 'Average',
-    field: TrendFunctionField.AVG,
-    alias: 'avg_range',
-  },
-  {
     label: 'Duration (p50)',
     field: TrendFunctionField.P50,
     alias: 'percentile_range',
+    chartLabel: 'p50()',
+    legendLabel: 'p50',
   },
   {
-    label: 'User Misery',
-    field: TrendFunctionField.USER_MISERY,
-    alias: 'user_misery_range',
+    label: 'Duration (average)',
+    field: TrendFunctionField.AVG,
+    alias: 'avg_range',
+    chartLabel: 'avg(transaction.duration)',
+    legendLabel: 'average',
   },
 ];
 

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -237,28 +237,6 @@ describe('Performance > Trends', function() {
     });
   });
 
-  it('transaction list renders user misery', async function() {
-    const projects = [TestStubs.Project()];
-    const data = initializeData(projects, {project: ['-1']});
-
-    const location = {
-      query: {...trendsViewQuery, trendFunction: TrendFunctionField.USER_MISERY},
-    };
-    const wrapper = mountWithTheme(
-      <PerformanceLanding organization={data.organization} location={location} />,
-      data.routerContext
-    );
-    await tick();
-    wrapper.update();
-
-    const firstTransaction = wrapper.find('TrendsListItem').first();
-    expect(firstTransaction.find('ItemTransactionAbsoluteFaster').text()).toMatch(
-      '863 → 1.6k miserable users'
-    );
-    expect(firstTransaction.find('ItemTransactionPrimary').text()).toMatch('797 less');
-    expect(firstTransaction.find('ItemTransactionSecondary').text()).toMatch('92%');
-  });
-
   it('choosing a trend function changes location', async function() {
     const projects = [TestStubs.Project()];
     const data = initializeData(projects, {project: ['-1']});
@@ -320,7 +298,7 @@ describe('Performance > Trends', function() {
 
       const field = [...trendFunctionFields, ...defaultFields];
 
-      expect(field).toHaveLength(6);
+      expect(field).toHaveLength(5);
 
       // Improved trends call
       expect(trendsMock).toHaveBeenNthCalledWith(


### PR DESCRIPTION
Multiple small changes to improve trends ui usability.

This improves the following:
* Add tooltip to widget titles
* Add separate baselines and change legend labels
* Add tooltip to percent for clarification
* Add project avatar and tooltip for it, move tooltip for total events to transaction
* Change default query to hint at more capabilities for internal testing
* Change trend dropdown copy to 'display' as it is less confusing
* Fix y-axis, tooltips and chart trend labels
* Change copy for trend functions, rearrange so p50 is first, remove misery for now
* Fix period split disappearing when clicking the legend