### PR TITLE
ref(py3): Handle decoding from redis in tsdb

### DIFF
--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -11,6 +11,7 @@ from hashlib import md5
 
 import six
 from django.utils import timezone
+from django.utils.encoding import force_bytes
 from pkg_resources import resource_string
 
 from sentry.tsdb.base import BaseTSDB
@@ -173,9 +174,7 @@ class RedisTSDB(BaseTSDB):
         if isinstance(model_key, six.integer_types):
             vnode = model_key % self.vnodes
         else:
-            if isinstance(model_key, six.text_type):
-                model_key = model_key.encode("utf-8")
-            vnode = crc32(model_key) % self.vnodes
+            vnode = crc32(force_bytes(model_key)) % self.vnodes
 
         return (
             u"{prefix}{model}:{epoch}:{vnode}".format(
@@ -727,7 +726,9 @@ class RedisTSDB(BaseTSDB):
         results = {}
         cluster, _ = self.get_cluster(environment_id)
         for key, responses in cluster.execute_commands(commands).items():
-            results[key] = [(member, float(score)) for member, score in responses[0].value]
+            results[key] = [
+                (member.decode("utf-8"), float(score)) for member, score in responses[0].value
+            ]
 
         return results
 
@@ -757,7 +758,7 @@ class RedisTSDB(BaseTSDB):
             ]
 
         def unpack_response(response):
-            return {item: float(score) for item, score in response.value}
+            return {item.decode("utf-8"): float(score) for item, score in response.value}
 
         results = {}
         cluster, _ = self.get_cluster(environment_id)

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -690,11 +690,11 @@ class RedisTSDBTest(TestCase):
         assert client.exists("1:e")
 
         assert CountMinScript(["1:i", "1:e"], ["RANKED"] + parameters, client=client) == [
-            ["iota", "9"],
-            ["theta", "8"],
-            ["eta", "7"],
-            ["zeta", "6"],
-            ["foxtrot", "6"],
+            [b"iota", b"9"],
+            [b"theta", b"8"],
+            [b"eta", b"7"],
+            [b"zeta", b"6"],
+            [b"foxtrot", b"6"],
         ]
 
     def test_frequency_table_import_export_source_estimators(self):
@@ -748,11 +748,11 @@ class RedisTSDBTest(TestCase):
         assert client.exists("1:e")
 
         assert CountMinScript(["1:i", "1:e"], ["RANKED"] + parameters, client=client) == [
-            ["iota", "9"],
-            ["baz", "9"],
-            ["theta", "8"],
-            ["eta", "7"],
-            ["bar", "7"],
+            [b"iota", b"9"],
+            [b"baz", b"9"],
+            [b"theta", b"8"],
+            [b"eta", b"7"],
+            [b"bar", b"7"],
         ]
 
     def test_frequency_table_import_export_destination_estimators(self):
@@ -806,9 +806,9 @@ class RedisTSDBTest(TestCase):
         assert client.exists("1:e")
 
         assert CountMinScript(["1:i", "1:e"], ["RANKED"] + parameters, client=client) == [
-            ["iota", "9"],
-            ["baz", "9"],
-            ["theta", "8"],
-            ["eta", "7"],
-            ["bar", "7"],
+            [b"iota", b"9"],
+            [b"baz", b"9"],
+            [b"theta", b"8"],
+            [b"eta", b"7"],
+            [b"bar", b"7"],
         ]


### PR DESCRIPTION
This decodes responses for tsdb at redis query time where needed.

The tests that explicitly call the cmsketch script must compare bytes since that's the direct response out of redis.