### PR TITLE
feat(apm) Add transaction status breakdown

### DIFF
--- a/docs-ui/components/charts-breakdownBars.stories.js
+++ b/docs-ui/components/charts-breakdownBars.stories.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import {withInfo} from '@storybook/addon-info';
+
+import BreakdownBars from 'app/components/charts/breakdownBars';
+
+export default {
+  title: 'Charts/BreakdownBars',
+};
+
+export const Default = withInfo('Horizontal bar chart with labels')(() => {
+  const data = [
+    {label: 'unknown', value: 910},
+    {label: 'not_found', value: 40},
+    {label: 'data_loss', value: 30},
+    {label: 'cancelled', value: 20},
+  ];
+  return (
+    <div className="section">
+      <BreakdownBars data={data} />
+    </div>
+  );
+});
+
+Default.story = {
+  name: 'BreakdownBars',
+};

--- a/src/sentry/static/sentry/app/components/charts/breakdownBars.tsx
+++ b/src/sentry/static/sentry/app/components/charts/breakdownBars.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {formatPercentage} from 'app/utils/formatters';
+import space from 'app/styles/space';
+
+type Point = {
+  label: string;
+  value: number;
+};
+
+type Props = {
+  /**
+   * The data to display. The caller should order the points
+   * in the order they want bars displayed.
+   */
+  data: Point[];
+};
+
+function BreakdownBars({data}: Props) {
+  const total = data.reduce((sum, point) => point.value + sum, 0);
+  return (
+    <BreakdownGrid>
+      {data.map((point, i) => (
+        <React.Fragment key={`${i}:${point.label}`}>
+          <Percentage>{formatPercentage(point.value / total, 0)}</Percentage>
+          <BarContainer>
+            <Bar style={{width: `${((point.value / total) * 100).toFixed(2)}%`}} />
+            <Label>{point.label}</Label>
+          </BarContainer>
+        </React.Fragment>
+      ))}
+    </BreakdownGrid>
+  );
+}
+
+export default BreakdownBars;
+
+const BreakdownGrid = styled('div')`
+  display: grid;
+  grid-template-columns: min-content auto;
+  column-gap: ${space(1)};
+  row-gap: ${space(1)};
+`;
+
+const Percentage = styled('div')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  text-align: right;
+`;
+
+const BarContainer = styled('div')`
+  padding-left: ${space(1)};
+  padding-right: ${space(1)};
+  position: relative;
+`;
+
+const Label = styled('span')`
+  position: relative;
+  color: ${p => p.theme.gray700};
+  z-index: 2;
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const Bar = styled('div')`
+  border-radius: 2px;
+  background-color: ${p => p.theme.gray300};
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  height: 100%;
+  width: 0%;
+`;

--- a/src/sentry/static/sentry/app/components/charts/errorPanel.tsx
+++ b/src/sentry/static/sentry/app/components/charts/errorPanel.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-const ErrorPanel = styled('div')`
+const ErrorPanel = styled('div')<{height?: string}>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -8,7 +8,7 @@ const ErrorPanel = styled('div')`
   flex: 1;
   flex-shrink: 0;
   overflow: hidden;
-  height: 200px;
+  height: ${p => p.height || '200px'};
   position: relative;
   border-color: transparent;
   margin-bottom: 0;

--- a/src/sentry/static/sentry/app/components/loadingMask.tsx
+++ b/src/sentry/static/sentry/app/components/loadingMask.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 const LoadingMask = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.gray200};
   border-radius: ${p => p.theme.borderRadius};
   position: absolute;
   top: 0;

--- a/src/sentry/static/sentry/app/components/placeholder.tsx
+++ b/src/sentry/static/sentry/app/components/placeholder.tsx
@@ -33,7 +33,7 @@ const Placeholder = styled((props: Props) => {
   justify-content: center;
 
   background-color: ${p => (p.error ? p.theme.red100 : p.theme.gray200)};
-${p => p.error && `color: ${p.theme.red300};`}
+  ${p => p.error && `color: ${p.theme.red300};`}
   width: ${p => p.width};
   height: ${p => p.height};
   ${p => (p.shape === 'circle' ? 'border-radius: 100%;' : '')}

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -79,6 +79,10 @@ const PERFORMANCE_TERMS: Record<string, TermFormatter> = {
       "User misery is the percentage of users who are experiencing load times 4x your organization's apdex threshold of %sms.",
       organization.apdexThreshold
     ),
+  statusBreakdown: () =>
+    t(
+      'The breakdown of transaction statuses. This may indicate what type of failure it is.'
+    ),
 };
 
 export function getTermHelp(

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -22,6 +22,7 @@ import UserStats from './userStats';
 import TransactionSummaryCharts from './charts';
 import RelatedIssues from './relatedIssues';
 import SidebarCharts from './sidebarCharts';
+import StatusBreakdown from './statusBreakdown';
 
 type Props = {
   location: Location;
@@ -139,6 +140,11 @@ class SummaryContent extends React.Component<Props, State> {
               eventView={eventView}
             />
             <SidebarCharts organization={organization} eventView={eventView} />
+            <StatusBreakdown
+              eventView={eventView}
+              organization={organization}
+              location={location}
+            />
             <Tags
               generateUrl={this.generateTagUrl}
               totalValues={totalValues}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/statusBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/statusBreakdown.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import {Location} from 'history';
+import styled from '@emotion/styled';
+
+import {t} from 'app/locale';
+import {LightWeightOrganization} from 'app/types';
+import BreakdownBars from 'app/components/charts/breakdownBars';
+import {SectionHeading} from 'app/components/charts/styles';
+import Placeholder from 'app/components/placeholder';
+import QuestionTooltip from 'app/components/questionTooltip';
+import EventView from 'app/utils/discover/eventView';
+import DiscoverQuery from 'app/utils/discover/discoverQuery';
+import {getTermHelp} from 'app/views/performance/data';
+import space from 'app/styles/space';
+
+type Props = {
+  organization: LightWeightOrganization;
+  location: Location;
+  eventView: EventView;
+};
+
+function StatusBreakdown({eventView, location, organization}: Props) {
+  const breakdownView = eventView
+    .withColumns([
+      {kind: 'function', function: ['count', '', '']},
+      {kind: 'field', field: 'transaction.status'},
+    ])
+    .withSorts([{kind: 'desc', field: 'count()'}]);
+
+  return (
+    <Container>
+      <SectionHeading>
+        {t('Status Breakdown')}
+        <QuestionTooltip
+          position="top"
+          title={getTermHelp(organization, 'statusBreakdown')}
+          size="sm"
+        />
+      </SectionHeading>
+      <DiscoverQuery
+        eventView={breakdownView}
+        location={location}
+        orgSlug={organization.slug}
+      >
+        {({isLoading, tableData}) => {
+          if (isLoading) {
+            return <Placeholder height="150px" />;
+          }
+          if (!tableData) {
+            return 'oh no';
+          }
+          const points = tableData.data.map(row => ({
+            label: String(row['transaction.status']),
+            value: parseInt(String(row.count), 10),
+          }));
+          return <BreakdownBars data={points} />;
+        }}
+      </DiscoverQuery>
+    </Container>
+  );
+}
+
+export default StatusBreakdown;
+
+const Container = styled('div')`
+  margin-bottom: ${space(4)};
+`;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/statusBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/statusBreakdown.tsx
@@ -7,6 +7,9 @@ import {LightWeightOrganization} from 'app/types';
 import BreakdownBars from 'app/components/charts/breakdownBars';
 import {SectionHeading} from 'app/components/charts/styles';
 import Placeholder from 'app/components/placeholder';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
+import ErrorPanel from 'app/components/charts/errorPanel';
+import {IconWarning} from 'app/icons';
 import QuestionTooltip from 'app/components/questionTooltip';
 import EventView from 'app/utils/discover/eventView';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
@@ -25,7 +28,7 @@ function StatusBreakdown({eventView, location, organization}: Props) {
       {kind: 'function', function: ['count', '', '']},
       {kind: 'field', field: 'transaction.status'},
     ])
-    .withSorts([{kind: 'desc', field: 'count()'}]);
+    .withSorts([{kind: 'desc', field: 'count'}]);
 
   return (
     <Container>
@@ -42,12 +45,19 @@ function StatusBreakdown({eventView, location, organization}: Props) {
         location={location}
         orgSlug={organization.slug}
       >
-        {({isLoading, tableData}) => {
+        {({isLoading, error, tableData}) => {
           if (isLoading) {
-            return <Placeholder height="150px" />;
+            return <Placeholder height="125px" />;
           }
-          if (!tableData) {
-            return 'oh no';
+          if (error) {
+            return (
+              <ErrorPanel height="125px">
+                <IconWarning color="gray500" size="lg" />
+              </ErrorPanel>
+            );
+          }
+          if (!tableData || tableData.data.length === 0) {
+            return <EmptyStateWarning small>{t('No data available')}</EmptyStateWarning>;
           }
           const points = tableData.data.map(row => ({
             label: String(row['transaction.status']),


### PR DESCRIPTION
Add a breakdown of the transaction status codes to the transaction summary view. This helps uncover what is inside a transaction's failure_rate() value.

I've also normalized the background color of the chart loading state to be consistent with the Placeholder element. Having charts and placeholders adjacent made the contrast really noticeable.

![Screen Shot 2020-09-18 at 1 14 49 PM](https://user-images.githubusercontent.com/24086/93626398-5e02f080-f9b1-11ea-935e-6893cf1ba9d2.png)
