### PR TITLE
fix(trends): Fix default period and remove trends query when navigating away

### DIFF
--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -128,6 +128,11 @@ export class QueryResults {
     return this.tagValues[key];
   }
 
+  hasTags(key: string) {
+    const tags = this.getTags(key);
+    return tags && tags.length;
+  }
+
   removeTag(key: string) {
     this.tokens = this.tokens.filter(token => token.key !== key);
     delete this.tagValues[key];

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -198,7 +198,7 @@ class PerformanceLanding extends React.Component<Props, State> {
       viewKey !== FilterViews.TRENDS && location.query.view === FilterViews.TRENDS;
 
     if (isNavigatingAwayFromTrends) {
-      // This stops errors for occuring when navigating to others views since we are appending aggregates to the trends view
+      // This stops errors from occurring when navigating to other views since we are appending aggregates to the trends view
       newQuery.query = '';
     }
 

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -178,12 +178,16 @@ class PerformanceLanding extends React.Component<Props, State> {
 
     // This is a temporary change for trends to test adding a default count to increase relevancy
     if (viewKey === FilterViews.TRENDS) {
+      const hasStartAndEnd = newQuery.start && newQuery.end;
+      if (!newQuery.statsPeriod && !hasStartAndEnd) {
+        newQuery.statsPeriod = DEFAULT_TRENDS_STATS_PERIOD;
+      }
       if (!newQuery.query) {
         newQuery.query =
           'count():>1000 transaction.duration:>0 p50():>0 avg(transaction.duration):>0';
       }
       if (!newQuery.query.includes('count()')) {
-        newQuery.query += 'count():>1000';
+        newQuery.query += (newQuery.query ? ' ' : '') + 'count():>1000';
       }
       if (!newQuery.query.includes('transaction.duration')) {
         newQuery.query += ' transaction.duration:>0';
@@ -208,6 +212,7 @@ class PerformanceLanding extends React.Component<Props, State> {
                     key={viewKey}
                     barId={viewKey}
                     size="small"
+                    data-test-id={'landing-header-' + viewKey.toLowerCase()}
                     onClick={() => this.handleViewChange(viewKey)}
                   >
                     {this.getViewLabel(viewKey)}

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -193,7 +193,7 @@ class PerformanceLanding extends React.Component<Props, State> {
       if (!query.includes('count()')) {
         conditions.setTag('count()', ['>1000']);
       }
-      if (!query.includes('transaction.duration')) {
+      if (!conditions.getTags('transaction.duration')) {
         conditions.setTag('transaction.duration', ['>0']);
       }
 

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -190,10 +190,10 @@ class PerformanceLanding extends React.Component<Props, State> {
         conditions.setTag('count()', ['>1000']);
         conditions.setTag('transaction.duration', ['>0']);
       }
-      if (!query.includes('count()')) {
+      if (!conditions.hasTags('count()')) {
         conditions.setTag('count()', ['>1000']);
       }
-      if (!conditions.getTags('transaction.duration')) {
+      if (!conditions.hasTags('transaction.duration')) {
         conditions.setTag('transaction.duration', ['>0']);
       }
 

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -194,6 +194,14 @@ class PerformanceLanding extends React.Component<Props, State> {
       }
     }
 
+    const isNavigatingAwayFromTrends =
+      viewKey !== FilterViews.TRENDS && location.query.view === FilterViews.TRENDS;
+
+    if (isNavigatingAwayFromTrends) {
+      // This stops errors for occuring when navigating to others views since we are appending aggregates to the trends view
+      newQuery.query = '';
+    }
+
     ReactRouter.browserHistory.push({
       pathname: location.pathname,
       query: {...newQuery, view: viewKey},


### PR DESCRIPTION
### Summary
This fixes an issue with default period when clicking the trends tab, as well as removing the query when navigating away from trends to stop errors when running those aggregates on transactions or key transactions. Added some tests to cover these cases as well.