### PR TITLE
fix: Bump pytest-sentry

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ pytest==4.6.5
 pytest-cov==2.5.1
 pytest-django==3.5.1
 pytest-html==1.22.0
-pytest-sentry==0.1.4
+pytest-sentry==0.1.5
 pytest-rerunfailures==8.0
 responses>=0.8.1,<0.9.0
 werkzeug==0.15.5

--- a/src/sentry/testutils/asserts.py
+++ b/src/sentry/testutils/asserts.py
@@ -12,7 +12,7 @@ def assert_mock_called_once_with_partial(mock, *args, **kwargs):
     for i, arg in enumerate(args):
         assert m_args[i] == arg
     for kwarg in kwargs:
-        assert m_kwargs[kwarg] == kwargs[kwarg]
+        assert m_kwargs[kwarg] == kwargs[kwarg], (m_kwargs[kwarg], kwargs[kwarg])
 
 
 commit_file_type_choices = {c[0] for c in CommitFileChange._meta.get_field("type").choices}

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -45,7 +45,6 @@ def test_simple(post_event_with_sdk):
     assert event.data["logentry"]["formatted"] == "internal client test"
 
 
-@pytest.mark.xfail
 @pytest.mark.django_db
 def test_recursion_breaker(settings, post_event_with_sdk):
     # If this test terminates at all then we avoided recursion.


### PR DESCRIPTION
Need this bugfix to unbreak tests: https://github.com/untitaker/pytest-sentry/commit/f2965e21bce8686ae79779d5a2e823c7564d003d