### PR TITLE
build(webpack): Change `IS_CI` to enable when in CI and snapshots

### DIFF
--- a/docs-ui/components/getDynamicText.stories.js
+++ b/docs-ui/components/getDynamicText.stories.js
@@ -10,8 +10,8 @@ export default {
 export const GetDynamicText = withInfo(
   `
   Use this to wrap dynamic content (i.e. dates) for acceptance/snapshot tests.
-  Currently checks for IS_CI env var.
-  (webpack config has webpack.DefinePlugin for "process.env.IS_CI")
+  Currently checks for IS_ACCEPTANCE_TEST env var.
+  (webpack config has webpack.DefinePlugin for "process.env.IS_ACCEPTANCE_TEST")
   `
 )(() => {
   return (

--- a/src/sentry/static/sentry/app/components/charts/baseChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.tsx
@@ -3,7 +3,7 @@ import ReactEchartsCore from 'echarts-for-react/lib/core';
 import {EChartOption, ECharts} from 'echarts/lib/echarts';
 import styled from '@emotion/styled';
 
-import {IS_CI} from 'app/constants';
+import {IS_ACCEPTANCE_TEST} from 'app/constants';
 import {
   Series,
   EChartEventHandler,
@@ -391,7 +391,7 @@ class BaseChart extends React.Component<Props, State> {
             ...style,
           }}
           option={{
-            animation: IS_CI ? false : true,
+            animation: IS_ACCEPTANCE_TEST ? false : true,
             ...options,
             useUTC: utc,
             color: colors || this.getColorPalette(),

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -7,7 +7,7 @@ import styled from '@emotion/styled';
 import memoize from 'lodash/memoize';
 
 import {domId} from 'app/utils/domId';
-import {IS_CI} from 'app/constants';
+import {IS_ACCEPTANCE_TEST} from 'app/constants';
 
 const IS_HOVERABLE_DELAY = 50; // used if isHoverable is true (for hiding AND showing)
 
@@ -109,7 +109,7 @@ class Tooltip extends React.Component<Props, State> {
   };
 
   async componentDidMount() {
-    if (IS_CI) {
+    if (IS_ACCEPTANCE_TEST) {
       const TooltipStore = (
         await import(/* webpackChunkName: "TooltipStore" */ 'app/stores/tooltipStore')
       ).default;
@@ -120,7 +120,7 @@ class Tooltip extends React.Component<Props, State> {
   async componentWillUnmount() {
     const {usesGlobalPortal} = this.state;
 
-    if (IS_CI) {
+    if (IS_ACCEPTANCE_TEST) {
       const TooltipStore = (
         await import(/* webpackChunkName: "TooltipStore" */ 'app/stores/tooltipStore')
       ).default;

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -244,7 +244,7 @@ export const ORGANIZATION_FETCH_ERROR_TYPES = {
 export const CONFIG_DOCS_URL = 'https://docs.sentry.io/server/config/';
 export const DISCOVER2_DOCS_URL = 'https://docs.sentry.io/product/discover-queries/';
 
-export const IS_CI = !!process.env.IS_CI;
+export const IS_ACCEPTANCE_TEST = !!process.env.IS_ACCEPTANCE_TEST;
 export const NODE_ENV = process.env.NODE_ENV;
 export const DISABLE_RR_WEB = !!process.env.DISABLE_RR_WEB;
 export const SPA_DSN = process.env.SPA_DSN;

--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Global, css} from '@emotion/core';
 
-import {IS_CI} from 'app/constants';
+import {IS_ACCEPTANCE_TEST} from 'app/constants';
 import {Theme} from 'app/utils/theme';
 
 const styles = (theme: Theme) => css`
@@ -32,7 +32,7 @@ const styles = (theme: Theme) => css`
     }
   }
 
-  ${IS_CI
+  ${IS_ACCEPTANCE_TEST
     ? css`
         input,
         select {

--- a/src/sentry/static/sentry/app/utils/getDynamicText.tsx
+++ b/src/sentry/static/sentry/app/utils/getDynamicText.tsx
@@ -1,7 +1,7 @@
-import {IS_CI} from 'app/constants';
+import {IS_ACCEPTANCE_TEST} from 'app/constants';
 
 // Return a specified "fixed" string when we are in a testing environment
-// (more specifically, when IS_CI is true)
+// (more specifically, when IS_ACCEPTANCE_TEST is true)
 export default function getDynamicText<Value, Fixed = Value>({
   value,
   fixed,
@@ -9,5 +9,5 @@ export default function getDynamicText<Value, Fixed = Value>({
   value: Value;
   fixed: Fixed;
 }): Value | Fixed {
-  return IS_CI ? fixed : value;
+  return IS_ACCEPTANCE_TEST ? fixed : value;
 }

--- a/src/sentry/static/sentry/app/utils/marked.tsx
+++ b/src/sentry/static/sentry/app/utils/marked.tsx
@@ -1,7 +1,7 @@
 import marked from 'marked'; // eslint-disable-line no-restricted-imports
 import dompurify from 'dompurify';
 
-import {IS_CI, NODE_ENV} from 'app/constants';
+import {IS_ACCEPTANCE_TEST, NODE_ENV} from 'app/constants';
 
 // Only https and mailto, (e.g. no javascript, vbscript, data protocols)
 const safeLinkPattern = /^(https?:|mailto:)/i;
@@ -57,7 +57,7 @@ marked.setOptions({
   //      as a html error, instead of throwing an exception, however none of
   //      our tests are rendering failed markdown so this is likely a safe
   //      tradeoff to turn off off the deprecation warning.
-  silent: !!IS_CI || NODE_ENV === 'test',
+  silent: !!IS_ACCEPTANCE_TEST || NODE_ENV === 'test',
 });
 
 const sanitizedMarked = (...args: Parameters<typeof marked>) =>

--- a/src/sentry/static/sentry/app/utils/testableTransition.tsx
+++ b/src/sentry/static/sentry/app/utils/testableTransition.tsx
@@ -1,6 +1,6 @@
 import {Transition} from 'framer-motion';
 
-import {IS_CI} from 'app/constants';
+import {IS_ACCEPTANCE_TEST} from 'app/constants';
 
 /**
  * Use with a framer-motion transition to disable the animation in testing
@@ -16,7 +16,7 @@ import {IS_CI} from 'app/constants';
  *
  * This function simply disables the animation `type`.
  */
-const testableTransition = !IS_CI
+const testableTransition = !IS_ACCEPTANCE_TEST
   ? (t?: Transition) => t
   : function (transition?: Transition): Transition {
       return {

--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.tsx
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.tsx
@@ -5,7 +5,7 @@ import {motion, AnimatePresence} from 'framer-motion';
 import scrollToElement from 'scroll-to-element';
 import styled from '@emotion/styled';
 
-import {IS_CI} from 'app/constants';
+import {IS_ACCEPTANCE_TEST} from 'app/constants';
 import {analytics} from 'app/utils/analytics';
 import {t} from 'app/locale';
 import Hook from 'app/components/hook';
@@ -148,7 +148,7 @@ class Onboarding extends React.Component<Props, State> {
       align: 'middle',
       offset: 0,
       // Disable animations in CI - must be < 0 to disable
-      duration: IS_CI ? -1 : 300,
+      duration: IS_ACCEPTANCE_TEST ? -1 : 300,
     });
   };
 

--- a/tests/js/spec/utils/getDynamicText.spec.jsx
+++ b/tests/js/spec/utils/getDynamicText.spec.jsx
@@ -5,7 +5,7 @@ describe('getDynamicText', function () {
 
   it('renders actual value', function () {
     jest.doMock('app/constants', () => ({
-      IS_CI: false,
+      IS_ACCEPTANCE_TEST: false,
     }));
     const getDynamicText = require('app/utils/getDynamicText').default;
 
@@ -17,9 +17,9 @@ describe('getDynamicText', function () {
     ).toEqual('Dynamic Content');
   });
 
-  it('renders fixed content when `app/constants/IS_CI` is true', function () {
+  it('renders fixed content when `app/constants/IS_ACCEPTANCE_TEST` is true', function () {
     jest.doMock('app/constants', () => ({
-      IS_CI: true,
+      IS_ACCEPTANCE_TEST: true,
     }));
     const getDynamicText = require('app/utils/getDynamicText').default;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,10 @@ const {env} = process;
 const IS_PRODUCTION = env.NODE_ENV === 'production';
 const IS_TEST = env.NODE_ENV === 'test' || env.TEST_SUITE;
 const IS_STORYBOOK = env.STORYBOOK_BUILD === '1';
-const IS_CI = !!env.CI || !!env.TRAVIS;
+// This is used to stop rendering dynamic content for tests/snapshots
+// We want it in the case where we are running tests and it is in CI,
+// this should not happen in local
+const IS_CI = (!!env.CI || !!env.TRAVIS) && !!env.VISUAL_SNAPSHOT_ENABLE;
 const IS_DEPLOY_PREVIEW = !!env.NOW_GITHUB_DEPLOYMENT;
 const IS_UI_DEV_ONLY = !!env.SENTRY_UI_DEV_ONLY;
 const DEV_MODE = !(IS_PRODUCTION || IS_CI);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,8 @@ const IS_STORYBOOK = env.STORYBOOK_BUILD === '1';
 // This is used to stop rendering dynamic content for tests/snapshots
 // We want it in the case where we are running tests and it is in CI,
 // this should not happen in local
-const IS_CI = (!!env.CI || !!env.TRAVIS) && !!env.VISUAL_SNAPSHOT_ENABLE;
+const IS_CI = !!env.CI || !!env.TRAVIS;
+const IS_ACCEPTANCE_TEST = IS_CI && !!env.VISUAL_SNAPSHOT_ENABLE;
 const IS_DEPLOY_PREVIEW = !!env.NOW_GITHUB_DEPLOYMENT;
 const IS_UI_DEV_ONLY = !!env.SENTRY_UI_DEV_ONLY;
 const DEV_MODE = !(IS_PRODUCTION || IS_CI);
@@ -310,7 +311,7 @@ let appConfig = {
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify(env.NODE_ENV),
-        IS_CI: JSON.stringify(IS_CI),
+        IS_ACCEPTANCE_TEST: JSON.stringify(IS_ACCEPTANCE_TEST),
         DEPLOY_PREVIEW_CONFIG: JSON.stringify(DEPLOY_PREVIEW_CONFIG),
         EXPERIMENTAL_SPA: JSON.stringify(SENTRY_EXPERIMENTAL_SPA),
         SPA_DSN: JSON.stringify(env.SENTRY_SPA_DSN),
@@ -382,7 +383,7 @@ let appConfig = {
   devtool: IS_PRODUCTION ? 'source-map' : 'cheap-module-eval-source-map',
 };
 
-if (IS_TEST || IS_CI || IS_STORYBOOK) {
+if (IS_TEST || IS_ACCEPTANCE_TEST || IS_STORYBOOK) {
   appConfig.resolve.alias['integration-docs-platforms'] = path.join(
     __dirname,
     'tests/fixtures/integration-docs/_platforms.json'


### PR DESCRIPTION
This changes `IS_CI` to be enabled only when we are in a CI environment and we are using visual snapshots. We also rename the `IS_CI` constant in our frontend app to `IS_ACCEPTANCE_TEST` to better reflect this change (in the future we may want to add the env var to our `Makefile`). The reason for this change is because we are now starting to use CI for releases and this will cause our JS bundle to be in this test mode.

Fixes #21409