### PR TITLE
ref(py3): Correctly compare bytes in javascript processor

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -400,7 +400,7 @@ def fetch_file(url, project=None, release=None, dist=None, allow_scraping=True):
         # Discard leading whitespace (often found before doctype)
         body_start = result.body[:20].lstrip()
 
-        if body_start[:1] == u"<":
+        if body_start[:1] == b"<":
             error = {"type": EventError.JS_INVALID_CONTENT, "url": url}
             raise http.CannotFetch(error)
 


### PR DESCRIPTION
You'll notice the block of code immediately before this verifies that the `result.body` is a byte string.

https://github.com/getsentry/sentry/blob/b4fad92aeadf8a123ff60ab299c4d85837691407/src/sentry/lang/javascript/processor.py#L372-L405