### PR TITLE
Feat: Reserve integration platform slug

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -152,6 +152,7 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         "_experiment",
         "sentry-apps",
         "resources",
+        "integration-platform",
     )
 )
 


### PR DESCRIPTION
There's been a page at https://sentry.io/integration-platform/ forever but my original branch reserving this was never merged. Tying up loose ends now.