### PR TITLE
fix(jira): adds CSP header

### DIFF
--- a/src/sentry/integrations/jira/ui_hook.py
+++ b/src/sentry/integrations/jira/ui_hook.py
@@ -19,7 +19,10 @@ class JiraUiHookView(View):
     def get_response(self, context):
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         res = render_to_response("sentry/integrations/jira-config.html", context, self.request)
+        # X-Frame-Options is a deprecated for content-securyity policy
+        # but omitting this field breaks could break in certain browsers because we will set it to deny elsewhere
         res["X-Frame-Options"] = "ALLOW-FROM %s" % self.request.GET["xdm_e"]
+        res["Content-Security-Policy"] = u"frame-ancestors %s" % self.request.GET["xdm_e"]
         return res
 
     def get(self, request, *args, **kwargs):

--- a/src/sentry/integrations/jira/ui_hook.py
+++ b/src/sentry/integrations/jira/ui_hook.py
@@ -19,9 +19,9 @@ class JiraUiHookView(View):
     def get_response(self, context):
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         res = render_to_response("sentry/integrations/jira-config.html", context, self.request)
-        # X-Frame-Options is a deprecated for content-securyity policy
-        # but omitting this field breaks could break in certain browsers because we will set it to deny elsewhere
-        res["X-Frame-Options"] = "ALLOW-FROM %s" % self.request.GET["xdm_e"]
+        # we aren't actually displaying it on the same page but we don't want to set it to deny
+        # which security.py will do
+        res["X-Frame-Options"] = "SAMEORIGIN"
         res["Content-Security-Policy"] = u"frame-ancestors %s" % self.request.GET["xdm_e"]
         return res
 


### PR DESCRIPTION
This is the second attempt to add the CSP header for the Jira UI hook (first attempt here https://github.com/getsentry/sentry/pull/20866). 

The header `X-Frame-Options` with the `ALLOW_FROM` block has been deprecated in supporting browsers in favor of the `Content-Security-Policy` header with the `frame-ancestors` block. A recent getsentry PR (getsentry/getsentry#4460) allows us to specify a block in the `Content-Security-Policy` header without it getting wiped out by getsentry.

I am keeping the `X-Frame-Options` header of `SAMEORIGIN` so we don't set it to `deny` later:
https://github.com/getsentry/sentry/blob/d71df7367678d9e04bd735b46dbb986992e2c511/src/sentry/middleware/security.py#L11-L12

I am a bit concerned some browser might not like the CSP header take priority over the `X-Frame-Options` header.
