### PR TITLE
ci(release): Remove unnecessary sleep btw prepare & publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           GIT_AUTHOR_NAME: getsentry-bot
           EMAIL: bot@getsentry.com
           ZEUS_API_TOKEN: ${{ secrets.ZEUS_API_TOKEN }}
-     - uses: getsentry/craft@master
+      - uses: getsentry/craft@master
         with:
           action: publish
           version: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,7 @@ jobs:
           GIT_AUTHOR_NAME: getsentry-bot
           EMAIL: bot@getsentry.com
           ZEUS_API_TOKEN: ${{ secrets.ZEUS_API_TOKEN }}
-      # Wait until the builds start. Craft should do this automatically
-      # but it is broken now.
-      # TODO: Remove this once getsentry/craft#111 is fixed
-      - run: sleep 10
-      - uses: getsentry/craft@master
+     - uses: getsentry/craft@master
         with:
           action: publish
           version: ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
getsentry/craft#117 is merged and released and seems to work so no need for this `sleep 10` anymore.
