### PR TITLE
build(gha): Move `#test-getsentry` parsing out of acceptance workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -7,49 +7,6 @@ on:
   pull_request:
 
 jobs:
-  parse-commit-message:
-    if: ${{ github.ref != 'refs/heads/master' }}
-    runs-on: ubuntu-16.04
-    outputs:
-      commit: ${{ steps.commit.outputs.message }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Parse commit message
-        id: commit
-        run: |
-          echo "::set-output name=message::$(git show -s --format=%B)"
-
-  getsentry:
-    needs: parse-commit-message
-    if: ${{ contains(needs.parse-commit-message.outputs.commit, '#test-getsentry') }}
-    runs-on: ubuntu-16.04
-    steps:
-      - name: getsentry token
-        id: getsentry
-        uses: getsentry/action-github-app-token@v1
-        with:
-          app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
-          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
-
-      # Notify getsentry
-      - name: Dispatch getsentry tests
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ steps.getsentry.outputs.token }}
-          script: |
-            github.actions.createWorkflowDispatch({
-              owner: 'getsentry',
-              repo: 'getsentry',
-              workflow_id: 'acceptance.yml',
-              ref: 'master',
-              inputs: {
-                'sentry-sha': '${{ github.event.pull_request.head.sha }}',
-              }
-            })
-
   jest:
     runs-on: ubuntu-16.04
     env:

--- a/.github/workflows/sentry-pr-bot.yml
+++ b/.github/workflows/sentry-pr-bot.yml
@@ -1,0 +1,48 @@
+# This responds to comments on Pull Requests
+name: sentry pr bot
+on: issue_comment
+
+jobs:
+  test:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: echo "$STEPS_CONTEXT"
+
+  test-getsentry:
+    name: test getsentry
+    if: ${{ contains(github.event.issue_comment.comment, '#test-getsentry') }}
+    runs-on: ubuntu-16.04
+    steps:
+      - name: getsentry token
+        id: getsentry
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
+          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
+      # Notify getsentry
+      - name: Dispatch getsentry tests
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ steps.getsentry.outputs.token }}
+          script: |
+            github.actions.createWorkflowDispatch({
+              owner: 'getsentry',
+              repo: 'getsentry',
+              workflow_id: 'acceptance.yml',
+              ref: 'master',
+              inputs: {
+                'sentry-sha': '${{ github.event.pull_request.head.sha }}',
+              }
+            })

--- a/.github/workflows/sentry-pull-request-bot.yml
+++ b/.github/workflows/sentry-pull-request-bot.yml
@@ -13,21 +13,39 @@ jobs:
   test-getsentry:
     name: test getsentry
     runs-on: ubuntu-16.04
+
     # Ensure this bot only responds for pull requests and only for the main repository
     if: >-
       (github.event.issue.pull_request.url != '' || github.event.pull_request.id != '') &&
       (contains(github.event.comment.body, '#test-getsentry') || contains(github.event.pull_request.body, '#test-getsentry')) &&
       github.repository == 'getsentry/sentry'
+
     steps:
-      - name: getsentry token
+      - name: Check getsentry membership
+        id: org
+        uses: actions/github-script@v3
+        with:
+          script: |
+            try {
+              const result = await github.orgs.checkMembershipForUser({
+                org: 'getsentry',
+                username: context.payload.sender.login,
+              })
+              return result.status == 204;
+            } catch {
+              return false;
+            }
+
+      - name: Fetch getsentry token
+        if: steps.org.outputs.result == 'true'
         id: getsentry
         uses: getsentry/action-github-app-token@v1
         with:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-      # Notify getsentry
       - name: Dispatch getsentry tests
+        if: steps.org.outputs.result == 'true'
         uses: actions/github-script@v3
         with:
           github-token: ${{ steps.getsentry.outputs.token }}

--- a/.github/workflows/sentry-pull-request-bot.yml
+++ b/.github/workflows/sentry-pull-request-bot.yml
@@ -1,27 +1,19 @@
-# This responds to comments on Pull Requests
-name: sentry pr bot
-on: issue_comment
+name: sentry pull request bot
+
+# Note this event happens on Issue comments AND PR comments,
+# we make sure that we only respond to PR comments.
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request:
+    types: [opened, edited]
 
 jobs:
-  test:
-    runs-on: ubuntu-16.04
-    steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Dump job context
-        env:
-          JOB_CONTEXT: ${{ toJson(job) }}
-        run: echo "$JOB_CONTEXT"
-      - name: Dump steps context
-        env:
-          STEPS_CONTEXT: ${{ toJson(steps) }}
-        run: echo "$STEPS_CONTEXT"
-
+  # TODO(billy): Move this into an external action as we add more functionality
   test-getsentry:
     name: test getsentry
-    if: ${{ contains(github.event.issue_comment.comment, '#test-getsentry') }}
+    # Ensure this bot only responds for pull requests and only for the main repository
+    if: ${{ (github.event.issue.pull_request.url != '' || github.event.pull_request.id != '') && (contains(github.event.comment.body, '#test-getsentry') || contains(github.event.pull_request.body, '#test-getsentry'))  && github.repository == 'billyvg/sentry' }}
     runs-on: ubuntu-16.04
     steps:
       - name: getsentry token

--- a/.github/workflows/sentry-pull-request-bot.yml
+++ b/.github/workflows/sentry-pull-request-bot.yml
@@ -12,9 +12,12 @@ jobs:
   # TODO(billy): Move this into an external action as we add more functionality
   test-getsentry:
     name: test getsentry
-    # Ensure this bot only responds for pull requests and only for the main repository
-    if: ${{ (github.event.issue.pull_request.url != '' || github.event.pull_request.id != '') && (contains(github.event.comment.body, '#test-getsentry') || contains(github.event.pull_request.body, '#test-getsentry'))  && github.repository == 'billyvg/sentry' }}
     runs-on: ubuntu-16.04
+    # Ensure this bot only responds for pull requests and only for the main repository
+    if: >-
+      (github.event.issue.pull_request.url != '' || github.event.pull_request.id != '') &&
+      (contains(github.event.comment.body, '#test-getsentry') || contains(github.event.pull_request.body, '#test-getsentry')) &&
+      github.repository == 'getsentry/sentry'
     steps:
       - name: getsentry token
         id: getsentry


### PR DESCRIPTION
This also changes the commit message parsing to instead use PR body and/or comments.

I considered using labels to trigger the event because 1) it would be more discoverable since you have the list of labels in front of you, 2) have less comment spam (which would notify people subscribed to the issue). However I decided against this because 1) it's less flexible than text (e.g. if we needed commands that takes in arguments) and 2) it triggers an event for each label added.

I changed it from commit messages as they are easy to forget to include and it is kind of a pain to parse them using GH's workflow events.

#test-getsentry