### PR TITLE
feat(metric_alerts): Update alert rule api to accept `event_type` list (WOR-317)

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -586,6 +586,7 @@ def create_alert_rule(
     excluded_projects=None,
     dataset=QueryDatasets.EVENTS,
     user=None,
+    event_types=None,
     **kwargs
 ):
     """
@@ -610,6 +611,7 @@ def create_alert_rule(
     :param excluded_projects: List of projects to exclude if we're using
     `include_all_projects`.
     :param dataset: The dataset that this query will be executed on
+    :param event_types: List of `EventType` that this alert will be related to
 
     :return: The created `AlertRule`
     """
@@ -625,6 +627,7 @@ def create_alert_rule(
             timedelta(minutes=time_window),
             timedelta(minutes=resolution),
             environment,
+            event_types=event_types,
         )
         alert_rule = AlertRule.objects.create(
             organization=organization,
@@ -710,6 +713,7 @@ def update_alert_rule(
     include_all_projects=None,
     excluded_projects=None,
     user=None,
+    event_types=None,
     **kwargs
 ):
     """
@@ -733,6 +737,7 @@ def update_alert_rule(
     from this organization
     :param excluded_projects: List of projects to exclude if we're using
     `include_all_projects`. Ignored otherwise.
+    :param event_types: List of `EventType` that this alert will be related to
     :return: The updated `AlertRule`
     """
     if (
@@ -763,6 +768,8 @@ def update_alert_rule(
         updated_fields["include_all_projects"] = include_all_projects
     if dataset is not None and dataset.value != alert_rule.snuba_query.dataset:
         updated_query_fields["dataset"] = dataset
+    if event_types is not None:
+        updated_query_fields["event_types"] = event_types
 
     with transaction.atomic():
         incidents = Incident.objects.filter(alert_rule=alert_rule).exists()
@@ -781,6 +788,7 @@ def update_alert_rule(
             updated_query_fields.setdefault(
                 "time_window", timedelta(seconds=snuba_query.time_window)
             )
+            updated_query_fields.setdefault("event_types", None)
             update_snuba_query(
                 alert_rule.snuba_query,
                 resolution=timedelta(minutes=DEFAULT_ALERT_RULE_RESOLUTION),

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -875,6 +875,7 @@ class Factories(object):
         threshold_type=AlertRuleThresholdType.ABOVE,
         resolve_threshold=None,
         user=None,
+        event_types=None,
     ):
         if not name:
             name = petname.Generate(2, " ", letters=10).title()
@@ -894,6 +895,7 @@ class Factories(object):
             include_all_projects=include_all_projects,
             excluded_projects=excluded_projects,
             user=user,
+            event_types=event_types,
         )
 
         if date_added is not None:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from sentry.api.serializers import serialize
 from sentry.incidents.models import AlertRule, AlertRuleThresholdType
 from sentry.models.organizationmember import OrganizationMember
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils import json
@@ -58,6 +58,7 @@ class AlertRuleBase(object):
                     ],
                 },
             ],
+            "event_types": [SnubaQueryEventType.EventType.ERROR.name.lower()],
         }
 
 

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -45,6 +45,7 @@ class CreateSnubaQueryTest(TestCase):
         assert snuba_query.time_window == int(time_window.total_seconds())
         assert snuba_query.resolution == int(resolution.total_seconds())
         assert snuba_query.environment == self.environment
+        assert set(snuba_query.event_types) == set([SnubaQueryEventType.EventType.ERROR])
 
     def test_event_types(self):
         dataset = QueryDatasets.EVENTS
@@ -131,19 +132,30 @@ class UpdateSnubaQueryTest(TestCase):
             timedelta(minutes=100),
             timedelta(minutes=2),
             self.environment,
+            [SnubaQueryEventType.EventType.ERROR],
         )
         dataset = QueryDatasets.TRANSACTIONS
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
-        update_snuba_query(snuba_query, dataset, query, aggregate, time_window, resolution, None)
+        event_types = [SnubaQueryEventType.EventType.ERROR, SnubaQueryEventType.EventType.DEFAULT]
+        update_snuba_query(
+            snuba_query, dataset, query, aggregate, time_window, resolution, None, event_types,
+        )
         assert snuba_query.dataset == dataset.value
         assert snuba_query.query == query
         assert snuba_query.aggregate == aggregate
         assert snuba_query.time_window == int(time_window.total_seconds())
         assert snuba_query.resolution == int(resolution.total_seconds())
         assert snuba_query.environment is None
+        assert set(snuba_query.event_types) == set(event_types)
+
+        event_types = [SnubaQueryEventType.EventType.DEFAULT]
+        update_snuba_query(
+            snuba_query, dataset, query, aggregate, time_window, resolution, None, event_types,
+        )
+        assert set(snuba_query.event_types) == set(event_types)
 
     def test_environment(self):
         snuba_query = create_snuba_query(
@@ -161,13 +173,17 @@ class UpdateSnubaQueryTest(TestCase):
         aggregate = "count()"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
-        update_snuba_query(snuba_query, dataset, query, aggregate, time_window, resolution, new_env)
+        event_types = snuba_query.event_types
+        update_snuba_query(
+            snuba_query, dataset, query, aggregate, time_window, resolution, new_env, None
+        )
         assert snuba_query.dataset == dataset.value
         assert snuba_query.query == query
         assert snuba_query.aggregate == aggregate
         assert snuba_query.time_window == int(time_window.total_seconds())
         assert snuba_query.resolution == int(resolution.total_seconds())
         assert snuba_query.environment == new_env
+        assert set(snuba_query.event_types) == set(event_types)
 
     def test_subscriptions(self):
         snuba_query = create_snuba_query(
@@ -186,7 +202,9 @@ class UpdateSnubaQueryTest(TestCase):
         aggregate = "count()"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
-        update_snuba_query(snuba_query, dataset, query, aggregate, time_window, resolution, new_env)
+        update_snuba_query(
+            snuba_query, dataset, query, aggregate, time_window, resolution, new_env, None
+        )
         sub.refresh_from_db()
         assert sub.snuba_query == snuba_query
         assert sub.status == QuerySubscription.Status.UPDATING.value


### PR DESCRIPTION
This allows frontend to pass `eventTypes` to the create/update metric alerts endpoints. This
parameter is a list of strings representing the event types associated with this alert - `error`,
`default`, etc.

Depends on https://github.com/getsentry/sentry/pull/21261