### PR TITLE
feat(event-search): Allow for arbitrary trailing optional arguments

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1473,6 +1473,20 @@ class Function(object):
             == 1
         ), u"{}: only one of column, aggregate, or transform is allowed".format(self.name)
 
+        # assert that no duplicate argument names are used
+        names = set()
+        for arg in self.args:
+            assert arg.name not in names, u"{}: argument {} specified more than once".format(
+                self.name, arg.name
+            )
+            names.add(arg.name)
+
+        for calculation in self.calculated_args:
+            assert (
+                calculation["name"] not in names
+            ), u"{}: argument {} specified more than once".format(self.name, calculation["name"])
+            names.add(calculation["name"])
+
     def validate_argument_count(self, field, arguments):
         """
         Validate the number of required arguments the function defines against

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1492,15 +1492,15 @@ class Function(object):
             required_args_count = self.required_args_count
             if required_args_count == total_args_count:
                 raise InvalidSearchQuery(
-                    u"{}: expected {:g} arguments".format(field, total_args_count)
+                    u"{}: expected {:g} argument(s)".format(field, total_args_count)
                 )
             elif args_count < required_args_count:
                 raise InvalidSearchQuery(
-                    u"{}: expected at least {:g} arguments".format(field, required_args_count)
+                    u"{}: expected at least {:g} argument(s)".format(field, required_args_count)
                 )
             elif args_count > total_args_count:
                 raise InvalidSearchQuery(
-                    u"{}: expected at most {:g} arguments".format(field, total_args_count)
+                    u"{}: expected at most {:g} argument(s)".format(field, total_args_count)
                 )
 
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1208,8 +1208,8 @@ def get_json_meta_type(field_alias, snuba_type):
     function_match = FUNCTION_ALIAS_PATTERN.match(field_alias)
     if function_match and snuba_json != "string":
         function_definition = FUNCTIONS.get(function_match.group(1))
-        if function_definition and function_definition.get("result_type"):
-            return function_definition.get("result_type")
+        if function_definition and function_definition.result_type:
+            return function_definition.result_type
     if "duration" in field_alias:
         return "duration"
     if field_alias == "transaction.status":
@@ -1365,233 +1365,325 @@ class IntervalDefault(NumberRange):
         return int(interval)
 
 
+class Function(object):
+    def __init__(
+        self,
+        name,
+        required_args=None,
+        optional_args=None,
+        calculated_args=None,
+        column=None,
+        aggregate=None,
+        transform=None,
+        result_type=None,
+    ):
+        """
+        Specifies a function interface that must be followed when defining new functions
+
+        :param str name: The name of the function, this refers to the name to invoke.
+        :param list[FunctionArg] required_args: The list of required arguments to the function.
+            If any of these arguments are not specified, an error will be raised.
+        :param list[FunctionArg] optional_args: The list of optional arguments to the function.
+            If any of these arguments are not specified, they will be filled using their default value.
+        :param list[obj] calculated_args: The list of calculated arguments to the function.
+            These arguments will be computed based on the list of specified arguments.
+        :param [str, [any], str or None] column: The column to be passed to snuba once formatted.
+            The arguments will be filled into the column where needed. This must not be an aggregate.
+        :param [str, [any], str or None] aggregate: The aggregate to be passed to snuba once formatted.
+            The arguments will be filled into the aggregate where needed. This must be an aggregate.
+        :param str transform: NOTE: Use aggregate over transform whenever possible.
+            An aggregate string to be passed to snuba once formatted. The arguments
+            will be filled into the string using `.format(...)`.
+        :param str result_type: The resulting type of this function. Can be any of the following
+            (duration, string, number, integer, percentage, date).
+        """
+
+        self.name = name
+        self.result_type = result_type
+        self.required_args = [] if required_args is None else required_args
+        self.optional_args = [] if optional_args is None else optional_args
+        self.calculated_args = [] if calculated_args is None else calculated_args
+        self.column = column
+        self.aggregate = aggregate
+        self.transform = transform
+
+    @property
+    def required_args_count(self):
+        return len(self.required_args)
+
+    @property
+    def optional_args_count(self):
+        return len(self.optional_args)
+
+    @property
+    def total_args_count(self):
+        return self.required_args_count + self.optional_args_count
+
+    @property
+    def args(self):
+        return self.required_args + self.optional_args
+
+    def format_as_arguments(self, field, columns, params):
+        # make sure to validate the argument count first to
+        # ensure the right number of arguments have been passed
+        self.validate_argument_count(field, columns)
+
+        columns = [column for column in columns]
+
+        # use default values to populate optional arguments if any
+        for argument in self.args[len(columns) :]:
+            try:
+                default = argument.get_default(params)
+            except InvalidFunctionArgument as e:
+                raise InvalidSearchQuery(u"{}: invalid arguments: {}".format(field, e))
+
+            # Hacky, but we expect column arguments to be strings so easiest to convert it back
+            columns.append(six.text_type(default))
+
+        arguments = {}
+
+        # normalize the arguments before putting it in a dict
+        for column_value, argument in zip(columns, self.args):
+            try:
+                normalized_value = argument.normalize(column_value)
+                arguments[argument.name] = normalized_value
+            except InvalidFunctionArgument as e:
+                raise InvalidSearchQuery(
+                    u"{}: {} argument invalid: {}".format(field, argument.name, e)
+                )
+
+        # populate any computed args
+        for calculation in self.calculated_args:
+            arguments[calculation["name"]] = calculation["fn"](arguments)
+
+        return arguments
+
+    def validate(self):
+        pass
+
+    def validate_argument_count(self, field, arguments):
+        """
+        Validate the number of required arguments the function defines against
+        provided arguments. Raise an exception if there is a mismatch in the
+        number of arguments. Do not return any values.
+
+        There are 4 cases:
+            1. provided # of arguments != required # of arguments AND provided # of arguments != total # of arguments (bad, raise an error)
+            2. provided # of arguments < required # of arguments (bad, raise an error)
+            3. provided # of arguments > total # of arguments (bad, raise an error)
+            4. required # of arguments <= provided # of arguments <= total # of arguments (good, pass the validation)
+        """
+        args_count = len(arguments)
+        total_args_count = self.total_args_count
+        if args_count != total_args_count:
+            required_args_count = self.required_args_count
+            if required_args_count == total_args_count:
+                raise InvalidSearchQuery(
+                    u"{}: expected {:g} arguments".format(field, total_args_count)
+                )
+            elif args_count < required_args_count:
+                raise InvalidSearchQuery(
+                    u"{}: expected at least {:g} arguments".format(field, required_args_count)
+                )
+            elif args_count > total_args_count:
+                raise InvalidSearchQuery(
+                    u"{}: expected at most {:g} arguments".format(field, total_args_count)
+                )
+
+
 # When adding functions to this list please also update
 # static/sentry/app/utils/discover/fields.tsx so that
 # the UI builder stays in sync.
 FUNCTIONS = {
-    "percentile": {
-        "name": "percentile",
-        "args": [DurationColumnNoLookup("column"), NumberRange("percentile", 0, 1)],
-        "aggregate": [u"quantile({percentile:g})", ArgValue("column"), None],
-        "result_type": "duration",
-    },
-    "p50": {
-        "name": "p50",
-        "args": [],
-        "aggregate": [u"quantile(0.5)", "transaction.duration", None],
-        "result_type": "duration",
-    },
-    "p75": {
-        "name": "p75",
-        "args": [],
-        "aggregate": [u"quantile(0.75)", "transaction.duration", None],
-        "result_type": "duration",
-    },
-    "p95": {
-        "name": "p95",
-        "args": [],
-        "aggregate": [u"quantile(0.95)", "transaction.duration", None],
-        "result_type": "duration",
-    },
-    "p99": {
-        "name": "p99",
-        "args": [],
-        "aggregate": [u"quantile(0.99)", "transaction.duration", None],
-        "result_type": "duration",
-    },
-    "p100": {
-        "name": "p100",
-        "args": [],
-        "aggregate": [u"max", "transaction.duration", None],
-        "result_type": "duration",
-    },
-    "eps": {
-        "name": "eps",
-        "args": [IntervalDefault("interval", 1, None)],
-        "transform": u"divide(count(), {interval:g})",
-        "result_type": "number",
-    },
-    "epm": {
-        "name": "epm",
-        "args": [IntervalDefault("interval", 60, None)],
-        "transform": u"divide(count(), divide({interval:g}, 60))",
-        "result_type": "number",
-    },
-    "last_seen": {
-        "name": "last_seen",
-        "args": [],
-        "aggregate": ["max", "timestamp", "last_seen"],
-        "result_type": "date",
-    },
-    "latest_event": {
-        "name": "latest_event",
-        "args": [],
-        "aggregate": ["argMax", ["id", "timestamp"], "latest_event"],
-        "result_type": "string",
-    },
-    "apdex": {
-        "name": "apdex",
-        "args": [NumberRange("satisfaction", 0, None)],
-        "transform": u"apdex(duration, {satisfaction:g})",
-        "result_type": "number",
-    },
-    "user_misery": {
-        "name": "user_misery",
-        "args": [NumberRange("satisfaction", 0, None)],
-        "calculated_args": [{"name": "tolerated", "fn": lambda args: args["satisfaction"] * 4.0}],
-        "transform": u"uniqIf(user, greater(duration, {tolerated:g}))",
-        "result_type": "number",
-    },
-    "failure_rate": {
-        "name": "failure_rate",
-        "args": [],
-        "transform": "failure_rate()",
-        "result_type": "percentage",
-    },
-    # The user facing signature for this function is histogram(<column>, <num_buckets>)
-    # Internally, snuba.discover.query() expands the user request into this value by
-    # calculating the bucket size and start_offset.
-    "histogram": {
-        "name": "histogram",
-        "args": [
-            DurationColumnNoLookup("column"),
-            NumberRange("num_buckets", 1, 500),
-            NumberRange("bucket_size", 0, None),
-            NumberRange("start_offset", 0, None),
-        ],
-        "column": [
-            "multiply",
-            [
-                ["floor", [["divide", [ArgValue("column"), ArgValue("bucket_size")]]]],
-                ArgValue("bucket_size"),
+    function.name: function
+    for function in [
+        Function(
+            "percentile",
+            required_args=[DurationColumnNoLookup("column"), NumberRange("percentile", 0, 1)],
+            aggregate=[u"quantile({percentile:g})", ArgValue("column"), None],
+            result_type="duration",
+        ),
+        Function(
+            "p50",
+            aggregate=[u"quantile(0.5)", "transaction.duration", None],
+            result_type="duration",
+        ),
+        Function(
+            "p75",
+            aggregate=[u"quantile(0.75)", "transaction.duration", None],
+            result_type="duration",
+        ),
+        Function(
+            "p95",
+            aggregate=[u"quantile(0.95)", "transaction.duration", None],
+            result_type="duration",
+        ),
+        Function(
+            "p99",
+            aggregate=[u"quantile(0.99)", "transaction.duration", None],
+            result_type="duration",
+        ),
+        Function("p100", aggregate=[u"max", "transaction.duration", None], result_type="duration",),
+        Function(
+            "eps",
+            optional_args=[IntervalDefault("interval", 1, None)],
+            transform=u"divide(count(), {interval:g})",
+            result_type="number",
+        ),
+        Function(
+            "epm",
+            optional_args=[IntervalDefault("interval", 60, None)],
+            transform=u"divide(count(), divide({interval:g}, 60))",
+            result_type="number",
+        ),
+        Function("last_seen", aggregate=["max", "timestamp", "last_seen"], result_type="date",),
+        Function(
+            "latest_event",
+            aggregate=["argMax", ["id", "timestamp"], "latest_event"],
+            result_type="string",
+        ),
+        Function(
+            "apdex",
+            required_args=[NumberRange("satisfaction", 0, None)],
+            transform=u"apdex(duration, {satisfaction:g})",
+            result_type="number",
+        ),
+        Function(
+            "user_misery",
+            required_args=[NumberRange("satisfaction", 0, None)],
+            calculated_args=[{"name": "tolerated", "fn": lambda args: args["satisfaction"] * 4.0}],
+            transform=u"uniqIf(user, greater(duration, {tolerated:g}))",
+            result_type="number",
+        ),
+        Function("failure_rate", transform="failure_rate()", result_type="percentage",),
+        # The user facing signature for this function is histogram(<column>, <num_buckets>)
+        # Internally, snuba.discover.query() expands the user request into this value by
+        # calculating the bucket size and start_offset.
+        Function(
+            "histogram",
+            required_args=[
+                DurationColumnNoLookup("column"),
+                NumberRange("num_buckets", 1, 500),
+                NumberRange("bucket_size", 0, None),
+                NumberRange("start_offset", 0, None),
             ],
-            None,
-        ],
-        "result_type": "number",
-    },
-    "count_unique": {
-        "name": "count_unique",
-        "args": [CountColumn("column")],
-        "aggregate": ["uniq", ArgValue("column"), None],
-        "result_type": "integer",
-    },
-    "count": {
-        "name": "count",
-        "args": [NullColumn("column")],
-        "aggregate": ["count", None, None],
-        "result_type": "integer",
-    },
-    "min": {
-        "name": "min",
-        "args": [NumericColumnNoLookup("column")],
-        "aggregate": ["min", ArgValue("column"), None],
-    },
-    "max": {
-        "name": "max",
-        "args": [NumericColumnNoLookup("column")],
-        "aggregate": ["max", ArgValue("column"), None],
-    },
-    "avg": {
-        "name": "avg",
-        "args": [DurationColumnNoLookup("column")],
-        "aggregate": ["avg", ArgValue("column"), None],
-        "result_type": "duration",
-    },
-    "sum": {
-        "name": "sum",
-        "args": [DurationColumnNoLookup("column")],
-        "aggregate": ["sum", ArgValue("column"), None],
-        "result_type": "duration",
-    },
-    # Currently only being used by the baseline PoC
-    "absolute_delta": {
-        "name": "absolute_delta",
-        "args": [DurationColumn("column"), NumberRange("target", 0, None)],
-        "transform": u"abs(minus({column}, {target:g}))",
-        "result_type": "duration",
-    },
-    # These range functions for performance trends, these aren't If functions
-    # to avoid allowing arbitrary if statements
-    # Not yet supported in Discover, and shouldn't be added to fields.tsx
-    "percentile_range": {
-        "name": "percentile_range",
-        "args": [
-            DurationColumn("column"),
-            NumberRange("percentile", 0, 1),
-            DateArg("start"),
-            DateArg("end"),
-            NumberRange("index", 1, None),
-        ],
-        "aggregate": [
-            u"quantileIf({percentile:.2f})({column},and(greaterOrEquals(timestamp,toDateTime('{start}')),less(timestamp,toDateTime('{end}'))))",
-            None,
-            "percentile_range_{index:g}",
-        ],
-        "result_type": "duration",
-    },
-    "avg_range": {
-        "name": "avg_range",
-        "args": [
-            DurationColumn("column"),
-            DateArg("start"),
-            DateArg("end"),
-            NumberRange("index", 1, None),
-        ],
-        "aggregate": [
-            u"avgIf({column},and(greaterOrEquals(timestamp,toDateTime('{start}')),less(timestamp,toDateTime('{end}'))))",
-            None,
-            "avg_range_{index:g}",
-        ],
-        "result_type": "duration",
-    },
-    "user_misery_range": {
-        "name": "user_misery_range",
-        "args": [
-            NumberRange("satisfaction", 0, None),
-            DateArg("start"),
-            DateArg("end"),
-            NumberRange("index", 1, None),
-        ],
-        "calculated_args": [{"name": "tolerated", "fn": lambda args: args["satisfaction"] * 4.0}],
-        "aggregate": [
-            u"uniqIf(user,and(greater(duration,{tolerated:g}),and(greaterOrEquals(timestamp,toDateTime('{start}')),less(timestamp,toDateTime('{end}')))))",
-            None,
-            u"user_misery_range_{index:g}",
-        ],
-        "result_type": "number",
-    },
-    "count_range": {
-        "name": "count_range",
-        "args": [DateArg("start"), DateArg("end"), NumberRange("index", 1, None)],
-        "aggregate": [
-            u"countIf(and(greaterOrEquals(timestamp,toDateTime('{start}')),less(timestamp,toDateTime('{end}'))))",
-            None,
-            "count_range_{index:g}",
-        ],
-        "result_type": "integer",
-    },
-    "percentage": {
-        "name": "percentage",
-        "args": [FunctionArg("numerator"), FunctionArg("denominator")],
-        "aggregate": [
-            u"if(greater({denominator},0),divide({numerator},{denominator}),null)",
-            None,
-            None,
-        ],
-        "result_type": "percentage",
-    },
-    "minus": {
-        "name": "minus",
-        "args": [FunctionArg("minuend"), FunctionArg("subtrahend")],
-        "aggregate": [u"minus", [ArgValue("minuend"), ArgValue("subtrahend")], None],
-        "result_type": "duration",
-    },
-    "absolute_correlation": {
-        "name": "absolute_correlation",
-        "args": [],
-        "aggregate": ["abs", [["corr", ["toUnixTimestamp", ["timestamp"], "duration"]]], None],
-        "result_type": "number",
-    },
+            column=[
+                "multiply",
+                [
+                    ["floor", [["divide", [ArgValue("column"), ArgValue("bucket_size")]]]],
+                    ArgValue("bucket_size"),
+                ],
+                None,
+            ],
+            result_type="number",
+        ),
+        Function(
+            "count_unique",
+            required_args=[CountColumn("column")],
+            aggregate=["uniq", ArgValue("column"), None],
+            result_type="integer",
+        ),
+        Function(
+            "count",
+            optional_args=[NullColumn("column")],
+            aggregate=["count", None, None],
+            result_type="integer",
+        ),
+        Function(
+            "min",
+            required_args=[NumericColumnNoLookup("column")],
+            aggregate=["min", ArgValue("column"), None],
+        ),
+        Function(
+            "max",
+            required_args=[NumericColumnNoLookup("column")],
+            aggregate=["max", ArgValue("column"), None],
+        ),
+        Function(
+            "avg",
+            required_args=[NumericColumnNoLookup("column")],
+            aggregate=["avg", ArgValue("column"), None],
+            result_type="duration",
+        ),
+        Function(
+            "sum",
+            required_args=[NumericColumnNoLookup("column")],
+            aggregate=["sum", ArgValue("column"), None],
+            result_type="duration",
+        ),
+        # Currently only being used by the baseline PoC
+        Function(
+            "absolute_delta",
+            required_args=[DurationColumn("column"), NumberRange("target", 0, None)],
+            transform=u"abs(minus({column}, {target:g}))",
+            result_type="duration",
+        ),
+        # These range functions for performance trends, these aren't If functions
+        # to avoid allowing arbitrary if statements
+        # Not yet supported in Discover, and shouldn't be added to fields.tsx
+        Function(
+            "percentile_range",
+            required_args=[
+                DurationColumn("column"),
+                NumberRange("percentile", 0, 1),
+                DateArg("start"),
+                DateArg("end"),
+                NumberRange("index", 1, None),
+            ],
+            aggregate=[
+                u"quantileIf({percentile:.2f})({column},and(greaterOrEquals(timestamp,toDateTime('{start}')),less(timestamp,toDateTime('{end}'))))",
+                None,
+                "percentile_range_{index:g}",
+            ],
+            result_type="duration",
+        ),
+        Function(
+            "user_misery_range",
+            required_args=[
+                NumberRange("satisfaction", 0, None),
+                DateArg("start"),
+                DateArg("end"),
+                NumberRange("index", 1, None),
+            ],
+            aggregate=[
+                u"avgIf({column},and(greaterOrEquals(timestamp,toDateTime('{start}')),less(timestamp,toDateTime('{end}'))))",
+                None,
+                "avg_range_{index:g}",
+            ],
+            result_type="duration",
+        ),
+        Function(
+            "count_range",
+            required_args=[DateArg("start"), DateArg("end"), NumberRange("index", 1, None)],
+            aggregate=[
+                u"countIf(and(greaterOrEquals(timestamp,toDateTime('{start}')),less(timestamp,toDateTime('{end}'))))",
+                None,
+                "count_range_{index:g}",
+            ],
+            result_type="integer",
+        ),
+        Function(
+            "percentage",
+            required_args=[FunctionArg("numerator"), FunctionArg("denominator")],
+            aggregate=[
+                u"if(greater({denominator},0),divide({numerator},{denominator}),null)",
+                None,
+                None,
+            ],
+            result_type="percentage",
+        ),
+        Function(
+            "minus",
+            required_args=[FunctionArg("minuend"), FunctionArg("subtrahend")],
+            aggregate=[u"minus", [ArgValue("minuend"), ArgValue("subtrahend")], None],
+            result_type="duration",
+        ),
+        Function(
+            "absolute_correlation",
+            aggregate=["abs", [["corr", ["toUnixTimestamp", ["timestamp"], "duration"]]], None],
+            result_type="number",
+        ),
+    ]
 }
 
 
@@ -1643,86 +1735,20 @@ def parse_function(field, match=None):
     )
 
 
-def count_required_arguments(function):
-    n = 0
-    for arg in function["args"]:
-        if arg.has_default:
-            break
-        n += 1
-    return n
-
-
-def count_total_arguments(function):
-    return len(function["args"])
-
-
-def validate_argument_count(field, function, arguments):
-    """
-    Validate the number of required arguments the function defines against
-    provided arguments. Raise an exception if there is a mismatch in the
-    number of arguments. Do not return any values.
-
-    There are 4 cases:
-        1. provided # of arguments != required # of arguments AND provided # of arguments != total # of arguments (bad, raise an error)
-        2. provided # of arguments < required # of arguments (bad, raise an error)
-        3. provided # of arguments > total # of arguments (bad, raise an error)
-        4. required # of arguments <= provided # of arguments <= total # of arguments (good, pass the validation)
-    """
-    args_count = len(arguments)
-    total_args_count = count_total_arguments(function)
-    if args_count != total_args_count:
-        required_args_count = count_required_arguments(function)
-        if required_args_count == total_args_count:
-            raise InvalidSearchQuery(
-                u"{}: expected {:g} arguments".format(field, len(function["args"]))
-            )
-        elif args_count < required_args_count:
-            raise InvalidSearchQuery(
-                u"{}: expected at least {:g} arguments".format(field, required_args_count)
-            )
-        elif args_count > total_args_count:
-            raise InvalidSearchQuery(
-                u"{}: expected at most {:g} arguments".format(field, total_args_count)
-            )
-
-
 def resolve_function(field, match=None, params=None):
     function, columns = parse_function(field, match)
     function = FUNCTIONS[match.group("function")]
 
-    validate_argument_count(field, function, columns)
+    arguments = function.format_as_arguments(field, columns, params)
 
-    columns_with_defaults = [col for col in columns]
-    for argument in function["args"][len(columns) :]:
-        assert argument.has_default
-        try:
-            default = argument.get_default(params)
-        except InvalidFunctionArgument as e:
-            raise InvalidSearchQuery(u"{}: invalid arguments: {}".format(field, e))
-
-        # Hacky, but we expect column arguments to be strings so easiest to convert it back
-        columns_with_defaults.append(six.text_type(default) if default else default)
-
-    arguments = {}
-    for column_value, argument in zip(columns_with_defaults, function["args"]):
-        try:
-            normalized_value = argument.normalize(column_value)
-            arguments[argument.name] = normalized_value
-        except InvalidFunctionArgument as e:
-            raise InvalidSearchQuery(u"{}: {} argument invalid: {}".format(field, argument.name, e))
-
-    if "calculated_args" in function:
-        for calculation in function["calculated_args"]:
-            arguments[calculation["name"]] = calculation["fn"](arguments)
-
-    if "transform" in function:
-        snuba_string = function["transform"].format(**arguments)
+    if function.transform is not None:
+        snuba_string = function.transform.format(**arguments)
         return (
             [],
-            [[snuba_string, None, get_function_alias_with_columns(function["name"], columns)]],
+            [[snuba_string, None, get_function_alias_with_columns(function.name, columns)]],
         )
-    elif "aggregate" in function:
-        aggregate = deepcopy(function["aggregate"])
+    elif function.aggregate is not None:
+        aggregate = deepcopy(function.aggregate)
 
         aggregate[0] = aggregate[0].format(**arguments)
         if isinstance(aggregate[1], (list, tuple)):
@@ -1733,19 +1759,19 @@ def resolve_function(field, match=None, params=None):
             arg = aggregate[1].arg
             aggregate[1] = arguments[arg]
         if aggregate[2] is None:
-            aggregate[2] = get_function_alias_with_columns(function["name"], columns)
+            aggregate[2] = get_function_alias_with_columns(function.name, columns)
         else:
             aggregate[2] = aggregate[2].format(**arguments)
 
         return ([], [aggregate])
-    elif "column" in function:
+    elif function.column is not None:
         # These can be very nested functions, so we need to iterate through all the layers
-        addition = deepcopy(function["column"])
+        addition = deepcopy(function.column)
         format_column_arguments(addition, arguments)
         if len(addition) < 3:
-            addition.append(get_function_alias_with_columns(function["name"], columns))
+            addition.append(get_function_alias_with_columns(function.name, columns))
         elif len(addition) == 3 and addition[2] is None:
-            addition[2] = get_function_alias_with_columns(function["name"], columns)
+            addition[2] = get_function_alias_with_columns(function.name, columns)
         return ([addition], [])
 
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1444,11 +1444,10 @@ class Function(object):
 
         arguments = {}
 
-        # normalize the arguments before putting it in a dict
+        # normalize the arguments before putting them in a dict
         for column_value, argument in zip(columns, self.args):
             try:
-                normalized_value = argument.normalize(column_value)
-                arguments[argument.name] = normalized_value
+                arguments[argument.name] = argument.normalize(column_value)
             except InvalidFunctionArgument as e:
                 raise InvalidSearchQuery(
                     u"{}: {} argument invalid: {}".format(field, argument.name, e)

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -14,6 +14,7 @@ from sentry import eventstore
 from sentry.api.event_search import (
     AggregateKey,
     event_search_grammar,
+    FUNCTIONS,
     get_filter,
     resolve_field_list,
     parse_search_query,
@@ -2235,6 +2236,22 @@ class ResolveFieldListTest(unittest.TestCase):
                 "minus_user_misery_range_1_user_misery_range_2",
             ],
         ]
+
+    def test_functions_args_well_defined(self):
+        """
+        Asserts that all functions are well defined.
+
+        A function is said to be not well defined if an optional argument preceeds a non-optional argument.
+        """
+        for function in FUNCTIONS.values():
+            has_default = False
+            for arg in function["args"]:
+                assert (
+                    not has_default or arg.has_default
+                ), "default arguments must not preceed other arguments in function: {}".format(
+                    function["name"]
+                )
+                has_default = arg.has_default
 
     def test_rollup_with_unaggregated_fields(self):
         with pytest.raises(InvalidSearchQuery) as err:

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -138,12 +138,12 @@ class TestAlertRuleSerializer(TestCase):
             {"aggregate": "count_unique(123, hello)"},
             {
                 "aggregate": [
-                    "Invalid Metric: count_unique(123, hello): expected at most 1 arguments"
+                    "Invalid Metric: count_unique(123, hello): expected at most 1 argument(s)"
                 ]
             },
         )
         self.run_fail_validation_test(
-            {"aggregate": "max()"}, {"aggregate": ["Invalid Metric: max(): expected 1 arguments"]}
+            {"aggregate": "max()"}, {"aggregate": ["Invalid Metric: max(): expected 1 argument(s)"]}
         )
         aggregate = "count_unique(tags[sentry:user])"
         base_params = self.valid_params.copy()

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -136,7 +136,11 @@ class TestAlertRuleSerializer(TestCase):
         )
         self.run_fail_validation_test(
             {"aggregate": "count_unique(123, hello)"},
-            {"aggregate": ["Invalid Metric: count_unique(123, hello): expected 1 arguments"]},
+            {
+                "aggregate": [
+                    "Invalid Metric: count_unique(123, hello): expected at most 1 arguments"
+                ]
+            },
         )
         self.run_fail_validation_test(
             {"aggregate": "max()"}, {"aggregate": ["Invalid Metric: max(): expected 1 arguments"]}


### PR DESCRIPTION
Currently, we only allow for a single optional argument. This argument must be
the first and only argument to the function. This change maintains this semantic
and allows for more flexibility by allow any number of optional arguments
provided they are at the end.

This will be useful for the upcoming measurements histogram function.