### PR TITLE
feat(metric_alerts): Update DetailedIncidentSerializer to work correctly with boolean search (WOR-318, WOR-319)

### DIFF
--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -52,7 +52,7 @@ class DetailedIncidentSerializerTest(TestCase):
         serializer = DetailedIncidentSerializer()
         result = serialize(incident, serializer=serializer)
         assert result["alertRule"] == serialize(incident.alert_rule)
-        assert result["discoverQuery"] == "event.type:error {}".format(query)
+        assert result["discoverQuery"] == "(event.type:error) AND ({})".format(query)
 
     def test_error_alert_rule_unicode(self):
         query = u"统一码"
@@ -61,7 +61,7 @@ class DetailedIncidentSerializerTest(TestCase):
         serializer = DetailedIncidentSerializer()
         result = serialize(incident, serializer=serializer)
         assert result["alertRule"] == serialize(incident.alert_rule)
-        assert result["discoverQuery"] == u"event.type:error {}".format(query)
+        assert result["discoverQuery"] == u"(event.type:error) AND ({})".format(query)
 
     def test_transaction_alert_rule(self):
         query = "test query"
@@ -71,4 +71,4 @@ class DetailedIncidentSerializerTest(TestCase):
         serializer = DetailedIncidentSerializer()
         result = serialize(incident, serializer=serializer)
         assert result["alertRule"] == serialize(incident.alert_rule)
-        assert result["discoverQuery"] == "event.type:transaction {}".format(query)
+        assert result["discoverQuery"] == "(event.type:transaction) AND ({})".format(query)


### PR DESCRIPTION
This updates `DetailedIncidentSerializer` to correctly format `discoverQuery` so that it will work
as expected for boolean searches. Essentially this changes `discoverQuery` from `event.type:error
release:123 OR release:456` to `(event.type:error) AND (release:123 OR release:456)`.

Depends on https://github.com/getsentry/sentry/pull/21290