### PR TITLE
build(gha): Fix eslint error annotations

### DIFF
--- a/.github/eslint-stylish.json
+++ b/.github/eslint-stylish.json
@@ -1,0 +1,22 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "eslint-stylish",
+            "pattern": [
+                {
+                    "regexp": "^([^\\s].*)$",
+                    "file": 1
+                },
+                {
+                    "regexp": "^\\s+(\\d+):(\\d+)\\s+(error|warning|info)\\s+(.*)\\s\\s+(.*)$",
+                    "line": 1,
+                    "column": 2,
+                    "severity": 3,
+                    "message": 4,
+                    "code": 5,
+                    "loop": true
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -63,18 +63,22 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      # Setup custom tsc matcher, see https://github.com/actions/setup-node/issues/97
+      - name: setup matchers
+        id: matchers
+        run: |
+          echo "::remove-matcher owner=masters::"
+          echo "::add-matcher::.github/tsc.json"
+          echo "::add-matcher::.github/eslint-stylish.json"
+
       - name: eslint + fix
-        uses: getsentry/action-eslint-fix@master
+        uses: getsentry/action-eslint-fix@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Setup custom tsc matcher, see https://github.com/actions/setup-node/issues/97
       - name: tsc
-        id: tsc
         if: always()
         run: |
-          echo "::remove-matcher owner=tsc::"
-          echo "::add-matcher::.github/tsc.json"
           yarn tsc -p config/tsconfig.build.json
 
   webpack:


### PR DESCRIPTION
Previously the matcher was loaded with the `action/setup-node` action, but
we removed that in favor of `volta-cli/action`. This moves the `eslint`
matcher locally.

The matchers are used to annotate errors within the PR. e.g. if a lint error happens on `foo.jsx`, you will see the error message at the line where it occurred, in the `Files changed` tab of a PR.