### PR TITLE
fix(events): release:latest in issues events

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -81,7 +81,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         params = {
             "group_ids": [group.id],
             "project_id": [group.project_id],
-            "organization_id": group.project.organization,
+            "organization_id": group.project.organization_id,
             "start": start if start else default_start,
             "end": end if end else default_end,
         }

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -81,6 +81,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         params = {
             "group_ids": [group.id],
             "project_id": [group.project_id],
+            "organization_id": group.project.organization,
             "start": start if start else default_start,
             "end": end if end else default_end,
         }

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -908,7 +908,7 @@ def format_search_filter(term, params):
                         value,
                         params["project_id"],
                         params.get("environment_objects"),
-                        params["organization_id"],
+                        params.get("organization_id"),
                     )
                 ),
             )

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1729,6 +1729,17 @@ class GetSnubaQueryArgsTest(TestCase):
         result = get_filter("!last_seen():<=2020-04-01T19:34:52+00:00")
         assert result.having == [["last_seen", ">", 1585769692]]
 
+    def test_release_latest(self):
+        result = get_filter(
+            "release:latest",
+            params={"organization_id": self.organization.id, "project_id": [self.project.id]},
+        )
+        assert result.conditions == [[["isNull", ["release"]], "=", 1]]
+
+        # When organization id isn't included, project_id should unfortunately be an object
+        result = get_filter("release:latest", params={"project_id": [self.project]})
+        assert result.conditions == [[["isNull", ["release"]], "=", 1]]
+
     @pytest.mark.xfail(reason="this breaks issue search so needs to be redone")
     def test_trace_id(self):
         result = get_filter("trace:{}".format("a0fa8803753e40fd8124b21eeb2986b5"))

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -183,6 +183,25 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             [six.text_type(event_1.event_id), six.text_type(event_2.event_id)]
         )
 
+    def test_search_by_release(self):
+        self.login_as(user=self.user)
+        self.create_release(self.project, version="first-release")
+        event_1 = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "fingerprint": ["group-1"],
+                "timestamp": iso_format(self.min_ago),
+                "release": "first-release",
+            },
+            project_id=self.project.id,
+        )
+        url = u"/api/0/issues/{}/events/?query=release:latest".format(event_1.group.id)
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["eventID"] == event_1.event_id
+
     def test_environment(self):
         self.login_as(user=self.user)
         events = {}


### PR DESCRIPTION
- Fixes SENTRY-HH1
- The group endpoint didn't include organization_id in its params so I
  added that
- But also added a test to event_search.py so no organization_id doesn't
  break either