### PR TITLE
fix(sentry-apps): check date deleted for installable sentry apps

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1243,6 +1243,7 @@ def get_alertable_sentry_apps(organization_id, with_metric_alerts=False):
         installations__organization_id=organization_id,
         is_alertable=True,
         installations__status=SentryAppInstallationStatus.INSTALLED,
+        installations__date_deleted=None,
     )
 
     if with_metric_alerts:

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from django.utils import timezone
+
 from sentry.utils.compat.mock import MagicMock, patch
 
 from sentry.testutils.cases import RuleTestCase
@@ -62,3 +64,25 @@ class NotifyEventServiceActionTest(RuleTestCase):
         assert plugin.should_notify.call_count == 1
         assert results[0].callback is notify_sentry_app
         assert results[1].callback is plugin.rule_notify
+
+    def test_sentry_app_installed(self):
+        event = self.get_event()
+
+        self.create_sentry_app(
+            organization=event.organization, name="Test Application", is_alertable=True
+        )
+
+        self.install = self.create_sentry_app_installation(
+            slug="test-application", organization=event.organization
+        )
+
+        rule = self.get_rule(data={"service": "test-application"})
+
+        results = rule.get_services()
+        assert len(results) == 1
+
+        self.install.date_deleted = timezone.now()
+        self.install.save()
+
+        results = rule.get_services()
+        assert len(results) == 0


### PR DESCRIPTION
This PR fixes a bug where uninstalled Sentry Apps show up in the dropdown for issue and metric alerts. This is because we weren't checking the `date_deleted` field of the installation.