### PR TITLE
feat(Integrations): Add Datadog metrics to integration installation

### DIFF
--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -36,6 +36,7 @@ from sentry.signals import (
     team_created,
     user_feedback_received,
 )
+from sentry.utils import metrics
 from sentry.utils.javascript import has_sourcemap
 
 DEFAULT_TAGS = frozenset(
@@ -427,6 +428,15 @@ def record_integration_added(integration, organization, user, **kwargs):
         organization_id=organization.id,
         provider=integration.provider,
         id=integration.id,
+    )
+    metrics.incr(
+        "integration.added",
+        sample_rate=1.0,
+        tags={
+            "integration": integration.provider,
+            "integation_id": integration.id,
+            "organization": organization.id,
+        },
     )
 
 

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -430,13 +430,7 @@ def record_integration_added(integration, organization, user, **kwargs):
         id=integration.id,
     )
     metrics.incr(
-        "integration.added",
-        sample_rate=1.0,
-        tags={
-            "integration": integration.provider,
-            "integation_id": integration.id,
-            "organization": organization.id,
-        },
+        "integration.added", sample_rate=1.0, tags={"integration_slug": integration.provider},
     )
 
 


### PR DESCRIPTION
**Context**
We (ecosystem team) want to know when integration installation fails (so we can address broken installs).

This is a first pass at adding metrics to the signal receiver for installation to collect data. In Datadog we'll monitor the rate of install and determine some criteria for alerting like if the number of installs drops dramatically for a period of time, or ceases. 