### PR TITLE
feat(trends): Add tooltip to baseline comparison

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -388,7 +388,10 @@ function TrendsListItem(props: TrendsListItemProps) {
             <ProjectAvatar project={project} />
           </Tooltip>
         )}
-        <CompareLink {...props} />
+
+        <Tooltip title={t('Compare baselines')}>
+          <CompareLink {...props} />
+        </Tooltip>
       </ItemTransactionDurationChange>
       <ItemTransactionStatus color={color}>
         {currentTrendFunction === TrendFunctionField.USER_MISERY ? (


### PR DESCRIPTION
### Summary
This adds a tooltip to indicate what the link does.

#### Screenshot
![Screen Shot 2020-09-24 at 5 58 34 PM](https://user-images.githubusercontent.com/6111995/94214960-ee4ca400-fe8f-11ea-991b-23f5c3eb8316.png)

VIS-158