### PR TITLE
chore(py3): Bump redis-py-cluster to 2.1.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -44,9 +44,7 @@ python-u2flib-server>=5.0.0,<6.0.0
 PyYAML>=5.3,<5.4
 qrcode>=6.1.0,<6.2.0
 rb>=1.8.0,<2.0.0
-# redis-py-cluster==2.1.0 isn't released yet, so just pinning to the current latest commit
-# in the repo.
-redis-py-cluster @ https://github.com/Grokzen/redis-py-cluster/archive/d3ef787e033e0bbf97d0b3d17fc46cb5ae36d660.zip#egg=redis-py-cluster
+redis-py-cluster==2.1.0
 redis==3.3.11
 requests-oauthlib==1.2.0
 requests[security]>=2.20.0,<2.21.0


### PR DESCRIPTION
redis-py-cluster released 2.1.0 officially, so we can stop using the pinned sha.