### PR TITLE
fix(api): can't compare datetime.datetime to NoneType

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -99,9 +99,7 @@ class GroupSerializerBase(Serializer):
         # Fallback to the 30 days ago if we are not able to calculate the value.
         last_seen = None
         for item in seen_stats.values():
-            if last_seen is None or (
-                item["last_seen"] is not None and last_seen > item["last_seen"]
-            ):
+            if last_seen is None or (item["last_seen"] and last_seen > item["last_seen"]):
                 last_seen = item["last_seen"]
 
         if last_seen is None:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -90,9 +90,8 @@ class GroupSerializerBase(Serializer):
         """
         raise NotImplementedError
 
-    def _get_group_snuba_stats(self, item_list, seen_stats):
-        filter_keys = {}
-
+    @staticmethod
+    def _get_start_from_seen_stats(seen_stats):
         # Try to figure out what is a reasonable time frame to look into stats,
         # based on a given "seen stats".  We try to pick a day prior to the earliest last seen,
         # but it has to be at least 14 days, and not more than 90 days ago.
@@ -103,13 +102,17 @@ class GroupSerializerBase(Serializer):
                 last_seen = item["last_seen"]
 
         if last_seen is None:
-            start = datetime.now(pytz.utc) - timedelta(days=30)
-        else:
-            start = max(
-                min(last_seen - timedelta(days=1), datetime.now(pytz.utc) - timedelta(days=14)),
-                datetime.now(pytz.utc) - timedelta(days=90),
-            )
+            return datetime.now(pytz.utc) - timedelta(days=30)
 
+        return max(
+            min(last_seen - timedelta(days=1), datetime.now(pytz.utc) - timedelta(days=14)),
+            datetime.now(pytz.utc) - timedelta(days=90),
+        )
+
+    def _get_group_snuba_stats(self, item_list, seen_stats):
+        start = self._get_start_from_seen_stats(seen_stats)
+
+        filter_keys = {}
         for item in item_list:
             filter_keys.setdefault("project_id", []).append(item.project_id)
             filter_keys.setdefault("group_id", []).append(item.id)

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -103,14 +103,12 @@ class GroupSerializerBase(Serializer):
                 item["last_seen"] is not None and last_seen > item["last_seen"]
             ):
                 last_seen = item["last_seen"]
-        if last_seen is not None:
-            last_seen = last_seen - timedelta(days=1)
 
         if last_seen is None:
             start = datetime.now(pytz.utc) - timedelta(days=30)
         else:
             start = max(
-                min(last_seen, datetime.now(pytz.utc) - timedelta(days=14)),
+                min(last_seen - timedelta(days=1), datetime.now(pytz.utc) - timedelta(days=14)),
                 datetime.now(pytz.utc) - timedelta(days=90),
             )
 

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import pytz
 import six
 
 from datetime import timedelta
@@ -344,6 +345,13 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert iso_format(result["lastSeen"]) == iso_format(self.week_ago)
         assert iso_format(result["firstSeen"]) == iso_format(self.week_ago)
         assert result["count"] == "1"
+
+    def test_get_start_from_seen_stats(self):
+        for days, expected in [(None, 30), (0, 14), (1000, 90)]:
+            last_seen = None if days is None else before_now(days=days).replace(tzinfo=pytz.UTC)
+            start = GroupSerializerSnuba._get_start_from_seen_stats({"": {"last_seen": last_seen}})
+
+            assert iso_format(start) == iso_format(before_now(days=expected))
 
 
 class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -2,13 +2,10 @@
 
 from __future__ import absolute_import
 
-from sentry.utils.compat import mock
 import six
 
 from datetime import timedelta
-
 from django.utils import timezone
-from sentry.utils.compat.mock import patch
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import (
@@ -30,6 +27,8 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
+from sentry.utils.compat import mock
+from sentry.utils.compat.mock import patch
 
 
 class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):


### PR DESCRIPTION
The function tries to find the earliest `last_seen` but has a fallback when it can't find one. It seems safe to just continue when the datetime is None.
 
https://sentry.io/organizations/sentry/issues/1945991817/activity