### PR TITLE
ref(rediscluster): Reset cluster nodes and retry on ClusterError

### DIFF
--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -14,6 +14,7 @@ from redis.client import Script, StrictRedis
 from redis.connection import ConnectionPool, Encoder
 from redis.exceptions import ConnectionError, BusyLoadingError
 from rediscluster import RedisCluster
+from rediscluster.exceptions import ClusterError
 
 from sentry import options
 from sentry.exceptions import InvalidConfiguration
@@ -93,6 +94,7 @@ class RetryingRedisCluster(RedisCluster):
         except (
             ConnectionError,
             BusyLoadingError,
+            ClusterError,
             KeyError,  # see: https://github.com/Grokzen/redis-py-cluster/issues/287
         ):
             self.connection_pool.nodes.reset()


### PR DESCRIPTION
Trying to prevent errors caused by cluster nodes going away.

- https://sentry.io/organizations/sentry/issues/1896931572/events/f1aa0185abdb4bbbaa1080e500b9b587/?environment=prod&project=1
- https://github.com/Grokzen/redis-py-cluster/issues/301