### PR TITLE
fix(releases): Use sql formatting instead of string formatting for list of ids

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -446,7 +446,7 @@ def bulk_fetch_project_latest_releases(projects):
                 release_project_join_sql
             ),
             # guess what, formatting tuples works in psycopg2
-            tuple(six.text_type(i.id) for i in projects),
+            (tuple(six.text_type(i.id) for i in projects),),
         )
     )
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -445,7 +445,7 @@ def bulk_fetch_project_latest_releases(projects):
             """.format(
                 release_project_join_sql
             ),
-            # guess what, formatting tuples works in psycopg2
+            # formatting tuples works specifically in psycopg2
             (tuple(six.text_type(i.id) for i in projects),),
         )
     )

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -438,13 +438,15 @@ def bulk_fetch_project_latest_releases(projects):
             ) as release_id,
             p.id as project_id
             FROM sentry_project p
-            WHERE p.id IN ({})
+            WHERE p.id IN %s
         ) as lr
         JOIN sentry_release r
         ON r.id = lr.release_id
-        """.format(
-                release_project_join_sql, ", ".join(six.text_type(i.id) for i in projects)
-            )
+            """.format(
+                release_project_join_sql
+            ),
+            # guess what, formatting tuples works in psycopg2
+            tuple(six.text_type(i.id) for i in projects),
         )
     )
 


### PR DESCRIPTION
This stuff "breaks" our Performance (tm) monitoring as span descriptions get really long.