### PR TITLE
fix(workflow): Aborting snapshot creation if project is deleted

### DIFF
--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -219,11 +219,6 @@ def process_pending_incident_snapshots():
                     incident.status == IncidentStatus.CLOSED.value
                     and not IncidentSnapshot.objects.filter(incident=incident).exists()
                 ):
-                    project_ids = list(
-                        IncidentProject.objects.filter(incident=incident).values_list(
-                            "project_id", flat=True
-                        )
-                    )
-                    if project_ids:
+                    if IncidentProject.objects.filter(incident=incident).exists():
                         create_incident_snapshot(incident, windowed_stats=True)
                 pending_snapshot.delete()

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -196,6 +196,7 @@ def process_pending_incident_snapshots():
     has passed it's target_run_date.
     """
     from sentry.incidents.logic import create_incident_snapshot
+    from sentry.utils.snuba import UnqualifiedQueryError
 
     batch_size = 50
 
@@ -218,5 +219,8 @@ def process_pending_incident_snapshots():
                     incident.status == IncidentStatus.CLOSED.value
                     and not IncidentSnapshot.objects.filter(incident=incident).exists()
                 ):
-                    create_incident_snapshot(incident, windowed_stats=True)
+                    try:
+                        create_incident_snapshot(incident, windowed_stats=True)
+                    except UnqualifiedQueryError:
+                        pass
                 pending_snapshot.delete()


### PR DESCRIPTION
If a project is deleted in the time between an incident's resolution and snapshot creation, then the task to create the snapshot can fail with an UnqualifiedQueryError because no project id's can be found.

This PR adds a check for this, and deletes the pending incident snapshot if the query fails.

The original implementation was wrapping `create_incident_snapshot` in a try/except that caught `UnqualifiedQueryError` but I opted to change this to an explicit project_id check so that I don't unintentionally capture other errors that we may want to be made aware of if they're happening.

Fixes SENTRY-H8E