### PR TITLE
dev: pure venv bootstrapper

### DIFF
--- a/scripts/bootstrap-py2-venv
+++ b/scripts/bootstrap-py2-venv
@@ -43,6 +43,7 @@ if ! [[ "$(python2.7 -V 2>&1)" = "Python $(awk -v ORS='' 'FNR == 1' .python-vers
     abort "Your python2.7 version isn't as expected. Please run: make setup-pyenv"
 fi
 
+python2.7 -m pip install -U pip         || { echo "bootstrap failed!"; return 1; }
 python2.7 -m pip install -U virtualenv  || { echo "bootstrap failed!"; return 1; }
 python2.7 -m virtualenv .venv           || { echo "bootstrap failed!"; return 1; }
 source .venv/bin/activate               || { echo "bootstrap failed!"; return 1; }

--- a/scripts/bootstrap-py2-venv
+++ b/scripts/bootstrap-py2-venv
@@ -1,0 +1,50 @@
+# This script is meant to be sourced by bash, not executed.
+# As such, don't use exit, use return.
+
+# This script is purely a python virtualenv bootstrap, not the entire development environment.
+# For the entire thing, you should still use make bootstrap.
+# Eventually, the goal would be to have an idempotent single script that does
+# everything make bootstrap does and more (system dependencies and so on).
+
+# This... doesn't quite work.
+# set -e
+# trap "echo 'bootstrap FAILED.' && trap - ERR && return" ERR
+
+# So just going to sprinkle returns everywhere.
+
+command -v pyenv >/dev/null || {
+    echo "You need to install pyenv. https://develop.sentry.dev/environment/#python"
+    return 1
+}
+
+command -v direnv >/dev/null || {
+    echo "You need to install direnv. https://develop.sentry.dev/environment/#direnv"
+    return 1
+}
+
+gitroot="$(git rev-parse --show-toplevel)"
+cd "$gitroot"
+
+if [[ -f .venv/bin/activate ]]; then
+    echo "You seem to have a virtualenv already. This script is meant to start one from scratch. Continue (y/N)?"
+    read resp
+    case "$resp" in
+      y|Y ) echo "Okay, let's do this." ;;
+      * ) echo "Aborted!"; return 1     ;;
+    esac
+fi
+
+deactivate 2>/dev/null || true
+rm -rf .venv/
+
+if ! [[ "$(python2.7 -V 2>&1)" = "Python $(awk -v ORS='' 'FNR == 1' .python-version)" ]]; then
+    abort "Your python2.7 version isn't as expected. Please run: make setup-pyenv"
+fi
+
+python2.7 -m pip install -U virtualenv  || { echo "bootstrap failed!"; return 1; }
+python2.7 -m virtualenv .venv           || { echo "bootstrap failed!"; return 1; }
+source .venv/bin/activate               || { echo "bootstrap failed!"; return 1; }
+make setup-git                          || { echo "bootstrap failed!"; return 1; }
+make install-py-dev                     || { echo "bootstrap failed!"; return 1; }
+deactivate                              || { echo "bootstrap failed!"; return 1; }
+direnv allow                            || { echo "bootstrap failed!"; return 1; }

--- a/scripts/bootstrap-py3-venv
+++ b/scripts/bootstrap-py3-venv
@@ -43,6 +43,7 @@ if ! [[ "$(python3 -V 2>&1)" = "Python $(awk -v ORS='' 'FNR == 2' .python-versio
     abort "Your python3 version isn't as expected. Please run: make setup-pyenv"
 fi
 
+python3 -m pip install -U pip           || { echo "bootstrap failed!"; return 1; }
 python3 -m pip install -U virtualenv    || { echo "bootstrap failed!"; return 1; }
 python3 -m virtualenv .venv3            || { echo "bootstrap failed!"; return 1; }
 source .venv3/bin/activate              || { echo "bootstrap failed!"; return 1; }

--- a/scripts/bootstrap-py3-venv
+++ b/scripts/bootstrap-py3-venv
@@ -22,12 +22,12 @@ command -v direnv >/dev/null || {
     return 1
 }
 
-unset SENTRY_PYTHON3
+export SENTRY_PYTHON3=1
 
 gitroot="$(git rev-parse --show-toplevel)"
 cd "$gitroot"
 
-if [[ -f .venv/bin/activate ]]; then
+if [[ -f .venv3/bin/activate ]]; then
     echo "You seem to have a virtualenv already. This script is meant to start one from scratch. Continue (y/N)?"
     read resp
     case "$resp" in
@@ -37,15 +37,15 @@ if [[ -f .venv/bin/activate ]]; then
 fi
 
 deactivate 2>/dev/null || true
-rm -rf .venv/
+rm -rf .venv3/
 
-if ! [[ "$(python2.7 -V 2>&1)" = "Python $(awk -v ORS='' 'FNR == 1' .python-version)" ]]; then
-    abort "Your python2.7 version isn't as expected. Please run: make setup-pyenv"
+if ! [[ "$(python3 -V 2>&1)" = "Python $(awk -v ORS='' 'FNR == 2' .python-version)" ]]; then
+    abort "Your python3 version isn't as expected. Please run: make setup-pyenv"
 fi
 
-python2.7 -m pip install -U virtualenv  || { echo "bootstrap failed!"; return 1; }
-python2.7 -m virtualenv .venv           || { echo "bootstrap failed!"; return 1; }
-source .venv/bin/activate               || { echo "bootstrap failed!"; return 1; }
+python3 -m pip install -U virtualenv    || { echo "bootstrap failed!"; return 1; }
+python3 -m virtualenv .venv3            || { echo "bootstrap failed!"; return 1; }
+source .venv3/bin/activate              || { echo "bootstrap failed!"; return 1; }
 make setup-git                          || { echo "bootstrap failed!"; return 1; }
 make install-py-dev                     || { echo "bootstrap failed!"; return 1; }
 deactivate                              || { echo "bootstrap failed!"; return 1; }


### PR DESCRIPTION
This is purely a virtualenv and python dependency bootstrapper. Original intention was to make it easier to bring up a py3 venv, I've also provided a py2 version.

As noted in the comments...

```
# This script is purely a python virtualenv bootstrap, not the entire development environment. 
# For the entire thing, you should still use make bootstrap.
# Eventually, the goal would be to have an idempotent single script that does
# everything make bootstrap does and more (system dependencies and so on).
```

You should be able to `source ./scripts/bootstrap-py3-venv` and it should just work, no matter the environment.
