### PR TITLE
change(workflow): Reduce eventIdLookup rate limit to 1/s

### DIFF
--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -43,19 +43,19 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
         if len(event_id) != 32:
             return Response({"detail": "Event ID must be 32 characters."}, status=400)
 
-        # Limit to 100req/s
+        # Limit to 1 req/s
         if ratelimiter.is_limited(
             u"api:event-id-lookup:{}".format(
                 md5_text(
                     request.user.id if request.user and request.user.is_authenticated() else ""
                 ).hexdigest()
             ),
-            limit=100,
+            limit=1,
             window=1,
         ):
             return Response(
                 {
-                    "detail": "You are attempting to use this endpoint too quickly. Limit is 100 requests/second."
+                    "detail": "You are attempting to use this endpoint too quickly. Limit is 1 request per second."
                 },
                 status=429,
             )

--- a/tests/snuba/api/endpoints/test_organization_eventid.py
+++ b/tests/snuba/api/endpoints/test_organization_eventid.py
@@ -64,6 +64,3 @@ class EventIdLookupEndpointTest(APITestCase, SnubaTestCase):
         resp = self.client.get(url, format="json")
 
         assert resp.status_code == 429
-        assert resp.data == {
-            "detail": "You are attempting to use this endpoint too quickly. Limit is 100 requests/second."
-        }


### PR DESCRIPTION
After some discussion, we've (James, Zac, Manu) decided that this rate is all that's needed for this endpoint.

If you know of a use-case where this should be higher than 1/s, please speak now :-)