### PR TITLE
test(reprocessing2): Skip deadlocking/looping tests

### DIFF
--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -59,6 +59,7 @@ def register_event_preprocessor(register_plugin):
 
 @pytest.mark.django_db
 @pytest.mark.snuba
+@pytest.mark.skip(reason="Some of these tests deadlock on CI")
 @pytest.mark.parametrize("change_groups", (True, False), ids=("new_group", "same_group"))
 def test_basic(
     task_runner,
@@ -137,6 +138,7 @@ def test_basic(
 
 @pytest.mark.django_db
 @pytest.mark.snuba
+@pytest.mark.skip(reason="Some of these tests deadlock on CI")
 def test_concurrent_events_go_into_new_group(
     default_project, reset_snuba, register_event_preprocessor, process_and_save, burst_task_runner
 ):
@@ -178,6 +180,7 @@ def test_concurrent_events_go_into_new_group(
 
 @pytest.mark.django_db
 @pytest.mark.snuba
+@pytest.mark.skip(reason="Some of these tests deadlock on CI")
 def test_max_events(
     default_project,
     reset_snuba,


### PR DESCRIPTION
Temporary workaround for tests not working on CI.

```
tests/sentry/tasks/test_reprocessing2.py .

No output has been received in the last 10m0s, this potentially indicates a
stalled build or something wrong with the build itself.
```