### PR TITLE
ci(release): Bring back PyPI releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -12,8 +12,7 @@ statusProvider:
       - 'onpremise-builder (sentryio)'
 targets:
   - name: github
-# Skip publishing to PyPI until we get the 2.1.0 release for https://github.com/Grokzen/redis-py-cluster/
-#  - name: pypi
+  - name: pypi
   - name: docker
     source: us.gcr.io/sentryio/sentry
     target: getsentry/sentry


### PR DESCRIPTION
Follow up to #21051, reverts #20795.
