### PR TITLE
ref(py3): Fix onboarding invite members snapshot

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/projectSetup/inviteMembers.tsx
+++ b/src/sentry/static/sentry/app/views/onboarding/projectSetup/inviteMembers.tsx
@@ -95,7 +95,7 @@ class InviteMembers extends React.Component<Props, State> {
             apiMethod="POST"
             submitLabel={t('Invite Member')}
             onSubmitSuccess={this.handleSubmitSuccess}
-            initialData={{teams: [project?.teams[0]?.slug]}}
+            initialData={{teams: [project?.teams?.[0]?.slug]}}
             {...formProps}
           >
             <HelpText>


### PR DESCRIPTION
I honestly don't know exactly why this fixes the test, but in the acceptance test the teams hasn't been populated yet. I think due to a race condition that I am not about to dig deep into at the moment, since in manual testing there is no problem.

Also this code is probably more correct anyway.