### PR TITLE
fix(omni-search): Allow routeSource to work without org / project

### DIFF
--- a/src/sentry/static/sentry/app/components/search/sources/routeSource.tsx
+++ b/src/sentry/static/sentry/app/components/search/sources/routeSource.tsx
@@ -125,12 +125,6 @@ class RouteSource extends React.Component<Props, State> {
   async createSearch() {
     const {project, organization} = this.props;
 
-    // Can't search routes without org and project
-    if (!project || !organization) {
-      this.setState({fuzzy: null});
-      return;
-    }
-
     const context = {
       project,
       organization,

--- a/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/navigationConfiguration.tsx
@@ -3,8 +3,8 @@ import {NavigationSection} from 'app/views/settings/types';
 import {Organization, Project} from 'app/types';
 
 type ConfigParams = {
-  organization: Organization;
-  project: Project;
+  organization?: Organization;
+  project?: Project;
 };
 
 const pathPrefix = '/settings/:orgId/projects/:projectId';
@@ -69,7 +69,7 @@ export default function getConfiguration({
         {
           path: `${pathPrefix}/proguard/`,
           title: t('ProGuard'),
-          show: () => organization.features?.includes('android-mappings'),
+          show: () => !!organization?.features?.includes('android-mappings'),
         },
         {
           path: `${pathPrefix}/security-and-privacy/`,


### PR DESCRIPTION
Originally in https://github.com/getsentry/sentry/pull/20954 I had thought we _needed_ to pass project and org so the route map context could be evaluated in NavigationConfig's that used them to map values, but turns out this isn't strictly required, and passing an org and project a lot of times is not possible