### PR TITLE
ref(releases): Add Release Health compact option

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1057,6 +1057,7 @@ export type ReleaseProject = {
   platform: PlatformKey;
   platforms: PlatformKey[];
   newGroups: number;
+  hasHealthData: boolean;
   healthData?: Health;
 };
 

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/compactContent.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/compactContent.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {t} from 'app/locale';
+import {PanelBody} from 'app/components/panels';
+import {ReleaseProject, Release} from 'app/types';
+import space from 'app/styles/space';
+
+import ClippedHealthRows from '../clippedHealthRows';
+import Header from './header';
+import Item from './item';
+import ProjectName from './projectName';
+import IssuesQuantity from './issuesQuantity';
+
+type Props = {
+  projects: Array<ReleaseProject>;
+  releaseVersion: Release['version'];
+  orgSlug: string;
+};
+
+const CompactContent = ({projects, releaseVersion, orgSlug}: Props) => (
+  <React.Fragment>
+    <Header>{t('Projects')}</Header>
+    <PanelBody>
+      <StyledClippedHealthRows maxVisibleItems={12}>
+        {projects.map(project => {
+          const {id, slug, newGroups = 0} = project;
+          return (
+            <StyledItem key={`${releaseVersion}-${slug}-health`}>
+              <ProjectName
+                orgSlug={orgSlug}
+                project={project}
+                releaseVersion={releaseVersion}
+              />
+              <IssuesQuantity
+                orgSlug={orgSlug}
+                releaseVersion={releaseVersion}
+                projectId={id}
+                newGroups={newGroups}
+                isCompact
+              />
+            </StyledItem>
+          );
+        })}
+      </StyledClippedHealthRows>
+    </PanelBody>
+  </React.Fragment>
+);
+
+export default CompactContent;
+
+const StyledItem = styled(Item)`
+  align-items: center;
+  border-right: 1px solid ${p => p.theme.borderLight};
+  display: grid;
+  grid-template-columns: minmax(100px, max-content) auto;
+  grid-column-gap: ${space(2)};
+  justify-content: space-between;
+  :last-child {
+    border-right: 1px solid ${p => p.theme.borderLight};
+  }
+`;
+
+const StyledClippedHealthRows = styled(ClippedHealthRows)`
+  display: grid;
+  grid-template-columns: 1fr;
+  margin-right: -1px;
+  margin-bottom: -1px;
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+`;

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/header.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/header.tsx
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+import {PanelHeader} from 'app/components/panels';
+
+const Header = styled(PanelHeader)`
+  border-top: 1px solid ${p => p.theme.borderDark};
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  color: ${p => p.theme.gray500};
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+export default Header;

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {Location} from 'history';
+import partition from 'lodash/partition';
+import flatten from 'lodash/flatten';
+
+import {Release, GlobalSelection} from 'app/types';
+
+import Content from './content';
+import CompactContent from './compactContent';
+
+type Props = {
+  release: Release;
+  orgSlug: string;
+  location: Location;
+  showPlaceholders: boolean;
+  selection: GlobalSelection;
+};
+
+const ReleaseHealth = ({
+  release,
+  orgSlug,
+  location,
+  selection,
+  showPlaceholders,
+}: Props) => {
+  // sort health rows inside release card alphabetically by project name,
+  // but put the ones with project selected in global header to top
+  const sortedProjects = flatten(
+    partition(
+      release.projects.sort((a, b) => a.slug.localeCompare(b.slug)),
+      p => selection.projects.includes(p.id)
+    )
+  );
+
+  const hasAtLeastOneHealthData = sortedProjects.some(
+    sortedProject => sortedProject.hasHealthData
+  );
+
+  const contentProps = {
+    projects: sortedProjects,
+    releaseVersion: release.version,
+    orgSlug,
+  };
+
+  if (hasAtLeastOneHealthData) {
+    return (
+      <Content
+        {...contentProps}
+        location={location}
+        showPlaceholders={showPlaceholders}
+      />
+    );
+  }
+
+  return <CompactContent {...contentProps} />;
+};
+
+export default ReleaseHealth;

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/issuesQuantity.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/issuesQuantity.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {t, tn} from 'app/locale';
+import Tooltip from 'app/components/tooltip';
+import Link from 'app/components/links/link';
+import Count from 'app/components/count';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
+import space from 'app/styles/space';
+
+import {getReleaseNewIssuesUrl} from '../../utils';
+
+type Props = {
+  orgSlug: string;
+  newGroups: number;
+  projectId: number;
+  releaseVersion: string;
+  isCompact?: boolean;
+};
+
+const IssuesQuantity = ({
+  orgSlug,
+  newGroups,
+  projectId,
+  releaseVersion,
+  isCompact = false,
+}: Props) => (
+  <Tooltip title={t('Open in Issues')}>
+    <Link to={getReleaseNewIssuesUrl(orgSlug, projectId, releaseVersion)}>
+      {isCompact ? (
+        <Issues>
+          <StyledCount value={newGroups} />
+          <span>{tn('issue', 'issues', newGroups)}</span>
+        </Issues>
+      ) : (
+        <Count value={newGroups} />
+      )}
+    </Link>
+  </Tooltip>
+);
+
+export default IssuesQuantity;
+
+const Issues = styled('div')`
+  display: grid;
+  grid-gap: ${space(0.5)};
+  grid-template-columns: auto max-content;
+  justify-content: flex-end;
+  align-items: center;
+  text-align: end;
+`;
+
+// overflowEllipsis is useful if the count's value is over 1000000000
+const StyledCount = styled(Count)`
+  ${overflowEllipsis}
+`;

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/item.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/item.tsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+import {PanelItem} from 'app/components/panels';
+import space from 'app/styles/space';
+
+const Item = styled(PanelItem)`
+  padding: ${space(1)} ${space(2)};
+  min-height: 46px;
+`;
+export default Item;

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/projectName.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/projectName.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import GlobalSelectionLink from 'app/components/globalSelectionLink';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
+import {ReleaseProject} from 'app/types';
+
+type Props = {
+  orgSlug: string;
+  releaseVersion: string;
+  project: ReleaseProject;
+};
+
+const ProjectName = ({orgSlug, releaseVersion, project}: Props) => (
+  <GlobalSelectionLink
+    to={{
+      pathname: `/organizations/${orgSlug}/releases/${encodeURIComponent(
+        releaseVersion
+      )}/`,
+      query: {project: project.id},
+    }}
+  >
+    <ProjectBadge project={project} avatarSize={16} />
+  </GlobalSelectionLink>
+);
+
+export default ProjectName;

--- a/tests/js/sentry-test/fixtures/release.js
+++ b/tests/js/sentry-test/fixtures/release.js
@@ -31,12 +31,12 @@ export function Release(params, healthParams) {
     ref: null,
     projects: [
       {
+        hasHealthData: true,
         healthData: {
           totalUsers24h: null,
           durationP50: 231,
           totalSessions: 74949,
           totalUsers: 2544,
-          hasHealthData: true,
           crashFreeSessions: 99.59839357429719,
           sessionsErrored: 301,
           stats: {

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -8,6 +8,7 @@ import ReleasesList from 'app/views/releases/list/';
 
 describe('ReleasesList', function () {
   const {organization, routerContext, router} = initializeOrg();
+
   const props = {
     router,
     organization,
@@ -32,7 +33,17 @@ describe('ReleasesList', function () {
       body: [
         TestStubs.Release({version: '1.0.0'}),
         TestStubs.Release({version: '1.0.1'}),
-        TestStubs.Release({version: 'af4f231ec9a8'}, {hasHealthData: false}),
+        {
+          ...TestStubs.Release({version: 'af4f231ec9a8'}),
+          projects: [
+            {
+              id: 4383604,
+              name: 'Sentry-IOS-Shop',
+              slug: 'sentry-ios-shop',
+              hasHealthData: false,
+            },
+          ],
+        },
       ],
     });
 
@@ -57,8 +68,10 @@ describe('ReleasesList', function () {
     expect(items).toHaveLength(3);
     expect(items.at(0).text()).toContain('1.0.0');
     expect(items.at(0).text()).toContain('Release adoption');
+    expect(items.at(1).text()).toContain('1.0.1');
+    expect(items.at(1).find('DailyUsersColumn').at(1).text()).toContain('\u2014');
     expect(items.at(2).text()).toContain('af4f231ec9a8');
-    expect(items.at(2).find('DailyUsersColumn').at(1).text()).toContain('\u2014');
+    expect(items.at(2).find('Header').text()).toEqual('Projects');
   });
 
   it('displays the right empty state', function () {


### PR DESCRIPTION
**Description:** If there is no release health data, the UI should display a compact card view.

closes: https://app.asana.com/0/1182975495223914/1189879791807897

The Compact Version looks like below:

![image](https://user-images.githubusercontent.com/29228205/92392018-ef56a500-f11d-11ea-8a4f-19ebf6e87eac.png)

#sync-getsentry