### PR TITLE
ci(zeus): Defer job update to prevent race conditions

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -157,8 +157,9 @@ steps:
   - |
     # Only push to Zeus from releases/*
     [[ ! "$BRANCH_NAME" =~ ^releases/ ]] && exit 0
-    npx -p "@zeus-ci/cli" zeus job update --build $BUILD_ID --job 1 --ref $COMMIT_SHA --build-label GCB --job-label "OSS Packages" --status passed
+    npx -p "@zeus-ci/cli" zeus job update --build $BUILD_ID --job 1 --ref $COMMIT_SHA --build-label GCB --job-label "OSS Packages"
     npx -p "@zeus-ci/cli" zeus upload --build $BUILD_ID --job 1 --type "application/x-pywheel+zip" dist/*.whl
+    npx -p "@zeus-ci/cli" zeus job update --build $BUILD_ID --job 1 --ref $COMMIT_SHA --build-label GCB --job-label "OSS Packages" --status passed
 timeout: 2400s
 options:
   # We need more memory for Webpack builds & e2e onpremise tests

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -1,165 +1,175 @@
 steps:
-- name: 'gcr.io/kaniko-project/executor:v0.22.0'
-  id: builder-image
-  args: [
-    '--cache=true',
-    '--build-arg', 'SOURCE_COMMIT=$COMMIT_SHA',
-    '--destination=us.gcr.io/$PROJECT_ID/sentry-builder:$COMMIT_SHA',
-    '-f', './docker/builder.dockerfile'
-  ]
-  timeout: 180s
-- name: 'us.gcr.io/$PROJECT_ID/sentry-builder:$COMMIT_SHA'
-  id: builder-run
-  env:
-    - 'SOURCE_COMMIT=$COMMIT_SHA'
-  timeout: 360s
-- name: 'gcr.io/kaniko-project/executor:v0.22.0'
-  id: runtime-image-py2
-  waitFor:
-    - builder-run
-  args: [
-    '--cache=true',
-    '--build-arg', 'SOURCE_COMMIT=$COMMIT_SHA',
-    '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA',
-    '-f', './docker/Dockerfile'
-  ]
-  timeout: 300s
-- name: 'gcr.io/kaniko-project/executor:v0.22.0'
-  id: runtime-image-py3
-  waitFor:
-    - builder-run
-  args: [
-    '--cache=true',
-    '--build-arg', 'SOURCE_COMMIT=$COMMIT_SHA',
-    '--build-arg', 'PY_VER=3.6.10',
-    '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA-py3',
-    '-f', './docker/Dockerfile'
-  ]
-  timeout: 300s
-- name: 'gcr.io/$PROJECT_ID/docker-compose'
-  id: get-onpremise-repo
-  waitFor:  ['-']
-  entrypoint: 'bash'
-  args:
-  - '-e'
-  - '-c'
-  - |
-    mkdir onpremise && cd onpremise
-    curl -L "https://github.com/getsentry/onpremise/archive/master.tar.gz" | tar xzf - --strip-components=1
-    echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
-- name: 'gcr.io/$PROJECT_ID/docker-compose'
-  id: e2e-test-py2
-  waitFor:
-    - runtime-image-py2
-    - get-onpremise-repo
-  entrypoint: 'bash'
-  dir: onpremise
-  env:
-  - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
-  args:
-  - '-e'
-  - '-c'
-  - |
-    ./install.sh
-    set +e
-    ./test.sh
-    test_return=$?
-    set -e
-    if [[ $test_return -ne 0 ]]; then
-      echo "Test failed.";
-      docker-compose ps;
-      docker-compose logs nginx web relay;
-      exit $test_return;
-    fi
-  timeout: 450s
-- name: 'gcr.io/$PROJECT_ID/docker-compose'
-  id: e2e-test-py3
-  waitFor:
-    - runtime-image-py3
-    - get-onpremise-repo
-    - e2e-test-py2
-  entrypoint: 'bash'
-  dir: onpremise
-  env:
-  - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
-  - 'SENTRY_PYTHON3=1'
-  args:
-  - '-e'
-  - '-c'
-  - |
-    ./install.sh
-    set +e
-    ./test.sh
-    test_return=$?
-    set -e
-    if [[ $test_return -ne 0 ]]; then
-      echo "Test failed.";
-      docker-compose ps;
-      docker-compose logs nginx web relay;
-      exit $test_return;
-    fi
-  timeout: 450s
-- name: 'gcr.io/cloud-builders/docker'
-  id: docker-push
-  waitFor:
-    - e2e-test-py2
-  secretEnv: ['DOCKER_PASSWORD']
-  entrypoint: 'bash'
-  env:
-  - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
-  args:
-  - '-e'
-  - '-c'
-  - |
-    # Only push to Docker Hub from master
-    [ "$BRANCH_NAME" != "master" ] && exit 0
-    # Need to pull the image first due to Kaniko
-    docker pull $SENTRY_IMAGE
-    echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
-    docker $SENTRY_IMAGE $DOCKER_REPO:$SHORT_SHA
-    docker push $DOCKER_REPO:$SHORT_SHA
-    docker $SENTRY_IMAGE $DOCKER_REPO:$COMMIT_SHA
-    docker push $DOCKER_REPO:$COMMIT_SHA
-    docker $SENTRY_IMAGE $DOCKER_REPO:nightly
-    docker push $DOCKER_REPO:nightly
-- name: 'gcr.io/cloud-builders/docker'
-  id: docker-push-py3
-  waitFor:
-    - e2e-test-py3
-  secretEnv: ['DOCKER_PASSWORD']
-  entrypoint: 'bash'
-  env:
-  - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
-  args:
-  - '-e'
-  - '-c'
-  - |
-    # Only push to Docker Hub from master
-    [ "$BRANCH_NAME" != "master" ] && exit 0
-    # Need to pull the image first due to Kaniko
-    docker pull $SENTRY_IMAGE-py3
-    echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
-    docker $SENTRY_IMAGE-py3 $DOCKER_REPO:$SHORT_SHA-py3
-    docker push $DOCKER_REPO:$SHORT_SHA-py3
-    docker $SENTRY_IMAGE-py3 $DOCKER_REPO:$COMMIT_SHA-py3
-    docker push $DOCKER_REPO:$COMMIT_SHA-py3
-    docker $SENTRY_IMAGE-py3 $DOCKER_REPO:nightly-py3
-    docker push $DOCKER_REPO:nightly-py3
-- name: 'node:12'
-  id: zeus-upload
-  waitFor:
-    - builder-run
-  secretEnv: ['ZEUS_HOOK_BASE']
-  entrypoint: 'bash'
-  args:
-  - '-e'
-  - '-c'
-  - |
-    # Only push to Zeus from releases/*
-    [[ ! "$BRANCH_NAME" =~ ^releases/ ]] && exit 0
-    npx -p "@zeus-ci/cli" zeus job update --build $BUILD_ID --job 1 --ref $COMMIT_SHA --build-label GCB --job-label "OSS Packages"
-    npx -p "@zeus-ci/cli" zeus upload --build $BUILD_ID --job 1 --type "application/x-pywheel+zip" dist/*.whl
-    npx -p "@zeus-ci/cli" zeus job update --build $BUILD_ID --job 1 --ref $COMMIT_SHA --build-label GCB --job-label "OSS Packages" --status passed
+  - name: 'gcr.io/kaniko-project/executor:v0.22.0'
+    id: builder-image
+    args:
+      [
+        '--cache=true',
+        '--build-arg',
+        'SOURCE_COMMIT=$COMMIT_SHA',
+        '--destination=us.gcr.io/$PROJECT_ID/sentry-builder:$COMMIT_SHA',
+        '-f',
+        './docker/builder.dockerfile',
+      ]
+    timeout: 180s
+  - name: 'us.gcr.io/$PROJECT_ID/sentry-builder:$COMMIT_SHA'
+    id: builder-run
+    env:
+      - 'SOURCE_COMMIT=$COMMIT_SHA'
+    timeout: 360s
+  - name: 'gcr.io/kaniko-project/executor:v0.22.0'
+    id: runtime-image-py2
+    waitFor:
+      - builder-run
+    args:
+      [
+        '--cache=true',
+        '--build-arg',
+        'SOURCE_COMMIT=$COMMIT_SHA',
+        '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA',
+        '-f',
+        './docker/Dockerfile',
+      ]
+    timeout: 300s
+  - name: 'gcr.io/kaniko-project/executor:v0.22.0'
+    id: runtime-image-py3
+    waitFor:
+      - builder-run
+    args:
+      [
+        '--cache=true',
+        '--build-arg',
+        'SOURCE_COMMIT=$COMMIT_SHA',
+        '--build-arg',
+        'PY_VER=3.6.10',
+        '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA-py3',
+        '-f',
+        './docker/Dockerfile',
+      ]
+    timeout: 300s
+  - name: 'gcr.io/$PROJECT_ID/docker-compose'
+    id: get-onpremise-repo
+    waitFor: ['-']
+    entrypoint: 'bash'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        mkdir onpremise && cd onpremise
+        curl -L "https://github.com/getsentry/onpremise/archive/master.tar.gz" | tar xzf - --strip-components=1
+        echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
+  - name: 'gcr.io/$PROJECT_ID/docker-compose'
+    id: e2e-test-py2
+    waitFor:
+      - runtime-image-py2
+      - get-onpremise-repo
+    entrypoint: 'bash'
+    dir: onpremise
+    env:
+      - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        ./install.sh
+        set +e
+        ./test.sh
+        test_return=$?
+        set -e
+        if [[ $test_return -ne 0 ]]; then
+          echo "Test failed.";
+          docker-compose ps;
+          docker-compose logs nginx web relay;
+          exit $test_return;
+        fi
+    timeout: 450s
+  - name: 'gcr.io/$PROJECT_ID/docker-compose'
+    id: e2e-test-py3
+    waitFor:
+      - runtime-image-py3
+      - get-onpremise-repo
+      - e2e-test-py2
+    entrypoint: 'bash'
+    dir: onpremise
+    env:
+      - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
+      - 'SENTRY_PYTHON3=1'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        ./install.sh
+        set +e
+        ./test.sh
+        test_return=$?
+        set -e
+        if [[ $test_return -ne 0 ]]; then
+          echo "Test failed.";
+          docker-compose ps;
+          docker-compose logs nginx web relay;
+          exit $test_return;
+        fi
+    timeout: 450s
+  - name: 'gcr.io/cloud-builders/docker'
+    id: docker-push
+    waitFor:
+      - e2e-test-py2
+    secretEnv: ['DOCKER_PASSWORD']
+    entrypoint: 'bash'
+    env:
+      - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        # Only push to Docker Hub from master
+        [ "$BRANCH_NAME" != "master" ] && exit 0
+        # Need to pull the image first due to Kaniko
+        docker pull $SENTRY_IMAGE
+        echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
+        docker $SENTRY_IMAGE $DOCKER_REPO:$SHORT_SHA
+        docker push $DOCKER_REPO:$SHORT_SHA
+        docker $SENTRY_IMAGE $DOCKER_REPO:$COMMIT_SHA
+        docker push $DOCKER_REPO:$COMMIT_SHA
+        docker $SENTRY_IMAGE $DOCKER_REPO:nightly
+        docker push $DOCKER_REPO:nightly
+  - name: 'gcr.io/cloud-builders/docker'
+    id: docker-push-py3
+    waitFor:
+      - e2e-test-py3
+    secretEnv: ['DOCKER_PASSWORD']
+    entrypoint: 'bash'
+    env:
+      - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        # Only push to Docker Hub from master
+        [ "$BRANCH_NAME" != "master" ] && exit 0
+        # Need to pull the image first due to Kaniko
+        docker pull $SENTRY_IMAGE-py3
+        echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
+        docker $SENTRY_IMAGE-py3 $DOCKER_REPO:$SHORT_SHA-py3
+        docker push $DOCKER_REPO:$SHORT_SHA-py3
+        docker $SENTRY_IMAGE-py3 $DOCKER_REPO:$COMMIT_SHA-py3
+        docker push $DOCKER_REPO:$COMMIT_SHA-py3
+        docker $SENTRY_IMAGE-py3 $DOCKER_REPO:nightly-py3
+        docker push $DOCKER_REPO:nightly-py3
+  - name: 'node:12'
+    id: zeus-upload
+    waitFor:
+      - builder-run
+    secretEnv: ['ZEUS_HOOK_BASE']
+    entrypoint: 'bash'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        # Only push to Zeus from releases/*
+        [[ ! "$BRANCH_NAME" =~ ^releases/ ]] && exit 0
+        npx -p "@zeus-ci/cli" zeus job update --build $BUILD_ID --job 1 --ref $COMMIT_SHA --build-label GCB --job-label "OSS Packages"
+        npx -p "@zeus-ci/cli" zeus upload --build $BUILD_ID --job 1 --type "application/x-pywheel+zip" dist/*.whl
+        npx -p "@zeus-ci/cli" zeus job update --build $BUILD_ID --job 1 --ref $COMMIT_SHA --build-label GCB --job-label "OSS Packages" --status passed
 timeout: 2400s
 options:
   # We need more memory for Webpack builds & e2e onpremise tests
@@ -169,16 +179,16 @@ options:
     - 'SENTRY_TEST_HOST=http://nginx'
     - 'CI=1'
 secrets:
-- kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
-  secretEnv:
-    # This is a personal access token for the sentrybuilder account, encrypted using the
-    # short guide at http://bit.ly/2Pg6uw9
-    DOCKER_PASSWORD: |
-      CiQAE8gN7y3OMxn+a1kofmK4Bi8jQZtdRFj2lYYwaZHVeIIBUzMSTQA9tvn8XCv2vqj6u8CHoeSP
-      TVW9pLvSCorKoeNtOp0eb+6V1yNJW/+JC07DNO1KLbTbodbuza6jKJHU5xeAJ4kGQI78UY5Vu1Gp
-      QcMK
-    ZEUS_HOOK_BASE: |
-      CiQAE8gN75WxSPytiv8kAp3cOp3RJHMqnfwH2bPDLJnwRxjQUJYSpAEAPbb5/GE1N8kUiC2YLh2n
-      IinZi+rM5umfESVC5lhzDkDqBiGLEvAKtAHOvnbVbdm/Ui5KytpUUGb+QRajw9MFGZlavUz81wyu
-      QDOpuajIhRNhhTZsJIhvFDkpQQykSgM2A7uKSQtQTLI9+njyB4F+SQEgaB6SvC7gMCqhSqYH+qJB
-      r1OJiKninNgwred/uJU0ZcVnNERNZ/hOyC1p/lXS7LHooA==
+  - kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
+    secretEnv:
+      # This is a personal access token for the sentrybuilder account, encrypted using the
+      # short guide at http://bit.ly/2Pg6uw9
+      DOCKER_PASSWORD: |
+        CiQAE8gN7y3OMxn+a1kofmK4Bi8jQZtdRFj2lYYwaZHVeIIBUzMSTQA9tvn8XCv2vqj6u8CHoeSP
+        TVW9pLvSCorKoeNtOp0eb+6V1yNJW/+JC07DNO1KLbTbodbuza6jKJHU5xeAJ4kGQI78UY5Vu1Gp
+        QcMK
+      ZEUS_HOOK_BASE: |
+        CiQAE8gN75WxSPytiv8kAp3cOp3RJHMqnfwH2bPDLJnwRxjQUJYSpAEAPbb5/GE1N8kUiC2YLh2n
+        IinZi+rM5umfESVC5lhzDkDqBiGLEvAKtAHOvnbVbdm/Ui5KytpUUGb+QRajw9MFGZlavUz81wyu
+        QDOpuajIhRNhhTZsJIhvFDkpQQykSgM2A7uKSQtQTLI9+njyB4F+SQEgaB6SvC7gMCqhSqYH+qJB
+        r1OJiKninNgwred/uJU0ZcVnNERNZ/hOyC1p/lXS7LHooA==


### PR DESCRIPTION
Currently, push a passed job to Zeus and afterwards upload the required wheel
artifact. If craft checks the job between these two steps, it finds a passed job
without artifact and fails instantly.

To avoid this race condition, first mark the job as pending, then upload the
artifact and finally update the job as passed.

