### PR TITLE
feat(performance): adds transactions for external linked issues

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -88,6 +88,10 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
     this.submitTransaction?.finish();
   };
 
+  handleSubmitError = () => {
+    this.submitTransaction?.finish();
+  };
+
   onRequestSuccess({stateKey, data}) {
     if (stateKey === 'integrationDetails' && !this.state.dynamicFieldValues) {
       this.setState({
@@ -99,6 +103,10 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
   onLoadAllEndpointsSuccess() {
     this.loadTransasaction?.finish();
   }
+
+  onRequestError = () => {
+    this.loadTransasaction?.finish();
+  };
 
   refetchConfig = () => {
     const {dynamicFieldValues} = this.state;
@@ -228,6 +236,7 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
         submitDisabled={this.state.reloading}
         footerClass="modal-footer"
         onPreSubmit={this.handlePreSubmit}
+        onSubmitError={this.handleSubmitError}
       >
         {config.map(field => (
           <FieldFromConfig

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as queryString from 'query-string';
+import * as Sentry from '@sentry/react';
 import debounce from 'lodash/debounce';
 
 import {addSuccessMessage} from 'app/actionCreators/indicator';
@@ -49,6 +50,12 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
   };
 
   shouldRenderBadRequests = true;
+  loadTransasaction?: ReturnType<typeof Sentry.startTransaction>;
+  submitTransaction?: ReturnType<typeof Sentry.startTransaction>;
+
+  componentDidMount() {
+    this.loadTransasaction = this.startTransaction('load');
+  }
 
   getEndpoints(): [string, string][] {
     const {group, integration, action} = this.props;
@@ -60,9 +67,25 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
     ];
   }
 
+  startTransaction = (type: 'load' | 'submit') => {
+    const {action, group, integration} = this.props;
+    const transaction = Sentry.startTransaction({name: `externalIssueForm.${type}`});
+    transaction.setTag('issueAction', action);
+    transaction.setTag('groupID', group.id);
+    transaction.setTag('projectID', group.project.id);
+    transaction.setTag('integrationSlug', integration.provider.slug);
+    transaction.setTag('integrationType', 'firstParty');
+    return transaction;
+  };
+
+  handlePreSubmit = () => {
+    this.submitTransaction = this.startTransaction('submit');
+  };
+
   onSubmitSuccess = (data: PlatformExternalIssue) => {
     addSuccessMessage(MESSAGES_BY_ACTION[this.props.action]);
     this.props.onSubmitSuccess(data);
+    this.submitTransaction?.finish();
   };
 
   onRequestSuccess({stateKey, data}) {
@@ -71,6 +94,10 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
         dynamicFieldValues: this.getDynamicFields(data),
       });
     }
+  }
+
+  onLoadAllEndpointsSuccess() {
+    this.loadTransasaction?.finish();
   }
 
   refetchConfig = () => {
@@ -200,6 +227,7 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
         submitLabel={SUBMIT_LABEL_BY_ACTION[action]}
         submitDisabled={this.state.reloading}
         footerClass="modal-footer"
+        onPreSubmit={this.handlePreSubmit}
       >
         {config.map(field => (
           <FieldFromConfig

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -118,6 +118,7 @@ jest.mock('@sentry/react', () => {
     withScope: jest.spyOn(SentryReact, 'withScope'),
     Severity: SentryReact.Severity,
     withProfiler: SentryReact.withProfiler,
+    startTransaction: () => ({finish: jest.fn(), setTag: jest.fn()}),
   };
 });
 


### PR DESCRIPTION
I messed up the previous PR (https://github.com/getsentry/sentry/pull/21093) with force pushes so this is a redo.

This PR adds two transactions for external linked issues: loading the form (externalIssueForm.load) and submitting the form to create a linked issue (externalIssueForm.submit). I've also added some tags to the transactions to help with debugging in case we need to debug.

