### PR TITLE
feat(comparison-cleanup): tweak copy and padding

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -376,19 +376,19 @@ class SpanBar extends React.Component<Props, State> {
           label = t('+ %s slower', duration);
         }
 
-        return <ComparisonReportLabelContainer>{label}</ComparisonReportLabelContainer>;
+        return <NotableComparisonReport>{label}</NotableComparisonReport>;
       }
       case 'baseline': {
         return (
           <ComparisonReportLabelContainer>
-            {t('removed from baseline')}
+            {t('Only in baseline')}
           </ComparisonReportLabelContainer>
         );
       }
       case 'regression': {
         return (
           <ComparisonReportLabelContainer>
-            {t('missing from regression')}
+            {t('No change')}
           </ComparisonReportLabelContainer>
         );
       }
@@ -526,11 +526,8 @@ const getHatchPattern = ({spanBarHatch}) => {
 
 const ComparisonSpanBarRectangle = styled(SpanBarRectangle)`
   position: absolute;
-  top: 4px;
-  left: 1px;
-
+  left: 0;
   height: 16px;
-
   ${getHatchPattern};
 `;
 
@@ -538,12 +535,14 @@ const ComparisonReportLabelContainer = styled('div')`
   position: absolute;
   user-select: none;
   right: ${space(1)};
-
+  color: ${p => p.theme.gray500};
   line-height: 16px;
-  top: 4px;
-  height: 16px;
-
   font-size: ${p => p.theme.fontSizeExtraSmall};
+`;
+
+const NotableComparisonReport = styled(ComparisonReportLabelContainer)`
+  font-weight: bold;
+  color: ${p => p.theme.gray800};
 `;
 
 export default SpanBar;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -357,7 +357,7 @@ class SpanBar extends React.Component<Props, State> {
         let label: string = '';
 
         if (baselineDuration === regressionDuration) {
-          label = 'no change';
+          label = 'No change';
         }
 
         if (baselineDuration > regressionDuration) {
@@ -387,9 +387,7 @@ class SpanBar extends React.Component<Props, State> {
       }
       case 'regression': {
         return (
-          <ComparisonReportLabelContainer>
-            {t('No change')}
-          </ComparisonReportLabelContainer>
+          <ComparisonReportLabelContainer>{t('Added')}</ComparisonReportLabelContainer>
         );
       }
       default: {

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -535,14 +535,12 @@ const ComparisonReportLabelContainer = styled('div')`
   position: absolute;
   user-select: none;
   right: ${space(1)};
-  color: ${p => p.theme.gray500};
   line-height: 16px;
   font-size: ${p => p.theme.fontSizeExtraSmall};
 `;
 
 const NotableComparisonReport = styled(ComparisonReportLabelContainer)`
   font-weight: bold;
-  color: ${p => p.theme.gray800};
 `;
 
 export default SpanBar;

--- a/src/sentry/static/sentry/app/views/performance/compare/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanDetail.tsx
@@ -125,7 +125,7 @@ const MatchedSpanDetailsContent = (props: {
       />
       <Row
         baselineTitle={t('Baseline Span ID')}
-        regressionTitle={t('Regressive Span ID')}
+        regressionTitle={t("This Event's Span ID")}
         renderBaselineContent={() => baselineSpan.span_id}
         renderRegressionContent={() => regressionSpan.span_id}
       />
@@ -268,9 +268,8 @@ const RowSplitter = styled('div')`
 const SpanBarContainer = styled('div')`
   position: relative;
   height: 16px;
-
-  margin-top: ${space(1)};
-  margin-bottom: ${space(1)};
+  margin-top: ${space(3)};
+  margin-bottom: ${space(2)};
 `;
 
 const SpanBars = (props: {
@@ -363,7 +362,7 @@ const RowContainer = styled('div')`
 `;
 
 const RowTitle = styled('div')`
-  font-size: ${p => p.theme.fontSizeMedium};
+  font-size: 13px;
   font-weight: 600;
 `;
 

--- a/src/sentry/static/sentry/app/views/performance/compare/transactionSummary.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/transactionSummary.tsx
@@ -69,7 +69,7 @@ class TransactionSummary extends React.Component<Props> {
           <Regression />
           <EventRowContent>
             <Content>
-              <ContentTitle>{t('Regressive Event')}</ContentTitle>
+              <ContentTitle>{t('This Event')}</ContentTitle>
               <EventId>
                 <span>{t('ID')}: </span>
                 <StyledLink


### PR DESCRIPTION
- 'missing from regression' changes to 'added'
- 'removed from baseline' changes to 'only in baseline'
- 'regressive event' changes to 'this event'

**Before**
![Screen Shot 2020-09-11 at 12 44 38 PM](https://user-images.githubusercontent.com/4830259/92966554-9c863180-f42c-11ea-857b-d1bc826016cc.png)

**After**
![Screen Shot 2020-09-11 at 12 59 27 PM](https://user-images.githubusercontent.com/4830259/92967893-e112cc80-f42e-11ea-82a2-db0e97b1565c.png)

