### PR TITLE
chore: remove DJANGO_VERSION

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -100,9 +100,6 @@ jobs:
         SENTRY_SKIP_BACKEND_VALIDATION: 1
         MIGRATIONS_TEST_MIGRATE: 0
 
-        # Use this to override the django version in the requirements file.
-        DJANGO_VERSION: ">=1.11,<1.12"
-
         # Node configuration
         NODE_OPTIONS: --max-old-space-size=4096
         NODE_ENV: development

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -18,9 +18,6 @@ jobs:
         # The hostname used to communicate with the PostgreSQL from sentry
         DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
 
-        # Use this to override the django version in the requirements file.
-        DJANGO_VERSION: ">=1.11,<1.12"
-
       services:
         postgres:
           image: postgres:9.6

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,9 +20,6 @@ jobs:
       # The hostname used to communicate with the PostgreSQL from sentry
       DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
 
-      # Use this to override the django version in the requirements file.
-      DJANGO_VERSION: ">=1.11,<1.12"
-
     services:
       postgres:
         image: postgres:9.6
@@ -121,9 +118,6 @@ jobs:
 
       SENTRY_LIGHT_BUILD: 1
       SENTRY_SKIP_BACKEND_VALIDATION: 1
-
-      # Use this to override the django version in the requirements file.
-      DJANGO_VERSION: ">=1.11,<1.12"
 
       PYTEST_SENTRY_DSN: https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
       # XXX(py3): Reruns are disabled for until all tests are passing.

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ env:
     - SENTRY_LIGHT_BUILD=1
     - SENTRY_SKIP_BACKEND_VALIDATION=1
     - MIGRATIONS_TEST_MIGRATE=0
-    # Use this to override the django version in the requirements file.
-    - DJANGO_VERSION=">=1.11,<1.12"
     - VOLTA_VERSION=0.8.1
     - VOLTA_HOME="${HOME}/.volta"
     - PATH="${HOME}/.volta/bin:${PATH}"

--- a/setup.py
+++ b/setup.py
@@ -40,14 +40,6 @@ def get_requirements(env):
 install_requires = get_requirements("base")
 dev_requires = get_requirements("dev")
 
-# override django version in requirements file if DJANGO_VERSION is set
-DJANGO_VERSION = os.environ.get("DJANGO_VERSION")
-if DJANGO_VERSION:
-    install_requires = [
-        u"Django{}".format(DJANGO_VERSION) if r.startswith("Django>=") else r
-        for r in install_requires
-    ]
-
 
 class SentrySDistCommand(SDistCommand):
     # If we are not a light build we want to also execute build_assets as


### PR DESCRIPTION
I don't see us upgrading Django anytime soon, and even if we were to, it'd be cleaner to just explicitly pip install over it exclusively in CI rather than change behavior in setup.py.

I double checked the [org-wide search](https://github.com/search?q=org%3Agetsentry+DJANGO_VERSION&type=Code), this is exclusively inside sentry.

