### PR TITLE
test(relay): Use nightly builds for testing

### DIFF
--- a/src/sentry/utils/pytest/relay.py
+++ b/src/sentry/utils/pytest/relay.py
@@ -96,7 +96,7 @@ def relay_server_setup(live_server, tmpdir_factory):
     container_name = _relay_server_container_name()
     _remove_container_if_exists(docker_client, container_name)
     options = {
-        "image": "us.gcr.io/sentryio/relay:latest",
+        "image": "us.gcr.io/sentryio/relay:nightly",
         "ports": {"%s/tcp" % relay_port: relay_port},
         "network": network,
         "detach": True,


### PR DESCRIPTION
This was missed in #21362, since Relay integration tests apparently do not use devservices to start the Relay container.