### PR TITLE
feat(workflow): Dynamic counts redesign

### DIFF
--- a/src/sentry/static/sentry/app/components/barChart.tsx
+++ b/src/sentry/static/sentry/app/components/barChart.tsx
@@ -15,7 +15,7 @@ const BarChart = ({points = [], secondaryPoints = [], ...rest}: Props) => {
   const formattedPoints = points.map(point => ({
     x: point.x,
     y: [point.y],
-    color: secondaryPoints.length ? theme.gray500 : undefined,
+    color: theme.purple400,
   }));
   const formattedSecondaryPoints = secondaryPoints.map(point => ({
     x: point.x,

--- a/src/sentry/static/sentry/app/components/barChart.tsx
+++ b/src/sentry/static/sentry/app/components/barChart.tsx
@@ -15,7 +15,7 @@ const BarChart = ({points = [], secondaryPoints = [], ...rest}: Props) => {
   const formattedPoints = points.map(point => ({
     x: point.x,
     y: [point.y],
-    color: theme.purple400,
+    color: secondaryPoints.length ? theme.purple400 : undefined,
   }));
   const formattedSecondaryPoints = secondaryPoints.map(point => ({
     x: point.x,

--- a/src/sentry/static/sentry/app/components/stackedBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.tsx
@@ -371,7 +371,7 @@ class StackedBarChart extends React.Component<Props, State> {
       const pct2 = y2 && calcPct(y2, i);
 
       const pt = (
-        <RectGroup key={i}>
+        <RectGroup key={i} showSecondaryPoints={showSecondaryPoints}>
           <rect
             x={index * pointWidth + '%'}
             y={100.0 - pct - prevPct + '%'}
@@ -543,8 +543,8 @@ const CircleSvg = styled('svg')<{size: number; offset: number; left: number}>`
   }
 `;
 
-const RectGroup = styled('g')`
-  opacity: 0.7;
+const RectGroup = styled('g')<{showSecondaryPoints: boolean}>`
+  opacity: ${p => (p.showSecondaryPoints ? 0.7 : 1)};
 
   &:hover {
     opacity: 1;

--- a/src/sentry/static/sentry/app/components/stackedBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.tsx
@@ -371,7 +371,7 @@ class StackedBarChart extends React.Component<Props, State> {
       const pct2 = y2 && calcPct(y2, i);
 
       const pt = (
-        <React.Fragment key={i}>
+        <RectGroup key={i}>
           <rect
             x={index * pointWidth + '%'}
             y={100.0 - pct - prevPct + '%'}
@@ -402,7 +402,7 @@ class StackedBarChart extends React.Component<Props, State> {
               {y2}
             </rect>
           )}
-        </React.Fragment>
+        </RectGroup>
       );
       prevPct += pct;
       if (pct2) prevPct2 += pct2;
@@ -540,6 +540,14 @@ const CircleSvg = styled('svg')<{size: number; offset: number; left: number}>`
 
   &:hover circle {
     fill: ${p => p.theme.purple400};
+  }
+`;
+
+const RectGroup = styled('g')`
+  opacity: 0.7;
+
+  &:hover {
+    opacity: 1;
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/stackedBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.tsx
@@ -33,7 +33,7 @@ type DefaultProps = {
    */
   points: Points;
   secondaryPoints: Points;
-  showSecondaryPoints?: boolean;
+  showSecondaryPoints: boolean;
   series: Series;
   markers: Marker[];
   barClasses: string[];
@@ -107,6 +107,7 @@ class StackedBarChart extends React.Component<Props, State> {
     label: '',
     points: [],
     secondaryPoints: [],
+    showSecondaryPoints: false,
     series: [],
     markers: [],
     barClasses: ['chart-bar'],

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -189,7 +189,7 @@ const StreamGroup = createReactClass({
     const {period, start, end} = selection.datetime || {};
     const summary =
       !!start && !!end
-        ? 'the selected period'
+        ? 'time range'
         : getRelativeSummary(period || DEFAULT_STATS_PERIOD).toLowerCase();
 
     const primaryCount =
@@ -237,7 +237,7 @@ const StreamGroup = createReactClass({
             {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
               const topLevelCx = classNames('dropdown', {
                 'anchor-middle': true,
-                open: isOpen,
+                open: isOpen && hasDynamicIssueCounts,
               });
 
               return (
@@ -257,38 +257,32 @@ const StreamGroup = createReactClass({
                       )}
                     </div>
                   </span>
-                  {isOpen && (
-                    <ul {...getMenuProps({className: 'dropdown-menu inverted'})}>
-                      {data.filtered && (
-                        <React.Fragment>
-                          <StyledMenuItem to={this.getDiscoverUrl(true)}>
-                            <MenuItemText>{t('Matching search filters')}</MenuItemText>
-                            <MenuItemCount value={data.filtered.count} />
-                          </StyledMenuItem>
-                          <MenuItem divider />
-                        </React.Fragment>
-                      )}
+                  <ul {...getMenuProps({className: 'dropdown-menu inverted'})}>
+                    {data.filtered && (
+                      <React.Fragment>
+                        <StyledMenuItem to={this.getDiscoverUrl(true)}>
+                          <MenuItemText>{t('Matching search filters')}</MenuItemText>
+                          <MenuItemCount value={data.filtered.count} />
+                        </StyledMenuItem>
+                        <MenuItem divider />
+                      </React.Fragment>
+                    )}
 
-                      <StyledMenuItem to={this.getDiscoverUrl()}>
-                        <MenuItemText>
-                          {data.filtered
-                            ? t(`Without search filters`)
-                            : t(`In ${summary}`)}
-                        </MenuItemText>
-                        <MenuItemCount value={data.count} />
-                      </StyledMenuItem>
+                    <StyledMenuItem to={this.getDiscoverUrl()}>
+                      <MenuItemText>{t(`Total in ${summary}`)}</MenuItemText>
+                      <MenuItemCount value={data.count} />
+                    </StyledMenuItem>
 
-                      {data.lifetime && (
-                        <React.Fragment>
-                          <MenuItem divider />
-                          <StyledMenuItem>
-                            <MenuItemText>{t('Since issue began')}</MenuItemText>
-                            <MenuItemCount value={data.lifetime.count} />
-                          </StyledMenuItem>
-                        </React.Fragment>
-                      )}
-                    </ul>
-                  )}
+                    {data.lifetime && (
+                      <React.Fragment>
+                        <MenuItem divider />
+                        <StyledMenuItem>
+                          <MenuItemText>{t('Since issue began')}</MenuItemText>
+                          <MenuItemCount value={data.lifetime.count} />
+                        </StyledMenuItem>
+                      </React.Fragment>
+                    )}
+                  </ul>
                 </span>
               );
             }}
@@ -299,7 +293,7 @@ const StreamGroup = createReactClass({
             {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
               const topLevelCx = classNames('dropdown', {
                 'anchor-middle': true,
-                open: isOpen,
+                open: isOpen && hasDynamicIssueCounts,
               });
 
               return (
@@ -316,38 +310,32 @@ const StreamGroup = createReactClass({
                       )}
                     </div>
                   </span>
-                  {isOpen && (
-                    <ul {...getMenuProps({className: 'dropdown-menu inverted'})}>
-                      {data.filtered && (
-                        <React.Fragment>
-                          <StyledMenuItem to={this.getDiscoverUrl(true)}>
-                            <MenuItemText>{t('Matching search filters')}</MenuItemText>
-                            <MenuItemCount value={data.filtered.userCount} />
-                          </StyledMenuItem>
-                          <MenuItem divider />
-                        </React.Fragment>
-                      )}
+                  <ul {...getMenuProps({className: 'dropdown-menu inverted'})}>
+                    {data.filtered && (
+                      <React.Fragment>
+                        <StyledMenuItem to={this.getDiscoverUrl(true)}>
+                          <MenuItemText>{t('Matching search filters')}</MenuItemText>
+                          <MenuItemCount value={data.filtered.userCount} />
+                        </StyledMenuItem>
+                        <MenuItem divider />
+                      </React.Fragment>
+                    )}
 
-                      <StyledMenuItem to={this.getDiscoverUrl()}>
-                        <MenuItemText>
-                          {data.filtered
-                            ? t(`Without search filters`)
-                            : t(`In ${summary}`)}
-                        </MenuItemText>
-                        <MenuItemCount value={data.userCount} />
-                      </StyledMenuItem>
+                    <StyledMenuItem to={this.getDiscoverUrl()}>
+                      <MenuItemText>{t(`Total in ${summary}`)}</MenuItemText>
+                      <MenuItemCount value={data.userCount} />
+                    </StyledMenuItem>
 
-                      {data.lifetime && (
-                        <React.Fragment>
-                          <MenuItem divider />
-                          <StyledMenuItem>
-                            <MenuItemText>{t('Since issue began')}</MenuItemText>
-                            <MenuItemCount value={data.lifetime.userCount} />
-                          </StyledMenuItem>
-                        </React.Fragment>
-                      )}
-                    </ul>
-                  )}
+                    {data.lifetime && (
+                      <React.Fragment>
+                        <MenuItem divider />
+                        <StyledMenuItem>
+                          <MenuItemText>{t('Since issue began')}</MenuItemText>
+                          <MenuItemCount value={data.lifetime.userCount} />
+                        </StyledMenuItem>
+                      </React.Fragment>
+                    )}
+                  </ul>
                 </span>
               );
             }}

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -6,25 +6,25 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import styled from '@emotion/styled';
+import classNames from 'classnames';
 
 import {PanelItem} from 'app/components/panels';
 import {valueIsEqual} from 'app/utils';
-import theme from 'app/utils/theme';
-import {IconOpen} from 'app/icons';
 import AssigneeSelector from 'app/components/assigneeSelector';
 import Count from 'app/components/count';
+import DropdownMenu from 'app/components/dropdownMenu';
 import EventOrGroupExtraDetails from 'app/components/eventOrGroupExtraDetails';
 import EventOrGroupHeader from 'app/components/eventOrGroupHeader';
 import GroupChart from 'app/components/stream/groupChart';
 import GroupCheckBox from 'app/components/stream/groupCheckBox';
 import GroupStore from 'app/stores/groupStore';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
+import MenuItem from 'app/components/menuItem';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import space from 'app/styles/space';
-import Tooltip from 'app/components/tooltip';
 import SentryTypes from 'app/sentryTypes';
 import {getRelativeSummary} from 'app/components/organizations/timeRangeSelector/utils';
-import {DEFAULT_STATS_PERIOD, MENU_CLOSE_DELAY} from 'app/constants';
+import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import EventView from 'app/utils/discover/eventView';
@@ -68,7 +68,6 @@ const StreamGroup = createReactClass({
         ...data,
         filtered: this.props.useFilteredStats ? data.filtered : undefined,
       },
-      showLifetimeStats: false,
     };
   },
 
@@ -95,7 +94,7 @@ const StreamGroup = createReactClass({
     if (!valueIsEqual(this.state.data, nextState.data)) {
       return true;
     }
-    return this.state.showLifetimeStats !== nextState.showLifetimeStats;
+    return false;
   },
 
   componentWillUnmount() {
@@ -127,22 +126,11 @@ const StreamGroup = createReactClass({
     SelectedGroupStore.toggleSelect(this.state.data.id);
   },
 
-  toggleShowLifetimeStats(showLifetimeStats) {
-    if (this.hoverWait) {
-      clearTimeout(this.hoverWait);
-    }
-
-    this.hoverWait = setTimeout(
-      () => this.setState({showLifetimeStats}),
-      MENU_CLOSE_DELAY
-    );
-
-    this.setState({showLifetimeStats});
-  },
-
   getDiscoverUrl(filtered) {
     const {organization, query, selection} = this.props;
     const {data} = this.state;
+
+    // TODO: @taylangocmen when there is no discover query open events page
 
     const {period, start, end} = selection.datetime || {};
 
@@ -184,7 +172,7 @@ const StreamGroup = createReactClass({
   },
 
   render() {
-    const {data, showLifetimeStats} = this.state;
+    const {data} = this.state;
     const {
       query,
       hasGuideAnchor,
@@ -197,15 +185,12 @@ const StreamGroup = createReactClass({
     } = this.props;
 
     const hasDynamicIssueCounts = organization.features.includes('dynamic-issue-counts');
-    const hasDiscoverQuery = organization.features.includes('discover-basic');
 
     const {period, start, end} = selection.datetime || {};
     const summary =
       !!start && !!end
         ? 'the selected period'
         : getRelativeSummary(period || DEFAULT_STATS_PERIOD).toLowerCase();
-
-    const popperStyle = {maxWidth: 'none'};
 
     const primaryCount =
       data.filtered && hasDynamicIssueCounts ? data.filtered.count : data.count;
@@ -216,28 +201,12 @@ const StreamGroup = createReactClass({
     const secondaryUserCount =
       data.filtered && hasDynamicIssueCounts ? data.userCount : undefined;
 
-    const mouseEventHandlers = hasDynamicIssueCounts
-      ? {
-          onMouseEnter: () => this.toggleShowLifetimeStats(true),
-          onMouseLeave: () => this.toggleShowLifetimeStats(false),
-        }
-      : {};
-
-    // TODO: @taylangocmen discover links on telescopes
-    // TODO: @taylangocmen sort rows when clicked on a column
-    // TODO: @taylangocmen onboarding callouts when for when feature ships
-
     const showSecondaryPoints = Boolean(
-      showLifetimeStats &&
-        withChart &&
-        data &&
-        data.filtered &&
-        hasDynamicIssueCounts &&
-        statsPeriod
+      withChart && data && data.filtered && hasDynamicIssueCounts && statsPeriod
     );
 
     return (
-      <Group data-test-id="group" onClick={this.toggleSelect} {...mouseEventHandlers}>
+      <Group data-test-id="group" onClick={this.toggleSelect}>
         {canSelect && (
           <GroupCheckbox ml={2}>
             <GroupCheckBox id={data.id} />
@@ -264,90 +233,125 @@ const StreamGroup = createReactClass({
           </Box>
         )}
         <Flex width={[40, 60, 80, 80]} mx={2} justifyContent="flex-end">
-          <Tooltip
-            disabled={!hasDynamicIssueCounts}
-            popperStyle={popperStyle}
-            isHoverable
-            title={
-              <TooltipContent>
-                {data.filtered && (
-                  <tr>
-                    <TooltipCount value={data.filtered.count} />
-                    <TooltipText>{t('Matching search filters')}</TooltipText>
-                    {hasDiscoverQuery && (
-                      <StyledIconOpen
-                        to={this.getDiscoverUrl(true)}
-                        color={theme.blue300}
+          <DropdownMenu isNestedDropdown>
+            {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
+              const topLevelCx = classNames('dropdown', {
+                'anchor-middle': true,
+                open: isOpen,
+              });
+
+              return (
+                <span
+                  {...getRootProps({
+                    className: topLevelCx,
+                  })}
+                >
+                  <span {...getActorProps({})}>
+                    <div className="dropdown-actor-title">
+                      <PrimaryCount
+                        value={primaryCount}
+                        filtered={secondaryCount !== undefined}
                       />
-                    )}
-                  </tr>
-                )}
-                <tr>
-                  <TooltipCount value={data.count} />
-                  <TooltipText>
-                    {data.filtered ? t(`Without search filters`) : t(`In ${summary}`)}
-                  </TooltipText>
-                  {hasDiscoverQuery && (
-                    <StyledIconOpen to={this.getDiscoverUrl()} color={theme.blue300} />
+                      {secondaryCount !== undefined && (
+                        <SecondaryCount value={secondaryCount} />
+                      )}
+                    </div>
+                  </span>
+                  {isOpen && (
+                    <ul {...getMenuProps({className: 'dropdown-menu inverted'})}>
+                      {data.filtered && (
+                        <React.Fragment>
+                          <StyledMenuItem to={this.getDiscoverUrl(true)}>
+                            <MenuItemText>{t('Matching search filters')}</MenuItemText>
+                            <MenuItemCount value={data.filtered.count} />
+                          </StyledMenuItem>
+                          <MenuItem divider />
+                        </React.Fragment>
+                      )}
+
+                      <StyledMenuItem to={this.getDiscoverUrl()}>
+                        <MenuItemText>
+                          {data.filtered
+                            ? t(`Without search filters`)
+                            : t(`In ${summary}`)}
+                        </MenuItemText>
+                        <MenuItemCount value={data.count} />
+                      </StyledMenuItem>
+
+                      {data.lifetime && (
+                        <React.Fragment>
+                          <MenuItem divider />
+                          <StyledMenuItem>
+                            <MenuItemText>{t('Since issue began')}</MenuItemText>
+                            <MenuItemCount value={data.lifetime.count} />
+                          </StyledMenuItem>
+                        </React.Fragment>
+                      )}
+                    </ul>
                   )}
-                </tr>
-                {data.lifetime && (
-                  <tr>
-                    <TooltipCount value={data.lifetime.count} />
-                    <TooltipText>{t('Since issue began')}</TooltipText>
-                  </tr>
-                )}
-              </TooltipContent>
-            }
-          >
-            <PrimaryCount value={primaryCount} />
-            {showLifetimeStats && secondaryCount !== undefined && (
-              <SecondaryCount value={secondaryCount} />
-            )}
-          </Tooltip>
+                </span>
+              );
+            }}
+          </DropdownMenu>
         </Flex>
         <Flex width={[40, 60, 80, 80]} mx={2} justifyContent="flex-end">
-          <Tooltip
-            disabled={!hasDynamicIssueCounts}
-            popperStyle={popperStyle}
-            isHoverable
-            title={
-              <TooltipContent>
-                {data.filtered && (
-                  <tr>
-                    <TooltipCount value={data.filtered.userCount} />
-                    <TooltipText>{t('Matching search filters')}</TooltipText>
-                    {hasDiscoverQuery && (
-                      <StyledIconOpen
-                        to={this.getDiscoverUrl(true)}
-                        color={theme.blue300}
-                      />
-                    )}
-                  </tr>
-                )}
-                <tr>
-                  <TooltipCount value={data.userCount} />
-                  <TooltipText>
-                    {data.filtered ? t(`Without search filters`) : t(`In ${summary}`)}
-                  </TooltipText>
-                  {hasDiscoverQuery && (
-                    <StyledIconOpen to={this.getDiscoverUrl()} color={theme.blue300} />
+          <DropdownMenu isNestedDropdown>
+            {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
+              const topLevelCx = classNames('dropdown', {
+                'anchor-middle': true,
+                open: isOpen,
+              });
+
+              return (
+                <span
+                  {...getRootProps({
+                    className: topLevelCx,
+                  })}
+                >
+                  <span {...getActorProps({})}>
+                    <div className="dropdown-actor-title">
+                      <PrimaryCount value={primaryUserCount} />
+                      {secondaryUserCount !== undefined && (
+                        <SecondaryCount dark value={secondaryUserCount} />
+                      )}
+                    </div>
+                  </span>
+                  {isOpen && (
+                    <ul {...getMenuProps({className: 'dropdown-menu inverted'})}>
+                      {data.filtered && (
+                        <React.Fragment>
+                          <StyledMenuItem to={this.getDiscoverUrl(true)}>
+                            <MenuItemText>{t('Matching search filters')}</MenuItemText>
+                            <MenuItemCount value={data.filtered.userCount} />
+                          </StyledMenuItem>
+                          <MenuItem divider />
+                        </React.Fragment>
+                      )}
+
+                      <StyledMenuItem to={this.getDiscoverUrl()}>
+                        <MenuItemText>
+                          {data.filtered
+                            ? t(`Without search filters`)
+                            : t(`In ${summary}`)}
+                        </MenuItemText>
+                        <MenuItemCount value={data.userCount} />
+                      </StyledMenuItem>
+
+                      {data.lifetime && (
+                        <React.Fragment>
+                          <MenuItem divider />
+                          <StyledMenuItem>
+                            <MenuItemText>{t('Since issue began')}</MenuItemText>
+                            <MenuItemCount value={data.lifetime.userCount} />
+                          </StyledMenuItem>
+                        </React.Fragment>
+                      )}
+                    </ul>
                   )}
-                </tr>
-                {data.lifetime && (
-                  <tr>
-                    <TooltipCount value={data.lifetime.userCount} />
-                    <TooltipText>{t('Since issue began')}</TooltipText>
-                  </tr>
-                )}
-              </TooltipContent>
-            }
-          >
-            <PrimaryCount value={primaryUserCount} />
-            {showLifetimeStats && secondaryUserCount !== undefined && (
-              <SecondaryCount value={secondaryUserCount} />
-            )}
-          </Tooltip>
+                </span>
+              );
+            }}
+          </DropdownMenu>
         </Flex>
         <Box width={80} mx={2} className="hidden-xs hidden-sm">
           <AssigneeSelector id={data.id} memberList={memberList} />
@@ -377,51 +381,53 @@ const GroupCheckbox = styled(Box)`
 
 const PrimaryCount = styled(Count)`
   font-size: ${p => p.theme.fontSizeExtraLarge};
-  color: ${p => p.theme.gray700};
+  color: ${p => (p.filtered ? p.theme.purple400 : p.theme.gray700)};
 `;
 
 const SecondaryCount = styled(({value, ...p}) => <Count {...p} value={value} />)`
-  position: absolute;
   font-size: ${p => p.theme.fontSizeExtraLarge};
-  color: ${p => p.theme.gray500};
+  color: ${p => (p.dark ? p.theme.gray700 : p.theme.gray500)};
 
   :before {
     content: '/';
+    color: ${p => p.theme.gray500};
   }
 `;
 
-const TooltipContent = styled(({children, ...p}) => (
-  <table {...p}>
-    <tbody>{children}</tbody>
-  </table>
+const StyledMenuItem = styled(({to, children, ...p}) => (
+  <MenuItem noAnchor>
+    {to ? (
+      <Link to={to}>
+        <div {...p}>{children}</div>
+      </Link>
+    ) : (
+      <div className="dropdown-toggle">
+        <div {...p}>{children}</div>
+      </div>
+    )}
+  </MenuItem>
 ))`
   margin: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 `;
 
-const TooltipCount = styled(({value, ...p}) => (
-  <td {...p}>
+const MenuItemCount = styled(({value, ...p}) => (
+  <div {...p}>
     <Count value={value} />
-  </td>
+  </div>
 ))`
   text-align: right;
   font-weight: bold;
-  padding: ${space(0.5)};
+  padding-left: ${space(1)};
 `;
 
-const TooltipText = styled('td')`
+const MenuItemText = styled('div')`
+  white-space: nowrap;
   font-weight: normal;
   text-align: left;
-  padding: ${space(0.5)} ${space(1)};
-`;
-
-const StyledIconOpen = styled(({to, ...p}) => (
-  <td {...p}>
-    <Link title={t('Open in Discover')} to={to} target="_blank">
-      <IconOpen size="xs" color={p.color} />
-    </Link>
-  </td>
-))`
-  padding: ${space(0.5)};
+  padding-right: ${space(1)};
 `;
 
 export default withGlobalSelection(withOrganization(StreamGroup));

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1234,6 +1234,11 @@ header + .alert {
   background-clip: padding-box;
   color: @gray-darker;
 
+  &.inverted {
+    top: auto;
+    bottom: 32px;
+  }
+
   &:after {
     width: 0;
     height: 0;
@@ -1248,6 +1253,13 @@ header + .alert {
     z-index: -1;
   }
 
+  &.inverted:after {
+    border-top: 8px solid #fff;
+    border-bottom: 8px solid transparent;
+    top: auto;
+    bottom: -16px;
+  }
+
   &:before {
     width: 0;
     height: 0;
@@ -1260,6 +1272,13 @@ header + .alert {
     top: -9px;
     left: 11px;
     z-index: -2;
+  }
+
+  &.inverted:before {
+    border-top: 9px solid rgba(52, 60, 69, 0.35);
+    border-bottom: 9px solid transparent;
+    top: auto;
+    bottom: -18px;
   }
 
   &.dropdown-menu-right {
@@ -1305,6 +1324,25 @@ header + .alert {
       // top caret
       left: auto;
       right: 11px;
+    }
+  }
+}
+
+.anchor-middle {
+  .dropdown-menu {
+    left: auto;
+    right: 50%;
+    transform: translateX(calc(50%));
+
+    &:after {
+      left: calc(50% - 5px);
+      right: auto;
+    }
+
+    &:before {
+      // top caret
+      left: calc(50% - 6px);
+      right: auto;
     }
   }
 }


### PR DESCRIPTION
This changes dynamic counts in the issue stream:

Changes from [WOR-254](https://getsentry.atlassian.net/browse/WOR-254)
- Made the hover state, showing filtered stats / filtered results in the bar chart, persistent, used to be on hover we would toggle those

Changes from [WOR-266](https://getsentry.atlassian.net/browse/WOR-266)
- Changed the color of the filtered stats, events w/ 2 different colors, users with a single color
- Changed the color of the bars of the chart
- When you are not hovering on a bar, opacity is 0.7, when you are it is 1, so that it is clear which bar you are hovering on
- Changed the tooltip to be a dropdown menu to copy the style
  - Added the middle caret option to dropdown menu
  - Added the inverted style to expand the menu up
- Changed the tooltip text a bit 

![Screen Shot 2020-09-25 at 2 24 30 PM](https://user-images.githubusercontent.com/15015880/94317290-d54cfd00-ff3a-11ea-8ff1-245583c177cc.png)


Resolves: 
[WOR-254](https://getsentry.atlassian.net/browse/WOR-254)
[WOR-266](https://getsentry.atlassian.net/browse/WOR-266)