### PR TITLE
feat(api-docs): Fix API docs tests which returned empty arrays

### DIFF
--- a/api-docs/components/schemas/plugin.json
+++ b/api-docs/components/schemas/plugin.json
@@ -3,10 +3,8 @@
     "type": "object",
     "required": [
       "assets",
-      "author",
       "canDisable",
       "contexts",
-      "description",
       "doc",
       "enabled",
       "hasConfiguration",
@@ -14,12 +12,10 @@
       "isTestable",
       "metadata",
       "name",
-      "resourceLinks",
       "shortName",
       "slug",
       "status",
       "type",
-      "version"
     ],
     "properties": {
       "assets": {

--- a/api-docs/components/schemas/users.json
+++ b/api-docs/components/schemas/users.json
@@ -90,7 +90,8 @@
         "type": "string"
       },
       "lastLogin": {
-        "type": "string"
+        "type": "string",
+        "nullable": true
       },
       "isSuperuser": {
         "type": "boolean"

--- a/tests/apidocs/endpoints/organizations/test-org-index.py
+++ b/tests/apidocs/endpoints/organizations/test-org-index.py
@@ -10,7 +10,7 @@ from tests.apidocs.util import APIDocsTestCase
 
 class OrganizationIndexDocs(APIDocsTestCase):
     def setUp(self):
-        self.create_organization()
+        self.create_organization(owner=self.user, name="Rowdy Tiger")
 
         self.url = reverse("sentry-api-0-organizations",)
 

--- a/tests/apidocs/endpoints/organizations/test-org-users.py
+++ b/tests/apidocs/endpoints/organizations/test-org-users.py
@@ -10,14 +10,18 @@ from tests.apidocs.util import APIDocsTestCase
 
 class OrganizationUsersDocs(APIDocsTestCase):
     def setUp(self):
-        organization = self.create_organization(owner=self.user, name="Rowdy Tiger")
-        self.create_user(email="colleen@sentry.io")
+        self.owner_user = self.create_user("foo@localhost", username="foo")
+        self.user_2 = self.create_user("bar@localhost", username="bar")
 
+        self.org = self.create_organization(owner=self.owner_user)
+        self.org.member_set.create(user=self.user_2)
+        self.team = self.create_team(organization=self.org, members=[self.owner_user, self.user_2])
+        self.project = self.create_project(teams=[self.team])
+
+        self.login_as(user=self.user_2)
         self.url = reverse(
-            "sentry-api-0-organization-users", kwargs={"organization_slug": organization.slug},
+            "sentry-api-0-organization-users", kwargs={"organization_slug": self.org.slug},
         )
-
-        self.login_as(user=self.user)
 
     def test_get(self):
         response = self.client.get(self.url)

--- a/tests/apidocs/endpoints/projects/test-dsyms.py
+++ b/tests/apidocs/endpoints/projects/test-dsyms.py
@@ -18,6 +18,7 @@ class ProjectDsymsDocs(APIDocsTestCase):
             "sentry-api-0-dsym-files",
             kwargs={"organization_slug": self.organization.slug, "project_slug": self.project.slug},
         )
+        self.create_dif_file(project=self.project)
 
         self.login_as(user=self.user)
 

--- a/tests/apidocs/endpoints/projects/test-project-index.py
+++ b/tests/apidocs/endpoints/projects/test-project-index.py
@@ -10,9 +10,12 @@ from tests.apidocs.util import APIDocsTestCase
 
 class ProjectIndexDocs(APIDocsTestCase):
     def setUp(self):
-        self.url = reverse("sentry-api-0-projects")
+        self.org = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.org, members=[self.user])
+        self.project = self.create_project(teams=[self.team])
 
         self.login_as(user=self.user)
+        self.url = reverse("sentry-api-0-projects")
 
     def test_get(self):
         response = self.client.get(self.url)

--- a/tests/apidocs/endpoints/projects/test-users.py
+++ b/tests/apidocs/endpoints/projects/test-users.py
@@ -6,10 +6,27 @@ from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 
 from tests.apidocs.util import APIDocsTestCase
+from sentry.models import EventUser
 
 
 class ProjectUsersDocs(APIDocsTestCase):
     def setUp(self):
+        self.project = self.create_project()
+        self.euser1 = EventUser.objects.create(
+            project_id=self.project.id,
+            ident="1",
+            email="foo@example.com",
+            username="foobar",
+            ip_address="127.0.0.1",
+        )
+
+        self.euser2 = EventUser.objects.create(
+            project_id=self.project.id,
+            ident="2",
+            email="bar@example.com",
+            username="baz",
+            ip_address="192.168.0.1",
+        )
         self.url = reverse(
             "sentry-api-0-project-users",
             kwargs={"organization_slug": self.organization.slug, "project_slug": self.project.slug},

--- a/tests/apidocs/endpoints/teams/test-stats.py
+++ b/tests/apidocs/endpoints/teams/test-stats.py
@@ -10,12 +10,16 @@ from tests.apidocs.util import APIDocsTestCase
 
 class TeamsStatsDocs(APIDocsTestCase):
     def setUp(self):
-        team = self.create_team(organization=self.organization)
-        self.create_project(name="foo", organization=self.organization, teams=[team])
+
+        self.team = self.create_team(organization=self.organization, members=[self.user])
+        self.project.add_team(self.team)
+
+        self.create_event("a", message="oh no")
+        self.create_event("b", message="oh my")
 
         self.url = reverse(
             "sentry-api-0-team-stats",
-            kwargs={"organization_slug": self.organization.slug, "team_slug": team.slug},
+            kwargs={"organization_slug": self.organization.slug, "team_slug": self.team.slug},
         )
 
         self.login_as(user=self.user)

--- a/tests/apidocs/openapi-derefed.json
+++ b/tests/apidocs/openapi-derefed.json
@@ -4183,7 +4183,8 @@
                             "type": "string"
                           },
                           "lastLogin": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                           },
                           "isSuperuser": {
                             "type": "boolean"

--- a/tests/apidocs/openapi-derefed.json
+++ b/tests/apidocs/openapi-derefed.json
@@ -5329,10 +5329,8 @@
                         "type": "object",
                         "required": [
                           "assets",
-                          "author",
                           "canDisable",
                           "contexts",
-                          "description",
                           "doc",
                           "enabled",
                           "hasConfiguration",
@@ -5340,12 +5338,10 @@
                           "isTestable",
                           "metadata",
                           "name",
-                          "resourceLinks",
                           "shortName",
                           "slug",
                           "status",
-                          "type",
-                          "version"
+                          "type"
                         ],
                         "properties": {
                           "assets": {
@@ -6097,10 +6093,8 @@
                         "type": "object",
                         "required": [
                           "assets",
-                          "author",
                           "canDisable",
                           "contexts",
-                          "description",
                           "doc",
                           "enabled",
                           "hasConfiguration",
@@ -6108,12 +6102,10 @@
                           "isTestable",
                           "metadata",
                           "name",
-                          "resourceLinks",
                           "shortName",
                           "slug",
                           "status",
-                          "type",
-                          "version"
+                          "type"
                         ],
                         "properties": {
                           "assets": {


### PR DESCRIPTION
Some of the tests from https://github.com/getsentry/sentry/pull/21023 and https://github.com/getsentry/sentry/pull/21033 were returning empty arrays, but we weren't checking for that so they silently passed. This PR fixes those tests now that the util asserts there are not empty arrays. 