### PR TITLE
ref(frames): Remove Frame Platform Border && Replace platform icon with PlatformIcons

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
@@ -388,7 +388,6 @@ export class Line extends React.Component<Props, State> {
       'system-frame': !data.inApp,
       'frame-errors': data.errors,
       'leads-to-app': this.leadsToApp(),
-      [this.getPlatform()]: true,
     });
     const props = {className};
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import styled from '@emotion/styled';
+import PlatformIcon from 'platformicons';
 
 import Line from 'app/components/events/interfaces/frame/line';
 import {t} from 'app/locale';
@@ -221,9 +223,24 @@ export default class StacktraceContent extends React.Component<Props, State> {
     const className = this.getClassName();
 
     return (
-      <div className={className}>
+      <Wrapper className={className}>
+        <StyledPlatformIcon
+          platform={platform}
+          size="20px"
+          style={{borderRadius: '3px 0 0 3px'}}
+        />
         <ul>{frames}</ul>
-      </div>
+      </Wrapper>
     );
   }
 }
+
+const Wrapper = styled('div')`
+  position: relative;
+`;
+
+const StyledPlatformIcon = styled(PlatformIcon)`
+  position: absolute;
+  top: -1px;
+  left: -20px;
+`;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1538,7 +1538,7 @@ ul.crumbs {
           display: block;
           width: 100%;
           height: 15px;
-          #gradient > .vertical(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));;
+          #gradient > .vertical(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
           z-index: 1;
         }
 

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -700,7 +700,7 @@
   list-style-type: none;
   padding-left: 0;
   border: 1px solid @trim-dark;
-  border-radius: 3px;
+  border-radius: 0 3px 3px 3px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
   margin-bottom: 20px;
 }
@@ -1538,7 +1538,7 @@ ul.crumbs {
           display: block;
           width: 100%;
           height: 15px;
-          #gradient > .vertical(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+          #gradient > .vertical(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));;
           z-index: 1;
         }
 

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1226,74 +1226,6 @@ div.traceback > ul {
   }
 }
 
-/* Language & Framework frame icons */
-
-.frame {
-  position: relative;
-
-  &.cocoa {
-    .frame-language-icon(cocoa, #fff, @blue, '\e912', true);
-  }
-
-  &.objc {
-    .frame-language-icon(objc, #fff, @blue, '\e912', true);
-  }
-
-  &.javascript {
-    .frame-language-icon(javascript, #000, @yellow, 'JS');
-  }
-}
-
-.frame-language-icon(@selectorName, @color, @background, @content, @icon : false) {
-  &:before {
-    content: '';
-    display: block;
-    position: absolute;
-    top: -1px;
-    left: 0;
-    right: -1px;
-    height: 1px;
-    background: @background;
-    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
-  }
-
-  &:after {
-    content: @content;
-    display: block;
-    position: absolute;
-    width: 20px;
-    height: 20px;
-    color: @color;
-    font-size: 11px;
-    background: @background;
-    text-align: center;
-    line-height: 20px;
-    top: -1px;
-    left: -20px;
-    border-radius: 3px 0 0 3px;
-  }
-
-  &:after when(@icon =true) {
-    font-family: 'sentry-simple';
-    speak: none;
-    font-style: normal;
-    font-weight: normal;
-    font-variant: normal;
-    text-transform: none;
-
-    /* Better Font Rendering =========== */
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
-  & + .@{selectorName} {
-    &:before,
-    &:after {
-      display: none;
-    }
-  }
-}
-
 #full-message {
   line-height: 1.5em;
 
@@ -1606,7 +1538,7 @@ ul.crumbs {
           display: block;
           width: 100%;
           height: 15px;
-          #gradient > .vertical(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+          #gradient > .vertical(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));;
           z-index: 1;
         }
 


### PR DESCRIPTION
Since we no longer offer support for mixed stacktraces, it no longer makes sense to display the platform icon and the top colored border. The idea was to better visualize the mixed stacktraces.

![image](https://user-images.githubusercontent.com/29228205/96180389-a7a01600-0f32-11eb-9b8e-732cdb74af37.png)
