### PR TITLE
fix(dashboards) Restrict geo and release events to errors.

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboards/data/queries/errorsByGeo.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/data/queries/errorsByGeo.jsx
@@ -8,7 +8,10 @@ import {t} from 'app/locale';
 const errorsByGeo = {
   name: t('Errors By Country'),
   fields: ['geo.country_code'],
-  conditions: [['geo.country_code', OPERATOR.IS_NOT_NULL, null]],
+  conditions: [
+    ['event.type', OPERATOR.NOT_EQUAL, 'transaction'],
+    ['geo.country_code', OPERATOR.IS_NOT_NULL, null],
+  ],
   aggregations: [['count()', null, 'count']],
   limit: 10,
 

--- a/src/sentry/static/sentry/app/views/dashboards/data/queries/eventsByRelease.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/data/queries/eventsByRelease.jsx
@@ -2,12 +2,13 @@
  * Events by Release
  */
 import {t} from 'app/locale';
+import {OPERATOR} from 'app/views/discover/data';
 
 const eventsByRelease = {
   name: t('Events by Release'),
   fields: ['release'],
   constraints: ['recentReleases'],
-  conditions: [],
+  conditions: [['event.type', OPERATOR.NOT_EQUAL, 'transaction']],
   aggregations: [['count()', null, 'Events']],
   limit: 5000,
 


### PR DESCRIPTION
Transactions are not expected to show up in these charts. Add conditions to make sure that doesn't happen.

Fixes VIS-150