### PR TITLE
chore(mocks): Add transactions as something that we can mock

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -326,7 +326,7 @@ def create_sample_time_series(event, release=None):
         now = now - timedelta(hours=1)
 
 
-def main(num_events=1, extra_events=False):
+def main(num_events=1, extra_events=False, load_transactions=False):
     user = User.objects.filter(is_superuser=True)[0]
 
     dummy_user, _ = User.objects.get_or_create(
@@ -564,6 +564,43 @@ def main(num_events=1, extra_events=False):
                         user=generate_user(),
                     )
 
+            if load_transactions:
+                for day in range(14):
+                    for hour in range(24):
+                        timestamp = timezone.now() - timedelta(days=day, hours=hour)
+                        transaction_user = generate_user()
+                        transaction1 = create_sample_event(
+                            project=project,
+                            platform="javascript-transaction",
+                            event_id=uuid4().hex,
+                            user=transaction_user,
+                            timestamp=timestamp,
+                            # start_timestamp decreases based on day so that there's a trend
+                            start_timestamp=timestamp
+                            - timedelta(
+                                milliseconds=int(random.normalvariate(2000 - 50 * day, 250))
+                            ),
+                            measurements={
+                                "fp": {"value": random.normalvariate(2000, 200)},
+                                "fcp": {"value": random.normalvariate(2250, 200)},
+                                "lcp": {"value": random.normalvariate(2800, 400)},
+                                "fid": {"value": random.normalvariate(5, 2)},
+                            },
+                        )
+                        create_sample_event(
+                            project=project,
+                            platform="transaction",
+                            event_id=uuid4().hex,
+                            user=transaction_user,
+                            timestamp=timestamp,
+                            # start_timestamp increases based on day so that there's a trend
+                            start_timestamp=timestamp
+                            - timedelta(
+                                milliseconds=int(random.normalvariate(2000 + 50 * day, 250))
+                            ),
+                            trace=transaction1.get_tag("trace"),
+                        )
+
             for _ in range(num_events):
                 event1 = create_sample_event(
                     project=project,
@@ -719,12 +756,19 @@ if __name__ == "__main__":
 
     parser = OptionParser()
     parser.add_option("--events", dest="num_events", default=1, type=int)
-    parser.add_option("--extra-events", dest="extra_events", default=False, action="store_true")
+    parser.add_option("--extra-events", dest="extra_events", default=True, action="store_true")
+    parser.add_option(
+        "--load-transactions", dest="load_transactions", default=False, action="store_true"
+    )
 
     (options, args) = parser.parse_args()
 
     try:
-        main(num_events=options.num_events, extra_events=options.extra_events)
+        main(
+            num_events=options.num_events,
+            extra_events=options.extra_events,
+            load_transactions=options.load_transactions,
+        )
     except Exception:
         # Avoid reporting any issues recursively back into Sentry
         import traceback

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -598,6 +598,7 @@ def main(num_events=1, extra_events=False, load_transactions=False):
                             - timedelta(
                                 milliseconds=int(random.normalvariate(2000 + 50 * day, 250))
                             ),
+                            # match the trace from the javascript transaction
                             trace=transaction1.get_tag("trace"),
                         )
 

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -581,10 +581,10 @@ def main(num_events=1, extra_events=False, load_transactions=False):
                                 milliseconds=int(random.normalvariate(2000 - 50 * day, 250))
                             ),
                             measurements={
-                                "fp": {"value": random.normalvariate(2000, 200)},
-                                "fcp": {"value": random.normalvariate(2250, 200)},
-                                "lcp": {"value": random.normalvariate(2800, 400)},
-                                "fid": {"value": random.normalvariate(5, 2)},
+                                "fp": {"value": max(random.normalvariate(2000, 200), 1000)},
+                                "fcp": {"value": max(random.normalvariate(2250, 200), 1000)},
+                                "lcp": {"value": max(random.normalvariate(2800, 400), 2000)},
+                                "fid": {"value": max(random.normalvariate(5, 2), 1)},
                             },
                         )
                         create_sample_event(

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -757,7 +757,7 @@ if __name__ == "__main__":
 
     parser = OptionParser()
     parser.add_option("--events", dest="num_events", default=1, type=int)
-    parser.add_option("--extra-events", dest="extra_events", default=True, action="store_true")
+    parser.add_option("--extra-events", dest="extra_events", default=False, action="store_true")
     parser.add_option(
         "--load-transactions", dest="load_transactions", default=False, action="store_true"
     )

--- a/src/sentry/data/samples/javascript-transaction.json
+++ b/src/sentry/data/samples/javascript-transaction.json
@@ -1,0 +1,170 @@
+{
+   "platform": "transaction",
+   "message": "",
+   "tags": [
+      [
+         "application",
+         "countries"
+      ],
+      [
+         "browser",
+         "Firefox 81.0"
+      ],
+      [
+         "browser.name",
+         "Firefox"
+      ],
+      [
+         "environment",
+         "dev"
+      ],
+      [
+         "release",
+         "v0.1"
+      ],
+      [
+         "user",
+         "ip:127.0.0.1"
+      ],
+      [
+         "trace",
+         "a7d67cf796774551a95be6543cacd459"
+      ],
+      [
+         "trace.ctx",
+         "a7d67cf796774551a95be6543cacd459-babaae0d4b7512d9"
+      ],
+      [
+         "trace.span",
+         "babaae0d4b7512d9"
+      ],
+      [
+         "transaction",
+         "/country/:countryCode"
+      ],
+      [
+         "url",
+         "http://countries:8000/country/CAN"
+      ]
+   ],
+   "breadcrumbs": {
+      "values": [
+         {
+                "type": "http",
+                "category": "ajax",
+                "timestamp": 1463077692.0,
+                "data": {
+                    "reason": "OK",
+                    "status_code": 200,
+                    "url": "Http://countries:8000/country/CAN",
+                    "method": "GET"
+                }
+         }
+      ]
+   },
+   "contexts": {
+      "trace": {
+         "parent_span_id": "8988cec7cc0779c1",
+         "type": "trace",
+         "op": "pageload",
+         "trace_id": "a7d67cf796774551a95be6543cacd459",
+         "span_id": "babaae0d4b7512d9",
+         "status": "ok"
+      },
+      "browser": {
+         "version": "81.0",
+         "type": "browser",
+         "name": "Firefox"
+      }
+   },
+   "environment": "dev",
+   "extra": {},
+   "logger": "",
+   "metadata": {
+      "location": "/country/:countryCode",
+      "title": "/country/:countryCode"
+   },
+   "request": {
+      "url": "http://countries:8000/country/:countryCode",
+      "headers": [
+         [
+            "Accept",
+            "*/*"
+         ],
+         [
+            "Accept-Encoding",
+            "gzip, deflate"
+         ],
+         [
+            "Connection",
+            "keep-alive"
+         ],
+         [
+            "Content-Length",
+            ""
+         ],
+         [
+            "Content-Type",
+            "text/plain"
+         ],
+         [
+            "Host",
+            "countries:8000"
+         ],
+         [
+            "Referer",
+            "fixtures.transaction"
+         ],
+         [
+            "Sentry-Trace",
+            "a7d67cf796774551a95be6543cacd459-8988cec7cc0779c1-1"
+         ],
+         [
+            "User-Agent",
+	    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:81.0) Gecko/20100101 Firefox/81.0"
+         ]
+      ],
+      "env": {
+         "SERVER_PORT": "8000",
+         "SERVER_NAME": "a90286977562"
+      },
+      "query_string": [
+         [
+            "countryCode",
+            "CAN"
+         ]
+      ],
+      "method": "GET",
+      "inferred_content_type": "text/plain"
+   },
+   "spans": [
+      {
+         "same_process_as_parent":true,
+         "description": "GET /country_by_code/",
+         "parent_span_id": "babaae0d4b7512d9",
+         "trace_id": "a7d67cf796774551a95be6543cacd459",
+         "op": "http",
+         "data": {"duration": 1.75, "offset": 0.02},
+         "span_id": "c048b4fffdc4279d"
+      }
+   ],
+   "transaction": "/country/:countryCode",
+   "type": "transaction",
+   "user": {
+      "ip_address": "127.0.0.1"
+   },
+   "measurements": {
+      "fp": {
+         "value": 2258.060000000114
+      },
+      "fcp": {
+         "value": 2258.060000000114
+      },
+      "lcp": {
+         "value": 2807.335
+      },
+      "fid": {
+         "value": 3.4900000027846545
+      }
+   }
+}

--- a/src/sentry/data/samples/javascript-transaction.json
+++ b/src/sentry/data/samples/javascript-transaction.json
@@ -56,7 +56,7 @@
                 "data": {
                     "reason": "OK",
                     "status_code": 200,
-                    "url": "Http://countries:8000/country/CAN",
+                    "url": "http://countries:8000/country/CAN",
                     "method": "GET"
                 }
          }
@@ -120,7 +120,7 @@
             "a7d67cf796774551a95be6543cacd459-8988cec7cc0779c1-1"
          ],
          [
-            "User-Agent",
+          "User-Agent",
 	    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:81.0) Gecko/20100101 Firefox/81.0"
          ]
       ],

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -103,7 +103,13 @@ def generate_user(username=None, email=None, ip_address=None, id=None):
 
 
 def load_data(
-    platform, default=None, sample_name=None, timestamp=None, start_timestamp=None, trace=None
+    platform,
+    default=None,
+    sample_name=None,
+    timestamp=None,
+    start_timestamp=None,
+    trace=None,
+    span=None,
 ):
     # NOTE: Before editing this data, make sure you understand the context
     # in which its being used. It is NOT only used for local development and
@@ -170,7 +176,9 @@ def load_data(
 
         if trace is None:
             trace = uuid4().hex
-        span = uuid4().hex[:16]
+        if span is None:
+            span = uuid4().hex[:16]
+
         for tag in data["tags"]:
             if tag[0] == "trace":
                 tag[1] = trace

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -188,6 +188,7 @@ def load_data(
             offset = span.get("data", {}).get("offset", 0)
 
             span_start = data["start_timestamp"] + offset
+            span["trace_id"] = trace
             span.setdefault("start_timestamp", span_start)
             span.setdefault("timestamp", span_start + duration)
 

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -352,7 +352,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     def test_event_detail_view_from_transactions_query(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
-        event_data = generate_transaction()
+        event_data = generate_transaction(trace="a" * 32)
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
 
         # Create a child event that is linked to the parent so we have coverage
@@ -394,7 +394,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     def test_transaction_event_detail_view_ops_filtering(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
-        event_data = generate_transaction()
+        event_data = generate_transaction(trace="a" * 32)
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
 
         with self.feature(FEATURE_NAMES):

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -59,10 +59,12 @@ def transactions_query(**kwargs):
     return urlencode(options, doseq=True)
 
 
-def generate_transaction():
+def generate_transaction(trace=None):
     start_datetime = before_now(minutes=1, milliseconds=500)
     end_datetime = before_now(minutes=1)
-    event_data = load_data("transaction", timestamp=end_datetime, start_timestamp=start_datetime)
+    event_data = load_data(
+        "transaction", timestamp=end_datetime, start_timestamp=start_datetime, trace=trace
+    )
     event_data.update({"event_id": "a" * 32})
 
     # generate and build up span tree
@@ -355,7 +357,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
         # Create a child event that is linked to the parent so we have coverage
         # of traversal buttons.
-        child_event = generate_transaction()
+        child_event = generate_transaction(trace=event_data["contexts"]["trace"]["trace_id"])
         child_event["event_id"] = "b" * 32
         child_event["contexts"]["trace"]["parent_span_id"] = event_data["spans"][4]["span_id"]
         child_event["transaction"] = "z-child-transaction"

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -59,11 +59,15 @@ def transactions_query(**kwargs):
     return urlencode(options, doseq=True)
 
 
-def generate_transaction(trace=None):
+def generate_transaction(trace=None, span=None):
     start_datetime = before_now(minutes=1, milliseconds=500)
     end_datetime = before_now(minutes=1)
     event_data = load_data(
-        "transaction", timestamp=end_datetime, start_timestamp=start_datetime, trace=trace
+        "transaction",
+        timestamp=end_datetime,
+        start_timestamp=start_datetime,
+        trace=trace,
+        span=span,
     )
     event_data.update({"event_id": "a" * 32})
 
@@ -352,12 +356,14 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     def test_event_detail_view_from_transactions_query(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
-        event_data = generate_transaction(trace="a" * 32)
+        event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
 
         # Create a child event that is linked to the parent so we have coverage
         # of traversal buttons.
-        child_event = generate_transaction(trace=event_data["contexts"]["trace"]["trace_id"])
+        child_event = generate_transaction(
+            trace=event_data["contexts"]["trace"]["trace_id"], span="bc" * 8
+        )
         child_event["event_id"] = "b" * 32
         child_event["contexts"]["trace"]["parent_span_id"] = event_data["spans"][4]["span_id"]
         child_event["transaction"] = "z-child-transaction"
@@ -394,7 +400,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     def test_transaction_event_detail_view_ops_filtering(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
-        event_data = generate_transaction(trace="a" * 32)
+        event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
 
         with self.feature(FEATURE_NAMES):

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -64,7 +64,9 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
     def test_view_details_from_summary(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
-        event = make_event(load_data("transaction", timestamp=before_now(minutes=1)))
+        event = make_event(
+            load_data("transaction", timestamp=before_now(minutes=1), trace="a" * 32)
+        )
         self.store_event(data=event, project_id=self.project.id)
 
         with self.feature(FEATURE_NAMES):

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -65,7 +65,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
         event = make_event(
-            load_data("transaction", timestamp=before_now(minutes=1), trace="a" * 32)
+            load_data("transaction", timestamp=before_now(minutes=1), trace="a" * 32, span="ab" * 8)
         )
         self.store_event(data=event, project_id=self.project.id)
 

--- a/tests/acceptance/test_transaction_comparison.py
+++ b/tests/acceptance/test_transaction_comparison.py
@@ -31,13 +31,13 @@ class TransactionComparison(AcceptanceTestCase, SnubaTestCase):
     def test_transaction_comparison(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
-        baseline_event_data = generate_transaction(trace="a" * 32)
+        baseline_event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
         baseline_event = self.store_event(
             data=baseline_event_data, project_id=self.project.id, assert_no_errors=True
         )
         baseline_event_slug = u"{}:{}".format(self.project.slug, baseline_event.event_id)
 
-        regression_event_data = generate_transaction(trace="b" * 32)
+        regression_event_data = generate_transaction(trace="b" * 32, span="bc" * 8)
         regression_event_data.update({"event_id": "b" * 32})
 
         regression_event_data["spans"] = regress_spans(regression_event_data["spans"])

--- a/tests/acceptance/test_transaction_comparison.py
+++ b/tests/acceptance/test_transaction_comparison.py
@@ -31,13 +31,13 @@ class TransactionComparison(AcceptanceTestCase, SnubaTestCase):
     def test_transaction_comparison(self, mock_now):
         mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
 
-        baseline_event_data = generate_transaction()
+        baseline_event_data = generate_transaction(trace="a" * 32)
         baseline_event = self.store_event(
             data=baseline_event_data, project_id=self.project.id, assert_no_errors=True
         )
         baseline_event_slug = u"{}:{}".format(self.project.slug, baseline_event.event_id)
 
-        regression_event_data = generate_transaction()
+        regression_event_data = generate_transaction(trace="b" * 32)
         regression_event_data.update({"event_id": "b" * 32})
 
         regression_event_data["spans"] = regress_spans(regression_event_data["spans"])


### PR DESCRIPTION
- This will create a large number of transactions over the last 14 days
  - This is so there would be visible trends
<img width="1691" alt="image" src="https://user-images.githubusercontent.com/4205004/95517387-e6602a00-098e-11eb-84d9-2bf64bc132ab.png">
   - Values for aggregates
<img width="2530" alt="image" src="https://user-images.githubusercontent.com/4205004/95517468-0e4f8d80-098f-11eb-83c6-b1757b7b1fcd.png">
  - And a distribution in Real User Monitoring
<img width="2530" alt="image" src="https://user-images.githubusercontent.com/4205004/95517435-fd068100-098e-11eb-8c20-786f167290f2.png">
- Because of how many transactions are mocked its only optional whether
  or not they're added with `--load-transactions`
- This also should fix a bug with load_mock("transactions") where more
  than 4 transactions couldn't be saved, this seemed to have been due to
  the trace being identical