### PR TITLE
chore(react): Make tooltipstore forward compatible with v17rc

### DIFF
--- a/src/sentry/static/sentry/app/stores/tooltipStore.tsx
+++ b/src/sentry/static/sentry/app/stores/tooltipStore.tsx
@@ -16,9 +16,11 @@ const TooltipStore: TooltipStoreInterface = {
   getOpenableSingleTooltips() {
     return this.tooltips.filter(tooltip => {
       // Filtering out disabled tooltips and lists of tooltips (which cause rendering issues for snapshots) using the internal 'key'
+      const internals =
+        (tooltip as any)._reactInternalFiber || (tooltip as any)._reactInternals;
       return (
         !(tooltip.props as any).disabled &&
-        !(tooltip as any)._reactInternalFiber.key &&
+        !internals.key &&
         !(tooltip.props as any).disableForVisualTest
       );
     });

--- a/src/sentry/static/sentry/app/stores/tooltipStore.tsx
+++ b/src/sentry/static/sentry/app/stores/tooltipStore.tsx
@@ -16,11 +16,11 @@ const TooltipStore: TooltipStoreInterface = {
   getOpenableSingleTooltips() {
     return this.tooltips.filter(tooltip => {
       // Filtering out disabled tooltips and lists of tooltips (which cause rendering issues for snapshots) using the internal 'key'
-      const internals =
+      const _internals =
         (tooltip as any)._reactInternalFiber || (tooltip as any)._reactInternals;
       return (
         !(tooltip.props as any).disabled &&
-        !internals.key &&
+        !_internals.key &&
         !(tooltip.props as any).disableForVisualTest
       );
     });


### PR DESCRIPTION
### Summary
Fixes the issue with `tooltipStore` not being forward compatible with v17, we can remove `_reactInternalFiber` in a separate PR after we upgrade.