### PR TITLE
fix(alert): Add missing redirect

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -270,6 +270,7 @@ function routes() {
           }
         />
         <Redirect from="new/" to="/organizations/:orgId/alerts/:projectId/new/" />
+        <Redirect from="rules/" to="/organizations/:orgId/alerts/rules/" />
         <Redirect from="rules/new/" to="/organizations/:orgId/alerts/:projectId/new/" />
         <Redirect
           from="metric-rules/new/"


### PR DESCRIPTION
Noticed that I missed one redirect from https://github.com/getsentry/sentry/pull/20304 :/ 
Should remove one more case from JAVASCRIPT-3DR