### PR TITLE
fix: Fix missing argument to similarity.delete

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -110,7 +110,7 @@ class GroupDeletionTask(ModelDeletionTask):
         from sentry import similarity
 
         if not self.skip_models or similarity not in self.skip_models:
-            similarity.delete(instance)
+            similarity.delete(None, instance)
 
         return super(GroupDeletionTask, self).delete_instance(instance)
 

--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -129,10 +129,10 @@ def _build_dispatcher(methodname):
     v2_method = getattr(features2, methodname)
 
     def inner(project, *args, **kwargs):
-        if feature_flags.has("projects:similarity-indexing", project):
+        if project is None or feature_flags.has("projects:similarity-indexing", project):
             v1_method(*args, **kwargs)
 
-        if feature_flags.has("projects:similarity-indexing-v2", project):
+        if project is None or feature_flags.has("projects:similarity-indexing-v2", project):
             v2_method(*args, **kwargs)
 
     inner.__name__ = methodname


### PR DESCRIPTION
We do not have a project and cannot fetch one efficiently. It's fine to delete if the featureflag is disabled, it just shortcuts in redis then because it was never indexed.

Fix SENTRY-HWW

Continued from #20889 