### PR TITLE
fix(breadcrumbs): Display the icon info when crumb is not an exception

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbsV2/index.tsx
@@ -191,7 +191,7 @@ class Breadcrumbs extends React.Component<Props, State> {
     const levelTag = (event.tags || []).find(tag => tag.key === 'level');
 
     return {
-      type: BreadcrumbType.ERROR,
+      type: BreadcrumbType.INFO,
       level: (levelTag?.value as BreadcrumbLevelType) || BreadcrumbLevelType.UNDEFINED,
       category: 'message',
       message: event.message,


### PR DESCRIPTION
closes: https://app.asana.com/0/1182975495223914/1194690232691713


**Problem:**
Basically a crumb + capture message (so no exception, level is info) shows the right level but the icon is the 🔥

**Solution:**
When the breadcrumb is not of type exception and has a message, the displayed icon will be the "IconInfo". 
