### PR TITLE
feat(alert): Disable 'none' match for migrated alert-filter projects

### DIFF
--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -136,6 +136,14 @@ class RuleSerializer(serializers.Serializer):
                     }
                 )
 
+        # ensure that if a user has alert-filters enabled, they do not use a 'none' match on conditions
+        if project_has_filters and attrs.get("actionMatch") == "none":
+            raise serializers.ValidationError(
+                {
+                    "conditions": u"The 'none' match on conditions is outdated and no longer supported."
+                }
+            )
+
         return attrs
 
     def save(self, rule):

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -59,6 +59,11 @@ const ACTION_MATCH_CHOICES: Array<[IssueAlertRule['actionMatch'], string]> = [
   ['none', t('none')],
 ];
 
+const ACTION_MATCH_CHOICES_MIGRATED: Array<[IssueAlertRule['actionMatch'], string]> = [
+  ['all', t('all')],
+  ['any', t('any')],
+];
+
 const defaultRule: UnsavedIssueAlertRule = {
   actionMatch: 'all',
   filterMatch: 'all',
@@ -512,29 +517,42 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                           {
                             when: <Badge />,
                             selector: (
-                              <EmbeddedWrapper>
-                                <EmbeddedSelectField
-                                  className={classNames({
-                                    error: this.hasError('actionMatch'),
-                                  })}
-                                  inline={false}
-                                  styles={{
-                                    control: provided => ({
-                                      ...provided,
-                                      minHeight: '20px',
-                                      height: '20px',
-                                    }),
-                                  }}
-                                  isSearchable={false}
-                                  isClearable={false}
-                                  name="actionMatch"
-                                  required
-                                  flexibleControlStateSize
-                                  choices={ACTION_MATCH_CHOICES}
-                                  onChange={val => this.handleChange('actionMatch', val)}
-                                  disabled={!hasAccess}
-                                />
-                              </EmbeddedWrapper>
+                              <Feature
+                                features={['projects:alert-filters']}
+                                project={project}
+                              >
+                                {({hasFeature}) => (
+                                  <EmbeddedWrapper>
+                                    <EmbeddedSelectField
+                                      className={classNames({
+                                        error: this.hasError('actionMatch'),
+                                      })}
+                                      inline={false}
+                                      styles={{
+                                        control: provided => ({
+                                          ...provided,
+                                          minHeight: '20px',
+                                          height: '20px',
+                                        }),
+                                      }}
+                                      isSearchable={false}
+                                      isClearable={false}
+                                      name="actionMatch"
+                                      required
+                                      flexibleControlStateSize
+                                      choices={
+                                        hasFeature
+                                          ? ACTION_MATCH_CHOICES_MIGRATED
+                                          : ACTION_MATCH_CHOICES
+                                      }
+                                      onChange={val =>
+                                        this.handleChange('actionMatch', val)
+                                      }
+                                      disabled={!hasAccess}
+                                    />
+                                  </EmbeddedWrapper>
+                                )}
+                              </Feature>
                             ),
                           }
                         )}


### PR DESCRIPTION
Due to the splitting of conditions into conditions and filters, having a `none` match on conditions no longer makes a lot of sense. This `none` match will still exist on filters where it can be applied to event attribute filters. 

This will only apply to projects that are newly created or have been migrated to fit the new issue alert filter format where `none` is disabled anyways.

![image](https://user-images.githubusercontent.com/9372512/93915868-a59dbb00-fcd6-11ea-9da2-9020fc228c68.png)
