### PR TITLE
fix(ui): Fix dynamic content in `<ErrorBoundary>`

### DIFF
--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -8,6 +8,7 @@ import {t} from 'app/locale';
 import Alert from 'app/components/alert';
 import DetailedError from 'app/components/errors/detailedError';
 import {IconFlag} from 'app/icons';
+import getDynamicText from 'app/utils/getDynamicText';
 
 type DefaultProps = {
   mini: boolean;
@@ -109,7 +110,10 @@ class ErrorBoundary extends React.Component<Props, State> {
     return (
       <Wrapper>
         <DetailedError
-          heading={getExclamation()}
+          heading={getDynamicText({
+            value: getExclamation(),
+            fixed: exclamation[0],
+          })}
           message={t(
             `Something went horribly wrong rendering this page.
 We use a decent error reporting service so this will probably be fixed soon. Unless our error reporting service is also broken. That would be awkward.


### PR DESCRIPTION
An `<ErrorBoundary>` was added in https://github.com/getsentry/sentry/pull/21255 as for whatever reason, having a custom monospace font was causing breadcrumbs to crash (but only in CI and not locally).