### PR TITLE
fix(ui): tidied up Alerts page design

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/header.tsx
@@ -35,7 +35,7 @@ const AlertHeader = ({router, organization, activeTab}: Props) => {
   return (
     <Layout.Header>
       <StyledLayoutHeaderContent>
-        <StyledLayoutTitle>{t('Alerts')} </StyledLayoutTitle>
+        <StyledLayoutTitle>{t('Alerts')}</StyledLayoutTitle>
         <StyledNavTabs underlined>
           <Feature features={['incidents']} organization={organization}>
             <li className={activeTab === 'stream' ? 'active' : ''}>

--- a/src/sentry/static/sentry/app/views/alerts/list/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/header.tsx
@@ -7,7 +7,6 @@ import {Organization} from 'app/types';
 import {navigateTo} from 'app/actionCreators/navigation';
 import {t} from 'app/locale';
 import Feature from 'app/components/acl/feature';
-import FeatureBadge from 'app/components/featureBadge';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import NavTabs from 'app/components/navTabs';
@@ -36,28 +35,18 @@ const AlertHeader = ({router, organization, activeTab}: Props) => {
   return (
     <Layout.Header>
       <StyledLayoutHeaderContent>
-        <StyledLayoutTitle>
-          {t('Alerts')}{' '}
-          <FeatureBadge
-            title={
-              activeTab === 'stream'
-                ? t('This page is in beta and currently only shows metric alerts.')
-                : undefined
-            }
-            type="beta"
-          />
-        </StyledLayoutTitle>
+        <StyledLayoutTitle>{t('Alerts')} </StyledLayoutTitle>
         <StyledNavTabs underlined>
           <Feature features={['incidents']} organization={organization}>
             <li className={activeTab === 'stream' ? 'active' : ''}>
               <Link to={`/organizations/${organization.slug}/alerts/`}>
-                {t('Stream')}
+                {t('Metric Alerts')}
               </Link>
             </li>
           </Feature>
           <li className={activeTab === 'rules' ? 'active' : ''}>
             <Link to={`/organizations/${organization.slug}/alerts/rules/`}>
-              {t('Rules')}
+              {t('Alert Rules')}
             </Link>
           </li>
         </StyledNavTabs>

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -339,6 +339,7 @@ class IncidentsListContainer extends React.Component<Props> {
 }
 
 const StyledButtonBar = styled(ButtonBar)`
+  width: 100px;
   margin-bottom: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -171,10 +171,8 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
           !hasAlertRule
             ? t('No metric alert rules exist for these projects.')
             : status === 'open'
-            ? t(
-                'Everything’s a-okay. There are no unresolved metric alerts in these projects.'
-              )
-            : t('There are no resolved metric alerts in these projects.')
+            ? t('No unresolved metric alerts in these projects.')
+            : t('No resolved metric alerts in these projects.')
         }
         description={tct('Learn more about [link:Metric Alerts]', {
           link: <ExternalLink href={DOCS_URL} />,
@@ -265,22 +263,24 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
           <Layout.Body>
             <Layout.Main fullWidth>
               {!this.tryRenderOnboarding() && (
-                <StyledButtonBar merged active={status}>
-                  <Button
-                    to={{pathname, query: openIncidentsQuery}}
-                    barId="open"
-                    size="small"
-                  >
-                    {t('Active')}
-                  </Button>
-                  <Button
-                    to={{pathname, query: closedIncidentsQuery}}
-                    barId="closed"
-                    size="small"
-                  >
-                    {t('Resolved')}
-                  </Button>
-                </StyledButtonBar>
+                <NavWrapper>
+                  <StyledButtonBar merged active={status}>
+                    <Button
+                      to={{pathname, query: openIncidentsQuery}}
+                      barId="open"
+                      size="small"
+                    >
+                      {t('Unresolved')}
+                    </Button>
+                    <Button
+                      to={{pathname, query: closedIncidentsQuery}}
+                      barId="closed"
+                      size="small"
+                    >
+                      {t('Resolved')}
+                    </Button>
+                  </StyledButtonBar>
+                </NavWrapper>
               )}
               {this.renderList()}
             </Layout.Main>
@@ -341,12 +341,16 @@ class IncidentsListContainer extends React.Component<Props> {
 }
 
 const StyledButtonBar = styled(ButtonBar)`
-  width: 100px;
   margin-bottom: ${space(1)};
 `;
 
 const PaddedTitleAndSparkLine = styled(TitleAndSparkLine)`
   padding-left: ${space(2)};
+`;
+
+const NavWrapper = styled('div')`
+  display: flex;
+  justify-content: space-between;
 `;
 
 const StyledPanelHeader = styled(PanelHeader)`

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -263,24 +263,22 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
           <Layout.Body>
             <Layout.Main fullWidth>
               {!this.tryRenderOnboarding() && (
-                <NavWrapper>
-                  <StyledButtonBar merged active={status}>
-                    <Button
-                      to={{pathname, query: openIncidentsQuery}}
-                      barId="open"
-                      size="small"
-                    >
-                      {t('Unresolved')}
-                    </Button>
-                    <Button
-                      to={{pathname, query: closedIncidentsQuery}}
-                      barId="closed"
-                      size="small"
-                    >
-                      {t('Resolved')}
-                    </Button>
-                  </StyledButtonBar>
-                </NavWrapper>
+                <StyledButtonBar merged active={status}>
+                  <Button
+                    to={{pathname, query: openIncidentsQuery}}
+                    barId="open"
+                    size="small"
+                  >
+                    {t('Unresolved')}
+                  </Button>
+                  <Button
+                    to={{pathname, query: closedIncidentsQuery}}
+                    barId="closed"
+                    size="small"
+                  >
+                    {t('Resolved')}
+                  </Button>
+                </StyledButtonBar>
               )}
               {this.renderList()}
             </Layout.Main>
@@ -346,11 +344,6 @@ const StyledButtonBar = styled(ButtonBar)`
 
 const PaddedTitleAndSparkLine = styled(TitleAndSparkLine)`
   padding-left: ${space(2)};
-`;
-
-const NavWrapper = styled('div')`
-  display: flex;
-  justify-content: space-between;
 `;
 
 const StyledPanelHeader = styled(PanelHeader)`

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -196,9 +196,7 @@ describe('IncidentsList', function () {
     wrapper.update();
 
     expect(wrapper.find('PanelItem')).toHaveLength(0);
-    expect(wrapper.text()).toContain(
-      'There are no unresolved metric alerts in these projects'
-    );
+    expect(wrapper.text()).toContain('No unresolved metric alerts in these projects');
   });
 
   it('toggles open/closed', async function () {


### PR DESCRIPTION
- Renamed Stream to Metric Alerts because...it’s just metric alert status for now
- Changed `Active` -> `Unresolved` 
- Removed the Beta badge
- Fixed the empty state copy for the metric alert list 

### Before
  
<img width="1338" alt="Screen Shot 2020-10-08 at 2 24 59 PM" src="https://user-images.githubusercontent.com/1900676/95515199-13521400-0972-11eb-8e7f-2a79f28e313c.png">

### After

<img width="1339" alt="Screen Shot 2020-10-08 at 2 12 30 PM" src="https://user-images.githubusercontent.com/1900676/95515217-1baa4f00-0972-11eb-9686-705e37abab58.png">
