### PR TITLE
fix(integrations): handle floating repository

### DIFF
--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
+import logging
 import six
+
 from sentry.app import locks
 from sentry.models import OrganizationOption
 from sentry.plugins import providers
@@ -15,6 +17,7 @@ from .webhook import parse_raw_user_email, parse_raw_user_name
 
 class BitbucketRepositoryProvider(providers.IntegrationRepositoryProvider):
     name = "Bitbucket"
+    logger = logging.getLogger("sentry.integrations.bitbucket")
 
     def get_installation(self, integration_id, organization_id):
         if integration_id is None:

--- a/src/sentry/integrations/bitbucket_server/repository.py
+++ b/src/sentry/integrations/bitbucket_server/repository.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import logging
 import six
 
 from datetime import datetime
@@ -15,6 +16,7 @@ from sentry.utils.hashlib import md5_text
 
 class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
     name = "Bitbucket Server"
+    logger = logging.getLogger("sentry.integrations.bitbucket_server")
 
     def get_installation(self, integration_id, organization_id):
         if integration_id is None:

--- a/src/sentry/integrations/example/repository.py
+++ b/src/sentry/integrations/example/repository.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from sentry.plugins import providers
 from sentry.models import Integration
 
@@ -8,6 +10,7 @@ from sentry.shared_integrations.exceptions import IntegrationError
 
 class ExampleRepositoryProvider(providers.IntegrationRepositoryProvider):
     name = "Example"
+    logger = logging.getLogger("sentry.integrations.example")
 
     def compare_commits(self, repo, start_sha, end_sha):
         installation = Integration.objects.get(id=repo.integration_id).get_installation(

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -12,7 +12,7 @@ WEBHOOK_EVENTS = ["push", "pull_request"]
 
 class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
     name = "GitHub"
-    logger = logging.getLogger("sentry.plugins.github")
+    logger = logging.getLogger("sentry.integrations.github")
     repo_provider = "github"
 
     def _validate_repo(self, client, installation, repo):

--- a/src/sentry/integrations/github_enterprise/repository.py
+++ b/src/sentry/integrations/github_enterprise/repository.py
@@ -12,7 +12,7 @@ WEBHOOK_EVENTS = ["push", "pull_request"]
 
 class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
     name = "GitHub Enterprise"
-    logger = logging.getLogger("sentry.plugins.github_enterprise")
+    logger = logging.getLogger("sentry.integrations.github_enterprise")
     repo_provider = "github_enterprise"
 
     def _validate_repo(self, client, installation, repo):

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import logging
 
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.plugins import providers
@@ -8,6 +9,7 @@ from sentry.models import Integration
 
 class GitlabRepositoryProvider(providers.IntegrationRepositoryProvider):
     name = "Gitlab"
+    logger = logging.getLogger("sentry.integrations.gitlab")
 
     def get_installation(self, integration_id, organization_id):
         if integration_id is None:

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import logging
 import six
 
 from sentry.plugins import providers
@@ -11,6 +12,7 @@ MAX_COMMIT_DATA_REQUESTS = 90
 
 class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
     name = "Azure DevOps"
+    logger = logging.getLogger("sentry.integrations.vsts")
 
     def get_installation(self, integration_id, organization_id):
         if integration_id is None:

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -47,6 +47,15 @@ class IntegrationRepositoryProvider(object):
             organization_id=organization.id, name=result["name"], integration_id=None
         ).first()
         if repo:
+            if self.logger:
+                self.logger.info(
+                    "repository.update",
+                    extra={
+                        "organization_id": organization.id,
+                        "repo_name": result["name"],
+                        "old_provider": repo.provider,
+                    },
+                )
             # update from params
             for field_name, field_value in six.iteritems(repo_update_params):
                 setattr(repo, field_name, field_value)

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from sentry import analytics
 from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.models import Repository, Integration
 from sentry.signals import repo_linked
@@ -33,37 +34,46 @@ class IntegrationRepositoryProvider(object):
         except Exception as e:
             return self.handle_api_error(e)
 
-        try:
-            with transaction.atomic():
-                repo = Repository.objects.create(
-                    organization_id=organization.id,
-                    name=result["name"],
-                    external_id=result.get("external_id"),
-                    url=result.get("url"),
-                    config=result.get("config") or {},
-                    provider=self.id,
-                    integration_id=result.get("integration_id"),
-                )
-        except IntegrityError:
-            # Try to delete webhook we just created
-            try:
-                repo = Repository(
-                    organization_id=organization.id,
-                    name=result["name"],
-                    external_id=result.get("external_id"),
-                    url=result.get("url"),
-                    config=result.get("config") or {},
-                    provider=self.id,
-                    integration_id=result.get("integration_id"),
-                )
-                self.on_delete_repository(repo)
-            except IntegrationError:
-                pass
-            return Response(
-                {"errors": {"__all__": "A repository with that name already exists"}}, status=400
-            )
+        repo_update_params = {
+            "external_id": result.get("external_id"),
+            "url": result.get("url"),
+            "config": result.get("config") or {},
+            "provider": self.id,
+            "integration_id": result.get("integration_id"),
+        }
+
+        # first check if there is a repository without an integration that matches
+        repo = Repository.objects.filter(
+            organization_id=organization.id, name=result["name"], integration_id=None
+        ).first()
+        if repo:
+            # update from params
+            for field_name, field_value in six.iteritems(repo_update_params):
+                setattr(repo, field_name, field_value)
+            # also update the status if it was in a bad state
+            repo.status = ObjectStatus.VISIBLE
+            repo.save()
         else:
-            repo_linked.send_robust(repo=repo, user=request.user, sender=self.__class__)
+            try:
+                with transaction.atomic():
+                    repo = Repository.objects.create(
+                        organization_id=organization.id, name=result["name"], **repo_update_params
+                    )
+            except IntegrityError:
+                # Try to delete webhook we just created
+                try:
+                    repo = Repository(
+                        organization_id=organization.id, name=result["name"], **repo_update_params
+                    )
+                    self.on_delete_repository(repo)
+                except IntegrationError:
+                    pass
+                return Response(
+                    {"errors": {"__all__": "A repository with that name already exists"}},
+                    status=400,
+                )
+            else:
+                repo_linked.send_robust(repo=repo, user=request.user, sender=self.__class__)
 
         analytics.record(
             "integration.repo.added",

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -8,6 +8,7 @@ from django.core.urlresolvers import reverse
 
 from sentry.constants import ObjectStatus
 from sentry.models import Integration, OrganizationIntegration, Repository
+from sentry.integrations.example import ExampleRepositoryProvider
 from sentry.plugins.providers.dummy.repository import DummyRepositoryProvider
 from sentry.testutils import APITestCase
 
@@ -198,3 +199,72 @@ class OrganizationRepositoriesCreateTest(APITestCase):
             response = self.client.post(url, data={"provider": "dummy", "name": "getsentry/sentry"})
 
         assert response.status_code == 403, (response.status_code, response.content)
+
+
+class OrganizationIntegrationRepositoriesCreateTest(APITestCase):
+    def setUp(self):
+        super(OrganizationIntegrationRepositoriesCreateTest, self).setUp()
+        self.org = self.create_organization(owner=self.user, name="baz")
+        self.integration = Integration.objects.create(provider="example")
+        self.integration.add_organization(self.org, self.user)
+        self.url = reverse("sentry-api-0-organization-repositories", args=[self.org.slug])
+        self.login_as(user=self.user)
+        self.repo_config_data = {
+            "integration_id": self.integration.id,
+            "external_id": "my_external_id",
+            "name": "getsentry/sentry",
+            "url": "https://github.com/getsentry/sentry",
+            "config": {"name": "getsentry/sentry"},
+        }
+
+    @patch.object(
+        ExampleRepositoryProvider, "get_repository_data", return_value={"my_config_key": "some_var"}
+    )
+    def test_simple(self, mock_build_repository_config):
+
+        with patch.object(
+            ExampleRepositoryProvider, "build_repository_config", return_value=self.repo_config_data
+        ) as mock_get_repository_data:
+            response = self.client.post(
+                self.url, data={"provider": "integrations:example", "name": "getsentry/sentry"}
+            )
+            mock_get_repository_data.assert_called_once_with(
+                organization=self.org, data={"my_config_key": "some_var"}
+            )
+
+        assert response.status_code == 201, (response.status_code, response.content)
+        assert response.data["id"]
+
+        repo = Repository.objects.get(id=response.data["id"])
+        assert repo.provider == "integrations:example"
+        assert repo.name == "getsentry/sentry"
+        assert repo.url == "https://github.com/getsentry/sentry"
+        assert repo.config == {"name": "getsentry/sentry"}
+
+    @patch.object(
+        ExampleRepositoryProvider, "get_repository_data", return_value={"my_config_key": "some_var"}
+    )
+    def test_floating_repo(self, mock_build_repository_config):
+        repo = Repository.objects.create(
+            organization_id=self.org.id, name="getsentry/sentry", status=2
+        )
+        with patch.object(
+            ExampleRepositoryProvider, "build_repository_config", return_value=self.repo_config_data
+        ) as mock_get_repository_data:
+            response = self.client.post(
+                self.url, data={"provider": "integrations:example", "name": "getsentry/sentry"}
+            )
+            mock_get_repository_data.assert_called_once_with(
+                organization=self.org, data={"my_config_key": "some_var"}
+            )
+
+        assert response.status_code == 201, (response.status_code, response.content)
+        assert response.data["id"]
+        assert response.data["id"] == six.text_type(repo.id)
+
+        repo = Repository.objects.get(id=response.data["id"])
+        assert repo.provider == "integrations:example"
+        assert repo.name == "getsentry/sentry"
+        assert repo.url == "https://github.com/getsentry/sentry"
+        assert repo.config == {"name": "getsentry/sentry"}
+        assert repo.status == 0


### PR DESCRIPTION
This PR handles the case where we have repositories that were generated from a `set_commits` operation but are not associated with any integration. See: https://github.com/getsentry/sentry/blob/382d958ad96f060186b21f985ef8a37dbed267e5/src/sentry/models/release.py#L434-L436

A user trying to add this repository to an integration like Github would get an `IntegrityError` because of the constraint on the organization and name. Before creating a new repository, we should query for a repository for that org/name combo that does not have an integration. If it exists, we update it with the parameters for that integration. If it doesn't exist, we just make a new repository.