### PR TITLE
feat(trends): Switch back to transactions as default for trends beta

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -43,9 +43,9 @@ import TrendsContent from './trends/content';
 import {modifyTrendsViewDefaultPeriod, DEFAULT_TRENDS_STATS_PERIOD} from './trends/utils';
 
 export enum FilterViews {
-  TRENDS = 'TRENDS',
   ALL_TRANSACTIONS = 'ALL_TRANSACTIONS',
   KEY_TRANSACTIONS = 'KEY_TRANSACTIONS',
+  TRENDS = 'TRENDS',
 }
 
 const VIEWS = Object.values(FilterViews).filter(view => view !== 'TRENDS');
@@ -173,14 +173,11 @@ class PerformanceLanding extends React.Component<Props, State> {
     return stringifyQueryObject(parsed);
   }
 
-  getCurrentView(hasTrendsFeature?: boolean): string {
+  getCurrentView(): string {
     const {location} = this.props;
     const currentView = location.query.view as FilterViews;
     if (Object.values(FilterViews).includes(currentView)) {
       return currentView;
-    }
-    if (hasTrendsFeature) {
-      return FilterViews.TRENDS;
     }
     return FilterViews.ALL_TRANSACTIONS;
   }
@@ -263,7 +260,7 @@ class PerformanceLanding extends React.Component<Props, State> {
       <Feature features={['trends']}>
         {({hasFeature}) =>
           hasFeature ? (
-            <ButtonBar merged active={this.getCurrentView(hasFeature)}>
+            <ButtonBar merged active={this.getCurrentView()}>
               {VIEWS_WITH_TRENDS.map(viewKey => {
                 return (
                   <Button
@@ -331,7 +328,7 @@ class PerformanceLanding extends React.Component<Props, State> {
 
   render() {
     const {organization, location, router, projects} = this.props;
-    const currentView = this.getCurrentView(organization.features.includes('trends'));
+    const currentView = this.getCurrentView();
     const isTrendsView = currentView === FilterViews.TRENDS;
     const eventView = isTrendsView
       ? modifyTrendsViewDefaultPeriod(this.state.eventView, location)

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -17,6 +17,7 @@ import {PageContent} from 'app/styles/organization';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import Alert from 'app/components/alert';
 import Feature from 'app/components/acl/feature';
+import FeatureBadge from 'app/components/featureBadge';
 import EventView from 'app/utils/discover/eventView';
 import space from 'app/styles/space';
 import Button from 'app/components/button';
@@ -153,7 +154,7 @@ class PerformanceLanding extends React.Component<Props, State> {
       case FilterViews.KEY_TRANSACTIONS:
         return t('By Key Transaction');
       case FilterViews.TRENDS:
-        return t('By Trends');
+        return t('By Trend');
       default:
         throw Error(`Unknown view: ${currentView}`);
     }
@@ -271,6 +272,7 @@ class PerformanceLanding extends React.Component<Props, State> {
                     onClick={() => this.handleViewChange(viewKey)}
                   >
                     {this.getViewLabel(viewKey)}
+                    {viewKey === FilterViews.TRENDS && <StyledFeatureBadge type="beta" />}
                   </Button>
                 );
               })}
@@ -413,6 +415,10 @@ const StyledSearchBar = styled(SearchBar)`
   flex-grow: 1;
 
   margin-bottom: ${space(2)};
+`;
+
+const StyledFeatureBadge = styled(FeatureBadge)`
+  height: 12px;
 `;
 
 export default withApi(

--- a/tests/js/spec/views/performance/landing.spec.jsx
+++ b/tests/js/spec/views/performance/landing.spec.jsx
@@ -311,8 +311,24 @@ describe('Performance > Landing', function () {
     expect(browserHistory.push).toHaveBeenCalledTimes(0);
   });
 
-  it('Default page (trends) with trends feature will update filters if none are set', async function () {
+  it('Default page (transactions) with trends feature will not update filters if none are set', async function () {
     const data = initializeTrendsData({view: undefined}, false);
+
+    const wrapper = mountWithTheme(
+      <PerformanceLanding
+        organization={data.organization}
+        location={data.router.location}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(browserHistory.push).toHaveBeenCalledTimes(0);
+  });
+
+  it('Visiting trends with trends feature will update filters if none are set', async function () {
+    const data = initializeTrendsData({view: FilterViews.TRENDS}, false);
 
     const wrapper = mountWithTheme(
       <PerformanceLanding


### PR DESCRIPTION
### Summary
This switches the default tab back to being 'all transactions' for the Trends beta, and adds a beta badge to the trends pill.

### Screenshot

![Screen Shot 2020-10-15 at 11 09 00 AM](https://user-images.githubusercontent.com/6111995/96169898-b9080480-0ed7-11eb-8501-c711e81da31f.png)
