### PR TITLE
fix(kafka): Update arbitrarily renamed `KafkaError` in commit retry policy

### DIFF
--- a/src/sentry/utils/batching_kafka_consumer.py
+++ b/src/sentry/utils/batching_kafka_consumer.py
@@ -409,7 +409,7 @@ class BatchingKafkaConsumer(object):
             except KafkaException as e:
                 if e.args[0].code() in (
                     KafkaError.REQUEST_TIMED_OUT,
-                    KafkaError.NOT_COORDINATOR_FOR_GROUP,
+                    KafkaError.NOT_COORDINATOR,
                     KafkaError._WAIT_COORD,
                 ):
                     logger.warning("Commit failed: %s (%d retries)", e, retries)


### PR DESCRIPTION
See getsentry/snuba#1429.

> Seems as though we don't do a whole lot of retrying. Not sure when this changed, but it was prior to or with the 1.5.0 release which we use.