### PR TITLE
ci(craft): Skip publishing releases to PyPI temporarily

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -12,7 +12,8 @@ statusProvider:
       - 'onpremise-builder (sentryio)'
 targets:
   - name: github
-  - name: pypi
+# Skip publishing to PyPI until we get the 2.1.0 release for https://github.com/Grokzen/redis-py-cluster/
+#  - name: pypi
   - name: docker
     source: us.gcr.io/sentryio/sentry
     target: getsentry/sentry


### PR DESCRIPTION
Since we need to use an unreleased SHA for https://github.com/Grokzen/redis-py-cluster/, we cannot publish Sentry wheels to PyPI due to its security restrictions (not allowing direct URLs as dependencies). We will skip publishing 20.9.0 to PyPI for now.
