### PR TITLE
fix(py3): Ensure project_ids is list for snuba releases query

### DIFF
--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -37,7 +37,7 @@ def get_changed_project_release_model_adoptions(project_ids):
         groupby=["release", "project_id"],
         start=start,
         referrer="sessions.get-adoption",
-        filter_keys={"project_id": project_ids},
+        filter_keys={"project_id": list(project_ids)},
     )["data"]:
         rv.append((x["project_id"], x["release"]))
 


### PR DESCRIPTION
In python3 this was becoming a keys view, which later we try and deep copy, which unfortunately does not work. Here we just ensure we're dealing with a list of project_ids

Explicitly this is problematic https://github.com/getsentry/sentry/blob/734ace4c2f12f27e2227d80b605c7ccd4fa44bdf/src/sentry/api/endpoints/organization_releases.py#L121