### PR TITLE
fix(incidents): Make sure that one failing snapshot doesn't block the snapshot queue.

### DIFF
--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from django.db import transaction
 from django.core.urlresolvers import reverse
 from django.utils import timezone
@@ -25,6 +27,8 @@ from sentry.tasks.base import instrumented_task
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
 
 INCIDENTS_SNUBA_SUBSCRIPTION_TYPE = "incidents"
 
@@ -215,11 +219,14 @@ def process_pending_incident_snapshots():
             process_pending_incident_snapshots.apply_async(countdown=1)
             break
         else:
-            with transaction.atomic():
-                if (
-                    incident.status == IncidentStatus.CLOSED.value
-                    and not IncidentSnapshot.objects.filter(incident=incident).exists()
-                ):
-                    if IncidentProject.objects.filter(incident=incident).exists():
-                        create_incident_snapshot(incident, windowed_stats=True)
-                pending_snapshot.delete()
+            try:
+                with transaction.atomic():
+                    if (
+                        incident.status == IncidentStatus.CLOSED.value
+                        and not IncidentSnapshot.objects.filter(incident=incident).exists()
+                    ):
+                        if IncidentProject.objects.filter(incident=incident).exists():
+                            create_incident_snapshot(incident, windowed_stats=True)
+                    pending_snapshot.delete()
+            except Exception:
+                logger.exception("An error occurred while taking an incident snapshot")


### PR DESCRIPTION
If we encounter an error while attempting to create a snapshot, just continue and process the rest
of the queue. We should still fix these errors separately, but we don't want to block the queue
entirely if something is broken.