### PR TITLE
fix(sentry-apps): aliases issue-link integration as project-management

### DIFF
--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -252,6 +252,7 @@ export const getCategories = (features: IntegrationFeature[]): string[] => {
       case 'actionable notification':
         return 'notification action';
       case 'issue basic':
+      case 'issue link':
       case 'issue sync':
         return 'project management';
       case 'commits':


### PR DESCRIPTION
We show all issue linking integrations as `project management` so this just adds another name mapping.