### PR TITLE
fix(discover): Percentile function should accept numeric arguments

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1555,7 +1555,7 @@ FUNCTIONS = {
     for function in [
         Function(
             "percentile",
-            required_args=[DurationColumnNoLookup("column"), NumberRange("percentile", 0, 1)],
+            required_args=[NumericColumnNoLookup("column"), NumberRange("percentile", 0, 1)],
             aggregate=[u"quantile({percentile:g})", ArgValue("column"), None],
             result_type="duration",
         ),

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2083,7 +2083,7 @@ class ResolveFieldListTest(unittest.TestCase):
             fields = ["percentile(id, 0.75)"]
             resolve_field_list(fields, eventstore.Filter())
         assert (
-            "percentile(id, 0.75): column argument invalid: id is not a duration column"
+            "percentile(id, 0.75): column argument invalid: id is not a numeric column"
             in six.text_type(err)
         )
 


### PR DESCRIPTION
Percentile function currently only accepts duration arguments but it should
accept numeric arguments in order to support numeric measurements.