### PR TITLE
fix(acceptance-tests): Add TimedRetryPolicy decorator to login_as

### DIFF
--- a/src/sentry/static/sentry/app/components/pluginConfig.jsx
+++ b/src/sentry/static/sentry/app/components/pluginConfig.jsx
@@ -102,7 +102,10 @@ class PluginConfig extends React.Component {
       typeof this.props.enabled !== 'undefined' ? this.props.enabled : data.enabled;
 
     return (
-      <Panel className={`plugin-config ref-plugin-config-${data.id}`} data-test-id="plugin-config">
+      <Panel
+        className={`plugin-config ref-plugin-config-${data.id}`}
+        data-test-id="plugin-config"
+      >
         <PanelHeader hasButtons>
           <PluginName>
             <StyledPluginIcon pluginId={data.id} />

--- a/src/sentry/static/sentry/app/components/pluginConfig.jsx
+++ b/src/sentry/static/sentry/app/components/pluginConfig.jsx
@@ -102,7 +102,7 @@ class PluginConfig extends React.Component {
       typeof this.props.enabled !== 'undefined' ? this.props.enabled : data.enabled;
 
     return (
-      <Panel className={`plugin-config ref-plugin-config-${data.id}`}>
+      <Panel className={`plugin-config ref-plugin-config-${data.id}`} data-test-id="plugin-config">
         <PanelHeader hasButtons>
           <PluginName>
             <StyledPluginIcon pluginId={data.id} />

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -224,6 +224,7 @@ class BaseTestCase(Fixtures, Exam):
             )
         # Save the session values.
         self.save_session()
+        time.sleep(5)
 
     def load_fixture(self, filepath):
         filepath = os.path.join(MODULE_ROOT, os.pardir, os.pardir, "tests", "fixtures", filepath)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -224,7 +224,6 @@ class BaseTestCase(Fixtures, Exam):
             )
         # Save the session values.
         self.save_session()
-        time.sleep(5)
 
     def load_fixture(self, filepath):
         filepath = os.path.join(MODULE_ROOT, os.pardir, os.pardir, "tests", "fixtures", filepath)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -85,6 +85,7 @@ from sentry.tagstore.snuba import SnubaTagStorage
 from sentry.utils import json
 from sentry.utils.auth import SSO_SESSION_KEY
 from sentry.testutils.helpers.datetime import iso_format
+from sentry.utils.retries import TimedRetryPolicy
 
 from .fixtures import Fixtures
 from .factories import Factories
@@ -178,6 +179,7 @@ class BaseTestCase(Fixtures, Exam):
 
     # TODO(dcramer): ideally superuser_sso would be False by default, but that would require
     # a lot of tests changing
+    @TimedRetryPolicy.wrap(timeout=5)
     def login_as(
         self, user, organization_id=None, organization_ids=None, superuser=False, superuser_sso=True
     ):

--- a/tests/acceptance/test_organization_plugin_detail_view.py
+++ b/tests/acceptance/test_organization_plugin_detail_view.py
@@ -38,7 +38,7 @@ class OrganizationPluginDetailedView(AcceptanceTestCase):
         self.browser.click('[id="react-select-2-option-0"]')
         # check if we got to the configuration page with the form
         self.browser.wait_until_not(".loading-indicator")
-        assert self.browser.element_exists('[id="id-api_key"]')
+        assert self.browser.element_exists_by_test_id("plugin-config")
 
     def test_uninstallation(self):
         self.plugin.set_option("api_key", "7c8951d1", self.project)

--- a/tests/acceptance/test_organization_plugin_detail_view.py
+++ b/tests/acceptance/test_organization_plugin_detail_view.py
@@ -38,6 +38,7 @@ class OrganizationPluginDetailedView(AcceptanceTestCase):
         self.browser.click('[id="react-select-2-option-0"]')
         # check if we got to the configuration page with the form
         self.browser.wait_until_not(".loading-indicator")
+        self.browser.snapshot("integrations - plugin config form")
         assert self.browser.element_exists_by_test_id("plugin-config")
 
     def test_uninstallation(self):


### PR DESCRIPTION
## Objective
There are two flaky errors associated with the OrganizationPluginDetailView acceptance test.
1. [ReadTimeout](https://sentry.io/organizations/sentry/issues/?project=2423079&query=is%3Aunresolved+HTTPConnectionPool&statsPeriod=14d
)

Acceptance tests keep failing on `self.login_as` here https://github.com/getsentry/sentry/blob/master/tests/acceptance/test_organization_plugin_detail_view.py#L22
with the following error:
```
ReadTimeoutError: HTTPConnectionPool(host='127.0.0.1', port=49586): Read timed out. (read timeout=<object object at 0x103f815e0>)
```
It is failing to save the cookie on this line:
https://github.com/getsentry/sentry/blob/master/src/sentry/utils/pytest/selenium.py#L394

This error is not exclusive to this acceptance test.

2. [Element does not exist](https://sentry.io/organizations/sentry/issues/1908396608/events/f0bf19d5312a43ca860c18aa9efa7a46/?project=2423079)

where selenium cannot find the form input's css id.


## Solution 
So in this PR, I added a `data-test-id` to the Plugin Configuration Form (bc the test checks for it's existence not contents). So now, selenium looks for the specific `data-test-id`. 

For the `ReadTimeoutError`, I added a TimeoutRetryPolicy decorator on `login_as`. 