### PR TITLE
feat(ui): Change `line-height` for `<TextArea>`

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/textarea.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/textarea.tsx
@@ -43,6 +43,7 @@ const propFilter = (p: string) =>
 
 const TextArea = styled(TextAreaControl, {shouldForwardProp: propFilter})`
   ${inputStyles};
+  line-height: 1.3em;
 `;
 
 export default TextArea;


### PR DESCRIPTION
This increases the line-height for our `<TextArea>` components as it is a bit cramped.

Old:
![image](https://user-images.githubusercontent.com/79684/96496212-cb4ab100-11fd-11eb-91e0-f803355b93bc.png)

New:
![image](https://user-images.githubusercontent.com/79684/96496225-cf76ce80-11fd-11eb-9c1c-4937c04945c1.png)
