### PR TITLE
fix(slack): Check for valid workspace

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1159,9 +1159,13 @@ def get_alert_rule_trigger_action_slack_channel_id(name, organization, integrati
     from sentry.integrations.slack.utils import get_channel_id
 
     try:
-        _prefix, channel_id, timed_out = get_channel_id(organization, integration_id, name)
-    except DuplicateDisplayNameError as e:
         integration = Integration.objects.get(id=integration_id)
+    except Integration.DoesNotExist:
+        raise InvalidTriggerActionError("Slack workspace is a required field.")
+
+    try:
+        _prefix, channel_id, timed_out = get_channel_id(organization, integration, name)
+    except DuplicateDisplayNameError as e:
         domain = integration.metadata["domain_name"]
 
         raise InvalidTriggerActionError(

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -80,9 +80,10 @@ class SlackNotifyServiceForm(forms.Form):
         # are assuming that they passed in the correct channel_id for the channel
         if not channel_id:
             try:
-                channel_prefix, channel_id, timed_out = self.channel_transformer(workspace, channel)
+                channel_prefix, channel_id, timed_out = self.channel_transformer(
+                    integration, channel
+                )
             except DuplicateDisplayNameError as e:
-                integration = Integration.objects.get(id=workspace)
                 domain = integration.metadata["domain_name"]
 
                 params = {"channel": e.message, "domain": domain}
@@ -225,5 +226,5 @@ class SlackNotifyServiceAction(EventAction):
             self.data, integrations=self.get_integrations(), channel_transformer=self.get_channel_id
         )
 
-    def get_channel_id(self, integration_id, name):
-        return get_channel_id(self.project.organization, integration_id, name)
+    def get_channel_id(self, integration, name):
+        return get_channel_id(self.project.organization, integration, name)

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -66,7 +66,13 @@ class SlackNotifyServiceForm(forms.Form):
         cleaned_data = super(SlackNotifyServiceForm, self).clean()
 
         workspace = cleaned_data.get("workspace")
-        # TODO(Steve): Add check that workspace exists
+        try:
+            integration = Integration.objects.get(id=workspace)
+        except Integration.DoesNotExist:
+            raise forms.ValidationError(
+                _("Slack workspace is a required field.",), code="invalid",
+            )
+
         channel = cleaned_data.get("channel", "")
 
         # XXX(meredith): If the user is creating/updating a rule via the API and provides

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -365,7 +365,7 @@ def get_channel_id(organization, integration, name):
     """
    Fetches the internal slack id of a channel.
    :param organization: The organization that is using this integration
-   :param integration: The integration of this slack integration
+   :param integration: The slack integration
    :param name: The name of the channel
    :return: a tuple of three values
        1. prefix: string (`"#"` or `"@"`)

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -361,7 +361,7 @@ def strip_channel_name(name):
     return name.lstrip(strip_channel_chars)
 
 
-def get_channel_id(organization, integration_id, name):
+def get_channel_id(organization, integration, name):
     """
    Fetches the internal slack id of a channel.
    :param organization: The organization that is using this integration
@@ -374,12 +374,6 @@ def get_channel_id(organization, integration_id, name):
    """
 
     name = strip_channel_name(name)
-    try:
-        integration = Integration.objects.get(
-            provider="slack", organizations=organization, id=integration_id
-        )
-    except Integration.DoesNotExist:
-        return None, None, False
 
     # XXX(meredith): For large accounts that have many, many channels it's
     # possible for us to timeout while attempting to paginate through to find the channel id

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -365,7 +365,7 @@ def get_channel_id(organization, integration, name):
     """
    Fetches the internal slack id of a channel.
    :param organization: The organization that is using this integration
-   :param integration_id: The integration id of this slack integration
+   :param integration: The integration of this slack integration
    :param name: The name of the channel
    :return: a tuple of three values
        1. prefix: string (`"#"` or `"@"`)

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -279,3 +279,12 @@ class SlackNotifyActionTest(RuleTestCase):
 
         form = rule.get_form_instance()
         assert form.is_valid()
+
+    def test_invalid_workspace(self):
+        # the workspace _should_ be the integration id
+
+        rule = self.get_rule(data={"workspace": "unknown", "channel": "#my-channel", "tags": ""})
+
+        form = rule.get_form_instance()
+        assert not form.is_valid()
+        assert [u"Slack workspace is a required field."] in form.errors.values()

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -66,7 +66,7 @@ class GetChannelIdWorkspaceTest(TestCase):
 
     def run_valid_test(self, channel, expected_prefix, expected_id, timed_out):
         assert (expected_prefix, expected_id, timed_out) == get_channel_id(
-            self.organization, self.integration.id, channel
+            self.organization, self.integration, channel
         )
 
     def test_valid_channel_selected(self):
@@ -83,11 +83,11 @@ class GetChannelIdWorkspaceTest(TestCase):
 
     def test_invalid_member_selected_display_name(self):
         with pytest.raises(DuplicateDisplayNameError):
-            get_channel_id(self.organization, self.integration.id, "@Morty")
+            get_channel_id(self.organization, self.integration, "@Morty")
 
     def test_invalid_channel_selected(self):
-        assert get_channel_id(self.organization, self.integration.id, "#fake-channel")[1] is None
-        assert get_channel_id(self.organization, self.integration.id, "@fake-user")[1] is None
+        assert get_channel_id(self.organization, self.integration, "#fake-channel")[1] is None
+        assert get_channel_id(self.organization, self.integration, "@fake-user")[1] is None
 
 
 class GetChannelIdBotTest(GetChannelIdWorkspaceTest):


### PR DESCRIPTION
**Context:**
There is a sentry error (SENTRY-HB3) that is caused when we don't have a valid workspace for a rule that is trying to set up a Slack action. The workspace is a Django `forms.ChoiceField` where we render the name of the Slack workspace and save the `integration_id` associated with that workspace in the rule data. 

We never deleted alert rules if you deleted your Slack integration. We _used_ to show `"[removed]"` in the details of the alert rules if you were looking at the list of them, but that looks like it's removed. ANYWAY. There are two cases where we are running into this bug:

1. Someone deleted Slack, but didn't update their rules. Now they are trying to update the rule again but there is no workspace to choose from.
2. Someone is using the API manually (in the sentry error if you look under "events" you can see this to be true) and they are passing in the workspace as the Slack workspace name, not the `integration_id`.

**Solution(ish)**
* Update `get_channel_id` to take the integration instead of the `integration_id`.

* Add a validation error for when we aren't able to get the integration. Because this is in the `clean` method, we hit the bug instead of hitting the validation error on the workspace field that would have been raised. 

<img width="1144" alt="Screen Shot 2020-10-12 at 4 38 17 PM" src="https://user-images.githubusercontent.com/15368179/95801209-79120900-0cae-11eb-9dd7-7b4e0cb0fa05.png">

This doesn't make it any clearer to the users doing this with an API token though. Not sure what the best thing is to do there since it's definitely not clear what that value actually should be. 

FIXES SENTRY-HB3