### PR TITLE
chore(py3): Bump rb requirements to use latest.

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -43,7 +43,7 @@ python3-saml>=1.4.0,<1.5
 python-u2flib-server>=5.0.0,<6.0.0
 PyYAML>=5.3,<5.4
 qrcode>=6.1.0,<6.2.0
-rb>=1.7.0,<2.0.0
+rb>=1.8.0,<2.0.0
 # redis-py-cluster==2.1.0 isn't released yet, so just pinning to the current latest commit
 # in the repo.
 redis-py-cluster @ https://github.com/Grokzen/redis-py-cluster/archive/d3ef787e033e0bbf97d0b3d17fc46cb5ae36d660.zip#egg=redis-py-cluster


### PR DESCRIPTION
This is already in production since we bumped this in getsentry. Now bumping this for any sentry
users.