### PR TITLE
feat(alert): Add stacktrace.abs_path as an alerting option

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -48,6 +48,7 @@ ATTR_CHOICES = [
     "stacktrace.code",
     "stacktrace.module",
     "stacktrace.filename",
+    "stacktrace.abs_path",
 ]
 
 
@@ -68,7 +69,7 @@ class EventAttributeCondition(EventCondition):
     - exception.{type,value}
     - user.{id,ip_address,email,FIELD}
     - http.{method,url}
-    - stacktrace.{code,module,filename}
+    - stacktrace.{code,module,filename,abs_path}
     - extra.{FIELD}
     """
 
@@ -150,11 +151,10 @@ class EventAttributeCondition(EventCondition):
                 stacks = [
                     e.stacktrace for e in event.interfaces["exception"].values if e.stacktrace
                 ]
-
             result = []
             for st in stacks:
                 for frame in st.frames:
-                    if path[1] in ("filename", "module"):
+                    if path[1] in ("filename", "module", "abs_path"):
                         result.append(getattr(frame, path[1]))
                     elif path[1] == "code":
                         if frame.pre_context:

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -28,6 +28,7 @@ class EventAttributeConditionTest(RuleTestCase):
                                     "filename": "example.php",
                                     "module": "example",
                                     "context_line": 'echo "hello";',
+                                    "abs_path": "path/to/example.php",
                                 }
                             ]
                         },
@@ -411,4 +412,54 @@ class EventAttributeConditionTest(RuleTestCase):
         self.assertPasses(rule, event)
 
         rule = self.get_rule(data={"match": MatchType.EQUAL, "attribute": "type", "value": "csp"})
+        self.assertDoesNotPass(rule, event)
+
+    def test_stacktrace_abs_path(self):
+        """Stacktrace.abs_path should match frames anywhere in the stack."""
+
+        event = self.get_event(
+            exception={
+                "values": [
+                    {
+                        "type": "SyntaxError",
+                        "value": "hello world",
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "filename": "example.php",
+                                    "module": "example",
+                                    "abs_path": "path/to/example.php",
+                                },
+                                {
+                                    "filename": "somecode.php",
+                                    "module": "somecode",
+                                    "abs_path": "path/to/somecode.php",
+                                },
+                                {
+                                    "filename": "othercode.php",
+                                    "module": "othercode",
+                                    "abs_path": "path/to/othercode.php",
+                                },
+                            ]
+                        },
+                    }
+                ]
+            }
+        )
+
+        # correctly matching filenames, at various locations in the stacktrace
+        for value in ["path/to/example.php", "path/to/somecode.php", "path/to/othercode.php"]:
+            rule = self.get_rule(
+                data={"match": MatchType.EQUAL, "attribute": "stacktrace.abs_path", "value": value}
+            )
+            self.assertPasses(rule, event)
+
+        # non-matching filename
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "stacktrace.abs_path",
+                "value": "path/to/foo.php",
+            }
+        )
         self.assertDoesNotPass(rule, event)


### PR DESCRIPTION
Some customers would like to be able to filter away alerts from third party libraries. This seems to be most easily distinguished by keywords in the absolute path of the stacktrace. This code exposes abs_path as a possible alerting option for the `EventAttributeCondition`. 

**Condition**
![image](https://user-images.githubusercontent.com/9372512/93377406-f4f07100-f828-11ea-94a7-68e0e3ccac79.png)

**Dropdown**
![image](https://user-images.githubusercontent.com/9372512/93377497-0f2a4f00-f829-11ea-98e9-74a8c52be535.png)
