### PR TITLE
ref(slack): Update CTA description and percentage

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import random
 import logging
 import six
 
@@ -23,8 +22,6 @@ from .utils import (
     get_integration_type,
 )
 
-# 50% of messages for workspace apps will get the upgrade CTA
-UPGRADE_MESSAGE_FREQUENCY = 0.50
 logger = logging.getLogger("sentry.rules")
 
 
@@ -162,9 +159,8 @@ class SlackNotifyServiceAction(EventAction):
                 # check if we should have the upgrade notice attachment
                 integration_type = get_integration_type(integration)
                 if integration_type == "workspace_app":
-                    if random.uniform(0, 1) < UPGRADE_MESSAGE_FREQUENCY:
-                        # stick the upgrade attachment first
-                        attachments.insert(0, build_upgrade_notice_attachment(event.group))
+                    # stick the upgrade attachment first
+                    attachments.insert(0, build_upgrade_notice_attachment(event.group))
 
                 span.set_tag("integration_type", integration_type)
                 span.set_tag("has_slack_upgrade_cta", len(attachments) > 1)

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -179,11 +179,12 @@ def build_upgrade_notice_attachment(group):
     )
 
     return {
-        "title": "Reminder",
+        "title": "Deprecation Notice",
         "text": (
-            u"It looks like you are still using the Legacy Sentry-Slack integration. "
-            u"You will need to upgrade by October 1st to continue receiving alerts. "
-            u"Click <{}|here> to upgrade.".format(url)
+            u"This alert is coming from a deprecated version of the Sentry-Slack integration. "
+            u"Your Slack integration, along with any data associated with it, will be *permanently deleted on January 14, 2021* "
+            u"if you do not transition to the new supported Slack integration. "
+            u"Click <{}|here> to complete the process.".format(url)
         ),
     }
 

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -5,7 +5,6 @@ import responses
 from six.moves.urllib.parse import parse_qs
 
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from sentry.models import Integration
 from sentry.testutils.cases import RuleTestCase
 from sentry.integrations.slack import SlackNotifyServiceAction
@@ -30,37 +29,8 @@ class SlackNotifyActionTest(RuleTestCase):
         assert form.cleaned_data["channel_id"] == expected_channel_id
         assert form.cleaned_data["channel"] == expected_channel
 
-    @patch("random.uniform", return_value=1)
     @responses.activate
-    def test_applies_correctly(self, mock_uniform):
-        event = self.get_event()
-
-        rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
-
-        results = list(rule.after(event=event, state=self.get_state()))
-        assert len(results) == 1
-
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/chat.postMessage",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-
-        # Trigger rule callback
-        results[0].callback(event, futures=[])
-        data = parse_qs(responses.calls[0].request.body)
-
-        assert "attachments" in data
-        attachments = json.loads(data["attachments"][0])
-
-        assert len(attachments) == 1
-        assert attachments[0]["title"] == event.title
-
-    @responses.activate
-    @patch("random.uniform", return_value=0.01)
-    def test_upgrade_notice_within_threshold(self, mock_uniform):
+    def test_upgrade_notice_workspace_app(self):
         event = self.get_event()
         rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
 
@@ -82,44 +52,12 @@ class SlackNotifyActionTest(RuleTestCase):
         assert "attachments" in data
         attachments = json.loads(data["attachments"][0])
 
+        # all workspaces apps should have the upgrade notice
         assert len(attachments) == 2
         assert attachments[1]["title"] == event.title
 
-        mock_uniform.assert_called_with(0, 1)
-
     @responses.activate
-    @patch("random.uniform", return_value=0.99)
-    def test_upgrade_notice_over_threshold(self, mock_uniform):
-        event = self.get_event()
-
-        rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
-
-        results = list(rule.after(event=event, state=self.get_state()))
-        assert len(results) == 1
-
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/chat.postMessage",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-
-        # Trigger rule callback
-        results[0].callback(event, futures=[])
-        data = parse_qs(responses.calls[0].request.body)
-
-        assert "attachments" in data
-        attachments = json.loads(data["attachments"][0])
-
-        assert len(attachments) == 1
-        assert attachments[0]["title"] == event.title
-
-        mock_uniform.assert_called_with(0, 1)
-
-    @responses.activate
-    @patch("random.uniform", return_value=0.49)
-    def test_upgrade_notice_bot_app(self, mock_uniform):
+    def test_no_upgrade_notice_bot_app(self):
         self.integration.metadata.update(
             {
                 "installation_type": "born_as_bot",
@@ -152,8 +90,6 @@ class SlackNotifyActionTest(RuleTestCase):
 
         assert len(attachments) == 1
         assert attachments[0]["title"] == event.title
-
-        assert mock_uniform.call_count == 0
 
     def test_render_label(self):
         rule = self.get_rule(


### PR DESCRIPTION
**Context:**
The legacy workspace Sentry-Slack integration is officially deprecated as of **October 1, 2020**. Up until today we've been sending reminders with slack alerts about this deprecation date. The original PR for these reminders can be found [here](https://github.com/getsentry/sentry/pull/20022).


**Reminder -> Deprecation Notice**
 Now that it's here we want to update the language to better reflect the upcoming deadline:

<img width="647" alt="Screen Shot 2020-10-01 at 11 32 17 AM" src="https://user-images.githubusercontent.com/15368179/94851367-32cec700-03dd-11eb-9c8d-0ed2ec914f57.png">

In addition to the update language, this PR makes it so _all_ (100%) alerts sent using the workspace app will have this notice attached. It is currently at 50%.