### PR TITLE
fix(workflow): Dynamic counts discovery link support text query

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/group.jsx
+++ b/src/sentry/static/sentry/app/components/stream/group.jsx
@@ -160,7 +160,7 @@ const StreamGroup = createReactClass({
           queryTerms.push(`${queryTag}:${queryVal}`);
         }
 
-      if (!hasDiscoverQuery && queryObj.__text) {
+      if (queryObj.__text) {
         queryTerms.push(queryObj.__text);
       }
     }


### PR DESCRIPTION
This fixes an issue where text queries in issue stream were excluded from discover link queries. Discover fully supports text search now, so it should be reincluded.