### PR TITLE
ref(alert): Refactor arguments for slack channel function

### DIFF
--- a/src/sentry/integrations/slack/tasks.py
+++ b/src/sentry/integrations/slack/tasks.py
@@ -58,18 +58,7 @@ class RedisRuleStatus(object):
 
 
 @instrumented_task(name="sentry.integrations.slack.search_channel_id", queue="integrations")
-def find_channel_id_for_rule(
-    name,
-    environment,
-    project,
-    action_match,
-    filter_match,
-    conditions,
-    actions,
-    frequency,
-    uuid,
-    rule_id=None,
-):
+def find_channel_id_for_rule(project, actions, uuid, rule_id=None, **kwargs):
     redis_rule_status = RedisRuleStatus(uuid)
 
     try:
@@ -118,16 +107,8 @@ def find_channel_id_for_rule(
                 action["channel_id"] = item_id
                 break
 
-        kwargs = {
-            "name": name,
-            "environment": environment,
-            "project": project,
-            "action_match": action_match,
-            "filter_match": filter_match,
-            "conditions": conditions,
-            "actions": actions,
-            "frequency": frequency,
-        }
+        kwargs["actions"] = actions
+        kwargs["project"] = project
 
         if rule_id:
             rule = Rule.objects.get(id=rule_id)


### PR DESCRIPTION
Previously this function broke due to an additional parameter being added to rule creation and had to be fixed here: https://github.com/getsentry/sentry/pull/20478

Removed unused parameters and configured this celery task/function to carry on extra parameters that are not used in the function's logic to be passed along to the rule creator/updater