### PR TITLE
build(github): Add getsentry/acceptance back with magic string

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     getsentry:
-      if: ${{ github.ref != 'refs/heads/master' }}
+      if: ${{ github.ref != 'refs/heads/master' && !contains(github.event.commits[0].message, '#test-getsentry') }}
       runs-on: ubuntu-16.04
       steps:
         - name: getsentry token

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -6,6 +6,33 @@ on:
   pull_request:
 
 jobs:
+    getsentry:
+      if: ${{ github.ref != 'refs/heads/master' }}
+      runs-on: ubuntu-16.04
+      steps:
+        - name: getsentry token
+          id: getsentry
+          uses: getsentry/action-github-app-token@v1
+          with:
+            app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
+            private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
+        # Notify getsentry
+        - name: Dispatch getsentry tests
+          uses: actions/github-script@v3
+          with:
+            github-token: ${{ steps.getsentry.outputs.token }}
+            script: |
+              github.actions.createWorkflowDispatch({
+                owner: 'getsentry',
+                repo: 'getsentry',
+                workflow_id: 'acceptance.yml',
+                ref: 'master',
+                inputs: {
+                  sha: '${{ github.event.pull_request.head.sha }}',
+                }
+              })
+
     jest:
       runs-on: ubuntu-latest
       env:


### PR DESCRIPTION
This allows you to opt in to a getsentry acceptance test run if your
latest commit message contains the string `#test-getsentry`

Reverts https://github.com/getsentry/sentry/pull/20544 (parent https://github.com/getsentry/sentry/pull/20367)