### PR TITLE
feat/fix(workflow): Add additional test, support empty filters

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -795,7 +795,10 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             )
             for item in item_list:
                 time_range_result[item].update(
-                    {"filtered": filtered_result.get(item), "lifetime": lifetime_result.get(item)}
+                    {
+                        "filtered": filtered_result.get(item) if filtered_result else None,
+                        "lifetime": lifetime_result.get(item) if lifetime_result else None,
+                    }
                 )
         return time_range_result
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -601,6 +601,9 @@ class GroupListTest(APITestCase, SnubaTestCase):
             assert int(response.data[0]["id"]) == group2.id
             assert response.data[0]["lifetime"] is not None
             assert response.data[0]["filtered"] is not None
+            assert response.data[0]["filtered"]["stats"] is not None
+            assert response.data[0]["lifetime"]["stats"] is None
+            assert response.data[0]["filtered"]["stats"] != response.data[0]["stats"]
 
             assert response.data[0]["lifetime"]["count"] == "4"
             assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
@@ -616,6 +619,25 @@ class GroupListTest(APITestCase, SnubaTestCase):
             ).replace(tzinfo=timezone.utc)
             assert response.data[0]["filtered"]["lastSeen"] == parse_datetime(
                 before_now_150_seconds
+            ).replace(tzinfo=timezone.utc)
+
+            # Empty filter test:
+            response = self.get_response(sort_by="date", limit=10, query="")
+            assert response.status_code == 200
+            assert len(response.data) == 2
+            assert int(response.data[0]["id"]) == group2.id
+            assert response.data[0]["lifetime"] is not None
+            assert response.data[0]["filtered"] is not None
+            assert response.data[0]["lifetime"]["stats"] is None
+            assert response.data[0]["filtered"]["stats"] is not None
+            assert response.data[0]["filtered"]["stats"] == response.data[0]["stats"]
+
+            assert response.data[0]["lifetime"]["count"] == "4"
+            assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
+                before_now_300_seconds
+            ).replace(tzinfo=timezone.utc)
+            assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
+                before_now_100_seconds
             ).replace(tzinfo=timezone.utc)
 
     def test_skipped_fields(self):


### PR DESCRIPTION
This PR adds a test for an empty filter and fixes the issues in the serializer in this case. We also opt to have filtered stats be equivalent to time range stats instead of None.