### PR TITLE
ref(py3): Fix header comparison in bitbucket test

### DIFF
--- a/tests/sentry_plugins/bitbucket/test_plugin.py
+++ b/tests/sentry_plugins/bitbucket/test_plugin.py
@@ -84,7 +84,7 @@ class BitbucketPluginTest(PluginTestCase):
         assert self.plugin.create_issue(request, group, form_data) == 1
 
         request = responses.calls[-1].request
-        assert request.headers.get("Authorization", "").startswith("OAuth ")
+        assert request.headers.get("Authorization", b"").startswith(b"OAuth ")
 
     @responses.activate
     def test_link_issue(self):


### PR DESCRIPTION
I'm not _positive_ this should be bytes, but I didn't dig too deep where
this is being set