### PR TITLE
fix(discover) Don't error on zero width buckets

### DIFF
--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -108,9 +108,9 @@ def get_rollup_from_request(request, params, default_interval, error):
     interval = parse_stats_period(request.GET.get("interval", default_interval))
     if interval is None:
         interval = timedelta(hours=1)
-
+    if interval.total_seconds() <= 0:
+        raise error.__class__("Interval cannot result in a zero duration.")
     date_range = params["end"] - params["start"]
     if date_range.total_seconds() / interval.total_seconds() > MAX_ROLLUP_POINTS:
         raise error
-
     return int(interval.total_seconds())

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -563,6 +563,21 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             )
         assert response.status_code == 400
 
+        with self.feature("organizations:discover-basic"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "end": iso_format(before_now()),
+                    "start": iso_format(before_now(hours=24)),
+                    "query": "",
+                    "interval": "0d",
+                    "yAxis": "count()",
+                },
+            )
+        assert response.status_code == 400
+        assert "zero duration" in response.data["detail"]
+
     def test_out_of_retention(self):
         with self.options({"system.event-retention-days": 10}):
             with self.feature("organizations:discover-basic"):


### PR DESCRIPTION
We should handle users requesting stats bucket widths that result in zero width values.