### PR TITLE
fix(issue_stream): Fix bug with aggregates on the issue stream when dynamic counts is enabled

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -740,6 +740,8 @@ class GroupSerializerSnuba(GroupSerializerBase):
         "active_at",
         "first_release",
         "first_seen",
+        "last_seen",
+        "times_seen",
     }
 
     def __init__(self, environment_ids=None, start=None, end=None, search_filters=None):

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -650,6 +650,24 @@ class GroupListTest(APITestCase, SnubaTestCase):
                 before_now_100_seconds
             ).replace(tzinfo=timezone.utc)
 
+    def test_aggregate_stats_regression_test(self):
+        with self.feature("organizations:dynamic-issue-counts"):
+            self.store_event(
+                data={
+                    "timestamp": iso_format(before_now(seconds=500)),
+                    "fingerprint": ["group-1"],
+                },
+                project_id=self.project.id,
+            )
+
+            self.login_as(user=self.user)
+            response = self.get_response(
+                sort_by="date", limit=10, query="times_seen:>0 last_seen:-1h"
+            )
+
+            assert response.status_code == 200
+            assert len(response.data) == 1
+
     def test_skipped_fields(self):
         with self.feature("organizations:dynamic-issue-counts"):
             event = self.store_event(


### PR DESCRIPTION
We end up with issues in the serializers where we try to query on these aggregate fields, but end up
trying to compare them to tag cols. @taylangocmen pointed out that we can just skip these fields and
it's the same since they're only group level properties. We still have issues with `date`, which
we'll fix separately.