### PR TITLE
feat(discover): Add auto aggregations

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -103,6 +103,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
                 limit=limit,
                 referrer=request.GET.get("referrer", "api.organization-events-v2"),
                 auto_fields=True,
+                auto_aggregations=True,
                 use_aggregate_conditions=True,
             )
 

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -42,17 +42,6 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
         "count_range": {"format": "count_range({start}, {end}, {index})", "alias": "count_range_"},
         "percentage": {"format": "percentage({alias}2, {alias}1)"},
     }
-    # Aggregations that will be automatically added if they're included in the query
-    # this is so they're only added as needed
-    auto_aggregations = [
-        "p50()",
-        "p75()",
-        "p95()",
-        "p99()",
-        "avg(transaction.duration)",
-        "count()",
-        "absolute_correlation()",
-    ]
 
     def has_feature(self, organization, request):
         return features.has("organizations:trends", organization, actor=request.user)
@@ -107,7 +96,7 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
                 limit=limit,
                 referrer="api.trends.get-percentage-change",
                 auto_fields=True,
-                auto_aggregations=self.auto_aggregations,
+                auto_aggregations=True,
                 use_aggregate_conditions=True,
             )
 

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -42,6 +42,17 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
         "count_range": {"format": "count_range({start}, {end}, {index})", "alias": "count_range_"},
         "percentage": {"format": "percentage({alias}2, {alias}1)"},
     }
+    # Aggregations that will be automatically added if they're included in the query
+    # this is so they're only added as needed
+    auto_aggregations = [
+        "p50()",
+        "p75()",
+        "p95()",
+        "p99()",
+        "avg(transaction.duration)",
+        "count()",
+        "absolute_correlation()",
+    ]
 
     def has_feature(self, organization, request):
         return features.has("organizations:trends", organization, actor=request.user)
@@ -88,7 +99,6 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
                     count_column["format"].format(start=start, end=middle, index="1"),
                     count_column["format"].format(start=middle, end=end, index="2"),
                     percentage_column["format"].format(alias=count_column["alias"]),
-                    "absolute_correlation()",
                 ],
                 query=query,
                 params=params,
@@ -97,6 +107,7 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
                 limit=limit,
                 referrer="api.trends.get-percentage-change",
                 auto_fields=True,
+                auto_aggregations=self.auto_aggregations,
                 use_aggregate_conditions=True,
             )
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -2055,8 +2055,8 @@ def resolve_field_list(fields, snuba_filter, auto_fields=True, auto_aggregations
         if agg_additions:
             aggregations.extend(agg_additions)
 
-    having_aggregates = [having[0] for having in snuba_filter.having]
-    if auto_aggregations is not None and len(having_aggregates) > 0:
+    if auto_aggregations is not None and snuba_filter.having:
+        having_aggregates = [having[0] for having in snuba_filter.having]
         for agg in auto_aggregations:
             _, agg_additions = resolve_field(agg, snuba_filter.date_params)
 

--- a/src/sentry/data_export/processors/discover.py
+++ b/src/sentry/data_export/processors/discover.py
@@ -76,6 +76,7 @@ class DiscoverProcessor(object):
                 limit=limit,
                 referrer="data_export.tasks.discover",
                 auto_fields=True,
+                auto_aggregations=True,
                 use_aggregate_conditions=True,
             )
 

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -28,7 +28,7 @@ class Filter(object):
     aggregations (Sequence[Any, str|None, str]): Aggregate functions to fetch.
     groupby (Sequence[str]): List of columns to group results by
 
-    _condition_aggregates (Sequence[str]): List of aggregates used in the condition
+    condition_aggregates (Sequence[str]): List of aggregates used in the condition
     """
 
     def __init__(

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -27,6 +27,8 @@ class Filter(object):
     selected_columns (Sequence[str]): List of columns to select
     aggregations (Sequence[Any, str|None, str]): Aggregate functions to fetch.
     groupby (Sequence[str]): List of columns to group results by
+
+    _condition_aggregates (Sequence[str]): List of aggregates used in the condition
     """
 
     def __init__(
@@ -43,6 +45,7 @@ class Filter(object):
         rollup=None,
         groupby=None,
         orderby=None,
+        condition_aggregates=None,
     ):
         self.start = start
         self.end = end
@@ -57,6 +60,7 @@ class Filter(object):
         self.aggregations = aggregations if aggregations is not None else []
         self.groupby = groupby
         self.orderby = orderby
+        self.condition_aggregates = condition_aggregates
 
     @property
     def filter_keys(self):

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -405,6 +405,7 @@ def query(
         for having_clause in snuba_filter.having:
             # The first element of the having can be an alias, or a nested array of functions. Loop through to make sure
             # any referenced functions are in the aggregations.
+            error_extra = u", and could not be automatically added" if auto_aggregations else u""
             if isinstance(having_clause[0], (list, tuple)):
                 # Functions are of the form [fn, [args]]
                 args_to_check = [[having_clause[0]]]
@@ -424,8 +425,8 @@ def query(
 
                 if len(conditions_not_in_aggregations) > 0:
                     raise InvalidSearchQuery(
-                        u"Aggregate(s) {} used in a condition but are not in the selected columns.".format(
-                            ", ".join(conditions_not_in_aggregations)
+                        u"Aggregate(s) {} used in a condition but are not in the selected columns{}.".format(
+                            ", ".join(conditions_not_in_aggregations), error_extra,
                         )
                     )
             else:
@@ -434,8 +435,8 @@ def query(
                 )
                 if not found:
                     raise InvalidSearchQuery(
-                        u"Aggregate {} used in a condition but is not a selected column, and could not be automatically added.".format(
-                            having_clause[0]
+                        u"Aggregate {} used in a condition but is not a selected column{}.".format(
+                            having_clause[0], error_extra,
                         )
                     )
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -348,7 +348,7 @@ def query(
         if not use_aggregate_conditions:
             assert (
                 not auto_aggregations
-            ), "Auto aggregations cannot be used without enabling aggregaet conditions"
+            ), "Auto aggregations cannot be used without enabling aggregate conditions"
             snuba_filter.having = []
 
     # We need to run a separate query to be able to properly bucket the values for the histogram

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -305,6 +305,7 @@ def query(
     limit=50,
     referrer=None,
     auto_fields=False,
+    auto_aggregations=None,
     use_aggregate_conditions=False,
     conditions=None,
 ):
@@ -326,6 +327,8 @@ def query(
     limit (int) The number of records to fetch.
     referrer (str|None) A referrer string to help locate the origin of this query.
     auto_fields (bool) Set to true to have project + eventid fields automatically added.
+    auto_aggregations (Sequence[str]) A list of aggregates, that automatically get added when used in conditions
+    use_aggregate_conditions (bool) Set to true if aggregates conditions should be used at all
     conditions (Sequence[any]) List of conditions that are passed directly to snuba without
                     any additional processing.
     """
@@ -381,7 +384,12 @@ def query(
             snuba_filter.orderby = [get_function_alias(o) for o in orderby]
 
         snuba_filter.update_with(
-            resolve_field_list(selected_columns, snuba_filter, auto_fields=auto_fields)
+            resolve_field_list(
+                selected_columns,
+                snuba_filter,
+                auto_fields=auto_fields,
+                auto_aggregations=auto_aggregations,
+            )
         )
 
         # Resolve the public aliases into the discover dataset names.

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -305,7 +305,7 @@ def query(
     limit=50,
     referrer=None,
     auto_fields=False,
-    auto_aggregations=None,
+    auto_aggregations=False,
     use_aggregate_conditions=False,
     conditions=None,
 ):
@@ -327,8 +327,9 @@ def query(
     limit (int) The number of records to fetch.
     referrer (str|None) A referrer string to help locate the origin of this query.
     auto_fields (bool) Set to true to have project + eventid fields automatically added.
-    auto_aggregations (Sequence[str]) A list of aggregates, that automatically get added when used in conditions
-    use_aggregate_conditions (bool) Set to true if aggregates conditions should be used at all
+    auto_aggregations (bool) Whether aggregates should be added automatically if they're used
+                    in conditions, and there's at least one aggregate already.
+    use_aggregate_conditions (bool) Set to true if aggregates conditions should be used at all.
     conditions (Sequence[any]) List of conditions that are passed directly to snuba without
                     any additional processing.
     """
@@ -430,7 +431,7 @@ def query(
                 )
                 if not found:
                     raise InvalidSearchQuery(
-                        u"Aggregate {} used in a condition but is not a selected column.".format(
+                        u"Aggregate {} used in a condition but is not a selected column, and could not be automatically added.".format(
                             having_clause[0]
                         )
                     )
@@ -503,6 +504,7 @@ def key_transaction_query(selected_columns, user_query, params, orderby, referre
         orderby=orderby,
         referrer=referrer,
         conditions=key_transaction_conditions(queryset),
+        auto_aggregations=True,
         use_aggregate_conditions=True,
     )
 
@@ -681,6 +683,7 @@ def top_events_timeseries(
                 orderby=orderby,
                 limit=limit,
                 referrer=referrer,
+                auto_aggregations=True,
                 use_aggregate_conditions=True,
             )
 
@@ -1110,6 +1113,7 @@ def find_measurements_min_max(
         limit=1,
         referrer="api.organization-events-measurements-min-max",
         auto_fields=True,
+        auto_aggregations=True,
         use_aggregate_conditions=True,
     )
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -346,6 +346,9 @@ def query(
 
         snuba_filter = get_filter(query, params)
         if not use_aggregate_conditions:
+            assert (
+                not auto_aggregations
+            ), "Auto aggregations cannot be used without enabling aggregaet conditions"
             snuba_filter.having = []
 
     # We need to run a separate query to be able to properly bucket the values for the histogram

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -510,6 +510,36 @@ export function measurementType(field: string) {
 
 const AGGREGATE_PATTERN = /^([^\(]+)\((.*?)(?:\s*,\s*(.*))?\)$/;
 
+export function generateAggregateFields(
+  organization: LightWeightOrganization,
+  eventFields: readonly Field[] | Field[]
+): Field[] {
+  const functions = Object.keys(AGGREGATIONS);
+  const fields = Object.values(eventFields).map(field => field.field);
+  functions.forEach(func => {
+    const parameters = AGGREGATIONS[func].parameters.map(param => {
+      const generator = AGGREGATIONS[func].generateDefaultValue;
+      if (typeof generator === 'undefined') {
+        return param;
+      }
+      return {
+        ...param,
+        defaultValue: generator({parameter: param, organization}),
+      };
+    });
+
+    if (parameters.every(param => typeof param.defaultValue !== 'undefined')) {
+      const newField = `${func}(${parameters
+        .map(param => param.defaultValue)
+        .join(',')})`;
+      if (fields.indexOf(newField) === -1) {
+        fields.push(newField);
+      }
+    }
+  });
+  return fields.map(field => ({field})) as Field[];
+}
+
 export function explodeFieldString(field: string): Column {
   const results = field.match(AGGREGATE_PATTERN);
 

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -24,6 +24,7 @@ import Confirm from 'app/components/confirm';
 import space from 'app/styles/space';
 import SearchBar from 'app/views/events/searchBar';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
+import {generateAggregateFields} from 'app/utils/discover/fields';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
@@ -375,6 +376,9 @@ class Results extends React.Component<Props, State> {
       incompatibleAlertNotice,
       confirmedQuery,
     } = this.state;
+    const fields = eventView.hasAggregateField()
+      ? generateAggregateFields(organization, eventView.fields)
+      : eventView.fields;
     const query = decodeScalar(location.query.query) || '';
     const title = this.getDocumentTitle();
 
@@ -397,7 +401,7 @@ class Results extends React.Component<Props, State> {
                   organization={organization}
                   projectIds={eventView.project}
                   query={query}
-                  fields={eventView.fields}
+                  fields={fields}
                   onSearch={this.handleSearch}
                 />
                 <ResultsChart

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -18,6 +18,7 @@ import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMess
 import Alert from 'app/components/alert';
 import Feature from 'app/components/acl/feature';
 import EventView from 'app/utils/discover/eventView';
+import {generateAggregateFields} from 'app/utils/discover/fields';
 import space from 'app/styles/space';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -373,7 +374,7 @@ class PerformanceLanding extends React.Component<Props, State> {
                     organization={organization}
                     projectIds={eventView.project}
                     query={filterString}
-                    fields={eventView.fields}
+                    fields={generateAggregateFields(organization, eventView.fields)}
                     onSearch={this.handleSearch}
                   />
                   <Charts

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import {GlobalSelection, Organization} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
-import {Field} from 'app/utils/discover/fields';
+import {generateAggregateFields} from 'app/utils/discover/fields';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import {t} from 'app/locale';
 import Feature from 'app/components/acl/feature';
@@ -93,11 +93,11 @@ class TrendsContent extends React.Component<Props, State> {
     const {previousTrendFunction} = this.state;
 
     const trendView = eventView.clone() as TrendView;
-    const fields = [
-      ...TRENDS_FUNCTIONS.map(({field}) => field),
-      'count()',
-      'absolute_correlation()',
-    ].map(field => ({field})) as Field[];
+    const fields = generateAggregateFields(organization, [
+      {
+        field: 'absolute_correlation()',
+      },
+    ]);
     const currentTrendFunction = getCurrentTrendFunction(location);
     const query = getTransactionSearchQuery(location);
     const showChangedProjects = hasMultipleProjects(selection);

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 
 import {GlobalSelection, Organization} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
+import {Field} from 'app/utils/discover/fields';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import {t} from 'app/locale';
 import Feature from 'app/components/acl/feature';
@@ -92,6 +93,11 @@ class TrendsContent extends React.Component<Props, State> {
     const {previousTrendFunction} = this.state;
 
     const trendView = eventView.clone() as TrendView;
+    const fields = [
+      ...TRENDS_FUNCTIONS.map(({field}) => field),
+      'count()',
+      'absolute_correlation()',
+    ].map(field => ({field})) as Field[];
     const currentTrendFunction = getCurrentTrendFunction(location);
     const query = getTransactionSearchQuery(location);
     const showChangedProjects = hasMultipleProjects(selection);
@@ -104,7 +110,7 @@ class TrendsContent extends React.Component<Props, State> {
               organization={organization}
               projectIds={trendView.project}
               query={query}
-              fields={trendView.fields}
+              fields={fields}
               onSearch={this.handleSearch}
             />
             <TrendsDropdown>

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -179,13 +179,10 @@ export function modifyTrendView(
 ) {
   const trendFunction = getCurrentTrendFunction(location);
 
-  const trendFunctionFields = TRENDS_FUNCTIONS.map(({field}) => field);
   const transactionField = isProjectOnly ? [] : ['transaction'];
-  const fields = [...trendFunctionFields, ...transactionField, 'project', 'count()'].map(
-    field => ({
-      field,
-    })
-  ) as Field[];
+  const fields = [...transactionField, 'project', 'count()'].map(field => ({
+    field,
+  })) as Field[];
 
   const trendSort = {
     field: `percentage_${trendFunction.alias}_2_${trendFunction.alias}_1`,

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -465,16 +465,11 @@ describe('Performance > Trends', function () {
           : aliasedFieldDivide;
 
       const defaultTrendsFields = ['project', 'count()'];
-      const trendFunctionFields = TRENDS_FUNCTIONS.map(({field}) => field);
 
-      const transactionFields = [
-        ...trendFunctionFields,
-        'transaction',
-        ...defaultTrendsFields,
-      ];
-      const projectFields = [...trendFunctionFields, ...defaultTrendsFields];
+      const transactionFields = ['transaction', ...defaultTrendsFields];
+      const projectFields = [...defaultTrendsFields];
 
-      expect(transactionFields).toHaveLength(8);
+      expect(transactionFields).toHaveLength(3);
       expect(projectFields).toHaveLength(transactionFields.length - 1);
 
       // Improved projects call

--- a/tests/snuba/api/endpoints/test_organization_events_trends.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trends.py
@@ -336,8 +336,6 @@ class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_1": 1,
             "count_range_2": 3,
@@ -376,8 +374,6 @@ class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_1": 1,
             "count_range_2": 3,
@@ -416,8 +412,6 @@ class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_1": 1,
             "count_range_2": 3,
@@ -456,8 +450,6 @@ class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_1": 1,
             "count_range_2": 3,
@@ -496,8 +488,6 @@ class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_2": 3,
             "count_range_1": 1,
@@ -536,8 +526,6 @@ class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_2": 3,
             "count_range_1": 1,
@@ -592,8 +580,6 @@ class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
         result_stats = response.data["stats"]
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_2": 4,
             "count_range_1": 0,

--- a/tests/snuba/api/endpoints/test_organization_events_trends.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trends.py
@@ -61,8 +61,6 @@ class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
         events = response.data
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_1": 1,
             "count_range_2": 3,
@@ -94,8 +92,6 @@ class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
         events = response.data
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_1": 1,
             "count_range_2": 3,
@@ -127,8 +123,6 @@ class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
         events = response.data
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_1": 1,
             "count_range_2": 3,
@@ -160,8 +154,6 @@ class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
         events = response.data
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_1": 1,
             "count_range_2": 3,
@@ -193,8 +185,6 @@ class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
         events = response.data
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_2": 3,
             "count_range_1": 1,
@@ -226,8 +216,6 @@ class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
         events = response.data
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
-        assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_2": 3,
             "count_range_1": 1,
@@ -275,7 +263,38 @@ class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
         events = response.data
 
         assert len(events["data"]) == 1
-        # Shouldn't do an exact match here because we aren't using the stable correlation function
+        assert events["data"][0] == {
+            "count_range_2": 4,
+            "count_range_1": 0,
+            "transaction": self.prototype["transaction"],
+            "project": self.project.slug,
+            "percentile_range_1": 0,
+            "percentile_range_2": 2000.0,
+            "percentage_count_range_2_count_range_1": None,
+            "minus_percentile_range_2_percentile_range_1": 0,
+            "percentage_percentile_range_2_percentile_range_1": None,
+        }
+
+    def test_auto_aggregation(self):
+        # absolute_correlation is automatically added, and not a part of data otherwise
+        with self.feature("organizations:trends"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    # Set the timeframe to where the second range has no transactions so all the counts/percentile are 0
+                    "end": iso_format(self.day_ago + timedelta(hours=2)),
+                    "start": iso_format(self.day_ago - timedelta(hours=2)),
+                    "field": ["project", "transaction"],
+                    "query": "event.type:transaction absolute_correlation():>0.2",
+                    "project": [self.project.id],
+                },
+            )
+        assert response.status_code == 200, response.content
+
+        events = response.data
+
+        assert len(events["data"]) == 1
         assert events["data"][0].pop("absolute_correlation") > 0.2
         assert events["data"][0] == {
             "count_range_2": 4,


### PR DESCRIPTION
- This will have discover/performance automatically add aggregations if
  they're used in a query
  - We currently pass a large number of selected columns for the trends
    queries just in case they get used, this way we only add those when
    they're used instead
  - eg. absolute_correlation is no longer added automatically
- This removes the extra fields from the trends endpoint calls
- This adds aggregations with no parameters or default parameters functions to trend autocomplete 
  - Also not including trendView in the fields anymore since its including the functions
  from the other performance views, can add these back if we want
  though.

ex.
absolute_correlation is in the auto complete now
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/4205004/95927484-d3819700-0d8c-11eb-8cb9-024eb238765a.png">

### before 
<img width="724" alt="image" src="https://user-images.githubusercontent.com/4205004/95927618-43901d00-0d8d-11eb-9b4b-178032a4058f.png">

### after
~80% previous size
<img width="727" alt="image" src="https://user-images.githubusercontent.com/4205004/95927640-530f6600-0d8d-11eb-9a03-bf480ce7f710.png">


