### PR TITLE
feat(email): Add categories to certain email types

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -87,6 +87,7 @@ class EmailActionHandler(ActionHandler):
             html_template=u"sentry/emails/incidents/trigger.html",
             type="incident.alert_rule_{}".format(display.lower()),
             context=context,
+            headers={"category": "metric_alert_email"},
         )
 
 

--- a/src/sentry/mail/activity/assigned.py
+++ b/src/sentry/mail/activity/assigned.py
@@ -52,3 +52,6 @@ class AssignedActivityEmail(ActivityEmail):
                 )
 
         raise NotImplementedError("Unknown Assignee Type ")
+
+    def get_category(self):
+        return "assigned_activity_email"

--- a/src/sentry/mail/activity/base.py
+++ b/src/sentry/mail/activity/base.py
@@ -126,6 +126,9 @@ class ActivityEmail(object):
         # use in case context of email changes depending on user
         return {}
 
+    def get_category(self):
+        raise NotImplementedError
+
     def get_headers(self):
         project = self.project
         group = self.group
@@ -138,6 +141,7 @@ class ActivityEmail(object):
                     "X-Sentry-Logger": group.logger,
                     "X-Sentry-Logger-Level": group.get_level_display(),
                     "X-Sentry-Reply-To": group_id_to_email(group.id),
+                    "category": self.get_category(),
                 }
             )
 

--- a/src/sentry/mail/activity/new_processing_issues.py
+++ b/src/sentry/mail/activity/new_processing_issues.py
@@ -53,3 +53,6 @@ class NewProcessingIssuesActivityEmail(ActivityEmail):
 
     def get_html_template(self):
         return "sentry/emails/activity/new_processing_issues.html"
+
+    def get_category(self):
+        return "new_processing_issues_activity_email"

--- a/src/sentry/mail/activity/note.py
+++ b/src/sentry/mail/activity/note.py
@@ -12,3 +12,6 @@ class NoteActivityEmail(ActivityEmail):
 
     def get_html_template(self):
         return "sentry/emails/activity/note.html"
+
+    def get_category(self):
+        return "note_activity_email"

--- a/src/sentry/mail/activity/regression.py
+++ b/src/sentry/mail/activity/regression.py
@@ -29,3 +29,6 @@ class RegressionActivityEmail(ActivityEmail):
             )
 
         return u"{author} marked {an issue} as a regression"
+
+    def get_category(self):
+        return "regression_activity_email"

--- a/src/sentry/mail/activity/release.py
+++ b/src/sentry/mail/activity/release.py
@@ -238,3 +238,6 @@ class ReleaseActivityEmail(ActivityEmail):
 
     def get_html_template(self):
         return "sentry/emails/activity/release.html"
+
+    def get_category(self):
+        return "release_activity_email"

--- a/src/sentry/mail/activity/resolved.py
+++ b/src/sentry/mail/activity/resolved.py
@@ -9,3 +9,6 @@ class ResolvedActivityEmail(ActivityEmail):
 
     def get_description(self):
         return u"{author} marked {an issue} as resolved"
+
+    def get_category(self):
+        return "resolved_activity_email"

--- a/src/sentry/mail/activity/resolved_in_release.py
+++ b/src/sentry/mail/activity/resolved_in_release.py
@@ -28,3 +28,6 @@ class ResolvedInReleaseActivityEmail(ActivityEmail):
                 },
             )
         return u"{author} marked {an issue} as resolved in an upcoming release"
+
+    def get_category(self):
+        return "resolved_in_release_activity_email"

--- a/src/sentry/mail/activity/unassigned.py
+++ b/src/sentry/mail/activity/unassigned.py
@@ -9,3 +9,6 @@ class UnassignedActivityEmail(ActivityEmail):
 
     def get_description(self):
         return u"{author} unassigned {an issue}"
+
+    def get_category(self):
+        return "unassigned_activity_email"

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -363,6 +363,7 @@ class MailAdapter(object):
             "X-Sentry-Logger-Level": group.get_level_display(),
             "X-Sentry-Project": project.slug,
             "X-Sentry-Reply-To": group_id_to_email(group.id),
+            "category": "issue_alert_email",
         }
 
         for user_id in self.get_send_to(
@@ -441,7 +442,10 @@ class MailAdapter(object):
                 "counts": counts,
             }
 
-            headers = {"X-Sentry-Project": project.slug}
+            headers = {
+                "X-Sentry-Project": project.slug,
+                "category": "digest_email",
+            }
 
             group = six.next(iter(counts))
             subject = self.get_digest_subject(group, counts, start)
@@ -514,7 +518,10 @@ class MailAdapter(object):
             )
         )
 
-        headers = {"X-Sentry-Project": project.slug}
+        headers = {
+            "X-Sentry-Project": project.slug,
+            "category": "user_report_email",
+        }
 
         # TODO(dcramer): this is copypasta'd from activity notifications
         # and while it'd be nice to re-use all of that, they are currently

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -545,6 +545,7 @@ def build_message(timestamp, duration, organization, user, reports):
             "report": to_context(organization, interval, reports),
             "user": user,
         },
+        headers={"category": "organization_report_email"},
     )
 
     message.add_users((user.id,))


### PR DESCRIPTION
Currently we don't track open/click rates for individual email types, only all emails in aggregate. We can start tackling this problem by using categories in our email header.

Added categories for:
- issue alert emails
- metric alert emails
- digest emails
- user report emails
- workflow activity emails `activity/*.py`
- organization report emails