### PR TITLE
feat(alert): Reintroduce 'none' operator

### DIFF
--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -131,14 +131,6 @@ class RuleSerializer(serializers.Serializer):
                     }
                 )
 
-        # ensure that if a user has alert-filters enabled, they do not use a 'none' match on conditions
-        if project_has_filters and attrs.get("actionMatch") == "none":
-            raise serializers.ValidationError(
-                {
-                    "conditions": u"The 'none' match on conditions is outdated and no longer supported."
-                }
-            )
-
         return attrs
 
     def save(self, rule):

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -59,11 +59,6 @@ const ACTION_MATCH_CHOICES: Array<[IssueAlertRule['actionMatch'], string]> = [
   ['none', t('none')],
 ];
 
-const ACTION_MATCH_CHOICES_MIGRATED: Array<[IssueAlertRule['actionMatch'], string]> = [
-  ['all', t('all')],
-  ['any', t('any')],
-];
-
 const defaultRule: UnsavedIssueAlertRule = {
   actionMatch: 'all',
   filterMatch: 'all',
@@ -530,11 +525,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                                       name="actionMatch"
                                       required
                                       flexibleControlStateSize
-                                      choices={
-                                        hasFeature
-                                          ? ACTION_MATCH_CHOICES_MIGRATED
-                                          : ACTION_MATCH_CHOICES
-                                      }
+                                      choices={ACTION_MATCH_CHOICES}
                                       onChange={val =>
                                         this.handleChange('actionMatch', val)
                                       }


### PR DESCRIPTION
Previously the `none` operator was taken out in https://github.com/getsentry/sentry/pull/20917. Upon further investigation, even though it does not make much sense to leave this operator in conditions/triggers, a lot of users have the `none` match applied. Previously, the migration strategy was to simply delete their rules when migrating them to issue alert filters or recommend them to change these `none` rules. However, this may just be too much work for a small deletion and in this case we are better off leaving the `none` operator in to support these rules in the new issue alert filter format.