### PR TITLE
fix(workflow): Issue stream first seen to use lifetime.firstSeen if available

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
@@ -28,6 +28,7 @@ function EventOrGroupExtraDetails({data, showAssignee, params}: Props) {
     annotations,
     shortId,
     project,
+    lifetime,
   } = data as Group;
 
   const issuesPath = `/organizations/${params.orgId}/issues/`;
@@ -44,7 +45,10 @@ function EventOrGroupExtraDetails({data, showAssignee, params}: Props) {
           }}
         />
       )}
-      <StyledTimes lastSeen={lastSeen} firstSeen={firstSeen} />
+      <StyledTimes
+        lastSeen={lifetime?.lastSeen || lastSeen}
+        firstSeen={lifetime?.firstSeen || firstSeen}
+      />
       {numComments > 0 && (
         <CommentsLink to={`${issuesPath}${id}/activity/`} className="comments">
           <IconChat


### PR DESCRIPTION
This fixes a consistency issue where if a use has dynamic counts feature the first seen and last seen in the issue stream they see is the product of the events in the selected period. This causes confusion where the dates essentially get clipped off by the date selection. Using filtered firstSeen and lastSeen brings it to parity with non-dynamic count dates.