### PR TITLE
fix(trends): Fix trends breaking on custom periods

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/changedProjects.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedProjects.tsx
@@ -82,9 +82,10 @@ function getDescription(
     absoluteChange < 1000 ? 0 : 2
   );
 
-  const period = trendView.statsPeriod
-    ? DEFAULT_RELATIVE_PERIODS[trendView.statsPeriod].toLowerCase()
-    : t('given timeframe');
+  const period =
+    trendView.statsPeriod && DEFAULT_RELATIVE_PERIODS[trendView.statsPeriod]
+      ? DEFAULT_RELATIVE_PERIODS[trendView.statsPeriod].toLowerCase()
+      : t('given timeframe');
 
   const improvedTemplate =
     'In the [period], [project] sped up by [absoluteChangeDuration] (a [percent] decrease in duration). See the top transactions that made that happen.';


### PR DESCRIPTION
This fixes an issue with using a custom periods with trends

Fixes JAVASCRIPT-22W6