### PR TITLE
fix(discover) Fix replacing OR conditions

### DIFF
--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -69,7 +69,7 @@ export class QueryResults {
         }
       }
 
-      if (tokenState === TokenType.QUERY) {
+      if (tokenState === TokenType.QUERY && token.length) {
         this.addQuery(token);
       } else if (tokenState === TokenType.TAG) {
         this.addStringTag(token);
@@ -138,9 +138,11 @@ export class QueryResults {
     // to see if that open paren corresponds to a closed paren with one or fewer items inside.
     // If it does, delete those parens, and loop again until there are no more parens to delete.
     let parensToDelete: number[] = [];
-    const cleanParens = (_, idx) => !parensToDelete.includes(idx);
+    const cleanParens = (_, idx: number) => !parensToDelete.includes(idx);
     do {
-      this.tokens = this.tokens.filter(cleanParens);
+      if (parensToDelete.length) {
+        this.tokens = this.tokens.filter(cleanParens);
+      }
       parensToDelete = [];
 
       for (let i = 0; i < this.tokens.length; i++) {
@@ -164,7 +166,7 @@ export class QueryResults {
             }
             alreadySeen = true;
           } else if (isOp(nextToken) && nextToken.value === ')') {
-            // We found another paren with zero or one term inside. Delete the pair.
+            // We found another paren with zero or one terms inside. Delete the pair.
             parensToDelete = [i, j];
             break;
           }

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -245,7 +245,38 @@ describe('utils/tokenizeSearch', function() {
       expect(results.formatString()).toEqual('x a:a y OR z ( b:b AND c:c )');
     });
 
-    it('remove tags from query object', function() {
+    it('adds tags to query', function() {
+      const results = new QueryResults(['tag:value']);
+
+      results.addStringTag('new:too');
+      expect(results.formatString()).toEqual('tag:value new:too');
+    });
+
+    it('setTag() replaces tags', function() {
+      const results = new QueryResults(['tag:value']);
+
+      results.setTag('tag', ['too']);
+      expect(results.formatString()).toEqual('tag:too');
+    });
+
+    it('setTag() replaces tags in OR', function() {
+      let results = new QueryResults([
+        '(',
+        'transaction:xyz',
+        'OR',
+        'transaction:abc',
+        ')',
+      ]);
+
+      results.setTag('transaction', ['def']);
+      expect(results.formatString()).toEqual('transaction:def');
+
+      results = new QueryResults(['(transaction:xyz', 'OR', 'transaction:abc)']);
+      results.setTag('transaction', ['def']);
+      expect(results.formatString()).toEqual('transaction:def');
+    });
+
+    it('removes tags from query object', function() {
       let results = new QueryResults(['x', 'a:a', 'b:b']);
       results.removeTag('a');
       expect(results.formatString()).toEqual('x b:b');


### PR DESCRIPTION
When conditions are combined with OR and then replaced with a cell action to focus on only one value the conditions would previously be corrupted.

Fixes VIS-149