### PR TITLE
 ref(API docs): Add beforeSend link/blurb in user feedback docs

### DIFF
--- a/api-docs/paths/projects/user-feedback.json
+++ b/api-docs/paths/projects/user-feedback.json
@@ -99,7 +99,7 @@
             "properties": {
               "event_id": {
                 "type": "string",
-                "description": "The event ID."
+                "description": "The event ID. This can be retrieved from the [beforeSend callback](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-beforesend)."
               },
               "name": {
                 "type": "string",

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -87,13 +87,7 @@ export default class RequestIntegrationModal extends AsyncComponent<Props, State
         <Body>
           <TextBlock>
             {t(
-              'Looks like your organization owner, manager, or admin needs to install %s. Want to send them a request?',
-              name
-            )}
-          </TextBlock>
-          <TextBlock>
-            {t(
-              '(Optional) You’ve got good reasons for installing the %s Integration. Share them with your organization owner.',
+              'Looks like your organization owner, manager, or admin needs to install %s. Want to send them a request?.',
               name
             )}
           </TextBlock>
@@ -101,6 +95,10 @@ export default class RequestIntegrationModal extends AsyncComponent<Props, State
             inline={false}
             flexibleControlStateSize
             stacked
+            label={t(
+              '(Optional) You’ve got good reasons for installing the %s Integration. Share them with your organization owner.',
+              name
+            )}
             name="message"
             type="string"
             onChange={value => this.setState({message: value})}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -87,7 +87,13 @@ export default class RequestIntegrationModal extends AsyncComponent<Props, State
         <Body>
           <TextBlock>
             {t(
-              'Looks like your organization owner, manager, or admin needs to install %s. Want to send them a request?.',
+              'Looks like your organization owner, manager, or admin needs to install %s. Want to send them a request?',
+              name
+            )}
+          </TextBlock>
+          <TextBlock>
+            {t(
+              '(Optional) You’ve got good reasons for installing the %s Integration. Share them with your organization owner.',
               name
             )}
           </TextBlock>
@@ -95,10 +101,6 @@ export default class RequestIntegrationModal extends AsyncComponent<Props, State
             inline={false}
             flexibleControlStateSize
             stacked
-            label={t(
-              '(Optional) You’ve got good reasons for installing the %s Integration. Share them with your organization owner.',
-              name
-            )}
             name="message"
             type="string"
             onChange={value => this.setState({message: value})}

--- a/tests/apidocs/openapi-derefed.json
+++ b/tests/apidocs/openapi-derefed.json
@@ -7217,7 +7217,7 @@
                 "properties": {
                   "event_id": {
                     "type": "string",
-                    "description": "The event ID."
+                    "description": "The event ID. This can be retrieved from the [beforeSend callback](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-beforesend)."
                   },
                   "name": {
                     "type": "string",


### PR DESCRIPTION
In order to make it clearer to customers how to use the user feedback submission endpoint, add a line of text with a link to the `beforeSend` documentation. Since don't have a general docs page for `beforeSend` and JavaScript is the most popular SDK, this links to the JS docs. 