### PR TITLE
feat(update-package): 3.1.1 to 3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "papaparse": "^5.2.0",
     "parseurl": "^1.3.2",
-    "platformicons": "^3.1.1",
+    "platformicons": "^3.2.0",
     "po-catalog-loader": "2.0.0",
     "prismjs": "^1.21.0",
     "prop-types": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11537,10 +11537,10 @@ pkg-up@2.0.0, pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-platformicons@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-3.1.1.tgz#ca50a544230b5656e012ed775957ffe88b6f938e"
-  integrity sha512-EdC6ig6jnOgx8Zx8Uw5LgALzX7EXCNGXzDO/eT2O1AXeJs+MTIpK3ULT3PT8HXDbPQ/1j3Fwh4CPctof9N0CvA==
+platformicons@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-3.2.0.tgz#18c551ad6588b15eb8e12706e129c647d91be3c5"
+  integrity sha512-E7N0YnqAFVKMsM/NQ5YxaIjW56Jj2LmdpuRxGR5c3o8R2+hqmNO1dPCpcvUbFQitQmrPqSH8SP56RNv8kb8blw==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Updated platformicons from 3.1.1 to 3.2.0. It's definitely working because of the lighter green bg for node 

**Before:**
![Screen Shot 2020-10-15 at 3 22 14 PM](https://user-images.githubusercontent.com/4830259/96192205-6724a600-0efa-11eb-8a50-82e54f0fb6a4.png)

**After:**
![Screen Shot 2020-10-15 at 3 19 42 PM](https://user-images.githubusercontent.com/4830259/96192149-49574100-0efa-11eb-8d5b-6cfacf48f0d3.png)
