### PR TITLE
ref(trends): Updating default trend filters

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -236,7 +236,7 @@ class PerformanceLanding extends React.Component<Props, State> {
           conditions.getTagValues('transaction.duration')
         );
       } else {
-        modifiedConditions.setTagValues('transaction.duration', ['>0']);
+        modifiedConditions.setTagValues('transaction.duration', ['>0', '<60min']);
       }
       newQuery.query = stringifyQueryObject(modifiedConditions);
     }

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -225,10 +225,10 @@ class PerformanceLanding extends React.Component<Props, State> {
     if (viewKey === FilterViews.TRENDS) {
       const modifiedConditions = new QueryResults([]);
 
-      if (conditions.hasTag('count()')) {
-        modifiedConditions.setTagValues('count()', conditions.getTagValues('count()'));
+      if (conditions.hasTag('epm()')) {
+        modifiedConditions.setTagValues('epm()', conditions.getTagValues('epm()'));
       } else {
-        modifiedConditions.setTagValues('count()', ['>1000']);
+        modifiedConditions.setTagValues('epm()', ['>0.01']);
       }
       if (conditions.hasTag('transaction.duration')) {
         modifiedConditions.setTagValues(
@@ -245,7 +245,7 @@ class PerformanceLanding extends React.Component<Props, State> {
 
     if (isNavigatingAwayFromTrends) {
       // This stops errors from occurring when navigating to other views since we are appending aggregates to the trends view
-      conditions.removeTag('count()');
+      conditions.removeTag('epm()');
       conditions.removeTag('transaction.duration');
 
       newQuery.query = stringifyQueryObject(conditions);

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -150,8 +150,8 @@ function handleChangeSelected(location: Location, trendChangeType: TrendChangeTy
 }
 
 enum FilterSymbols {
-  GREATER_THAN = '>',
-  LESS_THAN = '<',
+  GREATER_THAN_EQUALS = '>=',
+  LESS_THAN_EQUALS = '<=',
 }
 
 function handleFilterTransaction(location: Location, transaction: string) {
@@ -455,14 +455,22 @@ function TrendsListItem(props: TrendsListItemProps) {
         <CompareLink {...props} />
         <MenuItem
           onClick={() =>
-            handleFilterDuration(location, longestPeriodValue, FilterSymbols.GREATER_THAN)
+            handleFilterDuration(
+              location,
+              longestPeriodValue,
+              FilterSymbols.LESS_THAN_EQUALS
+            )
           }
         >
           <StyledMenuAction>{t('Show \u2264 %s', longestDuration)}</StyledMenuAction>
         </MenuItem>
         <MenuItem
           onClick={() =>
-            handleFilterDuration(location, longestPeriodValue, FilterSymbols.LESS_THAN)
+            handleFilterDuration(
+              location,
+              longestPeriodValue,
+              FilterSymbols.GREATER_THAN_EQUALS
+            )
           }
         >
           <StyledMenuAction>{t('Show \u2265 %s', longestDuration)}</StyledMenuAction>

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -197,7 +197,7 @@ class DefaultTrends extends React.Component<DefaultTrendsProps> {
     if (queryString || this.hasPushedDefaults) {
       return <React.Fragment>{children}</React.Fragment>;
     } else {
-      conditions.setTagValues('count()', ['>1000']);
+      conditions.setTagValues('epm()', ['>0.01']);
       conditions.setTagValues('transaction.duration', ['>0']);
     }
 

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -198,7 +198,7 @@ class DefaultTrends extends React.Component<DefaultTrendsProps> {
       return <React.Fragment>{children}</React.Fragment>;
     } else {
       conditions.setTagValues('epm()', ['>0.01']);
-      conditions.setTagValues('transaction.duration', ['>0']);
+      conditions.setTagValues('transaction.duration', ['>0', '<60min']);
     }
 
     const query = stringifyQueryObject(conditions);

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -144,7 +144,7 @@ export function modifyTrendView(
   const trendFunction = getCurrentTrendFunction(location);
 
   const transactionField = isProjectOnly ? [] : ['transaction'];
-  const fields = [...transactionField, 'project', 'count()'].map(field => ({
+  const fields = [...transactionField, 'project'].map(field => ({
     field,
   })) as Field[];
 

--- a/tests/js/spec/views/performance/landing.spec.jsx
+++ b/tests/js/spec/views/performance/landing.spec.jsx
@@ -40,7 +40,7 @@ function initializeTrendsData(query, addDefaultQuery = true) {
 
   const otherTrendsQuery = addDefaultQuery
     ? {
-        query: 'count():>1000 transaction.duration:>0',
+        query: 'epm():>0.01 transaction.duration:>0',
       }
     : {};
 
@@ -276,7 +276,7 @@ describe('Performance > Landing', function () {
 
   it('Navigating to trends does not modify statsPeriod when already set', async function () {
     const data = initializeTrendsData({
-      query: 'count():>500 transaction.duration:>10',
+      query: 'epm():>0.005 transaction.duration:>10',
       statsPeriod: '24h',
     });
 
@@ -298,7 +298,7 @@ describe('Performance > Landing', function () {
     expect(browserHistory.push).toHaveBeenCalledWith(
       expect.objectContaining({
         query: {
-          query: 'count():>500 transaction.duration:>10',
+          query: 'epm():>0.005 transaction.duration:>10',
           statsPeriod: '24h',
           view: 'TRENDS',
         },
@@ -359,7 +359,7 @@ describe('Performance > Landing', function () {
       1,
       expect.objectContaining({
         query: {
-          query: 'count():>1000 transaction.duration:>0',
+          query: 'epm():>0.01 transaction.duration:>0',
           view: 'TRENDS',
         },
       })
@@ -417,7 +417,7 @@ describe('Performance > Landing', function () {
     expect(browserHistory.push).toHaveBeenCalledWith(
       expect.objectContaining({
         query: {
-          query: 'count():>1000 transaction.duration:>0',
+          query: 'epm():>0.01 transaction.duration:>0',
           view: 'TRENDS',
         },
       })
@@ -428,7 +428,7 @@ describe('Performance > Landing', function () {
     const data = initializeTrendsData(
       {
         view: FilterViews.TRENDS,
-        query: 'device.family:Mac count():>1000 transaction.duration:>0',
+        query: 'device.family:Mac epm():>0.01 transaction.duration:>0',
       },
       false
     );

--- a/tests/js/spec/views/performance/landing.spec.jsx
+++ b/tests/js/spec/views/performance/landing.spec.jsx
@@ -40,7 +40,7 @@ function initializeTrendsData(query, addDefaultQuery = true) {
 
   const otherTrendsQuery = addDefaultQuery
     ? {
-        query: 'epm():>0.01 transaction.duration:>0',
+        query: 'epm():>0.01 transaction.duration:>0 transaction.duration:<60min',
       }
     : {};
 
@@ -276,7 +276,7 @@ describe('Performance > Landing', function () {
 
   it('Navigating to trends does not modify statsPeriod when already set', async function () {
     const data = initializeTrendsData({
-      query: 'epm():>0.005 transaction.duration:>10',
+      query: 'epm():>0.005 transaction.duration:>10 transaction.duration:<60min',
       statsPeriod: '24h',
     });
 
@@ -298,7 +298,7 @@ describe('Performance > Landing', function () {
     expect(browserHistory.push).toHaveBeenCalledWith(
       expect.objectContaining({
         query: {
-          query: 'epm():>0.005 transaction.duration:>10',
+          query: 'epm():>0.005 transaction.duration:>10 transaction.duration:<60min',
           statsPeriod: '24h',
           view: 'TRENDS',
         },
@@ -359,7 +359,7 @@ describe('Performance > Landing', function () {
       1,
       expect.objectContaining({
         query: {
-          query: 'epm():>0.01 transaction.duration:>0',
+          query: 'epm():>0.01 transaction.duration:>0 transaction.duration:<60min',
           view: 'TRENDS',
         },
       })
@@ -417,7 +417,7 @@ describe('Performance > Landing', function () {
     expect(browserHistory.push).toHaveBeenCalledWith(
       expect.objectContaining({
         query: {
-          query: 'epm():>0.01 transaction.duration:>0',
+          query: 'epm():>0.01 transaction.duration:>0 transaction.duration:<60min',
           view: 'TRENDS',
         },
       })
@@ -428,7 +428,8 @@ describe('Performance > Landing', function () {
     const data = initializeTrendsData(
       {
         view: FilterViews.TRENDS,
-        query: 'device.family:Mac epm():>0.01 transaction.duration:>0',
+        query:
+          'device.family:Mac epm():>0.01 transaction.duration:>0 transaction.duration:<60min',
       },
       false
     );

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -282,7 +282,7 @@ describe('Performance > Trends', function () {
       query: expect.objectContaining({
         project: expect.anything(),
         query:
-          'count():>1000 transaction.duration:>0 !transaction:/organizations/:orgId/performance/',
+          'epm():>0.01 transaction.duration:>0 !transaction:/organizations/:orgId/performance/',
         view: 'TRENDS',
       }),
     });
@@ -316,7 +316,7 @@ describe('Performance > Trends', function () {
     expect(browserHistory.push).toHaveBeenCalledWith({
       query: expect.objectContaining({
         project: expect.anything(),
-        query: 'count():>1000 transaction.duration:>863',
+        query: 'epm():>0.01 transaction.duration:>863',
         view: 'TRENDS',
       }),
     });
@@ -350,7 +350,7 @@ describe('Performance > Trends', function () {
     expect(browserHistory.push).toHaveBeenCalledWith({
       query: expect.objectContaining({
         project: expect.anything(),
-        query: 'count():>1000 transaction.duration:>0 transaction.duration:<863',
+        query: 'epm():>0.01 transaction.duration:>0 transaction.duration:<863',
         view: 'TRENDS',
       }),
     });

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -17,7 +17,7 @@ import {getUtcDateString} from 'app/utils/dates';
 
 const trendsViewQuery = {
   view: 'TRENDS',
-  query: 'count():>1000 transaction.duration:>0',
+  query: 'epm():>0.01 transaction.duration:>0',
 };
 
 jest.mock('moment', () => {
@@ -565,12 +565,12 @@ describe('Performance > Trends', function () {
           ? getTrendAliasedMinus(trendFunction.alias)
           : aliasedFieldDivide;
 
-      const defaultTrendsFields = ['project', 'count()'];
+      const defaultTrendsFields = ['project'];
 
       const transactionFields = ['transaction', ...defaultTrendsFields];
       const projectFields = [...defaultTrendsFields];
 
-      expect(transactionFields).toHaveLength(3);
+      expect(transactionFields).toHaveLength(2);
       expect(projectFields).toHaveLength(transactionFields.length - 1);
 
       // Improved projects call

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -316,7 +316,7 @@ describe('Performance > Trends', function () {
     expect(browserHistory.push).toHaveBeenCalledWith({
       query: expect.objectContaining({
         project: expect.anything(),
-        query: 'epm():>0.01 transaction.duration:>863',
+        query: 'epm():>0.01 transaction.duration:>0 transaction.duration:<=863',
         view: 'TRENDS',
       }),
     });
@@ -350,7 +350,7 @@ describe('Performance > Trends', function () {
     expect(browserHistory.push).toHaveBeenCalledWith({
       query: expect.objectContaining({
         project: expect.anything(),
-        query: 'epm():>0.01 transaction.duration:>0 transaction.duration:<863',
+        query: 'epm():>0.01 transaction.duration:>0 transaction.duration:>=863',
         view: 'TRENDS',
       }),
     });


### PR DESCRIPTION
- Note, that we'll eventually update performance to use tpm() instead
- `epm():>0.01` was chosen so that over a 2 week period its
  approximately equivalent to doing `count():>200`
  - 14dx24hx60m == 20,000 minutes * 0.01epm == 200events
- Adds `transaction.duration:<60min` to exclude some easy outliers
- As well, epm() means that regardless of the chosen statsPeriod the
  filter can still work
- Also removes `count()` as a default column, with auto aggregations
  `epm` will be added automatically. and we only want it added while
  the filter still has `epm()`