### PR TITLE
fix(trends): Switch offsets to transaction names

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -86,6 +86,10 @@ function onTrendsCursor(trendChangeType: TrendChangeType) {
     } else if (trendChangeType === TrendChangeType.REGRESSION) {
       cursorQuery.regressionCursor = cursor;
     }
+
+    const selectedQueryKey = getSelectedQueryKey(trendChangeType);
+    delete query[selectedQueryKey];
+
     browserHistory.push({
       pathname: path,
       query: {...query, ...cursorQuery},
@@ -110,31 +114,33 @@ function getSelectedTransaction(
   transactions?: NormalizedTrendsTransaction[]
 ): NormalizedTrendsTransaction | undefined {
   const queryKey = getSelectedQueryKey(trendChangeType);
-  const offsetString = decodeScalar(location.query[queryKey]);
-  const offset = offsetString ? parseInt(offsetString, 10) : 0;
-  if (!transactions || !transactions.length || offset >= transactions.length) {
+  const selectedTransactionName = decodeScalar(location.query[queryKey]);
+
+  if (!transactions) {
     return undefined;
   }
 
-  const transaction = transactions[offset];
-  return transaction;
+  const selectedTransaction = transactions.find(
+    transaction => transaction.transaction === selectedTransactionName
+  );
+
+  if (selectedTransaction) {
+    return selectedTransaction;
+  }
+
+  return transactions.length > 0 ? transactions[0] : undefined;
 }
 
-function handleChangeSelected(
-  location: Location,
-  trendChangeType: TrendChangeType,
-  transactions?: NormalizedTrendsTransaction[]
-) {
+function handleChangeSelected(location: Location, trendChangeType: TrendChangeType) {
   return function updateSelected(transaction?: NormalizedTrendsTransaction) {
-    const queryKey = getSelectedQueryKey(trendChangeType);
-    const offset = transaction ? transactions?.indexOf(transaction) : -1;
+    const selectedQueryKey = getSelectedQueryKey(trendChangeType);
     const query = {
       ...location.query,
     };
-    if (!offset || offset < 0) {
-      delete query[queryKey];
+    if (!transaction) {
+      delete query[selectedQueryKey];
     } else {
-      query[queryKey] = String(offset);
+      query[selectedQueryKey] = transaction?.transaction;
     }
     browserHistory.push({
       pathname: location.pathname,
@@ -241,8 +247,7 @@ function ChangedTransactions(props: Props) {
                           statsData={statsData}
                           handleSelectTransaction={handleChangeSelected(
                             location,
-                            trendChangeType,
-                            transactionsList
+                            trendChangeType
                           )}
                         />
                       ))}

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -63,7 +63,7 @@ class TrendsContent extends React.Component<Props, State> {
 
     Object.values(TrendChangeType).forEach(trendChangeType => {
       const queryKey = getSelectedQueryKey(trendChangeType);
-      offsets[queryKey] = 0;
+      offsets[queryKey] = undefined;
     });
 
     trackAnalyticsEvent({

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -110,9 +110,9 @@ export const trendToColor = {
   [TrendChangeType.REGRESSION]: theme.red400,
 };
 
-export const trendOffsetQueryKeys = {
-  [TrendChangeType.IMPROVED]: 'improvedOffset',
-  [TrendChangeType.REGRESSION]: 'regressionOffset',
+export const trendSelectedQueryKeys = {
+  [TrendChangeType.IMPROVED]: 'improvedSelected',
+  [TrendChangeType.REGRESSION]: 'regressionSelected',
 };
 
 export const trendCursorNames = {
@@ -405,7 +405,7 @@ export function getTrendAliasedMinus(alias: string) {
 }
 
 export function getSelectedQueryKey(trendChangeType: TrendChangeType) {
-  return trendOffsetQueryKeys[trendChangeType];
+  return trendSelectedQueryKeys[trendChangeType];
 }
 
 /**


### PR DESCRIPTION
### Summary
This makes switching between transactions cleaner as you'll always have the same transaction selected, it will be unselected if the data changes and the transaction is no longer visible, and makes links more accurate for lower stats period. Also fixes offset not clearing when changing pages.