### PR TITLE
fix(py3): Fix tests in test_organization_group_index

### DIFF
--- a/src/sentry/management/commands/send_fake_data.py
+++ b/src/sentry/management/commands/send_fake_data.py
@@ -23,7 +23,7 @@ def funcs():
     )
     loggers = itertools.cycle(["root", "foo", "foo.bar"])
     emails = itertools.cycle(["foo@example.com", "bar@example.com", "baz@example.com"])
-    timestamps = range(24 * 60 * 60)
+    timestamps = list(range(24 * 60 * 60))
     random.shuffle(timestamps)
     timestamps = itertools.cycle(timestamps)
 

--- a/src/sentry/management/commands/send_fake_data.py
+++ b/src/sentry/management/commands/send_fake_data.py
@@ -23,18 +23,12 @@ def funcs():
     )
     loggers = itertools.cycle(["root", "foo", "foo.bar"])
     emails = itertools.cycle(["foo@example.com", "bar@example.com", "baz@example.com"])
-    timestamps = list(range(24 * 60 * 60))
-    random.shuffle(timestamps)
-    timestamps = itertools.cycle(timestamps)
-
-    # def query(client):
-    #     duration = random.randint(0, 10000) / 1000.0
-    # return client.capture('Query', query=queries.next(),
-    # engine=engine.next(), time_spent=duration, data={'logger':
-    # loggers.next(), 'site': 'sql'})
+    timestamp_max = int(datetime.timedelta(days=1).total_seconds())
 
     def exception(client):
-        timestamp = datetime.datetime.utcnow() - datetime.timedelta(seconds=six.next(timestamps))
+        timestamp = datetime.datetime.utcnow() - datetime.timedelta(
+            seconds=random.randint(0, timestamp_max)
+        )
         try:
             raise six.next(exceptions)
         except Exception:

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -16,7 +16,7 @@ from sentry.api.event_search import convert_search_filter_to_snuba_query
 from sentry.api.paginator import DateTimePaginator, SequencePaginator, Paginator
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.models import Group
-from sentry.utils import snuba, metrics
+from sentry.utils import json, metrics, snuba
 
 
 def get_search_filter(search_filters, name, operator):
@@ -159,7 +159,7 @@ class AbstractQueryExecutor:
 
         selected_columns = []
         if get_sample:
-            query_hash = md5(repr(conditions)).hexdigest()[:8]
+            query_hash = md5(json.dumps(conditions).encode("utf-8")).hexdigest()[:8]
             selected_columns.append(
                 ("cityHash64", ("'{}'".format(query_hash), "group_id"), "sample")
             )

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -501,7 +501,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         old_sample_size = options.get("snuba.search.hits-sample-size")
         assert options.set("snuba.search.hits-sample-size", 1)
 
-        days = range(4)
+        days = list(range(4))
         days.reverse()
 
         self.login_as(user=self.user)
@@ -649,7 +649,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             assert response.data[0]["filtered"] is not None
 
     @patch(
-        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True,
+        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True
     )
     def test_ratelimit(self, is_limited):
         self.login_as(user=self.user)
@@ -1271,7 +1271,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             event = self.store_event(
                 data={
                     "fingerprint": ["put-me-in-group-1"],
-                    "user": {"id": six.text_type(i).encode("utf-8")},
+                    "user": {"id": six.text_type(i)},
                     "timestamp": iso_format(self.min_ago + timedelta(seconds=i)),
                 },
                 project_id=self.project.id,
@@ -1549,7 +1549,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert tombstone.data == group1.data
 
     @patch(
-        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True,
+        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True
     )
     def test_ratelimit(self, is_limited):
         self.login_as(user=self.user)
@@ -1677,7 +1677,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             assert not GroupHash.objects.filter(group_id=group.id).exists()
 
     @patch(
-        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True,
+        "sentry.api.helpers.group_index.ratelimiter.is_limited", autospec=True, return_value=True
     )
     def test_ratelimit(self, is_limited):
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -501,8 +501,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         old_sample_size = options.get("snuba.search.hits-sample-size")
         assert options.set("snuba.search.hits-sample-size", 1)
 
-        days = list(range(4))
-        days.reverse()
+        days = reversed(range(4))
 
         self.login_as(user=self.user)
         groups = []

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -985,7 +985,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             event = self.store_event(
                 data={
                     "fingerprint": ["put-me-in-group-1"],
-                    "user": {"id": six.text_type(i).encode("utf-8")},
+                    "user": {"id": six.text_type(i)},
                     "timestamp": iso_format(self.min_ago + timedelta(seconds=i)),
                 },
                 project_id=self.project.id,


### PR DESCRIPTION
This fixes tests in tests/snuba/api/endpoints/test_organization_group_index.py. Problems:
 - Treating the result of `range` like a list. Just casted as a list. I also searched for other uses
   of this in the codebase and fixed.
 - Needed to encode the result of a repr before passing to md5. Also converted from repr to
   json.dumps. I don't think that the hash is important here, so it's fine for it to change.