### PR TITLE
fix(git) Fixup ignored commit sha

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -51,5 +51,5 @@ f736793749a7e0a120a3d5f8630959864e553adb
 # https://github.com/getsentry/sentry/pull/14950
 6ffce5ab2755cda5721df8e8eeac8314b47fab2e
 
-# chore(prettier): Apply prettier 2.1
-81a96fe595e9711ef986a484bcae90775f566549
+# chore(prettier): Apply prettier 2.1 (#21605)
+032754739fd210e1d12c076bad4ce8093cbae574


### PR DESCRIPTION
After squash merging the sha changed.