### PR TITLE
fix: various issues with devservices

### DIFF
--- a/src/sentry/plugins/sentry_useragents/models.py
+++ b/src/sentry/plugins/sentry_useragents/models.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from ua_parser.user_agent_parser import Parse
-
 import sentry
 from sentry.plugins.bases.tag import TagPlugin
 
@@ -33,12 +31,19 @@ class UserAgentPlugin(TagPlugin):
         for key, value in headers:
             if key != "User-Agent":
                 continue
+
+            # ua_parser is imported here, and not module level, because it takes ~300ms to warmup,
+            # and that penalty is seen even in running sentry cli or pytest.
+            from ua_parser.user_agent_parser import Parse
+
             ua = Parse(value)
             if not ua:
                 continue
+
             result = self.get_tag_from_ua(ua)
             if result:
                 output.append(result)
+
         return output
 
 

--- a/src/sentry/plugins/sentry_useragents/models.py
+++ b/src/sentry/plugins/sentry_useragents/models.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from ua_parser.user_agent_parser import Parse
+
 import sentry
 from sentry.plugins.bases.tag import TagPlugin
 
@@ -31,19 +33,12 @@ class UserAgentPlugin(TagPlugin):
         for key, value in headers:
             if key != "User-Agent":
                 continue
-
-            # ua_parser is imported here, and not module level, because it takes ~300ms to warmup,
-            # and that penalty is seen even in running sentry cli or pytest.
-            from ua_parser.user_agent_parser import Parse
-
             ua = Parse(value)
             if not ua:
                 continue
-
             result = self.get_tag_from_ua(ua)
             if result:
                 output.append(result)
-
         return output
 
 

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -9,6 +9,17 @@ from six import text_type
 from sentry.utils.compat import map
 
 
+def get_docker_client():
+    import docker
+
+    client = docker.from_env()
+    try:
+        client.ping()
+        return client
+    except Exception:
+        raise click.ClickException("Make sure Docker is running.")
+
+
 def get_or_create(client, thing, name):
     from docker.errors import NotFound
 
@@ -38,13 +49,7 @@ def devservices(ctx):
 
     Do not use in production!
     """
-    import docker
-
-    ctx.obj["client"] = docker.from_env()
-    try:
-        ctx.obj["client"].ping()
-    except Exception:
-        raise click.ClickException("Make sure Docker is running.")
+    ctx.obj["client"] = get_docker_client()
 
     # Disable backend validation so no devservices commands depend on like,
     # redis to be already running.

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -48,6 +48,9 @@ def devservices():
 
     Do not use in production!
     """
+    # Disable backend validation so no devservices commands depend on like,
+    # redis to be already running.
+    os.environ["SENTRY_SKIP_BACKEND_VALIDATION"] = "1"
 
 
 @devservices.command()
@@ -66,9 +69,6 @@ def attach(project, fast, service):
     Note: This does not update images, you will have to use `devservices up`
     for that.
     """
-
-    os.environ["SENTRY_SKIP_BACKEND_VALIDATION"] = "1"
-
     from sentry.runner import configure
 
     configure()
@@ -110,8 +110,6 @@ def up(services, project, exclude, fast):
 
     You may also exclude services, for example: --exclude redis --exclude postgres.
     """
-    os.environ["SENTRY_SKIP_BACKEND_VALIDATION"] = "1"
-
     from sentry.runner import configure
 
     configure()


### PR DESCRIPTION
This fixes two longstanding issues with devservices.

1: Most selective `devservices up` don't work. For example: `sentry devservices up snuba clickhouse` would error like `KeyError redis`. This is due to an oversight with passing selected containers when it should be all containers, and selected service names. I also took the opportunity to refactor the service selection logic.

2: Some devservices commands like `rm`, fail if like, `redis` isn't running. This is because backends are being validated. The workaround is to set `SENTRY_SKIP_BACKEND_VALIDATION=1`, but let's just do that by default for _all_ devservices since it doesn't really make sense otherwise.

Also, some light refactoring to instantiate the docker client and save it to click context obj.

cc @billyvg for visibility: I will follow up with https://github.com/getsentry/sentry/pull/21286/files#r504262098 after this is merged.