### PR TITLE
fix(dev): pre-commit virtualenv 20.0.23 -> 20.0.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ setup-git: ensure-venv setup-git-config
 	@echo "--> Installing git hooks"
 	mkdir -p .git/hooks && cd .git/hooks && ln -sf ../../config/hooks/* ./
 	@PYENV_VERSION=$(REQUIRED_PY3_VERSION) python3 -c '' || (echo 'Please run `make setup-pyenv` to install the required Python 3 version.'; exit 1)
-	$(PIP) install "pre-commit==1.18.2" "virtualenv==20.0.23"
+	@# pre-commit loosely pins virtualenv, which has caused problems in the past.
+	$(PIP) install "pre-commit==1.18.2" "virtualenv==20.0.32"
 	@PYENV_VERSION=$(REQUIRED_PY3_VERSION) pre-commit install --install-hooks
 	@echo ""
 


### PR DESCRIPTION
Currently in a fresh py3 venv, when running `make setup-git` you'll get the nonfatal:

```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

virtualenv 20.0.23 requires importlib-metadata<2,>=0.12; python_version < "3.8", but you'll have importlib-metadata 2.0.0 which is incompatible.
```

This upgrades virtualenv (for pre-commit) to 20.0.32 which includes the fix: https://github.com/pypa/virtualenv/pull/1953. pre-commit does not yet have an upper pin for virtualenv which caused problems in the past with virtualenv, see https://github.com/getsentry/sentry/pull/19256.

Tested in provisioning a fresh venv in both py2 + py3.
