### PR TITLE
fix(ui):tidied up metric alert actions

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/actionTargetSelector.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/actionTargetSelector.tsx
@@ -92,6 +92,6 @@ export default function ActionTargetSelector(props: Props) {
       );
 
     default:
-      return <span />;
+      return null;
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -344,7 +344,7 @@ class ActionsPanel extends React.PureComponent<Props> {
               icon={<IconAdd isCircled color="gray500" />}
               onClick={this.handleAddAction}
             >
-              Add Item
+              Add New Action
             </Button>
           </StyledPanelItem>
         </PanelBody>
@@ -364,7 +364,6 @@ const PanelItemWrapper = styled(`div`)`
 const PanelItemGrid = styled(PanelItem)`
   display: flex;
   align-items: center;
-  gap: ${space(2)};
   padding: ${space(1)};
   border-bottom: 0;
   justify-content: between;
@@ -373,9 +372,12 @@ const PanelItemGrid = styled(PanelItem)`
 const PanelItemSelects = styled('div')`
   display: flex;
   width: 100%;
-  gap: 15px;
   > * {
     flex: 0 1 200px;
+
+    &:not(:last-child) {
+      margin-right: ${space(1)};
+    }
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -344,7 +344,7 @@ class ActionsPanel extends React.PureComponent<Props> {
               icon={<IconAdd isCircled color="gray500" />}
               onClick={this.handleAddAction}
             >
-              Add New Action
+              {t('Add New Action')}
             </Button>
           </StyledPanelItem>
         </PanelBody>
@@ -366,12 +366,12 @@ const PanelItemGrid = styled(PanelItem)`
   align-items: center;
   padding: ${space(1)};
   border-bottom: 0;
-  justify-content: between;
 `;
 
 const PanelItemSelects = styled('div')`
   display: flex;
   width: 100%;
+  margin-right: ${space(1)};
   > * {
     flex: 0 1 200px;
 
@@ -386,7 +386,7 @@ const StyledPanelItem = styled(PanelItem)`
 `;
 
 const RuleRowContainer = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px ${p => p.theme.borderLight} solid;
 `;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -259,62 +259,79 @@ class ActionsPanel extends React.PureComponent<Props> {
                 );
 
                 return (
-                  <PanelItemGrid key={i}>
-                    <SelectControl
-                      name="select-level"
-                      aria-label={t('Select a status level')}
-                      isDisabled={disabled || loading}
-                      placeholder={t('Select Level')}
-                      onChange={this.handleChangeActionLevel.bind(this, triggerIndex, i)}
-                      value={triggerIndex}
-                      options={levels}
-                    />
+                  <PanelItemWrapper key={i}>
+                    <RuleRowContainer>
+                      <PanelItemGrid>
+                        <PanelItemSelects>
+                          <SelectControl
+                            name="select-level"
+                            aria-label={t('Select a status level')}
+                            isDisabled={disabled || loading}
+                            placeholder={t('Select Level')}
+                            onChange={this.handleChangeActionLevel.bind(
+                              this,
+                              triggerIndex,
+                              i
+                            )}
+                            value={triggerIndex}
+                            options={levels}
+                          />
 
-                    <SelectControl
-                      name="select-action"
-                      aria-label={t('Select an Action')}
-                      isDisabled={disabled || loading}
-                      placeholder={t('Select Action')}
-                      onChange={this.handleChangeActionType.bind(this, triggerIndex, i)}
-                      value={getActionUniqueKey(action)}
-                      options={items ?? []}
-                    />
+                          <SelectControl
+                            name="select-action"
+                            aria-label={t('Select an Action')}
+                            isDisabled={disabled || loading}
+                            placeholder={t('Select Action')}
+                            onChange={this.handleChangeActionType.bind(
+                              this,
+                              triggerIndex,
+                              i
+                            )}
+                            value={getActionUniqueKey(action)}
+                            options={items ?? []}
+                          />
 
-                    {availableAction && availableAction.allowedTargetTypes.length > 1 ? (
-                      <SelectControl
-                        isDisabled={disabled || loading}
-                        value={action.targetType}
-                        options={availableAction?.allowedTargetTypes?.map(
-                          allowedType => ({
-                            value: allowedType,
-                            label: TargetLabel[allowedType],
-                          })
-                        )}
-                        onChange={this.handleChangeTarget.bind(this, triggerIndex, i)}
-                      />
-                    ) : (
-                      <span />
-                    )}
-                    <ActionTargetSelector
-                      action={action}
-                      availableAction={availableAction}
-                      disabled={disabled}
-                      loading={loading}
-                      onChange={this.handleChangeTargetIdentifier.bind(
-                        this,
-                        triggerIndex,
-                        i
-                      )}
-                      organization={organization}
-                      project={project}
-                    />
-                    <DeleteActionButton
-                      triggerIndex={triggerIndex}
-                      index={i}
-                      onClick={this.handleDeleteAction}
-                      disabled={disabled}
-                    />
-                  </PanelItemGrid>
+                          {availableAction &&
+                          availableAction.allowedTargetTypes.length > 1 ? (
+                            <SelectControl
+                              isDisabled={disabled || loading}
+                              value={action.targetType}
+                              options={availableAction?.allowedTargetTypes?.map(
+                                allowedType => ({
+                                  value: allowedType,
+                                  label: TargetLabel[allowedType],
+                                })
+                              )}
+                              onChange={this.handleChangeTarget.bind(
+                                this,
+                                triggerIndex,
+                                i
+                              )}
+                            />
+                          ) : null}
+                          <ActionTargetSelector
+                            action={action}
+                            availableAction={availableAction}
+                            disabled={disabled}
+                            loading={loading}
+                            onChange={this.handleChangeTargetIdentifier.bind(
+                              this,
+                              triggerIndex,
+                              i
+                            )}
+                            organization={organization}
+                            project={project}
+                          />
+                        </PanelItemSelects>
+                        <DeleteActionButton
+                          triggerIndex={triggerIndex}
+                          index={i}
+                          onClick={this.handleDeleteAction}
+                          disabled={disabled}
+                        />
+                      </PanelItemGrid>
+                    </RuleRowContainer>
+                  </PanelItemWrapper>
                 );
               })
             );
@@ -340,17 +357,36 @@ const ActionsPanelWithSpace = styled(ActionsPanel)`
   margin-top: ${space(4)};
 `;
 
-const PanelItemGrid = styled(PanelItem)`
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr min-content;
-  align-items: center;
-  grid-gap: ${space(2)};
+const PanelItemWrapper = styled(`div`)`
   padding: ${space(0.5)} ${space(2)} ${space(1)};
+`;
+
+const PanelItemGrid = styled(PanelItem)`
+  display: flex;
+  align-items: center;
+  gap: ${space(2)};
+  padding: ${space(1)};
   border-bottom: 0;
+  justify-content: between;
+`;
+
+const PanelItemSelects = styled('div')`
+  display: flex;
+  width: 100%;
+  gap: 15px;
+  > * {
+    flex: 0 1 200px;
+  }
 `;
 
 const StyledPanelItem = styled(PanelItem)`
   padding: ${space(1)} ${space(2)} ${space(2)};
+`;
+
+const RuleRowContainer = styled('div')`
+  background-color: ${p => p.theme.gray100};
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px ${p => p.theme.borderLight} solid;
 `;
 
 export default withOrganization(ActionsPanelWithSpace);

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -100,7 +100,7 @@ describe('Incident Rules Details', function() {
       .simulate('change', {target: {value: 12}});
 
     // Create a new action
-    wrapper.find('button[aria-label="Add Item"]').simulate('click');
+    wrapper.find('button[aria-label="Add New Action"]').simulate('click');
 
     // Save Trigger
     wrapper.find('button[aria-label="Save Rule"]').simulate('submit');


### PR DESCRIPTION
Fixing alignment issues and removing the weird empty `span` elements and complicated CSS Grid styles for the actions in the metric alert builder. Ideally this would use the same component as the one in the Issue Alert builder but that can be improved later. Also I want to make this page not be 🔥 on mobile but that’s also a job for later.

## Before

<img width="950" alt="Screen Shot 2020-09-16 at 8 36 42 PM" src="https://user-images.githubusercontent.com/1900676/93417646-7a8e1400-f85d-11ea-9010-d05ef7843333.png">
<img width="951" alt="Screen Shot 2020-09-16 at 8 36 49 PM" src="https://user-images.githubusercontent.com/1900676/93417650-7e219b00-f85d-11ea-8e87-8cd176cca25d.png">
<img width="944" alt="Screen Shot 2020-09-16 at 8 36 57 PM" src="https://user-images.githubusercontent.com/1900676/93417662-82e64f00-f85d-11ea-910e-4eed9c467d84.png">
<img width="418" alt="Screen Shot 2020-09-16 at 8 49 23 PM" src="https://user-images.githubusercontent.com/1900676/93417966-1fa8ec80-f85e-11ea-89c8-a03862135a7e.png">


## After

<img width="1142" alt="Screen Shot 2020-09-16 at 8 46 15 PM" src="https://user-images.githubusercontent.com/1900676/93417834-bfb24600-f85d-11ea-8cbe-dfed4aecdfce.png">
<img width="1144" alt="Screen Shot 2020-09-16 at 8 46 21 PM" src="https://user-images.githubusercontent.com/1900676/93417840-c2ad3680-f85d-11ea-87a0-e0dfd4aec884.png">
<img width="1037" alt="Screen Shot 2020-09-16 at 8 48 28 PM" src="https://user-images.githubusercontent.com/1900676/93417927-03a54b00-f85e-11ea-90fb-0f3fbc02675b.png">
<img width="470" alt="Screen Shot 2020-09-16 at 8 46 28 PM" src="https://user-images.githubusercontent.com/1900676/93417848-c5a82700-f85d-11ea-8ee3-77fed4a12c19.png">
<img width="462" alt="Screen Shot 2020-09-16 at 8 46 34 PM" src="https://user-images.githubusercontent.com/1900676/93417855-c93bae00-f85d-11ea-9cb5-532131d9f709.png">
