### PR TITLE
build(storybook): Include `integration-docs` fixtures in Vercel deploys

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -22,3 +22,5 @@
 !docs-ui/**
 !.storybook
 !.storybook/**
+!tests/fixtures/integration-docs
+!tests/fixtures/integration-docs/**


### PR DESCRIPTION
This is needed to be able to deploy storybook