### PR TITLE
feat(performance): adds transaction for SentryAppAuthorizationsEndpoint

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_authorizations.py
+++ b/src/sentry/api/endpoints/sentry_app_authorizations.py
@@ -2,41 +2,50 @@ from __future__ import absolute_import
 
 import logging
 
+import sentry_sdk
+
 from rest_framework.response import Response
 
 from sentry.api.bases import SentryAppAuthorizationsBaseEndpoint
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.token_exchange import GrantExchanger, Refresher, GrantTypes
 from sentry.api.serializers.models.apitoken import ApiTokenSerializer
+from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger(__name__)
 
 
 class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
+    @transaction_start("SentryAppAuthorizationsEndpoint")
     def post(self, request, installation):
-        try:
-            if request.json_body.get("grant_type") == GrantTypes.AUTHORIZATION:
-                token = GrantExchanger.run(
-                    install=installation,
-                    code=request.json_body.get("code"),
-                    client_id=request.json_body.get("client_id"),
-                    user=request.user,
-                )
-            elif request.json_body.get("grant_type") == GrantTypes.REFRESH:
-                token = Refresher.run(
-                    install=installation,
-                    refresh_token=request.json_body.get("refresh_token"),
-                    client_id=request.json_body.get("client_id"),
-                    user=request.user,
-                )
-            else:
-                return Response({"error": "Invalid grant_type"}, status=403)
-        except APIUnauthorized as e:
-            logger.error(e, exc_info=True)
-            return Response({"error": e.msg or "Unauthorized"}, status=403)
+        with sentry_sdk.configure_scope() as scope:
+            scope.set_tag("organization", installation.organization_id)
+            scope.set_tag("sentry_app_id", installation.sentry_app_id)
+            scope.set_tag("sentry_app_slug", installation.sentry_app.slug)
 
-        attrs = {"state": request.json_body.get("state"), "application": None}
+            try:
+                if request.json_body.get("grant_type") == GrantTypes.AUTHORIZATION:
+                    token = GrantExchanger.run(
+                        install=installation,
+                        code=request.json_body.get("code"),
+                        client_id=request.json_body.get("client_id"),
+                        user=request.user,
+                    )
+                elif request.json_body.get("grant_type") == GrantTypes.REFRESH:
+                    token = Refresher.run(
+                        install=installation,
+                        refresh_token=request.json_body.get("refresh_token"),
+                        client_id=request.json_body.get("client_id"),
+                        user=request.user,
+                    )
+                else:
+                    return Response({"error": "Invalid grant_type"}, status=403)
+            except APIUnauthorized as e:
+                logger.error(e, exc_info=True)
+                return Response({"error": e.msg or "Unauthorized"}, status=403)
 
-        body = ApiTokenSerializer().serialize(token, attrs, request.user)
+            attrs = {"state": request.json_body.get("state"), "application": None}
 
-        return Response(body, status=201)
+            body = ApiTokenSerializer().serialize(token, attrs, request.user)
+
+            return Response(body, status=201)


### PR DESCRIPTION
This PR adds a transaction for the `SentryAppAuthorizationsEndpoint` endpoint which is used during the token exchange (and refresh). This is a critical step during the installation process and if it's slow, it leads to bad user experience. I've added a few tags as well for debugging (`organization_id`, `sentry_app_id`, and `sentry_app_slug`).