### PR TITLE
fix(vsts): ado project limit

### DIFF
--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -40,7 +40,7 @@ class VstsApiPath(object):
 
 
 class VstsApiClient(ApiClient, OAuth2RefreshMixin):
-    api_version = "4.1"
+    api_version = "4.1"  # TODO: update api version
     api_version_preview = "-preview.1"
     integration_name = "vsts"
 
@@ -213,11 +213,25 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
         )
 
     def get_projects(self, instance):
-        # TODO(dcramer): VSTS doesn't provide a way to search, so we're
-        # making the assumption that a user has 100 or less projects today.
-        return self.get(
-            VstsApiPath.projects.format(instance=instance), params={"stateFilter": "WellFormed"}
-        )
+        limit = 100  # 100 is max
+        offset = 0
+        projects = []
+
+        # no one should have more than 1000 projects
+        for i in range(10):
+            # ADO supports a continuation token in the response but only in the newer API version (https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-6.1)
+            # the token comes as a repsponse header instead of the body and our API clients currently only return the body
+            # we can use count, $skip, and $top to get the same result
+            resp = self.get(
+                VstsApiPath.projects.format(instance=instance),
+                params={"stateFilter": "WellFormed", "$skip": offset, "$top": limit},
+            )
+            projects += resp["value"]
+            offset += resp["count"]
+            # if the number is lower than our limit, we can quit
+            if resp["count"] < limit:
+                return projects
+        return projects
 
     def get_users(self, account_name, continuation_token=None):
         """

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -163,7 +163,7 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
         project_selector = []
 
         try:
-            projects = client.get_projects(instance)["value"]
+            projects = client.get_projects(instance)
             all_states = set()
 
             for idx, project in enumerate(projects):

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -31,7 +31,7 @@ class VstsIssueSync(IssueSyncMixin):
     def get_project_choices(self, group, **kwargs):
         client = self.get_client()
         try:
-            projects = client.get_projects(self.instance)["value"]
+            projects = client.get_projects(self.instance)
         except (ApiError, ApiUnauthorized, KeyError) as e:
             self.raise_error(e)
 
@@ -235,7 +235,7 @@ class VstsIssueSync(IssueSyncMixin):
         # TODO(jess): figure out if there's a better way to do this
         vsts_project_name = work_item["fields"]["System.TeamProject"]
 
-        vsts_projects = client.get_projects(self.instance)["value"]
+        vsts_projects = client.get_projects(self.instance)
 
         vsts_project_id = None
         for p in vsts_projects:

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -37,7 +37,9 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         assert responses.calls[-2].request.url == "https://app.vssps.visualstudio.com/oauth2/token"
 
         # Then we request the Projects with the new token
-        assert responses.calls[-1].request.url == u"{}_apis/projects?stateFilter=WellFormed".format(
+        assert responses.calls[
+            -1
+        ].request.url == u"{}_apis/projects?%24top=100&%24skip=0&stateFilter=WellFormed".format(
             self.vsts_base_url.lower()
         )
 
@@ -77,7 +79,9 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         assert responses.calls[-2].request.url == "https://app.vssps.visualstudio.com/oauth2/token"
 
         # Then we request the Projects with the new token
-        assert responses.calls[-1].request.url == u"{}_apis/projects?stateFilter=WellFormed".format(
+        assert responses.calls[
+            -1
+        ].request.url == u"{}_apis/projects?%24top=100&%24skip=0&stateFilter=WellFormed".format(
             self.vsts_base_url.lower()
         )
 

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -364,7 +364,8 @@ class VstsIssueFormTest(VstsIssueBase):
                 "value": [
                     {"id": "project-1-id", "name": "project_1"},
                     {"id": "project-2-id", "name": "project_2"},
-                ]
+                ],
+                "count": 2,
             },
         )
         min_ago = iso_format(before_now(minutes=1))
@@ -532,7 +533,7 @@ class VstsIssueFormTest(VstsIssueBase):
         responses.add(
             responses.GET,
             "https://fabrikam-fiber-inc.visualstudio.com/_apis/projects",
-            json={"value": []},
+            json={"value": [], "count": 0},
         )
         fields = self.integration.get_create_issue_config(self.group)
 

--- a/tests/sentry/integrations/vsts/testutils.py
+++ b/tests/sentry/integrations/vsts/testutils.py
@@ -95,7 +95,7 @@ class VstsIntegrationTestCase(IntegrationTestCase):
         responses.add(
             responses.GET,
             u"https://{}.visualstudio.com/_apis/projects".format(self.vsts_account_name.lower()),
-            json={"value": [self.project_a, self.project_b]},
+            json={"value": [self.project_a, self.project_b], "count": 2},
         )
 
         responses.add(


### PR DESCRIPTION
Some organizations have more than 100 ADO projects which is a problem because we only fetch 100 at a time. This PR implements pagination by providing a `$skip` parameter and incrementing it by the page size (`$top`). I have chosen this approach over using a continuation token for a few reasons:

1. The API version we currently use (4.1) does not include a continuation token in the response
2. The continuation token comes in a response header which we normally don't have access to (we'd have to refactor the base integration client to return more than just the body of the response)

See docs: https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-6.1
