### PR TITLE
build(gha): Rename getsentry dispatch input

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -46,7 +46,7 @@ jobs:
                 workflow_id: 'acceptance.yml',
                 ref: 'master',
                 inputs: {
-                  sha: '${{ github.event.pull_request.head.sha }}',
+                  'sentry-sha': '${{ github.event.pull_request.head.sha }}',
                 }
               })
 

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -34,7 +34,7 @@ jobs:
                 workflow_id: 'javascript.yml',
                 ref: 'master',
                 inputs: {
-                  sha: '${{ github.event.pull_request.head.sha }}',
+                  'sentry-sha': '${{ github.event.pull_request.head.sha }}',
                 }
               })
 
@@ -73,6 +73,7 @@ jobs:
 
         # Setup custom tsc matcher, see https://github.com/actions/setup-node/issues/97
         - name: tsc
+          id: tsc
           if: always()
           run: |
             echo "::remove-matcher owner=tsc::"


### PR DESCRIPTION
This renames the getsentry workflow dispatch input name from `sha` to `sentry-sha` to be a bit more specific. This will help when reading workflows in getsentry.