### PR TITLE
build(gha): Use `pull_request_target` for acceptance workflow

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -17,11 +17,12 @@ on:
 
 jobs:
   getsentry:
-    if: ${{ github.ref != 'refs/heads/master' && secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY != ''}}
+    if: ${{ github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-16.04
     steps:
       - name: getsentry token
         id: getsentry
+        if: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY != '' }}
         uses: getsentry/action-github-app-token@v1
         with:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   getsentry:
-    if: ${{ github.ref != 'refs/heads/master' }}
+    if: ${{ github.ref != 'refs/heads/master' && secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY != ''}}
     runs-on: ubuntu-16.04
     steps:
       - name: getsentry token

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - name: getsentry token
         id: getsentry
-        if: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY != '' }}
         uses: getsentry/action-github-app-token@v1
         with:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -9,6 +9,11 @@ on:
       - '**.[tj]sx?'
       - package.json
       - yarn.lock
+  pull_request_target:
+    paths:
+      - '**.[tj]sx?'
+      - package.json
+      - yarn.lock
 
 jobs:
   getsentry:

--- a/.github/workflows/visual-snapshots-and-acceptance-py2.7.yml
+++ b/.github/workflows/visual-snapshots-and-acceptance-py2.7.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - releases/**
+  pull_request:
   pull_request_target:
 
 jobs:

--- a/.github/workflows/visual-snapshots-and-acceptance-py2.7.yml
+++ b/.github/workflows/visual-snapshots-and-acceptance-py2.7.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
       - releases/**
-  pull_request:
+  pull_request_target:
 
 jobs:
   frontend:


### PR DESCRIPTION
This changes our visual snapshots/acceptance workflow to use the `pull_request_target` event instead of `pull_request` so that we can have Visual Snapshots working on fork PRs. By default, forks do not have write access tokens, but when using `pull_request_target`, forked PRs will use the base repository workflows as the source. This ensures that secrets/apis do not get exposed from by the fork changing workflows. See https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target for more information