### PR TITLE
fix(sqs): add signature version for S3 client

### DIFF
--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -4,7 +4,7 @@ import logging
 
 import six
 import boto3
-from botocore.client import ClientError
+from botocore.client import ClientError, Config
 
 from sentry_plugins.base import CorePluginMixin
 from sentry.plugins.bases.data_forwarding import DataForwardingPlugin
@@ -148,7 +148,9 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
             )
 
         def s3_put_object(*args, **kwargs):
-            s3_client = boto3.client(service_name="s3", **boto3_args)
+            s3_client = boto3.client(
+                service_name="s3", config=Config(signature_version="s3v4"), **boto3_args
+            )
             return s3_client.put_object(*args, **kwargs)
 
         def sqs_send_message(message):


### PR DESCRIPTION
This fixes a bug we see when trying to push to S3 with the SQS integration:

> An error occurred (InvalidRequest) when calling the PutObject operation: The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256.

We just need to use a different signature. Solution stolen from [Stack Overflow](https://stackoverflow.com/questions/26533245/the-authorization-mechanism-you-have-provided-is-not-supported-please-use-aws4).

Fixes SENTRY-HW2