### PR TITLE
fix(trends): Change trends view default stats period to 14d

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -34,6 +34,7 @@ import Charts from './charts/index';
 import Onboarding from './onboarding';
 import {addRoutePerformanceContext, getTransactionSearchQuery} from './utils';
 import TrendsContent from './trends/content';
+import {modifyTrendsViewDefaultPeriod, DEFAULT_TRENDS_STATS_PERIOD} from './trends/utils';
 
 export enum FilterViews {
   ALL_TRANSACTIONS = 'ALL_TRANSACTIONS',
@@ -267,11 +268,14 @@ class PerformanceLanding extends React.Component<Props, State> {
 
   render() {
     const {organization, location, router, projects} = this.props;
-    const {eventView} = this.state;
+    const currentView = this.getCurrentView();
+    const isTrendsView = currentView === FilterViews.TRENDS;
+    const eventView = isTrendsView
+      ? modifyTrendsViewDefaultPeriod(this.state.eventView, location)
+      : this.state.eventView;
     const showOnboarding = this.shouldShowOnboarding();
     const filterString = getTransactionSearchQuery(location);
     const summaryConditions = this.getSummaryConditions(filterString);
-    const currentView = this.getCurrentView();
 
     return (
       <SentryDocumentTitle title={t('Performance')} objSlug={organization.slug}>
@@ -281,7 +285,7 @@ class PerformanceLanding extends React.Component<Props, State> {
               start: null,
               end: null,
               utc: false,
-              period: DEFAULT_STATS_PERIOD,
+              period: isTrendsView ? DEFAULT_TRENDS_STATS_PERIOD : DEFAULT_STATS_PERIOD,
             },
           }}
         >

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -32,6 +32,8 @@ import {
 } from './types';
 import {BaselineQueryResults} from '../transactionSummary/baselineQuery';
 
+export const DEFAULT_TRENDS_STATS_PERIOD = '14d';
+
 export const TRENDS_FUNCTIONS: TrendFunction[] = [
   {
     label: 'Duration (p50)',
@@ -164,6 +166,17 @@ export function modifyTrendView(
 
   trendView.sorts = [trendSort];
   trendView.fields = fields;
+}
+
+export function modifyTrendsViewDefaultPeriod(eventView: EventView, location: Location) {
+  const {query} = location;
+
+  const hasStartAndEnd = query.start && query.end;
+
+  if (!query.statsPeriod && !hasStartAndEnd) {
+    eventView.statsPeriod = DEFAULT_TRENDS_STATS_PERIOD;
+  }
+  return eventView;
 }
 
 export async function getTrendBaselinesForTransaction(

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -309,8 +309,9 @@ describe('Performance > Trends', function() {
             trendFunction: trendFunction.field,
             sort,
             query: expect.stringContaining(aliasedQueryDivide + ':<1'),
-            interval: '30m',
+            interval: '12h',
             field,
+            statsPeriod: '14d',
           }),
         })
       );
@@ -324,8 +325,9 @@ describe('Performance > Trends', function() {
             trendFunction: trendFunction.field,
             sort: '-' + sort,
             query: expect.stringContaining(aliasedQueryDivide + ':>1'),
-            interval: '30m',
+            interval: '12h',
             field,
+            statsPeriod: '14d',
           }),
         })
       );


### PR DESCRIPTION
### Summary
This switches out the default for performance (24h) with a higher default (14d) when on moving to Trends view without a set statsPeriod

VIS-123