### PR TITLE
build: Remove travis check for releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -10,7 +10,6 @@ statusProvider:
   config:
     contexts:
       - 'onpremise-builder (sentryio)'
-      - 'continuous-integration/travis-ci/push'
       - 'acceptance'
 targets:
   - name: github

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - releases/**
   pull_request:
 
 jobs:


### PR DESCRIPTION
Since we don't run travis on branches, this check would fail.
Also ensure acceptance tests do run on release branches.