### PR TITLE
fix(metric_alerts): Improve queue processing when snapshots fail to process

### DIFF
--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -31,6 +31,7 @@ from sentry.utils import metrics
 logger = logging.getLogger(__name__)
 
 INCIDENTS_SNUBA_SUBSCRIPTION_TYPE = "incidents"
+INCIDENT_SNAPSHOT_BATCH_SIZE = 50
 
 
 @instrumented_task(name="sentry.incidents.tasks.send_subscriber_notifications", queue="incidents")
@@ -196,29 +197,30 @@ def auto_resolve_snapshot_incidents(alert_rule_id, **kwargs):
 @instrumented_task(
     name="sentry.incidents.tasks.process_pending_incident_snapshots", queue="incident_snapshots"
 )
-def process_pending_incident_snapshots():
+def process_pending_incident_snapshots(next_id=None):
     """
     Processes PendingIncidentSnapshots and creates a snapshot for any snapshot that
     has passed it's target_run_date.
     """
     from sentry.incidents.logic import create_incident_snapshot
 
-    batch_size = 50
-
     now = timezone.now()
-    pending_snapshots = (
-        PendingIncidentSnapshot.objects.filter(target_run_date__lte=now)
-        .order_by("-id")
-        .select_related("incident")[: batch_size + 1]
-    )
+    pending_snapshots = PendingIncidentSnapshot.objects.filter(target_run_date__lte=now)
+    if next_id is not None:
+        pending_snapshots = pending_snapshots.filter(id__lte=next_id)
+    pending_snapshots = pending_snapshots.order_by("-id").select_related("incident")[
+        : INCIDENT_SNAPSHOT_BATCH_SIZE + 1
+    ]
 
     if not pending_snapshots:
         return
 
     for processed, pending_snapshot in enumerate(pending_snapshots):
         incident = pending_snapshot.incident
-        if processed >= batch_size:
-            process_pending_incident_snapshots.apply_async(countdown=1)
+        if processed >= INCIDENT_SNAPSHOT_BATCH_SIZE:
+            process_pending_incident_snapshots.apply_async(
+                countdown=1, kwargs={"next_id": pending_snapshot.id}
+            )
             break
         else:
             try:

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -13,6 +13,7 @@ from sentry.incidents.logic import (
     create_alert_rule_trigger,
     create_alert_rule_trigger_action,
     create_incident_activity,
+    create_incident_snapshot,
     subscribe_to_incident,
 )
 from sentry.incidents.models import (
@@ -317,3 +318,37 @@ class ProcessPendingIncidentSnapshots(TestCase):
         assert snapshot.event_stats_snapshot.period == incident.alert_rule.snuba_query.time_window
         assert snapshot.unique_users == 0
         assert snapshot.total_events == 0
+
+    def test_iterates_pages(self):
+        snapshot_calls = [0]
+
+        def exploding_create_snapshot(*args, **kwargs):
+            if snapshot_calls[0] < 1:
+                snapshot_calls[0] += 1
+                raise Exception("bad snapshot")
+            return create_incident_snapshot(*args, **kwargs)
+
+        incident = self.create_incident(
+            title="incident",
+            status=IncidentStatus.CLOSED.value,
+            date_started=datetime(2020, 5, 1),
+            date_closed=datetime(2020, 5, 5),
+        )
+        PendingIncidentSnapshot.objects.create(incident=incident, target_run_date=timezone.now())
+        other_incident = self.create_incident(
+            title="incident",
+            status=IncidentStatus.CLOSED.value,
+            date_started=datetime(2020, 5, 1),
+            date_closed=datetime(2020, 5, 5),
+        )
+        failing = PendingIncidentSnapshot.objects.create(
+            incident=other_incident, target_run_date=timezone.now()
+        )
+
+        with patch("sentry.incidents.tasks.INCIDENT_SNAPSHOT_BATCH_SIZE", new=1), patch(
+            "sentry.incidents.logic.create_incident_snapshot",
+        ) as mock_create_snapshot:
+            mock_create_snapshot.side_effect = exploding_create_snapshot
+            with self.tasks():
+                process_pending_incident_snapshots()
+            assert list(PendingIncidentSnapshot.objects.all()) == [failing]


### PR DESCRIPTION
Currently if we had a batch of 50 or more failed snapshots then we'd fail to process the rest of the
queue. This is because we don't keep track of which position we were at, and so when we call the
next task it just fetches an arbitrary set of `PendingIncidentSnapshot` rows, which will likely be
the same as the ones we last fetched.

This adds paging, so that we'll always iterate through all of the rows that are pending.