### PR TITLE
fix(csp): Correctly extract message for metadata in csp and co

### DIFF
--- a/src/sentry/eventtypes/security.py
+++ b/src/sentry/eventtypes/security.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
-from .base import DefaultEvent
+from .base import BaseEvent
+
+from sentry.utils.strings import strip
+from sentry.utils.safe import get_path
 
 LOCAL = "'self'"
 
@@ -24,50 +27,60 @@ def _normalize_uri(value):
     return urlunsplit((scheme, hostname, "", None, None))
 
 
-class CspEvent(DefaultEvent):
+class SecurityEvent(BaseEvent):
+    def get_metadata(self, data):
+        # Relay normalizes the message for security reports into the log entry
+        # field, so we grab the message from there.
+        # (https://github.com/getsentry/relay/pull/558)
+        message = strip(
+            get_path(data, "logentry", "formatted") or get_path(data, "logentry", "message")
+        )
+        return {"message": message}
+
+    def get_title(self, metadata):
+        # Due to a regression (https://github.com/getsentry/sentry/pull/19794)
+        # some events did not have message persisted but title. Because of this
+        # the title code has to take these into account.
+        return metadata.get("message") or metadata.get("title") or "<untitled>"
+
+    def get_location(self, metadata):
+        # Try to get location by preferring URI over origin.  This covers
+        # all the cases below where CSP sets URI and others set origin.
+        return metadata.get("uri") or metadata.get("origin")
+
+
+class CspEvent(SecurityEvent):
     key = "csp"
 
     def get_metadata(self, data):
-        metadata = DefaultEvent.get_metadata(self, data)
+        metadata = SecurityEvent.get_metadata(self, data)
         metadata["uri"] = _normalize_uri(data["csp"].get("blocked_uri") or "")
         metadata["directive"] = data["csp"].get("effective_directive")
         return metadata
 
-    def get_location(self, metadata):
-        return metadata.get("uri")
 
-
-class HpkpEvent(DefaultEvent):
+class HpkpEvent(SecurityEvent):
     key = "hpkp"
 
     def get_metadata(self, data):
-        metadata = DefaultEvent.get_metadata(self, data)
+        metadata = SecurityEvent.get_metadata(self, data)
         metadata["origin"] = data["hpkp"].get("hostname")
         return metadata
 
-    def get_location(self, metadata):
-        return metadata.get("origin")
 
-
-class ExpectCTEvent(DefaultEvent):
+class ExpectCTEvent(SecurityEvent):
     key = "expectct"
 
     def get_metadata(self, data):
-        metadata = DefaultEvent.get_metadata(self, data)
+        metadata = SecurityEvent.get_metadata(self, data)
         metadata["origin"] = data["expectct"].get("hostname")
         return metadata
 
-    def get_location(self, metadata):
-        return metadata.get("origin")
 
-
-class ExpectStapleEvent(DefaultEvent):
+class ExpectStapleEvent(SecurityEvent):
     key = "expectstaple"
 
     def get_metadata(self, data):
-        metadata = DefaultEvent.get_metadata(self, data)
+        metadata = SecurityEvent.get_metadata(self, data)
         metadata["origin"] = data["expectstaple"].get("hostname")
         return metadata
-
-    def get_location(self, metadata):
-        return metadata.get("origin")

--- a/src/sentry/static/sentry/app/utils/events.tsx
+++ b/src/sentry/static/sentry/app/utils/events.tsx
@@ -54,7 +54,10 @@ export function getTitle(event: Event | Group): EventTitle {
     result.title = metadata.directive || '';
     result.subtitle = metadata.uri || '';
   } else if (type === 'expectct' || type === 'expectstaple' || type === 'hpkp') {
-    result.title = metadata.message || '';
+    // Due to a regression some reports did not have message persisted
+    // (https://github.com/getsentry/sentry/pull/19794) so we need to fall
+    // back to the computed title for these.
+    result.title = metadata.message || result.title || '';
     result.subtitle = metadata.origin || '';
   } else if (type === 'default') {
     result.title = metadata.title || '';

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_basic.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_basic.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:14:40.325084Z'
+created: '2020-10-13T11:56:18.160211Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: style-src
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: example.com
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   blocked_uri: http://example.com/lol.css
   document_uri: http://example.com

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_coerce_blocked_uri_if_missing.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_coerce_blocked_uri_if_missing.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:14:40.332911Z'
+created: '2020-10-13T11:56:18.178328Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: script-src
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: '''self'''
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   document_uri: http://example.com
   effective_directive: script-src

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input0.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input0.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:22:50.644896Z'
+created: '2020-10-13T11:56:18.196473Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: img-src
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: google.com
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   blocked_uri: http://google.com/foo
   document_uri: http://example.com/foo

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input1.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input1.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:22:50.654549Z'
+created: '2020-10-13T11:56:18.215897Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: style-src
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: '''self'''
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   blocked_uri: ''
   document_uri: http://example.com/foo

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input2.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input2.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:22:50.665631Z'
+created: '2020-10-13T11:56:18.235225Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: script-src
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: '''self'''
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   blocked_uri: ''
   document_uri: http://example.com/foo

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input3.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input3.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:22:50.676447Z'
+created: '2020-10-13T11:56:18.253370Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: script-src
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: '''self'''
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   blocked_uri: ''
   document_uri: http://example.com/foo

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input4.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input4.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:22:50.686392Z'
+created: '2020-10-13T11:56:18.272290Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: script-src
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: '''self'''
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   blocked_uri: ''
   document_uri: http://example.com/foo

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input5.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input5.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:22:50.696501Z'
+created: '2020-10-13T11:56:18.290455Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: script-src
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: 'data:'
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   blocked_uri: data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D
   document_uri: http://example.com/foo

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input6.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input6.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:22:50.706905Z'
+created: '2020-10-13T11:56:18.307892Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: script-src
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: 'data:'
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   blocked_uri: data
   document_uri: http://example.com/foo

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input7.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input7.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:22:50.717311Z'
+created: '2020-10-13T11:56:18.326496Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: style-src-elem
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: fonts.google.com
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   blocked_uri: http://fonts.google.com/foo
   document_uri: http://example.com/foo

--- a/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input8.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_csp/test_get_message/input8.pysnap
@@ -1,9 +1,14 @@
 ---
-created: '2020-07-09T22:22:50.727784Z'
+created: '2020-10-13T11:56:18.343570Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_csp.py
 ---
 errors: null
+metadata:
+  directive: script-src-elem
+  message: XXX CSP MESSAGE NOT THROUGH RELAY XXX
+  uri: cdn.ajaxapis.com
+title: XXX CSP MESSAGE NOT THROUGH RELAY XXX
 to_json:
   blocked_uri: http://cdn.ajaxapis.com/foo
   document_uri: http://example.com/foo

--- a/tests/sentry/event_manager/interfaces/snapshots/test_expectct/test_basic.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_expectct/test_basic.pysnap
@@ -1,9 +1,13 @@
 ---
-created: '2019-03-14T17:12:35.477288Z'
+created: '2020-10-13T11:56:18.763884Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_expectct.py
 ---
 errors: null
+metadata:
+  message: XXX EXPECTCT MESSAGE NOT THROUGH RELAY XXX
+  origin: www.example.com
+title: XXX EXPECTCT MESSAGE NOT THROUGH RELAY XXX
 to_json:
   date_time: '2014-04-06T13:00:50Z'
   effective_expiration_date: '2014-05-01T12:40:50Z'

--- a/tests/sentry/event_manager/interfaces/snapshots/test_expectstaple/test_basic.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_expectstaple/test_basic.pysnap
@@ -1,9 +1,13 @@
 ---
-created: '2019-03-14T17:12:35.497460Z'
+created: '2020-10-13T11:56:18.783515Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_expectstaple.py
 ---
 errors: null
+metadata:
+  message: XXX EXPECTSTAPLE MESSAGE NOT THROUGH RELAY XXX
+  origin: www.example.com
+title: XXX EXPECTSTAPLE MESSAGE NOT THROUGH RELAY XXX
 to_json:
   cert_status: REVOKED
   date_time: '2014-04-06T13:00:50Z'

--- a/tests/sentry/event_manager/interfaces/test_csp.py
+++ b/tests/sentry/event_manager/interfaces/test_csp.py
@@ -5,19 +5,28 @@ from __future__ import absolute_import
 import pytest
 
 from sentry import eventstore
-from sentry.event_manager import EventManager
+from sentry.event_manager import EventManager, materialize_metadata
 
 
 @pytest.fixture
 def make_csp_snapshot(insta_snapshot):
     def inner(data):
-        mgr = EventManager(data={"csp": data})
+        mgr = EventManager(
+            data={"csp": data, "logentry": {"message": "XXX CSP MESSAGE NOT THROUGH RELAY XXX"}}
+        )
         mgr.normalize()
-        evt = eventstore.create_event(data=mgr.get_data())
+        data = mgr.get_data()
+        data.update(materialize_metadata(data))
+        evt = eventstore.create_event(data=data)
         interface = evt.interfaces.get("csp")
 
         insta_snapshot(
-            {"errors": evt.data.get("errors"), "to_json": interface and interface.to_json()}
+            {
+                "errors": evt.data.get("errors"),
+                "to_json": interface and interface.to_json(),
+                "metadata": evt.get_event_metadata(),
+                "title": evt.title,
+            }
         )
 
     return inner

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -945,7 +945,9 @@ class EventManagerTest(TestCase):
                     "csp": {
                         "effective_directive": "script-src",
                         "blocked_uri": "http://example.com",
-                    }
+                    },
+                    # this normally is noramlized in relay as part of ingest
+                    "logentry": {"message": "Blocked 'script' from 'example.com'"},
                 }
             )
         )
@@ -958,9 +960,9 @@ class EventManagerTest(TestCase):
         assert group.data.get("metadata") == {
             "directive": "script-src",
             "uri": "example.com",
-            # Relay will add a logentry that fixes this title, just not as part of StoreNormalizer
-            "title": "<unlabeled event>",
+            "message": "Blocked 'script' from 'example.com'",
         }
+        assert group.title == "Blocked 'script' from 'example.com'"
 
     def test_transaction_event_type(self):
         manager = EventManager(


### PR DESCRIPTION
In https://github.com/getsentry/relay/pull/558 and https://github.com/getsentry/sentry/pull/19794 the metadata extraction for CSP and security
events broke.  It no longer extracts message which breaks the UI for such security
events.

This code reintroduces the message extractor, also hacks together some tests
for metadata extraction and adds a workaround to the UI for the events that
were ingested in a broken way in the meantime.

Because unfortunately security events only get normalized into log records
in the ingest endpoint and not in the store normalizer, the tests cannot
accurately test what is happening.  This could be solved by moving the code
into the store normalizer in relay.