### PR TITLE
ref(gha): Fix pip cache and update to `actions/cache@v2`

### DIFF
--- a/.github/actions/setup-pip/action.yml
+++ b/.github/actions/setup-pip/action.yml
@@ -1,6 +1,7 @@
-# TODO(gha): Move this into `setup-sentry` action when
-# GitHub adds support for using other actions in composite actions
-# as ideally this would do `uses: actions/cache` in here instead of workflow
+# TODO(gha): Move restoring pip caches in here when GitHub
+# adds support for using other actions in composite actions
+# as ideally this action would do `uses: actions/cache` in here
+# instead of parent workflow
 name: 'pip Setup'
 description: 'Installs pip and configures cache dir as output. This is hopefully temporary, until composite actions can use other actions.'
 

--- a/.github/actions/setup-pip/action.yml
+++ b/.github/actions/setup-pip/action.yml
@@ -1,0 +1,29 @@
+# TODO(gha): Move this into `setup-sentry` action when
+# GitHub adds support for using other actions in composite actions
+# as ideally this would do `uses: actions/cache` in here instead of workflow
+name: 'pip Setup'
+description: 'Installs pip and configures cache dir as output. This is hopefully temporary, until composite actions can use other actions.'
+
+outputs:
+  pip-cache-dir:
+    description: 'Path to pip cache'
+    value: ${{ steps.pip-cache.outputs.pip-cache }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup default environment variables
+      shell: bash
+      run: |
+        echo "PIP_DISABLE_PIP_VERSION_CHECK=on" >> $GITHUB_ENV
+
+    - name: Install pip
+      shell: bash
+      run: |
+        pip install --no-cache-dir --upgrade "pip>=20.0.2"
+
+    - name: Get pip cache dir
+      id: pip-cache
+      shell: bash
+      run: |
+        echo "::set-output name=pip-cache::$(pip cache dir)"

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -95,17 +95,6 @@ runs:
         echo "::set-output name=matrix-instance-number::$(($MATRIX_INSTANCE+1))"
         echo "::set-output name=acceptance-dir::.artifacts/visual-snapshots/acceptance"
 
-    - name: Install pip
-      shell: bash
-      run: |
-        pip install --no-cache-dir --upgrade "pip>=20.0.2"
-
-    - name: Get pip cache dir
-      id: pip-cache
-      shell: bash
-      run: |
-        echo "::set-output name=pip-cache::$(pip cache dir)"
-
     - name: Install python dependencies
       shell: bash
       run: |

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -64,7 +64,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -124,7 +124,7 @@ jobs:
         id: pip
 
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
@@ -137,7 +137,7 @@ jobs:
         with:
           python: 2
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.setup.outputs.yarn-cache-dir }}
@@ -202,7 +202,7 @@ jobs:
         id: pip
 
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-py3-${{ hashFiles('**/requirements-*.txt') }}
@@ -216,7 +216,7 @@ jobs:
           python: 3
 
       - name: yarn cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.setup.outputs.yarn-cache-dir }}

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -7,247 +7,255 @@ on:
   pull_request:
 
 jobs:
-    parse-commit-message:
-      if: ${{ github.ref != 'refs/heads/master' }}
-      runs-on: ubuntu-16.04
-      outputs:
-        commit: ${{ steps.commit.outputs.message }}
-      steps:
-        - uses: actions/checkout@v2
-          with:
-            ref: ${{ github.event.pull_request.head.sha }}
+  parse-commit-message:
+    if: ${{ github.ref != 'refs/heads/master' }}
+    runs-on: ubuntu-16.04
+    outputs:
+      commit: ${{ steps.commit.outputs.message }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
-        - name: Parse commit message
-          id: commit
-          run: |
-            echo "::set-output name=message::$(git show -s --format=%B)"
+      - name: Parse commit message
+        id: commit
+        run: |
+          echo "::set-output name=message::$(git show -s --format=%B)"
 
-    getsentry:
-      needs: parse-commit-message
-      if: ${{ contains(needs.parse-commit-message.outputs.commit, '#test-getsentry') }}
-      runs-on: ubuntu-16.04
-      steps:
-        - name: getsentry token
-          id: getsentry
-          uses: getsentry/action-github-app-token@v1
-          with:
-            app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
-            private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+  getsentry:
+    needs: parse-commit-message
+    if: ${{ contains(needs.parse-commit-message.outputs.commit, '#test-getsentry') }}
+    runs-on: ubuntu-16.04
+    steps:
+      - name: getsentry token
+        id: getsentry
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
+          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-        # Notify getsentry
-        - name: Dispatch getsentry tests
-          uses: actions/github-script@v3
-          with:
-            github-token: ${{ steps.getsentry.outputs.token }}
-            script: |
-              github.actions.createWorkflowDispatch({
-                owner: 'getsentry',
-                repo: 'getsentry',
-                workflow_id: 'acceptance.yml',
-                ref: 'master',
-                inputs: {
-                  'sentry-sha': '${{ github.event.pull_request.head.sha }}',
-                }
-              })
+      # Notify getsentry
+      - name: Dispatch getsentry tests
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ steps.getsentry.outputs.token }}
+          script: |
+            github.actions.createWorkflowDispatch({
+              owner: 'getsentry',
+              repo: 'getsentry',
+              workflow_id: 'acceptance.yml',
+              ref: 'master',
+              inputs: {
+                'sentry-sha': '${{ github.event.pull_request.head.sha }}',
+              }
+            })
 
-    jest:
-      runs-on: ubuntu-16.04
-      env:
-        VISUAL_HTML_ENABLE: 1
-      steps:
-        - uses: actions/checkout@v2
+  jest:
+    runs-on: ubuntu-16.04
+    env:
+      VISUAL_HTML_ENABLE: 1
+    steps:
+      - uses: actions/checkout@v2
 
-        - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v1
 
-        # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
-        - name: Get yarn cache directory path
-          id: yarn-cache-dir-path
-          run: echo "::set-output name=dir::$(yarn cache dir)"
+      # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-        - uses: actions/cache@v1
-          id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-          with:
-            path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-            restore-keys: |
-              ${{ runner.os }}-yarn-
+      - uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-        - name: Install dependencies
-          run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-        - name: jest
-          run: |
-            NODE_ENV=production yarn build-css
-            yarn test-ci --forceExit
+      - name: jest
+        run: |
+          NODE_ENV=production yarn build-css
+          yarn test-ci --forceExit
 
-        - name: Save HTML artifacts
-          uses: actions/upload-artifact@v2
-          with:
-            name: jest-html
-            path: .artifacts/visual-snapshots/jest
+      - name: Save HTML artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jest-html
+          path: .artifacts/visual-snapshots/jest
 
-        - name: Create Images from HTML
-          uses: getsentry/action-html-to-image@main
-          with:
-            base-path: .artifacts/visual-snapshots/jest
-            css-path: src/sentry/static/sentry/dist/sentry.css
+      - name: Create Images from HTML
+        uses: getsentry/action-html-to-image@main
+        with:
+          base-path: .artifacts/visual-snapshots/jest
+          css-path: src/sentry/static/sentry/dist/sentry.css
 
-        - name: Save snapshots
-          if: always()
-          uses: getsentry/action-visual-snapshot@v2
-          with:
-            save-only: true
-            snapshot-path: .artifacts/visual-snapshots
+      - name: Save snapshots
+        if: always()
+        uses: getsentry/action-visual-snapshot@v2
+        with:
+          save-only: true
+          snapshot-path: .artifacts/visual-snapshots
 
-    acceptance:
-      # TODO(joshuarli): Convert to py3 with snapshots. See other TODO as well.
-      runs-on: ubuntu-16.04
-      strategy:
-        matrix:
-          instance: [0, 1, 2]
+  acceptance:
+    # TODO(joshuarli): Convert to py3 with snapshots. See other TODO as well.
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        instance: [0, 1, 2]
 
-      env:
-        VISUAL_SNAPSHOT_ENABLE: 1
+    env:
+      VISUAL_SNAPSHOT_ENABLE: 1
 
-      steps:
-        - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-        - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v1
 
-        # Until GH composite actions can use `uses`, we need to setup python here
-        - uses: actions/setup-python@v2
-          with:
-            python-version: 2.7.17
+      # Until GH composite actions can use `uses`, we need to setup python here
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 2.7.17
 
-        - name: Setup sentry env
-          uses: ./.github/actions/setup-sentry
-          id: setup
-          with:
-            python: 2
+      - name: Setup pip
+        uses: ./.github/actions/setup-pip
+        id: pip
 
-        - uses: actions/cache@v1
-          id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-          with:
-            path: ${{ steps.setup.outputs.yarn-cache-dir }}
-            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-            restore-keys: |
-              ${{ runner.os }}-yarn-
+      - name: pip cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.pip.outputs.pip-cache-dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-        - name: pip cache
-          uses: actions/cache@v1
-          with:
-            path: ${{ steps.setup.outputs.pip-cache-dir }}
-            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
-            restore-keys: |
-              ${{ runner.os }}-pip-
+      - name: Setup sentry env
+        uses: ./.github/actions/setup-sentry
+        id: setup
+        with:
+          python: 2
 
-        - name: Install Javascript Dependencies
-          run: |
-            yarn install --frozen-lockfile
+      - uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.setup.outputs.yarn-cache-dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-        - name: webpack
-          run: |
-            yarn webpack --display errors-only
+      - name: Install Javascript Dependencies
+        run: |
+          yarn install --frozen-lockfile
 
-        - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
-          if: always()
-          run: |
-            mkdir -p ${{ steps.setup.outputs.acceptance-dir }}
-            mkdir -p ${{ steps.setup.outputs.acceptance-dir }}-mobile
-            mkdir -p ${{ steps.setup.outputs.acceptance-dir }}-tooltips
-            make run-acceptance
-          env:
-            PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
-            USE_SNUBA: 1
+      - name: webpack
+        run: |
+          yarn webpack --display errors-only
 
-        - name: Save snapshots
-          if: always()
-          uses: getsentry/action-visual-snapshot@v2
-          with:
-            save-only: true
-            snapshot-path: .artifacts/visual-snapshots
+      - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
+        if: always()
+        run: |
+          mkdir -p ${{ steps.setup.outputs.acceptance-dir }}
+          mkdir -p ${{ steps.setup.outputs.acceptance-dir }}-mobile
+          mkdir -p ${{ steps.setup.outputs.acceptance-dir }}-tooltips
+          make run-acceptance
+        env:
+          PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
+          USE_SNUBA: 1
 
-    py3-acceptance:
-      name: 'python3.6 acceptance'
-      runs-on: ubuntu-16.04
-      strategy:
-        matrix:
-          instance: [0, 1, 2]
+      - name: Save snapshots
+        if: always()
+        uses: getsentry/action-visual-snapshot@v2
+        with:
+          save-only: true
+          snapshot-path: .artifacts/visual-snapshots
 
-      env:
-        MIGRATIONS_TEST_MIGRATE: 1
-        VISUAL_SNAPSHOT_ENABLE: 1
+  py3-acceptance:
+    name: 'python3.6 acceptance'
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        instance: [0, 1, 2]
 
-      steps:
-        - uses: actions/checkout@v2
+    env:
+      MIGRATIONS_TEST_MIGRATE: 1
+      VISUAL_SNAPSHOT_ENABLE: 1
 
-        - uses: volta-cli/action@v1
+    steps:
+      - uses: actions/checkout@v2
 
-        - name: Set python version output
-          id: python-version
-          run: |
-            echo "::set-output name=python-version::$(awk 'FNR == 2' .python-version)"
+      - uses: volta-cli/action@v1
 
-        # Until GH composite actions can use `uses`, we need to setup python here
-        - uses: actions/setup-python@v2
-          with:
-            python-version: ${{ steps.python-version.outputs.python-version }}
+      - name: Set python version output
+        id: python-version
+        run: |
+          echo "::set-output name=python-version::$(awk 'FNR == 2' .python-version)"
 
-        - name: Setup sentry python env
-          uses: ./.github/actions/setup-sentry
-          id: setup
-          with:
-            python: 3
+      # Until GH composite actions can use `uses`, we need to setup python here
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ steps.python-version.outputs.python-version }}
 
-        - name: yarn cache
-          uses: actions/cache@v1
-          id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-          with:
-            path: ${{ steps.setup.outputs.yarn-cache-dir }}
-            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-            restore-keys: |
-              ${{ runner.os }}-yarn-
+      - name: Setup pip
+        uses: ./.github/actions/setup-pip
+        id: pip
 
-        - name: pip cache
-          uses: actions/cache@v1
-          with:
-            path: ${{ steps.setup.outputs.pip-cache-dir }}
-            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
-            restore-keys: |
-              ${{ runner.os }}-pip-
+      - name: pip cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.pip.outputs.pip-cache-dir }}
+          key: ${{ runner.os }}-pip-py3-${{ hashFiles('**/requirements-*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-py3
 
-        - name: Install Javascript Dependencies
-          run: |
-            yarn install --frozen-lockfile
+      - name: Setup sentry python env
+        uses: ./.github/actions/setup-sentry
+        id: setup
+        with:
+          python: 3
 
-        - name: webpack
-          run: |
-            yarn webpack --display errors-only
+      - name: yarn cache
+        uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.setup.outputs.yarn-cache-dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-        - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
-          if: always()
-          run: |
-            mkdir -p ${{ steps.setup.outputs.acceptance-dir }}
-            mkdir -p ${{ steps.setup.outputs.acceptance-dir }}-mobile
-            mkdir -p ${{ steps.setup.outputs.acceptance-dir }}-tooltips
-            make run-acceptance
-          env:
-            PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
-            USE_SNUBA: 1
+      - name: Install Javascript Dependencies
+        run: |
+          yarn install --frozen-lockfile
 
-        # TODO(joshuarli): SENTRY_PYTHON3=1, snapshots, visual-diff needs py3-acceptance.
+      - name: webpack
+        run: |
+          yarn webpack --display errors-only
 
-    visual-diff:
-      if: ${{ github.ref != 'refs/heads/master' }}
-      needs: [acceptance, jest]
-      runs-on: ubuntu-16.04
+      - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
+        if: always()
+        run: |
+          mkdir -p ${{ steps.setup.outputs.acceptance-dir }}
+          mkdir -p ${{ steps.setup.outputs.acceptance-dir }}-mobile
+          mkdir -p ${{ steps.setup.outputs.acceptance-dir }}-tooltips
+          make run-acceptance
+        env:
+          PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
+          USE_SNUBA: 1
 
-      steps:
-        - name: Diff snapshots
-          id: visual-snapshots-diff
-          uses: getsentry/action-visual-snapshot@v2
-          with:
-            api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            gcs-bucket: 'sentry-visual-snapshots'
-            gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
+      # TODO(joshuarli): SENTRY_PYTHON3=1, snapshots, visual-diff needs py3-acceptance.
+
+  visual-diff:
+    if: ${{ github.ref != 'refs/heads/master' }}
+    needs: [acceptance, jest]
+    runs-on: ubuntu-16.04
+
+    steps:
+      - name: Diff snapshots
+        id: visual-snapshots-diff
+        uses: getsentry/action-visual-snapshot@v2
+        with:
+          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gcs-bucket: 'sentry-visual-snapshots'
+          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -205,9 +205,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
-          key: ${{ runner.os }}-pip-py3-${{ hashFiles('**/requirements-*.txt') }}
+          key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-py3
+            ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}
 
       - name: Setup sentry python env
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/apidocstest.yml
+++ b/.github/workflows/apidocstest.yml
@@ -21,7 +21,7 @@ jobs:
       MIGRATIONS_TEST_MIGRATE: 0
 
       PYTEST_SENTRY_DSN: https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079
-      PYTEST_ADDOPTS: "--reruns 5"
+      PYTEST_ADDOPTS: '--reruns 5'
 
       # The hostname used to communicate with the PostgreSQL from sentry
       DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
@@ -43,7 +43,7 @@ jobs:
           echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
           echo "::set-output name=python-version::$(awk 'FNR == 2' .python-version)"
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.config.outputs.yarn-cache-dir }}
@@ -66,7 +66,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -11,99 +11,99 @@ on:
       - yarn.lock
 
 jobs:
-    getsentry:
-      if: ${{ github.ref != 'refs/heads/master' }}
-      runs-on: ubuntu-16.04
-      steps:
-        - name: getsentry token
-          id: getsentry
-          uses: getsentry/action-github-app-token@v1
-          with:
-            app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
-            private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+  getsentry:
+    if: ${{ github.ref != 'refs/heads/master' }}
+    runs-on: ubuntu-16.04
+    steps:
+      - name: getsentry token
+        id: getsentry
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
+          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-        # Notify getsentry
-        - name: Dispatch getsentry tests
-          uses: actions/github-script@v3
-          with:
-            github-token: ${{ steps.getsentry.outputs.token }}
-            script: |
-              github.actions.createWorkflowDispatch({
-                owner: 'getsentry',
-                repo: 'getsentry',
-                workflow_id: 'javascript.yml',
-                ref: 'master',
-                inputs: {
-                  'sentry-sha': '${{ github.event.pull_request.head.sha }}',
-                }
-              })
+      # Notify getsentry
+      - name: Dispatch getsentry tests
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ steps.getsentry.outputs.token }}
+          script: |
+            github.actions.createWorkflowDispatch({
+              owner: 'getsentry',
+              repo: 'getsentry',
+              workflow_id: 'javascript.yml',
+              ref: 'master',
+              inputs: {
+                'sentry-sha': '${{ github.event.pull_request.head.sha }}',
+              }
+            })
 
-    build:
-      name: lint and typescript
-      if: ${{ github.ref != 'refs/heads/master' }}
-      runs-on: ubuntu-16.04
-      steps:
-        - uses: actions/checkout@v2
+  build:
+    name: lint and typescript
+    if: ${{ github.ref != 'refs/heads/master' }}
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
 
-        - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v1
 
-        # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
-        - name: Get yarn cache directory path
-          id: yarn-cache-dir-path
-          run: echo "::set-output name=dir::$(yarn cache dir)"
+      # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-        - uses: actions/cache@v1
-          id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-          with:
-            path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-            restore-keys: |
-              ${{ runner.os }}-yarn-
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-        - name: Install dependencies
-          run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-        - name: eslint + fix
-          uses: getsentry/action-eslint-fix@master
-          with:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: eslint + fix
+        uses: getsentry/action-eslint-fix@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        # Setup custom tsc matcher, see https://github.com/actions/setup-node/issues/97
-        - name: tsc
-          id: tsc
-          if: always()
-          run: |
-            echo "::remove-matcher owner=tsc::"
-            echo "::add-matcher::.github/tsc.json"
-            yarn tsc -p config/tsconfig.build.json
+      # Setup custom tsc matcher, see https://github.com/actions/setup-node/issues/97
+      - name: tsc
+        id: tsc
+        if: always()
+        run: |
+          echo "::remove-matcher owner=tsc::"
+          echo "::add-matcher::.github/tsc.json"
+          yarn tsc -p config/tsconfig.build.json
 
-    webpack:
-      runs-on: ubuntu-16.04
-      steps:
-        - uses: actions/checkout@v2
+  webpack:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
 
-        - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v1
 
-        # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
-        - name: Get yarn cache directory path
-          id: yarn-cache-dir-path
-          run: echo "::set-output name=dir::$(yarn cache dir)"
+      # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-        - uses: actions/cache@v1
-          id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-          with:
-            path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-            restore-keys: |
-              ${{ runner.os }}-yarn-
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-        - name: Install dependencies
-          run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-        - uses: getsentry/size-limit-action@v1-dev
-          with:
-            main_branch: master
-            skip_step: install
-            build_script: build
-            windows_verbatim_arguments: false
-            github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: getsentry/size-limit-action@v1-dev
+        with:
+          main_branch: master
+          skip_step: install
+          build_script: build
+          windows_verbatim_arguments: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -5,95 +5,95 @@ on:
       - 'src/sentry/migrations/*'
 
 jobs:
-    sql:
-      name: Generate SQL
-      runs-on: ubuntu-16.04
+  sql:
+    name: Generate SQL
+    runs-on: ubuntu-16.04
 
-      env:
-        PIP_DISABLE_PIP_VERSION_CHECK: on
-        SENTRY_LIGHT_BUILD: 1
-        SENTRY_SKIP_BACKEND_VALIDATION: 1
-        MIGRATIONS_TEST_MIGRATE: 0
+    env:
+      PIP_DISABLE_PIP_VERSION_CHECK: on
+      SENTRY_LIGHT_BUILD: 1
+      SENTRY_SKIP_BACKEND_VALIDATION: 1
+      MIGRATIONS_TEST_MIGRATE: 0
 
-        # The hostname used to communicate with the PostgreSQL from sentry
-        DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
+      # The hostname used to communicate with the PostgreSQL from sentry
+      DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
 
-      services:
-        postgres:
-          image: postgres:9.6
-          env:
-            POSTGRES_USER: postgres
-            POSTGRES_PASSWORD: postgres
-          ports:
-            # Maps tcp port 5432 on service container to the host
-            - 5432:5432
-          # needed because the postgres container does not provide a healthcheck
-          options: >-
-            --health-cmd pg_isready
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
+    services:
+      postgres:
+        image: postgres:9.6
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
-      steps:
-        - name: Install System Dependencies
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends \
-              libxmlsec1-dev \
-              libmaxminddb-dev
+    steps:
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libxmlsec1-dev \
+            libmaxminddb-dev
 
-        - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-        - name: Get changed migration files
-          id: file
-          run: |
-            echo $(git diff --diff-filter=AM --name-only origin/master HEAD)
-            echo "::set-output name=modified::$(git diff --diff-filter=AM --name-only origin/master HEAD | grep 'src/sentry/migrations/')"
+      - name: Get changed migration files
+        id: file
+        run: |
+          echo $(git diff --diff-filter=AM --name-only origin/master HEAD)
+          echo "::set-output name=modified::$(git diff --diff-filter=AM --name-only origin/master HEAD | grep 'src/sentry/migrations/')"
 
-        - name: Set up outputs
-          id: config
-          env:
-            MATRIX_INSTANCE: ${{ matrix.instance }}
-          run: |
-            echo "::set-output name=python-version::2.7.17"
+      - name: Set up outputs
+        id: config
+        env:
+          MATRIX_INSTANCE: ${{ matrix.instance }}
+        run: |
+          echo "::set-output name=python-version::2.7.17"
 
-        - name: Set up Python ${{ steps.config.outputs.python-version }}
-          uses: actions/setup-python@v2
-          with:
-            python-version: ${{ steps.config.outputs.python-version}}
+      - name: Set up Python ${{ steps.config.outputs.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ steps.config.outputs.python-version}}
 
-        - name: Install pip
-          run: |
-            pip install --no-cache-dir --upgrade "pip>=20.0.2"
+      - name: Install pip
+        run: |
+          pip install --no-cache-dir --upgrade "pip>=20.0.2"
 
-        - name: Get pip cache dir
-          id: pip-cache
-          run: |
-            echo "::set-output name=dir::$(pip cache dir)"
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
 
-        - name: pip cache
-          uses: actions/cache@v1
-          with:
-            path: ${{ steps.pip-cache.outputs.dir }}
-            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
-            restore-keys: |
-              ${{ runner.os }}-pip-
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-        - name: Install Python Dependencies
-          env:
-            PGPASSWORD: postgres
-          run: |
-            python setup.py install_egg_info
-            pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
-            pip install -U -e ".[dev]"
-            psql -c 'create database sentry;' -h localhost -U postgres
-            sentry init
+      - name: Install Python Dependencies
+        env:
+          PGPASSWORD: postgres
+        run: |
+          python setup.py install_egg_info
+          pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
+          pip install -U -e ".[dev]"
+          psql -c 'create database sentry;' -h localhost -U postgres
+          sentry init
 
-        - name: Generate SQL for migration
-          uses: getsentry/action-migrations@v1.0.7
-          env:
-            SENTRY_LOG_LEVEL: ERROR
-            PGPASSWORD: postgres
-          with:
-            githubToken: ${{ secrets.GITHUB_TOKEN }}
-            migration: ${{ steps.file.outputs.modified }}
+      - name: Generate SQL for migration
+        uses: getsentry/action-migrations@v1.0.7
+        env:
+          SENTRY_LOG_LEVEL: ERROR
+          PGPASSWORD: postgres
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          migration: ${{ steps.file.outputs.modified }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -128,9 +128,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
+          key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
@@ -180,9 +180,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
-          key: ${{ runner.os }}-pip-py3-${{ hashFiles('**/requirements-*.txt') }}
+          key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-py3
+            ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,19 +64,14 @@ jobs:
         with:
           python-version: ${{ steps.config.outputs.python-version}}
 
-      - name: Install pip
-        run: |
-          pip install --no-cache-dir --upgrade "pip>=20.0.2"
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+      - name: Setup pip
+        uses: ./.github/actions/setup-pip
+        id: pip
 
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
@@ -130,7 +125,7 @@ jobs:
         id: pip
 
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
@@ -182,7 +177,7 @@ jobs:
         id: pip
 
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-py3-${{ hashFiles('**/requirements-*.txt') }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -120,25 +120,28 @@ jobs:
         run: |
           echo "::set-output name=python-version::$(awk 'FNR == 2' .python-version)"
 
-
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ steps.python-version.outputs.python-version }}
+
+      - name: Setup pip
+        uses: ./.github/actions/setup-pip
+        id: pip
+
+      - name: pip cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.pip.outputs.pip-cache-dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
           python: 3
-
-      - name: pip cache
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.setup.outputs.pip-cache-dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
 
       - name: Python 3.6 backend (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
         if: always()
@@ -169,11 +172,22 @@ jobs:
         run: |
           echo "::set-output name=python-version::$(awk 'FNR == 2' .python-version)"
 
-
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ steps.python-version.outputs.python-version }}
+
+      - name: Setup pip
+        uses: ./.github/actions/setup-pip
+        id: pip
+
+      - name: pip cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.pip.outputs.pip-cache-dir }}
+          key: ${{ runner.os }}-pip-py3-${{ hashFiles('**/requirements-*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-py3
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry


### PR DESCRIPTION
Due to https://github.com/getsentry/sentry/pull/21203 - we are restoring
pip cache *AFTER* we `pip install`. We need to temporarily refactor pip
into its own action as we can not yet use other actions in composite
actions. (Thanks for catching this @joshuarli)

This also updates to `actions/cache@v2`.