### PR TITLE
feat(flag): Add trends specific feature flag

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -32,7 +32,7 @@ class OrganizationEventsTrendsEndpoint(OrganizationEventsV2EndpointBase):
     }
 
     def has_feature(self, organization, request):
-        return features.has("organizations:internal-catchall", organization, actor=request.user)
+        return features.has("organizations:trends", organization, actor=request.user)
 
     def get(self, request, organization):
         if not self.has_feature(organization, request):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -900,6 +900,8 @@ SENTRY_FEATURES = {
     "organizations:sso-saml2": True,
     # Enable Rippling SSO functionality.
     "organizations:sso-rippling": False,
+    # Enable trends view for performance.
+    "organizations:trends": False,
     # Enable graph for subscription quota for errors, transactions and
     # attachments
     "organizations:usage-stats-graph": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -99,6 +99,7 @@ default_manager.add("organizations:sso-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:sso-rippling", OrganizationFeature)  # NOQA
 default_manager.add("organizations:sso-saml2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:symbol-sources", OrganizationFeature)  # NOQA
+default_manager.add("organizations:trends", OrganizationFeature)  # NOQA
 default_manager.add("organizations:usage-stats-graph", OrganizationFeature)  # NOQA
 default_manager.add("organizations:dynamic-issue-counts", OrganizationFeature)  # NOQA
 # XXX(mark) Don't use this feature it is going away soon.

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -198,7 +198,7 @@ class PerformanceLanding extends React.Component<Props, State> {
 
   renderHeaderButtons() {
     return (
-      <Feature features={['internal-catchall']}>
+      <Feature features={['trends']}>
         {({hasFeature}) =>
           hasFeature ? (
             <ButtonBar merged active={this.getCurrentView()}>

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -73,7 +73,7 @@ class TrendsContent extends React.Component<Props, State> {
 
     const query = getTransactionSearchQuery(location);
     return (
-      <Feature features={['internal-catchall']}>
+      <Feature features={['trends']}>
         <StyledSearchContainer>
           <StyledSearchBar
             organization={organization}

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -31,7 +31,7 @@ function selectTrendFunction(wrapper, field) {
 }
 
 function initializeData(projects, query) {
-  const features = ['transaction-event', 'performance-view', 'internal-catchall'];
+  const features = ['transaction-event', 'performance-view', 'trends'];
   const organization = TestStubs.Organization({
     features,
     projects,

--- a/tests/snuba/api/endpoints/test_organization_events_trends.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trends.py
@@ -37,7 +37,7 @@ class OrganizationEventsTrendsEndpointTest(APITestCase, SnubaTestCase):
             self.store_event(data, project_id=self.project.id)
 
     def test_simple(self):
-        with self.feature("organizations:internal-catchall"):
+        with self.feature("organizations:trends"):
             url = reverse(
                 "sentry-api-0-organization-events-trends",
                 kwargs={"organization_slug": self.project.organization.slug},
@@ -80,7 +80,7 @@ class OrganizationEventsTrendsEndpointTest(APITestCase, SnubaTestCase):
         ]
 
     def test_avg_trend_function(self):
-        with self.feature("organizations:internal-catchall"):
+        with self.feature("organizations:trends"):
             url = reverse(
                 "sentry-api-0-organization-events-trends",
                 kwargs={"organization_slug": self.project.organization.slug},
@@ -124,7 +124,7 @@ class OrganizationEventsTrendsEndpointTest(APITestCase, SnubaTestCase):
         ]
 
     def test_misery_trend_function(self):
-        with self.feature("organizations:internal-catchall"):
+        with self.feature("organizations:trends"):
             url = reverse(
                 "sentry-api-0-organization-events-trends",
                 kwargs={"organization_slug": self.project.organization.slug},
@@ -168,7 +168,7 @@ class OrganizationEventsTrendsEndpointTest(APITestCase, SnubaTestCase):
         ]
 
     def test_invalid_trend_function(self):
-        with self.feature("organizations:internal-catchall"):
+        with self.feature("organizations:trends"):
             url = reverse(
                 "sentry-api-0-organization-events-trends",
                 kwargs={"organization_slug": self.project.organization.slug},
@@ -188,7 +188,7 @@ class OrganizationEventsTrendsEndpointTest(APITestCase, SnubaTestCase):
             assert response.status_code == 400
 
     def test_divide_by_zero(self):
-        with self.feature("organizations:internal-catchall"):
+        with self.feature("organizations:trends"):
             url = reverse(
                 "sentry-api-0-organization-events-trends",
                 kwargs={"organization_slug": self.project.organization.slug},
@@ -268,7 +268,7 @@ class OrganizationEventsTrendsPagingTest(APITestCase, SnubaTestCase):
         return links
 
     def test_pagination(self):
-        with self.feature("organizations:internal-catchall"):
+        with self.feature("organizations:trends"):
             url = reverse(
                 "sentry-api-0-organization-events-trends",
                 kwargs={"organization_slug": self.project.organization.slug},
@@ -301,7 +301,7 @@ class OrganizationEventsTrendsPagingTest(APITestCase, SnubaTestCase):
             assert len(response.data["events"]["data"]) == 5
 
     def test_pagination_with_query(self):
-        with self.feature("organizations:internal-catchall"):
+        with self.feature("organizations:trends"):
             url = reverse(
                 "sentry-api-0-organization-events-trends",
                 kwargs={"organization_slug": self.project.organization.slug},


### PR DESCRIPTION
### Summary
This will allow us to add more than just internal teams into trends, replacing the existing 'internal-catchall' guards