### PR TITLE
fix: Remove unnecessary onClick handler from ShortId component

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.jsx
@@ -57,6 +57,10 @@ class EventOrGroupExtraDetails extends React.Component {
             avatar={
               project && <ProjectBadge project={project} avatarSize={14} hideName />
             }
+            onClick={event => {
+              // prevent the clicks from propagating so that the short id can be selected
+              event.stopPropagation();
+            }}
           />
         )}
         <StyledTimes lastSeen={lastSeen} firstSeen={firstSeen} />

--- a/src/sentry/static/sentry/app/components/shortId.tsx
+++ b/src/sentry/static/sentry/app/components/shortId.tsx
@@ -8,23 +8,12 @@ import AutoSelectText from 'app/components/autoSelectText';
 type Props = {
   shortId: string;
   avatar?: React.ReactNode;
-  stopPropagation?: boolean;
 };
 
 export default class ShortId extends React.Component<Props> {
   static propTypes = {
     shortId: PropTypes.string.isRequired,
     avatar: PropTypes.node,
-  };
-
-  onClick = (event: React.MouseEvent) => {
-    if (this.props.stopPropagation === false) {
-      return;
-    }
-
-    // this is a hack for the stream so the click handler doesn't
-    // affect this element
-    event.stopPropagation();
   };
 
   render() {
@@ -35,7 +24,7 @@ export default class ShortId extends React.Component<Props> {
     }
 
     return (
-      <StyledShortId onClick={this.onClick} {...this.props}>
+      <StyledShortId {...this.props}>
         {avatar}
         <StyledAutoSelectText avatar={!!avatar}>{shortId}</StyledAutoSelectText>
       </StyledShortId>

--- a/src/sentry/static/sentry/app/components/shortId.tsx
+++ b/src/sentry/static/sentry/app/components/shortId.tsx
@@ -8,6 +8,7 @@ import AutoSelectText from 'app/components/autoSelectText';
 type Props = {
   shortId: string;
   avatar?: React.ReactNode;
+  stopPropagation?: boolean;
 };
 
 export default class ShortId extends React.Component<Props> {
@@ -16,11 +17,15 @@ export default class ShortId extends React.Component<Props> {
     avatar: PropTypes.node,
   };
 
-  preventPropagation(e: React.MouseEvent) {
+  onClick = (event: React.MouseEvent) => {
+    if (this.props.stopPropagation === false) {
+      return;
+    }
+
     // this is a hack for the stream so the click handler doesn't
     // affect this element
-    e.stopPropagation();
-  }
+    event.stopPropagation();
+  };
 
   render() {
     const {shortId, avatar} = this.props;
@@ -30,7 +35,7 @@ export default class ShortId extends React.Component<Props> {
     }
 
     return (
-      <StyledShortId onClick={this.preventPropagation} {...this.props}>
+      <StyledShortId onClick={this.onClick} {...this.props}>
         {avatar}
         <StyledAutoSelectText avatar={!!avatar}>{shortId}</StyledAutoSelectText>
       </StyledShortId>

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -220,7 +220,7 @@ const SPECIAL_FIELDS: SpecialFields = {
       return (
         <Container>
           <OverflowLink to={target} aria-label={issueID}>
-            <StyledShortId shortId={`${data.issue}`} stopPropagation={false} />
+            <StyledShortId shortId={`${data.issue}`} />
           </OverflowLink>
         </Container>
       );

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -187,7 +187,10 @@ const SPECIAL_FIELDS: SpecialFields = {
   'issue.id': {
     sortField: 'issue.id',
     renderFunc: (data, {organization}) => {
-      const target = `/organizations/${organization.slug}/issues/${data['issue.id']}/`;
+      const target = {
+        pathname: `/organizations/${organization.slug}/issues/${data['issue.id']}/`,
+      };
+
       return (
         <Container>
           <OverflowLink to={target} aria-label={data['issue.id']}>
@@ -210,7 +213,10 @@ const SPECIAL_FIELDS: SpecialFields = {
         );
       }
 
-      const target = `/organizations/${organization.slug}/issues/${issueID}/`;
+      const target = {
+        pathname: `/organizations/${organization.slug}/issues/${issueID}/`,
+      };
+
       return (
         <Container>
           <OverflowLink to={target} aria-label={issueID}>

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -220,7 +220,7 @@ const SPECIAL_FIELDS: SpecialFields = {
       return (
         <Container>
           <OverflowLink to={target} aria-label={issueID}>
-            <StyledShortId shortId={`${data.issue}`} />
+            <StyledShortId shortId={`${data.issue}`} stopPropagation={false} />
           </OverflowLink>
         </Container>
       );


### PR DESCRIPTION
This was causing hard reloads for when you click on the the `Issue` field cells in Discover.

<img width="1656" alt="Screen Shot 2020-09-10 at 1 25 26 PM" src="https://user-images.githubusercontent.com/139499/92771744-27055d00-f369-11ea-982e-a49bf0c16df5.png">


