### PR TITLE
fix(ads.js): Bring back ads.js for naive ad-blocker detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     cmdclass=cmdclass,
     license="BSL-1.1",
     include_package_data=True,
-    package_data={"sentry": ["static/sentry/dist/**"]},
+    package_data={"sentry": ["static/sentry/dist/**", "static/sentry/js/ads.js"]},
     exclude_package_data={"sentry": ["static/sentry/**"]},
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ setup(
         "sentry": [
             "static/sentry/{}/**".format(d) for d in ("app", "fonts", "images", "less", "vendor")
         ]
-        + ["static/sentry/*.*"]
     },
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ setup(
         "sentry": [
             "static/sentry/{}/**".format(d) for d in ("app", "fonts", "images", "less", "vendor")
         ]
-        + ["static/sentry/*"]
     },
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     cmdclass=cmdclass,
     license="BSL-1.1",
     include_package_data=True,
-    package_data={"sentry": ["static/sentry/dist/**", "static/sentry/js/ads.*"]},
+    package_data={"sentry": ["static/sentry/js/ads.js", "static/sentry/dist/**"]},
     exclude_package_data={"sentry": ["static/sentry/**"]},
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     cmdclass=cmdclass,
     license="BSL-1.1",
     include_package_data=True,
-    package_data={"sentry": ["static/sentry/dist/**", "static/sentry/js/ads.js"]},
+    package_data={"sentry": ["static/sentry/dist/**", "static/sentry/js/ads.*"]},
     exclude_package_data={"sentry": ["static/sentry/**"]},
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],

--- a/setup.py
+++ b/setup.py
@@ -108,9 +108,9 @@ setup(
     package_data={"sentry": ["static/sentry/dist/**", "static/sentry/js/**"]},
     exclude_package_data={
         "sentry": [
-            "static/sentry/{}/**".format(d)
-            for d in ("app", "fonts", "images", "less", "vendor") + "static/sentry/*"
+            "static/sentry/{}/**".format(d) for d in ("app", "fonts", "images", "less", "vendor")
         ]
+        + ["static/sentry/*"]
     },
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
         "sentry": [
             "static/sentry/{}/**".format(d) for d in ("app", "fonts", "images", "less", "vendor")
         ]
+        + ["static/sentry/*.*"]
     },
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,12 @@ setup(
     license="BSL-1.1",
     include_package_data=True,
     package_data={"sentry": ["static/sentry/dist/**", "static/sentry/js/**"]},
-    exclude_package_data={"sentry": ["static/sentry/**"]},
+    exclude_package_data={
+        "sentry": [
+            "static/sentry/{}/**".format(d)
+            for d in ("app", "fonts", "images", "less", "vendor") + "static/sentry/*"
+        ]
+    },
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],
         "sentry.apps": [

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     cmdclass=cmdclass,
     license="BSL-1.1",
     include_package_data=True,
-    package_data={"sentry": ["static/sentry/js/ads.js", "static/sentry/dist/**"]},
+    package_data={"sentry": ["static/sentry/dist/**", "static/sentry/js/**"]},
     exclude_package_data={"sentry": ["static/sentry/**"]},
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],


### PR DESCRIPTION
This file was removed from the production package in #21411. See the Nginx 404 log over at https://forum.sentry.io/t/upgrading-from-9-12-10-0-0-v20-6-0/11428/13?u=byk
