### PR TITLE
ref(tags): Fix custom tags issue

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -9,6 +9,7 @@ from sentry_relay import meta_with_chunks
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import EventAttachment, EventError, Release, UserReport
 from sentry.search.utils import convert_user_tag_to_query
+from sentry.utils.json import prune_empty_keys
 from sentry.utils.safe import get_path
 from sentry.sdk_updates import get_suggested_updates, SdkSetupState
 from sentry.eventstore.models import Event
@@ -98,12 +99,18 @@ class EventSerializer(Serializer):
         tags = sorted(
             [
                 {
-                    "key": kv[0].split("sentry:", 1)[-1],
+                    "key": kv[0] and kv[0].split("sentry:", 1)[-1],
                     "value": kv[1],
-                    "_meta": meta.get(kv[0]) or get_path(meta, six.text_type(i), "1") or None,
+                    "_meta": prune_empty_keys(
+                        {
+                            "key": get_path(meta, six.text_type(i), "0"),
+                            "value": get_path(meta, six.text_type(i), "1"),
+                        }
+                    )
+                    or None,
                 }
                 for i, kv in enumerate(raw_tags)
-                if kv is not None and kv[0] is not None and kv[1] is not None
+                if kv is not None
             ],
             key=lambda x: x["key"],
         )
@@ -115,11 +122,7 @@ class EventSerializer(Serializer):
             if query:
                 tag["query"] = query
 
-        tags_meta = {
-            six.text_type(i): {"value": e.pop("_meta")}
-            for i, e in enumerate(tags)
-            if e.get("_meta")
-        }
+        tags_meta = prune_empty_keys({six.text_type(i): e.pop("_meta") for i, e in enumerate(tags)})
 
         return (tags, meta_with_chunks(tags, tags_meta))
 
@@ -203,6 +206,7 @@ class EventSerializer(Serializer):
         return (
             not name.startswith("breadcrumbs.")
             and not name.startswith("extra.")
+            and not name.startswith("tags.")
             and ".frames." not in name
         )
 

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTags.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTags.tsx
@@ -5,10 +5,9 @@ import styled from '@emotion/styled';
 
 import {Event} from 'app/types';
 import EventDataSection from 'app/components/events/eventDataSection';
-import {generateQueryWithTag} from 'app/utils';
+import {defined, generateQueryWithTag} from 'app/utils';
 import {t} from 'app/locale';
 import Pills from 'app/components/pills';
-import {getMeta} from 'app/components/events/meta/metaProxy';
 import space from 'app/styles/space';
 
 import EventTagsPill from './eventTagsPill';
@@ -38,9 +37,9 @@ const EventTags = ({
   return (
     <StyledEventDataSection title={t('Tags')} type="tags">
       <Pills>
-        {tags.map(tag => (
+        {tags.map((tag, index) => (
           <EventTagsPill
-            key={tag.key}
+            key={!defined(tag.key) ? `tag-pill-${index}` : tag.key}
             tag={tag}
             projectId={projectId}
             orgId={orgId}
@@ -48,7 +47,6 @@ const EventTags = ({
             query={generateQueryWithTag(location.query, tag)}
             streamPath={streamPath}
             releasesPath={releasesPath}
-            meta={getMeta(tag, 'value')}
             hasQueryFeature={hasQueryFeature}
           />
         ))}

--- a/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPillValue.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags/eventTagsPillValue.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import {Meta, EventTag} from 'app/types';
+import Version from 'app/components/version';
+import AnnotatedText from 'app/components/events/meta/annotatedText';
+import DeviceName from 'app/components/deviceName';
+import Link from 'app/components/links/link';
+import {defined} from 'app/utils';
+
+type Props = {
+  isRelease: boolean;
+  streamPath: string;
+  locationSearch: string;
+  tag: EventTag;
+  meta?: Meta;
+};
+
+const EventTagsPillValue = ({
+  tag: {key, value},
+  meta,
+  isRelease,
+  streamPath,
+  locationSearch,
+}: Props) => {
+  const getContent = () =>
+    isRelease ? (
+      <Version version={String(value)} anchor={false} tooltipRawVersion truncate />
+    ) : (
+      <AnnotatedText
+        value={defined(value) && <DeviceName value={String(value)} />}
+        meta={meta}
+      />
+    );
+
+  const content = getContent();
+
+  if (!meta?.err?.length && defined(key)) {
+    return <Link to={{pathname: streamPath, search: locationSearch}}>{content}</Link>;
+  }
+
+  return content;
+};
+
+export default EventTagsPillValue;

--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText/index.tsx
@@ -53,7 +53,7 @@ const AnnotatedText = ({value, meta, ...props}: Props) => {
     }
 
     return (
-      <Tooltip
+      <StyledTooltipError
         title={
           <TooltipTitle>
             <strong>
@@ -68,7 +68,7 @@ const AnnotatedText = ({value, meta, ...props}: Props) => {
         }
       >
         <StyledIconWarning color="red500" />
-      </Tooltip>
+      </StyledTooltipError>
     );
   };
 
@@ -82,11 +82,13 @@ const AnnotatedText = ({value, meta, ...props}: Props) => {
 
 export default AnnotatedText;
 
-const StyledIconWarning = styled(IconWarning)`
-  padding-left: ${space(0.75)};
+const StyledTooltipError = styled(Tooltip)`
+  margin-left: ${space(0.75)};
+  vertical-align: middle;
 `;
 
 const StyledListItem = styled(ListItem)`
+  padding-left: ${space(3)};
   ul & {
     color: ${p => p.theme.white};
     &:before {
@@ -97,4 +99,8 @@ const StyledListItem = styled(ListItem)`
 
 const TooltipTitle = styled('div')`
   text-align: left;
+`;
+
+const StyledIconWarning = styled(IconWarning)`
+  vertical-align: middle;
 `;

--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText/redaction.tsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText/redaction.tsx
@@ -3,12 +3,15 @@ import styled from '@emotion/styled';
 
 type Props = {
   children: React.ReactNode;
+  withoutBackground?: boolean;
+  className?: string;
 };
 
-const Redaction = ({children}: Props) => <Wrapper>{children}</Wrapper>;
-export default Redaction;
-
-const Wrapper = styled('span')`
-  background: rgba(255, 0, 0, 0.05);
+const Redaction = styled(({children, className}: Props) => (
+  <span className={className}>{children}</span>
+))`
   cursor: default;
+  vertical-align: middle;
+  ${p => !p.withoutBackground && `background: rgba(255, 0, 0, 0.05);`}
 `;
+export default Redaction;

--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText/valueElement.tsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText/valueElement.tsx
@@ -17,7 +17,7 @@ const ValueElement = ({value, meta}: Props) => {
 
   if (meta?.err?.length) {
     return (
-      <Redaction>
+      <Redaction withoutBackground>
         <i>{`<${t('invalid')}>`}</i>
       </Redaction>
     );
@@ -32,7 +32,11 @@ const ValueElement = ({value, meta}: Props) => {
   }
 
   if (!value) {
-    return null;
+    return (
+      <Redaction withoutBackground>
+        <i>{`<${t('invalid')}>`}</i>
+      </Redaction>
+    );
   }
 
   if (React.isValidElement(value)) {

--- a/src/sentry/static/sentry/app/components/events/rrwebIntegration.jsx
+++ b/src/sentry/static/sentry/app/components/events/rrwebIntegration.jsx
@@ -42,7 +42,7 @@ export default class RRWebIntegration extends AsyncComponent {
     const url = `/api/0/projects/${orgId}/${projectId}/events/${event.id}/attachments/${attachment.id}/?download`;
 
     return (
-      <EventDataSection key="context-replay" title="Replay">
+      <EventDataSection key="context-replay" type="context-replay" title="Replay">
         <StyledPanel>
           <LazyLoad
             component={() =>

--- a/src/sentry/static/sentry/app/components/pill.tsx
+++ b/src/sentry/static/sentry/app/components/pill.tsx
@@ -82,11 +82,18 @@ const getPillValueStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
         margin: -1px;
       `;
     case 'error':
+      return `
+        border-left-color: ${theme.red400};
+        background: ${theme.red100};
+        border: 1px solid ${theme.red400};
+        margin: -1px;
+      `;
     case 'negative':
       return `
         border-left-color: ${theme.red400};
         background: ${theme.red100};
         border: 1px solid ${theme.red400};
+        font-family: ${theme.text.familyMono};
         margin: -1px;
       `;
     default:

--- a/src/sentry/static/sentry/app/components/pill.tsx
+++ b/src/sentry/static/sentry/app/components/pill.tsx
@@ -4,19 +4,17 @@ import styled from '@emotion/styled';
 import space from 'app/styles/space';
 import {Theme} from 'app/utils/theme';
 
-enum PILL_TYPE {
-  POSITIVE = 'positive',
-  NEGATIVE = 'negative',
-}
+type PillType = 'positive' | 'negative' | 'error';
 
 type Props = {
-  name: string;
-  value: string | boolean | undefined | null;
+  type?: PillType;
+  name?: React.ReactNode;
+  value?: string | boolean | null;
   children?: React.ReactNode;
 };
 
-const Pill = React.memo(({name, value, children}: Props) => {
-  const getTypeAndValue = (): Partial<{type: PILL_TYPE; renderValue: string}> => {
+const Pill = React.memo(({name, value, children, type}: Props) => {
+  const getTypeAndValue = (): Partial<{valueType: PillType; renderValue: string}> => {
     if (value === undefined) {
       return {};
     }
@@ -25,68 +23,77 @@ const Pill = React.memo(({name, value, children}: Props) => {
       case 'true':
       case true:
         return {
-          type: PILL_TYPE.POSITIVE,
+          valueType: 'positive',
           renderValue: 'true',
         };
       case 'false':
       case false:
         return {
-          type: PILL_TYPE.NEGATIVE,
+          valueType: 'negative',
           renderValue: 'false',
         };
       case null:
       case undefined:
         return {
-          type: PILL_TYPE.NEGATIVE,
+          valueType: 'error',
           renderValue: 'n/a',
         };
       default:
         return {
-          type: undefined,
+          valueType: undefined,
           renderValue: String(value),
         };
     }
   };
 
-  const {type, renderValue} = getTypeAndValue();
+  const {valueType, renderValue} = getTypeAndValue();
 
   return (
-    <StyledPill type={type}>
+    <StyledPill type={type ?? valueType}>
       <PillName>{name}</PillName>
       <PillValue>{children ?? renderValue}</PillValue>
     </StyledPill>
   );
 });
 
-const getPillBorder = ({type, theme}: {type?: PILL_TYPE; theme: Theme}) => {
+const getPillStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
   switch (type) {
-    case PILL_TYPE.POSITIVE:
+    case 'error':
       return `
-        background: ${theme.green100};
-        border: 1px solid ${theme.green400};
-      `;
-    case PILL_TYPE.NEGATIVE:
-      return `
+        background: ${theme.red100};
         background: ${theme.red100};
         border: 1px solid ${theme.red400};
       `;
     default:
-      return '';
+      return `
+        border: 1px solid ${theme.borderDark};
+      `;
   }
 };
 
-const getPillValueColor = ({type, theme}: {type?: PILL_TYPE; theme: Theme}) => {
+const getPillValueStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
   switch (type) {
-    case PILL_TYPE.POSITIVE:
+    case 'positive':
       return `
+        background: ${theme.green100};
+        border: 1px solid ${theme.green400};
         border-left-color: ${theme.green400};
+        font-family: ${theme.text.familyMono};
+        margin: -1px;
       `;
-    case PILL_TYPE.NEGATIVE:
+    case 'error':
+    case 'negative':
       return `
         border-left-color: ${theme.red400};
+        background: ${theme.red100};
+        border: 1px solid ${theme.red400};
+        margin: -1px;
       `;
     default:
-      return `background: ${theme.gray100};`;
+      return `
+        background: ${theme.gray100};
+        font-family: ${theme.text.familyMono};
+      `;
   }
 };
 
@@ -102,7 +109,6 @@ const PillValue = styled(PillName)`
   border-left: 1px solid ${p => p.theme.borderDark};
   border-radius: ${p =>
     `0 ${p.theme.button.borderRadius} ${p.theme.button.borderRadius} 0`};
-  font-family: ${p => p.theme.text.familyMono};
   max-width: 100%;
   display: flex;
   align-items: center;
@@ -127,11 +133,10 @@ const PillValue = styled(PillName)`
   }
 `;
 
-const StyledPill = styled('li')<{type?: PILL_TYPE}>`
+const StyledPill = styled('li')<{type?: PillType}>`
   white-space: nowrap;
-  margin: 0 10px 10px 0;
+  margin: 0 ${space(1)} ${space(1)} 0;
   display: flex;
-  border: 1px solid ${p => p.theme.borderDark};
   border-radius: ${p => p.theme.button.borderRadius};
   box-shadow: ${p => p.theme.dropShadowLightest};
   line-height: 1.2;
@@ -140,10 +145,10 @@ const StyledPill = styled('li')<{type?: PILL_TYPE}>`
     margin-right: 0;
   }
 
-  ${getPillBorder};
+  ${getPillStyle};
 
   ${PillValue} {
-    ${getPillValueColor};
+    ${getPillValueStyle};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -65,7 +65,6 @@ type Props = DefaultProps & {
    * Should be set to true if tooltip contains unisolated data (eg. dates)
    */
   disableForVisualTest?: boolean;
-
   className?: string;
 };
 


### PR DESCRIPTION
closes: https://app.asana.com/0/1182975495223914/1197541196070295

Description: The UI or the event json is not showing the keys of the custom tags that were left empty or exceeded in the desired length.


it looks like below:

Chrome

![image](https://user-images.githubusercontent.com/29228205/96445569-6482c300-1210-11eb-959c-d86e6e15acbb.png)



Mozilla:

![image](https://user-images.githubusercontent.com/29228205/96445524-56cd3d80-1210-11eb-82b5-1d5b3fc701ba.png)


Safari:

![image](https://user-images.githubusercontent.com/29228205/96445636-85e3af00-1210-11eb-8747-cd3a27e035ac.png)
