### PR TITLE
fix(jira): fix error in 2 way Jira sync when 'to' is not a key

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -793,7 +793,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         transitions = client.get_transitions(external_issue.key)
 
         try:
-            transition = [t for t in transitions if t["to"]["id"] == jira_status][0]
+            transition = [t for t in transitions if t.get("to", {}).get("id") == jira_status][0]
         except IndexError:
             # TODO(jess): Email for failure
             logger.warning(

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -387,6 +387,15 @@ SAMPLE_TRANSITION_RESPONSE = """
                     "self": "https://getsentry-dev.atlassian.net/rest/api/2/statuscategory/3"
                 }
             }
+        },
+        {
+            "hasScreen": false,
+            "id": "61",
+            "isAvailable": true,
+            "isConditional": false,
+            "isGlobal": true,
+            "isInitial": false,
+            "name": "Kicked"
         }
     ]
 }


### PR DESCRIPTION
Sometimes the transitions don't have a `to` field. We just need to ignore those transitions and not blow up with a `KeyError`. It's unclear what causes that situation but here is an example transition:
```
        {
            "hasScreen": false,
            "id": "61",
            "isAvailable": true,
            "isConditional": false,
            "isGlobal": true,
            "isInitial": false,
            "name": "Kicked"
        }
```

Fixes SENTRY-GQ1