### PR TITLE
fix(ui): Unhandled tag

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
@@ -37,8 +37,18 @@ const UnhandledTag = styled((props: React.ComponentProps<typeof Tag>) => (
   background-color: #ffecf0;
   color: ${p => p.theme.gray700};
   text-transform: none;
-  padding: 0 ${space(1)};
-  height: 21px;
+  padding: 0 ${space(0.75)};
+  height: 17px;
+
+  & > span {
+    margin-right: 0 ${space(0.5)};
+  }
+
+  & > span,
+  & svg {
+    height: 10px;
+    width: 10px;
+  }
 `;
 
 export default UnhandledTag;


### PR DESCRIPTION
• Tidied up visual design of temporary Unhandled tag 

## Before
  
<img width="523" alt="Screen Shot 2020-10-02 at 4 26 36 PM" src="https://user-images.githubusercontent.com/1900676/94977113-2ecda280-04cc-11eb-84e0-c2710174de67.png">


## After

<img width="429" alt="Screen Shot 2020-10-02 at 4 22 22 PM" src="https://user-images.githubusercontent.com/1900676/94977120-34c38380-04cc-11eb-844a-8e74aeb33cb1.png">
