### PR TITLE
ci(gcb): Increase build timeout for e2e on-premise tests

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
     echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
     ./install.sh
     ./test.sh || docker-compose logs nginx web relay
-  timeout: 300s
+  timeout: 450s
 - name: 'gcr.io/cloud-builders/docker'
   secretEnv: ['DOCKER_PASSWORD']
   entrypoint: 'bash'


### PR DESCRIPTION
Due to the newly added live-upgrade test, this step now requires more time (~7.5 minutes)
