### PR TITLE
feat(workflow): Add rate limiting to issues endpoints

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -31,7 +31,7 @@ from sentry.models import (
     User,
     UserReport,
 )
-from sentry.api.helpers.group_index import rate_limit_issue_endpoint
+from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.plugins.base import plugins
 from sentry.plugins.bases import IssueTrackingPlugin2
 from sentry.signals import issue_deleted
@@ -187,7 +187,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         ]
 
     @attach_scenarios([retrieve_aggregate_scenario])
-    @rate_limit_issue_endpoint(limit=10, window=1)
+    @rate_limit_endpoint(limit=10, window=1)
     def get(self, request, group):
         """
         Retrieve an Issue
@@ -336,7 +336,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             raise
 
     @attach_scenarios([update_aggregate_scenario])
-    @rate_limit_issue_endpoint(limit=10, window=1)
+    @rate_limit_endpoint(limit=10, window=1)
     def put(self, request, group):
         """
         Update an Issue
@@ -418,7 +418,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             raise
 
     @attach_scenarios([delete_aggregate_scenario])
-    @rate_limit_issue_endpoint(limit=10, window=1)
+    @rate_limit_endpoint(limit=10, window=1)
     def delete(self, request, group):
         """
         Remove an Issue

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -201,9 +201,8 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         :auth: required
         """
         try:
-            from sentry.utils import snuba
-
             # TODO(dcramer): handle unauthenticated/public response
+            from sentry.utils import snuba
 
             organization = group.project.organization
             environments = get_environments(request, organization)

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -31,6 +31,7 @@ from sentry.models import (
     User,
     UserReport,
 )
+from sentry.api.helpers.group_index import rate_limit_issue_endpoint
 from sentry.plugins.base import plugins
 from sentry.plugins.bases import IssueTrackingPlugin2
 from sentry.signals import issue_deleted
@@ -186,6 +187,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         ]
 
     @attach_scenarios([retrieve_aggregate_scenario])
+    @rate_limit_issue_endpoint(limit=10, window=1)
     def get(self, request, group):
         """
         Retrieve an Issue
@@ -199,8 +201,9 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         :auth: required
         """
         try:
-            # TODO(dcramer): handle unauthenticated/public response
             from sentry.utils import snuba
+
+            # TODO(dcramer): handle unauthenticated/public response
 
             organization = group.project.organization
             environments = get_environments(request, organization)
@@ -333,6 +336,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             raise
 
     @attach_scenarios([update_aggregate_scenario])
+    @rate_limit_issue_endpoint(limit=10, window=1)
     def put(self, request, group):
         """
         Update an Issue
@@ -414,6 +418,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             raise
 
     @attach_scenarios([delete_aggregate_scenario])
+    @rate_limit_issue_endpoint(limit=10, window=1)
     def delete(self, request, group):
         """
         Remove an Issue

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -15,7 +15,7 @@ from sentry.api.helpers.group_index import (
     build_query_params_from_request,
     delete_groups,
     get_by_short_id,
-    rate_limit_issue_endpoint,
+    rate_limit_endpoint,
     update_groups,
     ValidationError,
 )
@@ -62,7 +62,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         result = search.query(**query_kwargs)
         return result, query_kwargs
 
-    @rate_limit_issue_endpoint(limit=10, window=1)
+    @rate_limit_endpoint(limit=10, window=1)
     def get(self, request, organization):
         """
         List an Organization's Issues
@@ -104,22 +104,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                                           issues belong to.
         :auth: required
         """
-        # if ratelimiter.is_limited(
-        #     u"api:group-index-get:{}".format(
-        #         md5_text(
-        #             request.user.id if request.user else ""
-        #         ).hexdigest()
-        #     ),
-        #     limit=1,
-        #     window=1,
-        # ):
-        #     return Response(
-        #         {
-        #             "detail": "You are attempting to use this endpoint too quickly. Limit is 1 request per second."
-        #         },
-        #         status=429,
-        #     )
-
         stats_period = request.GET.get("groupStatsPeriod")
         if stats_period not in (None, "", "24h", "14d"):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
@@ -260,7 +244,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         # TODO(jess): add metrics that are similar to project endpoint here
         return response
 
-    @rate_limit_issue_endpoint(limit=10, window=1)
+    @rate_limit_endpoint(limit=10, window=1)
     def put(self, request, organization):
         """
         Bulk Mutate a List of Issues
@@ -322,22 +306,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                                      the bookmark flag.
         :auth: required
         """
-        # if ratelimiter.is_limited(
-        #     u"api:group-index-put:{}".format(
-        #         md5_text(
-        #             request.user.id if request.user else ""
-        #         ).hexdigest()
-        #     ),
-        #     limit=1,
-        #     window=1,
-        # ):
-        #     return Response(
-        #         {
-        #             "detail": "You are attempting to use this endpoint too quickly. Limit is 1 request per second."
-        #         },
-        #         status=429,
-        #     )
-
         projects = self.get_projects(request, organization)
         if len(projects) > 1 and not features.has(
             "organizations:global-views", organization, actor=request.user
@@ -355,7 +323,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         )
         return update_groups(request, projects, organization.id, search_fn)
 
-    @rate_limit_issue_endpoint(limit=10, window=1)
+    @rate_limit_endpoint(limit=10, window=1)
     def delete(self, request, organization):
         """
         Bulk Remove a List of Issues
@@ -376,21 +344,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                                           issues belong to.
         :auth: required
         """
-        # if ratelimiter.is_limited(
-        #     u"api:group-index-delete:{}".format(
-        #         md5_text(
-        #             request.user.id if request.user else ""
-        #         ).hexdigest()
-        #     ),
-        #     limit=1,
-        #     window=1,
-        # ):
-        #     return Response(
-        #         {
-        #             "detail": "You are attempting to use this endpoint too quickly. Limit is 1 request per second."
-        #         },
-        #         status=429,
-        #     )
         projects = self.get_projects(request, organization)
         if len(projects) > 1 and not features.has(
             "organizations:global-views", organization, actor=request.user

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -15,6 +15,7 @@ from sentry.api.helpers.group_index import (
     build_query_params_from_request,
     delete_groups,
     get_by_short_id,
+    rate_limit_issue_endpoint,
     update_groups,
     ValidationError,
 )
@@ -61,6 +62,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         result = search.query(**query_kwargs)
         return result, query_kwargs
 
+    @rate_limit_issue_endpoint(limit=10, window=1)
     def get(self, request, organization):
         """
         List an Organization's Issues
@@ -102,6 +104,22 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                                           issues belong to.
         :auth: required
         """
+        # if ratelimiter.is_limited(
+        #     u"api:group-index-get:{}".format(
+        #         md5_text(
+        #             request.user.id if request.user else ""
+        #         ).hexdigest()
+        #     ),
+        #     limit=1,
+        #     window=1,
+        # ):
+        #     return Response(
+        #         {
+        #             "detail": "You are attempting to use this endpoint too quickly. Limit is 1 request per second."
+        #         },
+        #         status=429,
+        #     )
+
         stats_period = request.GET.get("groupStatsPeriod")
         if stats_period not in (None, "", "24h", "14d"):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
@@ -242,6 +260,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         # TODO(jess): add metrics that are similar to project endpoint here
         return response
 
+    @rate_limit_issue_endpoint(limit=10, window=1)
     def put(self, request, organization):
         """
         Bulk Mutate a List of Issues
@@ -303,6 +322,21 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                                      the bookmark flag.
         :auth: required
         """
+        # if ratelimiter.is_limited(
+        #     u"api:group-index-put:{}".format(
+        #         md5_text(
+        #             request.user.id if request.user else ""
+        #         ).hexdigest()
+        #     ),
+        #     limit=1,
+        #     window=1,
+        # ):
+        #     return Response(
+        #         {
+        #             "detail": "You are attempting to use this endpoint too quickly. Limit is 1 request per second."
+        #         },
+        #         status=429,
+        #     )
 
         projects = self.get_projects(request, organization)
         if len(projects) > 1 and not features.has(
@@ -321,6 +355,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         )
         return update_groups(request, projects, organization.id, search_fn)
 
+    @rate_limit_issue_endpoint(limit=10, window=1)
     def delete(self, request, organization):
         """
         Bulk Remove a List of Issues
@@ -341,6 +376,21 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                                           issues belong to.
         :auth: required
         """
+        # if ratelimiter.is_limited(
+        #     u"api:group-index-delete:{}".format(
+        #         md5_text(
+        #             request.user.id if request.user else ""
+        #         ).hexdigest()
+        #     ),
+        #     limit=1,
+        #     window=1,
+        # ):
+        #     return Response(
+        #         {
+        #             "detail": "You are attempting to use this endpoint too quickly. Limit is 1 request per second."
+        #         },
+        #         status=429,
+        #     )
         projects = self.get_projects(request, organization)
         if len(projects) > 1 and not features.has(
             "organizations:global-views", organization, actor=request.user

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -457,12 +457,12 @@ def track_update_groups(function):
     return wrapper
 
 
-def rate_limit_issue_endpoint(limit=1, window=1):
+def rate_limit_endpoint(limit=1, window=1):
     def inner(function):
-        def wrapper(request, *args, **kwargs):
+        def wrapper(*args, **kwargs):
             try:
                 if ratelimiter.is_limited(
-                    u"api:issue-endpoint:{}".format(md5_text(function).hexdigest()),
+                    u"rate_limit_endpoint:{}".format(md5_text(function).hexdigest()),
                     limit=limit,
                     window=window,
                 ):
@@ -471,7 +471,7 @@ def rate_limit_issue_endpoint(limit=1, window=1):
                         status=429,
                     )
                 else:
-                    return function(request, *args, **kwargs)
+                    return function(*args, **kwargs)
             except Exception:
                 raise
 

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -30,6 +30,7 @@ from sentry.models import (
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import MockClock
 from sentry.plugins.base import plugins
+from sentry.utils.compat.mock import patch
 
 
 class GroupDetailsTest(APITestCase, SnubaTestCase):
@@ -299,6 +300,13 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         result = response.data["permalink"]
         assert "http://" in result
         assert "{}/issues/{}".format(group.organization.slug, group.id) in result
+
+    @patch(
+        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True,
+    )
+    def test_ratelimit(self, is_limited):
+        self.login_as(user=self.user)
+        self.get_valid_response(sort_by="date", limit=1, status_code=429)
 
 
 class GroupUpdateTest(APITestCase):
@@ -588,6 +596,13 @@ class GroupUpdateTest(APITestCase):
         assert tombstone.project == group.project
         assert tombstone.data == group.data
 
+    @patch(
+        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True,
+    )
+    def test_ratelimit(self, is_limited):
+        self.login_as(user=self.user)
+        self.get_valid_response(sort_by="date", limit=1, status_code=429)
+
 
 class GroupDeleteTest(APITestCase):
     def test_delete(self):
@@ -619,3 +634,10 @@ class GroupDeleteTest(APITestCase):
         # Now we killed everything with fire
         assert not Group.objects.filter(id=group.id).exists()
         assert not GroupHash.objects.filter(group_id=group.id).exists()
+
+    @patch(
+        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True,
+    )
+    def test_ratelimit(self, is_limited):
+        self.login_as(user=self.user)
+        self.get_valid_response(sort_by="date", limit=1, status_code=429)

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -306,7 +306,10 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
     )
     def test_ratelimit(self, is_limited):
         self.login_as(user=self.user)
-        self.get_valid_response(sort_by="date", limit=1, status_code=429)
+        group = self.create_group()
+        url = u"/api/0/issues/{}/".format(group.id)
+        response = self.client.get(url, sort_by="date", limit=1)
+        assert response.status_code == 429
 
 
 class GroupUpdateTest(APITestCase):
@@ -601,7 +604,10 @@ class GroupUpdateTest(APITestCase):
     )
     def test_ratelimit(self, is_limited):
         self.login_as(user=self.user)
-        self.get_valid_response(sort_by="date", limit=1, status_code=429)
+        group = self.create_group()
+        url = u"/api/0/issues/{}/".format(group.id)
+        response = self.client.put(url, sort_by="date", limit=1)
+        assert response.status_code == 429
 
 
 class GroupDeleteTest(APITestCase):
@@ -640,4 +646,7 @@ class GroupDeleteTest(APITestCase):
     )
     def test_ratelimit(self, is_limited):
         self.login_as(user=self.user)
-        self.get_valid_response(sort_by="date", limit=1, status_code=429)
+        group = self.create_group()
+        url = u"/api/0/issues/{}/".format(group.id)
+        response = self.client.delete(url, sort_by="date", limit=1)
+        assert response.status_code == 429

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -648,6 +648,13 @@ class GroupListTest(APITestCase, SnubaTestCase):
             assert response.data[0]["lifetime"] is not None
             assert response.data[0]["filtered"] is not None
 
+    @patch(
+        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True,
+    )
+    def test_ratelimit(self, is_limited):
+        self.login_as(user=self.user)
+        self.get_valid_response(sort_by="date", limit=1, status_code=429)
+
 
 class GroupUpdateTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-group-index"
@@ -1541,6 +1548,13 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert tombstone.project == group1.project
         assert tombstone.data == group1.data
 
+    @patch(
+        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True,
+    )
+    def test_ratelimit(self, is_limited):
+        self.login_as(user=self.user)
+        self.get_valid_response(sort_by="date", limit=1, status_code=429)
+
 
 class GroupDeleteTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-group-index"
@@ -1661,3 +1675,10 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         for group in groups:
             assert not Group.objects.filter(id=group.id).exists()
             assert not GroupHash.objects.filter(group_id=group.id).exists()
+
+    @patch(
+        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True,
+    )
+    def test_ratelimit(self, is_limited):
+        self.login_as(user=self.user)
+        self.get_valid_response(sort_by="date", limit=1, status_code=429)


### PR DESCRIPTION
Adding some rate limiting to our issue endpoints (list and details - get, put, and delete). Rate is set at 10 requests per second. 