### PR TITLE
feat(trends-fixes): clickable summary and compare in menu

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -444,6 +444,7 @@ function TrendsListItem(props: TrendsListItemProps) {
       </ItemTransactionPercentage>
       <StyledDropdownLink
         caret={false}
+        anchorRight
         title={
           <StyledButton
             size="xsmall"

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -442,7 +442,7 @@ function TrendsListItem(props: TrendsListItemProps) {
           )}
         </Tooltip>
       </ItemTransactionPercentage>
-      <StyledDropdownLink
+      <DropdownLink
         caret={false}
         anchorRight
         title={
@@ -458,21 +458,21 @@ function TrendsListItem(props: TrendsListItemProps) {
             handleFilterDuration(location, longestPeriodValue, FilterSymbols.GREATER_THAN)
           }
         >
-          <StyledMenuAction>{t('Exclude > %s', longestDuration)}</StyledMenuAction>
+          <StyledMenuAction>{t('Show \u2264 %s', longestDuration)}</StyledMenuAction>
         </MenuItem>
         <MenuItem
           onClick={() =>
             handleFilterDuration(location, longestPeriodValue, FilterSymbols.LESS_THAN)
           }
         >
-          <StyledMenuAction>{t('Exclude < %s', longestDuration)}</StyledMenuAction>
+          <StyledMenuAction>{t('Show \u2265 %s', longestDuration)}</StyledMenuAction>
         </MenuItem>
         <MenuItem
           onClick={() => handleFilterTransaction(location, transaction.transaction)}
         >
           <StyledMenuAction>{t('Hide from list')}</StyledMenuAction>
         </MenuItem>
-      </StyledDropdownLink>
+      </DropdownLink>
       <ItemTransactionDurationChange>
         {project && (
           <Tooltip title={transaction.project}>
@@ -596,10 +596,6 @@ const StyledButton = styled(Button)`
 const StyledMenuAction = styled('div')`
   white-space: nowrap;
   color: ${p => p.theme.textColor};
-`;
-
-const StyledDropdownLink = styled(DropdownLink)`
-  min-width: 200px;
 `;
 
 const StyledEmptyStateWarning = styled(EmptyStateWarning)`

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -400,14 +400,6 @@ function TrendsListItem(props: TrendsListItemProps) {
   return (
     <ListItemContainer data-test-id={'trends-list-item-' + trendChangeType}>
       <ItemRadioContainer color={color}>
-        <RadioLineItem index={index} role="radio">
-          <Radio
-            checked={isSelected}
-            onChange={() => handleSelectTransaction(transaction)}
-          />
-        </RadioLineItem>
-      </ItemRadioContainer>
-      <ItemTransactionName>
         <Tooltip
           title={
             <TooltipContent>
@@ -420,52 +412,15 @@ function TrendsListItem(props: TrendsListItemProps) {
             </TooltipContent>
           }
         >
-          <TransactionName onClick={() => handleSelectTransaction(transaction)}>
-            {transaction.transaction}
-          </TransactionName>
-        </Tooltip>
-        <StyledDropdownLink
-          caret={false}
-          title={
-            <StyledButton
-              size="zero"
-              borderless
-              icon={<IconEllipsis data-test-id="trends-item-action" />}
+          <RadioLineItem index={index} role="radio">
+            <Radio
+              checked={isSelected}
+              onChange={() => handleSelectTransaction(transaction)}
             />
-          }
-        >
-          <MenuItem>
-            <TransactionSummaryLink {...props} />
-          </MenuItem>
-          <MenuItem
-            onClick={() => handleFilterTransaction(location, transaction.transaction)}
-          >
-            <StyledMenuAction>{t('Hide from list')}</StyledMenuAction>
-          </MenuItem>
-          <MenuItem
-            onClick={() =>
-              handleFilterDuration(
-                location,
-                longestPeriodValue,
-                FilterSymbols.GREATER_THAN
-              )
-            }
-          >
-            <StyledMenuAction>
-              {t('Exclude transactions > %s', longestDuration)}
-            </StyledMenuAction>
-          </MenuItem>
-          <MenuItem
-            onClick={() =>
-              handleFilterDuration(location, longestPeriodValue, FilterSymbols.LESS_THAN)
-            }
-          >
-            <StyledMenuAction>
-              {t('Exclude transactions < %s', longestDuration)}
-            </StyledMenuAction>
-          </MenuItem>
-        </StyledDropdownLink>
-      </ItemTransactionName>
+          </RadioLineItem>
+        </Tooltip>
+      </ItemRadioContainer>
+      <TransactionSummaryLink {...props} />
       <ItemTransactionPercentage>
         <Tooltip title={percentChangeExplanation}>
           {currentTrendFunction === TrendFunctionField.USER_MISERY ? (
@@ -487,16 +442,43 @@ function TrendsListItem(props: TrendsListItemProps) {
           )}
         </Tooltip>
       </ItemTransactionPercentage>
+      <StyledDropdownLink
+        caret={false}
+        title={
+          <StyledButton
+            size="xsmall"
+            icon={<IconEllipsis data-test-id="trends-item-action" size="xs" />}
+          />
+        }
+      >
+        <CompareLink {...props} />
+        <MenuItem
+          onClick={() =>
+            handleFilterDuration(location, longestPeriodValue, FilterSymbols.GREATER_THAN)
+          }
+        >
+          <StyledMenuAction>{t('Exclude > %s', longestDuration)}</StyledMenuAction>
+        </MenuItem>
+        <MenuItem
+          onClick={() =>
+            handleFilterDuration(location, longestPeriodValue, FilterSymbols.LESS_THAN)
+          }
+        >
+          <StyledMenuAction>{t('Exclude < %s', longestDuration)}</StyledMenuAction>
+        </MenuItem>
+        <MenuItem
+          onClick={() => handleFilterTransaction(location, transaction.transaction)}
+        >
+          <StyledMenuAction>{t('Hide from list')}</StyledMenuAction>
+        </MenuItem>
+      </StyledDropdownLink>
       <ItemTransactionDurationChange>
         {project && (
           <Tooltip title={transaction.project}>
             <ProjectAvatar project={project} />
           </Tooltip>
         )}
-
-        <Tooltip title={t('Compare baselines')}>
-          <CompareLink {...props} />
-        </Tooltip>
+        <CompareDurations {...props} />
       </ItemTransactionDurationChange>
       <ItemTransactionStatus color={color}>
         {currentTrendFunction === TrendFunctionField.USER_MISERY ? (
@@ -521,14 +503,7 @@ function TrendsListItem(props: TrendsListItemProps) {
 type CompareLinkProps = TrendsListItemProps & {};
 
 const CompareLink = (props: CompareLinkProps) => {
-  const {
-    organization,
-    trendView: eventView,
-    transaction,
-    api,
-    location,
-    currentTrendFunction,
-  } = props;
+  const {organization, trendView: eventView, transaction, api, location} = props;
   const intervalRatio = getIntervalRatio(location);
 
   async function onLinkClick() {
@@ -560,8 +535,14 @@ const CompareLink = (props: CompareLinkProps) => {
     }
   }
 
+  return <MenuItem onClick={onLinkClick}>{t('Compare baselines')}</MenuItem>;
+};
+
+const CompareDurations = (props: CompareLinkProps) => {
+  const {transaction, currentTrendFunction} = props;
+
   return (
-    <DurationChange onClick={onLinkClick}>
+    <DurationChange>
       {transformDeltaSpread(
         transaction.aggregate_range_1,
         transaction.aggregate_range_2,
@@ -585,7 +566,7 @@ const TransactionSummaryLink = (props: TransactionSummaryLinkProps) => {
     projectID,
   });
 
-  return <StyledSummaryLink to={target}>{t('View Summary')}</StyledSummaryLink>;
+  return <ItemTransactionName to={target}>{transaction.transaction}</ItemTransactionName>;
 };
 
 const TransactionsListContainer = styled('div')`
@@ -611,30 +592,9 @@ const StyledButton = styled(Button)`
   vertical-align: middle;
 `;
 
-const TransactionName = styled('div')`
-  cursor: pointer;
-  margin-right: ${space(1)};
-  ${overflowEllipsis};
-`;
-
-const DurationChange = styled('a')`
-  margin: 0 ${space(1)};
-`;
-
 const StyledMenuAction = styled('div')`
   white-space: nowrap;
   color: ${p => p.theme.textColor};
-`;
-
-const StyledSummaryLink = styled(Link)`
-  .dropdown-menu li & {
-    padding: 0;
-  }
-  padding: 0;
-  color: ${p => p.theme.textColor};
-  :hover {
-    color: ${p => p.theme.textColor};
-  }
 `;
 
 const StyledDropdownLink = styled(DropdownLink)`
@@ -648,7 +608,7 @@ const StyledEmptyStateWarning = styled(EmptyStateWarning)`
 
 const ListItemContainer = styled('div')`
   display: grid;
-  grid-template-columns: 24px 75% auto;
+  grid-template-columns: 24px auto 100px 30px;
   grid-template-rows: repeat(2, auto);
   grid-column-gap: ${space(1)};
   border-top: 1px solid ${p => p.theme.borderLight};
@@ -657,20 +617,29 @@ const ListItemContainer = styled('div')`
 
 const ItemRadioContainer = styled('div')`
   grid-row: 1/3;
+  input {
+    cursor: pointer;
+  }
   input:checked::after {
     background-color: ${p => p.color};
   }
 `;
 
-const ItemTransactionName = styled('div')`
-  display: flex;
+const ItemTransactionName = styled(Link)`
   font-size: ${p => p.theme.fontSizeMedium};
+  margin-right: ${space(1)};
+  ${overflowEllipsis};
 `;
 
 const ItemTransactionDurationChange = styled('div')`
   display: flex;
   align-items: center;
   font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const DurationChange = styled('span')`
+  color: ${p => p.theme.gray500};
+  margin: 0 ${space(1)};
 `;
 
 const ItemTransactionPercentage = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -17,6 +17,7 @@ import {decodeScalar} from 'app/utils/queryString';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import Alert from 'app/components/alert';
+import {IconInfo} from 'app/icons';
 import ExternalLink from 'app/components/links/externalLink';
 
 import {getTransactionSearchQuery} from '../utils';
@@ -107,9 +108,9 @@ class TrendsContent extends React.Component<Props, State> {
     return (
       <Feature features={['trends']}>
         <DefaultTrends location={location} eventView={eventView}>
-          <Alert type="info">
+          <Alert type="info" icon={<IconInfo size="md" />}>
             {t(
-              "Performance trends is a new beta feature for organizations who have turned on Early Adopter in their account settings. We'd love to hear any feedback you have at"
+              "Performance Trends is a new beta feature for organizations who have turned on Early Adopter in their account settings. We'd love to hear any feedback you have at"
             )}{' '}
             <ExternalLink href="mailto:performance-feedback@sentry.io">
               performance-feedback@sentry.io

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -310,7 +310,7 @@ describe('Performance > Trends', function () {
     expect(menuActions).toHaveLength(3);
 
     const menuAction = menuActions.at(0);
-    expect(menuAction.text()).toEqual('Exclude > 863ms');
+    expect(menuAction.text()).toEqual('Show \u2264 863ms');
     menuAction.simulate('click');
 
     expect(browserHistory.push).toHaveBeenCalledWith({
@@ -344,7 +344,7 @@ describe('Performance > Trends', function () {
     expect(menuActions).toHaveLength(3);
 
     const menuAction = menuActions.at(1);
-    expect(menuAction.text()).toEqual('Exclude < 863ms');
+    expect(menuAction.text()).toEqual('Show \u2265 863ms');
     menuAction.simulate('click');
 
     expect(browserHistory.push).toHaveBeenCalledWith({

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -246,9 +246,8 @@ describe('Performance > Trends', function () {
     wrapper.find('DropdownLink').first().simulate('click');
 
     const firstTransaction = wrapper.find('TrendsListItem').first();
-    const summaryLink = firstTransaction.find('StyledSummaryLink');
+    const summaryLink = firstTransaction.find('ItemTransactionName');
 
-    expect(summaryLink.text()).toEqual('View Summary');
     expect(summaryLink.props().to.pathname).toEqual(
       '/organizations/org-slug/performance/summary/'
     );
@@ -276,7 +275,7 @@ describe('Performance > Trends', function () {
     const menuActions = firstTransaction.find('StyledMenuAction');
     expect(menuActions).toHaveLength(3);
 
-    const menuAction = menuActions.at(0);
+    const menuAction = menuActions.at(2);
     menuAction.simulate('click');
 
     expect(browserHistory.push).toHaveBeenCalledWith({
@@ -310,8 +309,8 @@ describe('Performance > Trends', function () {
     const menuActions = firstTransaction.find('StyledMenuAction');
     expect(menuActions).toHaveLength(3);
 
-    const menuAction = menuActions.at(1);
-    expect(menuAction.text()).toEqual('Exclude transactions > 863ms');
+    const menuAction = menuActions.at(0);
+    expect(menuAction.text()).toEqual('Exclude > 863ms');
     menuAction.simulate('click');
 
     expect(browserHistory.push).toHaveBeenCalledWith({
@@ -344,8 +343,8 @@ describe('Performance > Trends', function () {
     const menuActions = firstTransaction.find('StyledMenuAction');
     expect(menuActions).toHaveLength(3);
 
-    const menuAction = menuActions.at(2);
-    expect(menuAction.text()).toEqual('Exclude transactions < 863ms');
+    const menuAction = menuActions.at(1);
+    expect(menuAction.text()).toEqual('Exclude < 863ms');
     menuAction.simulate('click');
 
     expect(browserHistory.push).toHaveBeenCalledWith({


### PR DESCRIPTION
**Before:**
![Screen Shot 2020-10-17 at 11 29 06 AM](https://user-images.githubusercontent.com/4830259/96350744-fd2c0e00-106b-11eb-93e0-9e5483b2cc5c.png)

**After:** 
![Screen Shot 2020-10-19 at 9 54 07 AM](https://user-images.githubusercontent.com/4830259/96484097-16aa9280-11f1-11eb-90c3-70ec0a74b24d.png)