### PR TITLE
feat(metric-alert): adds front end for polling

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
@@ -20,7 +20,7 @@ export async function addOrUpdateRule(
   projectId: string,
   rule: IncidentRule,
   query?: object | any
-): Promise<unknown[]> {
+) {
   const isExisting = isSavedRule(rule);
   const endpoint = `/projects/${orgId}/${projectId}/alert-rules/${
     isSavedRule(rule) ? `${rule.id}/` : ''
@@ -31,6 +31,7 @@ export async function addOrUpdateRule(
     method,
     data: rule,
     query,
+    includeAllArgs: true,
   });
 }
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -437,11 +437,13 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       );
       // if we get a 202 back it means that we have an async task
       // running to lookup and verify the channel id for Slack.
-      // if we have a uuid in state, no need to start a new polling cycle
-      if (xhr && xhr.status === 202 && !uuid) {
-        this.setState({loading: true, uuid: resp.uuid});
-        this.fetchStatus(model);
-        addLoadingMessage(t('Looking through all your channels...'));
+      if (xhr && xhr.status === 202) {
+        // if we have a uuid in state, no need to start a new polling cycle
+        if (!uuid) {
+          this.setState({loading: true, uuid: resp.uuid});
+          this.fetchStatus(model);
+          addLoadingMessage(t('Looking through all your channels...'));
+        }
       } else {
         addSuccessMessage(ruleId ? t('Updated alert rule') : t('Created alert rule'));
         if (onSubmitSuccess) {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -437,6 +437,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       );
       // if we get a 202 back it means that we have an async task
       // running to lookup and verify the channel id for Slack.
+      // if we have a uuid in state, no need to start a new polling cycle
       if (xhr && xhr.status === 202 && !uuid) {
         this.setState({loading: true, uuid: resp.uuid});
         this.fetchStatus(model);

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -5,6 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import RuleFormContainer from 'app/views/settings/incidentRules/ruleForm';
+import FormModel from 'app/views/settings/components/forms/model';
 
 jest.mock('app/actionCreators/indicator');
 
@@ -91,8 +92,10 @@ describe('Incident Rules Form', function () {
     });
     describe('Slack async lookup', () => {
       const uuid = 'xxxx-xxxx-xxxx';
+      let model;
       beforeEach(() => {
         jest.useFakeTimers();
+        model = new FormModel();
       });
       afterEach(() => {
         jest.clearAllTimers();
@@ -119,7 +122,7 @@ describe('Incident Rules Form', function () {
         await Promise.resolve();
         ruleFormContainer.update();
 
-        ruleFormContainer.instance().fetchStatus();
+        ruleFormContainer.instance().fetchStatus(model);
         jest.runOnlyPendingTimers();
 
         await Promise.resolve();
@@ -155,7 +158,7 @@ describe('Incident Rules Form', function () {
         await Promise.resolve();
         ruleFormContainer.update();
 
-        ruleFormContainer.instance().fetchStatus();
+        ruleFormContainer.instance().fetchStatus(model);
         jest.runOnlyPendingTimers();
 
         await Promise.resolve();
@@ -186,7 +189,7 @@ describe('Incident Rules Form', function () {
         await Promise.resolve();
         ruleFormContainer.update();
 
-        ruleFormContainer.instance().fetchStatus();
+        ruleFormContainer.instance().fetchStatus(model);
         jest.runOnlyPendingTimers();
 
         await Promise.resolve();

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -3,7 +3,10 @@ import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
+import {addErrorMessage} from 'app/actionCreators/indicator';
 import RuleFormContainer from 'app/views/settings/incidentRules/ruleForm';
+
+jest.mock('app/actionCreators/indicator');
 
 describe('Incident Rules Form', function () {
   const {organization, project, routerContext} = initializeOrg();
@@ -85,6 +88,113 @@ describe('Incident Rules Form', function () {
           }),
         })
       );
+    });
+    describe('Slack async lookup', () => {
+      const uuid = 'xxxx-xxxx-xxxx';
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
+      afterEach(() => {
+        jest.clearAllTimers();
+      });
+      it('success status updates the rule', async () => {
+        const endpoint = `/projects/org-slug/project-slug/alert-rule-task/${uuid}/`;
+        const alertRule = TestStubs.IncidentRule({name: 'Slack Alert Rule'});
+        MockApiClient.addMockResponse({
+          url: endpoint,
+          body: {
+            status: 'success',
+            alertRule,
+          },
+        });
+
+        const onSubmitSuccess = jest.fn();
+        const wrapper = createWrapper({
+          ruleId: alertRule.id,
+          rule: alertRule,
+          onSubmitSuccess,
+        });
+        const ruleFormContainer = wrapper.find('RuleFormContainer');
+        ruleFormContainer.setState({uuid, loading: true});
+        await Promise.resolve();
+        ruleFormContainer.update();
+
+        ruleFormContainer.instance().fetchStatus();
+        jest.runOnlyPendingTimers();
+
+        await Promise.resolve();
+        ruleFormContainer.update();
+        expect(ruleFormContainer.state('loading')).toBe(false);
+        expect(onSubmitSuccess).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: alertRule.id,
+            name: alertRule.name,
+          }),
+          expect.anything()
+        );
+      });
+
+      it('pending status keeps loading true', async () => {
+        const endpoint = `/projects/org-slug/project-slug/alert-rule-task/${uuid}/`;
+        const alertRule = TestStubs.IncidentRule({name: 'Slack Alert Rule'});
+        MockApiClient.addMockResponse({
+          url: endpoint,
+          body: {
+            status: 'pending',
+          },
+        });
+
+        const onSubmitSuccess = jest.fn();
+        const wrapper = createWrapper({
+          ruleId: alertRule.id,
+          rule: alertRule,
+          onSubmitSuccess,
+        });
+        const ruleFormContainer = wrapper.find('RuleFormContainer');
+        ruleFormContainer.setState({uuid, loading: true});
+        await Promise.resolve();
+        ruleFormContainer.update();
+
+        ruleFormContainer.instance().fetchStatus();
+        jest.runOnlyPendingTimers();
+
+        await Promise.resolve();
+        ruleFormContainer.update();
+        expect(ruleFormContainer.state('loading')).toBe(true);
+        expect(onSubmitSuccess).not.toHaveBeenCalled();
+      });
+
+      it('failed status renders error message', async () => {
+        const endpoint = `/projects/org-slug/project-slug/alert-rule-task/${uuid}/`;
+        const alertRule = TestStubs.IncidentRule({name: 'Slack Alert Rule'});
+        MockApiClient.addMockResponse({
+          url: endpoint,
+          body: {
+            status: 'failed',
+            error: 'An error occurred',
+          },
+        });
+
+        const onSubmitSuccess = jest.fn();
+        const wrapper = createWrapper({
+          ruleId: alertRule.id,
+          rule: alertRule,
+          onSubmitSuccess,
+        });
+        const ruleFormContainer = wrapper.find('RuleFormContainer');
+        ruleFormContainer.setState({uuid, loading: true});
+        await Promise.resolve();
+        ruleFormContainer.update();
+
+        ruleFormContainer.instance().fetchStatus();
+        jest.runOnlyPendingTimers();
+
+        await Promise.resolve();
+        ruleFormContainer.update();
+        expect(ruleFormContainer.state('loading')).toBe(false);
+        expect(onSubmitSuccess).not.toHaveBeenCalled();
+        expect(addErrorMessage).toHaveBeenCalledWith('An error occurred');
+      });
     });
   });
 


### PR DESCRIPTION
This PR adds the front end for async metric alerts which was merged recently (https://github.com/getsentry/sentry/pull/21311). It's largely copied from the issue alerts. Here's how it works:

1. We make a request to save a metric alert as usual
2. If we get a `202` status code, it means that the alert rule is being saved in a task because we need more time to find the Slack channel(s).
3. In that response, we get a `uuid` which we save in component state.
4. We start polling the `/projects/:orgSlug/:projectSlug/alert-rule-task/:uuid/` for the status of the task saving the alert rule.
5. If we get a response `pending`, we keep polling the endpoint.
6. If we get a response `success` or `failed`, we stop polling and show success/failure
7. If we don't finish polling within 3 minutes, we give up and show an error message.


Toast we display while doing the polling:
![Screen Shot 2020-10-19 at 9 34 48 AM](https://user-images.githubusercontent.com/8533851/96479874-5b80fa00-11ee-11eb-91ab-09bc78e7fe2d.png)
