### PR TITLE
chore(py3): Make sure migrations are run before python 3 tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -266,7 +266,7 @@ jobs:
 
         SENTRY_LIGHT_BUILD: 1
         SENTRY_SKIP_BACKEND_VALIDATION: 1
-        MIGRATIONS_TEST_MIGRATE: 0
+        MIGRATIONS_TEST_MIGRATE: 1
 
         # Node configuration
         NODE_OPTIONS: --max-old-space-size=4096

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -118,7 +118,7 @@ jobs:
 
       SENTRY_LIGHT_BUILD: 1
       SENTRY_SKIP_BACKEND_VALIDATION: 1
-
+      MIGRATIONS_TEST_MIGRATE: 1
       PYTEST_SENTRY_DSN: https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
       # XXX(py3): Reruns are disabled for until all tests are passing.
       PYTEST_ADDOPTS: ""
@@ -193,7 +193,6 @@ jobs:
       # TODO(joshuarli):
       # - kakfa+zookeeper devservices necessary for what test suites?
       # - is `docker exec sentry_snuba snuba migrate` needed?
-      # - MIGRATIONS_TEST_MIGRATE=1
       # - TEST_SUITE=relay-integration
       # - TEST_SUITE=symbolicator
       # - TEST_SUITE=cli
@@ -219,6 +218,7 @@ jobs:
       USE_SNUBA: 1
       SENTRY_LIGHT_BUILD: 1
       SENTRY_SKIP_BACKEND_VALIDATION: 1
+      MIGRATIONS_TEST_MIGRATE: 1
 
       PYTEST_SENTRY_DSN: https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
       # XXX(py3): Reruns are disabled for until all tests are passing.
@@ -308,7 +308,7 @@ jobs:
             confluentinc/cp-kafka:5.1.2
           sentry devservices up postgres redis clickhouse snuba
 
-      - name: Python 3.6 snuba backend w/o migrations (${{ steps.config.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
+      - name: Python 3.6 snuba backend (${{ steps.config.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
         if: always()
         run: |
           make travis-test-snuba


### PR DESCRIPTION
We had this disabled since migrations were broken under py3. Now that they work, we should run them
on the py3 tests.