### PR TITLE
feat(trend-view): Adding events for beta testing

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -174,7 +174,7 @@ class PerformanceLanding extends React.Component<Props, State> {
   }
 
   handleViewChange(viewKey: FilterViews) {
-    const {location} = this.props;
+    const {location, organization} = this.props;
 
     const newQuery = {
       ...location.query,
@@ -182,6 +182,13 @@ class PerformanceLanding extends React.Component<Props, State> {
 
     const query = decodeScalar(location.query.query) || '';
     const conditions = tokenizeSearch(query);
+
+    trackAnalyticsEvent({
+      eventKey: 'performance_views.change_view',
+      eventName: 'Performance Views: Change View',
+      organization_id: parseInt(organization.id, 10),
+      view_name: viewKey,
+    });
 
     // This is a temporary change for trends to test adding a default count to increase relevancy
     if (viewKey === FilterViews.TRENDS) {

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -21,6 +21,7 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {formatPercentage, getDuration} from 'app/utils/formatters';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {t} from 'app/locale';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withProjects from 'app/utils/withProjects';
 import {IconEllipsis} from 'app/icons';
 import MenuItem from 'app/components/menuItem';
@@ -438,6 +439,12 @@ const CompareLink = (props: CompareLinkProps) => {
       transaction
     );
     if (baselines) {
+      trackAnalyticsEvent({
+        eventKey: 'performance_views.trends.compare_baselines',
+        eventName: 'Performance Views: Comparing baselines',
+        organization_id: parseInt(organization.id, 10),
+      });
+
       const {previousPeriod, currentPeriod} = baselines;
       const comparisonString = `${previousPeriod.project}:${previousPeriod.id}/${currentPeriod.project}:${currentPeriod.id}`;
       browserHistory.push({

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -8,6 +8,7 @@ import EventView from 'app/utils/discover/eventView';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import {t} from 'app/locale';
 import Feature from 'app/components/acl/feature';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import SearchBar from 'app/views/events/searchBar';
 import space from 'app/styles/space';
 
@@ -43,13 +44,20 @@ class TrendsContent extends React.Component<Props, State> {
   };
 
   handleTrendFunctionChange = (field: string) => {
-    const {location} = this.props;
+    const {organization, location} = this.props;
 
     const offsets = {};
 
     Object.values(TrendChangeType).forEach(trendChangeType => {
       const queryKey = getSelectedQueryKey(trendChangeType);
       offsets[queryKey] = 0;
+    });
+
+    trackAnalyticsEvent({
+      eventKey: 'performance_views.trends.change_function',
+      eventName: 'Performance Views: Change Function',
+      organization_id: parseInt(organization.id, 10),
+      function_name: field,
     });
 
     this.setState({


### PR DESCRIPTION
- 3 new events:
  - When changing the view in performance (ie. between trends or by
    transaction)
  - When the user compares baselines
  - When the function used to compute baselines is changed

Reload PR: https://github.com/getsentry/reload/pull/181