### PR TITLE
build(snapshots): Use child dirs for snapshots

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -218,9 +218,9 @@ jobs:
         - name: Run acceptance tests (#${{ steps.config.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
           if: always()
           run: |
-            mkdir -p ${{ steps.config.outputs.acceptance-dir }}
-            mkdir -p ${{ steps.config.outputs.acceptance-dir }}-mobile
-            mkdir -p ${{ steps.config.outputs.acceptance-dir }}-tooltips
+            mkdir -p ${{ steps.config.outputs.acceptance-dir }}/1680px
+            mkdir -p ${{ steps.config.outputs.acceptance-dir }}/375px
+            mkdir -p ${{ steps.config.outputs.acceptance-dir }}/tooltips
             [ "$GITHUB_REF" = "refs/heads/master" ] && export PYTEST_SENTRY_ALWAYS_REPORT=1
             make run-acceptance
           env:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -152,6 +152,7 @@ jobs:
             echo "::set-output name=matrix-instance-number::$(($MATRIX_INSTANCE+1))"
             echo "::set-output name=acceptance-dir::.artifacts/visual-snapshots/acceptance"
 
+
         # yarn cache
         - uses: actions/cache@v1
           id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -229,7 +230,7 @@ jobs:
 
         - name: Save snapshots
           if: always()
-          uses: getsentry/action-visual-snapshot@v2
+          uses: getsentry/action-visual-snapshot@v2-dev
           with:
             save-only: true
             snapshot-path: .artifacts/visual-snapshots
@@ -242,7 +243,7 @@ jobs:
       steps:
         - name: Diff snapshots
           id: visual-snapshots-diff
-          uses: getsentry/action-visual-snapshot@v2
+          uses: getsentry/action-visual-snapshot@v2-dev
           with:
             api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
             github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This refactors snapshots to use sub directories for snapshots instead of a different root directory.
It also makes the sub directories the widths of the window sizes where we take snapshots.

This will allow the action to group the snapshots together if they both change.

e.g. instead of:

```
acceptance/snapshot.png
acceptance-mobile/snapshot.png
```

we will have

```
acceptance/1680px/snapshot.png
acceptance/375px/snapshot.png
```