### PR TITLE
fix(perf): Fix 'Missing instrumentation' appearing for Ember SDK

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -604,6 +604,7 @@ export function isEventFromBrowserJavaScriptSDK(event: SentryTransactionEvent): 
     'sentry.javascript.browser',
     'sentry.javascript.react',
     'sentry.javascript.gatsby',
+    'sentry.javascript.ember',
   ].includes(sdkName.toLowerCase());
 }
 


### PR DESCRIPTION
### Summary

This includes ember in the list to check if it's from a browser sdk