### PR TITLE
fix(ui): Fix release series throwing React error

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -57,6 +57,7 @@ class ReleaseSeries extends React.Component {
   };
 
   componentDidMount() {
+    this._isMounted = true;
     const {releases} = this.props;
 
     if (releases) {
@@ -80,6 +81,11 @@ class ReleaseSeries extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this._isMounted = false;
+    this.props.api.clear();
+  }
+
   fetchData() {
     const {api, organization, projects, environments, period, start, end} = this.props;
     const conditions = {
@@ -91,7 +97,9 @@ class ReleaseSeries extends React.Component {
     };
     getOrganizationReleases(api, organization, conditions)
       .then(releases => {
-        this.setReleasesWithSeries(releases);
+        if (this._isMounted) {
+          this.setReleasesWithSeries(releases);
+        }
       })
       .catch(() => {
         addErrorMessage(t('Error fetching releases'));


### PR DESCRIPTION
### Summary
ReleaseSeries was (at least in tests) throwing updating on unmounted component error (see screenshot). This should fix it by checking whether it's mounted before setting state.

### Screenshot
![Screen Shot 2020-09-21 at 4 16 13 PM](https://user-images.githubusercontent.com/6111995/93831494-c955f800-fc27-11ea-822f-e237128ca68d.png)
