### PR TITLE
feat(workflow): Dynamic counts guide anchor for external release

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -112,7 +112,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             "organizations:dynamic-issue-counts", organization, actor=request.user
         )
 
-        if stats_period not in (None, "", "24h", "14d"):
+        if stats_period not in (None, "", "24h", "14d", "auto"):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
         elif stats_period is None:
             # default if no dynamic-issue-counts

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -115,13 +115,8 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         if stats_period not in (None, "", "24h", "14d"):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
         elif stats_period is None:
-            if has_dynamic_issue_counts and start and end:
-                # custom date range
-                stats_period = "auto"
-            else:
-                # default if no dynamic-issue-counts
-                stats_period = "24h"
-
+            # default if no dynamic-issue-counts
+            stats_period = "24h"
         elif stats_period == "":
             # disable stats
             stats_period = None

--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -110,18 +110,5 @@ GUIDES = {
             }
         ],
     },
-    "dynamic_counts": {
-        "id": 4,
-        "required_targets": ["dynamic_counts"],
-        "steps": [
-            {
-                "title": _("These counts have changed"),
-                "message": _(
-                    "These numbers and the bar chart now respect the time selected and any"
-                    "search filters you've applied. You can hover to see the totals."
-                ),
-                "target": "dynamic_counts",
-            }
-        ],
-    },
+    "dynamic_counts": {"id": 5, "required_targets": ["dynamic_counts"]},
 }

--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -110,4 +110,18 @@ GUIDES = {
             }
         ],
     },
+    "dynamic_counts": {
+        "id": 4,
+        "required_targets": ["dynamic_counts"],
+        "steps": [
+            {
+                "title": _("These counts have changed"),
+                "message": _(
+                    "These numbers and the bar chart now respect the time selected and any"
+                    "search filters you've applied. You can hover to see the totals."
+                ),
+                "target": "dynamic_counts",
+            }
+        ],
+    },
 }

--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -110,5 +110,5 @@ GUIDES = {
             }
         ],
     },
-    "dynamic_counts": {"id": 5, "required_targets": ["dynamic_counts"]},
+    "dynamic_counts": {"id": 7, "required_targets": ["dynamic_counts"]},
 }

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -109,10 +109,10 @@ export default function getGuidesContent(): GuidesContent {
           target: 'dynamic_counts',
           description: t(
             `These numbers and the bar chart now respect the time selected and any search
-            filters you've applied. You can hover to see the totals.`,
+            filters you've applied. You can hover to see the totals.`
           ),
         },
       ],
-    }
+    },
   ];
 }

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -100,5 +100,19 @@ export default function getGuidesContent(): GuidesContent {
         },
       ],
     },
+    {
+      guide: 'dynamic_counts',
+      requiredTargets: ['dynamic_counts'],
+      steps: [
+        {
+          title: t('These counts have changed'),
+          target: 'dynamic_counts',
+          description: t(
+            `These numbers and the bar chart now respect the time selected and any search
+            filters you've applied. You can hover to see the totals.`,
+          ),
+        },
+      ],
+    }
   ];
 }

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -273,55 +273,52 @@ const StreamGroup = createReactClass({
                 open: isOpen && hasDynamicIssueCounts,
               });
 
-            return (
-              <GuideAnchor
-                target="dynamic_counts"
-                disabled={!hasDynamicGuideAnchor}
-              >
-                <span
-                  {...getRootProps({
-                    className: topLevelCx,
-                  })}
-                >
-                  <span {...getActorProps({})}>
-                    <div className="dropdown-actor-title">
-                      <PrimaryCount
-                        value={primaryCount}
-                        filtered={secondaryCount !== undefined}
-                      />
-                      {secondaryCount !== undefined && (
-                        <SecondaryCount value={secondaryCount} />
+              return (
+                <GuideAnchor target="dynamic_counts" disabled={!hasDynamicGuideAnchor}>
+                  <span
+                    {...getRootProps({
+                      className: topLevelCx,
+                    })}
+                  >
+                    <span {...getActorProps({})}>
+                      <div className="dropdown-actor-title">
+                        <PrimaryCount
+                          value={primaryCount}
+                          filtered={secondaryCount !== undefined}
+                        />
+                        {secondaryCount !== undefined && (
+                          <SecondaryCount value={secondaryCount} />
+                        )}
+                      </div>
+                    </span>
+                    <ul {...getMenuProps({className: 'dropdown-menu inverted'})}>
+                      {data.filtered && (
+                        <React.Fragment>
+                          <StyledMenuItem to={this.getDiscoverUrl(true)}>
+                            <MenuItemText>{t('Matching search filters')}</MenuItemText>
+                            <MenuItemCount value={data.filtered.count} />
+                          </StyledMenuItem>
+                          <MenuItem divider />
+                        </React.Fragment>
                       )}
-                    </div>
+
+                      <StyledMenuItem to={this.getDiscoverUrl()}>
+                        <MenuItemText>{t(`Total in ${summary}`)}</MenuItemText>
+                        <MenuItemCount value={data.count} />
+                      </StyledMenuItem>
+
+                      {data.lifetime && (
+                        <React.Fragment>
+                          <MenuItem divider />
+                          <StyledMenuItem>
+                            <MenuItemText>{t('Since issue began')}</MenuItemText>
+                            <MenuItemCount value={data.lifetime.count} />
+                          </StyledMenuItem>
+                        </React.Fragment>
+                      )}
+                    </ul>
                   </span>
-                  <ul {...getMenuProps({className: 'dropdown-menu inverted'})}>
-                    {data.filtered && (
-                      <React.Fragment>
-                        <StyledMenuItem to={this.getDiscoverUrl(true)}>
-                          <MenuItemText>{t('Matching search filters')}</MenuItemText>
-                          <MenuItemCount value={data.filtered.count} />
-                        </StyledMenuItem>
-                        <MenuItem divider />
-                      </React.Fragment>
-                    )}
-
-                    <StyledMenuItem to={this.getDiscoverUrl()}>
-                      <MenuItemText>{t(`Total in ${summary}`)}</MenuItemText>
-                      <MenuItemCount value={data.count} />
-                    </StyledMenuItem>
-
-                    {data.lifetime && (
-                      <React.Fragment>
-                        <MenuItem divider />
-                        <StyledMenuItem>
-                          <MenuItemText>{t('Since issue began')}</MenuItemText>
-                          <MenuItemCount value={data.lifetime.count} />
-                        </StyledMenuItem>
-                      </React.Fragment>
-                    )}
-                  </ul>
-                </span>
-              </GuideAnchor>
+                </GuideAnchor>
               );
             }}
           </DropdownMenu>

--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -217,6 +217,8 @@ const StreamGroup = createReactClass({
 
     const hasDynamicIssueCounts = organization.features.includes('dynamic-issue-counts');
 
+    const hasDynamicGuideAnchor = hasDynamicIssueCounts && hasGuideAnchor;
+
     const {period, start, end} = selection.datetime || {};
     const summary =
       !!start && !!end
@@ -271,7 +273,11 @@ const StreamGroup = createReactClass({
                 open: isOpen && hasDynamicIssueCounts,
               });
 
-              return (
+            return (
+              <GuideAnchor
+                target="dynamic_counts"
+                disabled={!hasDynamicGuideAnchor}
+              >
                 <span
                   {...getRootProps({
                     className: topLevelCx,
@@ -315,6 +321,7 @@ const StreamGroup = createReactClass({
                     )}
                   </ul>
                 </span>
+              </GuideAnchor>
               );
             }}
           </DropdownMenu>

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -233,7 +233,7 @@ const IssueListOverview = createReactClass({
       : STATS_PERIODS
     ).has(currentPeriod)
       ? currentPeriod
-      : this.getDefaultGroupStatsPeriod();
+      : DEFAULT_GRAPH_STATS_PERIOD;
   },
 
   getEndpointParams() {
@@ -263,7 +263,7 @@ const IssueListOverview = createReactClass({
     }
 
     const groupStatsPeriod = this.getGroupStatsPeriod();
-    if (groupStatsPeriod !== this.getDefaultGroupStatsPeriod()) {
+    if (groupStatsPeriod !== DEFAULT_GRAPH_STATS_PERIOD) {
       params.groupStatsPeriod = groupStatsPeriod;
     }
 

--- a/tests/js/spec/components/streamGroup.spec.jsx
+++ b/tests/js/spec/components/streamGroup.spec.jsx
@@ -39,7 +39,7 @@ describe('StreamGroup', function () {
     );
 
     expect(component.find('GuideAnchor').exists()).toBe(true);
-    expect(component.find('GuideAnchor')).toHaveLength(2);
+    expect(component.find('GuideAnchor')).toHaveLength(3);
     expect(component).toSnapshot();
   });
 });

--- a/tests/sentry/api/endpoints/test_assistant.py
+++ b/tests/sentry/api/endpoints/test_assistant.py
@@ -48,15 +48,6 @@ class AssistantActivityTest(APITestCase):
         assert resp.status_code == 200
         assert resp.data == guides_with_seen
 
-    def test_validate_guides(self):
-        # Steps in different guides should not have the same target.
-        guides = list(self.guides.values())
-        for i in range(len(guides)):
-            for j in range(0, i):
-                steps_i = set(s["target"] for s in guides[i]["steps"])
-                steps_j = set(s["target"] for s in guides[j]["steps"])
-                assert not (steps_i & steps_j)
-
 
 class AssistantActivityV2Test(APITestCase):
     endpoint = "sentry-api-0-assistant"


### PR DESCRIPTION
This adds a guide anchor to the first issue row's dynamic event count. Also reverted the chart stats period selection to 24h from the selected period.

Resolves:
[WOR-145](https://getsentry.atlassian.net/browse/WOR-145) 
[WOR-309](https://getsentry.atlassian.net/browse/WOR-309) 