### PR TITLE
ref(discover): Change secondary sort to newest

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -50,7 +50,10 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
 
         sort_by = request.query_params.get("sortBy")
         if sort_by in ("name", "-name"):
-            order_by = "-lower_name" if sort_by.startswith("-") else "lower_name"
+            order_by = [
+                "-lower_name" if sort_by.startswith("-") else "lower_name",
+                "-date_created",
+            ]
         elif sort_by in ("dateCreated", "-dateCreated"):
             order_by = "-date_created" if sort_by.startswith("-") else "date_created"
         elif sort_by in ("dateUpdated", "-dateUpdated"):
@@ -58,7 +61,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         elif sort_by == "myqueries":
             order_by = [
                 Case(When(created_by_id=request.user.id, then=-1), default="created_by_id"),
-                "lower_name",
+                "-date_created",
             ]
         else:
             order_by = "lower_name"


### PR DESCRIPTION
- For myqureies and name, break ties with newest.
- This means that for my queries newest queries will be at the beggining
  of the list instead