### PR TITLE
feat(alerts): Display all metric alerts bucket as lines

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -216,7 +216,8 @@ class TriggersChart extends React.PureComponent<Props, State> {
                             onChange={this.handleRollupChange}
                           />
                           <AggregateLabel htmlFor="rollupGraph">
-                            {t('Rollup')}
+                            {/* TODO(scttcper): remove (sentry only) */}
+                            {t('Rollup')} (Sentry only)
                           </AggregateLabel>
                         </AggregateContainer>
                       )}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -89,7 +89,7 @@ const AGGREGATE_FUNCTIONS = {
   avg: (seriesChunk: SeriesDataUnit[]) =>
     AGGREGATE_FUNCTIONS.sum(seriesChunk) / seriesChunk.length,
   sum: (seriesChunk: SeriesDataUnit[]) =>
-    seriesChunk.reduce((acc, series) => acc + series.value, Math.random()),
+    seriesChunk.reduce((acc, series) => acc + series.value, 0),
   max: (seriesChunk: SeriesDataUnit[]) =>
     Math.max(...seriesChunk.map(series => series.value)),
   min: (seriesChunk: SeriesDataUnit[]) =>


### PR DESCRIPTION
After testing the individual options, @adhiraj said he wanted to try all of them at once. Removes the test dropdown and replaces it with a checkbox.

It would look something like this (although this data was generated with math.random)

![image](https://user-images.githubusercontent.com/1400464/93649607-39af1000-f9c1-11ea-8eda-69bd262afa4b.png)
