### PR TITLE
chore(mail): Remove uses of `has_issue_alerts_targeting` and related code.

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -15,26 +15,12 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         condition_list = []
         filter_list = []
 
-        has_issue_alerts_targeting = (
-            project.flags.has_issue_alerts_targeting
-            or request.query_params.get("issue_alerts_targeting") == "1"
-        )
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
             node = rule_cls(project)
-            context = {
-                "id": node.id,
-                "label": node.label,
-                "enabled": node.is_enabled(),
-            }
+            context = {"id": node.id, "label": node.label, "enabled": node.is_enabled()}
             if hasattr(node, "prompt"):
                 context["prompt"] = node.prompt
-
-            if (
-                node.id == "sentry.mail.actions.NotifyEmailAction"
-                and not has_issue_alerts_targeting
-            ):
-                continue
 
             if hasattr(node, "form_fields"):
                 context["formFields"] = node.form_fields

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -116,16 +116,11 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   }
 
   getEndpoints() {
-    const {params, location} = this.props;
-    const {ruleId, projectId, orgId} = params;
-    const {issue_alerts_targeting = 0} = location.query ?? {};
+    const {ruleId, projectId, orgId} = this.props.params;
 
     const endpoints = [
       ['environments', `/projects/${orgId}/${projectId}/environments/`],
-      [
-        'configs',
-        `/projects/${orgId}/${projectId}/rules/configuration/?issue_alerts_targeting=${issue_alerts_targeting}`,
-      ],
+      ['configs', `/projects/${orgId}/${projectId}/rules/configuration/`],
     ];
 
     if (ruleId) {

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -22,8 +22,7 @@ def get_activity_notifiers(project):
         for notifier in safe_execute(plugin.get_notifiers, _with_transaction=False) or ():
             results.append(notifier)
 
-    if project.flags.has_issue_alerts_targeting:
-        results.append(mail_adapter)
+    results.append(mail_adapter)
 
     return results
 

--- a/src/sentry/tasks/signals.py
+++ b/src/sentry/tasks/signals.py
@@ -21,5 +21,5 @@ def signal(name, payload, project_id=None, **kwargs):
     for plugin in plugins.for_project(project, version=2):
         safe_execute(plugin.handle_signal, name=name, payload=payload, project=project)
 
-    if project and project.flags.has_issue_alerts_targeting:
+    if project:
         safe_execute(mail_adapter.handle_signal, name=name, payload=payload, project=project)

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -76,8 +76,7 @@ describe('ProjectAlertsCreate', function() {
     browserHistory.replace = jest.fn();
     memberActionCreators.fetchOrgMembers = jest.fn();
     MockApiClient.addMockResponse({
-      url:
-        '/projects/org-slug/project-slug/rules/configuration/?issue_alerts_targeting=0',
+      url: '/projects/org-slug/project-slug/rules/configuration/',
       body: TestStubs.ProjectAlertRuleConfiguration(),
     });
     MockApiClient.addMockResponse({

--- a/tests/js/spec/views/settings/projectAlerts/issueEditor.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/issueEditor.spec.jsx
@@ -55,8 +55,7 @@ describe('ProjectAlerts -> IssueEditor', function() {
   beforeEach(async function() {
     browserHistory.replace = jest.fn();
     MockApiClient.addMockResponse({
-      url:
-        '/projects/org-slug/project-slug/rules/configuration/?issue_alerts_targeting=0',
+      url: '/projects/org-slug/project-slug/rules/configuration/',
       body: TestStubs.ProjectAlertRuleConfiguration(),
     });
     MockApiClient.addMockResponse({

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -8,10 +8,6 @@ from sentry.testutils import APITestCase
 
 
 class ProjectRuleConfigurationTest(APITestCase):
-    def setUp(self):
-        self.project.flags.has_issue_alerts_targeting = False
-        self.project.save()
-
     def test_simple(self):
         self.login_as(user=self.user)
 
@@ -62,17 +58,8 @@ class ProjectRuleConfigurationTest(APITestCase):
             assert len(response.data["actions"]) == expected_actions
             assert len(response.data["conditions"]) == 0
 
-    def test_filter_out_notify_email_action(self):
-        self.run_mock_rules_test(0, {})
-
-    def test_filter_show_notify_email_action_migrated_project(self):
-        self.project.flags.has_issue_alerts_targeting = True
-        self.project.save()
+    def test_filter_show_notify_email_action(self):
         self.run_mock_rules_test(1, {})
-
-    def test_filter_show_notify_email_action_override(self):
-        self.run_mock_rules_test(0, {"issue_alerts_targeting": "0"})
-        self.run_mock_rules_test(1, {"issue_alerts_targeting": "1"})
 
     def test_show_notify_event_service_action(self):
         rules = RuleRegistry()


### PR DESCRIPTION
This is no longer in use since we've been using `MailAdapter` to send mail for a long time now.
Removing code that checks for this and all usages. Will remove the bitfield and reset it to 0 in a
separate pr.

This should fix https://forum.sentry.io/t/cant-add-send-an-e-mail-action-for-some-projects/11006.
Not sure how they got into that state to begin with - the migration for this will always set
`has_issue_alerts_targeting` on the project to True, unless it was skipped somehow.