### PR TITLE
fix(Integrations): Fix request installation modal text overflow

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -87,7 +87,13 @@ export default class RequestIntegrationModal extends AsyncComponent<Props, State
         <Body>
           <TextBlock>
             {t(
-              'Looks like your organization owner, manager, or admin needs to install %s. Want to send them a request?.',
+              'Looks like your organization owner, manager, or admin needs to install %s. Want to send them a request?',
+              name
+            )}
+          </TextBlock>
+          <TextBlock>
+            {t(
+              '(Optional) You’ve got good reasons for installing the %s Integration. Share them with your organization owner.',
               name
             )}
           </TextBlock>
@@ -95,10 +101,6 @@ export default class RequestIntegrationModal extends AsyncComponent<Props, State
             inline={false}
             flexibleControlStateSize
             stacked
-            label={t(
-              '(Optional) You’ve got good reasons for installing the %s Integration. Share them with your organization owner.',
-              name
-            )}
             name="message"
             type="string"
             onChange={value => this.setState({message: value})}


### PR DESCRIPTION
The `RequestIntegrationModal` 's text was overflowing, so this PR makes it not look like a hot mess, and also gets rid of the trailing period after the question mark. 

**Before**

![Screen Shot 2020-10-14 at 11 52 21 AM](https://user-images.githubusercontent.com/29959063/96033468-f5bef780-0e14-11eb-9bbf-7b1ad736108b.png)


**After**

![Screen Shot 2020-10-14 at 11 56 09 AM](https://user-images.githubusercontent.com/29959063/96033491-fce60580-0e14-11eb-8a2f-bcf581c41eee.png)
