### PR TITLE
fix(tests): Fix unstable `test_multi_project` test

### DIFF
--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -415,7 +415,7 @@ class AlertRuleFetchForOrganizationTest(TestCase):
         assert [alert_rule1] == list(
             AlertRule.objects.fetch_for_organization(self.organization, [self.project])
         )
-        assert [alert_rule1, alert_rule2] == list(
+        assert set([alert_rule1, alert_rule2]) == set(
             AlertRule.objects.fetch_for_organization(self.organization, [project])
         )
 


### PR DESCRIPTION
The order isn't deterministic here, just using sets.