### PR TITLE
ref(py3): bigtable column family accepts a str, not bytes

### DIFF
--- a/src/sentry/nodestore/bigtable/backend.py
+++ b/src/sentry/nodestore/bigtable/backend.py
@@ -66,7 +66,8 @@ class BigtableNodeStorage(NodeStorage):
     """
 
     max_size = 1024 * 1024 * 10
-    column_family = b"x"
+    column_family = "x"
+
     ttl_column = b"t"
     flags_column = b"f"
     data_column = b"0"


### PR DESCRIPTION
See: https://googleapis.dev/python/bigtable/latest/row.html#google.cloud.bigtable.row.ConditionalRow.set_cell