### PR TITLE
fix(ui) Reduce errors from loader animation

### DIFF
--- a/src/sentry/static/sentry/app/components/loadingIndicator.tsx
+++ b/src/sentry/static/sentry/app/components/loadingIndicator.tsx
@@ -20,72 +20,93 @@ type Props = {
   children?: React.ReactNode;
 };
 
-function LoadingIndicator(props: Props) {
-  const {
-    hideMessage,
-    mini,
-    triangle,
-    overlay,
-    dark,
-    children,
-    finished,
-    className,
-    style,
-    relative,
-    size,
-    hideSpinner,
-  } = props;
-  const cx = classNames(className, {
-    overlay,
-    dark,
-    loading: true,
-    mini,
-    triangle,
-  });
+class LoadingIndicator extends React.Component<Props> {
+  static propTypes = {
+    overlay: PropTypes.bool,
+    dark: PropTypes.bool,
+    mini: PropTypes.bool,
+    triangle: PropTypes.bool,
+    finished: PropTypes.bool,
+    relative: PropTypes.bool,
+    hideMessage: PropTypes.bool,
+    size: PropTypes.number,
+    hideSpinner: PropTypes.bool,
+  };
 
-  const loadingCx = classNames({
-    relative,
-    'loading-indicator': true,
-    'load-complete': finished,
-  });
-
-  let loadingStyle = {};
-  if (size) {
-    loadingStyle = {
-      width: size,
-      height: size,
-    };
+  componentDidMount() {
+    if (this.videoRef.current) {
+      // Set muted as more browsers allow autoplay with muted video.
+      // We can't use the muted prop because of a react bug.
+      // https://github.com/facebook/react/issues/10389
+      // So we need to set the muted property then trigger play.
+      this.videoRef.current.muted = true;
+      this.videoRef.current.play();
+    }
   }
 
-  return (
-    <div className={cx} style={style}>
-      {!hideSpinner && (
-        <div className={loadingCx} style={loadingStyle}>
-          {triangle && (
-            <video autoPlay disablePictureInPicture loop height="150">
-              <source src={spinnerVideo} type="video/mp4" />
-            </video>
-          )}
-          {finished ? <div className="checkmark draw" style={style} /> : null}
-        </div>
-      )}
+  private videoRef = React.createRef<HTMLVideoElement>();
 
-      {!hideMessage && <div className="loading-message">{children}</div>}
-    </div>
-  );
+  render() {
+    const {
+      hideMessage,
+      mini,
+      triangle,
+      overlay,
+      dark,
+      children,
+      finished,
+      className,
+      style,
+      relative,
+      size,
+      hideSpinner,
+    } = this.props;
+    const cx = classNames(className, {
+      overlay,
+      dark,
+      loading: true,
+      mini,
+      triangle,
+    });
+
+    const loadingCx = classNames({
+      relative,
+      'loading-indicator': true,
+      'load-complete': finished,
+    });
+
+    let loadingStyle = {};
+    if (size) {
+      loadingStyle = {
+        width: size,
+        height: size,
+      };
+    }
+
+    return (
+      <div className={cx} style={style}>
+        {!hideSpinner && (
+          <div className={loadingCx} style={loadingStyle}>
+            {triangle && (
+              <video
+                ref={this.videoRef}
+                playsInline
+                disablePictureInPicture
+                loop
+                height="150"
+              >
+                <source src={spinnerVideo} type="video/mp4" />
+              </video>
+            )}
+            {finished ? <div className="checkmark draw" style={style} /> : null}
+          </div>
+        )}
+
+        {!hideMessage && <div className="loading-message">{children}</div>}
+      </div>
+    );
+  }
 }
-
-LoadingIndicator.propTypes = {
-  overlay: PropTypes.bool,
-  dark: PropTypes.bool,
-  mini: PropTypes.bool,
-  triangle: PropTypes.bool,
-  finished: PropTypes.bool,
-  relative: PropTypes.bool,
-  hideMessage: PropTypes.bool,
-  size: PropTypes.number,
-  hideSpinner: PropTypes.bool,
-};
 
 export default withProfiler(LoadingIndicator, {
   includeUpdates: false,

--- a/src/sentry/static/sentry/app/index.html
+++ b/src/sentry/static/sentry/app/index.html
@@ -18,7 +18,7 @@
         <div class="loading-mask"></div>
 
         <div class="loading-indicator">
-          <video autoplay disablePictureInPicture loop height="150">
+          <video autoplay muted disablePictureInPicture playsinline loop height="150">
             <source src="_assets/images/sentry-loader.mp4" type="video/mp4" />
           </video>
         </div>

--- a/src/sentry/templates/sentry/bases/react.html
+++ b/src/sentry/templates/sentry/bases/react.html
@@ -9,7 +9,7 @@
       <div class="loading-mask"></div>
 
       <div class="loading-indicator">
-        <video muted autoplay disablePictureInPicture loop playsinline height="150" id="animated-loader">
+        <video muted autoplay disablePictureInPicture loop playsinline height="150">
           <source src="{% asset_url "sentry" "images/sentry-loader.mp4" %}" type="video/mp4" />
         </video>
       </div>

--- a/src/sentry/templates/sentry/bases/react.html
+++ b/src/sentry/templates/sentry/bases/react.html
@@ -9,7 +9,7 @@
       <div class="loading-mask"></div>
 
       <div class="loading-indicator">
-        <video autoplay disablePictureInPicture loop height="150">
+        <video muted autoplay disablePictureInPicture loop playsinline height="150" id="animated-loader">
           <source src="{% asset_url "sentry" "images/sentry-loader.mp4" %}" type="video/mp4" />
         </video>
       </div>

--- a/tests/js/throw-on-react-error.js
+++ b/tests/js/throw-on-react-error.js
@@ -15,6 +15,8 @@ const IGNORED_ERRORS = [
     message.includes(
       'The pseudo class ":first-child" is potentially unsafe when doing server-side rendering.'
     ),
+  message =>
+    typeof message === 'string' && message.includes('HTMLMediaElement.prototype.play'),
 ];
 
 // This is needed because when we throw the captured error message, it will


### PR DESCRIPTION
Ensure the loading animation is 'muted' and 'playsinline' (for webkit). These additional attributes should help reduce the number of console errors we are getting from the loading animation.