### PR TITLE
feat(rum): Add data filters to RUM

### DIFF
--- a/src/sentry/api/endpoints/organization_events_measurements_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_measurements_histogram.py
@@ -20,6 +20,7 @@ class MeasurementsHistogramSerializer(serializers.Serializer):
     precision = serializers.IntegerField(default=0, min_value=0, max_value=4)
     min = serializers.FloatField(required=False)
     max = serializers.FloatField(required=False)
+    data_filter = serializers.CharField(required=False)
 
 
 class OrganizationEventsMeasurementsHistogramEndpoint(OrganizationEventsV2EndpointBase):
@@ -49,6 +50,7 @@ class OrganizationEventsMeasurementsHistogramEndpoint(OrganizationEventsV2Endpoi
                         data["precision"],
                         data.get("min"),
                         data.get("max"),
+                        data.get("data_filter"),
                         "api.organization-events-measurements-histogram",
                     )
 

--- a/src/sentry/api/endpoints/organization_events_measurements_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_measurements_histogram.py
@@ -12,6 +12,8 @@ from sentry.snuba import discover
 # The maximum number of measurements allowed to be queried at at time
 MAX_MEASUREMENTS = 4
 
+DATA_FILTERS = ["all", "exclude_outliers"]
+
 
 class MeasurementsHistogramSerializer(serializers.Serializer):
     query = serializers.CharField(required=False)
@@ -20,7 +22,7 @@ class MeasurementsHistogramSerializer(serializers.Serializer):
     precision = serializers.IntegerField(default=0, min_value=0, max_value=4)
     min = serializers.FloatField(required=False)
     max = serializers.FloatField(required=False)
-    dataFilter = serializers.CharField(required=False)
+    dataFilter = serializers.ChoiceField(choices=DATA_FILTERS, required=False)
 
 
 class OrganizationEventsMeasurementsHistogramEndpoint(OrganizationEventsV2EndpointBase):

--- a/src/sentry/api/endpoints/organization_events_measurements_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_measurements_histogram.py
@@ -20,7 +20,7 @@ class MeasurementsHistogramSerializer(serializers.Serializer):
     precision = serializers.IntegerField(default=0, min_value=0, max_value=4)
     min = serializers.FloatField(required=False)
     max = serializers.FloatField(required=False)
-    data_filter = serializers.CharField(required=False)
+    dataFilter = serializers.CharField(required=False)
 
 
 class OrganizationEventsMeasurementsHistogramEndpoint(OrganizationEventsV2EndpointBase):
@@ -50,7 +50,7 @@ class OrganizationEventsMeasurementsHistogramEndpoint(OrganizationEventsV2Endpoi
                         data["precision"],
                         data.get("min"),
                         data.get("max"),
-                        data.get("data_filter"),
+                        data.get("dataFilter"),
                         "api.organization-events-measurements-histogram",
                     )
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -960,6 +960,7 @@ def measurements_histogram_query(
     precision=0,
     min_value=None,
     max_value=None,
+    data_filter="upper_outer_fence",
     referrer=None,
 ):
     """
@@ -978,7 +979,11 @@ def measurements_histogram_query(
         If left unspecified, it is queried using `user_query` and `params`.
     :param float max_value: The maximum value allowed to be in the histogram.
         If left unspecified, it is queried using `user_query` and `params`.
+    :param str data_filter: Indicate the filter strategy to be applied to the data.
     """
+
+    if data_filter not in ("all", "upper_inner_fence", "upper_outer_fence", "p90", "p95", "p99"):
+        data_filter = "upper_inner_fence"
 
     multiplier = int(10 ** precision)
     if max_value is not None:
@@ -986,7 +991,7 @@ def measurements_histogram_query(
         # to be inclusive. So we adjust the specified max_value using the multiplier.
         max_value -= 0.1 / multiplier
     min_value, max_value = find_measurements_min_max(
-        measurements, min_value, max_value, user_query, params
+        measurements, min_value, max_value, user_query, params, data_filter
     )
 
     key_col = "array_join(measurements_key)"
@@ -1062,7 +1067,7 @@ def find_measurements_histogram_params(num_buckets, min_value, max_value, multip
     return HistogramParams(bucket_size, start_offset, multiplier)
 
 
-def find_measurements_min_max(measurements, min_value, max_value, user_query, params):
+def find_measurements_min_max(measurements, min_value, max_value, user_query, params, data_filter):
     """
     Find the min/max value of the specified measurements. If either min/max is already
     specified, it will be used and not queried for.
@@ -1075,6 +1080,7 @@ def find_measurements_min_max(measurements, min_value, max_value, user_query, pa
         If left unspecified, it is queried using `user_query` and `params`.
     :param str user_query: Filter query string to create conditions from.
     :param {str: str} params: Filtering parameters with start, end, project_id, environment
+    :param str data_filter: Indicate the filter strategy to be applied to the data.
     """
 
     if min_value is not None and max_value is not None:
@@ -1086,6 +1092,15 @@ def find_measurements_min_max(measurements, min_value, max_value, user_query, pa
             min_columns.append("min(measurements.{})".format(measurement))
         if max_value is None:
             max_columns.append("max(measurements.{})".format(measurement))
+        if data_filter in ("upper_inner_fence", "upper_outer_fence"):
+            max_columns.append("percentile(measurements.{}, 0.25)".format(measurement))
+            max_columns.append("percentile(measurements.{}, 0.75)".format(measurement))
+        if data_filter == "p90":
+            max_columns.append("percentile(measurements.{}, 0.9)".format(measurement))
+        if data_filter == "p95":
+            max_columns.append("percentile(measurements.{}, 0.95)".format(measurement))
+        if data_filter == "p99":
+            max_columns.append("percentile(measurements.{}, 0.99)".format(measurement))
 
     results = query(
         selected_columns=min_columns + max_columns,
@@ -1112,9 +1127,59 @@ def find_measurements_min_max(measurements, min_value, max_value, user_query, pa
         min_value = min(min_values) if min_values else None
 
     if max_value is None:
-        max_values = [row[get_function_alias(column)] for column in max_columns]
+        max_values = [
+            row[get_function_alias("max(measurements.{})".format(measurement))]
+            for measurement in measurements
+        ]
         max_values = list(filter(lambda v: v is not None, max_values))
         max_value = max(max_values) if max_values else None
+
+        fences = []
+        for measurement in measurements:
+            if data_filter == "p90":
+                column_name = get_function_alias(
+                    "percentile(measurements.{}, 0.9)".format(measurement)
+                )
+                fences.append(row[column_name])
+
+            if data_filter == "p95":
+                column_name = get_function_alias(
+                    "percentile(measurements.{}, 0.95)".format(measurement)
+                )
+                fences.append(row[column_name])
+
+            if data_filter == "p99":
+                column_name = get_function_alias(
+                    "percentile(measurements.{}, 0.99)".format(measurement)
+                )
+                fences.append(row[column_name])
+
+            if data_filter in ("upper_inner_fence", "upper_outer_fence"):
+                Q1_column_name = get_function_alias(
+                    "percentile(measurements.{}, 0.25)".format(measurement)
+                )
+                Q3_column_name = get_function_alias(
+                    "percentile(measurements.{}, 0.75)".format(measurement)
+                )
+
+                Q1 = row[Q1_column_name]
+                Q3 = row[Q3_column_name]
+                IQR = abs(Q3 - Q1)
+
+                if data_filter == "upper_inner_fence":
+                    upper_inner_fence = Q3 + 1.5 * IQR
+                    fences.append(upper_inner_fence)
+
+                if data_filter == "upper_outer_fence":
+                    upper_outer_fence = Q3 + 3 * IQR
+                    fences.append(upper_outer_fence)
+
+        fences = list(filter(lambda v: v is not None, fences))
+        max_fence_value = max(fences) if fences else None
+
+        candidates = [max_fence_value, max_value]
+        candidates = list(filter(lambda v: v is not None, candidates))
+        max_value = min(candidates) if candidates else None
 
     return min_value, max_value
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1151,7 +1151,6 @@ def find_measurements_min_max(
                     upper_outer_fence = third_quartile + 3 * interquartile_range
                     fences.append(upper_outer_fence)
 
-        fences = list(filter(lambda v: v is not None, fences))
         max_fence_value = max(fences) if fences else None
 
         candidates = [max_fence_value, max_value]

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -982,7 +982,10 @@ def measurements_histogram_query(
     :param str data_filter: Indicate the filter strategy to be applied to the data.
     """
 
-    if data_filter and data_filter not in ("all", "exclude_outliers"):
+    if data_filter is None:
+        data_filter = "all"
+
+    if data_filter not in ("all", "exclude_outliers"):
         raise Exception(u"{} is not a valid filter".format(data_filter))
 
     multiplier = int(10 ** precision)

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1067,7 +1067,9 @@ def find_measurements_histogram_params(num_buckets, min_value, max_value, multip
     return HistogramParams(bucket_size, start_offset, multiplier)
 
 
-def find_measurements_min_max(measurements, min_value, max_value, user_query, params, data_filter):
+def find_measurements_min_max(
+    measurements, min_value, max_value, user_query, params, data_filter="all"
+):
     """
     Find the min/max value of the specified measurements. If either min/max is already
     specified, it will be used and not queried for.

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -982,12 +982,6 @@ def measurements_histogram_query(
     :param str data_filter: Indicate the filter strategy to be applied to the data.
     """
 
-    if data_filter is None:
-        data_filter = "all"
-
-    if data_filter not in ("all", "exclude_outliers"):
-        raise Exception(u"{} is not a valid filter".format(data_filter))
-
     multiplier = int(10 ** precision)
     if max_value is not None:
         # We want the specified max_value to be exclusive, and the queried max_value

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1133,18 +1133,20 @@ def find_measurements_min_max(
         fences = []
         for measurement in measurements:
             if data_filter == "exclude_outliers":
-                Q1_column_name = get_function_alias(
+                # also known as the first quartile
+                p25_column = get_function_alias(
                     "percentile(measurements.{}, 0.25)".format(measurement)
                 )
-                Q3_column_name = get_function_alias(
+                # also known as the third quartile
+                p75_column = get_function_alias(
                     "percentile(measurements.{}, 0.75)".format(measurement)
                 )
 
-                Q1 = row[Q1_column_name]
-                Q3 = row[Q3_column_name]
-                IQR = abs(Q3 - Q1)
+                first_quartile = row[p25_column]
+                third_quartile = row[p75_column]
+                interquartile_range = abs(third_quartile - first_quartile)
 
-                upper_outer_fence = Q3 + 3 * IQR
+                upper_outer_fence = third_quartile + 3 * interquartile_range
                 fences.append(upper_outer_fence)
 
         fences = list(filter(lambda v: v is not None, fences))

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -960,7 +960,7 @@ def measurements_histogram_query(
     precision=0,
     min_value=None,
     max_value=None,
-    data_filter="all",
+    data_filter=None,
     referrer=None,
 ):
     """
@@ -1068,7 +1068,7 @@ def find_measurements_histogram_params(num_buckets, min_value, max_value, multip
 
 
 def find_measurements_min_max(
-    measurements, min_value, max_value, user_query, params, data_filter="all"
+    measurements, min_value, max_value, user_query, params, data_filter=None
 ):
     """
     Find the min/max value of the specified measurements. If either min/max is already
@@ -1131,8 +1131,8 @@ def find_measurements_min_max(
         max_value = max(max_values) if max_values else None
 
         fences = []
-        for measurement in measurements:
-            if data_filter == "exclude_outliers":
+        if data_filter == "exclude_outliers":
+            for measurement in measurements:
                 # also known as the first quartile
                 p25_column = get_function_alias(
                     "percentile(measurements.{}, 0.25)".format(measurement)

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1144,10 +1144,12 @@ def find_measurements_min_max(
 
                 first_quartile = row[p25_column]
                 third_quartile = row[p75_column]
-                interquartile_range = abs(third_quartile - first_quartile)
 
-                upper_outer_fence = third_quartile + 3 * interquartile_range
-                fences.append(upper_outer_fence)
+                if first_quartile is not None and third_quartile is not None:
+                    interquartile_range = abs(third_quartile - first_quartile)
+
+                    upper_outer_fence = third_quartile + 3 * interquartile_range
+                    fences.append(upper_outer_fence)
 
         fences = list(filter(lambda v: v is not None, fences))
         max_fence_value = max(fences) if fences else None

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -960,7 +960,7 @@ def measurements_histogram_query(
     precision=0,
     min_value=None,
     max_value=None,
-    data_filter="upper_outer_fence",
+    data_filter="all",
     referrer=None,
 ):
     """

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -982,8 +982,8 @@ def measurements_histogram_query(
     :param str data_filter: Indicate the filter strategy to be applied to the data.
     """
 
-    if data_filter not in ("all", "exclude_outliers"):
-        data_filter = "exclude_outliers"
+    if data_filter and data_filter not in ("all", "exclude_outliers"):
+        raise Exception(u"{} is not a valid filter".format(data_filter))
 
     multiplier = int(10 ** precision)
     if max_value is not None:

--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/constants.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/constants.tsx
@@ -46,6 +46,6 @@ export const WEB_VITAL_DETAILS: Record<WebVital, Vital> = {
 };
 
 export const FILTER_OPTIONS: SelectValue<string>[] = [
-  {label: t('Exclude outliers'), value: 'exclude_outliers'},
+  {label: t('Exclude Outliers'), value: 'exclude_outliers'},
   {label: t('View All'), value: 'all'},
 ];

--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/constants.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/constants.tsx
@@ -1,5 +1,6 @@
 import {t} from 'app/locale';
 import {WebVital, measurementType} from 'app/utils/discover/fields';
+import {SelectValue} from 'app/types';
 
 import {Vital} from './types';
 
@@ -43,3 +44,8 @@ export const WEB_VITAL_DETAILS: Record<WebVital, Vital> = {
     type: measurementType(WebVital.FID),
   },
 };
+
+export const FILTER_OPTIONS: SelectValue<string>[] = [
+  {label: t('Exclude outliers'), value: 'exclude_outliers'},
+  {label: t('View All'), value: 'all'},
+];

--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
@@ -19,12 +19,8 @@ import TransactionVitals from './transactionVitals';
 import TransactionHeader, {Tab} from '../transactionSummary/header';
 
 const FILTER_OPTIONS: SelectValue<string>[] = [
-  {label: t('Upper outer fence'), value: 'upper_outer_fence'},
-  {label: t('Upper inner fence'), value: 'upper_inner_fence'},
-  {label: t('P90'), value: 'p90'},
-  {label: t('P95'), value: 'p95'},
-  {label: t('P99'), value: 'p99'},
-  {label: t('All'), value: 'all'},
+  {label: t('Exclude outliers'), value: 'upper_inner_fence'},
+  {label: t('View All'), value: 'all'},
 ];
 
 type Props = {

--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
@@ -86,9 +86,9 @@ class RumContent extends React.Component<Props, State> {
   getActiveFilter() {
     const {location} = this.props;
 
-    const dataFilter = location.query.data_filter
-      ? decodeScalar(location.query.data_filter)
-      : 'upper_outer_fence';
+    const dataFilter = location.query.dataFilter
+      ? decodeScalar(location.query.dataFilter)
+      : FILTER_OPTIONS[0].value;
     return FILTER_OPTIONS.find(item => item.value === dataFilter) || FILTER_OPTIONS[0];
   }
 
@@ -99,7 +99,7 @@ class RumContent extends React.Component<Props, State> {
       query: {
         ...location.query,
         cursor: undefined,
-        data_filter: value,
+        dataFilter: value,
       },
     });
   };

--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
@@ -138,13 +138,6 @@ class RumContent extends React.Component<Props, State> {
                 fields={eventView.fields}
                 onSearch={this.handleSearch}
               />
-              <Button
-                onClick={this.handleResetView}
-                disabled={!isZoomed}
-                data-test-id="reset-view"
-              >
-                {t('Reset View')}
-              </Button>
               <DropdownControl
                 buttonProps={{prefix: t('Filter')}}
                 label={activeFilter.label}
@@ -160,6 +153,13 @@ class RumContent extends React.Component<Props, State> {
                   </DropdownItem>
                 ))}
               </DropdownControl>
+              <Button
+                onClick={this.handleResetView}
+                disabled={!isZoomed}
+                data-test-id="reset-view"
+              >
+                {t('Reset View')}
+              </Button>
             </StyledActions>
             <TransactionVitals
               organization={organization}
@@ -181,7 +181,7 @@ const StyledSearchBar = styled(SearchBar)`
 const StyledActions = styled('div')`
   display: grid;
   grid-gap: ${space(2)};
-  grid-template-columns: auto max-content;
+  grid-template-columns: auto max-content max-content;
   align-items: center;
   margin-bottom: ${space(3)};
 `;

--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
@@ -9,7 +9,7 @@ import * as Layout from 'app/components/layouts/thirds';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {Organization, Project, SelectValue} from 'app/types';
+import {Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/utils/queryString';
 import SearchBar from 'app/views/events/searchBar';
@@ -17,11 +17,7 @@ import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 
 import TransactionVitals from './transactionVitals';
 import TransactionHeader, {Tab} from '../transactionSummary/header';
-
-const FILTER_OPTIONS: SelectValue<string>[] = [
-  {label: t('Exclude outliers'), value: 'exclude_outliers'},
-  {label: t('View All'), value: 'all'},
-];
+import {FILTER_OPTIONS} from './constants';
 
 type Props = {
   location: Location;

--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
@@ -19,7 +19,7 @@ import TransactionVitals from './transactionVitals';
 import TransactionHeader, {Tab} from '../transactionSummary/header';
 
 const FILTER_OPTIONS: SelectValue<string>[] = [
-  {label: t('Exclude outliers'), value: 'upper_inner_fence'},
+  {label: t('Exclude outliers'), value: 'exclude_outliers'},
   {label: t('View All'), value: 'all'},
 ];
 

--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/measurementsHistogramQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/measurementsHistogramQuery.tsx
@@ -99,7 +99,7 @@ class MeasurementsHistogramQuery extends React.Component<Props, State> {
       num_buckets: numBuckets,
       min,
       max,
-      data_filter: dataFilter,
+      dataFilter,
     };
     const additionalApiPayload = omit(eventView.getEventsAPIPayload(location), [
       'field',

--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/measurementsHistogramQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/measurementsHistogramQuery.tsx
@@ -31,6 +31,7 @@ type Props = {
   children: (props: ChildrenProps) => React.ReactNode;
   min?: string;
   max?: string;
+  dataFilter?: string;
 };
 
 type State = {
@@ -60,7 +61,9 @@ class MeasurementsHistogramQuery extends React.Component<Props, State> {
     const minMaxChanged =
       prevProps.min !== this.props.min || prevProps.max !== this.props.max;
 
-    if (refetchCondition || eventViewValidation || minMaxChanged) {
+    const dataFilterChanged = prevProps.dataFilter !== this.props.dataFilter;
+
+    if (refetchCondition || eventViewValidation || minMaxChanged || dataFilterChanged) {
       this.fetchData();
     }
   }
@@ -73,7 +76,16 @@ class MeasurementsHistogramQuery extends React.Component<Props, State> {
   }
 
   fetchData = () => {
-    const {eventView, location, orgSlug, measurements, numBuckets, min, max} = this.props;
+    const {
+      eventView,
+      location,
+      orgSlug,
+      measurements,
+      numBuckets,
+      min,
+      max,
+      dataFilter,
+    } = this.props;
 
     if (!eventView.isValid()) {
       return;
@@ -87,6 +99,7 @@ class MeasurementsHistogramQuery extends React.Component<Props, State> {
       num_buckets: numBuckets,
       min,
       max,
+      data_filter: dataFilter,
     };
     const additionalApiPayload = omit(eventView.getEventsAPIPayload(location), [
       'field',

--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/transactionVitals.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/transactionVitals.tsx
@@ -17,11 +17,12 @@ type Props = {
   organization: Organization;
   location: Location;
   eventView: EventView;
+  dataFilter?: string;
 };
 
 class TransactionVitals extends React.Component<Props> {
   render() {
-    const {location, organization, eventView} = this.props;
+    const {location, organization, eventView, dataFilter} = this.props;
     const vitals = Object.values(WebVital);
 
     const colors = [...theme.charts.getColorPalette(vitals.length - 1)].reverse();
@@ -47,6 +48,7 @@ class TransactionVitals extends React.Component<Props> {
                 measurements={vitals.map(vital => WEB_VITAL_DETAILS[vital].slug)}
                 min={min}
                 max={max}
+                dataFilter={dataFilter}
               >
                 {results => (
                   <React.Fragment>

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -151,7 +151,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
             self.browser.snapshot("real user monitoring - exclude outliers")
 
             self.browser.element(
-                xpath="//button//span[contains(text(), 'Exclude outliers')]"
+                xpath="//button//span[contains(text(), 'Exclude Outliers')]"
             ).click()
 
             self.browser.element(xpath="//li//span[contains(text(), 'View All')]").click()

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -100,3 +100,60 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
             self.browser.wait_until_not('[data-test-id="stats-loading"]')
 
             self.browser.snapshot("real user monitoring")
+
+    @patch("django.utils.timezone.now")
+    def test_real_user_monitoring_filtering(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+
+        rum_path = u"/organizations/{}/performance/summary/rum/?{}".format(
+            self.org.slug,
+            urlencode({"transaction": "/country_by_code/", "project": self.project.id}),
+        )
+
+        # Create transactions
+        for seconds in range(3):
+            event_data = load_data("transaction", timestamp=before_now(minutes=2))
+            event_data["contexts"]["trace"]["op"] = "pageload"
+            event_data["event_id"] = ("c" * 31) + hex(seconds)[2:]
+            event_data["measurements"]["fp"]["value"] = seconds * 10
+            event_data["measurements"]["fcp"]["value"] = seconds * 10
+            event_data["measurements"]["lcp"]["value"] = seconds * 10
+            event_data["measurements"]["fid"]["value"] = seconds * 10
+            self.store_event(data=event_data, project_id=self.project.id)
+
+        # add anchor point
+        event_data = load_data("transaction", timestamp=before_now(minutes=1))
+        event_data["contexts"]["trace"]["op"] = "pageload"
+        event_data["event_id"] = "a" * 32
+        event_data["measurements"]["fp"]["value"] = 3000
+        event_data["measurements"]["fcp"]["value"] = 3000
+        event_data["measurements"]["lcp"]["value"] = 3000
+        event_data["measurements"]["fid"]["value"] = 3000
+        self.store_event(data=event_data, project_id=self.project.id)
+
+        # add outlier
+        event_data = load_data("transaction", timestamp=before_now(minutes=1))
+        event_data["contexts"]["trace"]["op"] = "pageload"
+        event_data["event_id"] = "b" * 32
+        event_data["measurements"]["fp"]["value"] = 3000000000
+        event_data["measurements"]["fcp"]["value"] = 3000000000
+        event_data["measurements"]["lcp"]["value"] = 3000000000
+        event_data["measurements"]["fid"]["value"] = 3000000000
+        self.store_event(data=event_data, project_id=self.project.id)
+
+        self.wait_for_event_count(self.project.id, 5)
+
+        with self.feature(list(FEATURE_NAMES) + ["organizations:measurements"]):
+            self.browser.get(rum_path)
+            self.page.wait_until_loaded()
+            self.browser.wait_until_not('[data-test-id="stats-loading"]')
+
+            self.browser.snapshot("real user monitoring - exclude outliers")
+
+            self.browser.element(
+                xpath="//button//span[contains(text(), 'Exclude outliers')]"
+            ).click()
+
+            self.browser.element(xpath="//li//span[contains(text(), 'View All')]").click()
+
+            self.browser.snapshot("real user monitoring - view all data")

--- a/tests/snuba/api/endpoints/test_organization_events_measurements_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_measurements_histogram.py
@@ -568,5 +568,5 @@ class OrganizationEventsMeasurementsHistogramEndpointTest(APITestCase, SnubaTest
         response = self.do_request(query)
         assert response.status_code == 400
         assert response.data == {
-            "detail": ["invalid is not a valid filter."],
+            "dataFilter": [u'"invalid" is not a valid choice.'],
         }

--- a/tests/snuba/api/endpoints/test_organization_events_measurements_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_measurements_histogram.py
@@ -556,3 +556,17 @@ class OrganizationEventsMeasurementsHistogramEndpointTest(APITestCase, SnubaTest
         response = self.do_request(query)
         assert response.status_code == 200
         assert response.data["data"] == self.as_response_data(specs)
+
+    def test_bad_params_invalid_data_filter(self):
+        query = {
+            "project": [self.project.id],
+            "measurement": ["foo", "bar"],
+            "num_buckets": 10,
+            "dataFilter": "invalid",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 400
+        assert response.data == {
+            "detail": ["invalid is not a valid filter."],
+        }

--- a/tests/snuba/api/endpoints/test_organization_events_measurements_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_measurements_histogram.py
@@ -570,3 +570,30 @@ class OrganizationEventsMeasurementsHistogramEndpointTest(APITestCase, SnubaTest
         assert response.data == {
             "dataFilter": [u'"invalid" is not a valid choice.'],
         }
+
+    def test_histogram_all_data_filter(self):
+        specs = [
+            (0, 1, [("foo", 4)]),
+            (4000, 4001, [("foo", 1)]),
+        ]
+        self.populate_measurements(specs)
+
+        query = {
+            "project": [self.project.id],
+            "measurement": ["foo"],
+            "num_buckets": 5,
+            "dataFilter": "all",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200
+
+        expected = [
+            (0, 1, [("foo", 4)]),
+            (801, 801, [("foo", 0)]),
+            (1602, 1602, [("foo", 0)]),
+            (2403, 2403, [("foo", 0)]),
+            (3204, 4001, [("foo", 1)]),
+        ]
+
+        assert response.data["data"] == self.as_response_data(expected)

--- a/tests/snuba/api/endpoints/test_organization_events_measurements_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_measurements_histogram.py
@@ -597,3 +597,30 @@ class OrganizationEventsMeasurementsHistogramEndpointTest(APITestCase, SnubaTest
         ]
 
         assert response.data["data"] == self.as_response_data(expected)
+
+    def test_histogram_exclude_outliers_data_filter(self):
+        specs = [
+            (0, 1, [("foo", 4)]),
+            (4000, 4001, [("foo", 1)]),
+        ]
+        self.populate_measurements(specs)
+
+        query = {
+            "project": [self.project.id],
+            "measurement": ["foo"],
+            "num_buckets": 5,
+            "dataFilter": "exclude_outliers",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200
+
+        expected = [
+            (0, 1, [("foo", 4)]),
+            (1, 1, [("foo", 0)]),
+            (2, 2, [("foo", 0)]),
+            (3, 3, [("foo", 0)]),
+            (4, 4, [("foo", 0)]),
+        ]
+
+        assert response.data["data"] == self.as_response_data(expected)


### PR DESCRIPTION
Add data filters to address outliers for histograms for the web vitals.

To address the outliers, an upper fence is applied to the data set to exclude outliers. The upper bound that will be used is:

- upper outer fence (`Q3 + (3 * IQR)`)

Other options exclude were:

- upper inner fence (`Q3 + (1.5 * IQR)`)
- P90
- P95
- P99

where `Q3 = P75`, and `IQR = P75 - P25`.

See: https://en.wikipedia.org/wiki/Outlier#Tukey's_fences

If any of these fences are greater than the max value of the data set, then the max value is instead used for the upper bound. This case can occur when the data is sparse.

An "All" option is provided, and it is synonymous with the max value of the data set. In other words, it is an option to display the entire range.

![Screen Shot 2020-10-08 at 9 15 24 PM](https://user-images.githubusercontent.com/139499/95530300-862bb100-09ab-11eb-92a3-fd884ccbf966.png)


## TODO

- [x] add tests
- [x] add acceptance test
- [x] "Filter: No Outliers"
