### PR TITLE
fix(alerts): Integration actions not showing

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.constants import SENTRY_RULES_WITH_MIGRATED_FILTERS
+from sentry.constants import MIGRATED_CONDITIONS
 from sentry.rules import rules
 from rest_framework.response import Response
 
@@ -22,7 +22,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         for rule_type, rule_cls in rules:
             node = rule_cls(project)
             # skip over conditions if they are not in the migrated set for a project with alert-filters
-            if project_has_filters and node.id not in SENTRY_RULES_WITH_MIGRATED_FILTERS:
+            if project_has_filters and node.id in MIGRATED_CONDITIONS:
                 continue
             context = {"id": node.id, "label": node.label, "enabled": node.is_enabled()}
             if hasattr(node, "prompt"):

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -247,10 +247,6 @@ MIGRATED_CONDITIONS = frozenset(
     ]
 )
 
-SENTRY_RULES_WITH_MIGRATED_FILTERS = frozenset(
-    [rule for rule in SENTRY_RULES if rule not in MIGRATED_CONDITIONS]
-)
-
 # methods as defined by http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html + PATCH
 HTTP_METHODS = ("GET", "POST", "PUT", "OPTIONS", "HEAD", "DELETE", "TRACE", "CONNECT", "PATCH")
 


### PR DESCRIPTION
Due to the way certain conditions/actions were being filtered away from projects with issue alert filters, integration actions were also being filtered away as well. This was because we were only including actions from the original base set of rules in `constants.py`. 

Changed the code to just strictly exclude the conditions that were migrated from the issue alert filter change. 