### PR TITLE
(onpremise) Fix `TypeError: a float is required` in 0024_auto_20191230_2052.py

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -104,14 +104,6 @@ class SnubaProtocolEventStream(EventStream):
         if unexpected_tags:
             logger.error("%r received unexpected tags: %r", self, unexpected_tags)
 
-        # When migrating old data from Sentry 9.0.0 to 9.1.2 to 10, event.datetime and the underlying event.timestamp
-        # may be None. datetime.fromtimestamp will error out because None is not a valid timestamp
-        try:
-            event_datetime = event.datetime
-        except TypeError:
-            event_datetime = received_timestamp
-        print(event_datetime)
-
         self._send(
             project.id,
             "insert",
@@ -125,7 +117,7 @@ class SnubaProtocolEventStream(EventStream):
                     # message but this is what snuba needs at the moment.
                     "message": event.search_message,
                     "platform": event.platform,
-                    "datetime": event_datetime,
+                    "datetime": event.datetime,
                     "data": event_data,
                     "primary_hash": primary_hash,
                     "retention_days": retention_days,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -104,6 +104,14 @@ class SnubaProtocolEventStream(EventStream):
         if unexpected_tags:
             logger.error("%r received unexpected tags: %r", self, unexpected_tags)
 
+        # When migrating old data from Sentry 9.0.0 to 9.1.2 to 10, event.datetime and the underlying event.timestamp
+        # may be None. datetime.fromtimestamp will error out because None is not a valid timestamp
+        try:
+            event_datetime = event.datetime
+        except TypeError:
+            event_datetime = received_timestamp
+        print(event_datetime)
+
         self._send(
             project.id,
             "insert",
@@ -117,7 +125,7 @@ class SnubaProtocolEventStream(EventStream):
                     # message but this is what snuba needs at the moment.
                     "message": event.search_message,
                     "platform": event.platform,
-                    "datetime": event.datetime,
+                    "datetime": event_datetime,
                     "data": event_data,
                     "primary_hash": primary_hash,
                     "retention_days": retention_days,

--- a/src/sentry/migrations/0024_auto_20191230_2052.py
+++ b/src/sentry/migrations/0024_auto_20191230_2052.py
@@ -56,7 +56,7 @@ def backfill_eventstream(apps, schema_editor):
             event.group = groups.get(event.group_id)
             # When migrating old data from Sentry 9.0.0 to 9.1.2 to 10 in rapid succession, the event timestamp may be
             # missing. This adds it back
-            if not event.data.data.get("timestamp"):
+            if "timestamp" not in event.data.data:
                 event.data.data['timestamp'] = to_timestamp(event.datetime)
         eventstore.bind_nodes(_events, "data")
 

--- a/src/sentry/migrations/0024_auto_20191230_2052.py
+++ b/src/sentry/migrations/0024_auto_20191230_2052.py
@@ -57,7 +57,7 @@ def backfill_eventstream(apps, schema_editor):
             # missing. This adds it back
             if not event.data.data.get("timestamp"):
                 # Python 2.7 way to convert datetime to timestamp.
-                timestamp = ((e.datetime.replace(tzinfo=None) - e.datetime.utcoffset()) - datetime(1970, 1, 1)).total_seconds()
+                timestamp = ((event.datetime.replace(tzinfo=None) - event.datetime.utcoffset()) - datetime(1970, 1, 1)).total_seconds()
                 event.data.data['timestamp'] = timestamp
         eventstore.bind_nodes(_events, "data")
 

--- a/src/sentry/migrations/0024_auto_20191230_2052.py
+++ b/src/sentry/migrations/0024_auto_20191230_2052.py
@@ -55,6 +55,18 @@ def backfill_eventstream(apps, schema_editor):
             event.group = groups.get(event.group_id)
         eventstore.bind_nodes(_events, "data")
 
+    def _attach_timestamp(_events):
+        """
+        When migrating old data from Sentry 9.0.0 to 9.1.2 to 10 in rapid succession, the event timestamp may be missing.
+        This function exists to attach the timestamp if its missing
+        """
+        for event in _events:
+            if not event.data.data.get("timestamp"):
+                # Python 2.7 way to convert datetime to timestamp.
+                timestamp = ((e.datetime.replace(tzinfo=None) - e.datetime.utcoffset()) - datetime(1970, 1, 1)).total_seconds()
+                e.data.data['timestamp'] = timestamp
+        eventstore.bind_nodes(_events, "data")
+
     if skip_backfill:
         print("Skipping backfill.\n")
         return
@@ -69,14 +81,7 @@ def backfill_eventstream(apps, schema_editor):
     print("Events to process: {}\n".format(count))
 
     processed = 0
-    for e in RangeQuerySetWrapper(events, step=100, callbacks=(_attach_related,)):
-
-        # When migrating old data from Sentry 9.0.0 to 9.1.2 to 10 in rapid succession, the event timestamp may be
-        # missing. To fix this we convert the datestamp to a timestamp.
-        if not e.data.data.get("timestamp"):
-            # Python 2.7 way to convert datetime to timestamp.
-            e.data.data['timestamp'] = ((e.datetime.replace(tzinfo=None) - e.datetime.utcoffset()) - datetime(1970, 1, 1)).total_seconds()
-
+    for e in RangeQuerySetWrapper(events, step=100, callbacks=(_attach_related, _attach_timestamp,)):
         event = NewEvent(
             project_id=e.project_id, event_id=e.event_id, group_id=e.group_id, data=e.data.data
         )


### PR DESCRIPTION
Fixes: https://github.com/getsentry/onpremise/issues/366

**Description of bug**
If an on-premise user has migrated rapidly (within the past 90 days) from 9.0.0 to 9.1.2 to 10.x they may encounter a `TypeError: a float is required` error because the event.timestamp does not exist and None is not a valid posix timestamp. 


The fix I've implemented wraps event.datetime in a try except block, and if it gets a type error uses the recieved_timestamp instead

**Alternative approaches considered:**
Something I considered, which may be cleaner from a maintainability perspective is overriding the insert logic in the migration, that way you don't have this try except block in a widely used code path

