### PR TITLE
build(pip): Enable the new 2020 resolver

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,6 +79,7 @@ RUN set -x \
   " \
   && apt-get update \
   && apt-get install -y --no-install-recommends $buildDeps \
+  && python -m pip install --upgrade 'pip>=20.2.0' \
   && pip install -r /tmp/dist/requirements.txt \
   && mkdir /tmp/uwsgi-dogstatsd \
   && wget -O - https://github.com/eventbrite/uwsgi-dogstatsd/archive/filters-and-tags.tar.gz | \
@@ -116,7 +117,7 @@ RUN set -x \
   && mkdir -p $SENTRY_CONF
 
 COPY /dist/*.whl /tmp/dist/
-RUN pip install /tmp/dist/*.whl --no-deps && pip check && rm -rf /tmp/dist
+RUN pip install /tmp/dist/*.whl --no-deps --use-feature=2020-resolver && pip check && rm -rf /tmp/dist
 RUN sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
 
 COPY ./docker/sentry.conf.py ./docker/config.yml $SENTRY_CONF/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN set -x \
   " \
   && apt-get update \
   && apt-get install -y --no-install-recommends $buildDeps \
-  && python -m pip install --upgrade 'pip>=20.2.0' \
+  && python -m pip install --upgrade 'pip>=20.3.0' \
   && pip install -r /tmp/dist/requirements.txt \
   && mkdir /tmp/uwsgi-dogstatsd \
   && wget -O - https://github.com/eventbrite/uwsgi-dogstatsd/archive/filters-and-tags.tar.gz | \
@@ -117,7 +117,7 @@ RUN set -x \
   && mkdir -p $SENTRY_CONF
 
 COPY /dist/*.whl /tmp/dist/
-RUN pip install /tmp/dist/*.whl --no-deps --use-feature=2020-resolver && pip check && rm -rf /tmp/dist
+RUN pip install /tmp/dist/*.whl --no-deps && pip check && rm -rf /tmp/dist
 RUN sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.txt
 
 COPY ./docker/sentry.conf.py ./docker/config.yml $SENTRY_CONF/


### PR DESCRIPTION
This reverts commit c9f3294e9e65787a75538994353141849b198070 and starts using `pip` `20.3.0` which has the new, strict resolver turned on by default.