### PR TITLE
fix(ui) Fix alignment of ? icons in headings

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/styles.tsx
+++ b/src/sentry/static/sentry/app/components/charts/styles.tsx
@@ -23,6 +23,7 @@ export const SectionHeading = styled('h4')`
   display: inline-grid;
   grid-auto-flow: column;
   grid-gap: ${space(1)};
+  align-items: center;
   color: ${p => p.theme.gray600};
   font-size: ${p => p.theme.fontSizeMedium};
   margin: ${space(1)} 0;


### PR DESCRIPTION
Center align the ? in headings so that they look better during loading and complete states.

### Before

![Screen Shot 2020-09-18 at 3 22 54 PM](https://user-images.githubusercontent.com/24086/93637391-8ac00380-f9c3-11ea-880a-37b3d632305b.png)

### After

![Screen Shot 2020-09-18 at 3 23 25 PM](https://user-images.githubusercontent.com/24086/93637403-901d4e00-f9c3-11ea-843f-20e57dbe32a2.png)
