### PR TITLE
build(github): Fix `#test-getsentry` logic

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -23,7 +23,7 @@ jobs:
 
     getsentry:
       needs: parse-commit-message
-      if: ${{ github.ref != 'refs/heads/master' && contains(needs.parse-commit-message.outputs.commit, '#test-getsentry') }}
+      if: ${{ contains(needs.parse-commit-message.outputs.commit, '#test-getsentry') }}
       runs-on: ubuntu-16.04
       steps:
         - name: getsentry token

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -19,7 +19,7 @@ jobs:
         - name: Parse commit message
           id: commit
           run: |
-            echo "::set-output name=message::$(git log --format=%B ${{ github.event.after }})"
+            echo "::set-output name=message::$(git show -s --format=%B)"
 
     getsentry:
       needs: parse-commit-message

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -6,8 +6,24 @@ on:
   pull_request:
 
 jobs:
+    parse-commit-message:
+      if: ${{ github.ref != 'refs/heads/master' }}
+      runs-on: ubuntu-16.04
+      outputs:
+        commit: ${{ steps.commit.outputs.message }}
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            ref: ${{ github.event.pull_request.head.sha }}
+
+        - name: Parse commit message
+          id: commit
+          run: |
+            echo "::set-output name=message::$(git log --format=%B ${{ github.event.after }})"
+
     getsentry:
-      if: ${{ github.ref != 'refs/heads/master' && !contains(github.event.commits[0].message, '#test-getsentry') }}
+      needs: parse-commit-message
+      if: ${{ github.ref != 'refs/heads/master' && contains(needs.parse-commit-message.outputs.commit, '#test-getsentry') }}
       runs-on: ubuntu-16.04
       steps:
         - name: getsentry token


### PR DESCRIPTION
Fixes the wrong logic but also this did not work because we need this on `pull_request` events which do not include a list of commits (it is only in the `push` event).