### PR TITLE
fix(py3): Fix tests in test_organization_events_facets

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -37,7 +37,8 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
                 break
         assert actual is not None, "Could not find {} facet in {}".format(key, response.data)
         assert "topValues" in actual
-        assert sorted(expected) == sorted(actual["topValues"])
+        key = lambda row: row["name"] if row["name"] is not None else ""
+        assert sorted(expected, key=key) == sorted(actual["topValues"], key=key)
 
     def test_performance_view_feature(self):
         with self.feature(


### PR DESCRIPTION
Main failure here was `TypeError: '<' not supported between instances of 'dict' and 'dict'`. We need
to be explicit when sorting dicts now, so I just used the `name` key which seems to be unique
for each dict.