### PR TITLE
ci(craft): Only wait on GCB and nothing else

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -7,6 +7,9 @@ changelog: CHANGES
 changelogPolicy: auto
 statusProvider:
   name: github
+  config:
+    contexts:
+      - 'onpremise-builder (sentryio)'
 targets:
   - name: github
   - name: pypi


### PR DESCRIPTION
Because GitHub actions does weird stuff with build statuses.
