### PR TITLE
feat(workflow): Change 'auto' text to custom periods

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/actions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.jsx
@@ -381,6 +381,7 @@ const IssueListActions = createReactClass({
       queryCount,
       query,
       realtimeActive,
+      selection,
       statsPeriod,
     } = this.props;
     const issues = this.state.selectedIds;
@@ -565,7 +566,7 @@ const IssueListActions = createReactClass({
                   active={statsPeriod === 'auto'}
                   onClick={this.handleSelectStatsPeriod.bind(this, 'auto')}
                 >
-                  {t('Auto')}
+                  {selection.datetime.period || t('Custom')}
                 </GraphToggle>
               ) : (
                 <GraphToggle


### PR DESCRIPTION
This changes the confusing `'Auto'` option in the issue stream bar chart to selected periods or `'Custom'`

Resolves: [WOR-265](https://getsentry.atlassian.net/browse/WOR-265)