### PR TITLE
feat(workflow): Skip snapshot creation if it already exists

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -302,6 +302,8 @@ def create_incident_snapshot(incident, windowed_stats=False):
     and total events, plus a time series snapshot of the entire incident.
     """
     assert incident.status == IncidentStatus.CLOSED.value
+    if IncidentSnapshot.objects.filter(incident=incident).exists():
+        return None
 
     start, end = calculate_incident_time_range(incident, windowed_stats=windowed_stats)
     if start == end:

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -585,6 +585,12 @@ class CreateIncidentSnapshotTest(TestCase, BaseIncidentsTest):
         start, end = calculate_incident_time_range(incident, windowed_stats=True)
         assert end == incident.current_end_date + timedelta(minutes=100)
 
+    def test_skip_existing(self):
+        incident = self.create_incident(self.organization)
+        incident.update(status=IncidentStatus.CLOSED.value)
+        create_incident_snapshot(incident, windowed_stats=False)
+        assert create_incident_snapshot(incident, windowed_stats=False) is None
+
 
 @freeze_time()
 class GetIncidentStatsTest(TestCase, BaseIncidentsTest):


### PR DESCRIPTION
Resolves https://sentry.io/organizations/sentry/issues/1958118553/?project=1&query=firstRelease%3A02f0908e9e497a014bbcbe7ec2a14afed7471249

Debating on updating the existing snapshot instead, as this may be caused by an incident reopening and being closed again?