### PR TITLE
feat(workflow): Adding additional logging for which user is being deleted

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -219,7 +219,11 @@ class UserDetailsEndpoint(UserEndpoint):
                 organization__in=remaining_org_ids, user=user
             ).delete()
 
-        logging_data = {"actor_id": request.user.id, "ip_address": request.META["REMOTE_ADDR"]}
+        logging_data = {
+            "actor_id": request.user.id,
+            "ip_address": request.META["REMOTE_ADDR"],
+            "user_id": user.id,
+        }
 
         hard_delete = serializer.validated_data.get("hardDelete", False)
 


### PR DESCRIPTION
As part of triaging an issue, it was noticed that this log did not include the ID of the user being deleted - it only included the ID of the user performing the deletion.

Dad said it best:
<img width="203" alt="Screen Shot 2020-09-24 at 10 31 06 AM" src="https://user-images.githubusercontent.com/6395250/94159148-36000b00-fe51-11ea-9291-dc02264b4d3b.png">

And here we are.