### PR TITLE
ref(relay): Add new relay design - Part 1

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -145,7 +145,7 @@ class RelayWrapper extends AsyncView<Props, State> {
               icon={<IconTelescope size="xl" />}
               title={t('The middle layer between your app and Sentry!')}
               description={t(
-                'Scrub all personally identifiable information before it arrives in Sentry. Relay improves event response time and acts as a proxy for organizations with restricted HTTP communication.'
+                'Scrub all personally identifiable information before it arrives at Sentry. Relay improves event response time and acts as a proxy for organizations with restricted HTTP communication.'
               )}
               action={
                 <EmptyMessageActions>

--- a/src/sentry/static/sentry/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -165,8 +165,6 @@ class RelayWrapper extends AsyncView<Props, State> {
           </Panel>
         ) : (
           <StyledPanelTable
-            isEmpty={relays.length === 0}
-            emptyMessage={t('No relays keys have been added yet.')}
             headers={[t('Display Name'), t('Relay Key'), t('Date Created'), '']}
           >
             {relays.map(({publicKey: key, name, created, description}) => {

--- a/src/sentry/static/sentry/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -145,7 +145,7 @@ class RelayWrapper extends AsyncView<Props, State> {
               icon={<IconTelescope size="xl" />}
               title={t('The middle layer between your app and Sentry!')}
               description={t(
-                'Scrub all personal information before it arrives in Sentry. Relay impove’s event reponse time and acts as a proxy for organizations that restrict HTTP communication.'
+                'Scrub all personally identifiable information before it arrives in Sentry. Relay improves event response time and acts as a proxy for organizations with restricted HTTP communication.'
               )}
               action={
                 <EmptyMessageActions>


### PR DESCRIPTION
Implemented the new relay design - Part 1 

It looks like below:

![image](https://user-images.githubusercontent.com/29228205/94450577-ba35f380-01ad-11eb-9143-8dde1450ab97.png)


depends on https://github.com/getsentry/sentry/pull/21017