### PR TITLE
ref(ui): Move Security & Privacy Fields to another file

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacyGroups.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacyGroups.tsx
@@ -7,7 +7,9 @@ import {
 } from 'app/utils/crashReports';
 import {JsonFormObject} from 'app/views/settings/components/forms/type';
 
-const organizationSecurityAndPrivacy: JsonFormObject[] = [
+// Export route to make these forms searchable by label/help
+export const route = '/settings/:orgId/security-and-privacy/';
+export default [
   {
     title: t('Security & Privacy'),
     fields: [
@@ -170,6 +172,4 @@ const organizationSecurityAndPrivacy: JsonFormObject[] = [
       },
     ],
   },
-];
-
-export default organizationSecurityAndPrivacy;
+] as JsonFormObject[];

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.tsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.tsx
@@ -10,15 +10,9 @@ import marked from 'app/utils/marked';
 import platforms from 'app/data/platforms';
 import slugify from 'app/utils/slugify';
 import ExternalLink from 'app/components/links/externalLink';
-import {
-  getStoreCrashReportsValues,
-  formatStoreCrashReports,
-  SettingScope,
-} from 'app/utils/crashReports';
 import space from 'app/styles/space';
 import {GroupingConfigItem} from 'app/components/events/groupingInfo';
 import {Field} from 'app/views/settings/components/forms/type';
-import Link from 'app/components/links/link';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/projects/:projectId/';
@@ -48,9 +42,6 @@ const RESOLVE_AGE_ALLOWED_VALUES = getResolveAgeAllowedValues();
 const ORG_DISABLED_REASON = t(
   "This option is enforced by your organization's settings and cannot be customized per-project."
 );
-
-// Check if a field has been set AND IS TRUTHY at the organization level.
-const hasOrgOverride = ({organization, name}) => organization[name];
 
 export const fields: Record<string, Field> = {
   slug: {
@@ -265,111 +256,6 @@ export const fields: Record<string, Field> = {
       </React.Fragment>
     ),
     visible: true,
-  },
-
-  dataScrubber: {
-    name: 'dataScrubber',
-    type: 'boolean',
-    label: t('Data Scrubber'),
-    disabled: hasOrgOverride,
-    disabledReason: ORG_DISABLED_REASON,
-    help: t('Enable server-side data scrubbing'),
-    // `props` are the props given to FormField
-    setValue: (val, props) =>
-      (props.organization && props.organization[props.name]) || val,
-    confirm: {
-      false: t('Are you sure you want to disable server-side data scrubbing?'),
-    },
-  },
-  dataScrubberDefaults: {
-    name: 'dataScrubberDefaults',
-    type: 'boolean',
-    disabled: hasOrgOverride,
-    disabledReason: ORG_DISABLED_REASON,
-    label: t('Use Default Scrubbers'),
-    help: t(
-      'Apply default scrubbers to prevent things like passwords and credit cards from being stored'
-    ),
-    // `props` are the props given to FormField
-    setValue: (val, props) =>
-      (props.organization && props.organization[props.name]) || val,
-    confirm: {
-      false: t('Are you sure you want to disable using default scrubbers?'),
-    },
-  },
-  scrubIPAddresses: {
-    name: 'scrubIPAddresses',
-    type: 'boolean',
-    disabled: hasOrgOverride,
-    disabledReason: ORG_DISABLED_REASON,
-    // `props` are the props given to FormField
-    setValue: (val, props) =>
-      (props.organization && props.organization[props.name]) || val,
-    label: t('Prevent Storing of IP Addresses'),
-    help: t('Preventing IP addresses from being stored for new events'),
-    confirm: {
-      false: t('Are you sure you want to disable scrubbing IP addresses?'),
-    },
-  },
-  sensitiveFields: {
-    name: 'sensitiveFields',
-    type: 'string',
-    multiline: true,
-    autosize: true,
-    maxRows: 10,
-    placeholder: t('email'),
-    label: t('Additional Sensitive Fields'),
-    help: t(
-      'Additional field names to match against when scrubbing data. Separate multiple entries with a newline'
-    ),
-    getValue: val => extractMultilineFields(val),
-    setValue: val => convertMultilineFieldValue(val),
-  },
-  safeFields: {
-    name: 'safeFields',
-    type: 'string',
-    multiline: true,
-    autosize: true,
-    maxRows: 10,
-    placeholder: t('business-email'),
-    label: t('Safe Fields'),
-    help: t(
-      'Field names which data scrubbers should ignore. Separate multiple entries with a newline'
-    ),
-    getValue: val => extractMultilineFields(val),
-    setValue: val => convertMultilineFieldValue(val),
-  },
-  storeCrashReports: {
-    name: 'storeCrashReports',
-    type: 'array',
-    label: t('Store Native Crash Reports'),
-    help: ({organization}) =>
-      tct(
-        'Store native crash reports such as Minidumps for improved processing and download in issue details. Overrides [organizationSettingsLink: organization settings].',
-        {
-          organizationSettingsLink: (
-            <Link to={`/settings/${organization.slug}/security-and-privacy/`} />
-          ),
-        }
-      ),
-    visible: ({features}) => features.has('event-attachments'),
-    placeholder: ({organization, value}) => {
-      // empty value means that this project should inherit organization settings
-      if (value === '') {
-        return tct('Inherit organization settings ([organizationValue])', {
-          organizationValue: formatStoreCrashReports(organization.storeCrashReports),
-        });
-      }
-
-      // HACK: some organization can have limit of stored crash reports a number that's not in the options (legacy reasons),
-      // we therefore display it in a placeholder
-      return formatStoreCrashReports(value);
-    },
-    choices: ({organization}) =>
-      getStoreCrashReportsValues(SettingScope.Project).map(value => [
-        value,
-        formatStoreCrashReports(value, organization.storeCrashReports),
-      ]),
   },
   allowedDomains: {
     name: 'allowedDomains',

--- a/src/sentry/static/sentry/app/data/forms/projectSecurityAndPrivacyGroups.tsx
+++ b/src/sentry/static/sentry/app/data/forms/projectSecurityAndPrivacyGroups.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+
+import {extractMultilineFields, convertMultilineFieldValue} from 'app/utils';
+import {
+  getStoreCrashReportsValues,
+  formatStoreCrashReports,
+  SettingScope,
+} from 'app/utils/crashReports';
+import Link from 'app/components/links/link';
+import {t, tct} from 'app/locale';
+import {JsonFormObject} from 'app/views/settings/components/forms/type';
+
+const ORG_DISABLED_REASON = t(
+  "This option is enforced by your organization's settings and cannot be customized per-project."
+);
+
+// Check if a field has been set AND IS TRUTHY at the organization level.
+const hasOrgOverride = ({organization, name}) => organization[name];
+
+export default [
+  {
+    title: t('Security & Privacy'),
+    fields: [
+      {
+        name: 'storeCrashReports',
+        type: 'array',
+        label: t('Store Native Crash Reports'),
+        help: ({organization}) =>
+          tct(
+            'Store native crash reports such as Minidumps for improved processing and download in issue details. Overrides [organizationSettingsLink: organization settings].',
+            {
+              organizationSettingsLink: (
+                <Link to={`/settings/${organization.slug}/security-and-privacy/`} />
+              ),
+            }
+          ),
+        visible: ({features}) => features.has('event-attachments'),
+        placeholder: ({organization, value}) => {
+          // empty value means that this project should inherit organization settings
+          if (value === '') {
+            return tct('Inherit organization settings ([organizationValue])', {
+              organizationValue: formatStoreCrashReports(organization.storeCrashReports),
+            });
+          }
+
+          // HACK: some organization can have limit of stored crash reports a number that's not in the options (legacy reasons),
+          // we therefore display it in a placeholder
+          return formatStoreCrashReports(value);
+        },
+        choices: ({organization}) =>
+          getStoreCrashReportsValues(SettingScope.Project).map(value => [
+            value,
+            formatStoreCrashReports(value, organization.storeCrashReports),
+          ]),
+      },
+    ],
+  },
+  {
+    title: t('Data Scrubbing'),
+    fields: [
+      {
+        name: 'dataScrubber',
+        type: 'boolean',
+        label: t('Data Scrubber'),
+        disabled: hasOrgOverride,
+        disabledReason: ORG_DISABLED_REASON,
+        help: t('Enable server-side data scrubbing'),
+        // `props` are the props given to FormField
+        setValue: (val, props) =>
+          (props.organization && props.organization[props.name]) || val,
+        confirm: {
+          false: t('Are you sure you want to disable server-side data scrubbing?'),
+        },
+      },
+      {
+        name: 'dataScrubberDefaults',
+        type: 'boolean',
+        disabled: hasOrgOverride,
+        disabledReason: ORG_DISABLED_REASON,
+        label: t('Use Default Scrubbers'),
+        help: t(
+          'Apply default scrubbers to prevent things like passwords and credit cards from being stored'
+        ),
+        // `props` are the props given to FormField
+        setValue: (val, props) =>
+          (props.organization && props.organization[props.name]) || val,
+        confirm: {
+          false: t('Are you sure you want to disable using default scrubbers?'),
+        },
+      },
+      {
+        name: 'scrubIPAddresses',
+        type: 'boolean',
+        disabled: hasOrgOverride,
+        disabledReason: ORG_DISABLED_REASON,
+        // `props` are the props given to FormField
+        setValue: (val, props) =>
+          (props.organization && props.organization[props.name]) || val,
+        label: t('Prevent Storing of IP Addresses'),
+        help: t('Preventing IP addresses from being stored for new events'),
+        confirm: {
+          false: t('Are you sure you want to disable scrubbing IP addresses?'),
+        },
+      },
+      {
+        name: 'sensitiveFields',
+        type: 'string',
+        multiline: true,
+        autosize: true,
+        maxRows: 10,
+        placeholder: t('email'),
+        label: t('Additional Sensitive Fields'),
+        help: t(
+          'Additional field names to match against when scrubbing data. Separate multiple entries with a newline'
+        ),
+        getValue: val => extractMultilineFields(val),
+        setValue: val => convertMultilineFieldValue(val),
+      },
+      {
+        name: 'safeFields',
+        type: 'string',
+        multiline: true,
+        autosize: true,
+        maxRows: 10,
+        placeholder: t('business-email'),
+        label: t('Safe Fields'),
+        help: t(
+          'Field names which data scrubbers should ignore. Separate multiple entries with a newline'
+        ),
+        getValue: val => extractMultilineFields(val),
+        setValue: val => convertMultilineFieldValue(val),
+      },
+    ],
+  },
+] as JsonFormObject[];

--- a/src/sentry/static/sentry/app/data/forms/projectSecurityAndPrivacyGroups.tsx
+++ b/src/sentry/static/sentry/app/data/forms/projectSecurityAndPrivacyGroups.tsx
@@ -10,6 +10,9 @@ import Link from 'app/components/links/link';
 import {t, tct} from 'app/locale';
 import {JsonFormObject} from 'app/views/settings/components/forms/type';
 
+// Export route to make these forms searchable by label/help
+export const route = '/settings/:orgId/projects/:projectId/security-and-privacy/';
+
 const ORG_DISABLED_REASON = t(
   "This option is enforced by your organization's settings and cannot be customized per-project."
 );

--- a/src/sentry/static/sentry/app/views/settings/organizationSecurityAndPrivacy/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationSecurityAndPrivacy/index.tsx
@@ -9,7 +9,7 @@ import AsyncView from 'app/views/asyncView';
 import {Organization} from 'app/types';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {updateOrganization} from 'app/actionCreators/organizations';
-import organizationSecurityAndPrivacy from 'app/data/forms/organizationSecurityAndPrivacy';
+import organizationSecurityAndPrivacyGroups from 'app/data/forms/organizationSecurityAndPrivacyGroups';
 import withOrganization from 'app/utils/withOrganization';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 
@@ -59,7 +59,7 @@ class OrganizationSecurityAndPrivacyContent extends AsyncView<Props> {
         >
           <JsonForm
             features={features}
-            forms={organizationSecurityAndPrivacy}
+            forms={organizationSecurityAndPrivacyGroups}
             disabled={!access.has('org:write')}
           />
         </Form>

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
@@ -75,7 +75,7 @@ export default function getConfiguration({
           path: `${pathPrefix}/security-and-privacy/`,
           title: t('Security & Privacy'),
           description: t(
-            'Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing)'
+            'Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing) for a project'
           ),
         },
 

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityAndPrivacy/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityAndPrivacy/index.tsx
@@ -7,7 +7,7 @@ import {t, tct} from 'app/locale';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import Form from 'app/views/settings/components/forms/form';
-import {fields} from 'app/data/forms/projectGeneralSettings';
+import projectSecurityAndPrivacyGroups from 'app/data/forms/projectSecurityAndPrivacyGroups';
 import ProjectActions from 'app/actions/projectActions';
 import {Organization, Project} from 'app/types';
 import withProject from 'app/utils/withProject';
@@ -54,28 +54,10 @@ class ProjectSecurityAndPrivacy extends React.Component<ProjectSecurityAndPrivac
           onSubmitError={() => addErrorMessage('Unable to save change')}
         >
           <JsonForm
-            title={title}
-            additionalFieldProps={{
-              organization,
-            }}
+            additionalFieldProps={{organization}}
             features={features}
             disabled={!access.has('project:write')}
-            fields={[fields.storeCrashReports]}
-          />
-          <JsonForm
-            title={t('Data Scrubbing')}
-            additionalFieldProps={{
-              organization,
-            }}
-            features={features}
-            disabled={!access.has('project:write')}
-            fields={[
-              fields.dataScrubber,
-              fields.dataScrubberDefaults,
-              fields.scrubIPAddresses,
-              fields.sensitiveFields,
-              fields.safeFields,
-            ]}
+            forms={projectSecurityAndPrivacyGroups}
           />
         </Form>
         <DataScrubbing


### PR DESCRIPTION
closes: https://github.com/getsentry/sentry/issues/20878

**Description:**
When going to general project settings and searching for data scrubbing, the user is forwarded to the anchor `#dataScrubbers` or `#dataScrubbersDefaults` as if the old settings, in General, were still there.

This removes data scrubbing Fields from `projectGeneralSettings.tsx` to the new file `/projectSecurityAndPrivacyGroups.tsx`