### PR TITLE
feat(rum): Add tooltip to failure region

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/vitalCard.tsx
@@ -398,8 +398,24 @@ class VitalCard extends React.Component<Props, State> {
         borderWidth: 1.5,
         borderType: 'dashed',
       },
-      silent: true,
     });
+
+    // TODO(tonyx): This conflicts with the types declaration of `MarkArea`
+    // if we add it in the constructor. So we opt to add it here so typescript
+    // doesn't complain.
+    series.markArea.tooltip = {
+      formatter: () =>
+        [
+          '<div class="tooltip-series tooltip-series-solo">',
+          '<span class="tooltip-label">',
+          '<strong>',
+          t('Fails threshold at %s.', getDuration(failureThreshold / 1000)),
+          '</strong>',
+          '</span>',
+          '</div>',
+          '<div class="tooltip-arrow"></div>',
+        ].join(''),
+    };
 
     const topRightPixel = mapPoint(
       {


### PR DESCRIPTION
This change adds a tooltip when the user hovers over the failure region to
explain why the red box is there. Hovering over any point in the red box will
trigger this tooltip except when the cursor is over a histogram bar which has
priority.