### PR TITLE
feat(measurements): Display measurements for transactions on the event details page

### DIFF
--- a/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
+++ b/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {Organization, Event} from 'app/types';
+import {IconSize} from 'app/utils/theme';
+import {t} from 'app/locale';
+import {SectionHeading} from 'app/components/charts/styles';
+import {Panel} from 'app/components/panels';
+import {getDuration} from 'app/utils/formatters';
+import space from 'app/styles/space';
+import Tooltip from 'app/components/tooltip';
+import {IconFire} from 'app/icons';
+import {WEB_VITAL_DETAILS} from 'app/views/performance/realUserMonitoring/constants';
+
+// translate known short form names into their long forms
+const LONG_MEASUREMENT_NAMES = {
+  fid: 'First Input Delay',
+  fp: 'First Paint',
+  fcp: 'First Contentful Paint',
+  lcp: 'Largest Contentful Paint',
+};
+
+type Props = {
+  organization: Organization;
+  event: Event;
+};
+class RealUserMonitoring extends React.Component<Props> {
+  hasMeasurements() {
+    const {event} = this.props;
+
+    if (!event.measurements) {
+      return false;
+    }
+
+    return Object.keys(event.measurements).length > 0;
+  }
+
+  renderMeasurements() {
+    const {event} = this.props;
+
+    if (!event.measurements) {
+      return null;
+    }
+
+    const measurementNames = Object.keys(event.measurements)
+      .filter(name => {
+        // ignore marker measurements
+        return !name.startsWith('mark.');
+      })
+      .sort();
+
+    return measurementNames.map(name => {
+      const value = event.measurements![name].value;
+
+      const record = Object.values(WEB_VITAL_DETAILS).find(vital => vital.slug === name);
+
+      const failedThreshold = record ? value >= record.failureThreshold : false;
+
+      return (
+        <div key={name}>
+          <StyledPanel failedThreshold={failedThreshold}>
+            <Name>{LONG_MEASUREMENT_NAMES[name] ?? name}</Name>
+            <ValueRow>
+              {failedThreshold ? (
+                <WarningIconContainer size="sm">
+                  <Tooltip
+                    title={`${getDuration(value / 1000, 3)} >= ${getDuration(
+                      record!.failureThreshold / 1000,
+                      3
+                    )}`}
+                    position="top"
+                    containerDisplayMode="inline-block"
+                  >
+                    <IconFire size="sm" />
+                  </Tooltip>
+                </WarningIconContainer>
+              ) : null}
+              <Value failedThreshold={failedThreshold}>
+                {getDuration(value / 1000, 3)}
+              </Value>
+            </ValueRow>
+          </StyledPanel>
+        </div>
+      );
+    });
+  }
+
+  render() {
+    const {organization} = this.props;
+
+    if (!organization.features.includes('measurements') || !this.hasMeasurements()) {
+      return null;
+    }
+
+    return (
+      <Container>
+        <SectionHeading>{t('Real User Monitoring')}</SectionHeading>
+        <Measurements>{this.renderMeasurements()}</Measurements>
+      </Container>
+    );
+  }
+}
+
+const Measurements = styled('div')`
+  display: grid;
+  grid-column-gap: ${space(1)};
+`;
+
+const Container = styled('div')`
+  color: ${p => p.theme.gray600};
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin-bottom: ${space(4)};
+`;
+
+const StyledPanel = styled(Panel)<{failedThreshold: boolean}>`
+  padding: ${space(1)};
+  margin-bottom: ${space(1)};
+
+  ${p => {
+    if (!p.failedThreshold) {
+      return null;
+    }
+
+    return `
+      border: 1px solid ${p.theme.red400};
+    `;
+  }};
+`;
+
+const Name = styled('div')``;
+
+const ValueRow = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const WarningIconContainer = styled('span')<{size: IconSize | string}>`
+  display: inline-block;
+  height: ${p => p.theme.iconSizes[p.size] ?? p.size};
+  line-height: ${p => p.theme.iconSizes[p.size] ?? p.size};
+  margin-right: ${space(1)};
+  color: ${p => p.theme.red400};
+`;
+
+const Value = styled('span')<{failedThreshold: boolean}>`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  ${p => {
+    if (!p.failedThreshold) {
+      return null;
+    }
+
+    return `
+      color: ${p.theme.red400};
+    `;
+  }};
+`;
+
+export default RealUserMonitoring;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -318,6 +318,8 @@ type SDKUpdatesSuggestion =
   | UpdateSdkSuggestion
   | ChangeSdkSuggestion;
 
+type Measurement = {value: number};
+
 type SentryEventBase = {
   id: string;
   eventID: string;
@@ -367,6 +369,8 @@ type SentryEventBase = {
   };
 
   sdkUpdates?: Array<SDKUpdatesSuggestion>;
+
+  measurements?: Record<string, Measurement>;
 };
 
 export type SentryTransactionEvent = {
@@ -1309,13 +1313,6 @@ export type TagWithTopValues = {
   uniqueValues: number;
   canDelete: boolean;
 };
-
-export type Measurement = {
-  name: string;
-  key: string;
-};
-
-export type MeasurementCollection = {[key: string]: Measurement};
 
 export type Level = 'error' | 'fatal' | 'info' | 'warning' | 'sample';
 

--- a/src/sentry/static/sentry/app/utils/withMeasurements.tsx
+++ b/src/sentry/static/sentry/app/utils/withMeasurements.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 
-import {MeasurementCollection} from 'app/types';
+export type Measurement = {
+  name: string;
+  key: string;
+};
+
+export type MeasurementCollection = {[key: string]: Measurement};
 
 type InjectedMeasurementsProps = {
   measurements: MeasurementCollection;

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -17,6 +17,7 @@ import Button from 'app/components/button';
 import Feature from 'app/components/acl/feature';
 import RootSpanStatus from 'app/components/events/rootSpanStatus';
 import OpsBreakdown from 'app/components/events/opsBreakdown';
+import RealUserMonitoring from 'app/components/events/realUserMonitoring';
 import EventMetadata from 'app/components/events/eventMetadata';
 import LoadingError from 'app/components/loadingError';
 import NotFound from 'app/components/errors/notFound';
@@ -241,6 +242,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
               />
               <RootSpanStatus event={event} />
               <OpsBreakdown event={event} />
+              <RealUserMonitoring organization={organization} event={event} />
               {event.groupID && (
                 <LinkedIssue groupId={event.groupID} eventId={event.eventID} />
               )}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -4,11 +4,11 @@ import styled from '@emotion/styled';
 
 import {Client} from 'app/api';
 import {t} from 'app/locale';
-import {Organization, TagCollection, MeasurementCollection} from 'app/types';
+import {Organization, TagCollection} from 'app/types';
 import {metric} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
 import withTags from 'app/utils/withTags';
-import withMeasurements from 'app/utils/withMeasurements';
+import withMeasurements, {MeasurementCollection} from 'app/utils/withMeasurements';
 import Pagination from 'app/components/pagination';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import {TableData} from 'app/utils/discover/discoverQuery';

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
@@ -17,6 +17,7 @@ import AsyncComponent from 'app/components/asyncComponent';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import RootSpanStatus from 'app/components/events/rootSpanStatus';
 import OpsBreakdown from 'app/components/events/opsBreakdown';
+import RealUserMonitoring from 'app/components/events/realUserMonitoring';
 import TagsTable from 'app/components/tagsTable';
 import Projects from 'app/utils/projects';
 import * as Layout from 'app/components/layouts/thirds';
@@ -173,6 +174,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
               />
               <RootSpanStatus event={event} />
               <OpsBreakdown event={event} />
+              <RealUserMonitoring organization={organization} event={event} />
               <TagsTable event={event} query={query} generateUrl={this.generateTagUrl} />
             </Layout.Side>
           )}


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/20674/

![Screen Shot 2020-10-02 at 6 19 40 PM](https://user-images.githubusercontent.com/139499/94974272-051c7780-04dc-11eb-8a44-e72ccbd62131.png)

