### PR TITLE
feat(api-docs): validate_schema

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ docker>=3.7.0,<3.8.0
 exam>=0.5.1
 freezegun==0.3.11
 honcho>=1.0.0,<1.1.0
+openapi-core @ https://github.com/getsentry/openapi-core/archive/master.zip#egg=openapi-core
 pytest==4.6.5
 pytest-cov==2.5.1
 pytest-django==3.5.1

--- a/tests/apidocs/endpoints/test_deploy.py
+++ b/tests/apidocs/endpoints/test_deploy.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import datetime
+
+from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
+
+from sentry.models import Deploy, Environment, Release
+from tests.apidocs.util import APIDocsTestCase
+
+
+class ReleaseDeploysDocs(APIDocsTestCase):
+    def test_simple(self):
+        project = self.create_project(name="foo")
+        release = Release.objects.create(organization_id=project.organization_id, version="1",)
+        release.add_project(project)
+        Deploy.objects.create(
+            environment_id=Environment.objects.create(
+                organization_id=project.organization_id, name="production"
+            ).id,
+            organization_id=project.organization_id,
+            release=release,
+            date_finished=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        )
+        Deploy.objects.create(
+            environment_id=Environment.objects.create(
+                organization_id=project.organization_id, name="staging"
+            ).id,
+            organization_id=project.organization_id,
+            release=release,
+        )
+
+        url = reverse(
+            "sentry-api-0-organization-release-deploys",
+            kwargs={"organization_slug": project.organization.slug, "version": release.version},
+        )
+
+        self.login_as(user=self.user)
+
+        data = {
+            "name": "foo",
+            "environment": "production",
+            "url": "https://www.example.com",
+        }
+        response = self.client.post(url, data)
+        request = RequestFactory().post(url, data)
+
+        self.validate_schema(response, request)

--- a/tests/apidocs/util.py
+++ b/tests/apidocs/util.py
@@ -23,8 +23,7 @@ class APIDocsTestCase(APITestCase):
 
     def validate_schema(self, request, response):
         result = ResponseValidator(self.create_schema()).validate(
-            DjangoOpenAPIRequest(request),
-            DjangoOpenAPIResponse(response)
+            DjangoOpenAPIRequest(request), DjangoOpenAPIResponse(response)
         )
 
         result.raise_for_errors()

--- a/tests/apidocs/util.py
+++ b/tests/apidocs/util.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import
 import os
 
 from django.conf import settings
-from django.test.client import RequestFactory
 from openapi_core import create_spec
+from openapi_core.contrib.django import DjangoOpenAPIRequest, DjangoOpenAPIResponse
+from openapi_core.validation.response.validators import ResponseValidator
 
 from sentry.utils import json
 from sentry.testutils import APITestCase
@@ -20,6 +21,11 @@ class APIDocsTestCase(APITestCase):
 
             return create_spec(data)
 
-    def validate_schema(self, response):
-        # TODO(meredith): Use validators to validate
-        pass
+    def validate_schema(self, request, response):
+        result = ResponseValidator(self.create_schema()).validate(
+            DjangoOpenAPIRequest(request),
+            DjangoOpenAPIResponse(response)
+        )
+
+        result.raise_for_errors()
+        assert result.errors == []

--- a/tests/apidocs/util.py
+++ b/tests/apidocs/util.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+
+import os
+
+from django.conf import settings
+from django.test.client import RequestFactory
+from openapi_core import create_spec
+
+from sentry.utils import json
+from sentry.testutils import APITestCase
+
+
+class APIDocsTestCase(APITestCase):
+    def create_schema(self):
+        path = os.path.join(os.path.dirname(__file__), "openapi-derefed.json")
+        with open(path, "r") as json_file:
+            data = json.load(json_file)
+            data["servers"][0]["url"] = settings.SENTRY_OPTIONS["system.url-prefix"]
+            del data["components"]
+
+            return create_spec(data)
+
+    def validate_schema(self, response):
+        # TODO(meredith): Use validators to validate
+        pass


### PR DESCRIPTION
Implement `validate_schema` so that endpoint test just have to pass in a URL.
Use Sentry-controlled fork: https://github.com/getsentry/openapi-core/.