### PR TITLE
chore(codeowners) Add data team as codeowners to relevant models

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -165,3 +165,24 @@ Makefile                    @getsentry/owners-sentry-dev
 /tests/apidocs/                               @getsentry/ecosystem
 
 ### End of Ecosystem ###
+
+
+### Data ###
+
+/src/sentry/models/featureadoption.py         @getsentry/data
+/src/sentry/models/group.py                   @getsentry/data
+/src/sentry/models/grouphash.py               @getsentry/data
+/src/sentry/models/grouprelease.py            @getsentry/data
+/src/sentry/models/groupresolution.py         @getsentry/data
+/src/sentry/models/integration.py             @getsentry/data
+/src/sentry/models/organization.py            @getsentry/data
+/src/sentry/models/organizationmember.py      @getsentry/data
+/src/sentry/models/organizationoption.py      @getsentry/data
+/src/sentry/models/project.py                 @getsentry/data
+/src/sentry/models/projectoption.py           @getsentry/data
+/src/sentry/models/release.py                 @getsentry/data
+/src/sentry/models/sentryapp.py               @getsentry/data
+/src/sentry/models/sentryappinstallation.py   @getsentry/data
+/src/sentry/models/user.py                    @getsentry/data
+
+### End of Data ###


### PR DESCRIPTION
Data team wants to follow changes made to certain models. Adding us to the codeowners here will alert us so we can see if anything needs to be done on our end to accommodate 