### PR TITLE
fix(snuba) The device.* fields are strings not numeric

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -37,10 +37,6 @@ BLACKLISTED_COLUMNS = frozenset(["project_id"])
 
 FUZZY_NUMERIC_KEYS = frozenset(
     [
-        "device.battery_level",
-        "device.charging",
-        "device.online",
-        "device.simulator",
         "error.handled",
         "stack.colno",
         "stack.in_app",


### PR DESCRIPTION
The device.* fields are part of the contexts data, which is stored as strings in
snuba. Treat these values as strings in sentry to avoid errors.