### PR TITLE
fix(ui): Highlight children is proper string

### DIFF
--- a/src/sentry/static/sentry/app/components/highlight.tsx
+++ b/src/sentry/static/sentry/app/components/highlight.tsx
@@ -20,7 +20,8 @@ type Props = Omit<React.HTMLAttributes<HTMLDivElement>, keyof HighlightProps> &
   HighlightProps;
 
 const HighlightComponent = ({className, children, disabled, text}: Props) => {
-  if (!text || disabled) {
+  // There are instances when children is not string in breadcrumbs but not caught by TS
+  if (!text || disabled || typeof children !== 'string') {
     return <React.Fragment>{children}</React.Fragment>;
   }
 


### PR DESCRIPTION
This fixes an error where sometimes highlighted elements created from breadcrumbs are passed React Nodes/objects as children instead of strings. This isn't caught in proptypes for some reason but this shouldn't cause any issues.

[Issue](https://sentry.io/organizations/sentry/issues/1770106500)

[Jira](https://getsentry.atlassian.net/browse/WOR-252)