### PR TITLE
fix(py3): Audit uses of `dict.items()` to make sure usage is safe.

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -250,7 +250,7 @@ class Group(Model):
     project = FlexibleForeignKey("sentry.Project")
     logger = models.CharField(max_length=64, blank=True, default=DEFAULT_LOGGER_NAME, db_index=True)
     level = BoundedPositiveIntegerField(
-        choices=LOG_LEVELS.items(), default=logging.ERROR, blank=True, db_index=True
+        choices=list(LOG_LEVELS.items()), default=logging.ERROR, blank=True, db_index=True
     )
     message = models.TextField()
     culprit = models.CharField(

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -28,16 +28,16 @@ MATCH_CHOICES = OrderedDict(
 
 
 class LevelEventForm(forms.Form):
-    level = forms.ChoiceField(choices=LEVEL_CHOICES.items())
-    match = forms.ChoiceField(choices=MATCH_CHOICES.items())
+    level = forms.ChoiceField(choices=list(LEVEL_CHOICES.items()))
+    match = forms.ChoiceField(choices=list(MATCH_CHOICES.items()))
 
 
 class LevelCondition(EventCondition):
     form_cls = LevelEventForm
     label = "The event's level is {match} {level}"
     form_fields = {
-        "level": {"type": "choice", "choices": LEVEL_CHOICES.items()},
-        "match": {"type": "choice", "choices": MATCH_CHOICES.items()},
+        "level": {"type": "choice", "choices": list(LEVEL_CHOICES.items())},
+        "match": {"type": "choice", "choices": list(MATCH_CHOICES.items())},
     }
 
     def passes(self, event, state, **kwargs):

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -34,7 +34,7 @@ MATCH_CHOICES = OrderedDict(
 
 class TaggedEventForm(forms.Form):
     key = forms.CharField(widget=forms.TextInput())
-    match = forms.ChoiceField(MATCH_CHOICES.items(), widget=forms.Select())
+    match = forms.ChoiceField(list(MATCH_CHOICES.items()), widget=forms.Select())
     value = forms.CharField(widget=forms.TextInput(), required=False)
 
     def clean(self):
@@ -53,7 +53,7 @@ class TaggedEventCondition(EventCondition):
 
     form_fields = {
         "key": {"type": "string", "placeholder": "key"},
-        "match": {"type": "choice", "choices": MATCH_CHOICES.items()},
+        "match": {"type": "choice", "choices": list(MATCH_CHOICES.items())},
         "value": {"type": "string", "placeholder": "value"},
     }
 

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -138,7 +138,7 @@ class RedisTSDB(BaseTSDB):
         results = defaultdict(list)
         for environment_id in environment_ids:
             results[self.get_cluster(environment_id)].append(environment_id)
-        return results.items()
+        return list(results.items())
 
     def add_environment_parameter(self, key, environment_id):
         if environment_id is not None:

--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -187,8 +187,9 @@ def bulk_delete_objects(
         logger.info(
             "object.delete.bulk_executed",
             extra=dict(
-                list(filters.items())
-                + [("model", model.__name__), ("transaction_id", transaction_id)]
+                filters,
+                model=model.__name__,
+                transaction_id=transaction_id,
             ),
         )
 

--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -187,7 +187,8 @@ def bulk_delete_objects(
         logger.info(
             "object.delete.bulk_executed",
             extra=dict(
-                filters.items() + [("model", model.__name__), ("transaction_id", transaction_id)]
+                list(filters.items())
+                + [("model", model.__name__), ("transaction_id", transaction_id)]
             ),
         )
 

--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -186,11 +186,7 @@ def bulk_delete_objects(
     if has_more and logger is not None and _leaf_re.search(model.__name__) is None:
         logger.info(
             "object.delete.bulk_executed",
-            extra=dict(
-                filters,
-                model=model.__name__,
-                transaction_id=transaction_id,
-            ),
+            extra=dict(filters, model=model.__name__, transaction_id=transaction_id),
         )
 
     return has_more

--- a/src/social_auth/utils.py
+++ b/src/social_auth/utils.py
@@ -108,7 +108,7 @@ def url_add_parameters(url, params):
     """Adds parameters to URL, parameter will be repeated if already present"""
     if params:
         fragments = list(urlparse(url))
-        fragments[4] = urlencode(parse_qsl(fragments[4]) + params.items())
+        fragments[4] = urlencode(parse_qsl(fragments[4]) + list(params.items()))
         url = urlunparse(fragments)
     return url
 

--- a/tests/sentry/celery/test_app.py
+++ b/tests/sentry/celery/test_app.py
@@ -10,7 +10,7 @@ app.loader.import_default_modules()
 
 # XXX(dcramer): this doesn't actually work as we'd expect, as if the task is imported
 # anywhere else before this code is run it will still show up as registered
-@pytest.mark.parametrize("name,entry", settings.CELERYBEAT_SCHEDULE.items())
+@pytest.mark.parametrize("name,entry", list(settings.CELERYBEAT_SCHEDULE.items()))
 def test_validate_celerybeat_schedule(name, entry):
     entry = ScheduleEntry(name=name, app=app, **entry)
     assert entry.task in app.tasks


### PR DESCRIPTION
After seeing unsafe uses of `dict.keys()` and `dict.values` I decided to do an audit for any unsafe
uses of `dict.items()` as well. This casts to list in situations where we're not just iterating over
the view.