### PR TITLE
ref(ingest) Remove deprecated event parameter from post_process_group

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -48,7 +48,6 @@ class EventStream(Service):
                 {"project": event.project_id, "event_id": event.event_id}
             )
             post_process_group.delay(
-                event=None,
                 is_new=is_new,
                 is_regression=is_regression,
                 is_new_group_environment=is_new_group_environment,

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -129,11 +129,11 @@ class NotifyEmailTest(RuleTestCase):
 
         with self.tasks():
             post_process_group(
-                event=event,
                 is_new=True,
                 is_regression=False,
                 is_new_group_environment=False,
                 cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
             )
 
         assert len(mail.outbox) == 1

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -57,11 +57,7 @@ class PostProcessGroupTest(TestCase):
         )
         cache_key = write_event_to_cache(event)
         post_process_group(
-            event=None,
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            cache_key=cache_key,
+            is_new=True, is_regression=False, is_new_group_environment=True, cache_key=cache_key,
         )
 
         mock_processor.assert_not_called()  # NOQA
@@ -77,7 +73,6 @@ class PostProcessGroupTest(TestCase):
         event = self.store_event(data={}, project_id=self.project.id)
 
         post_process_group(
-            event=None,
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
@@ -92,7 +87,6 @@ class PostProcessGroupTest(TestCase):
         cache_key = write_event_to_cache(event)
 
         post_process_group(
-            event=None,
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
@@ -100,50 +94,6 @@ class PostProcessGroupTest(TestCase):
             group_id=event.group_id,
         )
         assert event_processing_store.get(cache_key) is None
-
-    def test_processing_cache_cleared_with_event_param(self):
-        event = self.store_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
-
-        post_process_group(
-            event=event,
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            cache_key=cache_key,
-        )
-        assert event_processing_store.get(cache_key) is None
-
-    def test_processing_cache_does_not_error(self):
-        event = self.store_event(data={}, project_id=self.project.id)
-
-        post_process_group(
-            event=event,
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            cache_key="not-valid",
-        )
-        assert event_processing_store.get("not-valid") is None
-
-    @patch("sentry.rules.processor.RuleProcessor")
-    @patch("sentry.tasks.post_process.check_event_already_post_processed")
-    def test_already_processed_abort(self, mock_check, mock_processor):
-        mock_check.return_value = True
-
-        event = self.store_event(data={}, project_id=self.project.id)
-
-        post_process_group(
-            event=event,
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            cache_key=None,
-            group_id=event.group_id,
-        )
-
-        assert mock_check.call_count == 1
-        assert mock_processor.call_count == 0, "Should abort early"
 
     @patch("sentry.rules.processor.RuleProcessor")
     def test_rule_processor_backwards_compat(self, mock_processor):
@@ -156,7 +106,6 @@ class PostProcessGroupTest(TestCase):
         mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
 
         post_process_group(
-            event=None,
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
@@ -180,7 +129,6 @@ class PostProcessGroupTest(TestCase):
         mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
 
         post_process_group(
-            event=None,
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
@@ -213,7 +161,6 @@ class PostProcessGroupTest(TestCase):
         mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
 
         post_process_group(
-            event=None,
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
@@ -236,7 +183,6 @@ class PostProcessGroupTest(TestCase):
 
         # Check for has_reappeared=False if is_new=True
         post_process_group(
-            event=None,
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
@@ -249,7 +195,6 @@ class PostProcessGroupTest(TestCase):
         cache_key = write_event_to_cache(event)
         # Check for has_reappeared=True if is_new=False
         post_process_group(
-            event=None,
             is_new=False,
             is_regression=False,
             is_new_group_environment=True,
@@ -273,7 +218,6 @@ class PostProcessGroupTest(TestCase):
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now() + timedelta(hours=1))
 
         post_process_group(
-            event=None,
             is_new=True,
             is_regression=False,
             is_new_group_environment=True,
@@ -309,7 +253,6 @@ class PostProcessGroupTest(TestCase):
         )
         cache_key = write_event_to_cache(event)
         post_process_group(
-            event=None,
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
@@ -332,7 +275,6 @@ class PostProcessGroupTest(TestCase):
         )
         cache_key = write_event_to_cache(event)
         post_process_group(
-            event=None,
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
@@ -354,7 +296,6 @@ class PostProcessGroupTest(TestCase):
         )
         cache_key = write_event_to_cache(event)
         post_process_group(
-            event=None,
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
@@ -376,7 +317,6 @@ class PostProcessGroupTest(TestCase):
         cache_key = write_event_to_cache(event)
         event.group.assignee_set.create(team=self.team, project=self.project)
         post_process_group(
-            event=None,
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
@@ -402,7 +342,6 @@ class PostProcessGroupTest(TestCase):
         )
         cache_key = write_event_to_cache(event)
         post_process_group(
-            event=None,
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
@@ -411,35 +350,6 @@ class PostProcessGroupTest(TestCase):
         )
         assignee = event.group.assignee_set.first()
         assert assignee is None
-
-    # TODO(mark) Remove this after October 16 2020.
-    @patch("sentry.tasks.servicehooks.process_service_hook")
-    def test_event_parameter_backwards_compat(self, mock_process_service_hook):
-        # Ensure that post_process_group still does
-        # what it should when an event parameter is used.
-        # This ensures backwards compatibility for self-hosted.
-        event = self.store_event(data={}, project_id=self.project.id)
-        cache_key = write_event_to_cache(event)
-        hook = self.create_service_hook(
-            project=self.project,
-            organization=self.project.organization,
-            actor=self.user,
-            events=["event.created"],
-        )
-
-        with self.feature("projects:servicehooks"):
-            post_process_group(
-                event=event,
-                is_new=False,
-                is_regression=False,
-                is_new_group_environment=False,
-                cache_key=cache_key,
-                group_id=event.group_id,
-            )
-
-        mock_process_service_hook.delay.assert_called_once_with(
-            servicehook_id=hook.id, event=EventMatcher(event)
-        )
 
     @patch("sentry.tasks.servicehooks.process_service_hook")
     def test_service_hook_fires_on_new_event(self, mock_process_service_hook):
@@ -454,7 +364,6 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=None,
                 is_new=False,
                 is_regression=False,
                 is_new_group_environment=False,
@@ -486,7 +395,6 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=None,
                 is_new=False,
                 is_regression=False,
                 is_new_group_environment=False,
@@ -517,7 +425,6 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=None,
                 is_new=False,
                 is_regression=False,
                 is_new_group_environment=False,
@@ -538,7 +445,6 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=None,
                 is_new=True,
                 is_regression=False,
                 is_new_group_environment=False,
@@ -554,7 +460,6 @@ class PostProcessGroupTest(TestCase):
         cache_key = write_event_to_cache(event)
         group = event.group
         post_process_group(
-            event=None,
             is_new=True,
             is_regression=False,
             is_new_group_environment=False,
@@ -587,7 +492,6 @@ class PostProcessGroupTest(TestCase):
         )
 
         post_process_group(
-            event=None,
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
@@ -613,7 +517,6 @@ class PostProcessGroupTest(TestCase):
         cache_key = write_event_to_cache(event)
 
         post_process_group(
-            event=None,
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
@@ -633,7 +536,6 @@ class PostProcessGroupTest(TestCase):
         cache_key = write_event_to_cache(event)
 
         post_process_group(
-            event=None,
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
@@ -663,7 +565,6 @@ class PostProcessGroupTest(TestCase):
         )
 
         post_process_group(
-            event=None,
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -192,11 +192,11 @@ class TestProcessResourceChange(TestCase):
         event = self.store_event(data={}, project_id=self.project.id)
         with self.tasks():
             post_process_group(
-                event=event,
                 is_new=True,
                 is_regression=False,
                 is_new_group_environment=False,
                 cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
             )
 
         data = json.loads(faux(safe_urlopen).kwargs["data"])
@@ -257,11 +257,11 @@ class TestProcessResourceChange(TestCase):
 
         with self.tasks():
             post_process_group(
-                event=event,
                 is_new=False,
                 is_regression=False,
                 is_new_group_environment=False,
                 cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
             )
 
         data = json.loads(faux(safe_urlopen).kwargs["data"])
@@ -300,11 +300,11 @@ class TestProcessResourceChange(TestCase):
 
         with self.tasks():
             post_process_group(
-                event=event,
                 is_new=False,
                 is_regression=False,
                 is_new_group_environment=False,
                 cache_key=write_event_to_cache(event),
+                group_id=event.group_id,
             )
 
         assert not safe_urlopen.called


### PR DESCRIPTION
The event parameter was deprecated in september. With the 20.10 self-hosted release done we can remove this parameter now without impacting self-hosted or single tenant installs. The `post_process` task still accepts `**kwargs` so we shouldn't have any failures during a deploy.