### PR TITLE
fix(sentry-apps): adds a post install method for mediators

### DIFF
--- a/src/sentry/mediators/mediator.py
+++ b/src/sentry/mediators/mediator.py
@@ -145,7 +145,7 @@ class Mediator(object):
                 result = obj.call()
                 obj.audit()
                 obj.record_analytics()
-        obj.post_install()
+        obj.post_commit()
         return result
 
     def __init__(self, *args, **kwargs):
@@ -162,7 +162,7 @@ class Mediator(object):
         # used to record data to Amplitude
         pass
 
-    def post_install(self):
+    def post_commit(self):
         # used to call any hooks that have to happen after the transaction has been committed
         pass
 

--- a/src/sentry/mediators/mediator.py
+++ b/src/sentry/mediators/mediator.py
@@ -145,7 +145,8 @@ class Mediator(object):
                 result = obj.call()
                 obj.audit()
                 obj.record_analytics()
-                return result
+        obj.post_install()
+        return result
 
     def __init__(self, *args, **kwargs):
         self.kwargs = kwargs
@@ -159,6 +160,10 @@ class Mediator(object):
 
     def record_analytics(self):
         # used to record data to Amplitude
+        pass
+
+    def post_install(self):
+        # used to call any hooks that have to happen after the transaction has been committed
         pass
 
     def call(self):

--- a/src/sentry/mediators/sentry_app_installations/creator.py
+++ b/src/sentry/mediators/sentry_app_installations/creator.py
@@ -21,7 +21,6 @@ class Creator(Mediator):
         self._create_api_grant()
         self._create_install()
         self._create_service_hooks()
-        self._notify_service()
         self.install.is_new = True
         return self.install
 
@@ -54,7 +53,7 @@ class Creator(Mediator):
                 url=self.sentry_app.webhook_url,
             )
 
-    def _notify_service(self):
+    def post_install(self):
         if self.notify:
             installation_webhook.delay(self.install.id, self.user.id)
 

--- a/src/sentry/mediators/sentry_app_installations/creator.py
+++ b/src/sentry/mediators/sentry_app_installations/creator.py
@@ -53,7 +53,7 @@ class Creator(Mediator):
                 url=self.sentry_app.webhook_url,
             )
 
-    def post_install(self):
+    def post_commit(self):
         if self.notify:
             installation_webhook.delay(self.install.id, self.user.id)
 

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -35,22 +35,25 @@ class TestCreator(TestCase):
 
         self.creator = Creator(organization=self.org, slug="nulldb", user=self.user)
 
+    def run_creator(self):
+        return Creator.run(organization=self.org, slug="nulldb", user=self.user)
+
     @responses.activate
     def test_creates_installation(self):
         responses.add(responses.POST, "https://example.com/webhook")
-        install = self.creator.call()
+        install = self.run_creator()
         assert install.pk
 
     @responses.activate
     def test_creates_api_grant(self):
         responses.add(responses.POST, "https://example.com/webhook")
-        install = self.creator.call()
+        install = self.run_creator()
         assert ApiGrant.objects.filter(id=install.api_grant_id).exists()
 
     @responses.activate
     def test_creates_service_hooks(self):
         responses.add(responses.POST, "https://example.com/webhook")
-        install = self.creator.call()
+        install = self.run_creator()
 
         hook = ServiceHook.objects.get(organization_id=self.org.id)
 
@@ -80,14 +83,14 @@ class TestCreator(TestCase):
     @responses.activate
     def test_associations(self):
         responses.add(responses.POST, "https://example.com/webhook")
-        install = self.creator.call()
+        install = self.run_creator()
 
         assert install.api_grant is not None
 
     @responses.activate
     def test_pending_status(self):
         responses.add(responses.POST, "https://example.com/webhook")
-        install = self.creator.call()
+        install = self.run_creator()
 
         assert install.status == SentryAppInstallationStatus.PENDING
 
@@ -95,8 +98,7 @@ class TestCreator(TestCase):
     def test_installed_status(self):
         responses.add(responses.POST, "https://example.com/webhook")
         internal_app = self.create_internal_integration(name="internal", organization=self.org)
-        creator = Creator(organization=self.org, slug=internal_app.slug, user=self.user)
-        install = creator.call()
+        install = Creator.run(organization=self.org, slug=internal_app.slug, user=self.user)
 
         assert install.status == SentryAppInstallationStatus.INSTALLED
 

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -33,8 +33,6 @@ class TestCreator(TestCase):
             events=("issue.created",),
         )
 
-        self.creator = Creator(organization=self.org, slug="nulldb", user=self.user)
-
     def run_creator(self):
         return Creator.run(organization=self.org, slug="nulldb", user=self.user)
 

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -74,7 +74,7 @@ class TestCreator(TestCase):
     def test_notifies_service(self, run):
         with self.tasks():
             responses.add(responses.POST, "https://example.com/webhook")
-            install = self.creator.call()
+            install = Creator.run(organization=self.org, slug="nulldb", user=self.user)
             run.assert_called_once_with(install=install, user=self.user, action="created")
 
     @responses.activate

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -33,8 +33,8 @@ class TestCreator(TestCase):
             events=("issue.created",),
         )
 
-    def run_creator(self):
-        return Creator.run(organization=self.org, slug="nulldb", user=self.user)
+    def run_creator(self, **kwargs):
+        return Creator.run(organization=self.org, slug="nulldb", user=self.user, **kwargs)
 
     @responses.activate
     def test_creates_installation(self):
@@ -75,7 +75,7 @@ class TestCreator(TestCase):
     def test_notifies_service(self, run):
         with self.tasks():
             responses.add(responses.POST, "https://example.com/webhook")
-            install = Creator.run(organization=self.org, slug="nulldb", user=self.user)
+            install = self.run_creator()
             run.assert_called_once_with(install=install, user=self.user, action="created")
 
     @responses.activate

--- a/tests/sentry/mediators/sentry_apps/test_internal_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_internal_creator.py
@@ -13,45 +13,47 @@ class TestInternalCreator(TestCase):
         self.user = self.create_user()
         self.org = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.org)
-        self.creator = InternalCreator(
+
+    def run_creator(self, **kwargs):
+        return InternalCreator.run(
             name="nulldb",
             user=self.user,
             organization=self.org,
             scopes=("project:read",),
             webhook_url="http://example.com",
             schema={"elements": [self.create_issue_link_schema()]},
+            **kwargs
         )
 
     def test_slug(self):
-        sentry_app = self.creator.call()
+        sentry_app = self.run_creator()
         # test slug is the name + a UUID
         assert sentry_app.slug[:7] == "nulldb-"
         assert len(sentry_app.slug) == 13
 
     def test_creates_internal_sentry_app(self):
-        sentry_app = self.creator.call()
+        sentry_app = self.run_creator()
         assert sentry_app.author == self.org.name
         assert SentryApp.objects.filter(slug=sentry_app.slug).exists()
 
     def test_installs_to_org(self):
-        sentry_app = self.creator.call()
+        sentry_app = self.run_creator()
 
         assert SentryAppInstallation.objects.filter(
             organization=self.org, sentry_app=sentry_app
         ).exists()
 
     def test_author(self):
-        self.creator.kwargs["author"] = "custom"
-        sentry_app = self.creator.call()
+        sentry_app = self.run_creator(author="custom")
         assert sentry_app.author == "custom"
 
     @patch("sentry.tasks.sentry_apps.installation_webhook.delay")
     def test_does_not_notify_service(self, delay):
-        self.creator.call()
+        self.run_creator()
         assert not len(delay.mock_calls)
 
     def test_creates_access_token(self):
-        sentry_app = self.creator.call()
+        sentry_app = self.run_creator()
 
         install = SentryAppInstallation.objects.get(organization=self.org, sentry_app=sentry_app)
 

--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -139,7 +139,8 @@ class TestMediator(TestCase):
 
         assert not User.objects.filter(username="beep").exists()
 
-    def test_post_install(self):
-        with patch.object(MockMediator, "post_install") as mock:
-            MockMediator.run(user={"name": "Example"}, age=30)
-            mock.assert_called_once_with()
+    @patch.object(MockMediator, "post_commit")
+    def test_post_commit(self, mock_post_commit):
+        mediator = MockMediator(user={"name": "Example"}, age=30)
+        mediator.run(user={"name": "Example"}, age=30)
+        mock_post_commit.assert_called_once_with()

--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -138,3 +138,8 @@ class TestMediator(TestCase):
             TransactionMediator.run()
 
         assert not User.objects.filter(username="beep").exists()
+
+    def test_post_install(self):
+        with patch.object(MockMediator, "post_install") as mock:
+            MockMediator.run(user={"name": "Example"}, age=30)
+            mock.assert_called_once_with()

--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -140,7 +140,9 @@ class TestMediator(TestCase):
         assert not User.objects.filter(username="beep").exists()
 
     @patch.object(MockMediator, "post_commit")
-    def test_post_commit(self, mock_post_commit):
+    @patch.object(MockMediator, "call")
+    def test_post_commit(self, mock_call, mock_post_commit):
         mediator = MockMediator(user={"name": "Example"}, age=30)
         mediator.run(user={"name": "Example"}, age=30)
         mock_post_commit.assert_called_once_with()
+        mock_call.assert_called_once_with()


### PR DESCRIPTION
This fixes a bug where we try to query an installation to send the installation webhook and we get a `workflow_notification.missing_installation` error:
https://github.com/getsentry/sentry/blob/301db9560d2774f71e9ae2b4bc9687809ec0d0ba/src/sentry/tasks/sentry_apps.py#L219-L224

This is happening because the newly created installation has not been committed yet as it's within an atomic transaction:
https://github.com/getsentry/sentry/blob/301db9560d2774f71e9ae2b4bc9687809ec0d0ba/src/sentry/mediators/mediator.py#L140-L148

The `call` method for the Sentry App installation creator is where the `SentryAppInstallation` is created and the installation webhook task is kicked off.

The solution is to make a method we call outside of the transaction (`post_install`) which can handle sending off the installation webhook.