### PR TITLE
fix: Remove dead transactions consumers code

### DIFF
--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -24,7 +24,7 @@ from sentry.utils.batching_kafka_consumer import AbstractBatchWorker
 from sentry.attachments import CachedAttachment, attachment_cache
 from sentry.ingest.types import ConsumerType
 from sentry.ingest.userreport import Conflict, save_userreport
-from sentry.event_manager import save_attachment, save_transaction_events
+from sentry.event_manager import save_attachment
 from sentry.eventstore.processing import event_processing_store
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,6 @@ class IngestConsumerWorker(AbstractBatchWorker):
     def _flush_batch(self, batch):
         attachment_chunks = []
         other_messages = []
-        transactions = []
 
         projects_to_fetch = set()
 
@@ -57,8 +56,6 @@ class IngestConsumerWorker(AbstractBatchWorker):
 
                 if message_type == "event":
                     other_messages.append((process_event, message))
-                elif message_type == "transaction":
-                    transactions.append(message)
                 elif message_type == "attachment_chunk":
                     attachment_chunks.append(message)
                 elif message_type == "attachment":
@@ -85,10 +82,6 @@ class IngestConsumerWorker(AbstractBatchWorker):
                 for processing_func, message in other_messages:
                     processing_func(message, projects=projects)
 
-        if transactions:
-            with metrics.timer("ingest_consumer.process_transactions"):
-                process_transactions_batch(transactions, projects)
-
     def shutdown(self):
         pass
 
@@ -106,30 +99,6 @@ def trace_func(**span_kwargs):
         return inner
 
     return wrapper
-
-
-@trace_func(name="ingest_consumer.process_transactions_batch")
-@metrics.wraps("ingest_consumer.process_transactions_batch")
-def process_transactions_batch(messages, projects):
-    if options.get("store.transactions-celery") is True:
-        for message in messages:
-            _do_process_event(message, projects)
-        return
-
-    jobs = []
-    for message in messages:
-        payload = message["payload"]
-        project_id = int(message["project_id"])
-        start_time = float(message["start_time"])
-
-        if project_id not in projects:
-            continue
-
-        with metrics.timer("ingest_consumer.decode_transaction_json"):
-            data = json.loads(payload)
-        jobs.append({"data": data, "start_time": start_time})
-
-    save_transaction_events(jobs, projects)
 
 
 @metrics.wraps("ingest_consumer.process_event")

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -10,7 +10,7 @@ from django.core.cache import cache
 
 import sentry_sdk
 
-from sentry import eventstore, features, options
+from sentry import eventstore, features
 
 from sentry.models import Project
 from sentry.signals import event_accepted

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -196,7 +196,7 @@ register("store.lie-about-filter-status", default=False)
 
 # Toggles between processing transactions directly in the ingest consumer
 # (``False``) and spawning a save_event task (``True``).
-register("store.transactions-celery", default=False)
+register("store.transactions-celery", default=False)  # unused
 
 # Symbolicator refactors
 # - Disabling minidump stackwalking in endpoints

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -56,7 +56,7 @@ def get_test_message(request, default_project):
         em.normalize()
         normalized_event = dict(em.get_data())
         message = {
-            "type": request.param,
+            "type": "event",
             "start_time": time.time(),
             "event_id": event_id,
             "project_id": int(project_id),

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -8,7 +8,7 @@ import pytest
 
 from django.conf import settings
 
-from sentry import eventstore, options
+from sentry import eventstore
 from sentry.event_manager import EventManager
 from sentry.ingest.ingest_consumer import ConsumerType, get_ingest_consumer
 from sentry.utils import json
@@ -103,7 +103,6 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
         auto_offset_reset="earliest",
     )
 
-    options.set("store.transactions-celery", not inline_transactions)
     with task_runner():
         i = 0
         while i < MAX_POLL_ITERATIONS:

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -70,17 +70,8 @@ def get_test_message(request, default_project):
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.parametrize(
-    "inline_transactions", [True, False], ids=["inline_transactions", "worker_transactions"]
-)
 def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
-    task_runner,
-    kafka_producer,
-    kafka_admin,
-    requires_kafka,
-    default_project,
-    get_test_message,
-    inline_transactions,
+    task_runner, kafka_producer, kafka_admin, requires_kafka, default_project, get_test_message,
 ):
     group_id = "test-consumer"
     topic_event_name = ConsumerType.get_topic_name(ConsumerType.Events)


### PR DESCRIPTION
This code was never used as the message type for transactions is currently also `event`. The other code is used in event manager, and there it's somewhat useful to have dedicated codepath for transactions, even though the batching isn't part of why it's useful.

I have checked that the metrics `process_transactions_batch` is not seen in prod