### PR TITLE
feat(group): Use argMax for unhandled flag query

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -341,7 +341,9 @@ class GroupSerializerBase(Serializer):
         )
         merge_list_dictionaries(annotations_by_group_id, local_annotations_by_group_id)
 
-        snuba_stats = self._get_group_snuba_stats(item_list, seen_stats)
+        snuba_stats = {}
+        if has_unhandled_flag:
+            snuba_stats = self._get_group_snuba_stats(item_list, seen_stats)
 
         for item in item_list:
             active_date = item.active_at or item.first_seen

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -120,8 +120,13 @@ class GroupSerializerBase(Serializer):
             dataset=Dataset.Events,
             selected_columns=[
                 "group_id",
-                ["has", ["exception_stacks.mechanism_handled", 0], "unhandled"],
+                [
+                    "argMax",
+                    [["has", ["exception_stacks.mechanism_handled", 0]], "timestamp"],
+                    "unhandled",
+                ],
             ],
+            groupby=["group_id"],
             filter_keys=filter_keys,
             start=start,
             referrer="group.unhandled-flag",


### PR DESCRIPTION
Change the query to use `argMax`.  This now changes behavior slightly in that
it reflects the value of the last event and not all events.