### PR TITLE
fix(workflow): When there is no filtered data in the issue stream change the tooltip text

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -270,7 +270,7 @@ const StreamGroup = createReactClass({
                 <tr>
                   <TooltipCount value={data.count} />
                   <TooltipText>
-                    {data.filtered ? t(`Without search filters`) : t(`Within ${summary}`)}
+                    {data.filtered ? t(`Without search filters`) : t(`In ${summary}`)}
                   </TooltipText>
                   {hasDiscoverQuery && (
                     <StyledIconTelescope
@@ -316,7 +316,7 @@ const StreamGroup = createReactClass({
                 <tr>
                   <TooltipCount value={data.userCount} />
                   <TooltipText>
-                    {data.filtered ? t(`Without search filters`) : t(`Within ${summary}`)}
+                    {data.filtered ? t(`Without search filters`) : t(`In ${summary}`)}
                   </TooltipText>
                   {hasDiscoverQuery && (
                     <StyledIconTelescope

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -23,6 +23,7 @@ import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import space from 'app/styles/space';
 import Tooltip from 'app/components/tooltip';
 import SentryTypes from 'app/sentryTypes';
+import {getRelativeSummary} from 'app/components/organizations/timeRangeSelector/utils';
 import {DEFAULT_STATS_PERIOD, MENU_CLOSE_DELAY} from 'app/constants';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
@@ -176,11 +177,18 @@ const StreamGroup = createReactClass({
       memberList,
       withChart,
       statsPeriod,
+      selection,
       organization,
     } = this.props;
 
     const hasDynamicIssueCounts = organization.features.includes('dynamic-issue-counts');
     const hasDiscoverQuery = organization.features.includes('discover-basic');
+
+    const {period, start, end} = selection.datetime || {};
+    const summary =
+      !!start && !!end
+        ? 'the selected period'
+        : getRelativeSummary(period || DEFAULT_STATS_PERIOD).toLowerCase();
 
     const popperStyle = {maxWidth: 'none'};
 
@@ -261,7 +269,9 @@ const StreamGroup = createReactClass({
                 )}
                 <tr>
                   <TooltipCount value={data.count} />
-                  <TooltipText>{t(`Without search filters`)}</TooltipText>
+                  <TooltipText>
+                    {data.filtered ? t(`Without search filters`) : t(`Within ${summary}`)}
+                  </TooltipText>
                   {hasDiscoverQuery && (
                     <StyledIconTelescope
                       to={this.getDiscoverUrl()}
@@ -305,7 +315,9 @@ const StreamGroup = createReactClass({
                 )}
                 <tr>
                   <TooltipCount value={data.userCount} />
-                  <TooltipText>{t(`Without search filters`)}</TooltipText>
+                  <TooltipText>
+                    {data.filtered ? t(`Without search filters`) : t(`Within ${summary}`)}
+                  </TooltipText>
                   {hasDiscoverQuery && (
                     <StyledIconTelescope
                       to={this.getDiscoverUrl()}


### PR DESCRIPTION
When there were no filters and no filtered data on issue stream issues, the tooltip still said "Without search filters"
Change it back to showing the time range if there is no filter, when filtered it stays the same

Part of:
[WOR-239](https://getsentry.atlassian.net/browse/WOR-239)

OLD: No filter says "Without search filters"
![1](https://user-images.githubusercontent.com/15015880/93233665-33563500-f730-11ea-9e7b-da4a1f4a72e5.png)

NEW: No filter says "Within <time period>"
![2](https://user-images.githubusercontent.com/15015880/93236768-10c61b00-f734-11ea-9009-f8f1802111a1.png)

STAYS SAME: When filtered says "Without filters"
![3](https://user-images.githubusercontent.com/15015880/93233678-351ff880-f730-11ea-8667-511652288ebc.png)
