### PR TITLE
fix(py3): Fix unstable test_get_project_releases_by_stability test

### DIFF
--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -109,7 +109,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         assert data == {
             (self.project.id, self.session_release): format_timestamp(
                 self.session_started // 3600 * 3600
-            ),
+            )
         }
 
     def test_check_has_health_data(self):
@@ -119,9 +119,29 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         assert data == set([(self.project.id, self.session_release)])
 
     def test_get_project_releases_by_stability(self):
+        # Add an extra session with a different `distinct_id` so that sorting by users
+        # is stable
+        self.store_session(
+            {
+                "session_id": "5e910c1a-6941-460e-9843-24103fb6a63c",
+                "distinct_id": "39887d89-13b2-4c84-8c23-5d13d2102665",
+                "status": "ok",
+                "seq": 0,
+                "release": self.session_release,
+                "environment": "prod",
+                "retention_days": 90,
+                "org_id": self.project.organization_id,
+                "project_id": self.project.id,
+                "duration": None,
+                "errors": 0,
+                "started": self.session_started,
+                "received": self.received,
+            }
+        )
+
         for scope in "sessions", "users":
             data = get_project_releases_by_stability(
-                [self.project.id], offset=0, limit=100, scope=scope, stats_period="24h",
+                [self.project.id], offset=0, limit=100, scope=scope, stats_period="24h"
             )
 
             assert data == [


### PR DESCRIPTION
This test is unstable because both rows had 1 unique user each, and so sorting by users was
non-deterministic. Probably some difference in running these tests on GHA caused the sort 
result to change, rather than anything to do with py3. Added an extra session with a different 
user so that this will be stable regardless.