### PR TITLE
ref(stacetrace-link): ProjectStacktraceLinkEndpoint

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -33,12 +33,16 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         # should probably feature gate
         filepath = request.GET.get("file")
         if not filepath:
-            return Response("Filepath is required", status=400)
+            return Response({"detail": "Filepath is required"}, status=400)
 
         commitId = request.GET.get("commitId")
         result = {"config": None}
 
+        # xxx(meredith): if there are ever any changes to this query, make
+        # sure that we are still ordering by `id` because we want to make sure
+        # the ordering is deterministic
         configs = RepositoryProjectPathConfig.objects.filter(project=project)
+
         # we only want to attempt the stack trace linking IF the user
         # has a configuration set up, otherwise we don't care
         if not configs:

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.models import RepositoryProjectPathConfig
+from sentry.shared_integrations.exceptions import ApiError
+
+
+def get_link(config, filepath, version):
+    # feel like there has got to be a better way to do this
+    # if we already have the oi
+    oi = config.organization_integration
+    integration = oi.integration
+    install = integration.get_installation(oi.organization_id)
+
+    filepath.replace(config.stack_root, config.source_root)
+
+    return install.get_stacktrace_link(config.repository, filepath, version)
+
+
+class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
+    """
+        Returns valid links for source code providers so that
+        users can go from the file in the stack trace to the
+        provider of their choice.
+
+        `filepath`: The file path from the strack trace
+        `commitId` (optional): The commit_id for the last commit of the
+                               release associated to the stack trace's event
+
+    """
+
+    def get(self, request, project):
+        # should probably feature gate
+        filepath = request.GET.get("file")
+        commitId = request.GET.get("commitId")
+
+        results = []
+        # try and find any configurations set up, if there
+        # aren't any then we don't do anything else
+        configs = RepositoryProjectPathConfig.objects.filter(project=project,)
+
+        if not configs:
+            return Response(results)
+
+        for config in configs:
+            version = commitId or config.default_branch
+            try:
+                link = get_link(config, filepath, version)
+                # don't think we need the whole configuration, but we
+                # may want to know what provider it is e.g. GH
+                results.append({"config": config, "source_url": link})
+
+            except ApiError:
+                # this could mean either we couldn't find a match
+                # or something else when wrong with the request,
+                # either way, we have a configuration without a match
+                #
+                # not sure exactly what we want to show the user, if anything
+                pass
+
+        return Response(results)

--- a/src/sentry/api/serializers/models/repository_project_path_config.py
+++ b/src/sentry/api/serializers/models/repository_project_path_config.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.api.serializers import Serializer, register
+from sentry.models import RepositoryProjectPathConfig
+
+
+@register(RepositoryProjectPathConfig)
+class RepositoryProjectPathConfigSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            "id": six.text_type(obj.id),
+            "project": obj.project.slug,
+            "repo": obj.repository.name,
+            "stackRoot": obj.stack_root,
+            "sourceRoot": obj.source_root,
+            "organizationIntegration": six.text_type(obj.organization_integration_id),
+            "defaultBranch": obj.default_branch,
+        }

--- a/src/sentry/api/serializers/models/repository_project_path_config.py
+++ b/src/sentry/api/serializers/models/repository_project_path_config.py
@@ -11,10 +11,12 @@ class RepositoryProjectPathConfigSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
             "id": six.text_type(obj.id),
-            "project": obj.project.slug,
-            "repo": obj.repository.name,
+            "projectId": six.text_type(obj.project_id),
+            "projectSlug": obj.project.slug,
+            "repoId": six.text_type(obj.repository.id),
+            "repoName": obj.repository.name,
+            "organizationIntegrationId": six.text_type(obj.organization_integration_id),
             "stackRoot": obj.stack_root,
             "sourceRoot": obj.source_root,
-            "organizationIntegration": six.text_type(obj.organization_integration_id),
             "defaultBranch": obj.default_branch,
         }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -232,6 +232,7 @@ from .endpoints.project_user_details import ProjectUserDetailsEndpoint
 from .endpoints.project_user_reports import ProjectUserReportsEndpoint
 from .endpoints.project_user_stats import ProjectUserStatsEndpoint
 from .endpoints.project_users import ProjectUsersEndpoint
+from .endpoints.project_stacktrace_link import ProjectStacktraceLinkEndpoint
 from .endpoints.prompts_activity import PromptsActivityEndpoint
 from .endpoints.relay_details import RelayDetailsEndpoint
 from .endpoints.relay_healthcheck import RelayHealthCheck
@@ -1579,6 +1580,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/tombstones/(?P<tombstone_id>\d+)/$",
                     GroupTombstoneDetailsEndpoint.as_view(),
                     name="sentry-api-0-group-tombstone-details",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/stacktrace-link/$",
+                    ProjectStacktraceLinkEndpoint.as_view(),
+                    name="sentry-api-0-project-stacktrace-link",
                 ),
             ]
         ),

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -306,6 +306,15 @@ class IntegrationInstallation(object):
         identity = Identity.objects.get(id=self.org_integration.default_auth_id)
         return identity
 
+    def get_stacktrace_link(self, repo, path, version):
+        """
+        Handle formatting and returning back the stack trace link if the client
+        request was successful.
+
+        If no file was found return `None`, and re-raise for non "Not Found" errors
+        """
+        pass
+
     def error_message_from_json(self, data):
         return data.get("message", "unknown error")
 

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -306,15 +306,6 @@ class IntegrationInstallation(object):
         identity = Identity.objects.get(id=self.org_integration.default_auth_id)
         return identity
 
-    def get_stacktrace_link(self, repo, path, version):
-        """
-        Handle formatting and returning back the stack trace link if the client
-        request was successful.
-
-        If no file was found return `None`, and re-raise for non "Not Found" errors
-        """
-        pass
-
     def error_message_from_json(self, data):
         return data.get("message", "unknown error")
 

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -140,6 +140,9 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
     def get_issue_display_name(self, external_issue):
         return "display name: %s" % external_issue.key
 
+    def get_stacktrace_link(self, repo, path, version):
+        pass
+
 
 class ExampleIntegrationProvider(IntegrationProvider):
     """

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -100,7 +100,7 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
 
     def get_stacktrace_link(self, repo, filepath, default_version):
         try:
-            resp = self.get_client().get_file(repo.name, filepath)
+            resp = self.get_client().get_file_url(repo.name, filepath)
         except ApiError as e:
             if e.code != 404:
                 raise

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -98,6 +98,17 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
     def search_issues(self, query):
         return self.get_client().search_issues(query)
 
+    def get_stacktrace_link(self, repo, filepath, default_version):
+        try:
+            resp = self.get_client().get_file(repo.name, filepath)
+        except ApiError as e:
+            if e.code != 404:
+                raise
+            return
+
+        # if it exists return the url
+        return resp["html_url"]
+
     def get_unmigratable_repositories(self):
         accessible_repos = self.get_repositories()
         accessible_repo_names = [r["identifier"] for r in accessible_repos]

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -104,7 +104,7 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
         except ApiError as e:
             if e.code != 404:
                 raise
-            return
+            return None
 
         # if it exists return the url
         return resp["html_url"]

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -9,6 +9,15 @@ class RepositoryMixin(object):
     # dynamically given a search query
     repo_search = False
 
+    def get_stacktrace_link(self, repo, path, version):
+        """
+        Handle formatting and returning back the stack trace link if the client
+        request was successful.
+
+        If no file was found return `None`, and re-raise for non "Not Found" errors
+        """
+        raise NotImplementedError
+
     def get_repositories(self, query=None):
         """
         Get a list of available repositories for an installation

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -74,11 +74,13 @@ class ProjectStacktraceLinkTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["config"] == {
             "id": six.text_type(self.config.id),
-            "repo": self.repo.name,
-            "project": self.project.slug,
+            "projectId": six.text_type(self.project.id),
+            "projectSlug": self.project.slug,
+            "repoId": six.text_type(self.repo.id),
+            "repoName": self.repo.name,
             "sourceRoot": self.config.source_root,
             "stackRoot": self.config.stack_root,
-            "organizationIntegration": six.text_type(self.oi.id),
+            "organizationIntegrationId": six.text_type(self.oi.id),
             "defaultBranch": None,
         }
         assert not response.data["source_url"]
@@ -94,11 +96,13 @@ class ProjectStacktraceLinkTest(APITestCase):
             assert response.status_code == 200, response.content
             assert response.data["config"] == {
                 "id": six.text_type(self.config.id),
-                "repo": self.repo.name,
-                "project": self.project.slug,
+                "projectId": six.text_type(self.project.id),
+                "projectSlug": self.project.slug,
+                "repoId": six.text_type(self.repo.id),
+                "repoName": self.repo.name,
                 "sourceRoot": self.config.source_root,
                 "stackRoot": self.config.stack_root,
-                "organizationIntegration": six.text_type(self.oi.id),
+                "organizationIntegrationId": six.text_type(self.oi.id),
                 "defaultBranch": None,
             }
             assert response.data["source_url"] == "https://sourceurl.com/"

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -1,0 +1,104 @@
+from __future__ import absolute_import
+
+import six
+
+from django.core.urlresolvers import reverse
+from sentry.utils.compat import mock
+
+from sentry.integrations.example.integration import ExampleIntegration
+from sentry.models import RepositoryProjectPathConfig, Integration, OrganizationIntegration
+from sentry.testutils import APITestCase
+
+
+class ProjectStacktraceLinkTest(APITestCase):
+    def setUp(self):
+        self.org = self.create_organization(owner=self.user, name="blap")
+        self.project = self.create_project(
+            name="foo", organization=self.org, teams=[self.create_team(organization=self.org)]
+        )
+
+        self.integration = Integration.objects.create(provider="example", name="Example")
+        self.integration.add_organization(self.org, self.user)
+        self.oi = OrganizationIntegration.objects.get(integration_id=self.integration.id)
+
+        self.repo = self.create_repo(project=self.project, name="getsentry/sentry",)
+        self.repo.integration_id = self.integration.id
+        self.repo.provider = "example"
+        self.repo.save()
+
+        self.config = RepositoryProjectPathConfig.objects.create(
+            organization_integration=self.oi,
+            project=self.project,
+            repository=self.repo,
+            stack_root="/usr/src/getsentry",
+            source_root="",
+        )
+        self.filepath = "/usr/src/getsentry/src/sentry/src/sentry/utils/safe.py"
+        self.url = reverse(
+            "sentry-api-0-project-stacktrace-link",
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+            },
+        )
+
+    def test_no_filepath(self):
+        self.login_as(user=self.user)
+
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == 400, response.content
+
+    def test_no_configs(self):
+        self.login_as(user=self.user)
+        # new project that has no configurations set up for it
+        project = self.create_project(
+            name="bloop", organization=self.org, teams=[self.create_team(organization=self.org)],
+        )
+
+        path = reverse(
+            "sentry-api-0-project-stacktrace-link",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        url = u"{}?file={}".format(path, self.filepath)
+
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200, response.content
+        assert not response.data["config"]
+
+    def test_config_but_no_source_url(self):
+        self.login_as(user=self.user)
+        url = u"{}?file={}".format(self.url, self.filepath)
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert response.data["config"] == {
+            "id": six.text_type(self.config.id),
+            "repo": self.repo.name,
+            "project": self.project.slug,
+            "sourceRoot": self.config.source_root,
+            "stackRoot": self.config.stack_root,
+            "organizationIntegration": six.text_type(self.oi.id),
+            "defaultBranch": None,
+        }
+        assert not response.data["source_url"]
+
+    def test_config_and_source_url(self):
+        self.login_as(user=self.user)
+        url = u"{}?file={}".format(self.url, self.filepath)
+
+        with mock.patch.object(
+            ExampleIntegration, "get_stacktrace_link", return_value="https://sourceurl.com/"
+        ):
+            response = self.client.get(url)
+            assert response.status_code == 200, response.content
+            assert response.data["config"] == {
+                "id": six.text_type(self.config.id),
+                "repo": self.repo.name,
+                "project": self.project.slug,
+                "sourceRoot": self.config.source_root,
+                "stackRoot": self.config.stack_root,
+                "organizationIntegration": six.text_type(self.oi.id),
+                "defaultBranch": None,
+            }
+            assert response.data["source_url"] == "https://sourceurl.com/"


### PR DESCRIPTION
**Context:** 
Some initial project context and explanation of table being used in https://github.com/getsentry/sentry/pull/21331. The endpoint in this PR (`ProjectStacktraceLink`) will be used by frontend to query for the source code url for a specific file in the stack trace. We use the `RepositoryProjectPathConfig` table to see if we have any configurations setup that match the file we pass along in the request. 

**Parameters**
`file`: The file of the stack trace 
`commitId`*:  If we can get the commit.id from the frontend, then we can look up the sha to use for the branch, otherwise we rely on the `config.default_branch` (if the provider requires that be provided)

*_optional_

**Endpoint Response cases**
There three main cases:
* There are no configurations 
   * Return `{"config": null}`
* There are configurations and we got a match
   * Return `{"config": {config object...}, "source_url": "the_url"}`
* There are configurations but we failed to get a match because the file doesn't exist
    * Return `{"config": {config object...}, "source_url": null}`

Frontend design is still TBD at the moment, but essentially, if we have the `source_url` we render that, if we have a configuration that was setup but didn't get a match (`source_url` is null) when we queried the provider (e.g. GitHub) we can render some sort of "Not Found" info/a way to edit their configuration, and if there are no configurations, we don't need to render anything at all. 

**Notes:**
* If the provider 500s or something we should also handle that on the frontend
* This PR will need https://github.com/getsentry/sentry/pull/21454