### PR TITLE
fix(integrations): Return a value in create_comment

### DIFF
--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -315,7 +315,7 @@ class VstsIssueSync(IssueSyncMixin):
     def create_comment(self, issue_id, user_id, group_note):
         comment = group_note.data["text"]
         quoted_comment = self.create_comment_attribution(user_id, comment)
-        self.get_client().update_work_item(self.instance, issue_id, comment=quoted_comment)
+        return self.get_client().update_work_item(self.instance, issue_id, comment=quoted_comment)
 
     def create_comment_attribution(self, user_id, comment_text):
         # VSTS uses markdown or xml

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -489,8 +489,9 @@ class VstsIntegrationTest(VstsIntegrationTestCase):
         comment = Mock()
         comment.data = {"text": comment_text}
 
-        installation.create_comment(1, self.user.id, comment)
+        work_item = installation.create_comment(1, self.user.id, comment)
 
+        assert work_item and work_item["id"]
         assert (
             mock_update_work_item.call_args[1]["comment"]
             == "Sentry Admin wrote:\n\n<blockquote>%s</blockquote>" % comment_text


### PR DESCRIPTION
It looks like when we create a comment in VSTS we aren't returning a value.
So `comment` is `None` and get a `TypeError` when we call `get_comment_id`:
```
def get_comment_id(self, comment):
  return comment["id"]
```

https://sentry.io/organizations/sentry/issues/1189532689/