### PR TITLE
Github Action to generate openapi-derefed.json

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -46,8 +46,9 @@ jobs:
     - name: Git Commit & Push
       run: |
         cd sentry-api-schema
+        git remote -v
         git config user.name openapi-getsentry-bot
         git config user.email bot@getsentry.com
         git add .
         git commit -m "generated"
-        git push
+        git push origin main

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -40,7 +40,6 @@ jobs:
 
     - name: Copy artifact into getsentry/sentry-api-schema
       run: |
-        ls
         cp sentry/api-docs/openapi-derefed.json sentry-api-schema
 
     - name: Git Commit & Push

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,7 +1,7 @@
 name: openapi
 
 on:
-  push:
+  pull_request:
     branches:
       - master
 

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -20,6 +20,7 @@ jobs:
         ref: 'main'
         repository: getsentry/sentry-api-schema
         path: sentry-api-schema
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     # Install/setup node
     - uses: volta-cli/action@v1
@@ -38,8 +39,8 @@ jobs:
     - name: Git Commit & Push
       run: |
         cd sentry-api-schema
-        git config user.name github-actions
-        git config user.email github-actions@github.com
+        git config user.name openapi-getsentry-bot
+        git config user.email bot@getsentry.com
         git add .
         git commit -m "generated"
         git push

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -14,12 +14,12 @@ jobs:
       with:
         path: sentry
 
-    - name: Checkout getsentry/sentry-openapi-derefed
+    - name: Checkout getsentry/sentry-api-schema
       uses: actions/checkout@v2
       with:
         ref: 'main'
-        repository: getsentry/sentry-openapi-derefed
-        path: sentry-openapi-derefed
+        repository: getsentry/sentry-api-schema
+        path: sentry-api-schema
 
     # Install/setup node
     - uses: volta-cli/action@v1
@@ -29,13 +29,13 @@ jobs:
         cd sentry
         yarn run build-derefed-docs
 
-    - name: Copy artifact into getsentry/sentry-openapi-derefed
+    - name: Copy artifact into getsentry/sentry-api-schema
       run: |
-        cp /sentry/api-docs/openapi-derefed.json /sentry-openapi-derefed
+        cp /sentry/api-docs/api-schema.json /sentry-api-schema
 
     - name: Git Commit & Push
       run: |
-        cd sentry-openapi-derefed
+        cd sentry-api-schema
         git config user.name github-actions
         git config user.email github-actions@github.com
         git add .

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,7 +1,7 @@
 name: openapi
 
 on:
-  pull_request:
+  push:
     branches:
       - master
 

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         cd sentry
         yarn install --frozen-lockfile
-        yarn run build-derefed-docs
+        yarn run build-derefed-docs sentry/api-docs/openapi-derefed.json
 
     - name: Copy artifact into getsentry/sentry-api-schema
       run: |

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -9,6 +9,13 @@ jobs:
   deref_json:
     runs-on: ubuntu-latest
     steps:
+    - name: Getsentry Token
+      id: getsentry
+      uses: getsentry/action-github-app-token@v1
+      with:
+        app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
+        private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
     - name: Checkout getsentry/sentry
       uses: actions/checkout@v2
       with:
@@ -20,7 +27,7 @@ jobs:
         ref: 'main'
         repository: getsentry/sentry-api-schema
         path: sentry-api-schema
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ steps.getsentry.outputs.token }}
 
     # Install/setup node
     - uses: volta-cli/action@v1

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -46,7 +46,6 @@ jobs:
     - name: Git Commit & Push
       run: |
         cd sentry-api-schema
-        git remote -v
         if [ -n "$(git status --porcelain)" ]; then
           git config user.name openapi-getsentry-bot
           git config user.email bot@getsentry.com

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Build OpenAPI Derefed JSON
       run: |
         cd sentry
+        yarn install --frozen-lockfile
         yarn run build-derefed-docs
 
     - name: Copy artifact into getsentry/sentry-api-schema

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -32,7 +32,8 @@ jobs:
 
     - name: Copy artifact into getsentry/sentry-api-schema
       run: |
-        cp /sentry/api-docs/openapi-derefed.json /sentry-api-schema
+        ls
+        cp sentry/api-docs/openapi-derefed.json sentry-api-schema
 
     - name: Git Commit & Push
       run: |

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,41 @@
+name: openapi
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  deref_json:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout getsentry/sentry
+      uses: actions/checkout@v2
+      with:
+        path: sentry
+
+    - name: Checkout getsentry/sentry-openapi-derefed
+      uses: actions/checkout@v2
+      with:
+        ref: 'main'
+        repository: getsentry/sentry-openapi-derefed
+        path: sentry-openapi-derefed
+
+    - name: Build OpenAPI Derefed JSON
+      uses: volta-cli/action@v1
+      run: |
+        cd sentry
+        yarn run build-derefed-docs
+
+    - name: Copy artifact into getsentry/sentry-openapi-derefed
+      run: |
+      cp /sentry/api-docs/openapi-derefed.json /sentry-openapi-derefed
+
+    - name: Git Commit & Push
+      run: |
+      cd sentry-openapi-derefed
+      git config user.name github-actions
+      git config user.email github-actions@github.com
+      git add .
+      git commit -m "generated"
+      git push

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -43,14 +43,9 @@ jobs:
         cp sentry/api-docs/openapi-derefed.json sentry-api-schema
 
     - name: Git Commit & Push
-      run: |
-        cd sentry-api-schema
-        if [ -n "$(git status --porcelain)" ]; then
-          git config user.name openapi-getsentry-bot
-          git config user.email bot@getsentry.com
-          git add .
-          git commit -m "generated"
-          git push origin main
-        else
-          echo "no changes";
-        fi
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        branch: main
+        commit_message: Generated
+        commit_user_email: bot@getsentry.com
+        commit_user_name: openapi-getsentry-bot

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -21,8 +21,10 @@ jobs:
         repository: getsentry/sentry-openapi-derefed
         path: sentry-openapi-derefed
 
+    # Install/setup node
+    - uses: volta-cli/action@v1
+
     - name: Build OpenAPI Derefed JSON
-      uses: volta-cli/action@v1
       run: |
         cd sentry
         yarn run build-derefed-docs

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -29,13 +29,13 @@ jobs:
 
     - name: Copy artifact into getsentry/sentry-openapi-derefed
       run: |
-      cp /sentry/api-docs/openapi-derefed.json /sentry-openapi-derefed
+        cp /sentry/api-docs/openapi-derefed.json /sentry-openapi-derefed
 
     - name: Git Commit & Push
       run: |
-      cd sentry-openapi-derefed
-      git config user.name github-actions
-      git config user.email github-actions@github.com
-      git add .
-      git commit -m "generated"
-      git push
+        cd sentry-openapi-derefed
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -m "generated"
+        git push

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -47,8 +47,12 @@ jobs:
       run: |
         cd sentry-api-schema
         git remote -v
-        git config user.name openapi-getsentry-bot
-        git config user.email bot@getsentry.com
-        git add .
-        git commit -m "generated"
-        git push origin main
+        if [ -n "$(git status --porcelain)" ]; then
+          git config user.name openapi-getsentry-bot
+          git config user.email bot@getsentry.com
+          git add .
+          git commit -m "generated"
+          git push origin main
+        else
+          echo "no changes";
+        fi

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Copy artifact into getsentry/sentry-api-schema
       run: |
-        cp /sentry/api-docs/api-schema.json /sentry-api-schema
+        cp /sentry/api-docs/openapi-derefed.json /sentry-api-schema
 
     - name: Git Commit & Push
       run: |


### PR DESCRIPTION
## Objective
Github Action to generate openapi-derefed.json as a build artifact and store it in `getsentry/sentry-api-schema`.
This action will be triggered `on push to master`.

## Test Plan
Tested it with the `on pull request to master`:
<img width="1440" alt="Screen Shot 2020-09-23 at 2 17 08 PM" src="https://user-images.githubusercontent.com/10491193/94070814-b5390480-fda7-11ea-8182-75a46ab004a3.png">

Example Run: https://github.com/getsentry/sentry/pull/20895/checks?check_run_id=1157370846