### PR TITLE
fix(alerts): Redirect to alert rules after issue rule cancel

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -267,9 +267,9 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   };
 
   handleCancel = () => {
-    const {router} = this.props;
+    const {organization, router} = this.props;
 
-    router.push(recreateRoute('rules/', {...this.props, stepBack: -2}));
+    router.push(`/organizations/${organization.slug}/alerts/rules/`);
   };
 
   hasError = (field: string) => {


### PR DESCRIPTION
If a user uses "create from discover" and then switches to an issue alert, they are redirected with query parameters that break the rules list page. We do not want to preserve these query params after they have left rule creation.

doesn't fix this issue but its related
https://sentry.io/organizations/sentry/issues/1426858033/events/db47ce0a88174ab7bf456c9de00f933f/?project=11276

part 2 of https://github.com/getsentry/sentry/pull/20762