### PR TITLE
fix(ui): Correct quoting of tags with parens and spaces

### DIFF
--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -61,7 +61,7 @@ export class QueryResults {
       }
 
       let trailingParen = '';
-      if (token.endsWith(')')) {
+      if (token.endsWith(')') && !token.includes('(')) {
         const parenMatch = token.match(/\)+$/g);
         if (parenMatch) {
           trailingParen = parenMatch[0];

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -413,6 +413,11 @@ describe('utils/tokenizeSearch', function() {
         object: new QueryResults(['country:>canada', 'OR', 'coronaFree():<newzealand']),
         string: 'country:>canada OR coronaFree():<newzealand',
       },
+      {
+        name: 'should quote tags with parens and spaces',
+        object: new QueryResults(['release:4.9.0 build (0.0.01)', 'error.handled:0']),
+        string: 'release:"4.9.0 build (0.0.01)" error.handled:0',
+      },
     ];
 
     for (const {name, string, object} of cases) {


### PR DESCRIPTION
This is likely a hotfix for a specific scenario.
We will follow up with people with more context to figure out if there's a better solution.