### PR TITLE
ref: Bump sentry-relay to 0.8.1

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -54,7 +54,7 @@ requests[security]>=2.20.0,<2.21.0
 rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
-sentry-relay>=0.8.0,<0.9.0
+sentry-relay>=0.8.1,<0.9.0
 sentry-sdk>=0.17.7,<0.18.0
 simplejson>=3.11.0,<3.12.0
 six>=1.11.0,<1.12.0


### PR DESCRIPTION
Add support for measurement normalization.

Cherry picked from https://github.com/getsentry/sentry/pull/20719