### PR TITLE
fix(py3): Fix test_eventstream tests

### DIFF
--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -40,7 +40,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
         produce_args, produce_kwargs = list(self.kafka_eventstream.producer.produce.call_args)
         assert not produce_args
         assert produce_kwargs["topic"] == "events"
-        assert produce_kwargs["key"] == six.text_type(self.project.id)
+        assert produce_kwargs["key"] == six.text_type(self.project.id).encode("utf-8")
 
         version, type_, payload1, payload2 = json.loads(produce_kwargs["value"])
         assert version == 2


### PR DESCRIPTION
Only problem here was that we were comparing the string representation of `project.id` to the
encoded byte representation of `project.id`. The correct thing to compare is bytes, since that's
what we pass as the key to the producer.