### PR TITLE
fix(consumers): Create topics automatically by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1874,6 +1874,9 @@ KAFKA_TOPICS = {
     KAFKA_INGEST_TRANSACTIONS: {"cluster": "default", "topic": KAFKA_INGEST_TRANSACTIONS},
 }
 
+# If True, consumers will create the topics if they don't exist
+KAFKA_CONSUMER_AUTO_CREATE_TOPICS = True
+
 # For Jira, only approved apps can use the access_email_addresses scope
 # This scope allows Sentry to use the email endpoint (https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-user-email-get)
 # We use the email with Jira 2-way sync in order to match the user

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -7,7 +7,9 @@ import msgpack
 import pytest
 import random
 
+from confluent_kafka import KafkaError
 from django.conf import settings
+from django.test import override_settings
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
@@ -87,13 +89,14 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
         producer.produce(topic_event_name, message)
         event_ids.add(event_id)
 
-    consumer = get_ingest_consumer(
-        max_batch_size=2,
-        max_batch_time=5000,
-        group_id=group_id,
-        consumer_types=set([ConsumerType.Events]),
-        auto_offset_reset="earliest",
-    )
+    with override_settings(KAFKA_CONSUMER_AUTO_CREATE_TOPICS=True):
+        consumer = get_ingest_consumer(
+            max_batch_size=2,
+            max_batch_time=5000,
+            group_id=group_id,
+            consumer_types=set([ConsumerType.Events]),
+            auto_offset_reset="earliest",
+        )
 
     with task_runner():
         i = 0
@@ -114,3 +117,28 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
             assert message.data["contexts"]["trace"]
         else:
             assert message.data["extra"]["the_id"] == event_id
+
+
+def test_ingest_consumer_fails_when_not_autocreating_topics(
+    kafka_admin, requires_kafka,
+):
+    group_id = "test-consumer-{}".format(random.randint(0, 2 ** 16))
+    topic_event_name = ConsumerType.get_topic_name(ConsumerType.Events)
+
+    admin = kafka_admin(settings)
+    admin.delete_topic(topic_event_name)
+
+    with override_settings(KAFKA_CONSUMER_AUTO_CREATE_TOPICS=False):
+        consumer = get_ingest_consumer(
+            max_batch_size=2,
+            max_batch_time=5000,
+            group_id=group_id,
+            consumer_types=set([ConsumerType.Events]),
+            auto_offset_reset="earliest",
+        )
+
+    with pytest.raises(Exception) as err:
+        consumer._run_once()
+
+    kafka_error = err.value.args[0]
+    assert kafka_error.code() == KafkaError.UNKNOWN_TOPIC_OR_PART

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -70,36 +70,6 @@ def get_test_message(request, default_project):
     return inner
 
 
-def _wait_for_topic(admin_client, topic_name, timeout=5):
-    """
-    Wait until the given topic is in operable state
-    """
-    from confluent_kafka import KafkaError
-
-    start = time.time()
-    last_error = None
-
-    while True:
-        if time.time() > start + timeout:
-            raise Exception(
-                "Timeout when waiting for Kafka topic to become available, last error: {}".format(
-                    last_error
-                )
-            )
-
-        result = admin_client.list_topics(topic=topic_name)
-        topic_metadata = result.topics[topic_name]
-        if topic_metadata.error in {
-            KafkaError.UNKNOWN_TOPIC_OR_PART,
-            KafkaError.LEADER_NOT_AVAILABLE,
-        }:
-            last_error = topic_metadata.error
-            time.sleep(0.1)
-            continue
-        else:
-            break
-
-
 @pytest.mark.django_db(transaction=True)
 def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
     task_runner, kafka_producer, kafka_admin, requires_kafka, default_project, get_test_message,
@@ -116,8 +86,6 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
         message, event_id = get_test_message()
         producer.produce(topic_event_name, message)
         event_ids.add(event_id)
-
-    _wait_for_topic(admin.admin_client, topic_event_name)
 
     consumer = get_ingest_consumer(
         max_batch_size=2,


### PR DESCRIPTION
Fixes the issue introduced by #20208, when some ingest topics are not created automatically.
Relevant for local development and onpremise.