### PR TITLE
fix(ui): Pass itemProps to the rendered search item

### DIFF
--- a/src/sentry/static/sentry/app/components/search/index.jsx
+++ b/src/sentry/static/sentry/app/components/search/index.jsx
@@ -158,18 +158,15 @@ class Search extends React.Component {
       throw new Error('Invalid `renderItem`');
     }
 
-    return React.cloneElement(
-      renderItem({
-        item,
-        matches,
-        index,
-        highlighted,
-      }),
-      {
-        ...itemProps,
-        key,
-      }
-    );
+    const renderedItem = renderItem({
+      item,
+      matches,
+      index,
+      highlighted,
+      itemProps,
+    });
+
+    return React.cloneElement(renderedItem, {key});
   };
 
   render() {


### PR DESCRIPTION
Before we were passing these props via the cloned element, meaning we needed to be rendering a DOM element. In the case where we render a `React.Fragment`, the passed item props will not end up in the DOM.

Instead just pass `itemProps` and let the `renderItem` component spread them where appropriate, which we were already doing everywhere anyway.