### PR TITLE
ref(ts) Update GlobalSelectionStore to typescript

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -237,7 +237,7 @@ type Props = {
   /**
    * Should datetimes be formatted in UTC?
    */
-  utc?: boolean;
+  utc?: boolean | null;
   /**
    * Don't show the previous period's data. Will automatically disable
    * when start/end are used.

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.tsx
@@ -3,7 +3,8 @@ import identity from 'lodash/identity';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
 
-import {DATE_TIME, DATE_TIME_KEYS, URL_PARAM} from 'app/constants/globalSelectionHeader';
+import {GlobalSelection} from 'app/types';
+import {DATE_TIME_KEYS, URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {defined} from 'app/utils';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 
@@ -53,7 +54,6 @@ export function getStateFromQuery(
     period: period || null,
     start: start || null,
     end: end || null,
-
     // params from URL will be a string
     utc: typeof utc !== 'undefined' ? utc === 'true' : null,
   };
@@ -74,15 +74,16 @@ export function extractSelectionParameters(query) {
 export function extractDatetimeSelectionParameters(query) {
   return pickBy(pick(query, Object.values(DATE_TIME_KEYS)), identity);
 }
-export function getDefaultSelection() {
+export function getDefaultSelection(): GlobalSelection {
+  const utc = DEFAULT_PARAMS.utc;
   return {
     projects: [],
     environments: [],
     datetime: {
-      [DATE_TIME.START]: DEFAULT_PARAMS.start || null,
-      [DATE_TIME.END]: DEFAULT_PARAMS.end || null,
-      [DATE_TIME.PERIOD]: DEFAULT_PARAMS.statsPeriod || null,
-      [DATE_TIME.UTC]: DEFAULT_PARAMS.utc || null,
+      start: DEFAULT_PARAMS.start || null,
+      end: DEFAULT_PARAMS.end || null,
+      period: DEFAULT_PARAMS.statsPeriod || '',
+      utc: typeof utc !== 'undefined' ? utc === 'true' : null,
     },
   };
 }

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -512,7 +512,7 @@ export type GlobalSelection = {
     start: DateString;
     end: DateString;
     period: string;
-    utc: boolean;
+    utc: boolean | null;
   };
 };
 

--- a/src/sentry/static/sentry/app/views/discover/discover.tsx
+++ b/src/sentry/static/sentry/app/views/discover/discover.tsx
@@ -43,7 +43,7 @@ import createResultManager from './resultManager';
 import {SavedQuery} from './types';
 
 type DefaultProps = {
-  utc: boolean;
+  utc: boolean | null;
 };
 
 type Props = DefaultProps & {

--- a/src/sentry/static/sentry/app/views/discover/result/index.tsx
+++ b/src/sentry/static/sentry/app/views/discover/result/index.tsx
@@ -43,7 +43,7 @@ type ResultProps = {
   savedQuery: SavedQuery | null; // Provided if it's a saved search
   onFetchPage: (nextOrPrev: string) => void;
   onToggleEdit: () => void;
-  utc: boolean;
+  utc: boolean | null;
 };
 
 type ResultState = {

--- a/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/overview/chart/healthChart.tsx
@@ -13,7 +13,7 @@ import {YAxis} from './releaseChartControls';
 
 type Props = {
   reloading: boolean;
-  utc: boolean;
+  utc: boolean | null;
   timeseriesData: Series[];
   zoomRenderProps: any;
   yAxis: YAxis;


### PR DESCRIPTION
The type for `selection.datetime.utc` needed to be adjusted as it is a nullable boolean in practice. This required updates in a few other places to accommodate the new null type.