### PR TITLE
fix(ui): fix font size of empty message component

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
@@ -70,7 +70,7 @@ const IconWrapper = styled('div')`
   margin-bottom: ${space(1)};
 `;
 
-const Title = styled('h1')`
+const Title = styled('strong')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
   margin-bottom: ${space(1)};
 `;


### PR DESCRIPTION
## Before 

<img width="877" alt="Screen Shot 2020-10-09 at 12 08 39 PM" src="https://user-images.githubusercontent.com/1900676/95622392-4525b200-0a28-11eb-88c0-a827ea260006.png">


## After

<img width="875" alt="Screen Shot 2020-10-09 at 12 08 30 PM" src="https://user-images.githubusercontent.com/1900676/95622399-48b93900-0a28-11eb-8c9e-2e9b0c8f5ae2.png">
