### PR TITLE
fix(alert): 'View Alert Rules' now preserves the project from settings.

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/settings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/settings.jsx
@@ -77,12 +77,20 @@ class ProjectAlertSettings extends AsyncView {
       params: {orgId, projectId},
     } = this.props;
 
+    const {project} = this.state;
+
     return (
       <React.Fragment>
         <SettingsPageHeader
           title={t('Alerts Settings')}
           action={
-            <Button to={`/organizations/${orgId}/alerts/rules/`} size="small">
+            <Button
+              to={{
+                pathname: `/organizations/${orgId}/alerts/rules/`,
+                query: {project: project.id},
+              }}
+              size="small"
+            >
               {t('View Alert Rules')}
             </Button>
           }


### PR DESCRIPTION
Previously when clicking `View Alert Rules` on the settings page, the user would be redirected to the alert rule page with the project shown being preserved from global selection. This can cause users to click on `View Alert Rules` from settings and then view the alert rules from a completely separate project.

This code adds the project query parameter into the url to override global selection. Shown here:

![Kapture 2020-09-17 at 15 15 37](https://user-images.githubusercontent.com/9372512/93517208-1caf0a00-f8f9-11ea-85a9-49cac970161d.gif)
