### PR TITLE
feat(ui): Add header layout with tab nav story

### DIFF
--- a/docs-ui/components/layout-thirds.stories.js
+++ b/docs-ui/components/layout-thirds.stories.js
@@ -5,6 +5,8 @@ import {withInfo} from '@storybook/addon-info';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import Breadcrumbs from 'app/components/breadcrumbs';
+import NavTabs from 'app/components/navTabs';
+import Link from 'app/components/links/link';
 import * as Layout from 'app/components/layouts/thirds';
 import space from 'app/styles/space';
 
@@ -154,6 +156,47 @@ SingleColumnMode.story = {
   name: 'single column mode',
 };
 
+export const _6633WithTabNavigation = withInfo('Two column layout with tab navigation')(
+  () => (
+    <Container>
+      <BorderlessHeader>
+        <Layout.HeaderContent>
+          <Layout.Title>Alerts</Layout.Title>
+        </Layout.HeaderContent>
+        <Layout.HeaderActions>
+          <ButtonBar gap={1}>
+            <Button size="small">clicker</Button>
+            <Button size="small">clicker</Button>
+          </ButtonBar>
+        </Layout.HeaderActions>
+      </BorderlessHeader>
+      <TabLayoutHeader>
+        <StyledNavTabs underlined>
+          <li className="active">
+            <Link to="#">Active</Link>
+          </li>
+          <li>
+            <Link to="#">Inactive</Link>
+          </li>
+        </StyledNavTabs>
+      </TabLayoutHeader>
+      <Layout.Body>
+        <Layout.Main>
+          <h1>Content Region</h1>
+          <p>Some text here</p>
+        </Layout.Main>
+        <Layout.Side>
+          <h3>Sidebar content</h3>
+        </Layout.Side>
+      </Layout.Body>
+    </Container>
+  )
+);
+
+_6633WithTabNavigation.story = {
+  name: '66/33 with tab based nav',
+};
+
 const Container = styled('div')`
   background: ${p => p.theme.gray200};
   margin: ${space(2)};
@@ -162,4 +205,27 @@ const Container = styled('div')`
 
 const MarginedButtonBar = styled(ButtonBar)`
   margin-bottom: ${space(1)};
+`;
+
+const StyledNavTabs = styled(NavTabs)`
+  margin: 0;
+  border-bottom: 0 !important;
+  li {
+    margin-right: ${space(0.5)};
+  }
+  li > a {
+    padding: ${space(1)} ${space(2)};
+  }
+`;
+
+const BorderlessHeader = styled(Layout.Header)`
+  border-bottom: 0;
+`;
+
+const TabLayoutHeader = styled(Layout.Header)`
+  padding-top: 0;
+
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
+    padding-top: 0;
+  }
 `;

--- a/docs-ui/components/layout-thirds.stories.js
+++ b/docs-ui/components/layout-thirds.stories.js
@@ -5,7 +5,6 @@ import {withInfo} from '@storybook/addon-info';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import Breadcrumbs from 'app/components/breadcrumbs';
-import NavTabs from 'app/components/navTabs';
 import Link from 'app/components/links/link';
 import * as Layout from 'app/components/layouts/thirds';
 import space from 'app/styles/space';
@@ -161,7 +160,7 @@ export const _6633WithTabNavigation = withInfo('Two column layout with tab navig
     <Container>
       <BorderlessHeader>
         <Layout.HeaderContent>
-          <Layout.Title>Alerts</Layout.Title>
+          <StyledLayoutTitle>Alerts</StyledLayoutTitle>
         </Layout.HeaderContent>
         <Layout.HeaderActions>
           <ButtonBar gap={1}>
@@ -171,14 +170,14 @@ export const _6633WithTabNavigation = withInfo('Two column layout with tab navig
         </Layout.HeaderActions>
       </BorderlessHeader>
       <TabLayoutHeader>
-        <StyledNavTabs underlined>
+        <Layout.HeaderNavTabs underlined>
           <li className="active">
             <Link to="#">Active</Link>
           </li>
           <li>
             <Link to="#">Inactive</Link>
           </li>
-        </StyledNavTabs>
+        </Layout.HeaderNavTabs>
       </TabLayoutHeader>
       <Layout.Body>
         <Layout.Main>
@@ -207,15 +206,8 @@ const MarginedButtonBar = styled(ButtonBar)`
   margin-bottom: ${space(1)};
 `;
 
-const StyledNavTabs = styled(NavTabs)`
-  margin: 0;
-  border-bottom: 0 !important;
-  li {
-    margin-right: ${space(0.5)};
-  }
-  li > a {
-    padding: ${space(1)} ${space(2)};
-  }
+const StyledLayoutTitle = styled(Layout.Title)`
+  margin-top: ${space(0.5)};
 `;
 
 const BorderlessHeader = styled(Layout.Header)`

--- a/src/sentry/static/sentry/app/components/layouts/thirds.tsx
+++ b/src/sentry/static/sentry/app/components/layouts/thirds.tsx
@@ -7,10 +7,14 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
  * Base container for 66/33 containers.
  */
 export const Body = styled('div')`
-  padding: ${space(2)} ${space(4)};
+  padding: ${space(2)} ${space(2)};
   margin: 0;
   background-color: ${p => p.theme.white};
   flex-grow: 1;
+
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    padding: ${space(2)} ${space(4)};
+  }
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     display: grid;
@@ -93,6 +97,10 @@ export const Header = styled('div')`
 
   background-color: transparent;
   border-bottom: 1px solid ${p => p.theme.borderDark};
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    padding: ${space(2)} ${space(2)} 0 ${space(2)};
+  }
 
   @media (max-width: ${p => p.theme.breakpoints[1]}) {
     flex-direction: column;

--- a/src/sentry/static/sentry/app/components/layouts/thirds.tsx
+++ b/src/sentry/static/sentry/app/components/layouts/thirds.tsx
@@ -2,12 +2,13 @@ import styled from '@emotion/styled';
 
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
+import NavTabs from 'app/components/navTabs';
 
 /**
  * Base container for 66/33 containers.
  */
 export const Body = styled('div')`
-  padding: ${space(2)} ${space(2)};
+  padding: ${space(2)};
   margin: 0;
   background-color: ${p => p.theme.white};
   flex-grow: 1;
@@ -104,6 +105,20 @@ export const Header = styled('div')`
 
   @media (max-width: ${p => p.theme.breakpoints[1]}) {
     flex-direction: column;
+  }
+`;
+
+/**
+ * Styled Nav Tabs for use inside a Layout.Header component
+ */
+export const HeaderNavTabs = styled(NavTabs)`
+  margin: 0;
+  border-bottom: 0 !important;
+  li {
+    margin-right: ${space(0.5)};
+  }
+  li > a {
+    padding: ${space(1)} ${space(2)};
   }
 `;
 


### PR DESCRIPTION
Also slightly shrink thirds padding on mobile

We are using this layout on the new alerts page https://sentry.io/organizations/sentry/alerts/ and plan on using something similar for a new issues list page cc @robinrendle 

![image](https://user-images.githubusercontent.com/1400464/94213288-446b1880-fe8b-11ea-8607-7cdd84065511.png)

mobile
![image](https://user-images.githubusercontent.com/1400464/94213386-77ada780-fe8b-11ea-960b-f96009cfd18f.png)

