### PR TITLE
fix(relay): Skip generating caches for disabled project keys

### DIFF
--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -6,6 +6,7 @@ from django.conf import settings
 import sentry_sdk
 from sentry.utils.sdk import set_current_project
 
+from sentry.models.projectkey import ProjectKeyStatus
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.relay import projectconfig_debounce_cache
@@ -75,6 +76,9 @@ def update_config_cache(generate, organization_id=None, project_id=None, update_
                 # XXX(markus): This is currently the cleanest way to get only
                 # state for a single projectkey (considering quotas and
                 # everything)
+                if key.status != ProjectKeyStatus.ACTIVE:
+                    continue
+
                 project_config = get_project_config(project, project_keys=[key], full_config=True)
                 config_cache[key.public_key] = project_config.to_dict()
 

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -6,7 +6,6 @@ from django.conf import settings
 import sentry_sdk
 from sentry.utils.sdk import set_current_project
 
-from sentry.models.projectkey import ProjectKeyStatus
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.relay import projectconfig_debounce_cache
@@ -30,7 +29,7 @@ def update_config_cache(generate, organization_id=None, project_id=None, update_
         invalidated.
     """
 
-    from sentry.models import Project, ProjectKey
+    from sentry.models import Project, ProjectKey, ProjectKeyStatus
     from sentry.relay import projectconfig_cache
     from sentry.relay.config import get_project_config
 


### PR DESCRIPTION
In #21164, we introduced per-key caching of project configurations for Relay. There are two places where these configurations are generated:
- A HTTP endpoint called by Relay. The configuration is put into Redis for faster subsequent access.
- A background task creating configurations proactively into Redis when the project changes.

While the HTTP endpoint checks for disabled keys, the background task did not, which resulted in accepting events for disabled keys.