### PR TITLE
ref(omni-search): Improve overflow + scrolling on omni search

### DIFF
--- a/src/sentry/static/sentry/app/components/search/index.jsx
+++ b/src/sentry/static/sentry/app/components/search/index.jsx
@@ -256,7 +256,8 @@ const DropdownBox = styled('div')`
   right: 0;
   width: 400px;
   border-radius: 5px;
-  overflow: hidden;
+  overflow: auto;
+  max-height: 60vh;
 `;
 
 const SearchWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
@@ -3,11 +3,17 @@ import {css} from '@emotion/core';
 import React from 'react';
 import omit from 'lodash/omit';
 
-const SearchResultWrapper = styled(props => <div {...omit(props, 'highlighted')} />)`
+const SearchResultWrapper = styled(props => (
+  <div
+    {...omit(props, 'highlighted')}
+    ref={element => props.highlighted && element?.scrollIntoView?.({block: 'nearest'})}
+  />
+))`
   cursor: pointer;
   display: block;
   color: ${p => p.theme.gray800};
   padding: 10px;
+  scroll-margin: 120px;
 
   ${p =>
     p.highlighted &&


### PR DESCRIPTION
Instead of the result list being unbounded in size, it will now shrink to around 60% of the window size, and you may scroll the results AND use the keyboard to scroll within the pane