### PR TITLE
fix(workflow): Dynamic counts tooltip with multiple values

### DIFF
--- a/src/sentry/static/sentry/app/components/stackedBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.tsx
@@ -12,6 +12,7 @@ import theme from 'app/utils/theme';
 import {toTitleCase} from 'app/utils';
 import {formatFloat} from 'app/utils/formatters';
 import {t} from 'app/locale';
+import space from 'app/styles/space';
 
 type Point = {x: number; y: number[]; label?: string; color?: string};
 type Points = Point[];
@@ -324,7 +325,7 @@ class StackedBarChart extends React.Component<Props, State> {
               {totalY2 !== undefined && point.color && (
                 <TooltipColorIndicator color={point.color} />
               )}
-              {totalY2 !== undefined && ` ${t('Filtered')} `}
+              {totalY2 !== undefined && `${t('Filtered')} `}
               {toTitleCase(this.props.label)}
             </div>
             <div>{totalY.toLocaleString()}</div>
@@ -336,7 +337,7 @@ class StackedBarChart extends React.Component<Props, State> {
               {secondaryPoint.color && (
                 <TooltipColorIndicator color={secondaryPoint.color} />
               )}
-              {` ${t('Total')} `}
+              {`${t('Total')} `}
               {toTitleCase(this.props.label)}
             </div>
             <div>{totalY2.toLocaleString()}</div>
@@ -579,10 +580,9 @@ const TooltipColorIndicator = styled('span')<{color: string}>`
   display: inline-block;
   background-color: ${p => p.color};
   border-radius: 50%;
-  width: ${p => p.theme.iconSizes.xs};
-  height: ${p => p.theme.iconSizes.xs};
-  position: relative;
-  top: 1px;
+  width: 8px;
+  height: 8px;
+  margin-right: ${space(1)};
 `;
 
 export default StackedBarChart;

--- a/src/sentry/static/sentry/app/components/stackedBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.tsx
@@ -9,7 +9,9 @@ import Tooltip from 'app/components/tooltip';
 import Count from 'app/components/count';
 import {use24Hours, getTimeFormat} from 'app/utils/dates';
 import theme from 'app/utils/theme';
+import {toTitleCase} from 'app/utils';
 import {formatFloat} from 'app/utils/formatters';
+import {t} from 'app/locale';
 
 type Point = {x: number; y: number[]; label?: string; color?: string};
 type Points = Point[];
@@ -309,6 +311,8 @@ class StackedBarChart extends React.Component<Props, State> {
   renderTooltip = (point: Point, _pointIdx: number): React.ReactNode => {
     const timeLabel = this.getTimeLabel(point);
     const totalY = point.y.reduce((a, b) => a + b);
+    const secondaryPoint = this.state.secondaryPointIndex[_pointIdx];
+    const totalY2 = secondaryPoint?.y.reduce((a, b) => a + b);
     return (
       <React.Fragment>
         <div style={{width: '130px'}}>
@@ -316,7 +320,26 @@ class StackedBarChart extends React.Component<Props, State> {
         </div>
         {this.props.label && (
           <div className="value-label">
-            {totalY.toLocaleString()} {this.props.label}
+            <div>
+              {totalY2 !== undefined && point.color && (
+                <TooltipColorIndicator color={point.color} />
+              )}
+              {totalY2 !== undefined && ` ${t('Filtered')} `}
+              {toTitleCase(this.props.label)}
+            </div>
+            <div>{totalY.toLocaleString()}</div>
+          </div>
+        )}
+        {this.props.label && totalY2 !== undefined && (
+          <div className="value-label">
+            <div>
+              {secondaryPoint.color && (
+                <TooltipColorIndicator color={secondaryPoint.color} />
+              )}
+              {` ${t('Total')} `}
+              {toTitleCase(this.props.label)}
+            </div>
+            <div>{totalY2.toLocaleString()}</div>
           </div>
         )}
         {point.y.map((y, i) => {
@@ -550,6 +573,16 @@ const RectGroup = styled('g')<{showSecondaryPoints: boolean}>`
   &:hover {
     opacity: 1;
   }
+`;
+
+const TooltipColorIndicator = styled('span')<{color: string}>`
+  display: inline-block;
+  background-color: ${p => p.color};
+  border-radius: 50%;
+  width: ${p => p.theme.iconSizes.xs};
+  height: ${p => p.theme.iconSizes.xs};
+  position: relative;
+  top: 1px;
 `;
 
 export default StackedBarChart;

--- a/src/sentry/static/sentry/app/components/stackedBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/stackedBarChart.tsx
@@ -7,12 +7,12 @@ import styled from '@emotion/styled';
 
 import Tooltip from 'app/components/tooltip';
 import Count from 'app/components/count';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
 import {use24Hours, getTimeFormat} from 'app/utils/dates';
 import theme from 'app/utils/theme';
 import {toTitleCase} from 'app/utils';
 import {formatFloat} from 'app/utils/formatters';
-import {t} from 'app/locale';
-import space from 'app/styles/space';
 
 type Point = {x: number; y: number[]; label?: string; color?: string};
 type Points = Point[];

--- a/src/sentry/static/sentry/less/includes/tooltips.less
+++ b/src/sentry/static/sentry/less/includes/tooltips.less
@@ -52,9 +52,9 @@
   }
 
   .value-label {
-    padding: 3px 0;
     display: flex;
     justify-content: space-between;
+    padding: 3px 0;
   }
 
   .legend {

--- a/src/sentry/static/sentry/less/includes/tooltips.less
+++ b/src/sentry/static/sentry/less/includes/tooltips.less
@@ -53,6 +53,8 @@
 
   .value-label {
     padding: 3px 0;
+    display: flex;
+    justify-content: space-between;
   }
 
   .legend {


### PR DESCRIPTION
This adds filtered/total indicators and descriptors for issue stream chart tooltip.

When not filtered:
![Screen Shot 2020-10-07 at 2 13 55 PM](https://user-images.githubusercontent.com/15015880/95390367-1e417180-08aa-11eb-9b88-1043e0e6ce3f.png)
When filtered:
![Screen Shot 2020-10-07 at 3 35 55 PM](https://user-images.githubusercontent.com/15015880/95395518-abd58f00-08b3-11eb-95e5-ab4fd1d73ef0.png)


Resolves:
[WOR-308](https://getsentry.atlassian.net/browse/WOR-308)


