### PR TITLE
feat(workflow): Fetching first_seen and times_seen from the issue

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -787,9 +787,9 @@ class GroupSerializerSnuba(GroupSerializerBase):
         }
         user_counts = {item_id: value["count"] for item_id, value in seen_data.items()}
         last_seen = {item_id: value["last_seen"] for item_id, value in seen_data.items()}
-        times_seen = {item_id: value["times_seen"] for item_id, value in seen_data.items()}
         if not environment_ids:
-            first_seen = {item_id: value["first_seen"] for item_id, value in seen_data.items()}
+            first_seen = {item.id: item.first_seen for item in item_list}
+            times_seen = {item.id: item.times_seen for item in item_list}
         else:
             first_seen = {
                 ge["group_id"]: ge["first_seen__min"]
@@ -800,6 +800,8 @@ class GroupSerializerSnuba(GroupSerializerBase):
                 .values("group_id")
                 .annotate(Min("first_seen"))
             }
+            times_seen = {item_id: value["times_seen"] for item_id, value in seen_data.items()}
+
         attrs = {}
         for item in item_list:
             attrs[item] = {

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -787,11 +787,11 @@ class GroupSerializerSnuba(GroupSerializerBase):
         }
         user_counts = {item_id: value["count"] for item_id, value in seen_data.items()}
         last_seen = {item_id: value["last_seen"] for item_id, value in seen_data.items()}
-        if not environment_ids and not start and not end and not conditions:
-            first_seen = {item.id: item.first_seen for item in item_list}
-            times_seen = {item.id: item.times_seen for item in item_list}
+        if start or end or conditions:
+            first_seen = {item_id: value["first_seen"] for item_id, value in seen_data.items()}
+            times_seen = {item_id: value["times_seen"] for item_id, value in seen_data.items()}
         else:
-            if environment_ids and not start and not end and not conditions:
+            if environment_ids:
                 first_seen = {
                     ge["group_id"]: ge["first_seen__min"]
                     for ge in GroupEnvironment.objects.filter(
@@ -802,9 +802,8 @@ class GroupSerializerSnuba(GroupSerializerBase):
                     .annotate(Min("first_seen"))
                 }
             else:
-                first_seen = {item_id: value["first_seen"] for item_id, value in seen_data.items()}
-
-            times_seen = {item_id: value["times_seen"] for item_id, value in seen_data.items()}
+                first_seen = {item.id: item.first_seen for item in item_list}
+            times_seen = {item.id: item.times_seen for item in item_list}
 
         attrs = {}
         for item in item_list:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -787,7 +787,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         }
         user_counts = {item_id: value["count"] for item_id, value in seen_data.items()}
         last_seen = {item_id: value["last_seen"] for item_id, value in seen_data.items()}
-        if not environment_ids:
+        if not environment_ids and not start and not end and not conditions:
             first_seen = {item.id: item.first_seen for item in item_list}
             times_seen = {item.id: item.times_seen for item in item_list}
         else:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -791,15 +791,19 @@ class GroupSerializerSnuba(GroupSerializerBase):
             first_seen = {item.id: item.first_seen for item in item_list}
             times_seen = {item.id: item.times_seen for item in item_list}
         else:
-            first_seen = {
-                ge["group_id"]: ge["first_seen__min"]
-                for ge in GroupEnvironment.objects.filter(
-                    group_id__in=[item.id for item in item_list],
-                    environment_id__in=environment_ids,
-                )
-                .values("group_id")
-                .annotate(Min("first_seen"))
-            }
+            if environment_ids and not start and not end and not conditions:
+                first_seen = {
+                    ge["group_id"]: ge["first_seen__min"]
+                    for ge in GroupEnvironment.objects.filter(
+                        group_id__in=[item.id for item in item_list],
+                        environment_id__in=environment_ids,
+                    )
+                    .values("group_id")
+                    .annotate(Min("first_seen"))
+                }
+            else:
+                first_seen = {item_id: value["first_seen"] for item_id, value in seen_data.items()}
+
             times_seen = {item_id: value["times_seen"] for item_id, value in seen_data.items()}
 
         attrs = {}

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -607,11 +607,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
             self.login_as(user=self.user)
             response = self.get_response(sort_by="date", limit=10, query="server:example.com")
-            group_test = Group.objects.get(id=group2.id)
-            print("group2:", group2)
-            print("group2.times_seen:", group2.times_seen)
-            print("group_test:", group_test)
-            print("group_test.times_seen:", group_test.times_seen)
 
             assert response.status_code == 200
             assert len(response.data) == 2

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -551,110 +551,109 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert options.set("snuba.search.hits-sample-size", old_sample_size)
 
     def test_seen_stats(self):
-        with self.tasks():
-            with self.feature("organizations:dynamic-issue-counts"):
-                self.store_event(
-                    data={
-                        "timestamp": iso_format(before_now(seconds=500)),
-                        "fingerprint": ["group-1"],
-                    },
-                    project_id=self.project.id,
-                )
-                before_now_300_seconds = iso_format(before_now(seconds=300))
-                before_now_350_seconds = iso_format(before_now(seconds=350))
-                event2 = self.store_event(
-                    data={"timestamp": before_now_300_seconds, "fingerprint": ["group-2"]},
-                    project_id=self.project.id,
-                )
-                group2 = event2.group
-                group2.first_seen = before_now_350_seconds
-                group2.times_seen = 55
-                group2.save()
-                before_now_250_seconds = iso_format(before_now(seconds=250))
-                self.store_event(
-                    data={
-                        "timestamp": before_now_250_seconds,
-                        "fingerprint": ["group-2"],
-                        "tags": {"server": "example.com", "trace": "meow", "message": "foo"},
-                    },
-                    project_id=self.project.id,
-                )
-                self.store_event(
-                    data={
-                        "timestamp": iso_format(before_now(seconds=200)),
-                        "fingerprint": ["group-1"],
-                        "tags": {"server": "example.com", "trace": "woof", "message": "foo"},
-                    },
-                    project_id=self.project.id,
-                )
-                before_now_150_seconds = iso_format(before_now(seconds=150))
-                self.store_event(
-                    data={
-                        "timestamp": before_now_150_seconds,
-                        "fingerprint": ["group-2"],
-                        "tags": {"trace": "ribbit", "server": "example.com"},
-                    },
-                    project_id=self.project.id,
-                )
-                before_now_100_seconds = iso_format(before_now(seconds=100))
-                self.store_event(
-                    data={
-                        "timestamp": before_now_100_seconds,
-                        "fingerprint": ["group-2"],
-                        "tags": {"message": "foo", "trace": "meow"},
-                    },
-                    project_id=self.project.id,
-                )
+        with self.feature("organizations:dynamic-issue-counts"):
+            self.store_event(
+                data={
+                    "timestamp": iso_format(before_now(seconds=500)),
+                    "fingerprint": ["group-1"],
+                },
+                project_id=self.project.id,
+            )
+            before_now_300_seconds = iso_format(before_now(seconds=300))
+            before_now_350_seconds = iso_format(before_now(seconds=350))
+            event2 = self.store_event(
+                data={"timestamp": before_now_300_seconds, "fingerprint": ["group-2"]},
+                project_id=self.project.id,
+            )
+            group2 = event2.group
+            group2.first_seen = before_now_350_seconds
+            group2.times_seen = 55
+            group2.save()
+            before_now_250_seconds = iso_format(before_now(seconds=250))
+            self.store_event(
+                data={
+                    "timestamp": before_now_250_seconds,
+                    "fingerprint": ["group-2"],
+                    "tags": {"server": "example.com", "trace": "meow", "message": "foo"},
+                },
+                project_id=self.project.id,
+            )
+            self.store_event(
+                data={
+                    "timestamp": iso_format(before_now(seconds=200)),
+                    "fingerprint": ["group-1"],
+                    "tags": {"server": "example.com", "trace": "woof", "message": "foo"},
+                },
+                project_id=self.project.id,
+            )
+            before_now_150_seconds = iso_format(before_now(seconds=150))
+            self.store_event(
+                data={
+                    "timestamp": before_now_150_seconds,
+                    "fingerprint": ["group-2"],
+                    "tags": {"trace": "ribbit", "server": "example.com"},
+                },
+                project_id=self.project.id,
+            )
+            before_now_100_seconds = iso_format(before_now(seconds=100))
+            self.store_event(
+                data={
+                    "timestamp": before_now_100_seconds,
+                    "fingerprint": ["group-2"],
+                    "tags": {"message": "foo", "trace": "meow"},
+                },
+                project_id=self.project.id,
+            )
 
-                self.login_as(user=self.user)
-                response = self.get_response(sort_by="date", limit=10, query="server:example.com")
-                group_test = Group.objects.get(id=group2.id)
-                print("group2:", group2)
-                print("group2.times_seen:", group2.times_seen)
-                print("group_test:", group_test)
-                print("group_test.times_seen:", group_test.times_seen)
+            self.login_as(user=self.user)
+            response = self.get_response(sort_by="date", limit=10, query="server:example.com")
+            group_test = Group.objects.get(id=group2.id)
+            print("group2:", group2)
+            print("group2.times_seen:", group2.times_seen)
+            print("group_test:", group_test)
+            print("group_test.times_seen:", group_test.times_seen)
 
-                assert response.status_code == 200
-                assert len(response.data) == 2
-                assert int(response.data[0]["id"]) == group2.id
-                assert response.data[0]["lifetime"] is not None
-                assert response.data[0]["filtered"] is not None
-                assert response.data[0]["filtered"]["stats"] is not None
-                assert response.data[0]["lifetime"]["stats"] is None
-                assert response.data[0]["filtered"]["stats"] != response.data[0]["stats"]
+            assert response.status_code == 200
+            assert len(response.data) == 2
+            assert int(response.data[0]["id"]) == group2.id
+            assert response.data[0]["lifetime"] is not None
+            assert response.data[0]["filtered"] is not None
+            assert response.data[0]["filtered"]["stats"] is not None
+            assert response.data[0]["lifetime"]["stats"] is None
+            assert response.data[0]["filtered"]["stats"] != response.data[0]["stats"]
 
-                assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
-                    before_now_350_seconds  # Should match overridden value, not event value
-                ).replace(tzinfo=timezone.utc)
-                assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
-                    before_now_100_seconds
-                ).replace(tzinfo=timezone.utc)
-                assert response.data[0]["lifetime"]["count"] == "55"
+            assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
+                before_now_350_seconds  # Should match overridden value, not event value
+            ).replace(tzinfo=timezone.utc)
+            assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
+                before_now_100_seconds
+            ).replace(tzinfo=timezone.utc)
+            assert response.data[0]["lifetime"]["count"] == "55"
 
-                assert response.data[0]["filtered"]["count"] == "2"
-                assert response.data[0]["filtered"]["firstSeen"] == parse_datetime(
-                    before_now_250_seconds
-                ).replace(tzinfo=timezone.utc)
-                assert response.data[0]["filtered"]["lastSeen"] == parse_datetime(
-                    before_now_150_seconds
-                ).replace(tzinfo=timezone.utc)
+            assert response.data[0]["filtered"]["count"] == "2"
+            assert response.data[0]["filtered"]["firstSeen"] == parse_datetime(
+                before_now_250_seconds
+            ).replace(tzinfo=timezone.utc)
+            assert response.data[0]["filtered"]["lastSeen"] == parse_datetime(
+                before_now_150_seconds
+            ).replace(tzinfo=timezone.utc)
 
-                # Empty filter test:
-                response = self.get_response(sort_by="date", limit=10, query="")
-                assert response.status_code == 200
-                assert len(response.data) == 2
-                assert int(response.data[0]["id"]) == group2.id
-                assert response.data[0]["lifetime"] is not None
-                assert response.data[0]["filtered"] is None
-                assert response.data[0]["lifetime"]["stats"] is None
+            # Empty filter test:
+            response = self.get_response(sort_by="date", limit=10, query="")
+            assert response.status_code == 200
+            assert len(response.data) == 2
+            assert int(response.data[0]["id"]) == group2.id
+            assert response.data[0]["lifetime"] is not None
+            assert response.data[0]["filtered"] is None
+            assert response.data[0]["lifetime"]["stats"] is None
 
-                assert response.data[0]["lifetime"]["count"] == "55"
-                assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
-                    before_now_350_seconds  # Should match overridden value, not event value
-                ).replace(tzinfo=timezone.utc)
-                assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
-                    before_now_100_seconds
-                ).replace(tzinfo=timezone.utc)
+            assert response.data[0]["lifetime"]["count"] == "55"
+            assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
+                before_now_350_seconds  # Should match overridden value, not event value
+            ).replace(tzinfo=timezone.utc)
+            assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
+                before_now_100_seconds
+            ).replace(tzinfo=timezone.utc)
 
     def test_skipped_fields(self):
         with self.feature("organizations:dynamic-issue-counts"):

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -551,96 +551,110 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert options.set("snuba.search.hits-sample-size", old_sample_size)
 
     def test_seen_stats(self):
-        with self.feature("organizations:dynamic-issue-counts"):
-            self.store_event(
-                data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
-                project_id=self.project.id,
-            )
-            before_now_300_seconds = iso_format(before_now(seconds=300))
-            event2 = self.store_event(
-                data={"timestamp": before_now_300_seconds, "fingerprint": ["group-2"]},
-                project_id=self.project.id,
-            )
-            group2 = event2.group
-            before_now_250_seconds = iso_format(before_now(seconds=250))
-            self.store_event(
-                data={
-                    "timestamp": before_now_250_seconds,
-                    "fingerprint": ["group-2"],
-                    "tags": {"server": "example.com", "trace": "meow", "message": "foo"},
-                },
-                project_id=self.project.id,
-            )
-            self.store_event(
-                data={
-                    "timestamp": iso_format(before_now(seconds=200)),
-                    "fingerprint": ["group-1"],
-                    "tags": {"server": "example.com", "trace": "woof", "message": "foo"},
-                },
-                project_id=self.project.id,
-            )
-            before_now_150_seconds = iso_format(before_now(seconds=150))
-            self.store_event(
-                data={
-                    "timestamp": before_now_150_seconds,
-                    "fingerprint": ["group-2"],
-                    "tags": {"trace": "ribbit", "server": "example.com"},
-                },
-                project_id=self.project.id,
-            )
-            before_now_100_seconds = iso_format(before_now(seconds=100))
-            self.store_event(
-                data={
-                    "timestamp": before_now_100_seconds,
-                    "fingerprint": ["group-2"],
-                    "tags": {"message": "foo", "trace": "meow"},
-                },
-                project_id=self.project.id,
-            )
+        with self.tasks():
+            with self.feature("organizations:dynamic-issue-counts"):
+                self.store_event(
+                    data={
+                        "timestamp": iso_format(before_now(seconds=500)),
+                        "fingerprint": ["group-1"],
+                    },
+                    project_id=self.project.id,
+                )
+                before_now_300_seconds = iso_format(before_now(seconds=300))
+                before_now_350_seconds = iso_format(before_now(seconds=350))
+                event2 = self.store_event(
+                    data={"timestamp": before_now_300_seconds, "fingerprint": ["group-2"]},
+                    project_id=self.project.id,
+                )
+                group2 = event2.group
+                group2.first_seen = before_now_350_seconds
+                group2.times_seen = 55
+                group2.save()
+                before_now_250_seconds = iso_format(before_now(seconds=250))
+                self.store_event(
+                    data={
+                        "timestamp": before_now_250_seconds,
+                        "fingerprint": ["group-2"],
+                        "tags": {"server": "example.com", "trace": "meow", "message": "foo"},
+                    },
+                    project_id=self.project.id,
+                )
+                self.store_event(
+                    data={
+                        "timestamp": iso_format(before_now(seconds=200)),
+                        "fingerprint": ["group-1"],
+                        "tags": {"server": "example.com", "trace": "woof", "message": "foo"},
+                    },
+                    project_id=self.project.id,
+                )
+                before_now_150_seconds = iso_format(before_now(seconds=150))
+                self.store_event(
+                    data={
+                        "timestamp": before_now_150_seconds,
+                        "fingerprint": ["group-2"],
+                        "tags": {"trace": "ribbit", "server": "example.com"},
+                    },
+                    project_id=self.project.id,
+                )
+                before_now_100_seconds = iso_format(before_now(seconds=100))
+                self.store_event(
+                    data={
+                        "timestamp": before_now_100_seconds,
+                        "fingerprint": ["group-2"],
+                        "tags": {"message": "foo", "trace": "meow"},
+                    },
+                    project_id=self.project.id,
+                )
 
-            self.login_as(user=self.user)
-            response = self.get_response(sort_by="date", limit=10, query="server:example.com")
-            assert response.status_code == 200
-            assert len(response.data) == 2
-            assert int(response.data[0]["id"]) == group2.id
-            assert response.data[0]["lifetime"] is not None
-            assert response.data[0]["filtered"] is not None
-            assert response.data[0]["filtered"]["stats"] is not None
-            assert response.data[0]["lifetime"]["stats"] is None
-            assert response.data[0]["filtered"]["stats"] != response.data[0]["stats"]
+                self.login_as(user=self.user)
+                response = self.get_response(sort_by="date", limit=10, query="server:example.com")
+                group_test = Group.objects.get(id=group2.id)
+                print("group2:", group2)
+                print("group2.times_seen:", group2.times_seen)
+                print("group_test:", group_test)
+                print("group_test.times_seen:", group_test.times_seen)
 
-            assert response.data[0]["lifetime"]["count"] == "4"
-            assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
-                before_now_300_seconds
-            ).replace(tzinfo=timezone.utc)
-            assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
-                before_now_100_seconds
-            ).replace(tzinfo=timezone.utc)
+                assert response.status_code == 200
+                assert len(response.data) == 2
+                assert int(response.data[0]["id"]) == group2.id
+                assert response.data[0]["lifetime"] is not None
+                assert response.data[0]["filtered"] is not None
+                assert response.data[0]["filtered"]["stats"] is not None
+                assert response.data[0]["lifetime"]["stats"] is None
+                assert response.data[0]["filtered"]["stats"] != response.data[0]["stats"]
 
-            assert response.data[0]["filtered"]["count"] == "2"
-            assert response.data[0]["filtered"]["firstSeen"] == parse_datetime(
-                before_now_250_seconds
-            ).replace(tzinfo=timezone.utc)
-            assert response.data[0]["filtered"]["lastSeen"] == parse_datetime(
-                before_now_150_seconds
-            ).replace(tzinfo=timezone.utc)
+                assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
+                    before_now_350_seconds  # Should match overridden value, not event value
+                ).replace(tzinfo=timezone.utc)
+                assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
+                    before_now_100_seconds
+                ).replace(tzinfo=timezone.utc)
+                assert response.data[0]["lifetime"]["count"] == "55"
 
-            # Empty filter test:
-            response = self.get_response(sort_by="date", limit=10, query="")
-            assert response.status_code == 200
-            assert len(response.data) == 2
-            assert int(response.data[0]["id"]) == group2.id
-            assert response.data[0]["lifetime"] is not None
-            assert response.data[0]["filtered"] is None
-            assert response.data[0]["lifetime"]["stats"] is None
+                assert response.data[0]["filtered"]["count"] == "2"
+                assert response.data[0]["filtered"]["firstSeen"] == parse_datetime(
+                    before_now_250_seconds
+                ).replace(tzinfo=timezone.utc)
+                assert response.data[0]["filtered"]["lastSeen"] == parse_datetime(
+                    before_now_150_seconds
+                ).replace(tzinfo=timezone.utc)
 
-            assert response.data[0]["lifetime"]["count"] == "4"
-            assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
-                before_now_300_seconds
-            ).replace(tzinfo=timezone.utc)
-            assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
-                before_now_100_seconds
-            ).replace(tzinfo=timezone.utc)
+                # Empty filter test:
+                response = self.get_response(sort_by="date", limit=10, query="")
+                assert response.status_code == 200
+                assert len(response.data) == 2
+                assert int(response.data[0]["id"]) == group2.id
+                assert response.data[0]["lifetime"] is not None
+                assert response.data[0]["filtered"] is None
+                assert response.data[0]["lifetime"]["stats"] is None
+
+                assert response.data[0]["lifetime"]["count"] == "55"
+                assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
+                    before_now_350_seconds  # Should match overridden value, not event value
+                ).replace(tzinfo=timezone.utc)
+                assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
+                    before_now_100_seconds
+                ).replace(tzinfo=timezone.utc)
 
     def test_skipped_fields(self):
         with self.feature("organizations:dynamic-issue-counts"):

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -313,7 +313,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         result = serialize(group, serializer=GroupSerializerSnuba(environment_ids=[]))
         assert result["count"] == "3"
         assert iso_format(result["lastSeen"]) == iso_format(self.min_ago)
-        assert iso_format(result["firstSeen"]) == group.first_seen
+        assert result["firstSeen"] == group.first_seen
 
         # update this to something different to make sure it's being used
         group_env = GroupEnvironment.objects.get(group_id=group_id, environment_id=environment.id)

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -333,8 +333,6 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert iso_format(group_env2.first_seen) > iso_format(group_env.first_seen)
         assert result["userCount"] == 3
 
-        # test userCount, count, lastSeen filtering correctly by time
-        # firstSeen should still be from GroupEnvironment
         result = serialize(
             group,
             serializer=GroupSerializerSnuba(

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -313,7 +313,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         result = serialize(group, serializer=GroupSerializerSnuba(environment_ids=[]))
         assert result["count"] == "3"
         assert iso_format(result["lastSeen"]) == iso_format(self.min_ago)
-        assert iso_format(result["firstSeen"]) == iso_format(self.week_ago)
+        assert iso_format(result["firstSeen"]) == group.first_seen
 
         # update this to something different to make sure it's being used
         group_env = GroupEnvironment.objects.get(group_id=group_id, environment_id=environment.id)

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -345,7 +345,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         )
         assert result["userCount"] == 1
         assert iso_format(result["lastSeen"]) == iso_format(self.week_ago)
-        assert iso_format(result["firstSeen"]) == iso_format(group_env.first_seen)
+        assert iso_format(result["firstSeen"]) == iso_format(self.week_ago)
         assert result["count"] == "1"
 
 


### PR DESCRIPTION
With our recent changes, we began querying snuba for times_seen and first_seen counts on an issue. This means those values were only reflective of events within their retention period and were more costly to compute.

This PR switches to pulling the values from the issue itself if there are no environment filters.