### PR TITLE
feat(workflow): Dynamic issue counts - dynamic stacked bar chart

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -5,7 +5,7 @@ import six
 
 from django.conf import settings
 
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.response import Response
 
 from sentry import features
@@ -108,7 +108,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         try:
             start, end = get_date_range_from_params(request.GET)
         except InvalidParams as e:
-            return Response({"detail": six.text_type(e)}, status=400)
+            raise ParseError(detail=six.text_type(e))
 
         has_dynamic_issue_counts = features.has(
             "organizations:dynamic-issue-counts", organization, actor=request.user

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -105,19 +105,36 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         :auth: required
         """
         stats_period = request.GET.get("groupStatsPeriod")
-        if stats_period not in (None, "", "24h", "14d"):
-            return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
-        elif stats_period is None:
-            # default
-            stats_period = "24h"
-        elif stats_period == "":
-            # disable stats
-            stats_period = None
-
         try:
             start, end = get_date_range_from_params(request.GET)
         except InvalidParams as e:
             return Response({"detail": six.text_type(e)}, status=400)
+
+        has_dynamic_issue_counts = features.has(
+            "organizations:dynamic-issue-counts", organization, actor=request.user
+        )
+
+        if stats_period not in (None, "", "24h", "14d"):
+            return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
+        elif stats_period is None:
+            # stats_period = "14d"
+            if has_dynamic_issue_counts and start and end:
+                # custom date range
+                stats_period = "auto"
+            else:
+                # default if no dynamic-issue-counts
+                stats_period = "24h"
+
+        elif stats_period == "":
+            # disable stats
+            stats_period = None
+
+        if stats_period == "auto":
+            stats_period_start = start
+            stats_period_end = end
+        else:
+            stats_period_start = None
+            stats_period_end = None
 
         environments = self.get_environments(request, organization)
 
@@ -125,6 +142,8 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             StreamGroupSerializerSnuba,
             environment_ids=[env.id for env in environments],
             stats_period=stats_period,
+            stats_period_start=stats_period_start,
+            stats_period_end=stats_period_end,
         )
 
         projects = self.get_projects(request, organization)
@@ -200,7 +219,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
         lifetime_stats = serialize(results, request.user, serializer())
 
-        if features.has("organizations:dynamic-issue-counts", organization, actor=request.user):
+        if has_dynamic_issue_counts:
             snuba_filters = []
             if "search_filters" in query_kwargs and query_kwargs["search_filters"] is not None:
                 snuba_filters = [

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -109,7 +109,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
         elif stats_period is None:
             # default
-            stats_period = "24h"
+            stats_period = "14d"
         elif stats_period == "":
             # disable stats
             stats_period = None

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -109,7 +109,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
         elif stats_period is None:
             # default
-            stats_period = "14d"
+            stats_period = "24h"
         elif stats_period == "":
             # disable stats
             stats_period = None

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -117,7 +117,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         if stats_period not in (None, "", "24h", "14d"):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
         elif stats_period is None:
-            # stats_period = "14d"
             if has_dynamic_issue_counts and start and end:
                 # custom date range
                 stats_period = "auto"

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -526,6 +526,8 @@ class GroupStatsMixin(object):
         "24h": StatsPeriod(24, timedelta(hours=1)),
     }
 
+    CUSTOM_PERIOD_SEGMENTS = 29  # for 30 segments use 1/29th intervals
+
     def query_tsdb(self, group_ids, query_params):
         raise NotImplementedError
 
@@ -539,7 +541,8 @@ class GroupStatsMixin(object):
                     "start": self.stats_period_start,
                     "end": self.stats_period_end,
                     "rollup": int(
-                        (self.stats_period_end - self.stats_period_start).total_seconds() / 29
+                        (self.stats_period_end - self.stats_period_start).total_seconds()
+                        / self.CUSTOM_PERIOD_SEGMENTS
                     ),
                 }
             else:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -531,16 +531,25 @@ class GroupStatsMixin(object):
 
     def get_stats(self, item_list, user):
         if self.stats_period:
-            # we need to compute stats at 1d (1h resolution), and 14d
+            # we need to compute stats at 1d (1h resolution), and 14d or a custom given period
             group_ids = [g.id for g in item_list]
 
-            segments, interval = self.STATS_PERIOD_CHOICES[self.stats_period]
-            now = timezone.now()
-            query_params = {
-                "start": now - ((segments - 1) * interval),
-                "end": now,
-                "rollup": int(interval.total_seconds()),
-            }
+            if self.stats_period == "auto":
+                query_params = {
+                    "start": self.stats_period_start,
+                    "end": self.stats_period_end,
+                    "rollup": int(
+                        (self.stats_period_end - self.stats_period_start).total_seconds() / 29
+                    ),
+                }
+            else:
+                segments, interval = self.STATS_PERIOD_CHOICES[self.stats_period]
+                now = timezone.now()
+                query_params = {
+                    "start": now - ((segments - 1) * interval),
+                    "end": now,
+                    "rollup": int(interval.total_seconds()),
+                }
 
             return self.query_tsdb(group_ids, query_params)
 
@@ -550,15 +559,19 @@ class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
         self,
         environment_func=None,
         stats_period=None,
+        stats_period_start=None,
+        stats_period_end=None,
         matching_event_id=None,
         matching_event_environment=None,
     ):
         super(StreamGroupSerializer, self).__init__(environment_func)
 
         if stats_period is not None:
-            assert stats_period in self.STATS_PERIOD_CHOICES
+            assert stats_period in self.STATS_PERIOD_CHOICES or stats_period == "auto"
 
         self.stats_period = stats_period
+        self.stats_period_start = stats_period_start
+        self.stats_period_end = stats_period_end
         self.matching_event_id = matching_event_id
         self.matching_event_environment = matching_event_environment
 
@@ -678,6 +691,8 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         self,
         environment_ids=None,
         stats_period=None,
+        stats_period_start=None,
+        stats_period_end=None,
         matching_event_id=None,
         start=None,
         end=None,
@@ -686,9 +701,13 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         super(StreamGroupSerializerSnuba, self).__init__(environment_ids, start, end, snuba_filters)
 
         if stats_period is not None:
-            assert stats_period in self.STATS_PERIOD_CHOICES
+            assert stats_period in self.STATS_PERIOD_CHOICES or (
+                stats_period == "auto" and stats_period_start and stats_period_end
+            )
 
         self.stats_period = stats_period
+        self.stats_period_start = stats_period_start
+        self.stats_period_end = stats_period_end
         self.matching_event_id = matching_event_id
 
     def query_tsdb(self, group_ids, query_params):

--- a/src/sentry/static/sentry/app/components/barChart.tsx
+++ b/src/sentry/static/sentry/app/components/barChart.tsx
@@ -15,12 +15,12 @@ const BarChart = ({points = [], secondaryPoints = [], ...rest}: Props) => {
   const formattedPoints = points.map(point => ({
     x: point.x,
     y: [point.y],
-    color: theme.gray500,
+    color: secondaryPoints.length ? theme.gray500 : undefined,
   }));
   const formattedSecondaryPoints = secondaryPoints.map(point => ({
     x: point.x,
     y: [point.y],
-    color: theme.gray400,
+    color: secondaryPoints.length ? theme.gray400 : undefined,
   }));
   const props = {
     ...rest,

--- a/src/sentry/static/sentry/app/components/barChart.tsx
+++ b/src/sentry/static/sentry/app/components/barChart.tsx
@@ -4,10 +4,11 @@ import React from 'react';
 import StackedBarChart from 'app/components/stackedBarChart';
 import theme from 'app/utils/theme';
 
-type Props = Partial<Omit<React.ComponentProps<typeof StackedBarChart>, 'points'>> & {
+type Props = Partial<
+  Omit<React.ComponentProps<typeof StackedBarChart>, 'points' | 'secondaryPoints'>
+> & {
   points?: Array<{x: number; y: number; label?: string}>;
   secondaryPoints?: Array<{x: number; y: number; label?: string}>;
-  showSecondaryPoints?: boolean;
 };
 
 const BarChart = ({points = [], secondaryPoints = [], ...rest}: Props) => {
@@ -54,6 +55,7 @@ BarChart.propTypes = {
       label: PropTypes.string,
     })
   ),
+  showSecondaryPoints: PropTypes.bool,
 };
 
 export default BarChart;

--- a/src/sentry/static/sentry/app/components/barChart.tsx
+++ b/src/sentry/static/sentry/app/components/barChart.tsx
@@ -2,19 +2,42 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import StackedBarChart from 'app/components/stackedBarChart';
+import theme from 'app/utils/theme';
 
 type Props = Partial<Omit<React.ComponentProps<typeof StackedBarChart>, 'points'>> & {
   points?: Array<{x: number; y: number; label?: string}>;
+  secondaryPoints?: Array<{x: number; y: number; label?: string}>;
+  showSecondaryPoints?: boolean;
 };
 
-const BarChart = ({points = [], ...rest}: Props) => {
-  const formattedPoints = points.map(point => ({x: point.x, y: [point.y]}));
-  const props = {...rest, points: formattedPoints};
+const BarChart = ({points = [], secondaryPoints = [], ...rest}: Props) => {
+  const formattedPoints = points.map(point => ({
+    x: point.x,
+    y: [point.y],
+    color: theme.gray500,
+  }));
+  const formattedSecondaryPoints = secondaryPoints.map(point => ({
+    x: point.x,
+    y: [point.y],
+    color: theme.gray400,
+  }));
+  const props = {
+    ...rest,
+    points: formattedPoints,
+    secondaryPoints: formattedSecondaryPoints,
+  };
   return <StackedBarChart {...props} />;
 };
 
 BarChart.propTypes = {
   points: PropTypes.arrayOf(
+    PropTypes.shape({
+      x: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired,
+      label: PropTypes.string,
+    })
+  ),
+  secondaryPoints: PropTypes.arrayOf(
     PropTypes.shape({
       x: PropTypes.number.isRequired,
       y: PropTypes.number.isRequired,

--- a/src/sentry/static/sentry/app/components/stackedBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.tsx
@@ -11,10 +11,10 @@ import {use24Hours, getTimeFormat} from 'app/utils/dates';
 import theme from 'app/utils/theme';
 import {formatFloat} from 'app/utils/formatters';
 
-type Point = {x: number; y: number[]; label?: string};
+type Point = {x: number; y: number[]; label?: string; color?: string};
 type Points = Point[];
 type Series = Array<{
-  data: Array<{x: number; y: number}>;
+  data: Array<{x: number; y: number; color?: string}>;
   label?: string;
   color?: string;
 }>;
@@ -32,6 +32,8 @@ type DefaultProps = {
    * @deprecated
    */
   points: Points;
+  secondaryPoints: Points;
+  showSecondaryPoints?: boolean;
   series: Series;
   markers: Marker[];
   barClasses: string[];
@@ -56,7 +58,9 @@ type Props = DefaultProps & {
 
 type State = {
   series: Series;
+  secondarySeries: Series;
   pointIndex: Record<number, Point>;
+  secondaryPointIndex: Record<number, Point>;
   interval: number | null;
 };
 
@@ -102,6 +106,7 @@ class StackedBarChart extends React.Component<Props, State> {
   static defaultProps: DefaultProps = {
     label: '',
     points: [],
+    secondaryPoints: [],
     series: [],
     markers: [],
     barClasses: ['chart-bar'],
@@ -114,6 +119,7 @@ class StackedBarChart extends React.Component<Props, State> {
 
     // massage points
     let series = props.series;
+    let secondarySeries: Series = [];
 
     if (props.points?.length) {
       if (series?.length) {
@@ -121,11 +127,15 @@ class StackedBarChart extends React.Component<Props, State> {
       }
 
       series = this.pointsToSeries(props.points);
+      if (props.secondaryPoints.length)
+        secondarySeries = this.pointsToSeries(props.secondaryPoints);
     }
 
     this.state = {
       series,
+      secondarySeries,
       pointIndex: this.pointIndex(series),
+      secondaryPointIndex: this.pointIndex(secondarySeries),
       interval: this.getInterval(series),
     };
   }
@@ -133,17 +143,22 @@ class StackedBarChart extends React.Component<Props, State> {
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (nextProps.points || nextProps.series) {
       let series = nextProps.series;
+      let secondarySeries = this.state.secondarySeries;
       if (nextProps.points.length) {
         if (series.length) {
           throw new Error('Only one of [points|series] should be specified.');
         }
 
         series = this.pointsToSeries(nextProps.points);
+        if (nextProps.secondaryPoints.length)
+          secondarySeries = this.pointsToSeries(nextProps.secondaryPoints);
       }
 
       this.setState({
         series,
+        secondarySeries,
         pointIndex: this.pointIndex(series),
+        secondaryPointIndex: this.pointIndex(secondarySeries),
         interval: this.getInterval(series),
       });
     }
@@ -166,7 +181,7 @@ class StackedBarChart extends React.Component<Props, State> {
         if (!series[yIdx]) {
           series[yIdx] = {data: []};
         }
-        series[yIdx].data.push({x: p.x, y});
+        series[yIdx].data.push({x: p.x, y, color: p.color});
       });
     });
     return series;
@@ -177,7 +192,7 @@ class StackedBarChart extends React.Component<Props, State> {
     series.forEach(s => {
       s.data.forEach(p => {
         if (!points[p.x]) {
-          points[p.x] = {y: [], x: p.x};
+          points[p.x] = {y: [], x: p.x, color: p.color};
         }
         points[p.x].y.push(p.y);
       });
@@ -216,7 +231,7 @@ class StackedBarChart extends React.Component<Props, State> {
     return (
       <span>
         {timeMoment.format(format)}
-        &#8594
+        &#8594;
         {nextMoment.format(format)}
       </span>
     );
@@ -244,7 +259,7 @@ class StackedBarChart extends React.Component<Props, State> {
   maxPointValue(): number {
     return Math.max(
       10,
-      this.state.series
+      (this.state.secondarySeries.length ? this.state.secondarySeries : this.state.series)
         .map(s => Math.max(...s.data.map(p => p.y)))
         .reduce((a, b) => a + b, 0)
     );
@@ -327,38 +342,71 @@ class StackedBarChart extends React.Component<Props, State> {
 
   renderChartColumn(
     point: Point,
+    secondaryPoint: Point | null,
     maxval: number,
     pointWidth: number,
     index: number,
     _totalPoints: number
   ): React.ReactNode {
-    const totalY = point.y.reduce((a, b) => a + b);
+    const {showSecondaryPoints} = this.props;
+
+    const totalY = (secondaryPoint ? secondaryPoint : point).y.reduce((a, b) => a + b);
     const totalPct = totalY / maxval;
     // we leave a little extra space for bars with min-heights.
     const maxPercentage = 99;
 
     let prevPct = 0;
+    let prevPct2 = 0;
     const pts = point.y.map((y, i) => {
       const pct = Math.max(
         totalY && formatFloat((y / totalY) * totalPct * maxPercentage, 2),
         this.getMinHeight(i)
       );
 
+      const y2 = secondaryPoint && secondaryPoint.y[i];
+      const pct2 =
+        y2 &&
+        Math.max(
+          totalY && formatFloat((y2 / totalY) * totalPct * maxPercentage, 2),
+          this.getMinHeight(i)
+        );
+
       const pt = (
-        <rect
-          key={i}
-          x={index * pointWidth + '%'}
-          y={100.0 - pct - prevPct + '%'}
-          width={pointWidth - this.props.gap + '%'}
-          data-test-id="chart-column"
-          height={pct + '%'}
-          fill={this.state.series[i].color}
-          className={classNames(this.props.barClasses[i], 'barchart-rect')}
-        >
-          {y}
-        </rect>
+        <React.Fragment key={i}>
+          <rect
+            x={index * pointWidth + '%'}
+            y={100.0 - pct - prevPct + '%'}
+            width={pointWidth - this.props.gap + '%'}
+            data-test-id="chart-column"
+            height={pct + '%'}
+            fill={point.color}
+            className={classNames(
+              this.props.barClasses[i],
+              point.color ? '' : 'barchart-rect'
+            )}
+          >
+            {y}
+          </rect>
+          {showSecondaryPoints && pct2 && secondaryPoint && (
+            <rect
+              x={index * pointWidth + '%'}
+              y={100.0 - pct2 - prevPct2 + '%'}
+              width={pointWidth - this.props.gap + '%'}
+              data-test-id="chart-column"
+              height={pct2 - pct + '%'}
+              fill={secondaryPoint.color}
+              className={classNames(
+                this.props.barClasses[i],
+                secondaryPoint.color ? '' : 'barchart-rect'
+              )}
+            >
+              {y2}
+            </rect>
+          )}
+        </React.Fragment>
       );
       prevPct += pct;
+      if (pct2) prevPct2 += pct2;
       return pt;
     });
 
@@ -398,7 +446,7 @@ class StackedBarChart extends React.Component<Props, State> {
     const points = Object.keys(pointIndex)
       .map(k => {
         const p = pointIndex[k];
-        return {x: p.x, y: p.y};
+        return {x: p.x, y: p.y, color: p.color};
       })
       .sort((a, b) => a.x - b.x);
 
@@ -413,8 +461,19 @@ class StackedBarChart extends React.Component<Props, State> {
         );
       }
 
+      const secondaryPoint = this.props.secondaryPoints.length
+        ? this.props.secondaryPoints[index]
+        : null;
+
       children.push(
-        this.renderChartColumn(point, maxval, pointWidth, index, totalPoints)
+        this.renderChartColumn(
+          point,
+          secondaryPoint,
+          maxval,
+          pointWidth,
+          index,
+          totalPoints
+        )
       );
     });
 

--- a/src/sentry/static/sentry/app/components/stackedBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.tsx
@@ -127,8 +127,9 @@ class StackedBarChart extends React.Component<Props, State> {
       }
 
       series = this.pointsToSeries(props.points);
-      if (props.secondaryPoints.length)
+      if (props.secondaryPoints.length) {
         secondarySeries = this.pointsToSeries(props.secondaryPoints);
+      }
     }
 
     this.state = {
@@ -355,21 +356,19 @@ class StackedBarChart extends React.Component<Props, State> {
     // we leave a little extra space for bars with min-heights.
     const maxPercentage = 99;
 
-    let prevPct = 0;
-    let prevPct2 = 0;
-    const pts = point.y.map((y, i) => {
-      const pct = Math.max(
+    const calcPct = (y, i) =>
+      Math.max(
         totalY && formatFloat((y / totalY) * totalPct * maxPercentage, 2),
         this.getMinHeight(i)
       );
 
+    let prevPct = 0;
+    let prevPct2 = 0;
+    const pts = point.y.map((y, i) => {
+      const pct = calcPct(y, i);
+
       const y2 = secondaryPoint && secondaryPoint.y[i];
-      const pct2 =
-        y2 &&
-        Math.max(
-          totalY && formatFloat((y2 / totalY) * totalPct * maxPercentage, 2),
-          this.getMinHeight(i)
-        );
+      const pct2 = y2 && calcPct(y2, i);
 
       const pt = (
         <React.Fragment key={i}>

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -176,11 +176,15 @@ const StreamGroup = createReactClass({
       memberList,
       withChart,
       statsPeriod,
+      selection,
       organization,
     } = this.props;
 
     const hasDynamicIssueCounts = organization.features.includes('dynamic-issue-counts');
     const hasDiscoverQuery = organization.features.includes('discover-basic');
+
+    const {start, end} = selection.datetime || {};
+    const useAutoStatsPeriod = hasDynamicIssueCounts && !!start && !!end;
 
     const popperStyle = {maxWidth: 'none'};
 
@@ -204,6 +208,15 @@ const StreamGroup = createReactClass({
     // TODO: @taylangocmen sort rows when clicked on a column
     // TODO: @taylangocmen onboarding callouts when for when feature ships
 
+    const showSecondaryPoints = Boolean(
+      showLifetimeStats &&
+        withChart &&
+        data &&
+        data.filtered &&
+        hasDynamicIssueCounts &&
+        statsPeriod
+    );
+
     return (
       <Group data-test-id="group" onClick={this.toggleSelect} {...mouseEventHandlers}>
         {canSelect && (
@@ -224,9 +237,10 @@ const StreamGroup = createReactClass({
         {withChart && (
           <Box width={160} mx={2} className="hidden-xs hidden-sm">
             <GroupChart
-              statsPeriod={statsPeriod}
+              statsPeriod={useAutoStatsPeriod ? 'auto' : statsPeriod}
               data={data}
               hasDynamicIssueCounts={hasDynamicIssueCounts}
+              showSecondaryPoints={showSecondaryPoints}
             />
           </Box>
         )}
@@ -385,7 +399,7 @@ const TooltipText = styled('td')`
 
 const StyledIconTelescope = styled(({to, ...p}) => (
   <td {...p}>
-    <Link title={t('Open in Discover')} to={to}>
+    <Link title={t('Open in Discover')} to={to} target="_blank">
       <IconTelescope size="xs" color={p.color} />
     </Link>
   </td>

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -176,15 +176,11 @@ const StreamGroup = createReactClass({
       memberList,
       withChart,
       statsPeriod,
-      selection,
       organization,
     } = this.props;
 
     const hasDynamicIssueCounts = organization.features.includes('dynamic-issue-counts');
     const hasDiscoverQuery = organization.features.includes('discover-basic');
-
-    const {start, end} = selection.datetime || {};
-    const useAutoStatsPeriod = hasDynamicIssueCounts && !!start && !!end;
 
     const popperStyle = {maxWidth: 'none'};
 
@@ -237,7 +233,7 @@ const StreamGroup = createReactClass({
         {withChart && (
           <Box width={160} mx={2} className="hidden-xs hidden-sm">
             <GroupChart
-              statsPeriod={useAutoStatsPeriod ? 'auto' : statsPeriod}
+              statsPeriod={statsPeriod}
               data={data}
               hasDynamicIssueCounts={hasDynamicIssueCounts}
               showSecondaryPoints={showSecondaryPoints}

--- a/src/sentry/static/sentry/app/components/stream/groupChart.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.tsx
@@ -9,26 +9,42 @@ type Props = {
   data: Group;
   hasDynamicIssueCounts?: boolean;
   height: number;
+  showSecondaryPoints?: boolean;
 };
 
-function GroupChart({data, hasDynamicIssueCounts, statsPeriod, height = 24}: Props) {
-  // TODO: @taylangocmen pass filtered and unfiltered stats separately to chart and render both
-
+function GroupChart({
+  data,
+  hasDynamicIssueCounts,
+  statsPeriod,
+  showSecondaryPoints = false,
+  height = 24,
+}: Props) {
   const stats: GroupStats[] = statsPeriod
     ? hasDynamicIssueCounts && data.filtered
       ? data.filtered.stats[statsPeriod]
       : data.stats[statsPeriod]
     : null;
 
+  const secondaryStats: GroupStats[] | null =
+    statsPeriod && hasDynamicIssueCounts && data.filtered
+      ? data.stats[statsPeriod]
+      : null;
+
   if (!stats || !stats.length) {
     return null;
   }
   const chartData = stats.map(point => ({x: point[0], y: point[1]}));
+  const secondaryChartData =
+    secondaryStats && secondaryStats.length
+      ? secondaryStats.map(point => ({x: point[0], y: point[1]}))
+      : [];
 
   return (
     <LazyLoad debounce={50} height={height}>
       <BarChart
         points={chartData}
+        secondaryPoints={secondaryChartData}
+        showSecondaryPoints={showSecondaryPoints}
         height={height}
         label="events"
         minHeights={[3]}

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -692,6 +692,7 @@ export type Group = {
   shortId: string;
   stats: Record<string, GroupStats[]>;
   filtered?: any; // TODO(ts)
+  lifetime?: any; // TODO(ts)
   status: string;
   statusDetails: ResolutionStatusDetails;
   tags: Pick<Tag, 'key' | 'name' | 'totalValues'>[];

--- a/src/sentry/static/sentry/app/views/issueList/actions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.jsx
@@ -560,13 +560,21 @@ const IssueListActions = createReactClass({
               >
                 {t('24h')}
               </GraphToggle>
-
-              <GraphToggle
-                active={statsPeriod === '14d'}
-                onClick={this.handleSelectStatsPeriod.bind(this, '14d')}
-              >
-                {t('14d')}
-              </GraphToggle>
+              {hasDynamicIssueCounts ? (
+                <GraphToggle
+                  active={statsPeriod === 'auto'}
+                  onClick={this.handleSelectStatsPeriod.bind(this, 'auto')}
+                >
+                  {t('Auto')}
+                </GraphToggle>
+              ) : (
+                <GraphToggle
+                  active={statsPeriod === '14d'}
+                  onClick={this.handleSelectStatsPeriod.bind(this, '14d')}
+                >
+                  {t('14d')}
+                </GraphToggle>
+              )}
             </GraphHeader>
           </GraphHeaderWrapper>
           {hasDynamicIssueCounts ? (

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -47,8 +47,6 @@ import NoGroupsHandler from './noGroupsHandler';
 
 const MAX_ITEMS = 25;
 const DEFAULT_SORT = 'date';
-// the default period for the graph in each issue row
-const DEFAULT_GRAPH_STATS_PERIOD = '24h';
 // the allowed period choices for graph in each issue row
 const STATS_PERIODS = new Set(['14d', '24h']);
 
@@ -220,7 +218,7 @@ const IssueListOverview = createReactClass({
 
   getGroupStatsPeriod() {
     const currentPeriod = this.props.location.query.groupStatsPeriod;
-    return STATS_PERIODS.has(currentPeriod) ? currentPeriod : DEFAULT_GRAPH_STATS_PERIOD;
+    return STATS_PERIODS.has(currentPeriod) ? currentPeriod : DEFAULT_STATS_PERIOD;
   },
 
   getEndpointParams() {
@@ -250,7 +248,7 @@ const IssueListOverview = createReactClass({
     }
 
     const groupStatsPeriod = this.getGroupStatsPeriod();
-    if (groupStatsPeriod !== DEFAULT_GRAPH_STATS_PERIOD) {
+    if (groupStatsPeriod !== DEFAULT_STATS_PERIOD) {
       params.groupStatsPeriod = groupStatsPeriod;
     }
 

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -47,6 +47,8 @@ import NoGroupsHandler from './noGroupsHandler';
 
 const MAX_ITEMS = 25;
 const DEFAULT_SORT = 'date';
+// the default period for the graph in each issue row
+const DEFAULT_GRAPH_STATS_PERIOD = '24h';
 // the allowed period choices for graph in each issue row
 const STATS_PERIODS = new Set(['14d', '24h']);
 
@@ -218,7 +220,7 @@ const IssueListOverview = createReactClass({
 
   getGroupStatsPeriod() {
     const currentPeriod = this.props.location.query.groupStatsPeriod;
-    return STATS_PERIODS.has(currentPeriod) ? currentPeriod : DEFAULT_STATS_PERIOD;
+    return STATS_PERIODS.has(currentPeriod) ? currentPeriod : DEFAULT_GRAPH_STATS_PERIOD;
   },
 
   getEndpointParams() {
@@ -248,7 +250,7 @@ const IssueListOverview = createReactClass({
     }
 
     const groupStatsPeriod = this.getGroupStatsPeriod();
-    if (groupStatsPeriod !== DEFAULT_STATS_PERIOD) {
+    if (groupStatsPeriod !== DEFAULT_GRAPH_STATS_PERIOD) {
       params.groupStatsPeriod = groupStatsPeriod;
     }
 

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -51,6 +51,7 @@ const DEFAULT_SORT = 'date';
 const DEFAULT_GRAPH_STATS_PERIOD = '24h';
 // the allowed period choices for graph in each issue row
 const STATS_PERIODS = new Set(['14d', '24h']);
+const DYNAMIC_COUNTS_STATS_PERIODS = new Set(['14d', '24h', 'auto']);
 
 const IssueListOverview = createReactClass({
   displayName: 'IssueListOverview',
@@ -218,9 +219,20 @@ const IssueListOverview = createReactClass({
     return this.props.location.query.sort || DEFAULT_SORT;
   },
 
+  getDefaultGroupStatsPeriod() {
+    return this.props.organization.features.includes('dynamic-issue-counts')
+      ? 'auto'
+      : DEFAULT_GRAPH_STATS_PERIOD;
+  },
+
   getGroupStatsPeriod() {
     const currentPeriod = this.props.location.query.groupStatsPeriod;
-    return STATS_PERIODS.has(currentPeriod) ? currentPeriod : DEFAULT_GRAPH_STATS_PERIOD;
+    return (this.props.organization.features.includes('dynamic-issue-counts')
+      ? DYNAMIC_COUNTS_STATS_PERIODS
+      : STATS_PERIODS
+    ).has(currentPeriod)
+      ? currentPeriod
+      : this.getDefaultGroupStatsPeriod();
   },
 
   getEndpointParams() {
@@ -250,7 +262,7 @@ const IssueListOverview = createReactClass({
     }
 
     const groupStatsPeriod = this.getGroupStatsPeriod();
-    if (groupStatsPeriod !== DEFAULT_GRAPH_STATS_PERIOD) {
+    if (groupStatsPeriod !== this.getDefaultGroupStatsPeriod()) {
       params.groupStatsPeriod = groupStatsPeriod;
     }
 

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -1188,7 +1188,7 @@ describe('IssueList', function() {
         location: {
           query: {
             sort: 'date',
-            groupStatsPeriod: '14d',
+            groupStatsPeriod: '24h',
           },
         },
       });

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -1188,7 +1188,7 @@ describe('IssueList', function() {
         location: {
           query: {
             sort: 'date',
-            groupStatsPeriod: '24h',
+            groupStatsPeriod: '14d',
           },
         },
       });


### PR DESCRIPTION
In this PR:
- Discovery links in the stats tooltips now opens discovery in a new tab
- Changed the `groupSeenStats` options for the issue stream charts to `24h / Auto`, `auto ` represents the selected preset time period or start-end dates in the global selection header, split into 30 bars (will improve the rollup in a separate pr) 
- Changed the `StreamGroupSerializer` to accept start-end dates for start periods and calculate the rollup and add data to stats with `'auto'` as the period key
- Changed the issue stream `barChart` and `stackedBarChart` to accept a secondary set of data points and render the secondary data as the superset of the primary data, also limited this to the chart of the row being hovered on.


#### 24 hours, no filters, time range aug1-sep1 -> chart shows sep9-sep10

![Screen Shot 2020-09-10 at 5 26 57 PM](https://user-images.githubusercontent.com/15015880/92831061-d69ef700-f38a-11ea-9c40-aa8a018a4620.png)

#### Auto, no filters, time range aug1-sep1  -> chart shows aug1-sep1 with only non-filtered

![Screen Shot 2020-09-10 at 5 27 16 PM](https://user-images.githubusercontent.com/15015880/92831102-e1598c00-f38a-11ea-91b3-41ea4763a576.png)

#### 24 hours, filtering with a tag, time range aug1-sep1 -> chart shows sep9-sep10

![Screen Shot 2020-09-10 at 5 27 42 PM](https://user-images.githubusercontent.com/15015880/92831190-f2a29880-f38a-11ea-9e7b-d58e0766f111.png)

#### Auto, filtering with a tag, time range aug1-sep1  -> chart shows aug1-sep1 with filtered/non-filtered

![Screen Shot 2020-09-10 at 5 27 56 PM](https://user-images.githubusercontent.com/15015880/92831211-f9311000-f38a-11ea-9e4f-af29b1d7c2cb.png)


Resolves:
[WOR-235](https://getsentry.atlassian.net/browse/WOR-235)
[WOR-197](https://getsentry.atlassian.net/browse/WOR-197)