### PR TITLE
chore(issue stream): Update tooltip

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/groupChart.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.tsx
@@ -47,7 +47,7 @@ function GroupChart({
       data: secondaryStats.map(point => ({name: point[0] * 1000, value: point[1]})),
     });
     series.push({
-      seriesName: t('Filtered Events'),
+      seriesName: t('Matching Events'),
       data: stats.map(point => ({name: point[0] * 1000, value: point[1]})),
     });
   } else {


### PR DESCRIPTION
"Filtered" is generally used in the context of inbound filters which throw away events. Another option is to call it "Matching search filters" instead of "Matching events"