### PR TITLE
feat(sentry-apps): save creator of sentry app on creator columns

### DIFF
--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -90,6 +90,9 @@ class Creator(Mediator):
             "is_alertable": self.is_alertable,
             "verify_install": self.verify_install,
             "overview": self.overview,
+            "creator_user": self.user,
+            "creator_label": self.user.email
+            or self.user.username,  # email is not required for some users (sentry apps)
         }
 
         if self.is_internal:

--- a/tests/sentry/mediators/sentry_apps/test_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_creator.py
@@ -18,7 +18,7 @@ from sentry.testutils import TestCase
 
 class TestCreator(TestCase):
     def setUp(self):
-        self.user = self.create_user()
+        self.user = self.create_user(email="foo@bar.com", username="scuba_steve")
         self.org = self.create_organization(owner=self.user)
         self.creator = Creator(
             name="nulldb",
@@ -58,6 +58,17 @@ class TestCreator(TestCase):
 
         assert sentry_app
         assert sentry_app.scope_list == ["project:read"]
+
+        assert sentry_app.creator_user == self.user
+        assert sentry_app.creator_label == "foo@bar.com"
+
+    def test_creator_label_no_email(self):
+        self.user.email = ""
+        self.user.save()
+        sentry_app = self.creator.call()
+
+        assert sentry_app.creator_user == self.user
+        assert sentry_app.creator_label == "scuba_steve"
 
     def test_expands_rolled_up_events(self):
         self.creator.events = ["issue"]


### PR DESCRIPTION
This is a followup to https://github.com/getsentry/sentry/pull/21142

This PR writes to the two new columns when making a Sentry App: `creator_user` and the `creator_label`. The latter is the email and the username if the email doesn't exist.

After this is merged, I am going to attempt to backfill the old data with the Audit log entry table which records integrations being created.