### PR TITLE
fix(workflow): Fixing bug on incidents started before retention with time window less than total length

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -463,7 +463,12 @@ def get_incident_event_stats(incident, start=None, end=None, windowed_stats=Fals
     # they'll be included in the standard results anyway.
     start_query_params = None
     extra_buckets = []
-    if int(to_timestamp(incident.date_started)) % time_window:
+    retention = quotas.get_event_retention(organization=incident.organization) or 90
+    if (
+        incident.date_started
+        > datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=retention)
+        and int(to_timestamp(incident.date_started)) % time_window
+    ):
         start_query_params = build_extra_query_params(incident.date_started)
         snuba_params.append(start_query_params)
         extra_buckets.append(incident.date_started)


### PR DESCRIPTION
The additional query for the start bucket is causing an issue for incidents that have a length less than their time window and started before retention. 

Fixes https://sentry.io/organizations/sentry/issues/1955251162/