### PR TITLE
Hide p100() from transaction summary by default

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/utils.tsx
@@ -14,7 +14,7 @@ export function transactionSummaryRouteWithQuery({
   orgSlug: string;
   transaction: string;
   query: Query;
-  unselectedSeries?: string;
+  unselectedSeries?: string | string[];
   projectID?: string | string[];
 }) {
   const pathname = generateTransactionSummaryRoute({

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/utils.tsx
@@ -9,10 +9,12 @@ export function transactionSummaryRouteWithQuery({
   transaction,
   projectID,
   query,
+  unselectedSeries = 'p100()',
 }: {
   orgSlug: string;
   transaction: string;
   query: Query;
+  unselectedSeries?: string;
   projectID?: string | string[];
 }) {
   const pathname = generateTransactionSummaryRoute({
@@ -29,6 +31,7 @@ export function transactionSummaryRouteWithQuery({
       start: query.start,
       end: query.end,
       query: query.query,
+      unselectedSeries,
     },
   };
 }


### PR DESCRIPTION
Can be disabled by passing in `unselectedSeries: null` to `transactionSummaryRouteWithQuery` e.g.

``` 
const target = transactionSummaryRouteWithQuery({
  orgSlug: organization.slug,
  transaction: String(dataRow.transaction) || '',
  query: summaryView.generateQueryStringObject(),
  projectID,
  unselectedSeries: null,
});
``` 
Previously when clicking through to the Transaction Summary:
![Screen Shot 2020-09-22 at 2 05 21 PM](https://user-images.githubusercontent.com/155016/93920084-afc2b800-fcdc-11ea-92ac-9c34399af1b3.png)

Now:
![Screen Shot 2020-09-22 at 2 05 28 PM](https://user-images.githubusercontent.com/155016/93920093-b2bda880-fcdc-11ea-958b-32d7744ddb96.png)
