### PR TITLE
chore(py3): Make sentry backend and acceptance py3 tests required.

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -252,9 +252,8 @@ jobs:
             snapshot-path: .artifacts/visual-snapshots
 
     py3-acceptance:
-      name: 'py3 acceptance [ignore fails]'
+      name: 'py3.6 acceptance'
       runs-on: ubuntu-16.04
-      continue-on-error: true
       strategy:
         matrix:
           instance: [0, 1, 2]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -105,9 +105,8 @@ jobs:
           sentry django makemigrations -n ci_test --check --dry-run --no-input || (echo '::error::Error: Migration required -- to generate a migration, run `sentry django makemigrations -n <some_name>`' && exit 1)
 
   test-py3:
-    name: 'py3 [ignore fails]'
+    name: 'py3.6 Backend with migrations'
     runs-on: ubuntu-16.04
-    continue-on-error: true
     strategy:
       matrix:
         instance: [0, 1, 2, 3]


### PR DESCRIPTION
Leaving off snuba just for the moment since I've noticed it can be a little flaky, and don't want to
block people.