### PR TITLE
adds x frame options back

### DIFF
--- a/src/sentry/integrations/jira/ui_hook.py
+++ b/src/sentry/integrations/jira/ui_hook.py
@@ -19,7 +19,7 @@ class JiraUiHookView(View):
     def get_response(self, context):
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         res = render_to_response("sentry/integrations/jira-config.html", context, self.request)
-        res["Content-Security-Policy"] = u"frame-ancestors %s" % self.request.GET["xdm_e"]
+        res["X-Frame-Options"] = "ALLOW-FROM %s" % self.request.GET["xdm_e"]
         return res
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
We are seeing the following error when trying to install Jira:
`Refused to display ‘https://sentry.io/extensions/jira/ui-hook/?xdm_e=https%3A%2F%2Fgetsentry.atlassian.net&xdm_c=channel-sentry.io.jira__post-install-sentry&cp=&xdm_deprecated_addon_key_do_not_use=sentry.io.jira&lic=none&cv=1001.0.0-SNAPSHOT&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1NTcwNTg6MWY0MTc5MjktNjI2Mi00ZGE4LWIxNDgtM2NiNTdhYTgxNGNkIiwicXNoIjoiZmRkZGEwOTc2YmM1NGE4MWQ5MmQ3NzkyNjQ0Y2NiNjI2MDZmNjE2OWIzNWNiNzQ4YjQwZDY5ZDM4ZGE3NTQ5NyIsImlzcyI6ImppcmE6MmFjZWFmYjEtZDNlZS00MDg2LWI4YTgtMGI0ZDg4YjlhYmQxIiwiY29udGV4dCI6e30sImV4cCI6MTYwMDM4MTQ2NywiaWF0IjoxNjAwMzgwNTY3fQ.DbFUJ5kQ7Ik6WhTrJjNywZyyQMA_8ZGDJnUs4oHbNlQ’ in a frame because it set ‘X-Frame-Options’ to ‘deny’.`

I am reverting the change in the header from the PR (https://github.com/getsentry/sentry/pull/20734) in the hope that it clears this issue so people can install Jira.