### PR TITLE
fix(py3): Fix `test_discover_saved_queries.py` tests for Python 3.

### DIFF
--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -236,7 +236,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
         if bad_fields:
             raise serializers.ValidationError(
                 "You cannot use the %s attribute(s) with the selected version"
-                % ", ".join(bad_fields)
+                % ", ".join(sorted(bad_fields))
             )
 
 

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
-from sentry.testutils import APITestCase, SnubaTestCase
 from django.core.urlresolvers import reverse
 
 from sentry.discover.models import DiscoverSavedQuery
+from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 
 
@@ -248,7 +248,10 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
                 },
             )
         assert response.status_code == 400, response.content
-        assert "cannot use the environment, yAxis attribute(s)" in response.content
+        assert (
+            "You cannot use the environment, yAxis attribute(s) with the selected version"
+            == response.data["non_field_errors"][0]
+        )
 
 
 class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
@@ -272,7 +275,10 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
                 },
             )
         assert response.status_code == 400, response.content
-        assert "cannot use the conditions attribute(s)" in response.content
+        assert (
+            "You cannot use the conditions attribute(s) with the selected version"
+            == response.data["non_field_errors"][0]
+        )
 
     def test_post_require_selected_fields(self):
         with self.feature(self.feature_name):
@@ -287,7 +293,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
                 },
             )
         assert response.status_code == 400, response.content
-        assert "include at least one field" in response.content
+        assert "You must include at least one field." == response.data["non_field_errors"][0]
 
     def test_post_success(self):
         with self.feature(self.feature_name):


### PR DESCRIPTION
These tests were failing due to:
 - Comparing a string to the bytes from response.content
 - The string built was non-deterministic because a dict was used to construct it.