### PR TITLE
fix(jira): adds content security policy

### DIFF
--- a/src/sentry/integrations/jira/ui_hook.py
+++ b/src/sentry/integrations/jira/ui_hook.py
@@ -19,9 +19,6 @@ class JiraUiHookView(View):
     def get_response(self, context):
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         res = render_to_response("sentry/integrations/jira-config.html", context, self.request)
-        # X-Frame-Options is a deprecated for content-security-policy
-        # but omitting this field breaks things because we will set it to deny if we omit it
-        res["X-Frame-Options"] = "ALLOW-FROM %s" % self.request.GET["xdm_e"]
         res["Content-Security-Policy"] = u"frame-ancestors %s" % self.request.GET["xdm_e"]
         return res
 

--- a/src/sentry/integrations/jira/ui_hook.py
+++ b/src/sentry/integrations/jira/ui_hook.py
@@ -19,7 +19,7 @@ class JiraUiHookView(View):
     def get_response(self, context):
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         res = render_to_response("sentry/integrations/jira-config.html", context, self.request)
-        # X-Frame-Options is a deprecated for content-securyity policy
+        # X-Frame-Options is a deprecated for content-security-policy
         # but omitting this field breaks things because we will set it to deny if we omit it
         res["X-Frame-Options"] = "ALLOW-FROM %s" % self.request.GET["xdm_e"]
         res["Content-Security-Policy"] = u"frame-ancestors %s" % self.request.GET["xdm_e"]

--- a/src/sentry/integrations/jira/ui_hook.py
+++ b/src/sentry/integrations/jira/ui_hook.py
@@ -19,7 +19,10 @@ class JiraUiHookView(View):
     def get_response(self, context):
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         res = render_to_response("sentry/integrations/jira-config.html", context, self.request)
+        # X-Frame-Options is a deprecated for content-securyity policy
+        # but omitting this field breaks things because we will set it to deny if we omit it
         res["X-Frame-Options"] = "ALLOW-FROM %s" % self.request.GET["xdm_e"]
+        res["Content-Security-Policy"] = u"frame-ancestors %s" % self.request.GET["xdm_e"]
         return res
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
The header `X-Frame-Options` with the `ALLOW_FROM` block [has been deprecated in supporting browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) in favor of the `Content-Security-Policy` header with the `frame-ancestors` block. A recent getsentry PR (https://github.com/getsentry/getsentry/pull/4460) allows us to specify a block in the `Content-Security-Policy` header without it getting wiped out by getsentry.