### PR TITLE
fix(files) Delay file blob cleanup further

### DIFF
--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -435,11 +435,11 @@ class File(Model):
         blob_ids = [blob.id for blob in self.blobs.all()]
         super(File, self).delete(*args, **kwargs)
 
-        # Wait an hour to delete blobs. This helps prevent
+        # Wait to delete blobs. This helps prevent
         # races around frequently used blobs in debug images and release files.
         transaction.on_commit(
             lambda: delete_unreferenced_blobs.apply_async(
-                kwargs={"blob_ids": blob_ids}, countdown=60 * 60
+                kwargs={"blob_ids": blob_ids}, countdown=60 * 5
             )
         )
 


### PR DESCRIPTION
We're seeing integrity errors that appear to be caused by race conditions between deletions and new inserts. I'm hoping that by delaying the cleanup work we can avoid racing on hot blobs.

Refs SENTRY-HWV
Refs SENTRY-HWZ