### PR TITLE
fix(trends): Use transaction time and statsperiod for baseline

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -422,7 +422,6 @@ const CompareLink = (props: CompareLinkProps) => {
     trendView: eventView,
     transaction,
     api,
-    statsData,
     location,
     currentTrendFunction,
   } = props;
@@ -434,7 +433,6 @@ const CompareLink = (props: CompareLinkProps) => {
       api,
       organization,
       eventView,
-      statsData,
       intervalRatio,
       transaction
     );

--- a/src/sentry/static/sentry/app/views/performance/trends/types.ts
+++ b/src/sentry/static/sentry/app/views/performance/trends/types.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import EventView from 'app/utils/discover/eventView';
 import {EventsStatsData} from 'app/types';
 
@@ -100,6 +102,8 @@ export type NormalizedTrendsTransaction = BaseTrendsTransaction & {
   aggregate_range_2: number;
   percentage_aggregate_range_2_aggregate_range_1: number;
   minus_aggregate_range_2_aggregate_range_1: number;
+
+  received_at: Readonly<moment.MomentInput>;
 };
 
 export type NormalizedProjectTrend = Omit<NormalizedTrendsTransaction, 'transaction'>;

--- a/src/sentry/static/sentry/app/views/performance/trends/types.ts
+++ b/src/sentry/static/sentry/app/views/performance/trends/types.ts
@@ -103,7 +103,7 @@ export type NormalizedTrendsTransaction = BaseTrendsTransaction & {
   percentage_aggregate_range_2_aggregate_range_1: number;
   minus_aggregate_range_2_aggregate_range_1: number;
 
-  received_at: Readonly<moment.MomentInput>;
+  received_at: Readonly<moment.Moment>;
 };
 
 export type NormalizedProjectTrend = Omit<NormalizedTrendsTransaction, 'transaction'>;

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Location} from 'history';
 import styled from '@emotion/styled';
+import moment from 'moment';
 
 import theme from 'app/utils/theme';
 import {
@@ -21,7 +22,7 @@ import Count from 'app/components/count';
 import {Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {Client} from 'app/api';
-import {getUtcDateString} from 'app/utils/dates';
+import {getUtcDateString, parsePeriodToHours} from 'app/utils/dates';
 import {IconArrow} from 'app/icons';
 
 import {
@@ -31,7 +32,6 @@ import {
   TrendsTransaction,
   NormalizedTrendsTransaction,
   TrendFunctionField,
-  TrendsStats,
   ProjectTrend,
   NormalizedProjectTrend,
 } from './types';
@@ -222,7 +222,6 @@ export async function getTrendBaselinesForTransaction(
   api: Client,
   organization: Organization,
   eventView: EventView,
-  statsData: TrendsStats,
   intervalRatio: number,
   transaction: NormalizedTrendsTransaction
 ) {
@@ -232,17 +231,30 @@ export async function getTrendBaselinesForTransaction(
   const scopeQueryToTransaction = ` transaction:${transaction.transaction}`;
 
   const globalSelectionQuery = eventView.getGlobalSelectionQuery();
+  const statsPeriod = eventView.statsPeriod;
+
   delete globalSelectionQuery.statsPeriod;
   const baseApiPayload = {
     ...globalSelectionQuery,
     query: eventView.query + scopeQueryToTransaction,
   };
 
-  const stats = Object.values(statsData)[0].data;
+  const hasStartEnd = eventView.start && eventView.end;
 
-  const seriesStart = stats[0][0] * 1000;
-  const seriesEnd = stats.slice(-1)[0][0] * 1000;
-  const seriesSplit = seriesStart + (seriesEnd - seriesStart) * intervalRatio;
+  let seriesStart = moment(eventView.start);
+  let seriesEnd = moment(eventView.end);
+
+  if (!hasStartEnd) {
+    seriesEnd = transaction.received_at;
+    seriesStart = seriesEnd
+      .clone()
+      .subtract(parsePeriodToHours(statsPeriod || DEFAULT_TRENDS_STATS_PERIOD), 'hours');
+  }
+
+  const startTime = seriesStart.toDate().getTime();
+  const endTime = seriesEnd.toDate().getTime();
+
+  const seriesSplit = moment(startTime + (endTime - startTime) * intervalRatio);
 
   const previousPeriodPayload = {
     ...baseApiPayload,
@@ -331,6 +343,7 @@ export function normalizeTrends(data: Array<ProjectTrend>): Array<NormalizedProj
 export function normalizeTrends(
   data: Array<TrendsTransaction | ProjectTrend>
 ): Array<NormalizedTrendsTransaction | NormalizedProjectTrend> {
+  const received_at = moment(); // Adding the received time for the transaction so calls to get baseline always line up with the transaction
   return data.map(row => {
     const {
       project,
@@ -358,6 +371,7 @@ export function normalizeTrends(
       count_range_1,
       count_range_2,
       percentage_count_range_2_count_range_1,
+      received_at,
     };
 
     if ('transaction' in row) {


### PR DESCRIPTION
### Summary
This uses the time the transaction was received along with statsperiod to determine the baseline windows instead of using stats buckets, as the rounding of stats buckets were causing issues with baseline for small count transactions