### PR TITLE
ref(relay): Add v2 projectconfig endpoint

### DIFF
--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 
 from django.conf import settings
 
-from sentry_sdk import Hub
+from sentry_sdk import Hub, start_span, start_transaction, set_tag
 
 from sentry.api.base import Endpoint
 from sentry.api.permissions import RelayPermission
@@ -31,8 +31,8 @@ class RelayProjectConfigsEndpoint(Endpoint):
     permission_classes = (RelayPermission,)
 
     def post(self, request):
-        with Hub.current.start_transaction(
-            op="http.server", name="RelayProjectConfigsEndpoint", sampled=_sample_apm(),
+        with start_transaction(
+            op="http.server", name="RelayProjectConfigsEndpoint", sampled=_sample_apm()
         ):
             return self._post(request)
 
@@ -45,15 +45,102 @@ class RelayProjectConfigsEndpoint(Endpoint):
         if full_config_requested and not relay.is_internal:
             return Response("Relay unauthorized for full config information", 403)
 
-        with Hub.current.start_span(op="relay_fetch_projects"):
-            project_ids = set(request.relay_request_data.get("projects") or ())
+        version = request.GET.get("version")
+        set_tag("relay_protocol_version", version or "1")
+
+        if version == "2":
+            return self._post_by_key(request=request, full_config_requested=full_config_requested,)
+        else:
+            return self._post_by_project(
+                request=request, full_config_requested=full_config_requested,
+            )
+
+    def _post_by_key(self, request, full_config_requested):
+        public_keys = request.relay_request_data.get("publicKeys")
+        public_keys = set(public_keys or ())
+
+        project_keys = {}  # type: dict[str, ProjectKey]
+        project_ids = set()  # type: set[int]
+
+        with start_span(op="relay_fetch_keys"):
+            with metrics.timer("relay_project_configs.fetching_keys.duration"):
+                for key in ProjectKey.objects.get_many_from_cache(public_keys, key="public_key"):
+                    project_keys[key.public_key] = key
+                    project_ids.add(key.project_id)
+
+        projects = {}  # type: dict[int, Project]
+        organization_ids = set()  # type: set[int]
+
+        with start_span(op="relay_fetch_projects"):
+            with metrics.timer("relay_project_configs.fetching_projects.duration"):
+                for project in Project.objects.get_many_from_cache(project_ids):
+                    projects[project.id] = project
+                    organization_ids.add(project.organization_id)
+
+        # Preload all organizations and their options to prevent repeated
+        # database access when computing the project configuration.
+
+        orgs = {}  # type: dict[int, Organization]
+
+        with start_span(op="relay_fetch_orgs"):
+            with metrics.timer("relay_project_configs.fetching_orgs.duration"):
+                for org in Organization.objects.get_many_from_cache(organization_ids):
+                    if request.relay.has_org_access(org):
+                        orgs[org.id] = org
+
+        with start_span(op="relay_fetch_org_options"):
+            with metrics.timer("relay_project_configs.fetching_org_options.duration"):
+                for org_id in orgs:
+                    OrganizationOption.objects.get_all_values(org_id)
+
+        metrics.timing("relay_project_configs.projects_requested", len(project_ids))
+        metrics.timing("relay_project_configs.projects_fetched", len(projects))
+        metrics.timing("relay_project_configs.orgs_fetched", len(orgs))
+
+        configs = {}
+        for public_key in public_keys:
+            configs[public_key] = {"disabled": True}
+
+            key = project_keys.get(public_key)
+            if key is None:
+                continue
+
+            project = projects.get(key.project_id)
+            if project is None:
+                continue
+
+            organization = orgs.get(project.organization_id)
+            if organization is None:
+                continue
+
+            # Try to prevent organization from being fetched again in quotas.
+            project.organization = organization
+            project._organization_cache = organization
+
+            with Hub.current.start_span(op="get_config"):
+                with metrics.timer("relay_project_configs.get_config.duration"):
+                    project_config = config.get_project_config(
+                        project, full_config=full_config_requested, project_keys=[key],
+                    )
+
+            configs[public_key] = project_config.to_dict()
+
+        if full_config_requested:
+            projectconfig_cache.set_many(configs)
+
+        return Response({"configs": configs}, status=200)
+
+    def _post_by_project(self, request, full_config_requested):
+        project_ids = set(request.relay_request_data.get("projects") or ())
+
+        with start_span(op="relay_fetch_projects"):
             if project_ids:
                 with metrics.timer("relay_project_configs.fetching_projects.duration"):
                     projects = {p.id: p for p in Project.objects.get_many_from_cache(project_ids)}
             else:
                 projects = {}
 
-        with Hub.current.start_span(op="relay_fetch_orgs"):
+        with start_span(op="relay_fetch_orgs"):
             # Preload all organizations and their options to prevent repeated
             # database access when computing the project configuration.
             org_ids = set(project.organization_id for project in six.itervalues(projects))
@@ -68,7 +155,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
                 for org_id in six.iterkeys(orgs):
                     OrganizationOption.objects.get_all_values(org_id)
 
-        with Hub.current.start_span(op="relay_fetch_keys"):
+        with start_span(op="relay_fetch_keys"):
             project_keys = {}
             for key in ProjectKey.objects.filter(project_id__in=project_ids):
                 project_keys.setdefault(key.project_id, []).append(key)
@@ -93,7 +180,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
             project.organization = organization
             project._organization_cache = organization
 
-            with Hub.current.start_span(op="get_config"):
+            with start_span(op="get_config"):
                 with metrics.timer("relay_project_configs.get_config.duration"):
                     project_config = config.get_project_config(
                         project,

--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -45,15 +45,17 @@ class RelayProjectConfigsEndpoint(Endpoint):
         if full_config_requested and not relay.is_internal:
             return Response("Relay unauthorized for full config information", 403)
 
-        version = request.GET.get("version")
-        set_tag("relay_protocol_version", version or "1")
+        version = request.GET.get("version") or "1"
+        set_tag("relay_protocol_version", version)
 
         if version == "2":
             return self._post_by_key(request=request, full_config_requested=full_config_requested,)
-        else:
+        elif version == "1":
             return self._post_by_project(
                 request=request, full_config_requested=full_config_requested,
             )
+        else:
+            return Response("Unsupported version, we only support version null, 1 and 2.", 400)
 
     def _post_by_key(self, request, full_config_requested):
         public_keys = request.relay_request_data.get("publicKeys")

--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -13,7 +13,7 @@ from sentry.api.base import Endpoint
 from sentry.api.permissions import RelayPermission
 from sentry.api.authentication import RelayAuthentication
 from sentry.relay import config, projectconfig_cache
-from sentry.models import Project, ProjectKey, Organization, OrganizationOption
+from sentry.models import Project, ProjectKey, Organization, OrganizationOption, ProjectKeyStatus
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -67,6 +67,9 @@ class RelayProjectConfigsEndpoint(Endpoint):
         with start_span(op="relay_fetch_keys"):
             with metrics.timer("relay_project_configs.fetching_keys.duration"):
                 for key in ProjectKey.objects.get_many_from_cache(public_keys, key="public_key"):
+                    if key.status != ProjectKeyStatus.ACTIVE:
+                        continue
+
                     project_keys[key.public_key] = key
                     project_ids.add(key.project_id)
 

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -22,6 +22,7 @@ from sentry.utils.http import get_origins
 from sentry.utils.sdk import configure_scope
 from sentry.relay.utils import to_camel_case_name
 from sentry.datascrubbing import get_pii_config, get_datascrubbing_settings
+from sentry.models.projectkey import ProjectKeyStatus
 
 
 def get_project_key_config(project_key):
@@ -33,7 +34,10 @@ def get_public_key_configs(project, full_config, project_keys=None):
     public_keys = []
 
     for project_key in project_keys or ():
-        key = {"publicKey": project_key.public_key, "isEnabled": project_key.status == 0}
+        key = {
+            "publicKey": project_key.public_key,
+            "isEnabled": project_key.status == ProjectKeyStatus.ACTIVE,
+        }
 
         if full_config:
             key["quotas"] = [

--- a/src/sentry/utils/pytest/relay.py
+++ b/src/sentry/utils/pytest/relay.py
@@ -40,12 +40,8 @@ def _remove_container_if_exists(docker_client, container_name):
             pass  # could not remove the container nothing to do about it
 
 
-@pytest.fixture(
-    scope="session",
-    params=["latest", "cc3af8314c682da977e83e86edb876bcb7da3adc"],
-    ids=["relay_v1", "relay_v2"],
-)
-def relay_server_setup(live_server, tmpdir_factory, request):
+@pytest.fixture(scope="session")
+def relay_server_setup(live_server, tmpdir_factory):
     prefix = "test_relay_config_{}_".format(
         datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S_%f")
     )
@@ -100,7 +96,7 @@ def relay_server_setup(live_server, tmpdir_factory, request):
     container_name = _relay_server_container_name()
     _remove_container_if_exists(docker_client, container_name)
     options = {
-        "image": "us.gcr.io/sentryio/relay:{}".format(request.param),
+        "image": "us.gcr.io/sentryio/relay:latest",
         "ports": {"%s/tcp" % relay_port: relay_port},
         "network": network,
         "detach": True,

--- a/src/sentry/utils/pytest/relay.py
+++ b/src/sentry/utils/pytest/relay.py
@@ -40,8 +40,12 @@ def _remove_container_if_exists(docker_client, container_name):
             pass  # could not remove the container nothing to do about it
 
 
-@pytest.fixture(scope="session")
-def relay_server_setup(live_server, tmpdir_factory):
+@pytest.fixture(
+    scope="session",
+    params=["latest", "cc3af8314c682da977e83e86edb876bcb7da3adc"],
+    ids=["relay_v1", "relay_v2"],
+)
+def relay_server_setup(live_server, tmpdir_factory, request):
     prefix = "test_relay_config_{}_".format(
         datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S_%f")
     )
@@ -96,7 +100,7 @@ def relay_server_setup(live_server, tmpdir_factory):
     container_name = _relay_server_container_name()
     _remove_container_if_exists(docker_client, container_name)
     options = {
-        "image": "us.gcr.io/sentryio/relay:latest",
+        "image": "us.gcr.io/sentryio/relay:{}".format(request.param),
         "ports": {"%s/tcp" % relay_port: relay_port},
         "network": network,
         "detach": True,

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -1,0 +1,337 @@
+from __future__ import absolute_import
+
+import pytest
+import six
+import re
+
+from uuid import uuid4
+
+from django.core.urlresolvers import reverse
+
+from sentry import quotas
+from sentry.constants import ObjectStatus
+from sentry.utils import safe, json
+from sentry.models.relay import Relay
+from sentry.models import ProjectKey
+
+from sentry_relay.auth import generate_key_pair
+
+
+_date_regex = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$")
+
+
+def _get_all_keys(config):
+    for key in config:
+        yield key
+        if isinstance(config[key], dict):
+            for key in _get_all_keys(config[key]):
+                yield key
+
+
+@pytest.fixture
+def key_pair():
+    return generate_key_pair()
+
+
+@pytest.fixture
+def public_key(key_pair):
+    return key_pair[1]
+
+
+@pytest.fixture
+def private_key(key_pair):
+    return key_pair[0]
+
+
+@pytest.fixture
+def relay_id():
+    return six.text_type(uuid4())
+
+
+@pytest.fixture
+def relay(relay_id, public_key):
+    return Relay.objects.create(
+        relay_id=relay_id, public_key=six.text_type(public_key), is_internal=True
+    )
+
+
+@pytest.fixture(autouse=True)
+def setup_relay(default_project):
+    default_project.update_option("sentry:scrub_ip_address", True)
+
+
+@pytest.fixture
+def call_endpoint(client, relay, private_key, default_projectkey):
+    def inner(full_config, public_keys=None):
+        path = reverse("sentry-api-0-relay-projectconfigs") + "?version=2"
+
+        if public_keys is None:
+            public_keys = [six.text_type(default_projectkey.public_key)]
+
+        if full_config is None:
+            raw_json, signature = private_key.pack({"publicKeys": public_keys})
+        else:
+            raw_json, signature = private_key.pack(
+                {"publicKeys": public_keys, "fullConfig": full_config}
+            )
+
+        resp = client.post(
+            path,
+            data=raw_json,
+            content_type="application/json",
+            HTTP_X_SENTRY_RELAY_ID=relay.relay_id,
+            HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
+        )
+
+        return json.loads(resp.content), resp.status_code
+
+    return inner
+
+
+@pytest.fixture
+def add_org_key(default_organization, relay):
+    default_organization.update_option(
+        "sentry:trusted-relays", [{"public_key": relay.public_key, "name": "main-relay"}]
+    )
+
+
+@pytest.fixture
+def no_internal_networks(monkeypatch):
+    """
+    Disable is_internal_ip functionality (make all requests appear to be from external networks)
+    """
+    monkeypatch.setattr("sentry.auth.system.INTERNAL_NETWORKS", ())
+
+
+@pytest.mark.django_db
+def test_internal_relays_should_receive_minimal_configs_if_they_do_not_explicitly_ask_for_full_config(
+    call_endpoint, default_project
+):
+    result, status_code = call_endpoint(full_config=False)
+
+    assert status_code < 400
+
+    # Sweeping assertion that we do not have any snake_case in that config.
+    # Might need refining.
+    assert not set(x for x in _get_all_keys(result) if "-" in x or "_" in x)
+
+    cfg = safe.get_path(result, "configs", six.text_type(default_project.id))
+    assert safe.get_path(cfg, "config", "filterSettings") is None
+    assert safe.get_path(cfg, "config", "groupingConfig") is None
+
+
+@pytest.mark.django_db
+def test_internal_relays_should_receive_full_configs(
+    call_endpoint, default_project, default_projectkey
+):
+    result, status_code = call_endpoint(full_config=True)
+
+    assert status_code < 400
+
+    # Sweeping assertion that we do not have any snake_case in that config.
+    # Might need refining.
+    assert not set(x for x in _get_all_keys(result) if "-" in x or "_" in x)
+
+    cfg = safe.get_path(result, "configs", default_projectkey.public_key)
+    assert safe.get_path(cfg, "disabled") is False
+
+    (public_key,) = cfg["publicKeys"]
+    assert public_key["publicKey"] == default_projectkey.public_key
+    assert public_key["isEnabled"]
+    assert "quotas" in public_key
+
+    assert safe.get_path(cfg, "slug") == default_project.slug
+    last_change = safe.get_path(cfg, "lastChange")
+    assert _date_regex.match(last_change) is not None
+    last_fetch = safe.get_path(cfg, "lastFetch")
+    assert _date_regex.match(last_fetch) is not None
+    assert safe.get_path(cfg, "organizationId") == default_project.organization.id
+    assert safe.get_path(cfg, "projectId") == default_project.id
+    assert safe.get_path(cfg, "slug") == default_project.slug
+    assert safe.get_path(cfg, "rev") is not None
+
+    assert safe.get_path(cfg, "config", "trustedRelays") == []
+    assert safe.get_path(cfg, "config", "filterSettings") is not None
+    assert safe.get_path(cfg, "config", "groupingConfig", "enhancements") is not None
+    assert safe.get_path(cfg, "config", "groupingConfig", "id") is not None
+    assert safe.get_path(cfg, "config", "piiConfig", "applications") is None
+    assert safe.get_path(cfg, "config", "piiConfig", "rules") is None
+    assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubData") is True
+    assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubDefaults") is True
+    assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubIpAddresses") is True
+    assert safe.get_path(cfg, "config", "datascrubbingSettings", "sensitiveFields") == []
+    assert safe.get_path(cfg, "config", "quotas") == []
+
+    # Event retention depends on settings, so assert the actual value. Likely
+    # `None` in dev, but must not be missing.
+    assert cfg["config"]["eventRetention"] == quotas.get_event_retention(
+        default_project.organization
+    )
+
+
+@pytest.mark.django_db
+def test_trusted_external_relays_should_not_be_able_to_request_full_configs(
+    add_org_key, call_endpoint, no_internal_networks
+):
+    result, status_code = call_endpoint(full_config=True)
+    assert status_code == 403
+
+
+@pytest.mark.django_db
+def test_when_not_sending_full_config_info_into_a_internal_relay_a_restricted_config_is_returned(
+    call_endpoint, default_project
+):
+    result, status_code = call_endpoint(full_config=None)
+
+    assert status_code < 400
+
+    cfg = safe.get_path(result, "configs", six.text_type(default_project.id))
+    assert safe.get_path(cfg, "config", "filterSettings") is None
+    assert safe.get_path(cfg, "config", "groupingConfig") is None
+
+
+@pytest.mark.django_db
+def test_when_not_sending_full_config_info_into_an_external_relay_a_restricted_config_is_returned(
+    call_endpoint, add_org_key, relay, default_project
+):
+    relay.is_internal = False
+    relay.save()
+
+    result, status_code = call_endpoint(full_config=None)
+
+    assert status_code < 400
+
+    cfg = safe.get_path(result, "configs", six.text_type(default_project.id))
+    assert safe.get_path(cfg, "config", "filterSettings") is None
+    assert safe.get_path(cfg, "config", "groupingConfig") is None
+
+
+@pytest.mark.django_db
+def test_trusted_external_relays_should_receive_minimal_configs(
+    relay, add_org_key, call_endpoint, default_project, default_projectkey
+):
+    relay.is_internal = False
+    relay.save()
+
+    result, status_code = call_endpoint(full_config=False)
+
+    assert status_code < 400
+
+    cfg = safe.get_path(result, "configs", default_projectkey.public_key)
+    assert safe.get_path(cfg, "disabled") is False
+    (public_key,) = cfg["publicKeys"]
+    assert public_key["publicKey"] == default_projectkey.public_key
+    assert public_key["isEnabled"]
+    assert "quotas" not in public_key
+
+    assert safe.get_path(cfg, "slug") == default_project.slug
+    last_change = safe.get_path(cfg, "lastChange")
+    assert _date_regex.match(last_change) is not None
+    last_fetch = safe.get_path(cfg, "lastFetch")
+    assert _date_regex.match(last_fetch) is not None
+    assert safe.get_path(cfg, "organizationId") == default_project.organization.id
+    assert safe.get_path(cfg, "projectId") == default_project.id
+    assert safe.get_path(cfg, "slug") == default_project.slug
+    assert safe.get_path(cfg, "rev") is not None
+    assert safe.get_path(cfg, "config", "trustedRelays") == [relay.public_key]
+    assert safe.get_path(cfg, "config", "filterSettings") is None
+    assert safe.get_path(cfg, "config", "groupingConfig") is None
+    assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubData") is not None
+    assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubIpAddresses") is not None
+    assert safe.get_path(cfg, "config", "piiConfig", "rules") is None
+    assert safe.get_path(cfg, "config", "piiConfig", "applications") is None
+    assert safe.get_path(cfg, "config", "quotas") is None
+
+
+@pytest.mark.django_db
+def test_untrusted_external_relays_should_not_receive_configs(
+    call_endpoint, default_project, default_projectkey, no_internal_networks
+):
+    result, status_code = call_endpoint(full_config=False)
+
+    assert status_code < 400
+
+    cfg = result["configs"][default_projectkey.public_key]
+
+    assert cfg["disabled"]
+
+
+@pytest.fixture
+def projectconfig_cache_set(monkeypatch):
+    calls = []
+    monkeypatch.setattr("sentry.relay.projectconfig_cache.set_many", calls.append)
+    return calls
+
+
+@pytest.mark.django_db
+def test_relay_projectconfig_cache_minimal_config(
+    call_endpoint, default_project, projectconfig_cache_set, task_runner
+):
+    """
+    When a relay fetches a minimal config, that config should not end up in Redis.
+    """
+
+    with task_runner():
+        result, status_code = call_endpoint(full_config=False)
+        assert status_code < 400
+
+    assert not projectconfig_cache_set
+
+
+@pytest.mark.django_db
+def test_relay_projectconfig_cache_full_config(
+    call_endpoint, default_projectkey, projectconfig_cache_set, task_runner
+):
+    """
+    When a relay fetches a full config, that config should end up in Redis.
+    """
+
+    with task_runner():
+        result, status_code = call_endpoint(full_config=True)
+        assert status_code < 400
+
+    http_cfg = result["configs"][default_projectkey.public_key]
+    (call,) = projectconfig_cache_set
+    assert len(call) == 1
+    redis_cfg = call[six.text_type(default_projectkey.public_key)]
+
+    del http_cfg["lastFetch"]
+    del http_cfg["lastChange"]
+    del redis_cfg["lastFetch"]
+    del redis_cfg["lastChange"]
+
+    assert redis_cfg == http_cfg
+
+
+@pytest.mark.django_db
+def test_relay_nonexistent_project(call_endpoint, projectconfig_cache_set, task_runner):
+    wrong_public_key = ProjectKey.generate_api_key()
+
+    with task_runner():
+        result, status_code = call_endpoint(full_config=True, public_keys=[wrong_public_key])
+        assert status_code < 400
+
+    assert result == {"configs": {wrong_public_key: {"disabled": True}}}
+
+    assert projectconfig_cache_set == [
+        {six.text_type(wrong_public_key): result["configs"][wrong_public_key]}
+    ]
+
+
+@pytest.mark.django_db
+def test_relay_disabled_project(
+    call_endpoint, default_project, projectconfig_cache_set, task_runner
+):
+    default_project.update(status=ObjectStatus.PENDING_DELETION)
+
+    wrong_public_key = ProjectKey.generate_api_key()
+
+    with task_runner():
+        result, status_code = call_endpoint(full_config=True, public_keys=[wrong_public_key])
+        assert status_code < 400
+
+    assert result == {"configs": {wrong_public_key: {"disabled": True}}}
+
+    assert projectconfig_cache_set == [
+        {six.text_type(wrong_public_key): result["configs"][wrong_public_key]}
+    ]


### PR DESCRIPTION
In preparation for DSN moves, we need to change the entire projectconfig lookup to work by public key instead of project ID.