### PR TITLE
fix(auditlogs): trim actor label for audit log

### DIFF
--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -14,6 +14,9 @@ from sentry.db.models import (
 from sentry.utils.strings import truncatechars
 
 
+ACTOR_LABEL_LENGTH = 64
+
+
 class AuditLogEntryEvent(object):
     MEMBER_INVITE = 1
     MEMBER_ADD = 2
@@ -103,7 +106,7 @@ class AuditLogEntry(Model):
     __core__ = False
 
     organization = FlexibleForeignKey("sentry.Organization")
-    actor_label = models.CharField(max_length=64, null=True, blank=True)
+    actor_label = models.CharField(max_length=ACTOR_LABEL_LENGTH, null=True, blank=True)
     # if the entry was created via a user
     actor = FlexibleForeignKey("sentry.User", related_name="audit_actors", null=True, blank=True)
     # if the entry was created via an api key
@@ -200,6 +203,8 @@ class AuditLogEntry(Model):
                 self.actor_label = self.actor.username
             else:
                 self.actor_label = self.actor_key.key
+        # trim label to the max length
+        self.actor_label = self.actor_label[:ACTOR_LABEL_LENGTH]
         super(AuditLogEntry, self).save(*args, **kwargs)
 
     def get_actor_name(self):

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -14,7 +14,7 @@ from sentry.db.models import (
 from sentry.utils.strings import truncatechars
 
 
-ACTOR_LABEL_LENGTH = 64
+MAX_ACTOR_LABEL_LENGTH = 64
 
 
 class AuditLogEntryEvent(object):
@@ -106,7 +106,7 @@ class AuditLogEntry(Model):
     __core__ = False
 
     organization = FlexibleForeignKey("sentry.Organization")
-    actor_label = models.CharField(max_length=ACTOR_LABEL_LENGTH, null=True, blank=True)
+    actor_label = models.CharField(max_length=MAX_ACTOR_LABEL_LENGTH, null=True, blank=True)
     # if the entry was created via a user
     actor = FlexibleForeignKey("sentry.User", related_name="audit_actors", null=True, blank=True)
     # if the entry was created via an api key
@@ -204,7 +204,7 @@ class AuditLogEntry(Model):
             else:
                 self.actor_label = self.actor_key.key
         # trim label to the max length
-        self.actor_label = self.actor_label[:ACTOR_LABEL_LENGTH]
+        self.actor_label = self.actor_label[:MAX_ACTOR_LABEL_LENGTH]
         super(AuditLogEntry, self).save(*args, **kwargs)
 
     def get_actor_name(self):

--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -14,6 +14,8 @@ from sentry.models import (
 from sentry.testutils import TestCase
 from sentry.utils.audit import create_audit_entry
 
+username = "hello" * 20
+
 
 class FakeHttpRequest(object):
     def __init__(self, user):
@@ -23,7 +25,7 @@ class FakeHttpRequest(object):
 
 class CreateAuditEntryTest(TestCase):
     def setUp(self):
-        self.user = self.create_user()
+        self.user = self.create_user(username=username)
         self.req = FakeHttpRequest(self.user)
         self.org = self.create_organization(owner=self.user)
         self.team = self.create_team(organization=self.org)
@@ -68,6 +70,7 @@ class CreateAuditEntryTest(TestCase):
         )
 
         assert entry.actor == self.user
+        assert entry.actor_label == username[:64]  # needs trimming
         assert entry.target_object == self.org.id
         assert entry.event == AuditLogEntryEvent.ORG_REMOVE
 


### PR DESCRIPTION
This PR trims `actor_label` of audit log entries to the max DB length (64) characters. Since this field is only used in a UI, there shouldn't be issues in trimming the length as it should still be obvious to a user what the actor was based on the first 64 characters. This generally only applies to internal integrations that have a UUID at the end of the username. This is preferable to making a migration to change the field to a text field because the table is so large.

Fixes SENTRY-GN8