### PR TITLE
ref: use equality check for SENTRY_PYTHON3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import
 import os
 import sys
 
-if os.environ.get("SENTRY_PYTHON3") and sys.version_info[:2] != (3, 6):
+if os.environ.get("SENTRY_PYTHON3") == "1" and sys.version_info[:2] != (3, 6):
     sys.exit("Error: Sentry [In EXPERIMENTAL python 3 mode] requires Python 3.6.")
 
-if not os.environ.get("SENTRY_PYTHON3") and sys.version_info[:2] != (2, 7):
+if os.environ.get("SENTRY_PYTHON3") != "1" and sys.version_info[:2] != (2, 7):
     sys.exit("Error: Sentry requires Python 2.7.")
 
 from distutils.command.build import build as BuildCommand


### PR DESCRIPTION
The SENTRY_PYTHON3 check should use equality for 1 instead of presence, which remained true for empty strings.

This makes it possible to like, toggle it in dockerfiles. Ideally it's a truthy check, but this is just a temporary thing.

See https://github.com/getsentry/single-tenant/pull/274/files#r505777392.