### PR TITLE
fix(perf): Fix key transactions not reloading when switching

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
@@ -120,6 +120,7 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
     return (
       !isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload) ||
       prevProps.limit !== this.props.limit ||
+      prevProps.route !== this.props.route ||
       prevProps.cursor !== this.props.cursor
     );
   };

--- a/tests/js/spec/views/performance/landing.spec.jsx
+++ b/tests/js/spec/views/performance/landing.spec.jsx
@@ -60,6 +60,8 @@ function initializeTrendsData(query, addDefaultQuery = true) {
 }
 
 describe('Performance > Landing', function () {
+  let eventsMock;
+  let keyTransactionsMock;
   beforeEach(function () {
     browserHistory.push = jest.fn();
     jest.spyOn(globalSelection, 'updateDateTime');
@@ -89,7 +91,7 @@ describe('Performance > Landing', function () {
       method: 'POST',
       body: [],
     });
-    MockApiClient.addMockResponse({
+    eventsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/eventsv2/',
       body: {
         meta: {
@@ -118,6 +120,19 @@ describe('Performance > Landing', function () {
             user_misery_300: 122,
           },
         ],
+      },
+    });
+    keyTransactionsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/key-transactions/',
+      body: {
+        meta: {},
+        data: [],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/key-transactions-stats/',
+      body: {
+        data: [],
       },
     });
     MockApiClient.addMockResponse({
@@ -333,6 +348,35 @@ describe('Performance > Landing', function () {
         },
       })
     );
+  });
+
+  it('Changing views from all transactions to key transactions fires discover query', async function () {
+    const data = initializeTrendsData({view: FilterViews.ALL_TRANSACTIONS}, false);
+
+    const wrapper = mountWithTheme(
+      <PerformanceLanding
+        organization={data.organization}
+        location={data.router.location}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(eventsMock).toHaveBeenCalledTimes(1);
+    expect(keyTransactionsMock).toHaveBeenCalledTimes(0);
+
+    const changedViewData = initializeTrendsData(
+      {view: FilterViews.KEY_TRANSACTIONS},
+      false
+    );
+
+    wrapper.setProps({location: changedViewData.router.location});
+    await tick();
+    wrapper.update();
+
+    expect(eventsMock).toHaveBeenCalledTimes(1);
+    expect(keyTransactionsMock).toHaveBeenCalledTimes(1);
   });
 
   it('Tags are replaced with trends default query if navigating to trends', async function () {


### PR DESCRIPTION
### Summary
When switching from another tab, key transactions wasn't loading because of the generic discover query changes, which dropped the route check. This re-adds the route check to the generic query, as a changing route changes the shape of the request.