### PR TITLE
fix: Correct filepath for build artifact

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         cd sentry
         yarn install --frozen-lockfile
-        yarn run build-derefed-docs sentry/api-docs/openapi-derefed.json
+        yarn run build-derefed-docs api-docs/openapi-derefed.json
 
     - name: Copy artifact into getsentry/sentry-api-schema
       run: |


### PR DESCRIPTION
## Objective 
Fixes the following problem:
<img width="888" alt="Screen Shot 2020-09-25 at 11 21 38 AM" src="https://user-images.githubusercontent.com/10491193/94302609-539ca580-ff21-11ea-8698-623731a0566f.png">
