### PR TITLE
ref(alert): Add helper text and change styles slightly

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -75,7 +75,7 @@ class EventAttributeCondition(EventCondition):
     # TODO(dcramer): add support for stacktrace.vars.[name]
 
     form_cls = EventAttributeForm
-    label = u"An event's {attribute} value {match} {value}"
+    label = u"The event's {attribute} value {match} {value}"
 
     form_fields = {
         "attribute": {

--- a/src/sentry/rules/conditions/every_event.py
+++ b/src/sentry/rules/conditions/every_event.py
@@ -4,7 +4,7 @@ from sentry.rules.conditions.base import EventCondition
 
 
 class EveryEventCondition(EventCondition):
-    label = "An event occurs"
+    label = "The event occurs"
 
     def passes(self, event, state):
         return True

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -34,7 +34,7 @@ class LevelEventForm(forms.Form):
 
 class LevelCondition(EventCondition):
     form_cls = LevelEventForm
-    label = "An event's level is {match} {level}"
+    label = "The event's level is {match} {level}"
     form_fields = {
         "level": {"type": "choice", "choices": LEVEL_CHOICES.items()},
         "match": {"type": "choice", "choices": MATCH_CHOICES.items()},

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -49,7 +49,7 @@ class TaggedEventForm(forms.Form):
 
 class TaggedEventCondition(EventCondition):
     form_cls = TaggedEventForm
-    label = u"An event's tags match {key} {match} {value}"
+    label = u"The event's tags match {key} {match} {value}"
 
     form_fields = {
         "key": {"type": "string", "placeholder": "key"},

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -475,7 +475,14 @@ class IssueRuleEditor extends AsyncView<Props, State> {
             </Panel>
 
             <Panel>
-              <PanelHeader>{t('Alert Conditions')}</PanelHeader>
+              <StyledPanelHeader>
+                {t('Alert Conditions')}
+                <PanelHelpText>
+                  {t(
+                    'Conditions are evaluated every time an event is captured by Sentry.'
+                  )}
+                </PanelHelpText>
+              </StyledPanelHeader>
               <PanelBody>
                 {detailedError && (
                   <PanelAlert type="error">
@@ -693,6 +700,19 @@ const StyledForm = styled(Form)`
   position: relative;
 `;
 
+const StyledPanelHeader = styled(PanelHeader)`
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+const PanelHelpText = styled('div')`
+  color: ${p => p.theme.gray500};
+  font-size: 14px;
+  font-weight: normal;
+  text-transform: none;
+  margin-top: ${space(1)};
+`;
+
 const StyledAlert = styled(Alert)`
   margin-bottom: 0;
 `;
@@ -724,7 +744,7 @@ const StepConnector = styled('div')`
 `;
 
 const StepLead = styled('div')`
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(0.5)};
 `;
 
 const ChevronContainer = styled('div')`
@@ -735,7 +755,7 @@ const ChevronContainer = styled('div')`
 
 const Badge = styled('span')`
   display: inline-block;
-  min-width: 51px;
+  min-width: 56px;
   background-color: ${p => p.theme.purple400};
   padding: 0 ${space(0.75)};
   border-radius: ${p => p.theme.borderRadius};
@@ -743,7 +763,7 @@ const Badge = styled('span')`
   text-transform: uppercase;
   text-align: center;
   font-size: ${p => p.theme.fontSizeMedium};
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.5;
 `;
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -325,7 +325,7 @@ class Factories(object):
             },
             {
                 "id": "sentry.rules.conditions.every_event.EveryEventCondition",
-                "name": "An event occurs",
+                "name": "The event occurs",
             },
         ]
         return Rule.objects.create(

--- a/tests/acceptance/test_project_alert_settings.py
+++ b/tests/acceptance/test_project_alert_settings.py
@@ -31,7 +31,7 @@ class ProjectAlertSettingsTest(AcceptanceTestCase):
             },
             {
                 "id": "sentry.rules.conditions.every_event.EveryEventCondition",
-                "name": "An event occurs",
+                "name": "The event occurs",
             },
         ]
 

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -46,7 +46,7 @@ class EventAttributeConditionTest(RuleTestCase):
         rule = self.get_rule(
             data={"match": MatchType.EQUAL, "attribute": u"\xc3", "value": u"\xc4"}
         )
-        assert rule.render_label() == u"An event's \xc3 value equals \xc4"
+        assert rule.render_label() == u"The event's \xc3 value equals \xc4"
 
     def test_equals(self):
         event = self.get_event()

--- a/tests/sentry/rules/conditions/test_level_event.py
+++ b/tests/sentry/rules/conditions/test_level_event.py
@@ -9,7 +9,7 @@ class LevelConditionTest(RuleTestCase):
 
     def test_render_label(self):
         rule = self.get_rule(data={"match": MatchType.EQUAL, "level": "30"})
-        assert rule.render_label() == u"An event's level is equal to warning"
+        assert rule.render_label() == u"The event's level is equal to warning"
 
     def test_equals(self):
         event = self.store_event(data={"level": "info"}, project_id=self.project.id)

--- a/tests/sentry/rules/conditions/test_tagged_event.py
+++ b/tests/sentry/rules/conditions/test_tagged_event.py
@@ -19,7 +19,7 @@ class TaggedEventConditionTest(RuleTestCase):
 
     def test_render_label(self):
         rule = self.get_rule(data={"match": MatchType.EQUAL, "key": u"\xc3", "value": u"\xc4"})
-        assert rule.render_label() == u"An event's tags match \xc3 equals \xc4"
+        assert rule.render_label() == u"The event's tags match \xc3 equals \xc4"
 
     def test_equals(self):
         event = self.get_event()


### PR DESCRIPTION
Some small changes around the issue alert builder
- All instances of 'An event' --> 'The event' for clarity
- Added helper text to the conditions panel header so users understand how rules are evaluated
- Decreased margins for each section of the form (between `When an issue meets...` and the `Add a {condition/filter/action}`)
- Increased width of badge and thickness of text

**Before:**
![image](https://user-images.githubusercontent.com/9372512/92830020-da3e7800-f3a2-11ea-9a29-2ccd2c3dbee8.png)


**After:**
![image](https://user-images.githubusercontent.com/9372512/92829698-82a00c80-f3a2-11ea-94bf-fabdbdf2b6a6.png)
