### PR TITLE
ref(ts) Convert Inbound filters to typescript

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
@@ -25,6 +25,7 @@ type Props = {
   highlighted?: boolean;
   disabled?: boolean | ((props) => boolean);
   flexibleControlStateSize?: boolean;
+  getData?: (data) => any;
   stacked?: boolean;
   inline?: boolean;
   onBlur?: (value, event) => void;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.tsx
@@ -90,7 +90,14 @@ type Props = {
   formatMessageValue?: boolean | Function; //used in prettyFormString
   defaultValue?: any; //TODO(TS): Do we need this?
   resetOnError?: boolean;
+  /**
+   * Tranform input when a value is set to the model.
+   */
   transformInput?: (value: any) => any;
+  /**
+   * Transform data when saving on blur.
+   */
+  getData?: (value: any) => any;
 } & Omit<FieldControl['props'], typeof propsToObserver[number]> &
   Omit<Field['props'], 'inline'>;
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/index.tsx
@@ -1,5 +1,6 @@
 import {Link} from 'react-router';
 import React from 'react';
+import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {t} from 'app/locale';
 import GroupTombstones from 'app/views/settings/project/projectFilters/groupTombstones';
@@ -8,17 +9,17 @@ import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import ProjectFiltersChart from 'app/views/settings/project/projectFilters/projectFiltersChart';
 import ProjectFiltersSettings from 'app/views/settings/project/projectFilters/projectFiltersSettings';
-import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import recreateRoute from 'app/utils/recreateRoute';
 import withProject from 'app/utils/withProject';
+import {Project} from 'app/types';
 
-class ProjectFilters extends React.Component {
-  static propTypes = {
-    project: SentryTypes.Project,
-  };
+type Props = {
+  project: Project;
+} & RouteComponentProps<{projectId: string; orgId: string; filterType: string}, {}>;
 
+class ProjectFilters extends React.Component<Props> {
   render() {
     const {project, params} = this.props;
     const {orgId, projectId, filterType} = params;
@@ -29,7 +30,7 @@ class ProjectFilters extends React.Component {
     const features = new Set(project.features);
 
     return (
-      <div>
+      <React.Fragment>
         <SentryDocumentTitle title={t('Inbound Filters')} objSlug={projectId} />
         <SettingsPageHeader title={t('Inbound Data Filters')} />
         <PermissionAlert />
@@ -70,7 +71,7 @@ class ProjectFilters extends React.Component {
             />
           )}
         </div>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -1,8 +1,6 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 
-import SentryTypes from 'app/sentryTypes';
 import {intcomma} from 'app/utils';
 import {t, tn} from 'app/locale';
 import withApi from 'app/utils/withApi';
@@ -12,13 +10,33 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import StackedBarChart from 'app/components/stackedBarChart';
 import {formatAbbreviatedNumber} from 'app/utils/formatters';
+import {Project} from 'app/types';
+import {Client} from 'app/api';
 
-class ProjectFiltersChart extends React.Component {
-  static propTypes = {
-    api: PropTypes.object,
-    project: SentryTypes.Project,
-  };
+type Props = {
+  api: Client;
+  project: Project;
+  params: {orgId: string; projectId: string};
+};
 
+type StatRecord = {
+  data: {x: number; y: number}[];
+  label: string;
+  statName: string;
+};
+
+type State = {
+  loading: boolean;
+  error: boolean;
+  statsError: boolean;
+  querySince: number;
+  queryUntil: number;
+  rawStatsData: null | Record<string, any>;
+  formattedData: StatRecord[];
+  blankStats: boolean;
+};
+
+class ProjectFiltersChart extends React.Component<Props, State> {
   constructor(props) {
     super(props);
 
@@ -41,7 +59,7 @@ class ProjectFiltersChart extends React.Component {
     this.fetchData();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     if (prevProps.project !== this.props.project) {
       this.fetchData();
     }

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -224,7 +224,7 @@ class ProjectFiltersSettings extends AsyncComponent<Props, State> {
     onBlur: FormFieldProps['onBlur'],
     _filter,
     subfilters: RowState['subfilters'],
-    e
+    e: React.MouseEvent
   ) => {
     onChange?.(subfilters, e);
     onBlur?.(subfilters, e);


### PR DESCRIPTION
I have a chart to replace on this view so it makes sense to move to typescript first. I had to extend the `FormField` type to reflect load bearing real usage. The `getValue` prop ends up being consumed by FormModel in the `saveFieldRequest` method.