### PR TITLE
ref(apm): Increase idleTimeout to 5000 ms from default of 1000ms

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -61,6 +61,7 @@ function getSentryIntegrations(hasReplays: boolean = false) {
         Router.createRoutes(routes()),
         Router.match as any
       ),
+      idleTimeout: 5000,
     }),
   ];
   if (hasReplays) {


### PR DESCRIPTION
We'd like to increase the amount of time to capture most of the http request calls that are useful.

Ref: https://github.com/getsentry/sentry-javascript/blob/7c142839036e77161a6f707196762eb718b723cc/packages/tracing/src/browser/browsertracing.ts#L23-L30

