### PR TITLE
feat(api-docs): Add tests for Teams endpoints

### DIFF
--- a/tests/apidocs/endpoints/teams/test-by-slug.py
+++ b/tests/apidocs/endpoints/teams/test-by-slug.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
+
+from tests.apidocs.util import APIDocsTestCase
+
+
+class TeamsBySlugDocs(APIDocsTestCase):
+    def setUp(self):
+        organization = self.create_organization()
+        team = self.create_team(organization=self.organization)
+
+        self.url = reverse(
+            "sentry-api-0-team-details",
+            kwargs={"organization_slug": organization.slug, "team_slug": team.slug},
+        )
+
+        self.login_as(user=self.user)
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        request = RequestFactory().get(self.url)
+
+        self.validate_schema(request, response)
+
+    def test_put(self):
+        data = {"name": "foo"}
+        response = self.client.put(self.url, data)
+        request = RequestFactory().put(self.url, data)
+
+        self.validate_schema(request, response)

--- a/tests/apidocs/endpoints/teams/test-index.py
+++ b/tests/apidocs/endpoints/teams/test-index.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
+
+from tests.apidocs.util import APIDocsTestCase
+
+
+class TeamsIndexDocs(APIDocsTestCase):
+    def setUp(self):
+        organization = self.create_organization()
+        self.create_team(organization=self.organization)
+
+        self.url = reverse(
+            "sentry-api-0-organization-teams", kwargs={"organization_slug": organization.slug},
+        )
+
+        self.login_as(user=self.user)
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        request = RequestFactory().get(self.url)
+
+        self.validate_schema(request, response)
+
+    def test_post(self):
+        data = {"name": "foo"}
+        response = self.client.post(self.url, data)
+        request = RequestFactory().post(self.url, data)
+
+        self.validate_schema(request, response)

--- a/tests/apidocs/endpoints/teams/test-projects.py
+++ b/tests/apidocs/endpoints/teams/test-projects.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
+
+from tests.apidocs.util import APIDocsTestCase
+
+
+class TeamsProjectsDocs(APIDocsTestCase):
+    def setUp(self):
+        organization = self.create_organization()
+        team = self.create_team(organization=self.organization)
+        self.create_project(name="foo", organization=organization, teams=[team])
+
+        self.url = reverse(
+            "sentry-api-0-team-project-index",
+            kwargs={"organization_slug": organization.slug, "team_slug": team.slug},
+        )
+
+        self.login_as(user=self.user)
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        request = RequestFactory().get(self.url)
+
+        self.validate_schema(request, response)
+
+    def test_post(self):
+        data = {"name": "foo"}
+        response = self.client.post(self.url, data)
+        request = RequestFactory().post(self.url, data)
+
+        self.validate_schema(request, response)

--- a/tests/apidocs/endpoints/teams/test-stats.py
+++ b/tests/apidocs/endpoints/teams/test-stats.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from django.test.client import RequestFactory
+
+from tests.apidocs.util import APIDocsTestCase
+
+
+class TeamsStatsDocs(APIDocsTestCase):
+    def setUp(self):
+        organization = self.create_organization()
+        team = self.create_team(organization=self.organization)
+        self.create_project(name="foo", organization=organization, teams=[team])
+
+        self.url = reverse(
+            "sentry-api-0-team-stats",
+            kwargs={"organization_slug": organization.slug, "team_slug": team.slug},
+        )
+
+        self.login_as(user=self.user)
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        request = RequestFactory().get(self.url)
+
+        self.validate_schema(request, response)

--- a/tests/apidocs/util.py
+++ b/tests/apidocs/util.py
@@ -13,9 +13,7 @@ from sentry.testutils import APITestCase
 
 class APIDocsTestCase(APITestCase):
     def create_schema(self):
-        path = os.path.join(
-            os.path.dirname(__file__), "..", "..", "api-docs", "openapi-derefed.json"
-        )
+        path = os.path.join(os.path.dirname(__file__), "openapi-derefed.json")
         with open(path, "r") as json_file:
             data = json.load(json_file)
             data["servers"][0]["url"] = settings.SENTRY_OPTIONS["system.url-prefix"]


### PR DESCRIPTION
This PR adds tests to the documented Teams endpoints for the API docs to ensure the schema is valid. 

Since `openapi-derefed.json` moved, this also updates the util to find it in its new location. 