### PR TITLE
fix(monitors): Fix bug in monitors where task headers aren't always a dict.

### DIFF
--- a/src/sentry/utils/monitors.py
+++ b/src/sentry/utils/monitors.py
@@ -62,7 +62,11 @@ def report_monitor_begin(task, **kwargs):
     if not SENTRY_DSN or not API_ROOT:
         return
 
-    monitor_id = task.request.headers.get("X-Sentry-Monitor")
+    headers = task.request.headers
+    if not headers:
+        return
+
+    monitor_id = headers.get("X-Sentry-Monitor")
     if not monitor_id:
         return
 
@@ -77,7 +81,7 @@ def report_monitor_begin(task, **kwargs):
     )
     req.raise_for_status()
     # HACK:
-    task.request.headers["X-Sentry-Monitor-CheckIn"] = (req.json()["id"], time())
+    headers["X-Sentry-Monitor-CheckIn"] = (req.json()["id"], time())
 
 
 @suppress_errors
@@ -85,12 +89,16 @@ def report_monitor_complete(task, retval, **kwargs):
     if not SENTRY_DSN or not API_ROOT:
         return
 
-    monitor_id = task.request.headers.get("X-Sentry-Monitor")
+    headers = task.request.headers
+    if not headers:
+        return
+
+    monitor_id = headers.get("X-Sentry-Monitor")
     if not monitor_id:
         return
 
     try:
-        checkin_id, start_time = task.request.headers.get("X-Sentry-Monitor-CheckIn")
+        checkin_id, start_time = headers.get("X-Sentry-Monitor-CheckIn")
     except (ValueError, TypeError):
         return
 


### PR DESCRIPTION
In Celery 4.4.x, `task.request.headers` isn't guaranteed to be a dict - it can now be None. This
caused tasks that aren't set up to have monitors to error.

This code is totally untested, I'm not going to fix that here.

Fixes SENTRY-HT5