### PR TITLE
fix(releases): Fix wrong url

### DIFF
--- a/src/sentry/static/sentry/app/views/releasesV2/detail/repositorySwitcher.tsx
+++ b/src/sentry/static/sentry/app/views/releasesV2/detail/repositorySwitcher.tsx
@@ -39,10 +39,7 @@ class RepositorySwitcher extends React.PureComponent<Props, State> {
 
     router.push({
       ...location,
-      query: {
-        ...location.query,
-        activeRepo,
-      },
+      query: {...location.query, cursor: undefined, activeRepo},
     });
   };
 


### PR DESCRIPTION
The parameter `cursor` was still in the URL when switching the repository and this is wrong.