### PR TITLE
build(gha): env + service configuration cleanup

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -120,9 +120,6 @@ jobs:
         PYTEST_SENTRY_DSN: https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
         PYTEST_ADDOPTS: "--reruns 5"
 
-        # The hostname used to communicate with the PostgreSQL from sentry
-        DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
-
         # Number of matrix instances
         TOTAL_TEST_GROUPS: ${{ strategy.job-total }}
 
@@ -185,8 +182,6 @@ jobs:
             yarn install --frozen-lockfile
 
         - name: Install Python Dependencies
-          env:
-            PGPASSWORD: postgres
           run: |
             python setup.py install_egg_info
             pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
@@ -250,9 +245,6 @@ jobs:
         PYTEST_SENTRY_DSN: https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
         PYTEST_ADDOPTS: "--reruns 5"
 
-        # The hostname used to communicate with the PostgreSQL from sentry
-        DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
-
         # Number of matrix instances
         TOTAL_TEST_GROUPS: ${{ strategy.job-total }}
 
@@ -315,8 +307,6 @@ jobs:
             yarn install --frozen-lockfile
 
         - name: Install Python Dependencies
-          env:
-            PGPASSWORD: postgres
           run: |
             python setup.py install_egg_info
             pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -120,10 +120,6 @@ jobs:
         PYTEST_SENTRY_DSN: https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
         PYTEST_ADDOPTS: "--reruns 5"
 
-        # services configuration
-        SENTRY_KAFKA_HOSTS: kafka:9093
-        SENTRY_ZOOKEEPER_HOSTS: zookeeper:2182
-        SENTRY_REDIS_HOST: redis
         # The hostname used to communicate with the PostgreSQL from sentry
         DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
 
@@ -254,10 +250,6 @@ jobs:
         PYTEST_SENTRY_DSN: https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
         PYTEST_ADDOPTS: "--reruns 5"
 
-        # services configuration
-        SENTRY_KAFKA_HOSTS: kafka:9093
-        SENTRY_ZOOKEEPER_HOSTS: zookeeper:2182
-        SENTRY_REDIS_HOST: redis
         # The hostname used to communicate with the PostgreSQL from sentry
         DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
 

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -15,15 +15,9 @@ jobs:
         SENTRY_SKIP_BACKEND_VALIDATION: 1
         MIGRATIONS_TEST_MIGRATE: 0
 
-        # The hostname used to communicate with the PostgreSQL from sentry
-        DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
-
       services:
         postgres:
           image: postgres:9.6
-          env:
-            POSTGRES_USER: postgres
-            POSTGRES_PASSWORD: postgres
           ports:
             # Maps tcp port 5432 on service container to the host
             - 5432:5432
@@ -80,20 +74,17 @@ jobs:
               ${{ runner.os }}-pip-
 
         - name: Install Python Dependencies
-          env:
-            PGPASSWORD: postgres
           run: |
             python setup.py install_egg_info
             pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
             pip install -U -e ".[dev]"
-            psql -c 'create database sentry;' -h localhost -U postgres
+            psql -c 'create database sentry;' -h 127.0.0.1 -U postgres
             sentry init
 
         - name: Generate SQL for migration
           uses: getsentry/action-migrations@v1.0.7
           env:
             SENTRY_LOG_LEVEL: ERROR
-            PGPASSWORD: postgres
           with:
             githubToken: ${{ secrets.GITHUB_TOKEN }}
             migration: ${{ steps.file.outputs.modified }}

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -22,6 +22,7 @@ jobs:
             # Maps tcp port 5432 on service container to the host
             - 5432:5432
           # needed because the postgres container does not provide a healthcheck
+          # TODO: Could use devservices for this, but devservices currently lacks healthchecking.
           options: >-
             --health-cmd pg_isready
             --health-interval 10s

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,15 +23,9 @@ jobs:
       SENTRY_SKIP_BACKEND_VALIDATION: 1
       MIGRATIONS_TEST_MIGRATE: 0
 
-      # The hostname used to communicate with the PostgreSQL from sentry
-      DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
-
     services:
       postgres:
         image: postgres:9.6
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
@@ -82,19 +76,16 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install Python Dependencies
-        env:
-          PGPASSWORD: postgres
         run: |
           python setup.py install_egg_info
           pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
           pip install -U -e ".[dev]"
-          psql -c 'create database sentry;' -h localhost -U postgres
+          psql -c 'create database sentry;' -h 127.0.0.1 -U postgres
           sentry init
 
       - name: Check if a migration is required
         env:
           SENTRY_LOG_LEVEL: ERROR
-          PGPASSWORD: postgres
         run: |
           # Below will exit with non-zero status if model changes are missing migrations
           sentry django makemigrations -n ci_test --check --dry-run --no-input || (echo '::error::Error: Migration required -- to generate a migration, run `sentry django makemigrations -n <some_name>`' && exit 1)
@@ -116,9 +107,6 @@ jobs:
       PYTEST_SENTRY_DSN: https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
       PYTEST_ADDOPTS: "--reruns 3"
       PYTEST_SENTRY_ALWAYS_REPORT: 1
-
-      # services configuration
-      DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
 
       # Number of matrix instances
       TOTAL_TEST_GROUPS: ${{ strategy.job-total }}
@@ -164,8 +152,6 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install Python Dependencies
-        env:
-          PGPASSWORD: postgres
         run: |
           python setup.py install_egg_info
           pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
@@ -209,7 +195,6 @@ jobs:
       PYTEST_SENTRY_ALWAYS_REPORT: yes
 
       # services configuration
-      DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
       SENTRY_KAFKA_HOSTS: 127.0.0.1:9092
       SENTRY_ZOOKEEPER_HOSTS: 127.0.0.1:2181
 
@@ -257,8 +242,6 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install Python Dependencies
-        env:
-          PGPASSWORD: postgres
         run: |
           python setup.py install_egg_info
           pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
@@ -288,6 +271,7 @@ jobs:
             -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
             -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
             confluentinc/cp-kafka:5.1.2
+
           sentry devservices up postgres redis clickhouse snuba
 
       - name: Python 3.6 snuba backend (${{ steps.config.outputs.matrix-instance-number }} of ${{ strategy.job-total }})

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,6 +30,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck
+        # TODO: Could use devservices for this, but devservices currently lacks healthchecking.
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -118,7 +118,6 @@ jobs:
       PYTEST_SENTRY_ALWAYS_REPORT: 1
 
       # services configuration
-      SENTRY_REDIS_HOST: redis
       DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
 
       # Number of matrix instances
@@ -210,10 +209,9 @@ jobs:
       PYTEST_SENTRY_ALWAYS_REPORT: yes
 
       # services configuration
-      SENTRY_REDIS_HOST: redis
       DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
-      SENTRY_KAFKA_HOSTS: localhost:9092
-      SENTRY_ZOOKEEPER_HOSTS: localhost:2181
+      SENTRY_KAFKA_HOSTS: 127.0.0.1:9092
+      SENTRY_ZOOKEEPER_HOSTS: 127.0.0.1:2181
 
       # Number of matrix instances
       TOTAL_TEST_GROUPS: ${{ strategy.job-total }}
@@ -271,6 +269,7 @@ jobs:
           pip install -e git+https://github.com/getsentry/rb.git@master#egg=rb
 
       - name: Start devservices
+        # TODO: Use devservices kafka. See https://github.com/getsentry/sentry/pull/20986#issuecomment-704510570
         run: |
           sentry init
           docker run \

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1481,6 +1481,7 @@ SENTRY_DEVSERVICES = {
     },
     "zookeeper": {
         "image": "confluentinc/cp-zookeeper:5.1.2",
+        "ports": {"2181/tcp": 2181},
         "environment": {"ZOOKEEPER_CLIENT_PORT": "2181"},
         "volumes": {"zookeeper": {"bind": "/var/lib/zookeeper"}},
         "only_if": lambda settings, options: (


### PR DESCRIPTION
Some changes cherry-picked from https://github.com/getsentry/sentry/pull/20986. Also:

- always prefer `127.0.0.1` to remove the assumption on how DNS is configured on hosts, in general
- remove the need for DATABASE_URL (`DATABASES["default"]` is already there) and postgres passwords (not necessary) in testing