### PR TITLE
feat(api-docs): Update api-docs derefed version

### DIFF
--- a/api-docs/paths/events/tag-details.json
+++ b/api-docs/paths/events/tag-details.json
@@ -40,12 +40,10 @@
                 }
               }
             },
-            "example": [
-              {
-                "key": "ice_cream",
-                "totalValues": 6
-              }
-            ]
+            "example": {
+              "key": "ice_cream",
+              "totalValues": 6
+            }
           }
         }
       },

--- a/tests/apidocs/openapi-derefed.json
+++ b/tests/apidocs/openapi-derefed.json
@@ -10000,12 +10000,10 @@
                     }
                   }
                 },
-                "example": [
-                  {
-                    "key": "ice_cream",
-                    "totalValues": 6
-                  }
-                ]
+                "example": {
+                  "key": "ice_cream",
+                  "totalValues": 6
+                }
               }
             }
           },


### PR DESCRIPTION
This PR updates the api-schema files to include the fix from https://github.com/getsentry/sentry-api-schema/pull/28 where the tag-details endpoint's response was the incorrect format.