### PR TITLE
fix(trends): Fix comparison breadcrumbs for trends

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/compare/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/content.tsx
@@ -8,10 +8,12 @@ import {Event, Organization} from 'app/types';
 import {Panel} from 'app/components/panels';
 import * as Layout from 'app/components/layouts/thirds';
 import Breadcrumb from 'app/views/performance/breadcrumb';
+import {decodeScalar} from 'app/utils/queryString';
 
 import TraceView from './traceView';
 import TransactionSummary from './transactionSummary';
 import {isTransactionEvent} from './utils';
+import {FilterViews} from '../landing';
 
 type Props = {
   organization: Organization;
@@ -47,8 +49,12 @@ class TransactionComparisonContent extends React.Component<Props> {
   render() {
     const {baselineEvent, regressionEvent, organization, location, params} = this.props;
 
+    const isFromTrends = decodeScalar(location.query?.view) === FilterViews.TRENDS;
+
     const transactionName =
-      baselineEvent.title === regressionEvent.title ? baselineEvent.title : undefined;
+      baselineEvent.title === regressionEvent.title && !isFromTrends
+        ? baselineEvent.title
+        : undefined;
 
     return (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -55,6 +55,7 @@ import {
 } from './utils';
 import {transactionSummaryRouteWithQuery} from '../transactionSummary/utils';
 import {HeaderTitleLegend} from '../styles';
+import {getTransactionComparisonUrl} from '../utils';
 
 type Props = {
   api: Client;
@@ -426,7 +427,6 @@ const CompareLink = (props: CompareLinkProps) => {
     location,
     currentTrendFunction,
   } = props;
-  const summaryView = eventView.clone();
   const intervalRatio = getIntervalRatio(location);
 
   async function onLinkClick() {
@@ -446,14 +446,16 @@ const CompareLink = (props: CompareLinkProps) => {
       });
 
       const {previousPeriod, currentPeriod} = baselines;
-      const comparisonString = `${previousPeriod.project}:${previousPeriod.id}/${currentPeriod.project}:${currentPeriod.id}`;
-      browserHistory.push({
-        pathname: `/organizations/${organization.slug}/performance/compare/${comparisonString}/`,
-        query: {
-          ...summaryView.generateQueryStringObject(),
-          transaction: String(transaction.transaction),
-        },
+
+      const target = getTransactionComparisonUrl({
+        organization,
+        baselineEventSlug: `${previousPeriod.project}:${previousPeriod.id}`,
+        regressionEventSlug: `${currentPeriod.project}:${currentPeriod.id}`,
+        transaction: transaction.transaction,
+        query: location.query,
       });
+
+      browserHistory.push(target);
     }
   }
 


### PR DESCRIPTION
This fixes the comparison breadcrumb for trends (to not show Transaction Summary) and switches to using the comparison url util function for clarity and to maintain tags across views.