### PR TITLE
ci(release): Add sleep between prepare and publish back

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,9 @@ jobs:
           GIT_AUTHOR_NAME: getsentry-bot
           EMAIL: bot@getsentry.com
           ZEUS_API_TOKEN: ${{ secrets.ZEUS_API_TOKEN }}
+      # Wait until the builds start. Craft should do this automatically
+      # but it is broken now.
+      - run: sleep 10
       - uses: getsentry/craft@master
         with:
           action: publish


### PR DESCRIPTION
Turns out getsentry/craft#117 did not fix the issue fully.
