### PR TITLE
feat(rum): Add CLS, TTFB, and Request Time measurements to Discover

### DIFF
--- a/src/sentry/static/sentry/app/utils/measurements/measurements.tsx
+++ b/src/sentry/static/sentry/app/utils/measurements/measurements.tsx
@@ -12,6 +12,12 @@ const MEASUREMENTS: MeasurementCollection = {
   'measurements.fcp': {name: 'First Contentful Paint', key: 'measurements.fcp'},
   'measurements.lcp': {name: 'Largest Contentful Paint', key: 'measurements.lcp'},
   'measurements.fid': {name: 'First Input Delay', key: 'measurements.fid'},
+  'measurements.cls': {name: 'Cumulative Layout Shift', key: 'measurements.cls'},
+  'measurements.ttfb': {name: 'Time to First Byte', key: 'measurements.ttfb'},
+  'measurements.ttfb.requesttime': {
+    name: 'Request Time',
+    key: 'measurements.ttfb.requesttime',
+  },
 };
 
 type ChildrenProps = {

--- a/src/sentry/static/sentry/app/utils/measurements/measurements.tsx
+++ b/src/sentry/static/sentry/app/utils/measurements/measurements.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-export type Measurement = {
+type Measurement = {
   name: string;
   key: string;
 };
 
-export type MeasurementCollection = {[key: string]: Measurement};
+type MeasurementCollection = {[key: string]: Measurement};
 
 const MEASUREMENTS: MeasurementCollection = {
   'measurements.fp': {name: 'First Paint', key: 'measurements.fp'},

--- a/src/sentry/static/sentry/app/utils/measurements/measurements.tsx
+++ b/src/sentry/static/sentry/app/utils/measurements/measurements.tsx
@@ -7,10 +7,6 @@ export type Measurement = {
 
 export type MeasurementCollection = {[key: string]: Measurement};
 
-type InjectedMeasurementsProps = {
-  measurements: MeasurementCollection;
-};
-
 const MEASUREMENTS: MeasurementCollection = {
   'measurements.fp': {name: 'First Paint', key: 'measurements.fp'},
   'measurements.fcp': {name: 'First Contentful Paint', key: 'measurements.fcp'},
@@ -18,20 +14,22 @@ const MEASUREMENTS: MeasurementCollection = {
   'measurements.fid': {name: 'First Input Delay', key: 'measurements.fid'},
 };
 
-const withMeasurements = <P extends InjectedMeasurementsProps>(
-  WrappedComponent: React.ComponentType<P>
-) =>
-  class extends React.Component<Omit<P, keyof InjectedMeasurementsProps>> {
-    render() {
-      return (
-        <WrappedComponent
-          {...({
-            measurements: MEASUREMENTS,
-            ...this.props,
-          } as P)}
-        />
-      );
-    }
-  };
+type ChildrenProps = {
+  measurements: MeasurementCollection;
+};
 
-export default withMeasurements;
+type Props = {
+  children: (props: ChildrenProps) => React.ReactNode;
+};
+
+function Measurements(props: Props) {
+  return (
+    <React.Fragment>
+      {props.children({
+        measurements: MEASUREMENTS,
+      })}
+    </React.Fragment>
+  );
+}
+
+export default Measurements;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -8,7 +8,7 @@ import {Organization, TagCollection} from 'app/types';
 import {metric} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
 import withTags from 'app/utils/withTags';
-import withMeasurements, {MeasurementCollection} from 'app/utils/withMeasurements';
+import Measurements, {MeasurementCollection} from 'app/utils/measurements/measurements';
 import Pagination from 'app/components/pagination';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import {TableData} from 'app/utils/discover/discoverQuery';
@@ -147,29 +147,35 @@ class Table extends React.PureComponent<TableProps, TableState> {
   };
 
   render() {
-    const {eventView, tags, measurements} = this.props;
+    const {eventView, tags} = this.props;
     const {pageLinks, tableData, isLoading, error} = this.state;
     const tagKeys = Object.values(tags).map(({key}) => key);
-    const measurementKeys = Object.values(measurements).map(({key}) => key);
 
     return (
       <Container>
-        <TableView
-          {...this.props}
-          isLoading={isLoading}
-          error={error}
-          eventView={eventView}
-          tableData={tableData}
-          tagKeys={tagKeys}
-          measurementKeys={measurementKeys}
-        />
+        <Measurements>
+          {({measurements}) => {
+            const measurementKeys = Object.values(measurements).map(({key}) => key);
+            return (
+              <TableView
+                {...this.props}
+                isLoading={isLoading}
+                error={error}
+                eventView={eventView}
+                tableData={tableData}
+                tagKeys={tagKeys}
+                measurementKeys={measurementKeys}
+              />
+            );
+          }}
+        </Measurements>
         <Pagination pageLinks={pageLinks} />
       </Container>
     );
   }
 }
 
-export default withApi(withMeasurements(withTags(Table)));
+export default withApi(withTags(Table));
 
 const Container = styled('div')`
   min-width: 0;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -8,7 +8,7 @@ import {Organization, TagCollection} from 'app/types';
 import {metric} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
 import withTags from 'app/utils/withTags';
-import Measurements, {MeasurementCollection} from 'app/utils/measurements/measurements';
+import Measurements from 'app/utils/measurements/measurements';
 import Pagination from 'app/components/pagination';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import {TableData} from 'app/utils/discover/discoverQuery';
@@ -22,7 +22,6 @@ type TableProps = {
   organization: Organization;
   showTags: boolean;
   tags: TagCollection;
-  measurements: MeasurementCollection;
   setError: (msg: string, code: number) => void;
   title: string;
   onChangeShowTags: () => void;


### PR DESCRIPTION
- Add CLS, TTFB, and Request Time measurements to Discover column builder. Request Time captures the time spent making the request and receiving the first byte of the response.
- Refactor `withMeasurements` HoC into a render prop function. This provides more flexibility; and types better in TS. 