### PR TITLE
fix(discover) Hide the discover banner after a query is made

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -22,7 +22,6 @@ import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMess
 import SearchBar from 'app/components/searchBar';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import SentryTypes from 'app/sentryTypes';
-import localStorage from 'app/utils/localStorage';
 import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
 import EventView from 'app/utils/discover/eventView';
@@ -30,11 +29,9 @@ import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 
 import {DEFAULT_EVENT_VIEW} from './data';
-import {getPrebuiltQueries} from './utils';
+import {getPrebuiltQueries, isBannerHidden, setBannerHidden} from './utils';
 import QueryList from './queryList';
 import Banner from './banner';
-
-const BANNER_DISMISSED_KEY = 'discover-banner-dismissed';
 
 const SORT_OPTIONS: SelectValue<string>[] = [
   {label: t('My Queries'), value: 'myqueries'},
@@ -44,10 +41,6 @@ const SORT_OPTIONS: SelectValue<string>[] = [
   {label: t('Date Created (Oldest)'), value: 'dateCreated'},
   {label: t('Most Outdated'), value: 'dateUpdated'},
 ];
-
-function checkIsBannerHidden(): boolean {
-  return localStorage.getItem(BANNER_DISMISSED_KEY) === 'true';
-}
 
 type Props = {
   organization: Organization;
@@ -80,7 +73,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     errors: [],
 
     // local component state
-    isBannerHidden: checkIsBannerHidden(),
+    isBannerHidden: isBannerHidden(),
     isSmallBanner: this.mq?.matches,
     savedQueries: [],
     savedQueriesPageLinks: '',
@@ -173,14 +166,13 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const isBannerHidden = checkIsBannerHidden();
+    const isBannerHidden = isBannerHidden();
     if (isBannerHidden !== this.state.isBannerHidden) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
         isBannerHidden,
       });
     }
-
     const PAYLOAD_KEYS = ['sort', 'cursor', 'query'] as const;
 
     const payloadKeysChanged = !isEqual(
@@ -199,8 +191,8 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     this.fetchData({reloading: true});
   };
 
-  handleClick = () => {
-    localStorage.setItem(BANNER_DISMISSED_KEY, 'true');
+  handleBannerClick = () => {
+    setBannerHidden(true);
     this.setState({isBannerHidden: true});
   };
 
@@ -250,7 +242,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
         organization={organization}
         resultsUrl={resultsUrl}
         isSmallBanner={this.state.isSmallBanner}
-        onHideBanner={this.handleClick}
+        onHideBanner={this.handleBannerClick}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -166,11 +166,11 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const isBannerHidden = isBannerHidden();
-    if (isBannerHidden !== this.state.isBannerHidden) {
+    const isHidden = isBannerHidden();
+    if (isHidden !== this.state.isBannerHidden) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
-        isBannerHidden,
+        isBannerHidden: isHidden,
       });
     }
     const PAYLOAD_KEYS = ['sort', 'cursor', 'query'] as const;

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -19,6 +19,7 @@ import withProjects from 'app/utils/withProjects';
 import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
 import CreateAlertButton from 'app/components/createAlertButton';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
+import {setBannerHidden} from 'app/views/eventsV2/utils';
 
 import {handleCreateQuery, handleUpdateQuery, handleDeleteQuery} from './utils';
 
@@ -157,6 +158,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
       (savedQuery: SavedQuery) => {
         const view = EventView.fromSavedQuery(savedQuery);
 
+        setBannerHidden(true);
         this.setState({queryName: ''});
         browserHistory.push(view.getResultsViewUrlTarget(organization.slug));
       }

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -11,6 +11,7 @@ import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {disableMacros} from 'app/views/discover/result/utils';
 import {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
 import EventView from 'app/utils/discover/eventView';
+import localStorage from 'app/utils/localStorage';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
 import {
   Field,
@@ -479,4 +480,13 @@ export function generateFieldOptions({
   }
 
   return fieldOptions;
+}
+
+const BANNER_DISMISSED_KEY = 'discover-banner-dismissed';
+
+export function isBannerHidden(): boolean {
+  return localStorage.getItem(BANNER_DISMISSED_KEY) === 'true';
+}
+export function setBannerHidden(value: boolean) {
+  localStorage.setItem(BANNER_DISMISSED_KEY, value ? 'true' : 'false');
 }

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -6,6 +6,7 @@ import SavedQueryButtonGroup from 'app/views/eventsV2/savedQuery';
 import {ALL_VIEWS} from 'app/views/eventsV2/data';
 import EventView from 'app/utils/discover/eventView';
 import * as utils from 'app/views/eventsV2/savedQuery/utils';
+import {setBannerHidden, isBannerHidden} from 'app/views/eventsV2/utils';
 
 const SELECTOR_BUTTON_SAVE_AS = 'ButtonSaveAs';
 const SELECTOR_BUTTON_SAVED = '[data-test-id="discover2-savedquery-button-saved"]';
@@ -92,6 +93,31 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
       expect(buttonSaved.exists()).toBe(false);
       expect(buttonUpdate.exists()).toBe(false);
       expect(buttonDelete.exists()).toBe(false);
+    });
+
+    it('hides the banner when save is complete.', async () => {
+      const wrapper = generateWrappedComponent(
+        location,
+        organization,
+        errorsView,
+        undefined
+      );
+      setBannerHidden(false);
+
+      // Click on ButtonSaveAs to open dropdown
+      const buttonSaveAs = wrapper.find('DropdownControl').first();
+      buttonSaveAs.simulate('click');
+
+      // Fill in the Input
+      buttonSaveAs
+        .find('ButtonSaveInput')
+        .simulate('change', {target: {value: 'My New Query Name'}}); // currentTarget.value does not work
+      await tick();
+
+      // Click on Save in the Dropdown
+      await buttonSaveAs.find('ButtonSaveDropDown Button').simulate('click');
+      // Banner should be hidden.
+      expect(isBannerHidden()).toEqual(true);
     });
 
     it('saves a well-formed query', async () => {


### PR DESCRIPTION
The banner is reasonably large and many users are not aware that it can be hidden. If the user creates a query we can infer that they got through the documentation and don't need the banner anymore.

Fixes VIS-148