### PR TITLE
ref(breadcrumbs): Reverse Data

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/data/summary.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/data/summary.tsx
@@ -38,6 +38,7 @@ class Summary extends React.Component<Props, State> {
     }
 
     return Object.keys(kvData)
+      .reverse()
       .filter(key => defined(kvData[key]) && !!kvData[key])
       .map(key => {
         const value =


### PR DESCRIPTION
closes: https://app.asana.com/0/1182975495223914/1196751701455785

Switch order of "from" and "to" on navigation breadcrumb

![image](https://user-images.githubusercontent.com/29228205/95082265-14d5cf00-071b-11eb-9ec3-c5a87c30eefc.png)
