### PR TITLE
feat(perf): Instrument issues page 

### DIFF
--- a/src/sentry/static/sentry/app/utils/analytics.tsx
+++ b/src/sentry/static/sentry/app/utils/analytics.tsx
@@ -227,9 +227,7 @@ metric.measure = function metricMeasure({name, start, end, data = {}, noCleanup}
 const transactionDataStore = new Map<string, object>();
 
 const getCurrentTransaction = () => {
-  return Sentry.getCurrentHub()
-    .getScope()
-    ?.getTransaction();
+  return Sentry.getCurrentHub().getScope()?.getTransaction();
 };
 
 metric.startTransaction = ({name, traceId, op}) => {

--- a/src/sentry/static/sentry/app/views/issueList/container.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/container.jsx
@@ -28,14 +28,12 @@ class IssueListContainer extends React.Component {
    * lightweight organization
    */
   startMetricCollection() {
-    const startType = isLightweightOrganization(this.props.organization)
-      ? 'cold-start'
-      : 'warm-start';
+    const isLightWeight = isLightweightOrganization(this.props.organization);
+    const startType = isLightWeight ? 'cold-start' : 'warm-start';
     metric.mark({name: 'page-issue-list-start', data: {start_type: startType}});
-    metric.createSpan({
-      op: 'load',
-      description: 'issue-list-load',
-      label: 'issue-list-load',
+    metric.startTransaction({
+      name: 'issue-list.load',
+      op: isLightWeight ? 'pageload' : 'navigation',
     });
   }
 

--- a/src/sentry/static/sentry/app/views/issueList/container.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/container.jsx
@@ -32,6 +32,11 @@ class IssueListContainer extends React.Component {
       ? 'cold-start'
       : 'warm-start';
     metric.mark({name: 'page-issue-list-start', data: {start_type: startType}});
+    metric.createSpan({
+      op: 'load',
+      description: 'issue-list-load',
+      label: 'issue-list-load',
+    });
   }
 
   getTitle() {

--- a/src/sentry/static/sentry/app/views/issueList/container.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/container.jsx
@@ -32,8 +32,8 @@ class IssueListContainer extends React.Component {
     const startType = isLightWeight ? 'cold-start' : 'warm-start';
     metric.mark({name: 'page-issue-list-start', data: {start_type: startType}});
     metric.startTransaction({
-      name: 'issue-list.load',
-      op: isLightWeight ? 'pageload' : 'navigation',
+      name: '/organizations/:orgId/issues/',
+      op: isLightWeight ? 'pageload manual-first-paint' : 'navigation manual-first-paint',
     });
   }
 

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -130,8 +130,7 @@ const IssueListOverview = createReactClass({
               .toString(),
           },
         });
-        metric.endSpan({label: 'issue-list-load'});
-        metric.endTransaction();
+        metric.endTransaction({name: 'issue-list.load'});
       }
     }
 

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -130,6 +130,8 @@ const IssueListOverview = createReactClass({
               .toString(),
           },
         });
+        metric.endSpan({label: 'issue-list-load'});
+        metric.endTransaction();
       }
     }
 

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -130,7 +130,7 @@ const IssueListOverview = createReactClass({
               .toString(),
           },
         });
-        metric.endTransaction({name: 'issue-list.load'});
+        metric.endTransaction({name: '/organizations/:orgId/issues/'});
       }
     }
 


### PR DESCRIPTION
The transactions for the issues page frequently end too soon or drag on past the time when the issue page is already loaded due to deferred web requests. 

In order to address this I created a custom transaction which measures the time it takes for the issues page to load. 