### PR TITLE
fix(vitals): Show only web vitals on the event details

### DIFF
--- a/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
+++ b/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
@@ -58,7 +58,7 @@ class RealUserMonitoring extends React.Component<Props> {
       const currentValue = formattedValue(record, value);
       const thresholdValue = formattedValue(record, record?.failureThreshold ?? 0);
 
-      if (!LONG_MEASUREMENT_NAMES[name]) {
+      if (!LONG_MEASUREMENT_NAMES.hasOwnProperty(name)) {
         return null;
       }
 

--- a/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
+++ b/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
@@ -58,6 +58,10 @@ class RealUserMonitoring extends React.Component<Props> {
       const currentValue = formattedValue(record, value);
       const thresholdValue = formattedValue(record, record?.failureThreshold ?? 0);
 
+      if (!LONG_MEASUREMENT_NAMES[name]) {
+        return null;
+      }
+
       return (
         <div key={name}>
           <StyledPanel failedThreshold={failedThreshold}>


### PR DESCRIPTION


**Before:**

<img width="352" alt="Screen Shot 2020-10-21 at 3 32 04 PM" src="https://user-images.githubusercontent.com/139499/96773509-9fbcf780-13b2-11eb-9ee2-e5abd87a80de.png">


**After:**

<img width="351" alt="Screen Shot 2020-10-21 at 3 31 53 PM" src="https://user-images.githubusercontent.com/139499/96773511-a0558e00-13b2-11eb-803a-bebbf6562995.png">