### PR TITLE
feat(api-docs): Add @ecosystem to CODEOWNERS for API docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -160,4 +160,7 @@ Makefile                    @getsentry/owners-sentry-dev
 *sentry_app*.py                               @getsentry/ecosystem
 *sentryapp*.py                                @getsentry/ecosystem
 
+/api-docs/                                    @getsentry/ecosystem
+/tests/apidocs/                               @getsentry/ecosystem
+
 ### End of Ecosystem ###


### PR DESCRIPTION
As the ecosystem team now owns the API docs following our recent migration, they should be code owners for the API docs paths. 