### PR TITLE
fix(api): request.user.is_authenticated

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -43,7 +43,7 @@ class ProjectPermission(OrganizationPermission):
             )
         elif is_system_auth(request.auth):
             return True
-        elif request.user.is_authenticated():
+        elif request.user and request.user.is_authenticated():
             # this is only for team-less projects
             if is_active_superuser(request):
                 return True

--- a/tests/sentry/web/frontend/test_release_webhook.py
+++ b/tests/sentry/web/frontend/test_release_webhook.py
@@ -109,3 +109,8 @@ class BuiltinReleaseWebhookTest(ReleaseWebhookTestBase):
         assert resp.status_code == 201, resp.content
         data = json.loads(resp.content)
         assert data["version"] == "a"
+
+    def test_no_teams_and_no_user(self):
+        self.project.remove_team(self.team)
+        resp = self.client.post(self.path, user=None, content_type="application/json")
+        assert resp.status_code == 403


### PR DESCRIPTION
Getting a 500 when hitting the Release webhook for a project with no teams. 
`request.user` is `None` so `request.user.is_authenticated()` is raising an `AttributeError`.

Should I guard against null user more generally?

https://sentry.io/organizations/sentry/issues/1649762734/