### PR TITLE
fix(workflow): Revert "Revert dynamic count optimizations (#20904)"

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function
 
+import functools
 import itertools
 from collections import defaultdict
 from datetime import timedelta
@@ -15,6 +16,7 @@ import sentry_sdk
 
 from sentry import tagstore, tsdb
 from sentry.app import env
+from sentry.api.event_search import convert_search_filter_to_snuba_query
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer
 from sentry.api.fields.actor import Actor
@@ -43,7 +45,9 @@ from sentry.models import (
     UserOption,
     UserOptionValue,
 )
+from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tsdb.snuba import SnubaTSDB
+from sentry.utils import snuba
 from sentry.utils.db import attach_foreignkey
 from sentry.utils.safe import safe_execute
 from sentry.utils.compat import map, zip
@@ -433,18 +437,13 @@ class GroupSerializerBase(Serializer):
         permalink = self._get_permalink(obj, user)
         is_subscribed, subscription_details = self._get_subscription(attrs)
         share_id = attrs["share_id"]
-
-        return {
+        group_dict = {
             "id": six.text_type(obj.id),
             "shareId": share_id,
             "shortId": obj.qualified_short_id,
-            "count": six.text_type(attrs["times_seen"]),
-            "userCount": attrs["user_count"],
             "title": obj.title,
             "culprit": obj.culprit,
             "permalink": permalink,
-            "firstSeen": attrs["first_seen"],
-            "lastSeen": attrs["last_seen"],
             "logger": obj.logger or None,
             "level": LOG_LEVELS.get(obj.level, "unknown"),
             "status": status_label,
@@ -467,6 +466,16 @@ class GroupSerializerBase(Serializer):
             "hasSeen": attrs["has_seen"],
             "annotations": attrs["annotations"],
         }
+        group_dict.update(self._convert_seen_stats(attrs))
+        return group_dict
+
+    def _convert_seen_stats(self, stats):
+        return {
+            "count": six.text_type(stats["times_seen"]),
+            "userCount": stats["user_count"],
+            "firstSeen": stats["first_seen"],
+            "lastSeen": stats["last_seen"],
+        }
 
 
 @register(Group)
@@ -486,10 +495,7 @@ class GroupSerializer(GroupSerializerBase):
             project_id = item_list[0].project_id
             item_ids = [g.id for g in item_list]
             user_counts = tagstore.get_groups_user_counts(
-                [project_id],
-                item_ids,
-                environment_ids=environment and [environment.id],
-                snuba_filters=None,
+                [project_id], item_ids, environment_ids=environment and [environment.id]
             )
             first_seen = {}
             last_seen = {}
@@ -532,7 +538,7 @@ class GroupStatsMixin(object):
     def query_tsdb(self, group_ids, query_params):
         raise NotImplementedError
 
-    def get_stats(self, item_list, user):
+    def get_stats(self, item_list, user, **kwargs):
         if self.stats_period:
             # we need to compute stats at 1d (1h resolution), and 14d or a custom given period
             group_ids = [g.id for g in item_list]
@@ -564,7 +570,7 @@ class GroupStatsMixin(object):
                     "rollup": int(interval.total_seconds()),
                 }
 
-            return self.query_tsdb(group_ids, query_params)
+            return self.query_tsdb(group_ids, query_params, **kwargs)
 
 
 class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
@@ -588,7 +594,7 @@ class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
         self.matching_event_id = matching_event_id
         self.matching_event_environment = matching_event_environment
 
-    def query_tsdb(self, group_ids, query_params):
+    def query_tsdb(self, group_ids, query_params, **kwargs):
         try:
             environment = self.environment_func()
         except Environment.DoesNotExist:
@@ -648,42 +654,73 @@ class SharedGroupSerializer(GroupSerializer):
 
 
 class GroupSerializerSnuba(GroupSerializerBase):
-    def __init__(self, environment_ids=None, start=None, end=None, snuba_filters=None):
+    skip_snuba_fields = {
+        "query",
+        "status",
+        "bookmarked_by",
+        "assigned_to",
+        "unassigned",
+        "subscribed_by",
+        "active_at",
+        "first_release",
+        "first_seen",
+    }
+
+    def __init__(self, environment_ids=None, start=None, end=None, search_filters=None):
         self.environment_ids = environment_ids
         self.start = start
         self.end = end
-        self.snuba_filters = snuba_filters
+        self.conditions = (
+            [
+                convert_search_filter_to_snuba_query(search_filter)
+                for search_filter in search_filters
+                if search_filter.key.name not in self.skip_snuba_fields
+            ]
+            if search_filters is not None
+            else []
+        )
 
-    def _get_seen_stats(self, item_list, user):
+    def _execute_seen_stats_query(
+        self, item_list, start=None, end=None, conditions=None, environment_ids=None
+    ):
         project_ids = list(set([item.project_id for item in item_list]))
         group_ids = [item.id for item in item_list]
-        user_counts = tagstore.get_groups_user_counts(
-            project_ids,
-            group_ids,
-            environment_ids=self.environment_ids,
-            snuba_filters=self.snuba_filters,
-            start=self.start,
-            end=self.end,
+        aggregations = [
+            ["count()", "", "times_seen"],
+            ["min", "timestamp", "first_seen"],
+            ["max", "timestamp", "last_seen"],
+            ["uniq", "tags[sentry:user]", "count"],
+        ]
+        filters = {"project_id": project_ids, "group_id": group_ids}
+        if self.environment_ids:
+            filters["environment"] = self.environment_ids
+        result = snuba.aliased_query(
+            dataset=snuba.Dataset.Events,
+            start=start,
+            end=end,
+            groupby=["group_id"],
+            conditions=conditions,
+            filter_keys=filters,
+            aggregations=aggregations,
+            referrer="serializers.GroupSerializerSnuba._execute_seen_stats_query",
         )
-
-        seen_data = tagstore.get_group_seen_values_for_environments(
-            project_ids,
-            group_ids,
-            self.environment_ids,
-            snuba_filters=self.snuba_filters,
-            start=self.start,
-            end=self.end,
-        )
+        seen_data = {
+            issue["group_id"]: fix_tag_value_data(
+                dict(filter(lambda key: key[0] != "group_id", six.iteritems(issue)))
+            )
+            for issue in result["data"]
+        }
+        user_counts = {item_id: value["count"] for item_id, value in seen_data.items()}
         last_seen = {item_id: value["last_seen"] for item_id, value in seen_data.items()}
         times_seen = {item_id: value["times_seen"] for item_id, value in seen_data.items()}
-        if not self.environment_ids:
+        if not environment_ids:
             first_seen = {item_id: value["first_seen"] for item_id, value in seen_data.items()}
         else:
             first_seen = {
                 ge["group_id"]: ge["first_seen__min"]
                 for ge in GroupEnvironment.objects.filter(
                     group_id__in=[item.id for item in item_list],
-                    environment_id__in=self.environment_ids,
+                    environment_id__in=environment_ids,
                 )
                 .values("group_id")
                 .annotate(Min("first_seen"))
@@ -698,6 +735,15 @@ class GroupSerializerSnuba(GroupSerializerBase):
             }
         return attrs
 
+    def _get_seen_stats(self, item_list, user):
+        return self._execute_seen_stats_query(
+            item_list=item_list,
+            start=self.start,
+            end=self.end,
+            conditions=self.conditions,
+            environment_ids=self.environment_ids,
+        )
+
 
 class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
     def __init__(
@@ -709,9 +755,12 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         matching_event_id=None,
         start=None,
         end=None,
-        snuba_filters=None,
+        search_filters=None,
+        has_dynamic_issue_counts=False,
     ):
-        super(StreamGroupSerializerSnuba, self).__init__(environment_ids, start, end, snuba_filters)
+        super(StreamGroupSerializerSnuba, self).__init__(
+            environment_ids, start, end, search_filters
+        )
 
         if stats_period is not None:
             assert stats_period in self.STATS_PERIOD_CHOICES or (
@@ -722,22 +771,60 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         self.stats_period_start = stats_period_start
         self.stats_period_end = stats_period_end
         self.matching_event_id = matching_event_id
+        self.has_dynamic_issue_counts = has_dynamic_issue_counts
 
-    def query_tsdb(self, group_ids, query_params):
+    def _get_seen_stats(self, item_list, user):
+        partial_execute_seen_stats_query = functools.partial(
+            self._execute_seen_stats_query,
+            item_list=item_list,
+            environment_ids=self.environment_ids,
+            start=self.start,
+            end=self.end,
+        )
+        time_range_result = partial_execute_seen_stats_query()
+        if self.has_dynamic_issue_counts:
+            filtered_result = (
+                partial_execute_seen_stats_query(conditions=self.conditions)
+                if self.conditions
+                else None
+            )
+            lifetime_result = (
+                partial_execute_seen_stats_query(start=None, end=None)
+                if self.start or self.end
+                else None
+            )
+            for item in item_list:
+                time_range_result[item].update(
+                    {
+                        "filtered": filtered_result.get(item) if filtered_result else None,
+                        "lifetime": lifetime_result.get(item) if lifetime_result else None,
+                    }
+                )
+        return time_range_result
+
+    def query_tsdb(self, group_ids, query_params, conditions=None, environment_ids=None, **kwargs):
         return snuba_tsdb.get_range(
             model=snuba_tsdb.models.group,
             keys=group_ids,
-            environment_ids=self.environment_ids,
-            snuba_filters=self.snuba_filters,
+            environment_ids=environment_ids,
+            conditions=conditions,
             **query_params
         )
 
     def get_attrs(self, item_list, user):
         attrs = super(StreamGroupSerializerSnuba, self).get_attrs(item_list, user)
-
         if self.stats_period:
-            stats = self.get_stats(item_list, user)
+            partial_get_stats = functools.partial(
+                self.get_stats, item_list=item_list, user=user, environment_ids=self.environment_ids
+            )
+            stats = partial_get_stats()
+            if self.has_dynamic_issue_counts:
+                filtered_stats = (
+                    partial_get_stats(conditions=self.conditions) if self.conditions else None
+                )
             for item in item_list:
+                if self.has_dynamic_issue_counts:
+                    attrs[item].update({"filtered_stats": filtered_stats[item.id]})
                 attrs[item].update({"stats": stats[item.id]})
 
         return attrs
@@ -750,5 +837,12 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
 
         if self.matching_event_id:
             result["matchingEventId"] = self.matching_event_id
+
+        if self.has_dynamic_issue_counts:
+            if self.stats_period:
+                attrs["lifetime"].update({"stats": None})  # Not needed in current implementation
+                attrs["filtered"].update({"stats": {self.stats_period: attrs["filtered_stats"]}})
+            result["filtered"] = self._convert_seen_stats(attrs["filtered"])
+            result["lifetime"] = self._convert_seen_stats(attrs["lifetime"])
 
         return result

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -470,11 +470,7 @@ class Group(Model):
 
     def count_users_seen(self):
         return tagstore.get_groups_user_counts(
-            [self.project_id],
-            [self.id],
-            environment_ids=None,
-            snuba_filters=None,
-            start=self.first_seen,
+            [self.project_id], [self.id], environment_ids=None, start=self.first_seen,
         )[self.id]
 
     @classmethod

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -233,9 +233,7 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
-    def get_groups_user_counts(
-        self, project_ids, group_ids, environment_ids, snuba_filters, start=None, end=None
-    ):
+    def get_groups_user_counts(self, project_ids, group_ids, environment_ids, start=None, end=None):
         """
         >>> get_groups_user_counts([1, 2], [2, 3], [4, 5])
         `start` and `end` are only used by the snuba backend
@@ -316,6 +314,6 @@ class TagStorage(Service):
         return tag_keys
 
     def get_group_seen_values_for_environments(
-        self, project_ids, group_id_list, environment_ids, snuba_filters, start=None, end=None
+        self, project_ids, group_id_list, environment_ids, start=None, end=None
     ):
         raise NotImplementedError

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -26,7 +26,6 @@ from sentry.utils import snuba, metrics
 from sentry.utils.hashlib import md5_text
 from sentry.utils.dates import to_timestamp
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
-from sentry.utils.compat import filter
 
 
 SEEN_COLUMN = "timestamp"
@@ -406,11 +405,10 @@ class SnubaTagStorage(TagStorage):
         }
 
     def get_group_seen_values_for_environments(
-        self, project_ids, group_id_list, environment_ids, snuba_filters, start=None, end=None
+        self, project_ids, group_id_list, environment_ids, start=None, end=None
     ):
         # Get the total times seen, first seen, and last seen across multiple environments
         filters = {"project_id": project_ids, "group_id": group_id_list}
-
         if environment_ids:
             filters["environment"] = environment_ids
 
@@ -420,23 +418,17 @@ class SnubaTagStorage(TagStorage):
             ["max", SEEN_COLUMN, "last_seen"],
         ]
 
-        result = snuba.aliased_query(
-            dataset=snuba.Dataset.Events,
+        result = snuba.query(
             start=start,
             end=end,
             groupby=["group_id"],
-            conditions=snuba_filters,
+            conditions=None,
             filter_keys=filters,
             aggregations=aggregations,
             referrer="tagstore.get_group_seen_values_for_environments",
         )
 
-        return {
-            issue["group_id"]: fix_tag_value_data(
-                dict(filter(lambda key: key[0] != "group_id", six.iteritems(issue)))
-            )
-            for issue in result["data"]
-        }
+        return {issue: fix_tag_value_data(data) for issue, data in six.iteritems(result)}
 
     def get_group_tag_value_count(self, project_id, group_id, environment_id, key):
         tag = u"tags[{}]".format(key)
@@ -635,26 +627,23 @@ class SnubaTagStorage(TagStorage):
                 )
         return values
 
-    def get_groups_user_counts(
-        self, project_ids, group_ids, environment_ids, snuba_filters, start=None, end=None
-    ):
+    def get_groups_user_counts(self, project_ids, group_ids, environment_ids, start=None, end=None):
         filters = {"project_id": project_ids, "group_id": group_ids}
         if environment_ids:
             filters["environment"] = environment_ids
         aggregations = [["uniq", "tags[sentry:user]", "count"]]
 
-        result = snuba.aliased_query(
-            dataset=snuba.Dataset.Events,
+        result = snuba.query(
             start=start,
             end=end,
             groupby=["group_id"],
-            conditions=snuba_filters,
+            conditions=None,
             filter_keys=filters,
             aggregations=aggregations,
             referrer="tagstore.get_groups_user_counts",
         )
 
-        return defaultdict(int, {issue["group_id"]: issue["count"] for issue in result["data"]})
+        return defaultdict(int, {k: v for k, v in result.items() if v})
 
     def get_tag_value_paginator(
         self,

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -601,6 +601,9 @@ class GroupListTest(APITestCase, SnubaTestCase):
             assert int(response.data[0]["id"]) == group2.id
             assert response.data[0]["lifetime"] is not None
             assert response.data[0]["filtered"] is not None
+            assert response.data[0]["filtered"]["stats"] is not None
+            assert response.data[0]["lifetime"]["stats"] is None
+            assert response.data[0]["filtered"]["stats"] != response.data[0]["stats"]
 
             assert response.data[0]["lifetime"]["count"] == "4"
             assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
@@ -616,6 +619,25 @@ class GroupListTest(APITestCase, SnubaTestCase):
             ).replace(tzinfo=timezone.utc)
             assert response.data[0]["filtered"]["lastSeen"] == parse_datetime(
                 before_now_150_seconds
+            ).replace(tzinfo=timezone.utc)
+
+            # Empty filter test:
+            response = self.get_response(sort_by="date", limit=10, query="")
+            assert response.status_code == 200
+            assert len(response.data) == 2
+            assert int(response.data[0]["id"]) == group2.id
+            assert response.data[0]["lifetime"] is not None
+            assert response.data[0]["filtered"] is not None
+            assert response.data[0]["lifetime"]["stats"] is None
+            assert response.data[0]["filtered"]["stats"] is not None
+            assert response.data[0]["filtered"]["stats"] == response.data[0]["stats"]
+
+            assert response.data[0]["lifetime"]["count"] == "4"
+            assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
+                before_now_300_seconds
+            ).replace(tzinfo=timezone.utc)
+            assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
+                before_now_100_seconds
             ).replace(tzinfo=timezone.utc)
 
     def test_skipped_fields(self):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -306,7 +306,6 @@ class TagStorageTest(TestCase, SnubaTestCase):
             project_ids=[self.proj1.id],
             group_ids=[self.proj1group1.id, self.proj1group2.id],
             environment_ids=[self.proj1env1.id],
-            snuba_filters=None,
         ) == {self.proj1group1.id: 2, self.proj1group2.id: 1}
 
         # test filtering by date range where there shouldn't be results
@@ -315,7 +314,6 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 project_ids=[self.proj1.id],
                 group_ids=[self.proj1group1.id, self.proj1group2.id],
                 environment_ids=[self.proj1env1.id],
-                snuba_filters=None,
                 start=self.now - timedelta(days=5),
                 end=self.now - timedelta(days=4),
             )
@@ -604,7 +602,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
 
     def test_get_group_seen_values_for_environments(self):
         assert self.ts.get_group_seen_values_for_environments(
-            [self.proj1.id], [self.proj1group1.id], [self.proj1env1.id], []
+            [self.proj1.id], [self.proj1group1.id], [self.proj1env1.id]
         ) == {
             self.proj1group1.id: {
                 "first_seen": self.now - timedelta(seconds=2),
@@ -619,7 +617,6 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 [self.proj1.id],
                 [self.proj1group1.id],
                 [self.proj1env1.id],
-                [],
                 start=self.now - timedelta(hours=5),
                 end=self.now - timedelta(hours=4),
             )


### PR DESCRIPTION
This reverts commit 4e5077af42d771ffb256ba018e77dd7ea1c1e310 and implements a proper fix.

Added a test for an empty filter, made sure we're not overwriting stats, and opted to send filtered data as the time range data instead of None if they have no filters.