### PR TITLE
feat(msteams): checks if account is linked when user does linked command

### DIFF
--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -303,6 +303,20 @@ def build_unlink_identity_card(unlink_url):
     }
 
 
+def build_already_linked_identity_command_card():
+    link_identity = {
+        "type": "TextBlock",
+        "text": ("Your Microsoft Teams identity is already linked to a" " Sentry account."),
+        "wrap": True,
+    }
+    return {
+        "type": "AdaptiveCard",
+        "body": [link_identity],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.2",
+    }
+
+
 def build_group_title(group):
     # TODO: implement with event as well
     ev_metadata = group.get_event_metadata()

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -36,6 +36,7 @@ from .card_builder import (
     build_unrecognized_command_card,
     build_help_command_card,
     build_link_identity_command_card,
+    build_already_linked_identity_command_card,
 )
 from .client import (
     MsTeamsJwtClient,
@@ -446,17 +447,20 @@ class MsTeamsWebhookEndpoint(Endpoint):
         command_text = data.get("text", "").strip()
         lowercase_command = command_text.lower()
         conversation_id = data["conversation"]["id"]
+        teams_user_id = data["from"]["id"]
 
         # only supporting unlink for now
         if "unlink" in lowercase_command:
-            unlink_url = build_unlinking_url(
-                conversation_id, data["serviceUrl"], data["from"]["id"]
-            )
+            unlink_url = build_unlinking_url(conversation_id, data["serviceUrl"], teams_user_id)
             card = build_unlink_identity_card(unlink_url)
         elif "help" in lowercase_command:
             card = build_help_command_card()
         elif "link" == lowercase_command:  # don't to match other types of link commands
-            card = build_link_identity_command_card()
+            has_linked_identity = Identity.objects.filter(external_id=teams_user_id).exists()
+            if has_linked_identity:
+                card = build_already_linked_identity_command_card()
+            else:
+                card = build_link_identity_command_card()
         else:
             card = build_unrecognized_command_card(command_text)
 

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -7,7 +7,7 @@ import responses
 from copy import deepcopy
 from six.moves.urllib.parse import urlencode
 
-from sentry.models import Integration
+from sentry.models import Integration, Identity, IdentityProvider
 from sentry.testutils import APITestCase
 from sentry.utils.compat.mock import patch
 
@@ -415,6 +415,43 @@ class MsTeamsWebhookTest(APITestCase):
 
         assert resp.status_code == 204
         assert "Your Microsoft Teams identity will be linked to your Sentry account" in responses.calls[
+            3
+        ].request.body.decode(
+            "utf-8"
+        )
+        assert "Bearer my_token" in responses.calls[3].request.headers["Authorization"]
+
+    @responses.activate
+    @patch("jwt.decode")
+    @patch("time.time")
+    def test_link_command_already_linked(self, mock_time, mock_decode):
+        other_command = deepcopy(EXAMPLE_UNLINK_COMMAND)
+        other_command["text"] = "link"
+        idp = IdentityProvider.objects.create(type="msteams", external_id=team_id, config={})
+        Identity.objects.create(external_id=other_command["from"]["id"], idp=idp, user=self.user)
+        access_json = {"expires_in": 86399, "access_token": "my_token"}
+        responses.add(
+            responses.POST,
+            u"https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
+            json=access_json,
+        )
+        responses.add(
+            responses.POST,
+            u"https://smba.trafficmanager.net/amer/v3/conversations/%s/activities"
+            % other_command["conversation"]["id"],
+            json={},
+        )
+        mock_time.return_value = 1594839999 + 60
+        mock_decode.return_value = DECODED_TOKEN
+        resp = self.client.post(
+            path=webhook_url,
+            data=other_command,
+            format="json",
+            HTTP_AUTHORIZATION=u"Bearer %s" % TOKEN,
+        )
+
+        assert resp.status_code == 204
+        assert "Your Microsoft Teams identity is already linked to a Sentry account" in responses.calls[
             3
         ].request.body.decode(
             "utf-8"


### PR DESCRIPTION
Microsoft has requested us to tell the user if their account is already linked when using the `link` command. This PR checks the `Identity` table for any identities with the external id that matches the Team's user ID. If there's a match, we show the user the following:

![Screen Shot 2020-09-08 at 9 18 43 AM](https://user-images.githubusercontent.com/8533851/92503028-86227080-f1b5-11ea-801c-ed46acaf403b.png)
