### PR TITLE
fix(perf-views): Moving abs delta from an aggregate

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -75,7 +75,7 @@ class OrganizationEventBaseline(OrganizationEventsEndpointBase):
                     delta_column,
                 ],
                 # Find the most recent transaction that's closest to the baseline value
-                # id as the last item for consistent results
+                # id is the last item of the orderby for consistent results
                 orderby=[get_function_alias(delta_column), "-timestamp", "id"],
                 params=params,
                 query=request.GET.get("query"),

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1640,8 +1640,8 @@ FUNCTIONS = {
         # Currently only being used by the baseline PoC
         Function(
             "absolute_delta",
-            required_args=[DurationColumn("column"), NumberRange("target", 0, None)],
-            transform=u"abs(minus({column}, {target:g}))",
+            required_args=[DurationColumnNoLookup("column"), NumberRange("target", 0, None)],
+            column=["abs", [["minus", [ArgValue("column"), ArgValue("target")]]], None],
             result_type="duration",
         ),
         # These range functions for performance trends, these aren't If functions

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -987,8 +987,8 @@ def resolve_snuba_aliases(snuba_filter, resolve_func, function_translations=None
     if selected_columns:
         for (idx, col) in enumerate(selected_columns):
             if isinstance(col, (list, tuple)):
-                if len(col) == 3 and col[0] == "transform":
-                    # Add the name from the project transform, and remove the backticks so its not treated as a new col
+                if len(col) == 3:
+                    # Add the name from columns, and remove project backticks so its not treated as a new col
                     derived_columns.add(col[2].strip("`"))
                 resolve_complex_column(col, resolve_func)
             else:

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2032,12 +2032,23 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["groupby"] == []
 
     def test_absolute_delta_function(self):
-        fields = ["absolute_delta(transaction.duration,100)"]
+        fields = ["absolute_delta(transaction.duration,100)", "id"]
         result = resolve_field_list(fields, eventstore.Filter())
-        assert result["selected_columns"] == []
-        assert result["aggregations"] == [
-            ["abs(minus(duration, 100))", None, "absolute_delta_transaction_duration_100"],
+        assert result["selected_columns"] == [
+            [
+                "abs",
+                [["minus", ["transaction.duration", 100.0]]],
+                "absolute_delta_transaction_duration_100",
+            ],
+            "id",
+            "project.id",
+            [
+                "transform",
+                [["toString", ["project_id"]], ["array", []], ["array", []], "''"],
+                "`project.name`",
+            ],
         ]
+        assert result["aggregations"] == []
         assert result["groupby"] == []
 
         with pytest.raises(InvalidSearchQuery) as err:


### PR DESCRIPTION
- This shouldn't have been an aggregate, which was causing us to group
  by unnecessarily.
- Modified the api/event_search test to check for this