### PR TITLE
fix: Remove extra dash

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -43,7 +43,7 @@ jobs:
         cp sentry/api-docs/openapi-derefed.json sentry-api-schema
 
     - name: Git Commit & Push
-    - uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v4
       with:
         branch: main
         commit_message: Generated


### PR DESCRIPTION
## Objective
When https://github.com/getsentry/sentry/pull/20895 got merged, we had the following error:
<img width="544" alt="Screen Shot 2020-09-25 at 10 21 27 AM" src="https://user-images.githubusercontent.com/10491193/94297238-0caab200-ff19-11ea-90ef-9800885515e5.png">

This PR fixes that.