### PR TITLE
chore: Add comment to `BaseQuerySet.only`

### DIFF
--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -67,6 +67,10 @@ class BaseQuerySet(QuerySet):
         raise NotImplementedError("Use ``values_list`` instead [performance].")
 
     def only(self, *args, **kwargs):
+        # In rare cases Django can use this if a field is unexpectedly deferred. This
+        # mostly can happen if a field is added to a model, and then an old pickle is
+        # passed to a process running the new code. So if you see this error after a
+        # deploy of a model with a new field, it'll likely fix itself post-deploy.
         raise NotImplementedError("Use ``values_list`` instead [performance].")
 
 


### PR DESCRIPTION
We just saw an issue where we added a field to a model, and even though the field was created in the
database there were issues relating to it. Turns out that when we unpickle old models that are
missing the field they will be deferred. This in turn means that Django will fetch the fields upon
access using `.only`, which raises due to hitting the `NotImplementedError`.

Just leaving a comment here so that is more obvious the next time it happens. The actual thing that
caused this error was `_update_tracked_data`. Wondering if maybe we should only call it on certain
models that want to track their change state.