### PR TITLE
ref(ui) Replace inbound filter chart with echarts

### DIFF
--- a/src/sentry/static/sentry/less/project-settings.less
+++ b/src/sentry/static/sentry/less/project-settings.less
@@ -2,66 +2,6 @@
 * Inbound Data Filters
 * ============================================================================
 */
-
-.filtered-stats-barchart {
-  height: 100px;
-
-  a,
-  g {
-    > span,
-    > rect,
-    &:hover > rect {
-      left: 2px;
-      right: 2px;
-
-      &.ip-address {
-        background: @red-light;
-        fill: @red-light;
-      }
-
-      &.release-version {
-        background: @purple-light;
-        fill: @purple-light;
-      }
-
-      &.error-message {
-        background: @purple;
-        fill: @purple;
-      }
-
-      &.browser-extensions {
-        background: @gray;
-        fill: @gray;
-      }
-
-      &.legacy-browsers {
-        background: @gray-light;
-        fill: @gray-light;
-      }
-
-      &.localhost {
-        background: @blue;
-        fill: @blue;
-      }
-
-      &.web-crawlers {
-        background: @red;
-        fill: @red;
-      }
-
-      &.invalid-csp {
-        background: @blue-light;
-        fill: @blue-light;
-      }
-
-      &.cors {
-        background: @orange;
-        fill: @orange;
-      }
-    }
-  }
-}
-
 .legend {
   padding: 3px 0;
   position: relative;


### PR DESCRIPTION
Replace another chart with echarts. I have also updated the colours to use the theme colours. I tried to keep them close but the less colours and theme colours are noticably different. I've also replaced the loading spinner with a static placeholder. The spinner was too tall and resulted in layout shift after the chart data was loaded.

## Before

![Screen Shot 2020-10-21 at 11 38 37 AM](https://user-images.githubusercontent.com/24086/96743475-0b429d00-1392-11eb-8a25-bad6222112a9.png)

## After

![Screen Shot 2020-10-21 at 11 37 29 AM](https://user-images.githubusercontent.com/24086/96743507-139ad800-1392-11eb-9093-a84380d24014.png)
