### PR TITLE
fix(py3): add compat for logging._levelNames

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -263,8 +263,10 @@ def configure_structlog():
 
     lvl = os.environ.get("SENTRY_LOG_LEVEL")
 
-    if lvl and lvl not in logging._levelNames:
-        raise AttributeError("%s is not a valid logging level." % lvl)
+    if lvl:
+        levelNames = logging._levelNames if not six.PY3 else logging._nameToLevel
+        if lvl not in levelNames:
+            raise AttributeError("%s is not a valid logging level." % lvl)
 
     settings.LOGGING["root"].update({"level": lvl or settings.LOGGING["default_level"]})
 


### PR DESCRIPTION
Reproduce under py3 via `SENTRY_LOG_LEVEL=ERROR sentry django makemigrations -n test --check --dry-run --no-input`.

This was discovered here: https://github.com/getsentry/sentry/pull/21098#issuecomment-702389125

And also cherry-picked to there and it works.

No other occurrences org-wide.