### PR TITLE
ref(relay): Change relay port to 7899

### DIFF
--- a/config/relay/config.yml
+++ b/config/relay/config.yml
@@ -2,7 +2,7 @@
 relay:
   upstream: 'http://host.docker.internal:8000/'
   host: 0.0.0.0
-  port: 7999
+  port: 7899
 logging:
   level: INFO
   enable_backtraces: false

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1430,7 +1430,7 @@ SENTRY_WATCHERS = (
 # will split the requests between Relay and Sentry (all store requests will be passed to Relay, and the
 # rest will be forwarded to Sentry)
 SENTRY_USE_RELAY = True
-SENTRY_RELAY_PORT = 7999
+SENTRY_RELAY_PORT = 7899
 
 # The chunk size for attachments in blob store. Should be a power of two.
 SENTRY_ATTACHMENT_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
@@ -1561,7 +1561,7 @@ SENTRY_DEVSERVICES = {
     "relay": {
         "image": "us.gcr.io/sentryio/relay:latest",
         "pull": True,
-        "ports": {"7999/tcp": SENTRY_RELAY_PORT},
+        "ports": {"7899/tcp": SENTRY_RELAY_PORT},
         "volumes": {RELAY_CONFIG_DIR: {"bind": "/etc/relay"}},
         "command": ["run", "--config", "/etc/relay"],
         "only_if": lambda settings, options: settings.SENTRY_USE_RELAY,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -430,7 +430,7 @@ if (
   if (!IS_UI_DEV_ONLY) {
     // This proxies to local backend server
     const backendAddress = `http://localhost:${SENTRY_BACKEND_PORT}/`;
-    const relayAddress = 'http://127.0.0.1:7999';
+    const relayAddress = 'http://127.0.0.1:7899';
 
     appConfig.devServer = {
       ...appConfig.devServer,


### PR DESCRIPTION
The previous port `7999` was conflicting with a public port used for UI development