### PR TITLE
ref(platform-picker): Add language category icon

### DIFF
--- a/src/sentry/static/sentry/app/components/platformIcon.tsx
+++ b/src/sentry/static/sentry/app/components/platformIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from '@emotion/styled';
 
 const PLATFORM_TO_ICON = {
   apple: 'apple',
@@ -75,14 +76,28 @@ export function getIcon(platform: string): string {
   return icon;
 }
 
+const IconContainer = styled('div')`
+  position: relative;
+`;
+
+const LanguageIcon = styled('img')`
+  position: absolute;
+  bottom: -1px;
+  right: -1px;
+  height: 30%;
+  width: 30%;
+  border-radius: 2px;
+`;
+
 type Props = {
   platform: string;
   size?: string;
   width?: string;
   height?: string;
+  withLanguageIcon?: boolean;
 };
 
-const PlatformIcon = ({platform, size, ...props}: Props) => {
+const PlatformIcon = ({platform, size, withLanguageIcon, ...props}: Props) => {
   const width = props.width || size || '1em';
   const height = props.height || size || '1em';
 
@@ -91,6 +106,20 @@ const PlatformIcon = ({platform, size, ...props}: Props) => {
   const iconPath = require(`platformicons/${
     size === 'lg' ? 'svg_80x80' : 'svg'
   }/${icon}.svg`);
+
+  const language = platform.split('-')[0];
+  const langIcon = getIcon(language);
+
+  if (withLanguageIcon && langIcon !== icon && langIcon !== 'default') {
+    const langPath = require(`platformicons/svg/${getIcon(language)}.svg`);
+
+    return (
+      <IconContainer {...props}>
+        <img src={iconPath} width={width} height={height} />
+        <LanguageIcon src={langPath} />
+      </IconContainer>
+    );
+  }
 
   return <img src={iconPath} width={width} height={height} {...props} />;
 };

--- a/src/sentry/static/sentry/app/components/platformPicker.jsx
+++ b/src/sentry/static/sentry/app/components/platformPicker.jsx
@@ -47,7 +47,9 @@ class PlatformPicker extends React.Component {
     const categoryMatch = platform =>
       category === 'all' || currentCategory.platforms.includes(platform.id);
 
-    const filtered = platforms.filter(this.state.filter ? subsetMatch : categoryMatch);
+    const filtered = platforms
+      .filter(this.state.filter ? subsetMatch : categoryMatch)
+      .sort((a, b) => a.id.localeCompare(b.id));
 
     return this.props.showOther ? filtered : filtered.filter(({id}) => id !== 'other');
   }
@@ -153,7 +155,8 @@ const NavContainer = styled('div')`
   border-bottom: 1px solid ${p => p.theme.borderLight};
   margin-bottom: ${space(2)};
   display: grid;
-  grid-template-columns: 1fr 300px;
+  grid-gap: ${space(2)};
+  grid-template-columns: 1fr minmax(0, 300px);
   align-items: start;
 `;
 
@@ -182,6 +185,12 @@ const SearchBar = styled('div')`
 const CategoryNav = styled(NavTabs)`
   margin: 0;
   margin-top: 4px;
+  white-space: nowrap;
+
+  > li {
+    float: none;
+    display: inline-block;
+  }
 `;
 
 const PlatformList = styled('div')`
@@ -194,9 +203,6 @@ const PlatformList = styled('div')`
 const StyledPlatformIcon = styled(PlatformIcon)`
   width: 56px;
   height: 56px;
-  font-size: 42px;
-  line-height: 58px;
-  text-align: center;
   margin: ${space(2)};
   border-radius: 5px;
 `;
@@ -216,7 +222,7 @@ const ClearButton = styled(p => (
 
 const PlatformCard = styled(({platform, selected, onClear, ...props}) => (
   <div {...props}>
-    <StyledPlatformIcon platform={platform.id} size="lg" />
+    <StyledPlatformIcon platform={platform.id} withLanguageIcon size="lg" />
 
     <h3>{platform.name}</h3>
     {selected && <ClearButton onClick={onClear} />}
@@ -236,14 +242,15 @@ const PlatformCard = styled(({platform, selected, onClear, ...props}) => (
   }
 
   h3 {
-    display: block;
+    flex-grow: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 100%;
     text-align: center;
     font-size: 15px;
     margin: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    padding: 0 ${space(0.5)};
     line-height: 1.2;
   }
 `;

--- a/tests/js/spec/views/projectInstall/createProject.spec.jsx
+++ b/tests/js/spec/views/projectInstall/createProject.spec.jsx
@@ -89,7 +89,7 @@ describe('CreateProject', function() {
 
     node = wrapper.find('PlatformCard').last();
     node.simulate('click');
-    expect(wrapper.find('ProjectNameInput input').props().value).toBe('Ruby');
+    expect(wrapper.find('ProjectNameInput input').props().value).toBe('Rails');
 
     //but not replace it when project name is something else:
     wrapper.setState({projectName: 'another'});
@@ -115,12 +115,12 @@ describe('CreateProject', function() {
             slug: 'testOrg',
             teams: [{slug: 'test', id: '1', name: 'test', hasAccess: true}],
           },
-          location: {query: {platform: 'ruby'}},
+          location: {query: {platform: 'ruby-rails'}},
         },
       ])
     );
 
-    expect(wrapper.find('ProjectNameInput input').props().value).toBe('Ruby');
+    expect(wrapper.find('ProjectNameInput input').props().value).toBe('Rails');
 
     expect(wrapper).toSnapshot();
   });


### PR DESCRIPTION
- A new language icon can now be shown in the bottom right on the platform picker Using the `withLanguageIcon` prop.

 - Sorts the platforms in the platform list so the language shows up first in the list.

 - Adjusts the platform picker nav to allow more categories to fit

 This is a follow up to https://github.com/getsentry/sentry/pull/20723

![image](https://user-images.githubusercontent.com/1421724/93136620-1585c300-f691-11ea-95cc-43fa97f9426b.png)
