### PR TITLE
ci(gcb): Fix test.sh exit code on fail

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
     # The following trick is from https://stackoverflow.com/a/52400857/90297 with great gratuity
     echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
     ./install.sh
-    ./test.sh || docker-compose logs nginx web relay
+    ./test.sh || docker-compose logs nginx web relay && exit -1
   timeout: 450s
 - name: 'gcr.io/cloud-builders/docker'
   secretEnv: ['DOCKER_PASSWORD']

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -36,7 +36,12 @@ steps:
     # The following trick is from https://stackoverflow.com/a/52400857/90297 with great gratuity
     echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
     ./install.sh
-    ./test.sh || docker-compose logs nginx web relay && exit -1
+    if ! ./test.sh; then
+      echo "Test failed.";
+      docker-compose ps;
+      docker-compose logs nginx web relay;
+      exit -1;
+    fi
   timeout: 450s
 - name: 'gcr.io/cloud-builders/docker'
   secretEnv: ['DOCKER_PASSWORD']

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -36,11 +36,15 @@ steps:
     # The following trick is from https://stackoverflow.com/a/52400857/90297 with great gratuity
     echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
     ./install.sh
-    if ! ./test.sh; then
+    set +e
+    ./test.sh
+    test_return=$?
+    set -e
+    if [[ $test_return -ne 0 ]]; then
       echo "Test failed.";
       docker-compose ps;
       docker-compose logs nginx web relay;
-      exit -1;
+      exit $test_return;
     fi
   timeout: 450s
 - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
The added 'logs on fail' functionality was causing us to miss test failures. This PR adds an explicit `exit $test_return` after printing the logs to signal GCB of the failure.
