### PR TITLE
feat(vercel): adds instructions for Vercel

### DIFF
--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -69,12 +69,16 @@ class OrganizationIntegrationSerializer(Serializer):
         except NotImplementedError:
             # slack doesn't have an installation implementation
             config_data = obj.config
+            dynamic_display_information = None
         else:
             # just doing this to avoid querying for an object we already have
             installation._org_integration = obj
             config_data = installation.get_config_data()
+            dynamic_display_information = installation.get_dynamic_display_information()
 
         integration.update({"configData": config_data})
+        if dynamic_display_information:
+            integration.update({"dynamicDisplayInformation": dynamic_display_information})
 
         return integration
 

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -289,6 +289,9 @@ class IntegrationInstallation(object):
     def get_config_data(self):
         return self.org_integration.config
 
+    def get_dynamic_display_information(self):
+        return None
+
     def get_client(self):
         # Return the api client for a given provider
         raise NotImplementedError

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -6,6 +6,7 @@ import logging
 
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.serializers import ValidationError
+from six.moves.urllib.parse import urlencode
 
 
 from sentry.integrations import (
@@ -21,6 +22,7 @@ from sentry.pipeline import NestedPipelineView
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.utils.http import absolute_uri
 from sentry.models import (
+    Organization,
     Integration,
     Project,
     ProjectKey,
@@ -36,9 +38,11 @@ from .client import VercelClient
 
 logger = logging.getLogger("sentry.integrations.vercel")
 
-DESCRIPTION = """
+DESCRIPTION = _(
+    """
 Vercel is an all-in-one platform with Global CDN supporting static & JAMstack deployment and Serverless Functions.
 """
+)
 
 FEATURES = [
     FeatureDescription(
@@ -49,7 +53,7 @@ FEATURES = [
     ),
 ]
 
-INSTALL_NOTICE_TEXT = (
+INSTALL_NOTICE_TEXT = _(
     "Visit the Vercel Marketplace to install this integration. After installing the"
     " Sentry integration, you'll be redirected back to Sentry to finish syncing Vercel and Sentry projects."
 )
@@ -63,11 +67,19 @@ external_install = {
 
 
 configure_integration = {"title": _("Connect Your Projects")}
+connect_project_instruction = _(
+    "To complete installation, please connect your Sentry and Vercel projects."
+)
+install_source_code_integration = _(
+    "Install a [source code integration]({}) and configure your repositories."
+)
 
 disable_dialog = {
-    "actionText": "Visit Vercel",
-    "body": "In order to uninstall this integration, you must go"
-    " to Vercel and uninstall there by clicking 'Remove Configuration'.",
+    "actionText": _("Visit Vercel"),
+    "body": _(
+        "In order to uninstall this integration, you must go"
+        " to Vercel and uninstall there by clicking 'Remove Configuration'."
+    ),
 }
 
 
@@ -96,6 +108,21 @@ class VercelIntegration(IntegrationInstallation):
     @property
     def metadata(self):
         return self.model.metadata
+
+    def get_dynamic_display_information(self):
+        organization = Organization.objects.get_from_cache(id=self.organization_id)
+        source_code_link = absolute_uri(
+            u"/settings/%s/integrations/?%s"
+            % (organization.slug, urlencode({"category": "source code management"}))
+        )
+        return {
+            "configure_integration": {
+                "instructions": [
+                    connect_project_instruction,
+                    install_source_code_integration.format(source_code_link),
+                ]
+            }
+        }
 
     def get_client(self):
         access_token = self.metadata["access_token"]

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -858,6 +858,11 @@ export type Integration = {
       | 'born_as_bot'
       | 'migrated_to_bot';
   };
+  dynamicDisplayInformation?: {
+    configure_integration?: {
+      instructions: string[];
+    };
+  };
 };
 
 export type IntegrationExternalIssue = {

--- a/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -16,6 +16,8 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import withOrganization from 'app/utils/withOrganization';
 import {Organization, Integration, IntegrationProvider} from 'app/types';
 import {trackIntegrationEvent} from 'app/utils/integrationUtil';
+import {singleLineRenderer} from 'app/utils/marked';
+import Alert from 'app/components/alert';
 
 type RouteParams = {
   orgId: string;
@@ -123,6 +125,14 @@ class ConfigureIntegration extends AsyncView<Props, State> {
               }
             />
           </Form>
+        )}
+
+        {integration.dynamicDisplayInformation?.configure_integration?.instructions.map(
+          instruction => (
+            <Alert type="info">
+              <span dangerouslySetInnerHTML={{__html: singleLineRenderer(instruction)}} />
+            </Alert>
+          )
         )}
 
         {provider && provider.features.includes('alert-rule') && (


### PR DESCRIPTION
This PR adds instructions for the configure integration view for Vercel to help the user. See the alerts on the bottom:

![Screen Shot 2020-09-09 at 11 11 08 AM](https://user-images.githubusercontent.com/8533851/92637169-59da2300-f28d-11ea-99b0-5f30f9636466.png)


Because the link in the second instruction is dynamic, I had to add a new field to integrations called `dynamicDisplayInformation`. This is similar to the existing `aspects` field but might change from organization to organization.

I also added some translations where they were missing