### PR TITLE
feat(rum): The web vitals tab should not appear for non front end

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/realUserMonitoring/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/realUserMonitoring/index.tsx
@@ -152,9 +152,7 @@ function generateRumEventView(
   if (transactionName === undefined) {
     return undefined;
   }
-  const query = decodeScalar(location.query.query) || '';
-  const conditions = tokenizeSearch(query);
-  conditions
+  const conditions = tokenizeSearch(decodeScalar(location.query.query) || '')
     .setTagValues('event.type', ['transaction'])
     .setTagValues('transaction.op', ['pageload'])
     .setTagValues('transaction', [transactionName]);


### PR DESCRIPTION
It does not make sense to show the web vitals tab if it's not a front end
transaction. For example, it is confusing to see the `Web Vitals` tab if it is
a back end transaction. This change ensures that there are some measurement
data before showing the tab. This approach has some limitations. If there is
insufficient data, then we can't tell and it will be categorized as a non front
end transaction. What this means is that all non front end transactions will
never see the tab while actual front end transactions will only see the tab
when there is sufficient data.