### PR TITLE
test(relay): Xfail test_recursion_breaker, it's flaky in CI

### DIFF
--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -45,6 +45,7 @@ def test_simple(post_event_with_sdk):
     assert event.data["logentry"]["formatted"] == "internal client test"
 
 
+@pytest.mark.xfail
 @pytest.mark.django_db
 def test_recursion_breaker(settings, post_event_with_sdk):
     # If this test terminates at all then we avoided recursion.


### PR DESCRIPTION
Unless anyone has a better suggestion, I'm going to xfail this for being very flakey and blocking master.