### PR TITLE
ref(ts): Set children on Forms as optional

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -22,7 +22,7 @@ type RenderFunc = (props: RenderProps) => React.ReactNode;
 type Props = {
   apiMethod?: APIRequestMethod;
   apiEndpoint?: string;
-  children: React.ReactNode | RenderFunc;
+  children?: React.ReactNode | RenderFunc;
   className?: string;
   cancelLabel?: string;
   submitDisabled?: boolean;


### PR DESCRIPTION
Required to unblock `getsentry` PR mentioned below.