### PR TITLE
ref(ui) Update Project Key Stats to use echarts

### DIFF
--- a/docs-ui/components/miniBarChart.stories.js
+++ b/docs-ui/components/miniBarChart.stories.js
@@ -130,16 +130,24 @@ export const _MiniBarChart = withInfo('Stacked MiniBarChart')(() => {
       </div>
 
       <div className="section">
-        <h3>With yAxis labels</h3>
+        <h3>With yAxis labels and stacked results</h3>
         <MiniBarChart
           height={150}
           labelYAxisExtents
           isGroupedByDate
           showTimeInTooltip
+          stacked
           series={[
             {
-              seriesName: 'Events',
+              seriesName: 'Accepted',
               data: all.map((value, i) => ({
+                name: (startTime + interval * i) * 1000,
+                value,
+              })),
+            },
+            {
+              seriesName: 'Rejected',
+              data: current.map((value, i) => ({
                 name: (startTime + interval * i) * 1000,
                 value,
               })),

--- a/docs-ui/components/miniBarChart.stories.js
+++ b/docs-ui/components/miniBarChart.stories.js
@@ -67,64 +67,87 @@ export const _MiniBarChart = withInfo('Stacked MiniBarChart')(() => {
   ];
 
   return (
-    <div className="section">
-      <h2>Stacked MiniBarChart</h2>
+    <React.Fragment>
+      <div className="section">
+        <h2>Stacked MiniBarChart</h2>
 
-      <h3>With markers as per issue details</h3>
-      <MiniBarChart
-        width={294}
-        height={70}
-        isGroupedByDate
-        showTimeInTooltip
-        series={[
-          {
-            seriesName: 'All environments',
-            data: all.map((value, i) => ({
-              name: (startTime + interval * i) * 1000,
-              value,
-            })),
-          },
-          {
-            seriesName: 'Release abc123',
-            data: current.map((value, i) => ({
-              name: (startTime + interval * i) * 1000,
-              value,
-            })),
-          },
-        ]}
-        markers={[
-          {
-            barGap: '-100%',
-            name: 'First Seen',
-            value: (startTime + interval) * 1000,
-            color: theme.pink400,
-          },
-          {
-            name: 'Last Seen',
-            value: (startTime + interval * 23) * 1000,
-            color: theme.green400,
-          },
-        ]}
-      />
+        <h3>With markers as per issue details</h3>
+        <MiniBarChart
+          width={294}
+          height={70}
+          isGroupedByDate
+          showTimeInTooltip
+          series={[
+            {
+              seriesName: 'All environments',
+              data: all.map((value, i) => ({
+                name: (startTime + interval * i) * 1000,
+                value,
+              })),
+            },
+            {
+              seriesName: 'Release abc123',
+              data: current.map((value, i) => ({
+                name: (startTime + interval * i) * 1000,
+                value,
+              })),
+            },
+          ]}
+          markers={[
+            {
+              barGap: '-100%',
+              name: 'First Seen',
+              value: (startTime + interval) * 1000,
+              color: theme.pink400,
+            },
+            {
+              name: 'Last Seen',
+              value: (startTime + interval * 23) * 1000,
+              color: theme.green400,
+            },
+          ]}
+        />
+      </div>
 
-      <h3>No markers and emphasis colors</h3>
-      <MiniBarChart
-        width={160}
-        height={24}
-        isGroupedByDate
-        showTimeInTooltip
-        emphasisColors={[theme.purple400]}
-        series={[
-          {
-            seriesName: 'Events',
-            data: all.map((value, i) => ({
-              name: (startTime + interval * i) * 1000,
-              value,
-            })),
-          },
-        ]}
-      />
-    </div>
+      <div className="section">
+        <h3>No markers and emphasis colors</h3>
+        <MiniBarChart
+          width={160}
+          height={24}
+          isGroupedByDate
+          showTimeInTooltip
+          emphasisColors={[theme.purple400]}
+          series={[
+            {
+              seriesName: 'Events',
+              data: all.map((value, i) => ({
+                name: (startTime + interval * i) * 1000,
+                value,
+              })),
+            },
+          ]}
+        />
+      </div>
+
+      <div className="section">
+        <h3>With yAxis labels</h3>
+        <MiniBarChart
+          height={150}
+          labelYAxisExtents
+          isGroupedByDate
+          showTimeInTooltip
+          series={[
+            {
+              seriesName: 'Events',
+              data: all.map((value, i) => ({
+                name: (startTime + interval * i) * 1000,
+                value,
+              })),
+            },
+          ]}
+        />
+      </div>
+    </React.Fragment>
   );
 });
 

--- a/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
@@ -24,7 +24,7 @@ const defaultProps = {
   /**
    * Show max/min values on yAxis
    */
-  labelYAxisExtents: false as boolean,
+  labelYAxisExtents: false,
   /**
    * Whether not the series should be stacked.
    *
@@ -32,7 +32,7 @@ const defaultProps = {
    * breakdown data (issues). For these results `stacked` should be false.
    * Other endpoints return decomposed results that need to be stacked (outcomes).
    */
-  stacked: false as boolean,
+  stacked: false,
 };
 
 type Props = React.ComponentProps<typeof BaseChart> &

--- a/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
@@ -21,6 +21,10 @@ const defaultProps = {
    * Colors to use on the chart.
    */
   colors: [theme.gray400, theme.purple400] as string[],
+  /**
+   * Show max/min values on yAxis
+   */
+  labelYAxisExtents: false as boolean,
 };
 
 type Props = React.ComponentProps<typeof BaseChart> &
@@ -46,7 +50,14 @@ class MiniBarChart extends React.Component<Props> {
   static defaultProps = defaultProps;
 
   render() {
-    const {markers, emphasisColors, colors, series: _series, ...props} = this.props;
+    const {
+      markers,
+      emphasisColors,
+      colors,
+      series: _series,
+      labelYAxisExtents,
+      ...props
+    } = this.props;
     let series = [...this.props.series];
 
     // Ensure bars overlap and that empty values display as we're disabling the axis lines.
@@ -120,6 +131,17 @@ class MiniBarChart extends React.Component<Props> {
       };
       series.push(markerSeries);
     }
+    const yAxisOptions = labelYAxisExtents
+      ? {
+          showMinLabel: true,
+          showMaxLabel: true,
+          interval: Infinity,
+        }
+      : {
+          axisLabel: {
+            show: false,
+          },
+        };
 
     const chartOptions = {
       colors,
@@ -132,18 +154,16 @@ class MiniBarChart extends React.Component<Props> {
           // by having full bars for < 10 values.
           return Math.max(10, value.max);
         },
-        axisLabel: {
-          show: false,
-        },
         splitLine: {
           show: false,
         },
+        ...yAxisOptions,
       },
       grid: {
-        top: 0,
-        bottom: markers ? 4 : 0,
-        left: 0,
-        right: 0,
+        top: labelYAxisExtents ? 6 : 0,
+        bottom: markers || labelYAxisExtents ? 4 : 0,
+        left: markers ? 4 : 0,
+        right: markers ? 4 : 0,
       },
       xAxis: {
         axisLine: {

--- a/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
@@ -25,6 +25,14 @@ const defaultProps = {
    * Show max/min values on yAxis
    */
   labelYAxisExtents: false as boolean,
+  /**
+   * Whether not the series should be stacked.
+   *
+   * Some of our stats endpoints return data where the 'total' series includes
+   * breakdown data (issues). For these results `stacked` should be false.
+   * Other endpoints return decomposed results that need to be stacked (outcomes).
+   */
+  stacked: false as boolean,
 };
 
 type Props = React.ComponentProps<typeof BaseChart> &
@@ -56,6 +64,7 @@ class MiniBarChart extends React.Component<Props> {
       colors,
       series: _series,
       labelYAxisExtents,
+      stacked,
       ...props
     } = this.props;
     let series = [...this.props.series];
@@ -71,8 +80,14 @@ class MiniBarChart extends React.Component<Props> {
 
         if (i === 0) {
           updated.barMinHeight = 1;
-          updated.barGap = '-100%';
+          if (stacked === false) {
+            updated.barGap = '-100%';
+          }
         }
+        if (stacked) {
+          updated.stack = 'stack1';
+        }
+
         set(updated, 'itemStyle.opacity', 0.6);
         set(updated, 'itemStyle.emphasis.opacity', 1.0);
         if (emphasisColors && emphasisColors[i]) {

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyStats.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyStats.tsx
@@ -112,6 +112,7 @@ class KeyStats extends React.Component<Props, State> {
               series={this.state.series}
               height={150}
               colors={[theme.gray400, theme.red400]}
+              stacked
               labelYAxisExtents
             />
           ) : (


### PR DESCRIPTION
Replace the bar chart on Project Key stats with an echarts based one. MiniBarChart can now show min/max yAxis values and stack results as the StackedBarChart component did.

### Before

![Screen Shot 2020-10-20 at 12 50 27 PM](https://user-images.githubusercontent.com/24086/96623297-27cece80-12d9-11eb-9687-615ef885cd2a.png)

### After

![Screen Shot 2020-10-20 at 1 36 41 PM](https://user-images.githubusercontent.com/24086/96623417-59e03080-12d9-11eb-8953-7962b75dbfcd.png)

