### PR TITLE
feat(releases): Pass environment to release serializer on index page

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -281,6 +281,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
                 health_stat=health_stat,
                 health_stats_period=health_stats_period,
                 summary_stats_period=summary_stats_period,
+                environment=filter_params.get("environment"),
             ),
             **paginator_kwargs
         )

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -281,7 +281,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
                 health_stat=health_stat,
                 health_stats_period=health_stats_period,
                 summary_stats_period=summary_stats_period,
-                environment=filter_params.get("environment"),
+                environments=filter_params.get("environment") or None,
             ),
             **paginator_kwargs
         )


### PR DESCRIPTION
This should resolve issues where the environment was not reflected by
statistics on the overview page.