### PR TITLE
fix(Vercel): Handle 402 errors

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import logging
 
 from sentry.integrations.client import ApiClient
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.integrations.vercel.api")
@@ -40,9 +40,8 @@ class VercelClient(ApiClient):
                 method, path, headers=headers, data=data, params=params, allow_text=allow_text
             )
         except ApiError as e:
-            if e.code == 402:
-                raise IntegrationError("Payment Required")
-            raise IntegrationError(e.text)
+            if not e.code == 402:
+                raise e
 
     def get_team(self):
         assert self.team_id

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -6,7 +6,7 @@ from rest_framework.serializers import ValidationError
 
 
 from six.moves.urllib.parse import parse_qs
-from sentry.integrations.vercel import VercelIntegrationProvider, VercelClient
+from sentry.integrations.vercel import VercelIntegrationProvider
 from sentry.models import (
     Integration,
     OrganizationIntegration,
@@ -16,7 +16,6 @@ from sentry.models import (
     SentryAppInstallationForProvider,
     SentryAppInstallation,
 )
-from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import IntegrationTestCase
 from sentry.utils import json
 from sentry.utils.compat.mock import patch
@@ -478,22 +477,3 @@ class VercelIntegrationTest(IntegrationTestCase):
             ).encode("utf-8")
             in resp.content
         )
-
-    @responses.activate
-    def test_handles_402(self):
-        """Test that we handle a 402 error"""
-
-        responses.add(
-            responses.POST,
-            "https://api.vercel.com/v2/now/secrets",
-            json={"uid": "sec_1"},
-            status=402,
-        )
-
-        client = VercelClient("my_access_token")
-        with self.assertRaises(IntegrationError):
-            client.create_secret(self.project.id, "SENTRY_ORG_1234567", "foo")
-
-        resp_params = responses.calls[0].response
-        assert resp_params.status_code == 402
-        assert resp_params.reason == "Payment Required"


### PR DESCRIPTION
If a request to Vercel results in a 402 error, it's not actionable for us (just means the customer needs to pay Vercel) so we'll ignore it. 

Fixes [SENTRY-HER](https://sentry.io/organizations/sentry/issues/1834347712/?project=1&referrer=jira_integration).