### PR TITLE
test: overwrite petname's random with a separately seeded prng

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -5,7 +5,6 @@ from django.conf import settings
 
 import io
 import os
-import petname
 import random
 import six
 import warnings
@@ -13,6 +12,12 @@ from binascii import hexlify
 from hashlib import sha1
 from uuid import uuid4
 from importlib import import_module
+
+import petname
+
+# For more reproducible testing, we overwrite petname's random with a seeded PRNG
+# that does not share state with the generator bound to the module.
+petname.random = random.Random(123)
 
 from django.contrib.auth.models import AnonymousUser
 from django.db import transaction


### PR DESCRIPTION
I'm hoping this will get rid of all the visual snapshot diffs in py3 acceptance. See https://github.com/getsentry/sentry/pull/21186.