### PR TITLE
fix(alerts): Clickable event types from "create alert" button

### DIFF
--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -13,6 +13,7 @@ import {
   errorFieldConfig,
   transactionFieldConfig,
 } from 'app/views/settings/incidentRules/constants';
+import Link from 'app/components/links/link';
 
 /**
  * Discover query supports more features than alert rules
@@ -37,6 +38,7 @@ type IncompatibleQueryProperties = {
 type AlertProps = {
   incompatibleQuery: IncompatibleQueryProperties;
   eventView: EventView;
+  orgId: string;
   /**
    * Dismiss alert
    */
@@ -46,7 +48,12 @@ type AlertProps = {
 /**
  * Displays messages to the user on what needs to change in their query
  */
-function IncompatibleQueryAlert({incompatibleQuery, eventView, onClose}: AlertProps) {
+function IncompatibleQueryAlert({
+  incompatibleQuery,
+  eventView,
+  orgId,
+  onClose,
+}: AlertProps) {
   const {
     hasProjectError,
     hasEnvironmentError,
@@ -55,6 +62,12 @@ function IncompatibleQueryAlert({incompatibleQuery, eventView, onClose}: AlertPr
   } = incompatibleQuery;
 
   const totalErrors = Object.values(incompatibleQuery).filter(val => val === true).length;
+
+  const eventTypeError = eventView.clone();
+  eventTypeError.query += ' event.type:error';
+  const eventTypeTransaction = eventView.clone();
+  eventTypeTransaction.query += ' event.type:transaction';
+  const pathname = `/organizations/${orgId}/discover/results/`;
 
   return (
     <StyledAlert type="warning" icon={<IconInfo color="yellow400" size="sm" />}>
@@ -70,8 +83,22 @@ function IncompatibleQueryAlert({incompatibleQuery, eventView, onClose}: AlertPr
             tct(
               'An alert needs a filter of [error:event.type:error] or [transaction:event.type:transaction]. Use one of these and try again.',
               {
-                error: <StyledCode />,
-                transaction: <StyledCode />,
+                error: (
+                  <Link
+                    to={{
+                      pathname,
+                      query: eventTypeError.generateQueryStringObject(),
+                    }}
+                  />
+                ),
+                transaction: (
+                  <Link
+                    to={{
+                      pathname,
+                      query: eventTypeTransaction.generateQueryStringObject(),
+                    }}
+                  />
+                ),
               }
             )}
           {hasYAxisError &&
@@ -96,8 +123,22 @@ function IncompatibleQueryAlert({incompatibleQuery, eventView, onClose}: AlertPr
                 {tct(
                   'Use the filter [error:event.type:error] or [transaction:event.type:transaction].',
                   {
-                    error: <StyledCode />,
-                    transaction: <StyledCode />,
+                    error: (
+                      <Link
+                        to={{
+                          pathname,
+                          query: eventTypeError.generateQueryStringObject(),
+                        }}
+                      />
+                    ),
+                    transaction: (
+                      <Link
+                        to={{
+                          pathname,
+                          query: eventTypeTransaction.generateQueryStringObject(),
+                        }}
+                      />
+                    ),
                   }
                 )}
               </li>
@@ -229,6 +270,7 @@ function CreateAlertButton({
           <IncompatibleQueryAlert
             incompatibleQuery={errors}
             eventView={eventView}
+            orgId={organization.slug}
             onClose={onAlertClose}
           />
         ),


### PR DESCRIPTION
Clicking `event.type:error` will add it to the current query

![image](https://user-images.githubusercontent.com/1400464/93525069-562c4900-f8ea-11ea-9413-1321c7907817.png)
