### PR TITLE
feat(stacktrace link): Get source code files from GitHub and GitLab

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -115,7 +115,7 @@ class GitHubClientMixin(ApiClient):
 
     @transaction_start("GitHubClientMixin.check_file")
     def check_file(self, repo, path):
-        return self.head_cached(path="/repos/{}/contents/{}".format(repo, path)).text
+        return self.head_cached(path="/repos/{}/contents/{}".format(repo, path)).status_code
 
 
 class GitHubAppsClient(GitHubClientMixin):

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -113,9 +113,9 @@ class GitHubClientMixin(ApiClient):
             },
         )
 
-    @transaction_start("GitHubClientMixin")
-    def get_file_url(self, repo, path):
-        return self.get_cached(path="/repos/{}/contents/{}".format(repo, path))["html_url"]
+    @transaction_start("GitHubClientMixin.check_file")
+    def check_file(self, repo, path):
+        return self.head_cached(path="/repos/{}/contents/{}".format(repo, path)).text
 
 
 class GitHubAppsClient(GitHubClientMixin):

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -118,10 +118,9 @@ class GitHubClientMixin(ApiClient):
     def check_source_code_link(self, path):
         self.allow_text = True
         try:
-            return self.head(path=path).status_code == 200
+            return self.head_cached(path=path).status_code
         except ApiError as e:
-            if e.code == 404:
-                return False
+            return e.code
 
 
 class GitHubAppsClient(GitHubClientMixin):

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from sentry.integrations.github.utils import get_jwt
 from sentry.integrations.client import ApiClient
-from sentry.shared_integrations.exceptions import ApiError
 from sentry.web.decorators import transaction_start
 
 
@@ -115,12 +114,8 @@ class GitHubClientMixin(ApiClient):
         )
 
     @transaction_start("GitHubClientMixin")
-    def check_source_code_link(self, path):
-        self.allow_text = True
-        try:
-            return self.head_cached(path=path).status_code
-        except ApiError as e:
-            return e.code
+    def get_file_url(self, repo, path):
+        return self.get_cached(path="/repos/{}/contents/{}".format(repo, path))["html_url"]
 
 
 class GitHubAppsClient(GitHubClientMixin):

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -115,7 +115,7 @@ class GitHubClientMixin(ApiClient):
 
     @transaction_start("GitHubClientMixin.check_file")
     def check_file(self, repo, path):
-        return self.head_cached(path="/repos/{}/contents/{}".format(repo, path)).status_code
+        return self.head_cached(path="/repos/{}/contents/{}".format(repo, path))
 
 
 class GitHubAppsClient(GitHubClientMixin):

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -251,4 +251,4 @@ class GitLabApiClient(ApiClient):
         """
         self.base_url = self.metadata["base_url"]
         request_path = GitLabApiClientPath.file.format(project=project_id, path=path)
-        return self.head_cached(request_path, params={"ref": ref}).text
+        return self.head_cached(request_path, params={"ref": ref}).status_code

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -18,6 +18,7 @@ class GitLabApiClientPath(object):
     commits = u"/projects/{project}/repository/commits"
     compare = u"/projects/{project}/repository/compare"
     diff = u"/projects/{project}/repository/commits/{sha}/diff"
+    file = u"/projects/{project}/repository/files/{path}"
     group = u"/groups/{group}"
     group_projects = u"/groups/{group}/projects"
     hooks = u"/hooks"
@@ -29,7 +30,6 @@ class GitLabApiClientPath(object):
     project_hooks = u"/projects/{project}/hooks"
     project_hook = u"/projects/{project}/hooks/{hook_id}"
     user = u"/user"
-    file = u"/projects/{project}/repository/files/{path}"
 
     @staticmethod
     def build_api_url(base_url, path):
@@ -76,7 +76,6 @@ class GitLabApiClient(ApiClient):
 
     def __init__(self, installation):
         self.installation = installation
-        # self.base_url = self.metadata["base_url"]
         verify_ssl = self.metadata["verify_ssl"]
         self.is_refreshing_token = False
         super(GitLabApiClient, self).__init__(verify_ssl)

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -251,4 +251,4 @@ class GitLabApiClient(ApiClient):
         """
         self.base_url = self.metadata["base_url"]
         request_path = GitLabApiClientPath.file.format(project=project_id, path=path)
-        return self.head_cached(request_path, params={"ref": ref}).status_code
+        return self.head_cached(request_path, params={"ref": ref})

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -72,11 +72,11 @@ class GitLabSetupClient(ApiClient):
 
 
 class GitLabApiClient(ApiClient):
-    base_url = "https://gitlab.com"
     integration_name = "gitlab"
 
     def __init__(self, installation):
         self.installation = installation
+        # self.base_url = self.metadata["base_url"]
         verify_ssl = self.metadata["verify_ssl"]
         self.is_refreshing_token = False
         super(GitLabApiClient, self).__init__(verify_ssl)
@@ -250,6 +250,6 @@ class GitLabApiClient(ApiClient):
         See https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
         Path requires file path and ref
         """
+        self.base_url = self.metadata["base_url"]
         request_path = GitLabApiClientPath.file.format(project=project_id, path=path)
-        # TODO: handle on prem gitlab w/o a base url (so use the user's URL I guess?)
         return self.head_cached(request_path, params={"ref": ref}).text

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -29,7 +29,7 @@ class GitLabApiClientPath(object):
     project_hooks = u"/projects/{project}/hooks"
     project_hook = u"/projects/{project}/hooks/{hook_id}"
     user = u"/user"
-    file = u"/projects/{id}/repository/files/{path}"
+    file = u"/projects/{project}/repository/files/{path}"
 
     @staticmethod
     def build_api_url(base_url, path):
@@ -243,13 +243,13 @@ class GitLabApiClient(ApiClient):
         path = GitLabApiClientPath.diff.format(project=project_id, sha=sha)
         return self.get(path)
 
-    @transaction_start("GitLabApiClient")
-    def get_file(self, project_id, path, ref):
+    @transaction_start("GitLabApiClient.check_file")
+    def check_file(self, project_id, path, ref):
         """Fetch a file for stacktrace linking
 
         See https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
         Path requires file path and ref
         """
-
-        request_path = GitLabApiClientPath.file.format(id=project_id, path=path)
-        return self.get_cached(request_path, params={"ref": ref})
+        request_path = GitLabApiClientPath.file.format(project=project_id, path=path)
+        # TODO: handle on prem gitlab w/o a base url (so use the user's URL I guess?)
+        return self.head_cached(request_path, params={"ref": ref}).text

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -304,6 +304,6 @@ class BaseApiClient(object):
 
         result = cache.get(key)
         if result is None:
-            result = self.request("HEAD", path, *args, **kwargs)
+            result = self.head(path, *args, **kwargs)
             cache.set(key, result, self.cache_time)
         return result

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -45,7 +45,7 @@ class BaseApiResponse(object):
     @classmethod
     def from_response(self, response, allow_text=False):
         if response.request.method == "HEAD":
-            return TextApiResponse(response.status_code)
+            return TextApiResponse(response.status_code, response.headers, response.status_code)
         # XXX(dcramer): this doesnt handle leading spaces, but they're not common
         # paths so its ok
         elif response.text.startswith(u"<?xml"):

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -285,19 +285,6 @@ class BaseApiClient(object):
     def get(self, *args, **kwargs):
         return self.request("GET", *args, **kwargs)
 
-    def head(self, *args, **kwargs):
-        return self.request("HEAD", *args, **kwargs)
-
-    def head_cached(self, *args, **kwargs):
-        path = kwargs.get("path", None)
-        key = self.get_cache_prefix() + md5_text(self.build_url(path)).hexdigest()
-
-        result = cache.get(key)
-        if result is None:
-            result = self.request("HEAD", *args, **kwargs)
-            cache.set(key, result, self.cache_time)
-        return result
-
     def patch(self, *args, **kwargs):
         return self.request("PATCH", *args, **kwargs)
 

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -285,6 +285,19 @@ class BaseApiClient(object):
     def get(self, *args, **kwargs):
         return self.request("GET", *args, **kwargs)
 
+    def head(self, *args, **kwargs):
+        return self.request("HEAD", *args, **kwargs)
+
+    def head_cached(self, *args, **kwargs):
+        path = kwargs.get("path", None)
+        key = self.get_cache_prefix() + md5_text(self.build_url(path)).hexdigest()
+
+        result = cache.get(key)
+        if result is None:
+            result = self.request("HEAD", *args, **kwargs)
+            cache.set(key, result, self.cache_time)
+        return result
+
     def patch(self, *args, **kwargs):
         return self.request("PATCH", *args, **kwargs)
 

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -45,10 +45,10 @@ class BaseApiResponse(object):
     @classmethod
     def from_response(self, response, allow_text=False):
         if response.request.method == "HEAD":
-            return TextApiResponse(response.status_code, response.headers, response.status_code)
+            return BaseApiResponse(response.headers, response.status_code)
         # XXX(dcramer): this doesnt handle leading spaces, but they're not common
         # paths so its ok
-        elif response.text.startswith(u"<?xml"):
+        if response.text.startswith(u"<?xml"):
             return XmlApiResponse(response.text, response.headers, response.status_code)
         elif response.text.startswith("<"):
             if not allow_text:

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -73,7 +73,7 @@ class GitHubAppsClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
-    def test_not_get_file_url(self, get_jwt):
+    def test_fail_to_get_file_url(self, get_jwt):
         responses.add(
             method=responses.POST,
             url="https://api.github.com/app/installations/1/access_tokens",
@@ -89,3 +89,4 @@ class GitHubAppsClientTest(TestCase):
 
         with self.assertRaises(ApiError):
             self.client.get_file_url(repo, path)
+        assert responses.calls[1].response.status_code == 404

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -62,7 +62,7 @@ class GitHubAppsClientTest(TestCase):
         )
 
         resp = self.client.check_file(repo, path)
-        assert resp == 200
+        assert resp.status_code == 200
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -38,3 +38,63 @@ class GitHubAppsClientTest(TestCase):
         token = client.get_token()
         assert token == "12345token"
         assert len(responses.calls) == 1
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_check_source_code_link(self, get_jwt):
+        integration = Integration.objects.create(
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={"access_token": None, "expires_at": None},
+        )
+
+        install = integration.get_installation(organization_id="123")
+        client = install.get_client()
+
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/app/installations/1/access_tokens",
+            body='{"token": "12345token", "expires_at": "2030-01-01T00:00:00Z"}',
+            status=200,
+            content_type="application/json",
+        )
+
+        path = u"https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/github/client.py#L22"
+
+        responses.add(
+            method=responses.HEAD, url=path, status=200,
+        )
+
+        resp = client.check_source_code_link(path)
+        assert resp == 200
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_check_bad_source_code_link(self, get_jwt):
+        integration = Integration.objects.create(
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={"access_token": None, "expires_at": None},
+        )
+
+        install = integration.get_installation(organization_id="123")
+        client = install.get_client()
+
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/app/installations/1/access_tokens",
+            body='{"token": "12345token", "expires_at": "2030-01-01T00:00:00Z"}',
+            status=200,
+            content_type="application/json",
+        )
+
+        path = u"https://github.com/getsentry/sentry/blob/master/src/santry/integrations/github/client.py#L22"
+
+        responses.add(
+            method=responses.HEAD, url=path, status=404,
+        )
+
+        resp = client.check_source_code_link(path)
+        assert resp == 404

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -10,8 +10,7 @@ from sentry.models import Integration
 class GitHubAppsClientTest(TestCase):
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
-    def test_save_token(self, get_jwt):
-
+    def setUp(self, get_jwt):
         integration = Integration.objects.create(
             provider="github",
             name="Github Test Org",
@@ -20,7 +19,11 @@ class GitHubAppsClientTest(TestCase):
         )
 
         install = integration.get_installation(organization_id="123")
-        client = install.get_client()
+        self.client = install.get_client()
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_save_token(self, get_jwt):
 
         responses.add(
             method=responses.POST,
@@ -30,28 +33,18 @@ class GitHubAppsClientTest(TestCase):
             content_type="application/json",
         )
 
-        token = client.get_token()
+        token = self.client.get_token()
         assert token == "12345token"
         assert len(responses.calls) == 1
 
         # Second get_token doesn't have to make an API call
-        token = client.get_token()
+        token = self.client.get_token()
         assert token == "12345token"
         assert len(responses.calls) == 1
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_check_source_code_link(self, get_jwt):
-        integration = Integration.objects.create(
-            provider="github",
-            name="Github Test Org",
-            external_id="1",
-            metadata={"access_token": None, "expires_at": None},
-        )
-
-        install = integration.get_installation(organization_id="123")
-        client = install.get_client()
-
         responses.add(
             method=responses.POST,
             url="https://api.github.com/app/installations/1/access_tokens",
@@ -66,22 +59,12 @@ class GitHubAppsClientTest(TestCase):
             method=responses.HEAD, url=path, status=200,
         )
 
-        resp = client.check_source_code_link(path)
+        resp = self.client.check_source_code_link(path)
         assert resp == 200
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_check_bad_source_code_link(self, get_jwt):
-        integration = Integration.objects.create(
-            provider="github",
-            name="Github Test Org",
-            external_id="1",
-            metadata={"access_token": None, "expires_at": None},
-        )
-
-        install = integration.get_installation(organization_id="123")
-        client = install.get_client()
-
         responses.add(
             method=responses.POST,
             url="https://api.github.com/app/installations/1/access_tokens",
@@ -96,5 +79,5 @@ class GitHubAppsClientTest(TestCase):
             method=responses.HEAD, url=path, status=404,
         )
 
-        resp = client.check_source_code_link(path)
+        resp = self.client.check_source_code_link(path)
         assert resp == 404

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -126,42 +126,32 @@ class GitlabRefreshAuthTest(GitLabTestCase):
         self.assert_identity_was_not_refreshed()
 
     @responses.activate
-    def test_get_file(self):
+    def test_check_file(self):
         path = "file.py"
         ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
         responses.add(
-            responses.GET,
+            responses.HEAD,
             "https://example.gitlab.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
                 self.gitlab_id, path, ref
             ),
-            json={
-                u"file_name": u"file.py",
-                u"ref": u"537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3",
-                u"file_path": u"file.py",
-                u"size": 34,
-            },
+            json={"text": 200},
         )
 
-        resp = self.client.get_file(self.gitlab_id, path, ref)
+        resp = self.client.check_file(self.gitlab_id, path, ref)
         assert responses.calls[0].response.status_code == 200
-        assert resp == {
-            u"file_name": u"file.py",
-            u"size": 34,
-            u"ref": u"537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3",
-            u"file_path": u"file.py",
-        }
+        assert resp == 200
 
     @responses.activate
-    def test_fail_to_get_file(self):
+    def test_check_no_file(self):
         path = "file.py"
         ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
         responses.add(
-            responses.GET,
+            responses.HEAD,
             "https://example.gitlab.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
                 self.gitlab_id, path, ref
             ),
             status=404,
         )
         with self.assertRaises(ApiError):
-            self.client.get_file(self.gitlab_id, path, ref)
+            self.client.check_file(self.gitlab_id, path, ref)
         assert responses.calls[0].response.status_code == 404

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -139,7 +139,7 @@ class GitlabRefreshAuthTest(GitLabTestCase):
 
         resp = self.client.check_file(self.gitlab_id, path, ref)
         assert responses.calls[0].response.status_code == 200
-        assert resp == 200
+        assert resp.status_code == 200
 
     @responses.activate
     def test_check_no_file(self):

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -4,6 +4,7 @@ import pytest
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.models import Identity
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import json
 from .testutils import GitLabTestCase
 
@@ -25,6 +26,7 @@ class GitlabRefreshAuthTest(GitLabTestCase):
             "scope": "api",
         }
         self.original_identity_data = dict(self.client.identity.data)
+        self.gitlab_id = 123
 
     def tearDown(self):
         responses.reset()
@@ -122,3 +124,44 @@ class GitlabRefreshAuthTest(GitLabTestCase):
         self.assert_response_call(call, self.request_url, 200)
         assert resp == self.request_data
         self.assert_identity_was_not_refreshed()
+
+    @responses.activate
+    def test_get_file(self):
+        path = "file.py"
+        ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
+                self.gitlab_id, path, ref
+            ),
+            json={
+                u"file_name": u"file.py",
+                u"ref": u"537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3",
+                u"file_path": u"file.py",
+                u"size": 34,
+            },
+        )
+
+        resp = self.client.get_file(self.gitlab_id, path, ref)
+        assert responses.calls[0].response.status_code == 200
+        assert resp == {
+            u"file_name": u"file.py",
+            u"size": 34,
+            u"ref": u"537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3",
+            u"file_path": u"file.py",
+        }
+
+    @responses.activate
+    def test_fail_to_get_file(self):
+        path = "file.py"
+        ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
+                self.gitlab_id, path, ref
+            ),
+            status=404,
+        )
+        with self.assertRaises(ApiError):
+            self.client.get_file(self.gitlab_id, path, ref)
+        assert responses.calls[0].response.status_code == 404


### PR DESCRIPTION
## Context 
This quarter the ecosystem team is working on a stack trace linking project where a user will be able to click a link in their Sentry issue's stack trace and go directly to their source code file in either GitHub or GitLab (we might add support for more integrations later on). 

## Description
This PR implements methods on each supported integration's client to check that the file exists. They're both using transactions so we can measure the length of the requests as well as caching. 

### GitHub
We're doing a HEAD request to [this endpoint](https://developer.github.com/v3/repos/contents/#get-repository-content) to see if the file exists. 

### GitLab
We're also doing a HEAD request to [this endpoint](https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository) to see if the file exists.