### PR TITLE
ref(ts): Convert csp and cspContent interfaces to typescript

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/csp.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/csp.tsx
@@ -24,7 +24,7 @@ function getView(view, data) {
 
 type Props = {
   event: Event;
-  data: {[key: string]: any};
+  data: Record<string, any>;
 };
 
 export default class CspInterface extends React.Component<Props> {

--- a/src/sentry/static/sentry/app/components/events/interfaces/csp.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/csp.tsx
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import SentryTypes from 'app/sentryTypes';
 import ButtonBar from 'app/components/buttonBar';
 import Button from 'app/components/button';
 import EventDataSection from 'app/components/events/eventDataSection';
 import CSPContent from 'app/components/events/interfaces/cspContent';
 import CSPHelp from 'app/components/events/interfaces/cspHelp';
 import {t} from 'app/locale';
+import {Event} from 'app/types';
 
 function getView(view, data) {
   switch (view) {
@@ -22,9 +22,13 @@ function getView(view, data) {
   }
 }
 
-export default class CspInterface extends React.Component {
+type Props = {
+  event: Event;
+  data: {[key: string]: any};
+};
+
+export default class CspInterface extends React.Component<Props> {
   static propTypes = {
-    event: SentryTypes.Event.isRequired,
     data: PropTypes.object.isRequired,
   };
 
@@ -38,7 +42,7 @@ export default class CspInterface extends React.Component {
 
   render() {
     const {view} = this.state;
-    const {event, data} = this.props;
+    const {data} = this.props;
 
     const cleanData =
       data.original_policy !== 'string'
@@ -71,7 +75,6 @@ export default class CspInterface extends React.Component {
 
     return (
       <EventDataSection
-        event={event}
         type="csp"
         title={<h3>{t('CSP Report')}</h3>}
         actions={actions}

--- a/src/sentry/static/sentry/app/components/events/interfaces/cspContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/cspContent.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import KeyValueList from 'app/components/events/interfaces/keyValueList/keyValueList';
 
 type Props = {
-  data: {[key: string]: any};
+  data: Record<string, any>;
 };
 
 class CSPContent extends React.Component<Props> {

--- a/src/sentry/static/sentry/app/components/events/interfaces/cspContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/cspContent.tsx
@@ -3,7 +3,11 @@ import React from 'react';
 
 import KeyValueList from 'app/components/events/interfaces/keyValueList/keyValueList';
 
-class CSPContent extends React.Component {
+type Props = {
+  data: {[key: string]: any};
+};
+
+class CSPContent extends React.Component<Props> {
   static propTypes = {
     data: PropTypes.object.isRequired,
   };


### PR DESCRIPTION
### Summary
This converts `csp` and `cspContent` interfaces to typescript. Had to remove `event` as a prop from `csp` because it doesn't seem to get used in `EventDataSection`