### PR TITLE
fix(pypi): Use oss@sentry.io for author_email

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     name="sentry",
     version=VERSION,
     author="Sentry",
-    author_email="hello@sentry.io",
+    author_email="oss@sentry.io",
     url="https://sentry.io",
     description="A realtime logging and aggregation server.",
     long_description=open(os.path.join(ROOT, "README.md")).read(),


### PR DESCRIPTION
I don't think we monitor hello@sentry.io properly and even then, it is better to consolidate this under the oss@ group.
