### PR TITLE
fix(integrations): make email matching case insensitive

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -78,17 +78,19 @@ def get_users_for_authors(organization_id, authors, user=None):
     # Figure out which email address matches to a user
     users_by_email = {}
     for email in user_emails:
-        if email.email not in users_by_email:
+        # force emails to lower case so we can do case insensitive matching
+        lower_email = email.email.lower()
+        if lower_email not in users_by_email:
             user = users_by_id.get(six.text_type(email.user_id), None)
             # user can be None if there's a user associated
             # with user_email in separate organization
             if user:
-                users_by_email[email.email] = user
+                users_by_email[lower_email] = user
 
     results = {}
     for author in authors:
         results[six.text_type(author.id)] = users_by_email.get(
-            author.email, {"name": author.name, "email": author.email}
+            author.email.lower(), {"name": author.name, "email": author.email}
         )
 
     return results

--- a/src/sentry/models/commitauthor.py
+++ b/src/sentry/models/commitauthor.py
@@ -8,7 +8,7 @@ from sentry.db.models import BoundedPositiveIntegerField, Model, sane_repr
 
 class CommitAuthorManager(BaseManager):
     def get_or_create(self, organization_id, email, defaults, **kwargs):
-        # Force email address to lowercase because GitHub does this. Note though that this isn't technically
+        # Force email address to lowercase because many providers do this. Note though that this isn't technically
         # to spec; only the domain part of the email address is actually case-insensitive.
         # See: https://stackoverflow.com/questions/9807909/are-email-addresses-case-sensitive
         return super(CommitAuthorManager, self).get_or_create(

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -159,7 +159,9 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         assert not result["lastEvent"]
 
     def test_get_user_from_email(self):
-        user = User.objects.create(email="Stebe@sentry.io")
+        user = User.objects.create(
+            email="Stebe@sentry.io"
+        )  # upper case so we can test case sensitivity
         UserEmail.get_primary_email(user=user)
         project = self.create_project()
         self.create_member(user=user, organization=project.organization)

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -159,7 +159,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         assert not result["lastEvent"]
 
     def test_get_user_from_email(self):
-        user = User.objects.create(email="stebe@sentry.io")
+        user = User.objects.create(email="Stebe@sentry.io")
         UserEmail.get_primary_email(user=user)
         project = self.create_project()
         self.create_member(user=user, organization=project.organization)


### PR DESCRIPTION
This PR changes the commit serializer so that we can match the `CommitAuthor` and `UserEmail` rows based on a case insensitive email match. We use this in showing the commits for a release. This fixes the bug where the commit author is lower case but the `UserEmail` is not. Note this does mean that if two different users have email addresses that are case insensitive matches, it might pick the wrong one. However, this is an edge case that really should not happen (Scefali@sentry.io and scefali@sentry.io should not be two different users).

Before:
![Screen Shot 2020-09-17 at 12 26 10 PM](https://user-images.githubusercontent.com/8533851/93512139-1876f280-f8e1-11ea-95b9-4be1884b71bf.png)

After:

![Screen Shot 2020-09-17 at 12 25 01 PM](https://user-images.githubusercontent.com/8533851/93512155-1f056a00-f8e1-11ea-837a-f2c7a15eb937.png)
