### PR TITLE
fix(tests) Add discover integration tests to snuba makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ endif
 
 test-snuba:
 	@echo "--> Running snuba tests"
-	py.test tests/snuba tests/sentry/eventstream/kafka -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml" --junit-xml=".artifacts/snuba.junit.xml"
+	py.test tests/snuba tests/sentry/eventstream/kafka tests/sentry/snuba/test_discover.py -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml" --junit-xml=".artifacts/snuba.junit.xml"
 	@echo ""
 
 test-symbolicator:


### PR DESCRIPTION
The discover file has a number of use cases for snuba in it that are worth
having run automatically as well.