### PR TITLE
feat(alerts): Add bucketing to metric alert graph

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import maxBy from 'lodash/maxBy';
+import chunk from 'lodash/chunk';
 import styled from '@emotion/styled';
 
 import {Client} from 'app/api';
@@ -83,17 +84,47 @@ const AVAILABLE_TIME_PERIODS: Record<TimeWindow, TimePeriod[]> = {
   [TimeWindow.ONE_DAY]: [TimePeriod.THIRTY_DAYS],
 };
 
+const AGGREGATE_FUNCTIONS = {
+  none: (seriesChunk: SeriesDataUnit[]) => seriesChunk,
+  avg: (seriesChunk: SeriesDataUnit[]) =>
+    AGGREGATE_FUNCTIONS.sum(seriesChunk) / seriesChunk.length,
+  sum: (seriesChunk: SeriesDataUnit[]) =>
+    seriesChunk.reduce((acc, series) => acc + series.value, 0),
+  max: (seriesChunk: SeriesDataUnit[]) =>
+    Math.max(...seriesChunk.map(series => series.value)),
+};
+
+const AGGREGATE_FUNCTION_MAP: Record<keyof typeof AGGREGATE_FUNCTIONS, string> = {
+  none: t('None'),
+  avg: t('Average'),
+  sum: t('Sum'),
+  max: t('Max'),
+};
+
+type State = {
+  statsPeriod: TimePeriod;
+  aggregateFn: keyof typeof AGGREGATE_FUNCTIONS;
+};
+
 /**
  * This is a chart to be used in Metric Alert rules that fetches events based on
  * query, timewindow, and aggregations.
  */
-class TriggersChart extends React.PureComponent<Props> {
-  state = {
+class TriggersChart extends React.PureComponent<Props, State> {
+  state: State = {
     statsPeriod: TimePeriod.ONE_DAY,
+    aggregateFn: 'none',
   };
 
   handleStatsPeriodChange = (statsPeriod: {value: TimePeriod; label: string}) => {
     this.setState({statsPeriod: statsPeriod.value});
+  };
+
+  handleAggregateFunctionChange = (aggregateFn: {
+    value: keyof typeof AGGREGATE_FUNCTIONS;
+    label: string;
+  }) => {
+    this.setState({aggregateFn: aggregateFn.value});
   };
 
   render() {
@@ -109,7 +140,7 @@ class TriggersChart extends React.PureComponent<Props> {
       thresholdType,
       environment,
     } = this.props;
-    const {statsPeriod} = this.state;
+    const {statsPeriod, aggregateFn} = this.state;
 
     const statsPeriodOptions = AVAILABLE_TIME_PERIODS[timeWindow];
     const period = statsPeriodOptions.includes(statsPeriod)
@@ -131,8 +162,22 @@ class TriggersChart extends React.PureComponent<Props> {
       >
         {({loading, reloading, timeseriesData}) => {
           let maxValue: SeriesDataUnit | undefined;
-          if (timeseriesData && timeseriesData.length && timeseriesData[0].data) {
+          if (
+            timeseriesData &&
+            timeseriesData.length &&
+            timeseriesData[0].data !== undefined
+          ) {
             maxValue = maxBy(timeseriesData[0].data, ({value}) => value);
+            if (aggregateFn !== 'none') {
+              timeseriesData[0].data = chunk(timeseriesData[0].data, 2).map(
+                seriesChunk => {
+                  return {
+                    name: seriesChunk[0].name,
+                    value: AGGREGATE_FUNCTIONS[aggregateFn](seriesChunk),
+                  };
+                }
+              );
+            }
           }
 
           return (
@@ -140,26 +185,49 @@ class TriggersChart extends React.PureComponent<Props> {
               <StyledPanel>
                 <PanelBody withPadding>
                   <Feature features={['internal-catchall']} organization={organization}>
-                    <StyledSelectControl
-                      inline={false}
-                      styles={{
-                        control: provided => ({
-                          ...provided,
-                          minHeight: '25px',
-                          height: '25px',
-                        }),
-                      }}
-                      isSearchable={false}
-                      isClearable={false}
-                      disabled={loading || reloading}
-                      name="statsPeriod"
-                      value={period}
-                      choices={statsPeriodOptions.map(timePeriod => [
-                        timePeriod,
-                        TIME_PERIOD_MAP[timePeriod],
-                      ])}
-                      onChange={this.handleStatsPeriodChange}
-                    />
+                    <ControlsContainer>
+                      {/* TODO(scttcper): Remove internal aggregate experiment */}
+                      <AggregationSelectControl
+                        inline={false}
+                        styles={{
+                          control: provided => ({
+                            ...provided,
+                            minHeight: '25px',
+                            height: '25px',
+                          }),
+                        }}
+                        isSearchable={false}
+                        isClearable={false}
+                        disabled={loading || reloading}
+                        name="aggregateFn"
+                        value={aggregateFn}
+                        choices={Object.keys(AGGREGATE_FUNCTIONS).map(fnName => [
+                          fnName,
+                          AGGREGATE_FUNCTION_MAP[fnName],
+                        ])}
+                        onChange={this.handleAggregateFunctionChange}
+                      />
+                      <PeriodSelectControl
+                        inline={false}
+                        styles={{
+                          control: provided => ({
+                            ...provided,
+                            minHeight: '25px',
+                            height: '25px',
+                          }),
+                        }}
+                        isSearchable={false}
+                        isClearable={false}
+                        disabled={loading || reloading}
+                        name="statsPeriod"
+                        value={period}
+                        choices={statsPeriodOptions.map(timePeriod => [
+                          timePeriod,
+                          TIME_PERIOD_MAP[timePeriod],
+                        ])}
+                        onChange={this.handleStatsPeriodChange}
+                      />
+                    </ControlsContainer>
                   </Feature>
 
                   {loading || reloading ? (
@@ -212,9 +280,23 @@ const StyledPanel = styled(Panel)`
   margin-bottom: 0;
 `;
 
-const StyledSelectControl = styled(SelectControl)`
+const ControlsContainer = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const AggregationSelectControl = styled(SelectControl)`
+  display: inline-block;
+  width: 120px;
+  margin-right: ${space(1)};
+  font-weight: normal;
+  text-transform: none;
+  border: 0;
+`;
+
+const PeriodSelectControl = styled(SelectControl)`
+  display: inline-block;
   width: 180px;
-  margin: 0 0 ${space(1)} auto;
   font-weight: normal;
   text-transform: none;
   border: 0;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -168,8 +168,16 @@ class TriggersChart extends React.PureComponent<Props, State> {
             timeseriesData[0].data !== undefined
           ) {
             maxValue = maxBy(timeseriesData[0].data, ({value}) => value);
-            if (aggregateFn !== 'none') {
-              timeseriesData[0].data = chunk(timeseriesData[0].data, 2).map(
+            if (aggregateFn !== 'none' && timeseriesData[0].data.length > 400) {
+              let chunks = 0;
+              if (timeseriesData[0].data.length > 8000) {
+                chunks = 20;
+              } else if (timeseriesData[0].data.length > 4000) {
+                chunks = 10;
+              } else if (timeseriesData[0].data.length > 2000) {
+                chunks = 5;
+              }
+              timeseriesData[0].data = chunk(timeseriesData[0].data, chunks).map(
                 seriesChunk => {
                   return {
                     name: seriesChunk[0].name,
@@ -187,26 +195,28 @@ class TriggersChart extends React.PureComponent<Props, State> {
                   <Feature features={['internal-catchall']} organization={organization}>
                     <ControlsContainer>
                       {/* TODO(scttcper): Remove internal aggregate experiment */}
-                      <AggregationSelectControl
-                        inline={false}
-                        styles={{
-                          control: provided => ({
-                            ...provided,
-                            minHeight: '25px',
-                            height: '25px',
-                          }),
-                        }}
-                        isSearchable={false}
-                        isClearable={false}
-                        disabled={loading || reloading}
-                        name="aggregateFn"
-                        value={aggregateFn}
-                        choices={Object.keys(AGGREGATE_FUNCTIONS).map(fnName => [
-                          fnName,
-                          AGGREGATE_FUNCTION_MAP[fnName],
-                        ])}
-                        onChange={this.handleAggregateFunctionChange}
-                      />
+                      {timeseriesData?.[0] && timeseriesData[0].data.length > 400 && (
+                        <AggregationSelectControl
+                          inline={false}
+                          styles={{
+                            control: provided => ({
+                              ...provided,
+                              minHeight: '25px',
+                              height: '25px',
+                            }),
+                          }}
+                          isSearchable={false}
+                          isClearable={false}
+                          disabled={loading || reloading}
+                          name="aggregateFn"
+                          value={aggregateFn}
+                          choices={Object.keys(AGGREGATE_FUNCTIONS).map(fnName => [
+                            fnName,
+                            AGGREGATE_FUNCTION_MAP[fnName],
+                          ])}
+                          onChange={this.handleAggregateFunctionChange}
+                        />
+                      )}
                       <PeriodSelectControl
                         inline={false}
                         styles={{

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -92,13 +92,16 @@ const AGGREGATE_FUNCTIONS = {
     seriesChunk.reduce((acc, series) => acc + series.value, 0),
   max: (seriesChunk: SeriesDataUnit[]) =>
     Math.max(...seriesChunk.map(series => series.value)),
+  min: (seriesChunk: SeriesDataUnit[]) =>
+    Math.min(...seriesChunk.map(series => series.value)),
 };
 
 const AGGREGATE_FUNCTION_MAP: Record<keyof typeof AGGREGATE_FUNCTIONS, string> = {
   none: t('None'),
   avg: t('Average'),
   sum: t('Sum'),
-  max: t('Max'),
+  max: t('Maximum'),
+  min: t('Minimum'),
 };
 
 type State = {


### PR DESCRIPTION
Little experiment to test aggregation with the metric graph. This will only be available internally. The use-case is a 1 min window with 7 day time period is 10k data points making each datapoint too small on the graph. This lets us test out a few different styles of aggregation.

This will cut the number of points in half using the selected method.


![image](https://user-images.githubusercontent.com/1400464/93397935-7519d500-f82f-11ea-8c55-2444e4f4784e.png)
