### PR TITLE
fix(py3): Fix test_unmerge tests, and unsafe uses of dict.values()

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -58,7 +58,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsEndpointBase):
 
                 resp["project"]["topValues"] = filtered_values
 
-        return Response(resp.values())
+        return Response(list(resp.values()))
 
     def _validate_project_ids(self, request, organization, params):
         project_ids = params["project_id"]

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -146,7 +146,7 @@ class Strategy(object):
                             contributes=False,
                             hint="ignored because %s variant is not used"
                             % (
-                                mandatory_component_hashes.values()[0]
+                                list(mandatory_component_hashes.values())[0]
                                 if len(mandatory_component_hashes) == 1
                                 else "other mandatory"
                             ),

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -50,7 +50,7 @@ FEATURES = [
         Connect your Sentry and Vercel projects to automatically upload source maps and notify Sentry of new releases being deployed.
         """,
         IntegrationFeatures.DEPLOYMENT,
-    ),
+    )
 ]
 
 INSTALL_NOTICE_TEXT = _(
@@ -355,7 +355,7 @@ class VercelIntegrationProvider(IntegrationProvider):
                 extra={"error": six.text_type(err), "external_id": external_id},
             )
             try:
-                details = err.json["messages"][0].values().pop()
+                details = list(err.json["messages"][0].values()).pop()
             except Exception:
                 details = "Unknown Error"
             message = u"Could not create deployment webhook in Vercel: {}".format(details)

--- a/src/sentry/management/commands/merge_users.py
+++ b/src/sentry/management/commands/merge_users.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
                 continue
             members_by_email[member.user.email].append(member.user)
 
-        return members_by_email.values()
+        return list(members_by_email.values())
 
     def _confirm_merge(self, primary_user, other_users):
         message = u"Merge {} into {}? [Yn] ".format(

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -50,7 +50,7 @@ class ProjectDebugFileManager(BaseManager):
         ).values("file__checksum")
 
         for values in found:
-            missing.discard(values.values()[0])
+            missing.discard(list(values.values())[0])
 
         return sorted(missing)
 

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -84,7 +84,7 @@ def sync_group_assignee_inbound(integration, email, external_issue_key, assign=T
         )
     }
 
-    projects_by_user = get_user_project_ids(users.values())
+    projects_by_user = get_user_project_ids(list(users.values()))
 
     groups_assigned = []
     for group in affected_groups:

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -249,4 +249,4 @@ class FeatureSet(object):
         )
 
     def flush(self, project):
-        return self.index.flush(self.__get_scope(project), self.aliases.values())
+        return self.index.flush(self.__get_scope(project), list(self.aliases.values()))

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -301,7 +301,7 @@ class MessageBuilder(object):
         return self._txt_body
 
     def add_users(self, user_ids, project=None):
-        self._send_to.update(get_email_addresses(user_ids, project).values())
+        self._send_to.update(list(get_email_addresses(user_ids, project).values()))
 
     def build(self, to, reply_to=None, cc=None, bcc=None):
         if self.headers is None:

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -155,7 +155,7 @@ class ActivityMailPreview(object):
     def get_context(self):
         context = self.email.get_base_context()
         context["reason"] = get_random(self.request).choice(
-            GroupSubscriptionReason.descriptions.values()
+            list(GroupSubscriptionReason.descriptions.values())
         )
         context.update(self.email.get_context())
         add_unsubscribe_link(context)

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -44,7 +44,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             get_fingerprint(
                 self.store_event(data={"message": "Hello world"}, project_id=self.project.id)
             )
-            == hashlib.md5("Hello world").hexdigest()
+            == hashlib.md5(u"Hello world".encode("utf-8")).hexdigest()
         )
 
         assert (
@@ -54,7 +54,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
                     project_id=self.project.id,
                 )
             )
-            == hashlib.md5("Not hello world").hexdigest()
+            == hashlib.md5(u"Not hello world".encode("utf-8")).hexdigest()
         )
 
     def test_get_group_creation_attributes(self):
@@ -312,7 +312,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         assert source.id != destination.id
         assert source.project == destination.project
 
-        destination_event_ids = map(lambda event: event.event_id, events.values()[1])
+        destination_event_ids = map(lambda event: event.event_id, list(events.values())[1])
 
         assert set(
             UserReport.objects.filter(group_id=source.id).values_list("event_id", flat=True)
@@ -338,7 +338,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         ) == set([(u"red", 4), (u"green", 3), (u"blue", 3)])
 
         destination_event_ids = map(
-            lambda event: event.event_id, events.values()[0] + events.values()[2]
+            lambda event: event.event_id, list(events.values())[0] + list(events.values())[2]
         )
 
         assert set(
@@ -411,26 +411,28 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
                 assert actual.get(key, 0) == default
 
         assert_series_contains(
-            get_expected_series_values(rollup_duration, events.values()[1]),
+            get_expected_series_values(rollup_duration, list(events.values())[1]),
             time_series[source.id],
             0,
         )
 
         assert_series_contains(
-            get_expected_series_values(rollup_duration, events.values()[0] + events.values()[2]),
+            get_expected_series_values(
+                rollup_duration, list(events.values())[0] + list(events.values())[2]
+            ),
             time_series[destination.id],
             0,
         )
 
         assert_series_contains(
-            get_expected_series_values(rollup_duration, events.values()[1]),
+            get_expected_series_values(rollup_duration, list(events.values())[1]),
             environment_time_series[source.id],
             0,
         )
 
         assert_series_contains(
             get_expected_series_values(
-                rollup_duration, events.values()[0][:-1] + events.values()[2]
+                rollup_duration, list(events.values())[0][:-1] + list(events.values())[2]
             ),
             environment_time_series[destination.id],
             0,
@@ -463,7 +465,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
                 {
                     timestamp: len(values)
                     for timestamp, values in get_expected_series_values(
-                        rollup_duration, events.values()[1], collect_by_user_tag
+                        rollup_duration, list(events.values())[1], collect_by_user_tag
                     ).items()
                 },
                 series[source.id],
@@ -474,7 +476,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
                     timestamp: len(values)
                     for timestamp, values in get_expected_series_values(
                         rollup_duration,
-                        events.values()[0] + events.values()[2],
+                        list(events.values())[0] + list(events.values())[2],
                         collect_by_user_tag,
                     ).items()
                 },
@@ -484,7 +486,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         def strip_zeroes(data):
             for group_id, series in data.items():
                 for _, values in series:
-                    for key, val in values.items():
+                    for key, val in list(values.items()):
                         if val == 0:
                             values.pop(key)
 
@@ -521,7 +523,9 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
 
         assert_series_contains(
             get_expected_series_values(
-                rollup_duration, events.values()[1], functools.partial(collect_by_release, source)
+                rollup_duration,
+                list(events.values())[1],
+                functools.partial(collect_by_release, source),
             ),
             time_series[source.id],
             {},
@@ -530,7 +534,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         assert_series_contains(
             get_expected_series_values(
                 rollup_duration,
-                events.values()[0] + events.values()[2],
+                list(events.values())[0] + list(events.values())[2],
                 functools.partial(collect_by_release, destination),
             ),
             time_series[destination.id],
@@ -560,14 +564,18 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             return aggregate
 
         assert_series_contains(
-            get_expected_series_values(rollup_duration, events.values()[1], collect_by_environment),
+            get_expected_series_values(
+                rollup_duration, list(events.values())[1], collect_by_environment
+            ),
             time_series[source.id],
             {},
         )
 
         assert_series_contains(
             get_expected_series_values(
-                rollup_duration, events.values()[0] + events.values()[2], collect_by_environment
+                rollup_duration,
+                list(events.values())[0] + list(events.values())[2],
+                collect_by_environment,
             ),
             time_series[destination.id],
             {},


### PR DESCRIPTION
The issues here were:
 - Indexing into `dict.values()`, which fails in py3 since it's a view. Audited the rest of the
   codebase to find other unsafe uses.
 - md5 not being passed bytes