### PR TITLE
feat(vitals): Support measurements in metric alerts

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -50,7 +50,7 @@ from sentry.snuba.subscriptions import (
 from sentry.snuba.tasks import build_snuba_filter
 from sentry.utils.compat import zip
 from sentry.utils.dates import to_timestamp
-from sentry.utils.snuba import bulk_raw_query, SnubaQueryParams, SnubaTSResult
+from sentry.utils.snuba import bulk_raw_query, is_measurement, SnubaQueryParams, SnubaTSResult
 from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
 
 # We can return an incident as "windowed" which returns a range of points around the start of the incident
@@ -1350,7 +1350,12 @@ def get_column_from_aggregate(aggregate):
 
 def check_aggregate_column_support(aggregate):
     column = get_column_from_aggregate(aggregate)
-    return column is None or column.startswith("measurements.") or column in SUPPORTED_COLUMNS or column in TRANSLATABLE_COLUMNS
+    return (
+        column is None
+        or is_measurement(column)
+        or column in SUPPORTED_COLUMNS
+        or column in TRANSLATABLE_COLUMNS
+    )
 
 
 def translate_aggregate_field(aggregate, reverse=False):

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1350,7 +1350,7 @@ def get_column_from_aggregate(aggregate):
 
 def check_aggregate_column_support(aggregate):
     column = get_column_from_aggregate(aggregate)
-    return column is None or column in SUPPORTED_COLUMNS or column in TRANSLATABLE_COLUMNS
+    return column is None or column.startswith("measurements.") or column in SUPPORTED_COLUMNS or column in TRANSLATABLE_COLUMNS
 
 
 def translate_aggregate_field(aggregate, reverse=False):

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -6,6 +6,7 @@ import {
 } from 'app/views/settings/incidentRules/types';
 import EventView from 'app/utils/discover/eventView';
 import {AggregationKey, LooseFieldKey} from 'app/utils/discover/fields';
+import {WEB_VITAL_DETAILS} from 'app/views/performance/transactionVitals/constants';
 
 export const DEFAULT_AGGREGATE = 'count()';
 
@@ -17,6 +18,7 @@ export const DATASET_EVENT_TYPE_FILTERS = {
 type OptionConfig = {
   aggregations: AggregationKey[];
   fields: LooseFieldKey[];
+  measurementKeys?: string[];
 };
 
 /**
@@ -43,14 +45,8 @@ export const transactionFieldConfig: OptionConfig = {
     'p99',
     'p100',
   ],
-  fields: [
-    'transaction.duration',
-    'measurements.lcp',
-    'measurements.fcp',
-    'measurements.fp',
-    'measurements.fid',
-    'measurements.cls',
-  ],
+  fields: ['transaction.duration'],
+  measurementKeys: Object.keys(WEB_VITAL_DETAILS),
 };
 
 export function createDefaultTrigger(label: 'critical' | 'warning'): Trigger {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -43,7 +43,14 @@ export const transactionFieldConfig: OptionConfig = {
     'p99',
     'p100',
   ],
-  fields: ['transaction.duration'],
+  fields: [
+    'transaction.duration',
+    'measurements.lcp',
+    'measurements.fcp',
+    'measurements.fp',
+    'measurements.fid',
+    'measurements.cls',
+  ],
 };
 
 export function createDefaultTrigger(label: 'critical' | 'warning'): Trigger {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -34,22 +34,26 @@ const getFieldOptionConfig = (dataset: Dataset, organization: Organization) => {
   const aggregations = Object.fromEntries(
     config.aggregations.map(key => [key, AGGREGATIONS[key]])
   );
+
+  const hasMeasurementsFeature = organization.features.includes('measurements');
+
   const fields = Object.fromEntries(
-    config.fields.map(key => {
-      // XXX(epurkhiser): Temporary hack while we handle the translation of user ->
-      // tags[sentry:user].
-      if (key === 'user') {
-        return ['tags[sentry:user]', 'string'];
-      }
-
-      if (organization.features.includes('measurements')) {
+    config.fields
+      .filter(key => {
         if (key.startsWith('measurements.')) {
-          return [key, measurementType(key)];
+          return hasMeasurementsFeature;
         }
-      }
+        return true;
+      })
+      .map(key => {
+        // XXX(epurkhiser): Temporary hack while we handle the translation of user ->
+        // tags[sentry:user].
+        if (key === 'user') {
+          return ['tags[sentry:user]', 'string'];
+        }
 
-      return [key, FIELDS[key]];
-    })
+        return [key, FIELDS[key]];
+      })
   );
 
   return {aggregations, fields};

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -97,7 +97,7 @@ const MetricField = ({organization, ...props}: Props) => (
 
       const selectedField = fieldOptions[fieldKey]?.value;
       const numParameters: number =
-        selectedField && selectedField.kind === FieldValueKind.FUNCTION
+        selectedField?.kind === FieldValueKind.FUNCTION
           ? selectedField.meta.parameters.length
           : 0;
 

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -165,6 +165,15 @@ class TestAlertRuleSerializer(TestCase):
         alert_rule = serializer.save()
         assert alert_rule.snuba_query.aggregate == aggregate
 
+        aggregate = "sum(measurements.fp)"
+        base_params = self.valid_transaction_params.copy()
+        base_params["name"] = "measurement test"
+        base_params["aggregate"] = aggregate
+        serializer = AlertRuleSerializer(context=self.context, data=base_params)
+        assert serializer.is_valid(), serializer.errors
+        alert_rule = serializer.save()
+        assert alert_rule.snuba_query.aggregate == aggregate
+
     def test_alert_rule_resolved_invalid(self):
         self.run_fail_validation_test(
             {"resolve_threshold": 500},


### PR DESCRIPTION
Expose web vitals as options in metric alerts.

Depends on https://github.com/getsentry/sentry/pull/21566

## TODO

- [x] add test for measurement name validation