### PR TITLE
feat(api-docs): Fix silently failing API docs tests

### DIFF
--- a/api-docs/components/schemas/event.json
+++ b/api-docs/components/schemas/event.json
@@ -628,7 +628,20 @@
       },
       "errors": {
         "type": "array",
-        "items": {}
+        "items": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object"
+            }
+          }
+        }
       },
       "eventID": {
         "type": "string"

--- a/api-docs/components/schemas/plugin.json
+++ b/api-docs/components/schemas/plugin.json
@@ -30,6 +30,7 @@
       },
       "author": {
         "type": "object",
+        "nullable": true,
         "properties": {
           "name": {
             "type": "string"
@@ -74,6 +75,7 @@
       },
       "resourceLinks": {
         "type": "array",
+        "nullable": true,
         "items": {
           "type": "object",
           "properties": {
@@ -99,7 +101,8 @@
         "type": "string"
       },
       "version": {
-        "type": "string"
+        "type": "string",
+        "nullable": true
       }
     }
   }

--- a/api-docs/components/schemas/project.json
+++ b/api-docs/components/schemas/project.json
@@ -205,7 +205,16 @@
         "type": "string"
       },
       "team": {
-        "$ref": "team.json#/TeamMinimal"
+          "type": "object",
+          "nullable": true,
+          "oneOf": [
+            {
+              "$ref": "team.json#/TeamMinimal"
+            },
+            {
+              "$ref": "null.json#/NullValue"
+            }
+          ]
       },
       "teams": {
         "type": "array",

--- a/api-docs/components/schemas/project.json
+++ b/api-docs/components/schemas/project.json
@@ -339,6 +339,7 @@
       },
       "latestRelease": {
         "type": "object",
+        "nullable": true,
         "required": [
           "authors",
           "commitCount",

--- a/api-docs/components/schemas/user-feedback.json
+++ b/api-docs/components/schemas/user-feedback.json
@@ -48,7 +48,7 @@
         "type": "string"
       },
       "user": {
-        "type": "string",
+        "type": "object",
         "nullable": true
       }
     }

--- a/api-docs/paths/organizations/shortid.json
+++ b/api-docs/paths/organizations/shortid.json
@@ -87,7 +87,8 @@
                       "type": "integer"
                     },
                     "culprit": {
-                      "type": "string"
+                      "type": "string",
+                      "nullable": true,
                     },
                     "title": {
                       "type": "string"

--- a/api-docs/paths/projects/user-feedback.json
+++ b/api-docs/paths/projects/user-feedback.json
@@ -124,7 +124,7 @@
       "required": false
     },
     "responses": {
-      "201": {
+      "200": {
         "description": "Success",
         "content": {
           "application/json": {

--- a/tests/apidocs/endpoints/organizations/test-org-details.py
+++ b/tests/apidocs/endpoints/organizations/test-org-details.py
@@ -10,7 +10,7 @@ from tests.apidocs.util import APIDocsTestCase
 
 class OrganizationDetailsDocs(APIDocsTestCase):
     def setUp(self):
-        organization = self.create_organization()
+        organization = self.create_organization(owner=self.user, name="Rowdy Tiger")
 
         self.url = reverse(
             "sentry-api-0-organization-details", kwargs={"organization_slug": organization.slug},

--- a/tests/apidocs/endpoints/organizations/test-org-projects.py
+++ b/tests/apidocs/endpoints/organizations/test-org-projects.py
@@ -10,7 +10,7 @@ from tests.apidocs.util import APIDocsTestCase
 
 class OrganizationProjectsDocs(APIDocsTestCase):
     def setUp(self):
-        organization = self.create_organization()
+        organization = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.create_project(name="foo", organization=organization, teams=[])
         self.create_project(name="bar", organization=organization, teams=[])
 

--- a/tests/apidocs/endpoints/organizations/test-org-repos.py
+++ b/tests/apidocs/endpoints/organizations/test-org-repos.py
@@ -10,7 +10,7 @@ from tests.apidocs.util import APIDocsTestCase
 
 class OrganizationReposDocs(APIDocsTestCase):
     def setUp(self):
-        organization = self.create_organization()
+        organization = self.create_organization(owner=self.user, name="Rowdy Tiger")
         project = self.create_project(name="foo", organization=organization, teams=[])
         self.create_repo(project=project, name="getsentry/sentry")
 

--- a/tests/apidocs/endpoints/organizations/test-org-users.py
+++ b/tests/apidocs/endpoints/organizations/test-org-users.py
@@ -10,7 +10,7 @@ from tests.apidocs.util import APIDocsTestCase
 
 class OrganizationUsersDocs(APIDocsTestCase):
     def setUp(self):
-        organization = self.create_organization()
+        organization = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.create_user(email="colleen@sentry.io")
 
         self.url = reverse(

--- a/tests/apidocs/endpoints/organizations/test-repo-commits.py
+++ b/tests/apidocs/endpoints/organizations/test-repo-commits.py
@@ -10,7 +10,7 @@ from tests.apidocs.util import APIDocsTestCase
 
 class OrganizationRepoCommitsDocs(APIDocsTestCase):
     def setUp(self):
-        organization = self.create_organization()
+        organization = self.create_organization(owner=self.user, name="Rowdy Tiger")
         project = self.create_project(name="foo", organization=organization, teams=[])
         repo = self.create_repo(project=project, name="getsentry/sentry")
         release = self.create_release(project=project)

--- a/tests/apidocs/endpoints/organizations/test-shortid.py
+++ b/tests/apidocs/endpoints/organizations/test-shortid.py
@@ -10,10 +10,11 @@ from tests.apidocs.util import APIDocsTestCase
 
 class OrganizationShortIDDocs(APIDocsTestCase):
     def setUp(self):
-        event = self.create_event("a", message="oh no")
+        self.create_event("a", message="oh no")
+        group = self.group = self.create_group(project=self.project)
         self.url = reverse(
             "sentry-api-0-short-id-lookup",
-            kwargs={"organization_slug": self.organization.slug, "short_id": event.group.short_id},
+            kwargs={"organization_slug": self.organization.slug, "short_id": group.short_id},
         )
 
         self.login_as(user=self.user)

--- a/tests/apidocs/endpoints/organizations/test-shortid.py
+++ b/tests/apidocs/endpoints/organizations/test-shortid.py
@@ -10,11 +10,14 @@ from tests.apidocs.util import APIDocsTestCase
 
 class OrganizationShortIDDocs(APIDocsTestCase):
     def setUp(self):
-        self.create_event("a", message="oh no")
-        group = self.group = self.create_group(project=self.project)
+        group = self.create_group(project=self.project)
+
         self.url = reverse(
             "sentry-api-0-short-id-lookup",
-            kwargs={"organization_slug": self.organization.slug, "short_id": group.short_id},
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "short_id": group.qualified_short_id,
+            },
         )
 
         self.login_as(user=self.user)

--- a/tests/apidocs/endpoints/projects/test-dsyms.py
+++ b/tests/apidocs/endpoints/projects/test-dsyms.py
@@ -2,6 +2,10 @@
 
 from __future__ import absolute_import
 
+import zipfile
+from six import BytesIO
+
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 
@@ -24,12 +28,24 @@ class ProjectDsymsDocs(APIDocsTestCase):
         self.validate_schema(request, response)
 
     def test_post(self):
+        PROGUARD_UUID = "6dc7fdb0-d2fb-4c8e-9d6b-bb1aa98929b1"
+        PROGUARD_SOURCE = b"""\
+        org.slf4j.helpers.Util$ClassContextSecurityManager -> org.a.b.g$a:
+        65:65:void <init>() -> <init>
+        67:67:java.lang.Class[] getClassContext() -> getClassContext
+        65:65:void <init>(org.slf4j.helpers.Util$1) -> <init>
+        """
+        out = BytesIO()
+        f = zipfile.ZipFile(out, "w")
+        f.writestr("proguard/%s.txt" % PROGUARD_UUID, PROGUARD_SOURCE)
+        f.close()
+        data = {
+            "file": SimpleUploadedFile(
+                "symbols.zip", out.getvalue(), content_type="application/zip"
+            ),
+        }
 
-        dif = self.create_dif_file(
-            debug_id="dfb8e43a-f242-3d73-a453-aeb6a777ef75", features=["debug", "unwind"]
-        )
-        data = {"file": dif.file}
-        response = self.client.post(self.url, data, content_type="multipart/form-data")
+        response = self.client.post(self.url, data, format="multipart",)
         request = RequestFactory().post(self.url, data)
 
         self.validate_schema(request, response)

--- a/tests/apidocs/endpoints/projects/test-key-details.py
+++ b/tests/apidocs/endpoints/projects/test-key-details.py
@@ -10,14 +10,13 @@ from tests.apidocs.util import APIDocsTestCase
 
 class ProjectKeyDetailsDocs(APIDocsTestCase):
     def setUp(self):
-        key = self.create_project_key(project=self.project)
 
         self.url = reverse(
             "sentry-api-0-project-key-details",
             kwargs={
-                "organization_slug": self.organization.slug,
+                "organization_slug": self.project.organization.slug,
                 "project_slug": self.project.slug,
-                "key_id": key.id,
+                "key_id": self.projectkey.public_key,
             },
         )
 

--- a/tests/apidocs/endpoints/projects/test-keys.py
+++ b/tests/apidocs/endpoints/projects/test-keys.py
@@ -10,7 +10,6 @@ from tests.apidocs.util import APIDocsTestCase
 
 class ProjectKeysDocs(APIDocsTestCase):
     def setUp(self):
-        self.create_project_key(project=self.project)
 
         self.url = reverse(
             "sentry-api-0-project-keys",

--- a/tests/apidocs/endpoints/projects/test-service-hook-details.py
+++ b/tests/apidocs/endpoints/projects/test-service-hook-details.py
@@ -17,7 +17,7 @@ class ProjectServiceHookDetailsDocs(APIDocsTestCase):
             kwargs={
                 "organization_slug": self.organization.slug,
                 "project_slug": self.project.slug,
-                "hook_id": hook.id,
+                "hook_id": hook.guid,
             },
         )
 

--- a/tests/apidocs/endpoints/projects/test-service-hooks.py
+++ b/tests/apidocs/endpoints/projects/test-service-hooks.py
@@ -20,17 +20,17 @@ class ProjectServiceHooksDocs(APIDocsTestCase):
 
         self.login_as(user=self.user)
 
-        print("URL", self.url)
-
     def test_get(self):
-        response = self.client.get(self.url)
+        with self.feature("projects:servicehooks"):
+            response = self.client.get(self.url)
         request = RequestFactory().get(self.url)
 
         self.validate_schema(request, response)
 
     def test_post(self):
         data = {"url": "https://example.com/other-sentry-hook", "events": ["event.created"]}
-        response = self.client.post(self.url, data)
+        with self.feature("projects:servicehooks"):
+            response = self.client.post(self.url, data)
         request = RequestFactory().post(self.url, data)
 
         self.validate_schema(request, response)

--- a/tests/apidocs/openapi-derefed.json
+++ b/tests/apidocs/openapi-derefed.json
@@ -3369,21 +3369,42 @@
                       "slug": {
                         "type": "string"
                       },
-                      "team": {
-                        "type": "object",
-                        "required": ["id", "name", "slug"],
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "slug": {
-                            "type": "string"
-                          }
-                        }
-                      },
+                        "team": {
+                            "type": "object",
+                            "nullable": true,
+                            "oneOf": [
+                              {
+                              "type": "object",
+                              "required": ["id", "name", "slug"],
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "slug": {
+                                  "type": "string"
+                                }
+                              }
+                              },
+                              {
+                              "nullable": true,
+                              "not": {
+                                "anyOf": [
+                                  { "type": "string" },
+                                  { "type": "number" },
+                                  { "type": "boolean" },
+                                  { "type": "object" },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  }
+                                ]
+                              }
+                              }
+                            ]
+                        },
                       "teams": {
                         "type": "array",
                         "items": {
@@ -4049,7 +4070,8 @@
                           "type": "integer"
                         },
                         "culprit": {
-                          "type": "string"
+                          "type": "string",
+                          "nullable": true
                         },
                         "title": {
                           "type": "string"

--- a/tests/apidocs/openapi-derefed.json
+++ b/tests/apidocs/openapi-derefed.json
@@ -6658,7 +6658,7 @@
           "required": false
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "Success",
             "content": {
               "application/json": {
@@ -6711,7 +6711,7 @@
                       "type": "string"
                     },
                     "user": {
-                      "type": "string",
+                      "type": "object",
                       "nullable": true
                     }
                   }

--- a/tests/apidocs/openapi-derefed.json
+++ b/tests/apidocs/openapi-derefed.json
@@ -4714,6 +4714,7 @@
                     },
                     "latestRelease": {
                       "type": "object",
+                      "nullable": true,
                       "required": [
                         "authors",
                         "commitCount",
@@ -4920,10 +4921,8 @@
                         "type": "object",
                         "required": [
                           "assets",
-                          "author",
                           "canDisable",
                           "contexts",
-                          "description",
                           "doc",
                           "enabled",
                           "hasConfiguration",
@@ -4931,12 +4930,10 @@
                           "isTestable",
                           "metadata",
                           "name",
-                          "resourceLinks",
                           "shortName",
                           "slug",
                           "status",
-                          "type",
-                          "version"
+                          "type"
                         ],
                         "properties": {
                           "assets": {
@@ -4947,6 +4944,7 @@
                           },
                           "author": {
                             "type": "object",
+                            "nullable": true,
                             "properties": {
                               "name": {
                                 "type": "string"
@@ -4991,6 +4989,7 @@
                           },
                           "resourceLinks": {
                             "type": "array",
+                            "nullable": true,
                             "items": {
                               "type": "object",
                               "properties": {
@@ -5016,7 +5015,8 @@
                             "type": "string"
                           },
                           "version": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                           }
                         }
                       }
@@ -5461,6 +5461,7 @@
                     },
                     "latestRelease": {
                       "type": "object",
+                      "nullable": true,
                       "required": [
                         "authors",
                         "commitCount",
@@ -5667,10 +5668,8 @@
                         "type": "object",
                         "required": [
                           "assets",
-                          "author",
                           "canDisable",
                           "contexts",
-                          "description",
                           "doc",
                           "enabled",
                           "hasConfiguration",
@@ -5678,12 +5677,10 @@
                           "isTestable",
                           "metadata",
                           "name",
-                          "resourceLinks",
                           "shortName",
                           "slug",
                           "status",
-                          "type",
-                          "version"
+                          "type"
                         ],
                         "properties": {
                           "assets": {

--- a/tests/apidocs/openapi-derefed.json
+++ b/tests/apidocs/openapi-derefed.json
@@ -2012,7 +2012,20 @@
                         },
                         "errors": {
                           "type": "array",
-                          "items": {}
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "data": {
+                                "type": "object"
+                              }
+                            }
+                          }
                         },
                         "eventID": {
                           "type": "string"


### PR DESCRIPTION
Some of the tests from https://github.com/getsentry/sentry/pull/21023 and https://github.com/getsentry/sentry/pull/21033 were returning 404s or 403s, but we weren't checking for that so they silently passed. This PR fixes those tests now that the util asserts there is a 2xx response code. 