### PR TITLE
ref(attachments) Remove unreferenced FileBlobs incrementally

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -57,7 +57,6 @@ class EventDataDeletionTask(BaseDeletionTask):
 
         # Remove EventAttachment and UserReport
         event_ids = [event.event_id for event in events]
-
         EventAttachment.objects.filter(event_id__in=event_ids, project_id=self.project_id).delete()
         UserReport.objects.filter(event_id__in=event_ids, project_id=self.project_id).delete()
 

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -57,6 +57,7 @@ class EventDataDeletionTask(BaseDeletionTask):
 
         # Remove EventAttachment and UserReport
         event_ids = [event.event_id for event in events]
+
         EventAttachment.objects.filter(event_id__in=event_ids, project_id=self.project_id).delete()
         UserReport.objects.filter(event_id__in=event_ids, project_id=self.project_id).delete()
 

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -21,7 +21,7 @@ from django.utils import timezone
 
 from sentry.app import locks
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, JSONField, Model
-from sentry.tasks.files import delete_file as delete_file_task
+from sentry.tasks.files import delete_file as delete_file_task, delete_unreferenced_blobs
 from sentry.utils import metrics
 from sentry.utils.retries import TimedRetryPolicy
 
@@ -430,6 +430,12 @@ class File(Model):
         tf.flush()
         tf.seek(0)
         return tf
+
+    def delete(self, *args, **kwargs):
+        blob_ids = [blob.id for blob in self.blobs.all()]
+        super(File, self).delete(*args, **kwargs)
+
+        delete_unreferenced_blobs.delay(blob_ids)
 
 
 class FileBlobIndex(Model):

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -435,7 +435,7 @@ class File(Model):
         blob_ids = [blob.id for blob in self.blobs.all()]
         super(File, self).delete(*args, **kwargs)
 
-        delete_unreferenced_blobs.delay(blob_ids)
+        transaction.on_commit(delete_unreferenced_blobs.s(blob_ids).delay)
 
 
 class FileBlobIndex(Model):

--- a/src/sentry/tasks/files.py
+++ b/src/sentry/tasks/files.py
@@ -33,5 +33,8 @@ def delete_unreferenced_blobs(blob_ids):
     for blob_id in blob_ids:
         if FileBlobIndex.objects.filter(blob_id=blob_id).exists():
             continue
-        # Need to delete the record to ensure django hooks run.
-        FileBlob.objects.get(id=blob_id).delete()
+        try:
+            # Need to delete the record to ensure django hooks run.
+            FileBlob.objects.get(id=blob_id).delete()
+        except FileBlob.DoesNotExist:
+            pass

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -45,7 +45,7 @@ class FileTest(TestCase):
         baz_file.putfile(fileobj, 3)
 
         baz_id = baz_file.id
-        with self.tasks():
+        with self.tasks(), self.capture_on_commit_callbacks(execute=True):
             baz_file.delete()
 
         # remove all the blobs and blob indexes.
@@ -63,7 +63,7 @@ class FileTest(TestCase):
         raz_file = File.objects.create(name="baz-v2.js", type="default", size=7)
         raz_file.putfile(fileobj, 3)
 
-        with self.tasks():
+        with self.tasks(), self.capture_on_commit_callbacks(execute=True):
             baz_file.delete()
 
         # baz_file blob indexes should be gone

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -4,7 +4,7 @@ import os
 
 from django.core.files.base import ContentFile
 
-from sentry.models import File, FileBlob
+from sentry.models import File, FileBlob, FileBlobIndex
 from sentry.testutils import TestCase
 from sentry.utils.compat import map
 
@@ -39,6 +39,39 @@ class FileBlobTest(TestCase):
 
 
 class FileTest(TestCase):
+    def test_delete_also_removes_blobs(self):
+        fileobj = ContentFile("foo bar".encode("utf-8"))
+        baz_file = File.objects.create(name="baz.js", type="default", size=7)
+        baz_file.putfile(fileobj, 3)
+
+        baz_id = baz_file.id
+        with self.tasks():
+            baz_file.delete()
+
+        # remove all the blobs and blob indexes.
+        assert FileBlobIndex.objects.filter(file_id=baz_id).count() == 0
+        assert FileBlob.objects.count() == 0
+
+    def test_delete_does_not_remove_shared_blobs(self):
+        fileobj = ContentFile("foo bar".encode("utf-8"))
+        baz_file = File.objects.create(name="baz-v1.js", type="default", size=7)
+        baz_file.putfile(fileobj, 3)
+        baz_id = baz_file.id
+
+        # Rewind the file so we can use it again.
+        fileobj.seek(0)
+        raz_file = File.objects.create(name="baz-v2.js", type="default", size=7)
+        raz_file.putfile(fileobj, 3)
+
+        with self.tasks():
+            baz_file.delete()
+
+        # baz_file blob indexes should be gone
+        assert FileBlobIndex.objects.filter(file_id=baz_id).count() == 0
+
+        # Check that raz_file blob indexes are there.
+        assert len(raz_file.blobs.all()) == 3
+
     def test_file_handling(self):
         fileobj = ContentFile("foo bar".encode("utf-8"))
         file1 = File.objects.create(name="baz.js", type="default", size=7)


### PR DESCRIPTION
When we delete EventAttachments we also cascade and delete the referenced File records. This delete also cascades to the FileBlobIndex records via foreign keys in postgres. However, we leave behind the FileBlob records, and their referenced items in cloud storage. With this change we cascade deletes one level deeper and remove any blobs that are no longer referenced by a FileBlobIndex.

This should result in a less work for our periodic cleanup tasks to do as there are fewer 'dangling blobs' that need to be expunged.

Paired with @MeredithAnya