### PR TITLE
fix(breadcrumbs): Fix column width in case scrollbar is always present

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/list.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/list.tsx
@@ -59,7 +59,6 @@ class ListContainer extends React.Component<Props, State> {
     if (this.listRef) {
       cache.clearAll();
       this.listRef.forceUpdateGrid();
-      this.listRef.recomputeGridSize();
     }
   };
 


### PR DESCRIPTION
When the Scrollbar is always present, the table's header was a bit misaligned. This PR fixes the issue.

Before:
![image](https://user-images.githubusercontent.com/29228205/92613082-d505fe00-f2ba-11ea-877a-fca8bca50514.png)


After:

![image](https://user-images.githubusercontent.com/29228205/92613117-df27fc80-f2ba-11ea-81e5-e8e776011783.png)
