### PR TITLE
feat(workflow): Dynamic counts chart buckets and no filtered stats except issue list

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -527,7 +527,7 @@ class GroupStatsMixin(object):
     }
 
     CUSTOM_SEGMENTS = 29  # for 30 segments use 1/29th intervals
-    CUSTOM_ROLLUP = timedelta(hours=6).total_seconds()  # rollups should be increments of 6hs
+    CUSTOM_ROLLUP_6H = timedelta(hours=6).total_seconds()  # rollups should be increments of 6hs
 
     def query_tsdb(self, group_ids, query_params):
         raise NotImplementedError
@@ -541,14 +541,14 @@ class GroupStatsMixin(object):
                 total_period = (self.stats_period_end - self.stats_period_start).total_seconds()
                 rollup = total_period / self.CUSTOM_SEGMENTS
 
-                if rollup > self.CUSTOM_ROLLUP:
-                    rollup = round(rollup / self.CUSTOM_ROLLUP) * self.CUSTOM_ROLLUP
-                elif (2 * rollup) > self.CUSTOM_ROLLUP:
-                    rollup = self.CUSTOM_ROLLUP / 2
-                elif (3 * rollup) > self.CUSTOM_ROLLUP:
-                    rollup = self.CUSTOM_ROLLUP / 3
-                else:
-                    rollup = self.CUSTOM_ROLLUP / 6
+                if rollup > self.CUSTOM_ROLLUP_6H:
+                    rollup = round(rollup / self.CUSTOM_ROLLUP_6H) * self.CUSTOM_ROLLUP_6H
+                elif (2 * rollup) > self.CUSTOM_ROLLUP_6H:
+                    rollup = self.CUSTOM_ROLLUP_6H / 2  # 3hrs
+                elif (3 * rollup) > self.CUSTOM_ROLLUP_6H:
+                    rollup = self.CUSTOM_ROLLUP_6H / 3  # 2hr
+                elif total_period > timedelta(hours=24).total_seconds():
+                    rollup = self.CUSTOM_ROLLUP_6H / 6  # 1hr
 
                 query_params = {
                     "start": self.stats_period_start,

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -45,6 +45,7 @@ const StreamGroup = createReactClass({
     withChart: PropTypes.bool,
     selection: SentryTypes.GlobalSelection.isRequired,
     organization: SentryTypes.Organization.isRequired,
+    useFilteredStats: PropTypes.bool,
   },
 
   mixins: [Reflux.listenTo(GroupStore, 'onGroupChange')],
@@ -55,20 +56,34 @@ const StreamGroup = createReactClass({
       statsPeriod: '24h',
       canSelect: true,
       withChart: true,
+      useFilteredStats: false,
     };
   },
 
   getInitialState() {
+    const data = GroupStore.get(this.props.id);
+
     return {
-      data: GroupStore.get(this.props.id),
+      data: {
+        ...data,
+        filtered: this.props.useFilteredStats ? data.filtered : undefined,
+      },
       showLifetimeStats: false,
     };
   },
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.id !== this.props.id) {
+    if (
+      nextProps.id !== this.props.id ||
+      nextProps.useFilteredStats !== this.props.useFilteredStats
+    ) {
+      const data = GroupStore.get(this.props.id);
+
       this.setState({
-        data: GroupStore.get(this.props.id),
+        data: {
+          ...data,
+          filtered: nextProps.useFilteredStats ? data.filtered : undefined,
+        },
       });
     }
   },

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import {PanelItem} from 'app/components/panels';
 import {valueIsEqual} from 'app/utils';
 import theme from 'app/utils/theme';
-import {IconTelescope} from 'app/icons';
+import {IconOpen} from 'app/icons';
 import AssigneeSelector from 'app/components/assigneeSelector';
 import Count from 'app/components/count';
 import EventOrGroupExtraDetails from 'app/components/eventOrGroupExtraDetails';
@@ -260,7 +260,7 @@ const StreamGroup = createReactClass({
                     <TooltipCount value={data.filtered.count} />
                     <TooltipText>{t('Matching search filters')}</TooltipText>
                     {hasDiscoverQuery && (
-                      <StyledIconTelescope
+                      <StyledIconOpen
                         to={this.getDiscoverUrl(true)}
                         color={theme.blue300}
                       />
@@ -273,10 +273,7 @@ const StreamGroup = createReactClass({
                     {data.filtered ? t(`Without search filters`) : t(`In ${summary}`)}
                   </TooltipText>
                   {hasDiscoverQuery && (
-                    <StyledIconTelescope
-                      to={this.getDiscoverUrl()}
-                      color={theme.blue300}
-                    />
+                    <StyledIconOpen to={this.getDiscoverUrl()} color={theme.blue300} />
                   )}
                 </tr>
                 {data.lifetime && (
@@ -306,7 +303,7 @@ const StreamGroup = createReactClass({
                     <TooltipCount value={data.filtered.userCount} />
                     <TooltipText>{t('Matching search filters')}</TooltipText>
                     {hasDiscoverQuery && (
-                      <StyledIconTelescope
+                      <StyledIconOpen
                         to={this.getDiscoverUrl(true)}
                         color={theme.blue300}
                       />
@@ -319,10 +316,7 @@ const StreamGroup = createReactClass({
                     {data.filtered ? t(`Without search filters`) : t(`In ${summary}`)}
                   </TooltipText>
                   {hasDiscoverQuery && (
-                    <StyledIconTelescope
-                      to={this.getDiscoverUrl()}
-                      color={theme.blue300}
-                    />
+                    <StyledIconOpen to={this.getDiscoverUrl()} color={theme.blue300} />
                   )}
                 </tr>
                 {data.lifetime && (
@@ -405,10 +399,10 @@ const TooltipText = styled('td')`
   padding: ${space(0.5)} ${space(1)};
 `;
 
-const StyledIconTelescope = styled(({to, ...p}) => (
+const StyledIconOpen = styled(({to, ...p}) => (
   <td {...p}>
     <Link title={t('Open in Discover')} to={to} target="_blank">
-      <IconTelescope size="xs" color={p.color} />
+      <IconOpen size="xs" color={p.color} />
     </Link>
   </td>
 ))`

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -540,6 +540,7 @@ const IssueListOverview = createReactClass({
           query={this.getQuery()}
           hasGuideAnchor={hasGuideAnchor}
           memberList={members}
+          useFilteredStats
         />
       );
     });


### PR DESCRIPTION
In this PR:
- Made stacked bar chart buckets snap to multiples of 6h (or 3/2/1 hours if period is small)
- Remove telescope icon from tooltip
- Limited use of filtered stats to issue list only (other places have hardcoded filters)

Resolves part of:
[WOR-239](https://getsentry.atlassian.net/browse/WOR-239)