### PR TITLE
fix(issue_stream): Fix bug with searching in date/event.timestamp when dynamic counts is enabled

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -755,7 +755,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         # should try and encapsulate this logic, but if you're changing this, change it
         # there as well.
         self.start = None
-        start_params = [start, get_search_filter(search_filters, "date", ">")]
+        start_params = [_f for _f in [start, get_search_filter(search_filters, "date", ">")] if _f]
         if start_params:
             self.start = max([_f for _f in start_params if _f])
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -28,6 +28,8 @@ def get_search_filter(search_filters, name, operator):
     :param operator: '<' or '>'
     :return: The value of the field if found, else None
     """
+    if not search_filters:
+        return None
     assert operator in ("<", ">")
     comparator = max if operator.startswith(">") else min
     found_val = None

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -662,7 +662,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
             self.login_as(user=self.user)
             response = self.get_response(
-                sort_by="date", limit=10, query="times_seen:>0 last_seen:-1h"
+                sort_by="date", limit=10, query="times_seen:>0 last_seen:-1h date:-1h"
             )
 
             assert response.status_code == 200


### PR DESCRIPTION
We merge this value with start/end in the issue search backend. Copying the logic here to fix the
bug. We also add it to the skip fields so that we don't also include a separate conditon for
event.timestamp here, since this will fail.

Ideally we can follow this up with some improvements to make this logic shared better.