### PR TITLE
fix(alerts): Add a comment to guide people away from accessing `SENTRY_RULES` directly.

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -215,8 +215,9 @@ TAG_LABELS = {
 
 PROTECTED_TAG_KEYS = frozenset(["environment", "release", "sentry:release"])
 
-# TODO(dcramer): once this is more flushed out we want this to be extendable
-SENTRY_RULES = (
+# Don't use this variable directly. If you want a list of rules that are registered in
+# the system, access them via the `rules` registry in sentry/rules/__init__.py
+_SENTRY_RULES = (
     "sentry.mail.actions.NotifyEmailAction",
     "sentry.rules.actions.notify_event.NotifyEventAction",
     "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",

--- a/src/sentry/rules/__init__.py
+++ b/src/sentry/rules/__init__.py
@@ -5,13 +5,13 @@ from .registry import RuleRegistry  # NOQA
 
 
 def init_registry():
-    from sentry.constants import SENTRY_RULES
+    from sentry.constants import _SENTRY_RULES
     from sentry.plugins.base import plugins
     from sentry.utils.imports import import_string
     from sentry.utils.safe import safe_execute
 
     registry = RuleRegistry()
-    for rule in SENTRY_RULES:
+    for rule in _SENTRY_RULES:
         cls = import_string(rule)
         registry.add(cls)
     for plugin in plugins.all(version=2):

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -108,7 +108,7 @@ class RuleProcessorTestFilters(TestCase):
         "tests.sentry.rules.test_processor.MockFilterFalse",
     )
 
-    @patch("sentry.constants.SENTRY_RULES", MOCK_SENTRY_RULES_WITH_FILTERS)
+    @patch("sentry.constants._SENTRY_RULES", MOCK_SENTRY_RULES_WITH_FILTERS)
     def test_filter_passes(self):
         # setup a simple alert rule with 1 condition and 1 filter that always pass
         self.event = self.store_event(data={}, project_id=self.project.id)
@@ -139,7 +139,7 @@ class RuleProcessorTestFilters(TestCase):
             assert futures[0].rule == self.rule
             assert futures[0].kwargs == {}
 
-    @patch("sentry.constants.SENTRY_RULES", MOCK_SENTRY_RULES_WITH_FILTERS)
+    @patch("sentry.constants._SENTRY_RULES", MOCK_SENTRY_RULES_WITH_FILTERS)
     def test_filter_fails(self):
         # setup a simple alert rule with 1 condition and 1 filter that doesn't pass
         self.event = self.store_event(data={}, project_id=self.project.id)


### PR DESCRIPTION
This is an action item from a recent retro on a bug that was introduced into issue alerts. We want
to warn people away from accessing `SENTRY_RULES` directly, since it's not correct to do so. I also
renamed to `_SENTRY_RULES` to help drive the point home.