### PR TITLE
fix(discover) Don't allow focused tooltips

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -172,6 +172,7 @@ class Chart extends React.Component<ChartProps, State> {
         showSymbol: false,
       },
       tooltip: {
+        trigger: 'axis',
         truncate: 80,
         valueFormatter: (value: number) => tooltipFormatter(value, yAxis),
       },

--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -128,6 +128,7 @@ class ReleaseSeries extends React.Component {
           },
         },
         tooltip: tooltip || {
+          trigger: 'item',
           formatter: ({data}) => {
             // XXX using this.props here as this function does not get re-run
             // unless projects are changed. Using a closure variable would result

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -127,6 +127,7 @@ class DurationChart extends React.Component<Props> {
         showSymbol: false,
       },
       tooltip: {
+        trigger: 'axis',
         valueFormatter: tooltipFormatter,
       },
       yAxis: {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -24,6 +24,7 @@ import {
   formatFloat,
   formatPercentage,
 } from 'app/utils/formatters';
+import {tooltipFormatter} from 'app/utils/discover/charts';
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 import space from 'app/styles/space';
@@ -120,20 +121,10 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
     showTimeInTooltip: true,
     colors: [colors[0], colors[1], colors[2]],
     tooltip: {
+      trigger: 'axis',
       truncate: 80,
-      valueFormatter(value: number, seriesName: string) {
-        if (seriesName.includes('apdex')) {
-          return formatFloat(value, 2);
-        }
-        if (seriesName.includes('failure_rate')) {
-          return formatPercentage(value, 2);
-        }
-        if (typeof value === 'number') {
-          return value.toLocaleString();
-        }
-        return value;
-      },
-      nameFormatter(value) {
+      valueFormatter: tooltipFormatter,
+      nameFormatter(value: string) {
         return value === 'epm()' ? 'tpm()' : value;
       },
     },


### PR DESCRIPTION
Set chart tooltip to trigger on axis elements. This prevents individual series tooltips from showing. Because the chart tooltip is set to axis the release series tooltip needs to be forced to item mode.