### PR TITLE
ref(alert): Copy changes to alert rule form, removal of "The event occurs"

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -60,7 +60,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             data = serializer.validated_data
 
             # combine filters and conditions into one conditions criteria for the rule object
-            conditions = data["conditions"]
+            conditions = data.get("conditions", [])
             if "filters" in data:
                 conditions.extend(data["filters"])
 

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -71,7 +71,7 @@ class RuleSerializer(serializers.Serializer):
         choices=(("all", "all"), ("any", "any"), ("none", "none")), required=False
     )
     actions = ListField(child=RuleNodeField(type="action/event"))
-    conditions = ListField(child=RuleNodeField(type="condition/event"))
+    conditions = ListField(child=RuleNodeField(type="condition/event"), required=False)
     filters = ListField(child=RuleNodeField(type="filter/event"), required=False)
     frequency = serializers.IntegerField(min_value=5, max_value=60 * 24 * 30)
 
@@ -87,11 +87,6 @@ class RuleSerializer(serializers.Serializer):
             raise serializers.ValidationError(u"This environment has not been created.")
 
         return environment
-
-    def validate_conditions(self, value):
-        if not value:
-            raise serializers.ValidationError(u"Must select a condition.")
-        return value
 
     def validate_actions(self, value):
         if not value:

--- a/src/sentry/rules/conditions/every_event.py
+++ b/src/sentry/rules/conditions/every_event.py
@@ -8,3 +8,6 @@ class EveryEventCondition(EventCondition):
 
     def passes(self, event, state):
         return True
+
+    def is_enabled(self):
+        return False

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -503,18 +503,15 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                       />
                     </ChevronContainer>
 
-                    <StepContent>
-                      <StepLead>
-                        {tct(
-                          '[when:When] an event is captured by Sentry and [selector] of the following happens',
-                          {
-                            when: <Badge />,
-                            selector: (
-                              <Feature
-                                features={['projects:alert-filters']}
-                                project={project}
-                              >
-                                {({hasFeature}) => (
+                    <Feature features={['projects:alert-filters']} project={project}>
+                      {({hasFeature}) => (
+                        <StepContent>
+                          <StepLead>
+                            {tct(
+                              '[when:When] an event is captured by Sentry and [selector] of the following happens',
+                              {
+                                when: <Badge />,
+                                selector: (
                                   <EmbeddedWrapper>
                                     <EmbeddedSelectField
                                       className={classNames({
@@ -544,31 +541,35 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                                       disabled={!hasAccess}
                                     />
                                   </EmbeddedWrapper>
-                                )}
-                              </Feature>
-                            ),
-                          }
-                        )}
-                      </StepLead>
-                      <RuleNodeList
-                        nodes={this.state.configs?.conditions ?? null}
-                        items={conditions ?? []}
-                        placeholder={t('Add optional trigger...')}
-                        onPropertyChange={this.handleChangeConditionProperty}
-                        onAddRow={this.handleAddCondition}
-                        onDeleteRow={this.handleDeleteCondition}
-                        organization={organization}
-                        project={project}
-                        disabled={!hasAccess}
-                        error={
-                          this.hasError('conditions') && (
-                            <StyledAlert type="error">
-                              {this.state.detailedError?.conditions[0]}
-                            </StyledAlert>
-                          )
-                        }
-                      />
-                    </StepContent>
+                                ),
+                              }
+                            )}
+                          </StepLead>
+                          <RuleNodeList
+                            nodes={this.state.configs?.conditions ?? null}
+                            items={conditions ?? []}
+                            placeholder={
+                              hasFeature
+                                ? t('Add optional trigger...')
+                                : t('Add optional condition...')
+                            }
+                            onPropertyChange={this.handleChangeConditionProperty}
+                            onAddRow={this.handleAddCondition}
+                            onDeleteRow={this.handleDeleteCondition}
+                            organization={organization}
+                            project={project}
+                            disabled={!hasAccess}
+                            error={
+                              this.hasError('conditions') && (
+                                <StyledAlert type="error">
+                                  {this.state.detailedError?.conditions[0]}
+                                </StyledAlert>
+                              )
+                            }
+                          />
+                        </StepContent>
+                      )}
+                    </Feature>
                   </StepContainer>
                 </Step>
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -480,14 +480,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
             </Panel>
 
             <Panel>
-              <StyledPanelHeader>
-                {t('Alert Conditions')}
-                <PanelHelpText>
-                  {t(
-                    'Conditions are evaluated every time an event is captured by Sentry.'
-                  )}
-                </PanelHelpText>
-              </StyledPanelHeader>
+              <PanelHeader>{t('Alert Conditions')}</PanelHeader>
               <PanelBody>
                 {detailedError && (
                   <PanelAlert type="error">
@@ -513,7 +506,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                     <StepContent>
                       <StepLead>
                         {tct(
-                          '[when:When] an issue meets [selector] of the following conditions',
+                          '[when:When] an event is captured by Sentry and [selector] of the following happens',
                           {
                             when: <Badge />,
                             selector: (
@@ -560,7 +553,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                       <RuleNodeList
                         nodes={this.state.configs?.conditions ?? null}
                         items={conditions ?? []}
-                        placeholder={t('Add a condition...')}
+                        placeholder={t('Add optional trigger...')}
                         onPropertyChange={this.handleChangeConditionProperty}
                         onAddRow={this.handleAddCondition}
                         onDeleteRow={this.handleDeleteCondition}
@@ -600,7 +593,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
                       <StepContent>
                         <StepLead>
-                          {tct('[if:If] that issue has [selector] of these properties', {
+                          {tct('[if:If] [selector] of these filters match', {
                             if: <Badge />,
                             selector: (
                               <EmbeddedWrapper>
@@ -632,7 +625,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                         <RuleNodeList
                           nodes={this.state.configs?.filters ?? null}
                           items={filters ?? []}
-                          placeholder={t('Add a filter...')}
+                          placeholder={t('Add optional filter...')}
                           onPropertyChange={this.handleChangeFilterProperty}
                           onAddRow={this.handleAddFilter}
                           onDeleteRow={this.handleDeleteFilter}
@@ -672,7 +665,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                       <RuleNodeList
                         nodes={this.state.configs?.actions ?? null}
                         items={actions ?? []}
-                        placeholder={t('Add an action...')}
+                        placeholder={t('Add action...')}
                         onPropertyChange={this.handleChangeActionProperty}
                         onAddRow={this.handleAddAction}
                         onDeleteRow={this.handleDeleteAction}
@@ -721,19 +714,6 @@ export default withProject(withOrganization(IssueRuleEditor));
 
 const StyledForm = styled(Form)`
   position: relative;
-`;
-
-const StyledPanelHeader = styled(PanelHeader)`
-  flex-direction: column;
-  align-items: flex-start;
-`;
-
-const PanelHelpText = styled('div')`
-  color: ${p => p.theme.gray500};
-  font-size: 14px;
-  font-weight: normal;
-  text-transform: none;
-  margin-top: ${space(1)};
 `;
 
 const StyledAlert = styled(Alert)`

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -214,7 +214,7 @@ describe('ProjectAlertsCreate', function() {
         selectByValue(
           wrapper,
           'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
-          {selector: 'Select[placeholder="Add a condition..."]'}
+          {selector: 'Select[placeholder="Add optional trigger..."]'}
         );
 
         wrapper
@@ -227,7 +227,7 @@ describe('ProjectAlertsCreate', function() {
         selectByValue(
           wrapper,
           'sentry.rules.conditions.tagged_event.TaggedEventCondition',
-          {selector: 'Select[placeholder="Add a condition..."]'}
+          {selector: 'Select[placeholder="Add optional trigger..."]'}
         );
 
         // Edit new Condition
@@ -247,7 +247,7 @@ describe('ProjectAlertsCreate', function() {
         selectByValue(
           wrapper,
           'sentry.rules.filters.age_comparison.AgeComparisonFilter',
-          {selector: 'Select[placeholder="Add a filter..."]'}
+          {selector: 'Select[placeholder="Add optional filter..."]'}
         );
 
         wrapper
@@ -260,7 +260,7 @@ describe('ProjectAlertsCreate', function() {
         selectByValue(
           wrapper,
           'sentry.rules.filters.age_comparison.AgeComparisonFilter',
-          {selector: 'Select[placeholder="Add a filter..."]'}
+          {selector: 'Select[placeholder="Add optional filter..."]'}
         );
 
         const filterRuleNode = wrapper.find('RuleNode').at(1);
@@ -271,7 +271,7 @@ describe('ProjectAlertsCreate', function() {
 
         // Add an action and remove it
         selectByValue(wrapper, 'sentry.rules.actions.notify_event.NotifyEventAction', {
-          selector: 'Select[placeholder="Add an action..."]',
+          selector: 'Select[placeholder="Add action..."]',
         });
 
         wrapper
@@ -285,7 +285,7 @@ describe('ProjectAlertsCreate', function() {
           wrapper,
           'sentry.rules.actions.notify_event_service.NotifyEventServiceAction',
           {
-            selector: 'Select[placeholder="Add an action..."]',
+            selector: 'Select[placeholder="Add action..."]',
           }
         );
 

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -214,7 +214,7 @@ describe('ProjectAlertsCreate', function() {
         selectByValue(
           wrapper,
           'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
-          {selector: 'Select[placeholder="Add optional trigger..."]'}
+          {selector: 'Select[placeholder="Add optional condition..."]'}
         );
 
         wrapper
@@ -227,7 +227,7 @@ describe('ProjectAlertsCreate', function() {
         selectByValue(
           wrapper,
           'sentry.rules.conditions.tagged_event.TaggedEventCondition',
-          {selector: 'Select[placeholder="Add optional trigger..."]'}
+          {selector: 'Select[placeholder="Add optional condition..."]'}
         );
 
         // Edit new Condition


### PR DESCRIPTION
"The event occurs" condition is largely useless as an event must have occurred for an alert rule to even be evaluated. The inclusion of this condition may make customers believe that sentry won't even evaluate their alert rule unless this condition is explicitly supplied.

Disabled that condition (existing users with that condition in their rules will be unaffected but it is now unselectable for new rules) and also changed the wording of the form to make it clear the distinction between conditions (now referred to as triggers) and filters as per adi and robin's suggestions. 

Note: as a result of deleting "the event occurs" condition, I also made conditions optional, and if no conditions are set the rule still evaluates filters and triggers so long as the filters pass.

![image](https://user-images.githubusercontent.com/9372512/94215037-4f34a600-fea9-11ea-9312-1780c2fb498a.png)
