### PR TITLE
fix(py3): Fix uses of dict.keys

### DIFF
--- a/src/sentry/api/endpoints/organization_environments.py
+++ b/src/sentry/api/endpoints/organization_environments.py
@@ -15,7 +15,7 @@ class OrganizationEnvironmentsEndpoint(OrganizationEndpoint):
             return Response(
                 {
                     "detail": u"Invalid value for 'visibility', valid values are: {!r}".format(
-                        environment_visibility_filter_options.keys()
+                        sorted(environment_visibility_filter_options.keys())
                     )
                 },
                 status=400,

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -67,7 +67,7 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
         try:
             snuba_filter = eventstore.Filter(
                 conditions=[["event.type", "!=", "transaction"]],
-                project_ids=project_slugs_by_id.keys(),
+                project_ids=list(project_slugs_by_id.keys()),
                 event_ids=[event_id],
             )
             event = eventstore.get_events(filter=snuba_filter, limit=1)[0]

--- a/src/sentry/api/endpoints/project_environments.py
+++ b/src/sentry/api/endpoints/project_environments.py
@@ -67,7 +67,7 @@ class ProjectEnvironmentsEndpoint(ProjectEndpoint):
             return Response(
                 {
                     "detail": u"Invalid value for 'visibility', valid values are: {!r}".format(
-                        environment_visibility_filter_options.keys()
+                        sorted(environment_visibility_filter_options.keys())
                     )
                 },
                 status=400,

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -67,9 +67,9 @@ def fetch_state(project, records):
         "rules": Rule.objects.in_bulk(
             itertools.chain.from_iterable(record.value.rules for record in records)
         ),
-        "event_counts": tsdb.get_sums(tsdb.models.group, groups.keys(), start, end),
+        "event_counts": tsdb.get_sums(tsdb.models.group, list(groups.keys()), start, end),
         "user_counts": tsdb.get_distinct_counts_totals(
-            tsdb.models.users_affected_by_group, groups.keys(), start, end
+            tsdb.models.users_affected_by_group, list(groups.keys()), start, end
         ),
     }
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -867,7 +867,7 @@ def delete_alert_rule(alert_rule, user=None):
         if incidents:
             alert_rule.update(status=AlertRuleStatus.SNAPSHOT.value)
             AlertRuleActivity.objects.create(
-                alert_rule=alert_rule, user=user, type=AlertRuleActivityType.DELETED.value,
+                alert_rule=alert_rule, user=user, type=AlertRuleActivityType.DELETED.value
             )
         else:
             alert_rule.delete()
@@ -1115,7 +1115,7 @@ def update_alert_rule_trigger_action(
             organization = trigger_action.alert_rule_trigger.alert_rule.organization
 
             target_identifier, target_display = get_target_identifier_display_for_integration(
-                type, target_identifier, organization, integration.id,
+                type, target_identifier, organization, integration.id
             )
             updated_fields["target_display"] = target_display
 
@@ -1124,7 +1124,7 @@ def update_alert_rule_trigger_action(
             organization = trigger_action.alert_rule_trigger.alert_rule.organization
 
             target_identifier, target_display = get_alert_rule_trigger_action_sentry_app(
-                organization, sentry_app.id,
+                organization, sentry_app.id
             )
             updated_fields["target_display"] = target_display
 
@@ -1284,13 +1284,13 @@ def get_column_from_aggregate(aggregate):
 
 def check_aggregate_column_support(aggregate):
     column = get_column_from_aggregate(aggregate)
-    return column is None or column in SUPPORTED_COLUMNS or column in TRANSLATABLE_COLUMNS.keys()
+    return column is None or column in SUPPORTED_COLUMNS or column in TRANSLATABLE_COLUMNS
 
 
 def translate_aggregate_field(aggregate, reverse=False):
     column = get_column_from_aggregate(aggregate)
     if not reverse:
-        if column in TRANSLATABLE_COLUMNS.keys():
+        if column in TRANSLATABLE_COLUMNS:
             return aggregate.replace(column, TRANSLATABLE_COLUMNS[column])
     else:
         if column is not None:

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -154,7 +154,7 @@ class GroupSubscriptionManager(BaseManager):
 
         options = get_user_options(
             "workflow:notifications",
-            users.keys(),
+            list(users.keys()),
             group.project,
             UserOptionValue.participating_only,
         )

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -99,7 +99,7 @@ def organizations(metrics, since, until):
 
         results = {}
         for metric in metrics.values():
-            results[metric] = tsdb.get_range(metric, instances.keys(), since, until)
+            results[metric] = tsdb.get_range(metric, list(instances.keys()), since, until)
 
         for key, instance in six.iteritems(instances):
             values = []

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -360,7 +360,7 @@ def transform_results(result, translated_columns, snuba_filter, selected_columns
             for snuba_name, sentry_name in six.iteritems(translated_columns):
                 if sentry_name == col["name"]:
                     with sentry_sdk.start_span(
-                        op="discover.discover", description="transform_results.histogram_zerofill",
+                        op="discover.discover", description="transform_results.histogram_zerofill"
                     ) as span:
                         span.set_data("histogram_function", snuba_name)
                         result["data"] = zerofill_histogram(
@@ -853,10 +853,7 @@ def top_events_timeseries(
         # Using the top events add the order to the results
         for index, item in enumerate(top_events["data"]):
             result_key = create_result_key(item, translated_groupby, issues)
-            results[result_key] = {
-                "order": index,
-                "data": [],
-            }
+            results[result_key] = {"order": index, "data": []}
         for row in result["data"]:
             result_key = create_result_key(row, translated_groupby, issues)
             if result_key in results:
@@ -864,7 +861,7 @@ def top_events_timeseries(
             else:
                 logger.warning(
                     "discover.top-events.timeseries.key-mismatch",
-                    extra={"result_key": result_key, "top_event_keys": results.keys()},
+                    extra={"result_key": result_key, "top_event_keys": list(results.keys())},
                 )
         for key, item in six.iteritems(results):
             results[key] = SnubaTSResult(

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -230,7 +230,7 @@ class SnubaTSDB(BaseTSDB):
             keys = list(set(map(lambda x: int(x), keys)))
 
         # 10s is the only rollup under an hour that we support
-        if rollup and rollup == 10 and model in self.lower_rollup_query_settings.keys():
+        if rollup and rollup == 10 and model in self.lower_rollup_query_settings:
             model_query_settings = self.lower_rollup_query_settings.get(model)
         else:
             model_query_settings = self.model_query_settings.get(model)
@@ -342,7 +342,7 @@ class SnubaTSDB(BaseTSDB):
         self, model, keys, start, end, rollup=None, environment_ids=None, snuba_filters=None
     ):
         # 10s is the only rollup under an hour that we support
-        if rollup and rollup == 10 and model in self.lower_rollup_query_settings.keys():
+        if rollup and rollup == 10 and model in self.lower_rollup_query_settings:
             model_query_settings = self.lower_rollup_query_settings.get(model)
         else:
             model_query_settings = self.model_query_settings.get(model)
@@ -505,7 +505,7 @@ class SnubaTSDB(BaseTSDB):
         """
         if isinstance(items, collections.Mapping):
             return (
-                items.keys(),
+                list(items.keys()),
                 list(set.union(*(set(v) for v in items.values())) if items else []),
             )
         elif isinstance(items, (collections.Sequence, collections.Set)):

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -25,7 +25,7 @@ def summarize(sequence, max=3):
 
 def make_upgrade_message(service, modality, version, hosts):
     return u"{service} {modality} be upgraded to {version} on {hosts}.".format(
-        hosts=u",".join(map(force_text, summarize(hosts.keys(), 2))),
+        hosts=u",".join(map(force_text, summarize(list(hosts.keys()), 2))),
         modality=modality,
         service=service,
         version=version,

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -70,7 +70,7 @@ class DictContaining(object):
 
     def _args_match(self, other):
         for key in self.args:
-            if key not in other.keys():
+            if key not in other:
                 return False
         return True
 

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -73,7 +73,7 @@ class SnubaTSDBTest(OutcomesSnubaTest):
             )
 
             # Assert that the response has values set for the times we expect, and nothing more
-            assert self.organization.id in response.keys()
+            assert self.organization.id in response
             response_dict = {k: v for (k, v) in response[self.organization.id]}
 
             assert response_dict[floor_func(self.start_time)] == start_time_count
@@ -120,7 +120,7 @@ class SnubaTSDBTest(OutcomesSnubaTest):
             )
 
             # Assert that the response has values set for the times we expect, and nothing more
-            assert self.project.id in response.keys()
+            assert self.project.id in response
             response_dict = {k: v for (k, v) in response[self.project.id]}
 
             assert response_dict[floor_func(self.start_time)] == start_time_count
@@ -191,7 +191,7 @@ class SnubaTSDBTest(OutcomesSnubaTest):
             )
 
             # Assert that the response has values set for the times we expect, and nothing more
-            assert project_key.id in response.keys()
+            assert project_key.id in response
             response_dict = {k: v for (k, v) in response[project_key.id]}
 
             assert response_dict[floor_func(self.start_time)] == start_time_count

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -286,7 +286,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
                 project.id, [list(events.keys())[0]], source.id, destination.id
             )
             unmerge.delay(
-                project.id, source.id, destination.id, [events.keys()[0]], None, batch_size=5
+                project.id, source.id, destination.id, [list(events.keys())[0]], None, batch_size=5
             )
             eventstream.end_unmerge(eventstream_state)
 


### PR DESCRIPTION
This started off as a fix for
tests/snuba/api/endpoints/test_organization_eventid.py::EventIdLookupEndpointTest::test_missing_eventid.
Investigation into that test failure turned up that we were deepcopying the value of dict.keys().
Turns out that this fails in py3, since it's just a view of the dict. To be cautious, I went through
and did an audit of all uses of `.keys`. Anywhere that we don't just iterate over them I cast them
as a list to avoid any potential issues.