### PR TITLE
ref(frames): Need indication in Issues UI that you can expand the frame 

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
@@ -97,7 +97,7 @@ const Context = ({
                   <OpenInContextLine
                     key={index}
                     lineNo={line[0]}
-                    filename={frame.filename}
+                    filename={frame.filename || ''}
                     components={components}
                   />
                 </ErrorBoundary>
@@ -109,7 +109,7 @@ const Context = ({
       {(hasContextRegisters || hasContextVars) && (
         <StyledClippedBox clipHeight={100}>
           {hasContextRegisters && <FrameRegisters data={registers} key="registers" />}
-          {hasContextVars && <FrameVariables data={frame.vars} key="vars" />}
+          {hasContextVars && <FrameVariables data={frame.vars || {}} key="vars" />}
         </StyledClippedBox>
       )}
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -31,7 +31,9 @@ const DefaultTitle = ({frame, platform}: Props) => {
     event.stopPropagation();
   };
 
-  const getPathName = (shouldPrioritizeModuleName: boolean): GetPathNameOutput => {
+  const getPathName = (
+    shouldPrioritizeModuleName: boolean
+  ): GetPathNameOutput | undefined => {
     if (shouldPrioritizeModuleName) {
       if (frame.module) {
         return {
@@ -40,11 +42,14 @@ const DefaultTitle = ({frame, platform}: Props) => {
           meta: getMeta(frame, 'module'),
         };
       }
-      return {
-        key: 'filename',
-        value: frame.filename,
-        meta: getMeta(frame, 'filename'),
-      };
+      if (frame.filename) {
+        return {
+          key: 'filename',
+          value: frame.filename,
+          meta: getMeta(frame, 'filename'),
+        };
+      }
+      return undefined;
     }
 
     if (frame.filename) {
@@ -55,11 +60,15 @@ const DefaultTitle = ({frame, platform}: Props) => {
       };
     }
 
-    return {
-      key: 'module',
-      value: frame.module,
-      meta: getMeta(frame, 'module'),
-    };
+    if (frame.module) {
+      return {
+        key: 'module',
+        value: frame.module,
+        meta: getMeta(frame, 'module'),
+      };
+    }
+
+    return undefined;
   };
 
   // TODO(dcramer): this needs to use a formatted string so it can be
@@ -70,18 +79,20 @@ const DefaultTitle = ({frame, platform}: Props) => {
       framePlatform === 'java' || framePlatform === 'csharp';
 
     const pathName = getPathName(shouldPrioritizeModuleName);
-    const enablePathTooltip = defined(frame.absPath) && frame.absPath !== pathName.value;
+    const enablePathTooltip = defined(frame.absPath) && frame.absPath !== pathName?.value;
 
-    title.push(
-      <Tooltip key={pathName.key} title={frame.absPath} disabled={!enablePathTooltip}>
-        <code key="filename" className="filename">
-          <AnnotatedText
-            value={<Truncate value={pathName.value} maxLength={100} leftTrim />}
-            meta={pathName.meta}
-          />
-        </code>
-      </Tooltip>
-    );
+    if (pathName) {
+      title.push(
+        <Tooltip key={pathName.key} title={frame.absPath} disabled={!enablePathTooltip}>
+          <code key="filename" className="filename">
+            <AnnotatedText
+              value={<Truncate value={pathName.value} maxLength={100} leftTrim />}
+              meta={pathName.meta}
+            />
+          </code>
+        </Tooltip>
+      );
+    }
 
     // in case we prioritized the module name but we also have a filename info
     // we want to show a litle (?) icon that on hover shows the actual filename

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/defaultTitle/originalSourceInfo.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/defaultTitle/originalSourceInfo.tsx
@@ -1,21 +1,28 @@
 import React from 'react';
 
 import {t} from 'app/locale';
+import {defined} from 'app/utils';
 
 type Props = {
-  mapUrl?: string;
-  map: string;
+  map?: string | null;
+  mapUrl?: string | null;
 };
 
 // TODO(Priscila): Remove BR tags
 // mapUrl not always present; e.g. uploaded source maps
-const OriginalSourceInfo = ({mapUrl, map}: Props) => (
-  <React.Fragment>
-    <strong>{t('Source Map')}</strong>
-    <br />
-    {mapUrl ? mapUrl : map}
-    <br />
-  </React.Fragment>
-);
+const OriginalSourceInfo = ({mapUrl, map}: Props) => {
+  if (!defined(map) && !defined(mapUrl)) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      <strong>{t('Source Map')}</strong>
+      <br />
+      {mapUrl ?? map}
+      <br />
+    </React.Fragment>
+  );
+};
 
 export default OriginalSourceInfo;

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
@@ -4,27 +4,31 @@ import classNames from 'classnames';
 import scrollToElement from 'scroll-to-element';
 import styled from '@emotion/styled';
 
+import Button from 'app/components/button';
 import {defined, objectIsEmpty} from 'app/utils';
 import {t} from 'app/locale';
-import TogglableAddress from 'app/components/events/interfaces/togglableAddress';
+import TogglableAddress, {
+  AddressToggleIcon,
+} from 'app/components/events/interfaces/togglableAddress';
 import PackageLink from 'app/components/events/interfaces/packageLink';
-import PackageStatus from 'app/components/events/interfaces/packageStatus';
+import PackageStatus, {
+  PackageStatusIcon,
+} from 'app/components/events/interfaces/packageStatus';
 import StrictClick from 'app/components/strictClick';
-import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
 import withSentryAppComponents from 'app/utils/withSentryAppComponents';
 import {DebugMetaActions} from 'app/stores/debugMetaStore';
 import {SymbolicatorStatus} from 'app/components/events/interfaces/types';
 import {combineStatus} from 'app/components/events/interfaces/debugMeta/utils';
-import {IconRefresh, IconAdd, IconSubtract, IconQuestion, IconWarning} from 'app/icons';
+import {IconRefresh, IconChevron} from 'app/icons';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {Frame, SentryAppComponent, PlatformType} from 'app/types';
 import DebugImage from 'app/components/events/interfaces/debugMeta/debugImage';
 
-import FrameContext from './context';
-import FunctionName from './functionName';
+import Context from './context';
 import {getPlatform} from './utils';
 import DefaultTitle from './defaultTitle';
+import Symbol, {FunctionNameToggleIcon} from './symbol';
 
 type Props = {
   data: Frame;
@@ -38,6 +42,8 @@ type Props = {
   components: Array<SentryAppComponent>;
   showingAbsoluteAddress: boolean;
   onAddressToggle: (event: React.MouseEvent<SVGElement>) => void;
+  onFunctionNameToggle: (event: React.MouseEvent<SVGElement>) => void;
+  showCompleteFunctionName: boolean;
   image: React.ComponentProps<typeof DebugImage>['image'];
   maxLengthOfRelativeAddress: number;
   isFrameAfterLastNonApp: boolean;
@@ -62,10 +68,11 @@ export class Line extends React.Component<Props, State> {
     registers: PropTypes.objectOf(PropTypes.string.isRequired),
     components: PropTypes.array.isRequired,
     showingAbsoluteAddress: PropTypes.bool,
-    onAddressToggle: PropTypes.func,
+    onFunctionNameToggle: PropTypes.func,
     image: PropTypes.object,
     maxLengthOfRelativeAddress: PropTypes.number,
-    isFrameAfterLastNonApp: PropTypes.bool,
+    onAddressToggle: PropTypes.func,
+    showCompleteFunctionName: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -93,7 +100,7 @@ export class Line extends React.Component<Props, State> {
   }
 
   hasContextVars() {
-    return !objectIsEmpty(this.props.data.vars);
+    return !objectIsEmpty(this.props.data.vars || {});
   }
 
   hasContextRegisters() {
@@ -169,16 +176,19 @@ export class Line extends React.Component<Props, State> {
     if (!this.isExpandable()) {
       return null;
     }
+
+    const {isExpanded} = this.state;
+
     return (
-      <a
-        key="expander"
-        title={t('Toggle context')}
-        onClick={this.toggleContext}
-        className="btn btn-default btn-toggle"
-        css={this.getPlatform() === 'csharp' && {display: 'block !important'}} // remove important once we get rid of css files
-      >
-        {this.state.isExpanded ? <IconSubtract size="8px" /> : <IconAdd size="8px" />}
-      </a>
+      <ToggleContextButtonWrapper>
+        <ToggleContextButton title={t('Toggle Context')} onClick={this.toggleContext}>
+          <StyledIconChevron
+            isExpanded={!!isExpanded}
+            direction={isExpanded ? 'up' : 'down'}
+            size="8px"
+          />
+        </ToggleContextButton>
+      </ToggleContextButtonWrapper>
     );
   }
 
@@ -191,54 +201,6 @@ export class Line extends React.Component<Props, State> {
     const {data} = this.props;
 
     return data.trust === 'scan' || data.trust === 'cfi-scan';
-  }
-
-  getFrameHint() {
-    // returning [hintText, hintIcon]
-    const {symbolicatorStatus} = this.props.data;
-    const func = this.props.data.function || '<unknown>';
-    // Custom color used to match adjacent text.
-    const warningIcon = <IconQuestion size="xs" color={'#2c45a8' as any} />;
-    const errorIcon = <IconWarning size="xs" color="red400" />;
-
-    if (func.match(/^@objc\s/)) {
-      return [t('Objective-C -> Swift shim frame'), warningIcon];
-    }
-
-    if (func.match(/^__?hidden#\d+/)) {
-      return [t('Hidden function from bitcode build'), errorIcon];
-    }
-
-    if (!symbolicatorStatus && func === '<unknown>') {
-      // Only render this if the event was not symbolicated.
-      return [t('No function name was supplied by the client SDK.'), warningIcon];
-    }
-
-    if (
-      func === '<unknown>' ||
-      (func === '<redacted>' && symbolicatorStatus === SymbolicatorStatus.MISSING_SYMBOL)
-    ) {
-      switch (symbolicatorStatus) {
-        case SymbolicatorStatus.MISSING_SYMBOL:
-          return [t('The symbol was not found within the debug file.'), warningIcon];
-        case SymbolicatorStatus.UNKNOWN_IMAGE:
-          return [t('No image is specified for the address of the frame.'), warningIcon];
-        case SymbolicatorStatus.MISSING:
-          return [
-            t('The debug file could not be retrieved from any of the sources.'),
-            errorIcon,
-          ];
-        case SymbolicatorStatus.MALFORMED:
-          return [t('The retrieved debug file could not be processed.'), errorIcon];
-        default:
-      }
-    }
-
-    if (func === '<redacted>') {
-      return [t('Unknown system frame. Usually from beta SDKs'), warningIcon];
-    }
-
-    return [null, null];
   }
 
   renderLeadHint() {
@@ -278,9 +240,9 @@ export class Line extends React.Component<Props, State> {
           </RepeatedContent>
         </RepeatedFrames>
       );
-    } else {
-      return null;
     }
+
+    return null;
   }
 
   renderDefaultLine() {
@@ -305,15 +267,16 @@ export class Line extends React.Component<Props, State> {
       data,
       showingAbsoluteAddress,
       onAddressToggle,
+      onFunctionNameToggle,
       image,
       maxLengthOfRelativeAddress,
       isFrameAfterLastNonApp,
       includeSystemFrames,
+      showCompleteFunctionName,
     } = this.props;
-    const [hint, hintIcon] = this.getFrameHint();
 
-    const enablePathTooltip = defined(data.absPath) && data.absPath !== data.filename;
     const leadHint = this.renderLeadHint();
+    const packageStatus = this.packageStatus();
 
     return (
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : undefined}>
@@ -328,7 +291,7 @@ export class Line extends React.Component<Props, State> {
                 onClick={this.scrollToImage}
                 isClickable={this.shouldShowLinkToImage()}
               >
-                <PackageStatus status={this.packageStatus()} />
+                <PackageStatus status={packageStatus} tooltip={t('Image loaded')} />
               </PackageLink>
             </PackageInfo>
             {data.instructionAddr && (
@@ -339,25 +302,14 @@ export class Line extends React.Component<Props, State> {
                 isFoundByStackScanning={this.isFoundByStackScanning()}
                 isInlineFrame={this.isInlineFrame()}
                 onToggle={onAddressToggle}
-                maxLengthOfRelativeAddress={maxLengthOfRelativeAddress}
+                relativeAddressMaxlength={maxLengthOfRelativeAddress}
               />
             )}
-            <Symbol className="symbol">
-              <FunctionName frame={data} />{' '}
-              {hint !== null ? (
-                <HintStatus>
-                  <Tooltip title={hint}>{hintIcon}</Tooltip>
-                </HintStatus>
-              ) : null}
-              {data.filename && (
-                <Tooltip title={data.absPath} disabled={!enablePathTooltip}>
-                  <span className="filename">
-                    {data.filename}
-                    {data.lineNo ? ':' + data.lineNo : ''}
-                  </span>
-                </Tooltip>
-              )}
-            </Symbol>
+            <Symbol
+              frame={data}
+              showCompleteFunctionName={showCompleteFunctionName}
+              onFunctionNameToggle={onFunctionNameToggle}
+            />
           </NativeLineContent>
           {this.renderExpander()}
         </DefaultLine>
@@ -380,6 +332,7 @@ export class Line extends React.Component<Props, State> {
 
   render() {
     const data = this.props.data;
+
     const className = classNames({
       frame: true,
       'is-expandable': this.isExpandable(),
@@ -392,9 +345,9 @@ export class Line extends React.Component<Props, State> {
     const props = {className};
 
     return (
-      <li {...props}>
+      <StyledLi {...props}>
         {this.renderLine()}
-        <FrameContext
+        <Context
           frame={data}
           registers={this.props.registers}
           components={this.props.components}
@@ -406,10 +359,12 @@ export class Line extends React.Component<Props, State> {
           expandable={this.isExpandable()}
           isExpanded={this.state.isExpanded}
         />
-      </li>
+      </StyledLi>
     );
   }
 }
+
+export default withSentryAppComponents(Line, {componentType: 'stacktrace-link'});
 
 const RepeatedFrames = styled('div')`
   display: inline-block;
@@ -467,32 +422,46 @@ const DefaultLine = styled('div')`
   align-items: center;
 `;
 
-const HintStatus = styled('span')`
-  position: relative;
-  top: ${space(0.25)};
-  margin: 0 ${space(0.75)} 0 -${space(0.25)};
-`;
-
-const Symbol = styled('span')`
-  text-align: left;
-  grid-column-start: 1;
-  grid-column-end: -1;
-  order: 3;
-
-  @media (min-width: ${props => props.theme.breakpoints[0]}) {
-    order: 0;
-    grid-column-start: auto;
-    grid-column-end: auto;
-  }
-`;
-
 const StyledIconRefresh = styled(IconRefresh)`
   margin-right: ${space(0.25)};
 `;
 
 const LeadHint = styled('div')<{width?: string}>`
   ${overflowEllipsis}
-  width: ${p => (p.width ? p.width : '67px')}
+  max-width: ${p => (p.width ? p.width : '67px')}
 `;
 
-export default withSentryAppComponents(Line, {componentType: 'stacktrace-link'});
+const StyledIconChevron = styled(IconChevron, {
+  shouldForwardProp: prop => prop !== 'isExpanded',
+})<{isExpanded: boolean}>`
+  transform: rotate(${p => (p.isExpanded ? '180deg' : '0deg')});
+  transition: 0.1s all;
+`;
+
+const ToggleContextButtonWrapper = styled('span')`
+  margin-left: ${space(1)};
+`;
+
+// the Button's label has the padding of 3px because the button size has to be 16x16 px.
+const ToggleContextButton = styled(Button)`
+  span:first-child {
+    padding: 3px;
+  }
+`;
+
+const StyledLi = styled('li')`
+  ${PackageStatusIcon} {
+    flex-shrink: 0;
+  }
+  :hover {
+    ${PackageStatusIcon} {
+      visibility: visible;
+    }
+    ${AddressToggleIcon} {
+      visibility: visible;
+    }
+    ${FunctionNameToggleIcon} {
+      visibility: visible;
+    }
+  }
+`;

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
@@ -181,7 +181,12 @@ export class Line extends React.Component<Props, State> {
 
     return (
       <ToggleContextButtonWrapper>
-        <ToggleContextButton title={t('Toggle Context')} onClick={this.toggleContext}>
+        <ToggleContextButton
+          className="btn-toggle"
+          css={this.getPlatform() === 'csharp' && {display: 'block !important'}} // remove important once we get rid of css files
+          title={t('Toggle Context')}
+          onClick={this.toggleContext}
+        >
           <StyledIconChevron
             isExpanded={!!isExpanded}
             direction={isExpanded ? 'up' : 'down'}

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/symbol.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/symbol.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import space from 'app/styles/space';
+import Tooltip from 'app/components/tooltip';
+import {Frame} from 'app/types';
+import {defined} from 'app/utils';
+import {t} from 'app/locale';
+import {IconFilter} from 'app/icons';
+
+import FunctionName from './functionName';
+import {getFrameHint} from './utils';
+
+type Props = {
+  frame: Frame;
+  onFunctionNameToggle: (event: React.MouseEvent<SVGElement>) => void;
+  showCompleteFunctionName: boolean;
+};
+
+const Symbol = ({frame, onFunctionNameToggle, showCompleteFunctionName}: Props) => {
+  const hasFunctionNameHiddenDetails =
+    defined(frame.rawFunction) &&
+    defined(frame.function) &&
+    frame.function !== frame.rawFunction;
+
+  const getFunctionNameTooltipTitle = () => {
+    if (!hasFunctionNameHiddenDetails) {
+      return undefined;
+    }
+
+    if (!showCompleteFunctionName) {
+      return t('Expand function details');
+    }
+
+    return t('Hide function details');
+  };
+
+  const [hint, hintIcon] = getFrameHint(frame);
+  const enablePathTooltip = defined(frame.absPath) && frame.absPath !== frame.filename;
+  const functionNameTooltipTitle = getFunctionNameTooltipTitle();
+
+  return (
+    <Wrapper>
+      <FunctionNameToggleTooltip
+        title={functionNameTooltipTitle}
+        containerDisplayMode="inline-flex"
+      >
+        <FunctionNameToggleIcon
+          hasFunctionNameHiddenDetails={hasFunctionNameHiddenDetails}
+          onClick={hasFunctionNameHiddenDetails ? onFunctionNameToggle : undefined}
+          size="xs"
+          color="purple400"
+        />
+      </FunctionNameToggleTooltip>
+      <Data>
+        <StyledFunctionName
+          frame={frame}
+          showCompleteFunctionName={showCompleteFunctionName}
+          hasHiddenDetails={hasFunctionNameHiddenDetails}
+        />
+        {hint && (
+          <HintStatus>
+            <Tooltip title={hint}>{hintIcon}</Tooltip>
+          </HintStatus>
+        )}
+        {frame.filename && (
+          <FileNameTooltip title={frame.absPath} disabled={!enablePathTooltip}>
+            <Filename>
+              {'('}
+              {frame.filename}
+              {frame.lineNo && `:${frame.lineNo}`}
+              {')'}
+            </Filename>
+          </FileNameTooltip>
+        )}
+      </Data>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled('div')`
+  text-align: left;
+  grid-column-start: 1;
+  grid-column-end: -1;
+  order: 3;
+  flex: 1;
+
+  display: flex;
+
+  code {
+    background: transparent;
+    color: ${p => p.theme.gray800};
+    padding-right: ${space(0.5)};
+  }
+
+  @media (min-width: ${props => props.theme.breakpoints[0]}) {
+    order: 0;
+    grid-column-start: auto;
+    grid-column-end: auto;
+  }
+`;
+
+const StyledFunctionName = styled(FunctionName)`
+  margin-right: ${space(0.75)};
+`;
+
+const Data = styled('div')`
+  max-width: 100%;
+`;
+
+const HintStatus = styled('span')`
+  position: relative;
+  top: ${space(0.25)};
+  margin: 0 ${space(0.75)} 0 -${space(0.25)};
+`;
+
+const FileNameTooltip = styled(Tooltip)`
+  margin-right: ${space(0.5)};
+`;
+
+const Filename = styled('span')`
+  color: ${p => p.theme.purple400};
+`;
+
+const FunctionNameToggleIcon = styled(IconFilter, {
+  shouldForwardProp: prop => prop !== 'hasFunctionNameHiddenDetails',
+})<{
+  hasFunctionNameHiddenDetails: boolean;
+}>`
+  cursor: pointer;
+  visibility: hidden;
+  display: none;
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    display: block;
+  }
+  ${p => !p.hasFunctionNameHiddenDetails && 'opacity: 0; cursor: inherit;'};
+`;
+
+const FunctionNameToggleTooltip = styled(Tooltip)`
+  height: 16px;
+  align-items: center;
+  margin-right: ${space(0.75)};
+`;
+
+export default Symbol;
+export {FunctionNameToggleIcon};

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/utils.tsx
@@ -1,4 +1,9 @@
-import {PlatformType} from 'app/types';
+import React from 'react';
+
+import {PlatformType, Frame} from 'app/types';
+import {t} from 'app/locale';
+import {IconQuestion, IconWarning} from 'app/icons';
+import {SymbolicatorStatus} from 'app/components/events/interfaces/types';
 
 export function trimPackage(pkg: string) {
   const pieces = pkg.split(/^([a-z]:\\|\\\\)/i.test(pkg) ? '\\' : '/');
@@ -6,8 +11,54 @@ export function trimPackage(pkg: string) {
   return filename.replace(/\.(dylib|so|a|dll|exe)$/, '');
 }
 
-export function getPlatform(dataPlatform: PlatformType, platform: string) {
+export function getPlatform(dataPlatform: PlatformType | null, platform: string) {
   // prioritize the frame platform but fall back to the platform
   // of the stacktrace / exception
   return dataPlatform || platform;
+}
+
+export function getFrameHint(frame: Frame) {
+  // returning [hintText, hintIcon]
+  const {symbolicatorStatus} = frame;
+  const func = frame.function || '<unknown>';
+  // Custom color used to match adjacent text.
+  const warningIcon = <IconQuestion size="xs" color={'#2c45a8' as any} />;
+  const errorIcon = <IconWarning size="xs" color="red400" />;
+
+  if (func.match(/^@objc\s/)) {
+    return [t('Objective-C -> Swift shim frame'), warningIcon];
+  }
+  if (func.match(/^__?hidden#\d+/)) {
+    return [t('Hidden function from bitcode build'), errorIcon];
+  }
+  if (!symbolicatorStatus && func === '<unknown>') {
+    // Only render this if the event was not symbolicated.
+    return [t('No function name was supplied by the client SDK.'), warningIcon];
+  }
+
+  if (
+    func === '<unknown>' ||
+    (func === '<redacted>' && symbolicatorStatus === SymbolicatorStatus.MISSING_SYMBOL)
+  ) {
+    switch (symbolicatorStatus) {
+      case SymbolicatorStatus.MISSING_SYMBOL:
+        return [t('The symbol was not found within the debug file.'), warningIcon];
+      case SymbolicatorStatus.UNKNOWN_IMAGE:
+        return [t('No image is specified for the address of the frame.'), warningIcon];
+      case SymbolicatorStatus.MISSING:
+        return [
+          t('The debug file could not be retrieved from any of the sources.'),
+          errorIcon,
+        ];
+      case SymbolicatorStatus.MALFORMED:
+        return [t('The retrieved debug file could not be processed.'), errorIcon];
+      default:
+    }
+  }
+
+  if (func === '<redacted>') {
+    return [t('Unknown system frame. Usually from beta SDKs'), warningIcon];
+  }
+
+  return [null, null];
 }

--- a/src/sentry/static/sentry/app/components/events/interfaces/packageLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/packageLink.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import {IconChevron} from 'app/icons';
 import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
 import {defined} from 'app/utils';
 import {trimPackage} from 'app/components/events/interfaces/frame/utils';
-import {PackageStatusIcon} from 'app/components/events/interfaces/packageStatus';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 
 type Props = {
   onClick: (event: React.MouseEvent<HTMLAnchorElement>) => void;
   withLeadHint: boolean;
   includeSystemFrames: boolean;
-  packagePath?: string;
+  packagePath: string | null;
   isClickable?: boolean;
 };
 
@@ -56,42 +54,22 @@ class PackageLink extends React.Component<Props> {
           <span>{'<unknown>'}</span>
         )}
         {children}
-        {isClickable && <LinkChevron direction="right" size="xs" />}
       </Package>
     );
   }
 }
-
-const LinkChevron = styled(IconChevron)`
-  opacity: 0;
-  transition: all 0.2s ease-in-out;
-  vertical-align: top;
-  margin-left: ${space(0.5)};
-  flex-shrink: 0;
-`;
 
 const Package = styled('a')<Partial<Props>>`
   font-size: 13px;
   font-weight: bold;
   padding: 0 0 0 ${space(0.5)};
   color: ${p => p.theme.gray700};
-  cursor: ${p => (p.isClickable ? 'pointer' : 'default')};
-  ${PackageStatusIcon} {
-    opacity: 0;
-    flex-shrink: 0;
-  }
-  &:hover {
+  :hover {
     color: ${p => p.theme.gray700};
-    ${LinkChevron} {
-      opacity: 1;
-    }
-    ${PackageStatusIcon} {
-      opacity: 1;
-    }
   }
+  cursor: ${p => (p.isClickable ? 'pointer' : 'default')};
   display: flex;
-
-  align-items: flex-start;
+  align-items: center;
 
   ${p =>
     p.withLeadHint && (p.includeSystemFrames ? `max-width: 89px;` : `max-width: 76px;`)}

--- a/src/sentry/static/sentry/app/components/events/interfaces/packageStatus.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/packageStatus.tsx
@@ -10,39 +10,49 @@ type Props = {
   tooltip?: string;
 };
 
-class PackageStatus extends React.Component<Props> {
-  getIcon(status: Props['status']): React.ReactNode {
+const PackageStatus = ({status, tooltip}: Props) => {
+  const getIcon = () => {
     switch (status) {
       case 'success':
-        return <IconCheckmark isCircled color="green500" />;
+        return <IconCheckmark isCircled color="green500" size="xs" />;
       case 'empty':
-        return <IconCircle />;
+        return <IconCircle size="xs" />;
       case 'error':
       default:
-        return <IconFlag color="red400" />;
+        return <IconFlag color="red400" size="xs" />;
     }
+  };
+
+  const icon = getIcon();
+
+  if (status === 'empty') {
+    return null;
   }
 
-  render() {
-    const {status, tooltip} = this.props;
+  return (
+    <StyledTooltip
+      title={tooltip}
+      disabled={!(tooltip && tooltip.length)}
+      containerDisplayMode="inline-flex"
+    >
+      <PackageStatusIcon>{icon}</PackageStatusIcon>
+    </StyledTooltip>
+  );
+};
 
-    const icon = this.getIcon(status);
-
-    if (status === 'empty') {
-      return null;
-    }
-
-    return (
-      <Tooltip title={tooltip} disabled={!(tooltip && tooltip.length)}>
-        <PackageStatusIcon>{icon}</PackageStatusIcon>
-      </Tooltip>
-    );
-  }
-}
+const StyledTooltip = styled(Tooltip)`
+  margin-left: ${space(0.75)};
+`;
 
 export const PackageStatusIcon = styled('span')`
-  margin-left: ${space(0.5)};
-  opacity: 0;
+  height: 12px;
+  align-items: center;
+  cursor: pointer;
+  visibility: hidden;
+  display: none;
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    display: block;
+  }
 `;
 
 export default PackageStatus;

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
@@ -23,6 +23,7 @@ type Props = {
 
 type State = {
   showingAbsoluteAddresses: boolean;
+  showCompleteFunctionName: boolean;
 };
 
 export default class StacktraceContent extends React.Component<Props, State> {
@@ -33,6 +34,7 @@ export default class StacktraceContent extends React.Component<Props, State> {
 
   state: State = {
     showingAbsoluteAddresses: false,
+    showCompleteFunctionName: false,
   };
 
   renderOmittedFrames = (firstFrameOmitted, lastFrameOmitted) => {
@@ -95,6 +97,14 @@ export default class StacktraceContent extends React.Component<Props, State> {
     }));
   };
 
+  handleToggleFunctionName = (event: React.MouseEvent<SVGElement>) => {
+    event.stopPropagation(); // to prevent collapsing if collapsable
+
+    this.setState(prevState => ({
+      showCompleteFunctionName: !prevState.showCompleteFunctionName,
+    }));
+  };
+
   getClassName() {
     const {className = '', includeSystemFrames} = this.props;
 
@@ -104,7 +114,6 @@ export default class StacktraceContent extends React.Component<Props, State> {
 
     return `${className} traceback in-app-traceback`;
   }
-
   render() {
     const {
       data,
@@ -113,7 +122,7 @@ export default class StacktraceContent extends React.Component<Props, State> {
       platform,
       includeSystemFrames,
     } = this.props;
-    const {showingAbsoluteAddresses} = this.state;
+    const {showingAbsoluteAddresses, showCompleteFunctionName} = this.state;
 
     let firstFrameOmitted = null;
     let lastFrameOmitted = null;
@@ -196,6 +205,8 @@ export default class StacktraceContent extends React.Component<Props, State> {
             registers={{}} //TODO: Fix registers
             isFrameAfterLastNonApp={isFrameAfterLastNonApp}
             includeSystemFrames={includeSystemFrames}
+            onFunctionNameToggle={this.handleToggleFunctionName}
+            showCompleteFunctionName={showCompleteFunctionName}
           />
         );
       }
@@ -229,7 +240,7 @@ export default class StacktraceContent extends React.Component<Props, State> {
           size="20px"
           style={{borderRadius: '3px 0 0 3px'}}
         />
-        <ul>{frames}</ul>
+        <StyledList>{frames}</StyledList>
       </Wrapper>
     );
   }
@@ -243,4 +254,8 @@ const StyledPlatformIcon = styled(PlatformIcon)`
   position: absolute;
   top: -1px;
   left: -20px;
+`;
+
+const StyledList = styled('ul')`
+  list-style: none;
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
@@ -7,6 +7,7 @@ import {t} from 'app/locale';
 import {IconFilter} from 'app/icons';
 import {formatAddress, parseAddress} from 'app/components/events/interfaces/utils';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
+import {Theme} from 'app/utils/theme';
 
 type Props = {
   address: string;
@@ -14,28 +15,33 @@ type Props = {
   isAbsolute: boolean;
   isFoundByStackScanning: boolean;
   isInlineFrame: boolean;
-  maxLengthOfRelativeAddress: number;
+  relativeAddressMaxlength: number;
   onToggle: (event: React.MouseEvent<SVGElement>) => void;
 };
 
-class TogglableAddress extends React.Component<Props> {
-  convertAbsoluteAddressToRelative() {
-    const {startingAddress, address, maxLengthOfRelativeAddress} = this.props;
+const TogglableAddress = ({
+  startingAddress,
+  address,
+  relativeAddressMaxlength,
+  isInlineFrame,
+  isFoundByStackScanning,
+  isAbsolute,
+  onToggle,
+}: Props) => {
+  const convertAbsoluteAddressToRelative = () => {
     if (!startingAddress) {
       return '';
     }
 
     const relativeAddress = formatAddress(
       parseAddress(address) - parseAddress(startingAddress),
-      maxLengthOfRelativeAddress
+      relativeAddressMaxlength
     );
 
     return `+${relativeAddress}`;
-  }
+  };
 
-  getAddressTooltip() {
-    const {isInlineFrame, isFoundByStackScanning} = this.props;
-
+  const getAddressTooltip = () => {
     if (isInlineFrame && isFoundByStackScanning) {
       return t('Inline frame, found by stack scanning');
     }
@@ -48,79 +54,73 @@ class TogglableAddress extends React.Component<Props> {
       return t('Found by stack scanning');
     }
 
-    return null;
-  }
+    return undefined;
+  };
 
-  render() {
-    const {
-      address,
-      isAbsolute,
-      onToggle,
-      isFoundByStackScanning,
-      isInlineFrame,
-    } = this.props;
-    const relativeAddress = this.convertAbsoluteAddressToRelative();
-    const canBeConverted = !!(onToggle && relativeAddress);
+  const relativeAddress = convertAbsoluteAddressToRelative();
+  const canBeConverted = !!(onToggle && relativeAddress);
+  const formattedAddress = !relativeAddress || isAbsolute ? address : relativeAddress;
+  const tooltipTitle = getAddressTooltip();
 
-    const formattedAddress = !relativeAddress || isAbsolute ? address : relativeAddress;
-
-    return (
-      <Address>
-        {canBeConverted && (
-          <Tooltip title={isAbsolute ? t('Absolute') : t('Relative')}>
-            <Toggle onClick={onToggle} size="xs" />
-          </Tooltip>
-        )}
-
-        <Tooltip
-          title={this.getAddressTooltip()}
-          disabled={!(isFoundByStackScanning || isInlineFrame)}
+  return (
+    <Wrapper>
+      {canBeConverted && (
+        <AddressIconTooltip
+          title={isAbsolute ? t('Switch to absolute') : t('Switch to relative')}
+          containerDisplayMode="inline-flex"
         >
-          <AddressText
-            isFoundByStackScanning={isFoundByStackScanning}
-            isInlineFrame={isInlineFrame}
-            canBeConverted={canBeConverted}
-          >
-            {formattedAddress}
-          </AddressText>
-        </Tooltip>
-      </Address>
-    );
-  }
-}
+          <AddressToggleIcon onClick={onToggle} size="xs" color="purple400" />
+        </AddressIconTooltip>
+      )}
+      <Tooltip title={tooltipTitle} disabled={!(isFoundByStackScanning || isInlineFrame)}>
+        <Address
+          isFoundByStackScanning={isFoundByStackScanning}
+          isInlineFrame={isInlineFrame}
+          canBeConverted={canBeConverted}
+        >
+          {formattedAddress}
+        </Address>
+      </Tooltip>
+    </Wrapper>
+  );
+};
 
-const Toggle = styled(IconFilter)`
-  opacity: 0.33;
-  margin-right: 1ex;
+const AddressIconTooltip = styled(Tooltip)`
+  align-items: center;
+  margin-right: ${space(0.75)};
+`;
+
+const AddressToggleIcon = styled(IconFilter)`
   cursor: pointer;
   visibility: hidden;
-  position: relative;
-  top: 1px;
   display: none;
-
-  &:hover {
-    opacity: 1;
-  }
-
-  @media (min-width: ${props => props.theme.breakpoints[0]}) {
-    display: inline;
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    display: block;
   }
 `;
 
-const AddressText = styled('span')<Partial<Props> & {canBeConverted: boolean}>`
-  border-bottom: ${p => {
-    if (p.isFoundByStackScanning) {
-      return `1px dashed ${p.theme.red400}`;
-    } else if (p.isInlineFrame) {
-      return `1px dashed ${p.theme.blue400}`;
-    } else {
-      return 'none';
-    }
-  }};
+const getAddresstextBorderBottom = (
+  p: Pick<Partial<Props>, 'isFoundByStackScanning' | 'isInlineFrame'> & {theme: Theme}
+) => {
+  if (p.isFoundByStackScanning) {
+    return `1px dashed ${p.theme.red400}`;
+  }
+
+  if (p.isInlineFrame) {
+    return `1px dashed ${p.theme.blue400}`;
+  }
+
+  return 'none';
+};
+
+const Address = styled('span')<Partial<Props> & {canBeConverted: boolean}>`
   padding-left: ${p => (p.canBeConverted ? null : '18px')};
+  border-bottom: ${getAddresstextBorderBottom};
+  ${overflowEllipsis};
+  max-width: 93px;
 `;
 
-const Address = styled('span')`
+const Wrapper = styled('span')`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   color: ${p => p.theme.gray700};
@@ -128,20 +128,16 @@ const Address = styled('span')`
   width: 100%;
   flex-grow: 0;
   flex-shrink: 0;
-  display: block;
+  display: inline-flex;
+  align-items: center;
   padding: 0 ${space(0.5)} 0 0;
   order: 1;
 
-  &:hover ${Toggle} {
-    visibility: visible;
-  }
-
   @media (min-width: ${props => props.theme.breakpoints[0]}) {
     padding: 0 ${space(0.5)};
-    width: 117px;
     order: 0;
   }
-  ${overflowEllipsis}
 `;
 
 export default TogglableAddress;
+export {AddressToggleIcon};

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -65,6 +65,8 @@ type Props = DefaultProps & {
    * Should be set to true if tooltip contains unisolated data (eg. dates)
    */
   disableForVisualTest?: boolean;
+
+  className?: string;
 };
 
 type State = {
@@ -217,7 +219,7 @@ class Tooltip extends React.Component<Props, State> {
 
     propList.containerDisplayMode = this.props.containerDisplayMode;
     return (
-      <Container {...propList} ref={ref}>
+      <Container {...propList} className={this.props.className} ref={ref}>
         {children}
       </Container>
     );

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1489,29 +1489,37 @@ export type Widget = {
 
 export type EventGroupInfo = Record<EventGroupVariantKey, EventGroupVariant>;
 
-export type PlatformType = 'java' | 'csharp' | 'objc' | 'cocoa' | 'native' | 'other';
+export type PlatformType =
+  | 'java'
+  | 'csharp'
+  | 'objc'
+  | 'cocoa'
+  | 'native'
+  | 'javascript'
+  | 'other';
 
 export type Frame = {
-  filename: string;
-  module: string;
-  map: string;
-  preventCollapse: () => void;
-  errors: Array<any>;
+  absPath: string | null;
+  colNo: number | null;
   context: Array<[number, string]>;
-  vars: {[key: string]: any};
+  errors: Array<any> | null;
+  filename: string | null;
+  function: string | null;
   inApp: boolean;
-  function?: string;
-  absPath?: string;
-  rawFunction?: string;
-  platform: PlatformType;
-  lineNo?: number;
-  colNo?: number;
-  package?: string;
-  origAbsPath?: string;
-  mapUrl?: string;
-  instructionAddr?: string;
-  trust?: string;
-  symbolicatorStatus?: SymbolicatorStatus;
+  instructionAddr: string | null;
+  lineNo: number | null;
+  module: string | null;
+  package: string | null;
+  platform: PlatformType | null;
+  rawFunction: string | null;
+  symbol: string | null;
+  symbolAddr: string | null;
+  symbolicatorStatus: SymbolicatorStatus;
+  trust: any | null;
+  vars: Record<string, any> | null;
+  origAbsPath?: string | null;
+  mapUrl?: string | null;
+  map?: string | null;
 };
 
 /**

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -293,7 +293,7 @@ class Browser(object):
         """
         self.driver.implicitly_wait(duration)
 
-    def snapshot(self, name, mobile_only=False):
+    def snapshot(self, name, mobile_only=False, desktop_only=False):
         """
         Capture a screenshot of the current state of the page.
         """
@@ -337,11 +337,12 @@ class Browser(object):
                             "window.__closeAllTooltips && window.__closeAllTooltips()"
                         )
 
-            with self.mobile_viewport():
+            if not desktop_only:
                 # switch to a mobile sized viewport
-                self.driver.find_element_by_tag_name("body").screenshot(
-                    u"{}-mobile/{}.png".format(snapshot_dir, slugify(name))
-                )
+                with self.mobile_viewport():
+                    self.driver.find_element_by_tag_name("body").screenshot(
+                        u"{}-mobile/{}.png".format(snapshot_dir, slugify(name))
+                    )
 
         return self
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -293,7 +293,7 @@ class Browser(object):
         """
         self.driver.implicitly_wait(duration)
 
-    def snapshot(self, name, mobile_only=False, desktop_only=False):
+    def snapshot(self, name, mobile_only=False):
         """
         Capture a screenshot of the current state of the page.
         """
@@ -337,7 +337,6 @@ class Browser(object):
                             "window.__closeAllTooltips && window.__closeAllTooltips()"
                         )
 
-            if not desktop_only:
                 # switch to a mobile sized viewport
                 with self.mobile_viewport():
                     self.driver.find_element_by_tag_name("body").screenshot(

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -80,6 +80,13 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.page.visit_issue(self.org.slug, event.group.id)
         self.browser.snapshot("issue details cocoa")
 
+    def test_cocoa_event_frame_line_hover(self):
+        event = self.create_sample_event(platform="cocoa")
+        self.page.visit_issue(self.org.slug, event.group.id)
+        self.browser.wait_until_not(".loading")
+        self.browser.move_to(".traceback li:nth-child(2)")
+        self.browser.snapshot("issue details cocoa frame line hover", False, True)
+
     def test_unity_event(self):
         event = self.create_sample_event(default="unity", platform="csharp")
         self.page.visit_issue(self.org.slug, event.group.id)

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -85,7 +85,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.page.visit_issue(self.org.slug, event.group.id)
         self.browser.wait_until_not(".loading")
         self.browser.move_to(".traceback li:nth-child(2)")
-        self.browser.snapshot("issue details cocoa frame line hover", False, True)
+        self.browser.snapshot("issue details cocoa frame line hover")
 
     def test_unity_event(self):
         event = self.create_sample_event(default="unity", platform="csharp")

--- a/tests/js/spec/components/events/crashContent.spec.jsx
+++ b/tests/js/spec/components/events/crashContent.spec.jsx
@@ -6,7 +6,7 @@ import CrashContent from 'app/components/events/interfaces/crashContent';
 import {withMeta} from 'app/components/events/meta/metaProxy';
 
 describe('CrashContent', function () {
-  const exc = TestStubs.ExceptionWithMeta();
+  const exc = TestStubs.ExceptionWithMeta({platform: 'cocoa'});
   const event = TestStubs.Event();
 
   const proxiedExc = withMeta(exc);

--- a/tests/js/spec/components/events/interfaces/exceptionStacktraceContent.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/exceptionStacktraceContent.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 
 import ExceptionStacktraceContent from 'app/components/events/interfaces/exceptionStacktraceContent';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
@@ -87,19 +87,19 @@ describe('ExceptionStacktraceContent', () => {
   };
 
   it('default behaviour', () => {
-    const wrapper = mount(<ExceptionStacktraceContent {...props} />);
+    const wrapper = mountWithTheme(<ExceptionStacktraceContent {...props} />);
     expect(wrapper).toSnapshot();
   });
 
   it('should return an emptyRender', () => {
-    const wrapper = mount(
+    const wrapper = mountWithTheme(
       <ExceptionStacktraceContent {...props} stacktrace={undefined} />
     );
     expect(wrapper.isEmptyRender()).toBe(true);
   });
 
   it('should return the EmptyMessage component', () => {
-    const wrapper = mount(<ExceptionStacktraceContent {...props} />);
+    const wrapper = mountWithTheme(<ExceptionStacktraceContent {...props} />);
     const emptyMessageElement = wrapper.find(EmptyMessage).exists();
     expect(emptyMessageElement).toBe(true);
   });
@@ -107,20 +107,22 @@ describe('ExceptionStacktraceContent', () => {
   it('should not return the EmptyMessage component', () => {
     const modifiedProps = cloneDeep(props);
     modifiedProps.stacktrace.frames[0].inApp = true;
-    const wrapper = mount(<ExceptionStacktraceContent {...modifiedProps} />);
+    const wrapper = mountWithTheme(<ExceptionStacktraceContent {...modifiedProps} />);
     const emptyMessageElement = wrapper.find(EmptyMessage).exists();
     expect(emptyMessageElement).toBe(false);
   });
 
   it('should render system frames if "stackView: app" and there are no inApp frames and is a chained exceptions', () => {
-    const wrapper = mount(<ExceptionStacktraceContent {...props} chainedException />);
+    const wrapper = mountWithTheme(
+      <ExceptionStacktraceContent {...props} chainedException />
+    );
     expect(wrapper.find('Line').length).toBe(2);
   });
 
   it('should not render system frames if "stackView: app" and there are inApp frames and is a chained exceptions', () => {
     const modifiedProps = cloneDeep(props);
     modifiedProps.stacktrace.frames[0].inApp = true;
-    const wrapper = mount(
+    const wrapper = mountWithTheme(
       <ExceptionStacktraceContent {...modifiedProps} chainedException />
     );
 

--- a/tests/js/spec/components/events/interfaces/frame/line.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/frame/line.spec.jsx
@@ -76,6 +76,7 @@ describe('Frame - Line', function () {
       const frame = mountWithTheme(
         <Line data={data} registers={registers} components={[]} isExpanded />
       );
+
       expect(frame.find('FrameRegisters')).toHaveLength(0);
     });
 


### PR DESCRIPTION
closes https://app.asana.com/0/1182975495223914/1193781937756635


depends on https://github.com/getsentry/sentry/pull/21220

. Display some line actions, as "images loaded flag, switch to relative/absolute" when the user hovers the frame line
. Add a new line action to expand/collapse the functionName
. Update Action's icon color
. Update the icon of the button expand/collapse frame line


Now it looks like below:

![image](https://user-images.githubusercontent.com/29228205/95458215-282ea780-0972-11eb-95dc-ca20815598f3.png)

#sync-getsentry