### PR TITLE
feat(workflow): Dynamic counts tooltip links to events if user doesn't have discover

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -160,7 +160,9 @@ const StreamGroup = createReactClass({
           queryTerms.push(`${queryTag}:${queryVal}`);
         }
 
-      if (!hasDiscoverQuery && queryObj.__text) queryTerms.push(queryObj.__text);
+      if (!hasDiscoverQuery && queryObj.__text) {
+        queryTerms.push(queryObj.__text);
+      }
     }
 
     const commonQuery = {projects: [data.project.id]};
@@ -189,15 +191,15 @@ const StreamGroup = createReactClass({
 
       const discoverView = EventView.fromSavedQuery(discoverQuery);
       return discoverView.getResultsViewUrlTarget(organization.slug);
-    } else {
-      return {
-        pathname: `/organizations/${organization.slug}/issues/${data.id}/events/`,
-        query: {
-          ...commonQuery,
-          query: searchQuery,
-        },
-      };
     }
+
+    return {
+      pathname: `/organizations/${organization.slug}/issues/${data.id}/events/`,
+      query: {
+        ...commonQuery,
+        query: searchQuery,
+      },
+    };
   },
 
   render() {

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -32,6 +32,21 @@ import {t} from 'app/locale';
 import Link from 'app/components/links/link';
 import {queryToObj} from 'app/utils/stream';
 
+const DiscoveryExclusionFields = [
+  'query',
+  'status',
+  'bookmarked_by',
+  'assigned',
+  'assigned_to',
+  'unassigned',
+  'subscribed_by',
+  'active_at',
+  'first_release',
+  'first_seen',
+  'is',
+  '__text',
+];
+
 const StreamGroup = createReactClass({
   displayName: 'StreamGroup',
 
@@ -139,7 +154,7 @@ const StreamGroup = createReactClass({
     if (filtered && query) {
       const queryObj = queryToObj(query);
       for (const queryTag in queryObj)
-        if (!['is', '__text'].includes(queryTag)) {
+        if (!DiscoveryExclusionFields.includes(queryTag)) {
           const queryVal = queryObj[queryTag].includes(' ')
             ? `"${queryObj[queryTag]}"`
             : queryObj[queryTag];

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -385,7 +385,7 @@ const SecondaryCount = styled(({value, ...p}) => <Count {...p} value={value} />)
 const StyledMenuItem = styled(({to, children, ...p}) => (
   <MenuItem noAnchor>
     {to ? (
-      <Link to={to}>
+      <Link to={to} target="_blank">
         <div {...p}>{children}</div>
       </Link>
     ) : (


### PR DESCRIPTION
This modifies the dynamic counts tooltip link so that it links to issue page events tab with the related query. Also added a list of properties that needs to be removed from the query so that the search works both in discover and issue/events.

Resolves: [WOR-259](https://getsentry.atlassian.net/browse/WOR-259)