### PR TITLE
fix: There is always a project id when fetching span descendants

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -108,10 +108,6 @@ class SpanDetail extends React.Component<Props, State> {
       end,
     };
 
-    if (query.project.length === 0) {
-      delete query.project;
-    }
-
     return api.requestPromise(url, {
       method: 'GET',
       query,


### PR DESCRIPTION
Deleting code that will never run.

Surfaced from https://github.com/getsentry/sentry/pull/20702

cc @scttcper 