### PR TITLE
fix(trends): Fix project widgets not appearing for 'my projects'

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -32,10 +32,9 @@ type State = {
 };
 
 function hasMultipleProjects(selection: GlobalSelection) {
-  return (
-    selection.projects &&
-    (selection.projects.length > 1 || selection.projects[0] === ALL_ACCESS_PROJECTS)
-  );
+  const myProjectsSelected = selection.projects.length === 0;
+  const allProjectsSelected = selection.projects[0] === ALL_ACCESS_PROJECTS;
+  return myProjectsSelected || allProjectsSelected || selection.projects.length > 1;
 }
 
 class TrendsContent extends React.Component<Props, State> {


### PR DESCRIPTION
This fixes the multiple project check to allow 'my projects' when the projects selection is an empty array.