### PR TITLE
fix(ui): Protect against null current member in member filters

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -31,7 +31,7 @@ type Props = {
 } & RouteComponentProps<{orgId: string}, {}>;
 
 type State = AsyncView['state'] & {
-  member: Member & {roles: MemberRole[]};
+  member: (Member & {roles: MemberRole[]}) | null;
   members: Member[];
   invited: {[key: string]: 'loading' | 'success' | null};
 };
@@ -179,7 +179,7 @@ class OrganizationMembersList extends AsyncView<Props, State> {
               </Button>
               {isOpen && (
                 <StyledMembersFilter
-                  roles={currentMember.roles || MEMBER_ROLES}
+                  roles={currentMember?.roles ?? MEMBER_ROLES}
                   query={value}
                   onChange={(query: string) => handleChange(query)}
                 />


### PR DESCRIPTION
Fixes JAVASCRIPT-22TN

currentMember can be null if you are not a member of the org