### PR TITLE
fix(monitoring): Update amqp API

### DIFF
--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -32,9 +32,11 @@ class RedisBackend(object):
 class AmqpBackend(object):
     def __init__(self, broker_url):
         dsn = urlparse(broker_url)
+        host, port = dsn.hostname, dsn.port
+        if port is None:
+            port = 5672
         self.conn_info = dict(
-            host=dsn.hostname,
-            port=dsn.port,
+            host="%s:%d" % (host, port),
             userid=dsn.username,
             password=dsn.password,
             virtual_host=dsn.path[1:],


### PR DESCRIPTION
When switching from librabbitmq to py-amqp, the Connection API changed
slightly.

Both libraries accept the kwarg `host` with the form of
`host=host[:port]` but only librabbitmq accepted `host=host, port=port`.
In py-amqp the port was being lost.

So this swaps to the format that works for both.