### PR TITLE
fix(workflow): Add a guard for group on the assignee selector assignable team fetcher

### DIFF
--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -123,7 +123,7 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
     const group = GroupStore.get(this.props.id);
 
     return (
-      ProjectsStore.getBySlug(group.project.slug) || {
+      (group && ProjectsStore.getBySlug(group.project.slug)) || {
         teams: [],
       }
     ).teams


### PR DESCRIPTION
This fixes an issue where the assignee selector sometimes gets `undefined` for `group`. Adding a guard for the group is a common remedy we do for these situations.

Fixes: JAVASCRIPT-22DF