### PR TITLE
ref(tests) Try to improve consistency of store_event()

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -680,20 +680,27 @@ class SnubaTestCase(BaseTestCase):
             stored_group = stored_event.group
             if stored_group is not None:
                 self.store_group(stored_group)
-            # Verify that events have settled in snuba's storage.
-            # While snuba is synchronous, clickhouse isn't entirely synchronous.
-            attempt = 0
-            while attempt < 10:
-                did_store = eventstore.get_event_by_id(
-                    stored_event.project_id, stored_event.event_id
-                )
-                if did_store:
-                    break
-                attempt += 1
-                time.sleep(0.05)
-            if attempt == 10:
-                assert False, "Could not ensure event was persisted within 10 attempts"
             return stored_event
+
+    def wait_for_event_count(self, project_id, total, attempts=2):
+        """
+        Wait until the event count reaches the provided value or until attempts is reached.
+
+        Useful when you're storing several events and need to ensure that snuba/clickhouse
+        state has settled.
+        """
+        # Verify that events have settled in snuba's storage.
+        # While snuba is synchronous, clickhouse isn't entirely synchronous.
+        attempt = 0
+        snuba_filter = eventstore.Filter(project_ids=[project_id])
+        while attempt < attempts:
+            events = eventstore.get_events(snuba_filter)
+            if len(events) >= total:
+                break
+            attempt += 1
+            time.sleep(0.05)
+        if attempt == 10:
+            assert False, "Could not ensure event was persisted within 10 attempts"
 
     def store_session(self, session):
         assert (

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -691,6 +691,8 @@ class SnubaTestCase(BaseTestCase):
                     break
                 attempt += 1
                 time.sleep(0.05)
+            if attempt == 10:
+                assert False, "Could not ensure event was persisted within 10 attempts"
             return stored_event
 
     def store_session(self, session):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -699,7 +699,7 @@ class SnubaTestCase(BaseTestCase):
                 break
             attempt += 1
             time.sleep(0.05)
-        if attempt == 10:
+        if attempt == attempts:
             assert False, "Could not ensure event was persisted within 10 attempts"
 
     def store_session(self, session):

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -5,7 +5,7 @@ import pytz
 from six.moves.urllib.parse import urlencode
 from mock import patch
 
-from sentry.testutils import AcceptanceTestCase
+from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.samples import load_data
 
@@ -19,7 +19,7 @@ def make_event(event_data):
     return event_data
 
 
-class PerformanceSummaryTest(AcceptanceTestCase):
+class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
         super(PerformanceSummaryTest, self).setUp()
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
@@ -43,6 +43,7 @@ class PerformanceSummaryTest(AcceptanceTestCase):
         # Create a transaction
         event = make_event(load_data("transaction", timestamp=before_now(minutes=1)))
         self.store_event(data=event, project_id=self.project.id)
+        self.wait_for_event_count(self.project.id, 1)
 
         self.store_event(
             data={

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -505,7 +505,11 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
         groups = []
+
         for day in days:
+            patched_params_update.side_effect = [
+                (self.organization.id, {"project": [self.project.id]})
+            ]
             group = self.store_event(
                 data={
                     "timestamp": iso_format(before_now(days=day)),


### PR DESCRIPTION
We've hit a few scenarios where store_event() isn't resulting in a fully persisted event. Ensuring that the event can be fetched from eventstore should help eliminate a failure scenario.