### PR TITLE
fix(relay): Fix access admin permission

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationRelay/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRelay/index.tsx
@@ -5,23 +5,26 @@ import FeatureDisabled from 'app/components/acl/featureDisabled';
 import {PanelAlert} from 'app/components/panels';
 import {t} from 'app/locale';
 import withOrganization from 'app/utils/withOrganization';
+import Access from 'app/components/acl/access';
 
 import RelayWrapper from './relayWrapper';
 
 const OrganizationRelay = ({organization, ...props}: RelayWrapper['props']) => (
-  <Feature
-    features={['relay']}
-    organization={organization}
-    renderDisabled={() => (
-      <FeatureDisabled
-        alert={PanelAlert}
-        features={organization.features}
-        featureName={t('Relay')}
-      />
-    )}
-  >
-    <RelayWrapper organization={organization} {...props} />
-  </Feature>
+  <Access access={['org:admin']} organization={organization}>
+    <Feature
+      features={['relay']}
+      organization={organization}
+      renderDisabled={() => (
+        <FeatureDisabled
+          alert={PanelAlert}
+          features={organization.features}
+          featureName={t('Relay')}
+        />
+      )}
+    >
+      <RelayWrapper organization={organization} {...props} />
+    </Feature>
+  </Access>
 );
 
 export default withOrganization(OrganizationRelay);


### PR DESCRIPTION
closes: https://app.asana.com/0/1182975495223914/1195603349503129

Without permissions, users cannot see "Relays" in organization settings. However, if they know the URL, they can open the screen and see everything.