### PR TITLE
ci(gcb): Fix GCB failures due to missing extra $$

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -54,8 +54,6 @@ steps:
     - get-onpremise-repo
   entrypoint: 'bash'
   dir: onpremise
-  env:
-  - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
   args:
   - '-e'
   - '-c'
@@ -81,7 +79,6 @@ steps:
   entrypoint: 'bash'
   dir: onpremise
   env:
-  - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
   - 'SENTRY_PYTHON3=1'
   args:
   - '-e'
@@ -105,8 +102,6 @@ steps:
     - e2e-test-py2
   secretEnv: ['DOCKER_PASSWORD']
   entrypoint: 'bash'
-  env:
-  - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
   args:
   - '-e'
   - '-c'
@@ -114,22 +109,20 @@ steps:
     # Only push to Docker Hub from master
     [ "$BRANCH_NAME" != "master" ] && exit 0
     # Need to pull the image first due to Kaniko
-    docker pull $SENTRY_IMAGE
+    docker pull $$SENTRY_IMAGE
     echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
-    docker $SENTRY_IMAGE $DOCKER_REPO:$SHORT_SHA
-    docker push $DOCKER_REPO:$SHORT_SHA
-    docker $SENTRY_IMAGE $DOCKER_REPO:$COMMIT_SHA
-    docker push $DOCKER_REPO:$COMMIT_SHA
-    docker $SENTRY_IMAGE $DOCKER_REPO:nightly
-    docker push $DOCKER_REPO:nightly
+    docker $$SENTRY_IMAGE $$DOCKER_REPO:$SHORT_SHA
+    docker push $$DOCKER_REPO:$SHORT_SHA
+    docker $$SENTRY_IMAGE $$DOCKER_REPO:$COMMIT_SHA
+    docker push $$DOCKER_REPO:$COMMIT_SHA
+    docker $$SENTRY_IMAGE $$DOCKER_REPO:nightly
+    docker push $$DOCKER_REPO:nightly
 - name: 'gcr.io/cloud-builders/docker'
   id: docker-push-py3
   waitFor:
     - e2e-test-py3
   secretEnv: ['DOCKER_PASSWORD']
   entrypoint: 'bash'
-  env:
-  - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
   args:
   - '-e'
   - '-c'
@@ -137,14 +130,14 @@ steps:
     # Only push to Docker Hub from master
     [ "$BRANCH_NAME" != "master" ] && exit 0
     # Need to pull the image first due to Kaniko
-    docker pull $SENTRY_IMAGE-py3
+    docker pull $$SENTRY_IMAGE-py3
     echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
-    docker $SENTRY_IMAGE-py3 $DOCKER_REPO:$SHORT_SHA-py3
-    docker push $DOCKER_REPO:$SHORT_SHA-py3
-    docker $SENTRY_IMAGE-py3 $DOCKER_REPO:$COMMIT_SHA-py3
-    docker push $DOCKER_REPO:$COMMIT_SHA-py3
-    docker $SENTRY_IMAGE-py3 $DOCKER_REPO:nightly-py3
-    docker push $DOCKER_REPO:nightly-py3
+    docker $$SENTRY_IMAGE-py3 $$DOCKER_REPO:$SHORT_SHA-py3
+    docker push $$DOCKER_REPO:$SHORT_SHA-py3
+    docker $$SENTRY_IMAGE-py3 $$DOCKER_REPO:$COMMIT_SHA-py3
+    docker push $$DOCKER_REPO:$COMMIT_SHA-py3
+    docker $$SENTRY_IMAGE-py3 $$DOCKER_REPO:nightly-py3
+    docker push $$DOCKER_REPO:nightly-py3
 - name: 'node:12'
   id: zeus-upload
   waitFor:
@@ -164,6 +157,7 @@ options:
   # We need more memory for Webpack builds & e2e onpremise tests
   machineType: 'N1_HIGHCPU_8'
   env:
+    - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
     - 'DOCKER_REPO=getsentry/sentry'
     - 'SENTRY_TEST_HOST=http://nginx'
     - 'CI=1'


### PR DESCRIPTION
This is a follow up to #21360 as it failed to address the underlying issue. GCB uses the `$xxx` syntax for variable expansion and it opreates in 'loose' mode when a trigger runs the build. This means it simply replaces unknown substitions with empty strings. This collides with how we try to use env variables which has the same syntax so the need to use `$$` syntax for GCB to not replace them with empty strings.
