### PR TITLE
fix(Vercel): Handle KeyError for project_mappings

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 import six
 import logging
 
-from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.serializers import ValidationError
 from six.moves.urllib.parse import urlencode
@@ -207,7 +206,7 @@ class VercelIntegration(IntegrationInstallation):
         try:
             new_mappings = data["project_mappings"]
         except KeyError:
-            return HttpResponse("Failed to update configuration.")
+            return ValidationError("Failed to update configuration.")
 
         old_mappings = config.get("project_mappings") or []
 

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import six
 import logging
 
+from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.serializers import ValidationError
 from six.moves.urllib.parse import urlencode
@@ -203,7 +204,11 @@ class VercelIntegration(IntegrationInstallation):
         # data = {"project_mappings": [[sentry_project_id, vercel_project_id]]}
         vercel_client = self.get_client()
         config = self.org_integration.config
-        new_mappings = data["project_mappings"]
+        try:
+            new_mappings = data["project_mappings"]
+        except KeyError:
+            return HttpResponse("Failed to update configuration.")
+
         old_mappings = config.get("project_mappings") or []
 
         for mapping in new_mappings:


### PR DESCRIPTION
This wraps the project mappings in a try/catch in the event the request data is an empty dictionary - however, I was not able to replicate this behavior (it always has project mappings) and this only affected one user who currently has the integration set up successfully. 

Fixes [SENTRY-HCM](https://sentry.io/organizations/sentry/issues/1826620429/?project=1&referrer=jira_integration)