### PR TITLE
Sao Paulo is UTC-0300

### DIFF
--- a/src/sentry/static/sentry/app/data/timezones.tsx
+++ b/src/sentry/static/sentry/app/data/timezones.tsx
@@ -171,7 +171,7 @@ export default [
   ['Antarctica/Rothera', '(UTC-0300) Antarctica/Rothera'],
   ['Atlantic/Stanley', '(UTC-0300) Atlantic/Stanley'],
   ['America/Noronha', '(UTC-0200) America/Noronha'],
-  ['America/Sao_Paulo', '(UTC-0200) America/Sao_Paulo'],
+  ['America/Sao_Paulo', '(UTC-0300) America/Sao_Paulo'],
   ['Atlantic/South_Georgia', '(UTC-0200) Atlantic/South_Georgia'],
   ['America/Scoresbysund', '(UTC-0100) America/Scoresbysund'],
   ['Atlantic/Azores', '(UTC-0100) Atlantic/Azores'],


### PR DESCRIPTION
[São Paulo](https://en.wikipedia.org/wiki/S%C3%A3o_Paulo) is -03:00