### PR TITLE
fix(trends): Reset tags when visiting trends

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -27,7 +27,11 @@ import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
-import {tokenizeSearch, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {
+  tokenizeSearch,
+  stringifyQueryObject,
+  QueryResults,
+} from 'app/utils/tokenizeSearch';
 import {decodeScalar} from 'app/utils/queryString';
 
 import {generatePerformanceEventView, DEFAULT_STATS_PERIOD} from './data';
@@ -220,14 +224,22 @@ class PerformanceLanding extends React.Component<Props, State> {
     });
 
     if (viewKey === FilterViews.TRENDS) {
-      if (!conditions.hasTags('count()')) {
-        conditions.setTag('count()', ['>1000']);
-      }
-      if (!conditions.hasTags('transaction.duration')) {
-        conditions.setTag('transaction.duration', ['>0']);
-      }
+      const modifiedConditions = new QueryResults([]);
 
-      newQuery.query = stringifyQueryObject(conditions);
+      if (conditions.hasTags('count()')) {
+        modifiedConditions.setTag('count()', conditions.getTags('count()'));
+      } else {
+        modifiedConditions.setTag('count()', ['>1000']);
+      }
+      if (conditions.hasTags('transaction.duration')) {
+        modifiedConditions.setTag(
+          'transaction.duration',
+          conditions.getTags('transaction.duration')
+        );
+      } else {
+        modifiedConditions.setTag('transaction.duration', ['>0']);
+      }
+      newQuery.query = stringifyQueryObject(modifiedConditions);
     }
 
     const isNavigatingAwayFromTrends = viewKey !== FilterViews.TRENDS && currentView;

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -168,32 +168,37 @@ type DefaultTrendsProps = {
   eventView: EventView;
 };
 
-function DefaultTrends(props: DefaultTrendsProps) {
-  const {children, location, eventView} = props;
+class DefaultTrends extends React.Component<DefaultTrendsProps> {
+  hasPushedDefaults = false;
 
-  const queryString = decodeScalar(location.query.query) || '';
-  const conditions = tokenizeSearch(queryString);
+  render() {
+    const {children, location, eventView} = this.props;
 
-  if (queryString) {
-    return <React.Fragment>{children}</React.Fragment>;
-  } else {
-    conditions.setTag('count()', ['>1000']);
-    conditions.setTag('transaction.duration', ['>0']);
+    const queryString = decodeScalar(location.query.query);
+    const conditions = tokenizeSearch(queryString || '');
+
+    if (queryString || this.hasPushedDefaults) {
+      return <React.Fragment>{children}</React.Fragment>;
+    } else {
+      conditions.setTag('count()', ['>1000']);
+      conditions.setTag('transaction.duration', ['>0']);
+    }
+
+    const query = stringifyQueryObject(conditions);
+    eventView.query = query;
+
+    browserHistory.push({
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        cursor: undefined,
+        query: String(query).trim() || undefined,
+        view: FilterViews.TRENDS,
+      },
+    });
+    this.hasPushedDefaults = true;
+    return null;
   }
-
-  const query = stringifyQueryObject(conditions);
-  eventView.query = query;
-
-  browserHistory.push({
-    pathname: location.pathname,
-    query: {
-      ...location.query,
-      cursor: undefined,
-      query: String(query).trim() || undefined,
-      view: FilterViews.TRENDS,
-    },
-  });
-  return null;
 }
 
 const StyledSearchBar = styled(SearchBar)`

--- a/tests/js/spec/views/performance/landing.spec.jsx
+++ b/tests/js/spec/views/performance/landing.spec.jsx
@@ -328,7 +328,7 @@ describe('Performance > Landing', function() {
     );
   });
 
-  it('Tags are added to an existing query if navigating to trends', async function() {
+  it('Tags are replaced with trends default query if navigating to trends', async function() {
     const data = initializeTrendsData(
       {view: FilterViews.ALL_TRANSACTIONS, query: 'device.family:Mac'},
       false
@@ -350,7 +350,7 @@ describe('Performance > Landing', function() {
     expect(browserHistory.push).toHaveBeenCalledWith(
       expect.objectContaining({
         query: {
-          query: 'device.family:Mac count():>1000 transaction.duration:>0',
+          query: 'count():>1000 transaction.duration:>0',
           view: 'TRENDS',
         },
       })


### PR DESCRIPTION
### Summary
This removes tags aside from the trends defaults from the other tabs queries as it gets complicated supporting aggregates with our trends requests. This also fixes trends setting the default over top of an empty query by only pushing defaults once per component