### PR TITLE
ref(py3): Decode IngestConsumerWorker msgpack messages

### DIFF
--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -35,7 +35,7 @@ CACHE_TIMEOUT = 3600
 
 class IngestConsumerWorker(AbstractBatchWorker):
     def process_message(self, message):
-        message = msgpack.unpackb(message.value(), use_list=False)
+        message = msgpack.unpackb(message.value(), use_list=False, raw=False)
         return message
 
     def flush_batch(self, batch):


### PR DESCRIPTION
This sets `raw=False` the same way we did in 3cfd20f2ca for the grouping config messages between relay.

### I am opening this PR more for feedback than I am suggesting it is totally the correct thing.

I have my time split on a different project right now, so can't completely dedicate myself to verifying this.  However, someone who works more closely on relay may be able to.