### PR TITLE
fix(workflow): Respect retention period during incident start/end calculation

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -388,7 +388,10 @@ def calculate_incident_time_range(incident, start=None, end=None, windowed_stats
             start = end - timedelta(seconds=time_window * WINDOWED_STATS_DATA_POINTS)
 
     retention = quotas.get_event_retention(organization=incident.organization) or 90
-    start = max(start, datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=retention))
+    start = max(
+        start.replace(tzinfo=timezone.utc),
+        datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=retention),
+    )
     end = max(start, end)
 
     return start, end

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -388,7 +388,7 @@ def calculate_incident_time_range(incident, start=None, end=None, windowed_stats
             start = end - timedelta(seconds=time_window * WINDOWED_STATS_DATA_POINTS)
 
     retention = quotas.get_event_retention(organization=incident.organization) or 90
-    start = max(start, datetime.utcnow() - timedelta(days=retention))
+    start = max(start, datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=retention))
     end = max(start, end)
 
     return start, end

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -388,7 +388,7 @@ def calculate_incident_time_range(incident, start=None, end=None, windowed_stats
             start = end - timedelta(seconds=time_window * WINDOWED_STATS_DATA_POINTS)
 
     retention = quotas.get_event_retention(organization=incident.organization) or 90
-    start = max(start.replace(tzinfo=timezone.utc), datetime.utcnow() - timedelta(days=retention),)
+    start = max(start.replace(tzinfo=timezone.utc), datetime.utcnow() - timedelta(days=retention))
     end = max(start, end.replace(tzinfo=timezone.utc))
 
     return start, end

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -392,7 +392,7 @@ def calculate_incident_time_range(incident, start=None, end=None, windowed_stats
         start.replace(tzinfo=timezone.utc),
         datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=retention),
     )
-    end = max(start, end)
+    end = max(start, end.replace(tzinfo=timezone.utc))
 
     return start, end
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -388,7 +388,10 @@ def calculate_incident_time_range(incident, start=None, end=None, windowed_stats
             start = end - timedelta(seconds=time_window * WINDOWED_STATS_DATA_POINTS)
 
     retention = quotas.get_event_retention(organization=incident.organization) or 90
-    start = max(start.replace(tzinfo=timezone.utc), datetime.utcnow() - timedelta(days=retention))
+    start = max(
+        start.replace(tzinfo=timezone.utc),
+        datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=retention),
+    )
     end = max(start, end.replace(tzinfo=timezone.utc))
 
     return start, end

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -388,10 +388,8 @@ def calculate_incident_time_range(incident, start=None, end=None, windowed_stats
             start = end - timedelta(seconds=time_window * WINDOWED_STATS_DATA_POINTS)
 
     retention = quotas.get_event_retention(organization=incident.organization) or 90
-    if start < datetime.utcnow() - timedelta(days=retention):
-        start = datetime.utcnow() - timedelta(days=retention)
-        if end < start:
-            end = start
+    start = max(start, datetime.utcnow() - timedelta(days=retention))
+    end = max(start, end)
 
     return start, end
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -388,10 +388,7 @@ def calculate_incident_time_range(incident, start=None, end=None, windowed_stats
             start = end - timedelta(seconds=time_window * WINDOWED_STATS_DATA_POINTS)
 
     retention = quotas.get_event_retention(organization=incident.organization) or 90
-    start = max(
-        start.replace(tzinfo=timezone.utc),
-        datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=retention),
-    )
+    start = max(start.replace(tzinfo=timezone.utc), datetime.utcnow() - timedelta(days=retention),)
     end = max(start, end.replace(tzinfo=timezone.utc))
 
     return start, end

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -390,6 +390,8 @@ def calculate_incident_time_range(incident, start=None, end=None, windowed_stats
     retention = quotas.get_event_retention(organization=incident.organization) or 90
     if start < datetime.utcnow() - timedelta(days=retention):
         start = datetime.utcnow() - timedelta(days=retention)
+        if end < start:
+            end = start
 
     return start, end
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -279,6 +279,7 @@ def process_snoozes(group):
         return False
 
     if not snooze.is_valid(group, test_rates=True):
+        # TODO Put group in the inbox, track snooze vars
         snooze.delete()
         group.update(status=GroupStatus.UNRESOLVED)
         return True

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -279,7 +279,6 @@ def process_snoozes(group):
         return False
 
     if not snooze.is_valid(group, test_rates=True):
-        # TODO Put group in the inbox, track snooze vars
         snooze.delete()
         group.update(status=GroupStatus.UNRESOLVED)
         return True

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -559,6 +559,12 @@ class CreateIncidentSnapshotTest(TestCase, BaseIncidentsTest):
         assert start == datetime.utcnow() - timedelta(days=90)
         assert end == incident.date_closed + timedelta(minutes=time_window)
 
+        incident.update(date_closed=datetime.utcnow() - timedelta(days=95),)
+
+        start, end = calculate_incident_time_range(incident)
+        assert start == datetime.utcnow() - timedelta(days=90)
+        assert end == start
+
     def test_windowed_capped_end(self):
         # When processing PendingIncidentSnapshots, the task could run later than we'd like the
         # end to actually be, so we have logic to cap it to 10 datapoints, or 10 days, whichever is less. This tests that logic.

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import pytest
+import pytz
 import responses
 from datetime import datetime, timedelta
 from exam import fixture, patcher
@@ -556,13 +557,13 @@ class CreateIncidentSnapshotTest(TestCase, BaseIncidentsTest):
         )
 
         start, end = calculate_incident_time_range(incident)
-        assert start == datetime.utcnow() - timedelta(days=90)
-        assert end == incident.date_closed + timedelta(minutes=time_window)
+        assert start == datetime.utcnow().replace(tzinfo=pytz.utc) - timedelta(days=90)
+        assert end == incident.date_closed.replace(tzinfo=pytz.utc) + timedelta(minutes=time_window)
 
         incident.update(date_closed=datetime.utcnow() - timedelta(days=95),)
 
         start, end = calculate_incident_time_range(incident)
-        assert start == datetime.utcnow() - timedelta(days=90)
+        assert start == datetime.utcnow().replace(tzinfo=pytz.utc) - timedelta(days=90)
         assert end == start
 
     def test_windowed_capped_end(self):


### PR DESCRIPTION
We have an issue where it is possible to an incident snapshot to query outside of retention.

This PR fixes this issue by amending the incident start time calculation with a check that will bring the start time to the earliest point in time that we can query in Snuba. In addition, if the end time is now before the start time, we just make it the same and this ends up returning no relevant data for the incident.