### PR TITLE
fix(discover): Format y-axis with right units on landing page

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/charts.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/charts.tsx
@@ -5,6 +5,7 @@ import {
   MINUTE,
   SECOND,
   getDuration,
+  formatAbbreviatedNumber,
   formatPercentage,
 } from 'app/utils/formatters';
 import {t} from 'app/locale';
@@ -31,11 +32,15 @@ export function tooltipFormatter(value: number, seriesName: string): string {
  * Formatter for chart axis labels that handle a variety of discover result values
  * This function is *very similar* to tooltipFormatter but outputs data with less precision.
  */
-export function axisLabelFormatter(value: number, seriesName: string): string {
+export function axisLabelFormatter(
+  value: number,
+  seriesName: string,
+  abbreviation: boolean = false
+): string {
   switch (aggregateOutputType(seriesName)) {
     case 'integer':
     case 'number':
-      return value.toLocaleString();
+      return abbreviation ? formatAbbreviatedNumber(value) : value.toLocaleString();
     case 'percentage':
       return formatPercentage(value, 0);
     case 'duration':

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -10,10 +10,10 @@ import EventsRequest from 'app/components/charts/eventsRequest';
 import AreaChart from 'app/components/charts/areaChart';
 import {getInterval} from 'app/components/charts/utils';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
+import {axisLabelFormatter} from 'app/utils/discover/charts';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingContainer from 'app/components/loading/loadingContainer';
 import {IconWarning} from 'app/icons';
-import {formatAbbreviatedNumber} from 'app/utils/formatters';
 import theme from 'app/utils/theme';
 import EventView from 'app/utils/discover/eventView';
 
@@ -133,7 +133,7 @@ class MiniGraph extends React.Component<Props> {
                   color: theme.gray400,
                   fontFamily: theme.text.family,
                   fontSize: 12,
-                  formatter: formatAbbreviatedNumber,
+                  formatter: (value: number) => axisLabelFormatter(value, yAxis, true),
                   inside: true,
                   showMinLabel: false,
                   showMaxLabel: false,


### PR DESCRIPTION
The y-axis of the mini graphs on the discover landing page simply formats the
values as an abbreviated number. However, these values can be durations as well.
This change uses the same formatting as the discover graphs to format the y axis
label so it matches the units better.

Fixes #21355 