### PR TITLE
fix: Wait unitl plugin config form loads

### DIFF
--- a/tests/acceptance/test_organization_plugin_detail_view.py
+++ b/tests/acceptance/test_organization_plugin_detail_view.py
@@ -37,6 +37,7 @@ class OrganizationPluginDetailedView(AcceptanceTestCase):
 
         self.browser.click('[id="react-select-2-option-0"]')
         # check if we got to the configuration page with the form
+        self.browser.wait_until_not(".loading-indicator")
         self.browser.wait_until_test_id("plugin-config")
         self.browser.snapshot("integrations - plugin config form")
 

--- a/tests/acceptance/test_organization_plugin_detail_view.py
+++ b/tests/acceptance/test_organization_plugin_detail_view.py
@@ -37,9 +37,8 @@ class OrganizationPluginDetailedView(AcceptanceTestCase):
 
         self.browser.click('[id="react-select-2-option-0"]')
         # check if we got to the configuration page with the form
-        self.browser.wait_until_not(".loading-indicator")
+        self.browser.wait_until_test_id("plugin-config")
         self.browser.snapshot("integrations - plugin config form")
-        assert self.browser.element_exists_by_test_id("plugin-config")
 
     def test_uninstallation(self):
         self.plugin.set_option("api_key", "7c8951d1", self.project)


### PR DESCRIPTION
## Objective

For some reason, selenium is not waiting until `.loading-indicator` disappears. So instead we are waiting until the data-test-id appears. We will remove the assert because waiting until appearing is the same as asserting that it exists. If it doesn't exist it will timeout and error.