### PR TITLE
fix(rum): Changing filter type should reset the view port

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/content.tsx
@@ -65,17 +65,13 @@ class RumContent extends React.Component<Props, State> {
   handleResetView = () => {
     const {location} = this.props;
 
-    const queryParams = getParams({
-      ...(location.query || {}),
-    });
-
-    // reset the zoom parameters
-    delete queryParams.startMeasurements;
-    delete queryParams.endMeasurements;
-
     browserHistory.push({
       pathname: location.pathname,
-      query: queryParams,
+      query: {
+        ...location.query,
+        startMeasurements: undefined,
+        endMeasurements: undefined,
+      },
     });
   };
 
@@ -95,6 +91,8 @@ class RumContent extends React.Component<Props, State> {
       query: {
         ...location.query,
         cursor: undefined,
+        startMeasurements: undefined,
+        endMeasurements: undefined,
         dataFilter: value,
       },
     });


### PR DESCRIPTION
When changing the filter type from Exclude Outliers to View All, the view port
should reset to the default because otherwise the change will likely not do
anything to the current zoomed view.