### PR TITLE
chore: remove patch for django.http.parse_cookie

### DIFF
--- a/src/sentry/monkey/__init__.py
+++ b/src/sentry/monkey/__init__.py
@@ -36,42 +36,6 @@ def patch_httprequest_repr():
     HttpRequest.__repr__ = safe_httprequest_repr
 
 
-def patch_parse_cookie():
-    try:
-        from django.utils import six
-        from django.utils.encoding import force_str
-        from django.utils.six.moves import http_cookies
-        from django import http
-    except ImportError:
-        # This module is potentially imported before Django is installed
-        # during a setup.py run
-        return
-
-    # Backported from 1.8.15: https://github.com/django/django/blob/1.8.15/django/http/cookie.py#L91
-    # See https://www.djangoproject.com/weblog/2016/sep/26/security-releases/ for more context.
-    def safe_parse_cookie(cookie):
-        """
-        Return a dictionary parsed from a `Cookie:` header string.
-        """
-        cookiedict = {}
-        if six.PY2:
-            cookie = force_str(cookie)
-        for chunk in cookie.split(";"):
-            if "=" in chunk:
-                key, val = chunk.split("=", 1)
-            else:
-                # Assume an empty name per
-                # https://bugzilla.mozilla.org/show_bug.cgi?id=169091
-                key, val = "", chunk
-            key, val = key.strip(), val.strip()
-            if key or val:
-                # unquote using Python's algorithm.
-                cookiedict[key] = http_cookies._unquote(val)
-        return cookiedict
-
-    http.parse_cookie = safe_parse_cookie
-
-
 def patch_django_views_debug():
     # Prevent exposing any Django SETTINGS on our debug error page
     # This information is not useful for Sentry development
@@ -98,7 +62,6 @@ def patch_celery_imgcat():
 
 
 for patch in (
-    patch_parse_cookie,
     patch_httprequest_repr,
     patch_django_views_debug,
     patch_celery_imgcat,


### PR DESCRIPTION
This isn't needed anymore, [it's exactly the same in 1.11.27.](https://github.com/django/django/blob/1.11.27/django/http/cookie.py#L59)

