### PR TITLE
feat(discover): Allow columns that are number types to be used in aggregates.

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -85,7 +85,12 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['integer', 'number', 'duration', 'date'],
+        columnTypes: validateForNumericAggregate([
+          'integer',
+          'number',
+          'duration',
+          'date',
+        ]),
         required: true,
       },
     ],
@@ -97,7 +102,12 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['integer', 'number', 'duration', 'date'],
+        columnTypes: validateForNumericAggregate([
+          'integer',
+          'number',
+          'duration',
+          'date',
+        ]),
         required: true,
       },
     ],
@@ -109,7 +119,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration', 'number'],
+        columnTypes: validateForNumericAggregate(['duration', 'number']),
         defaultValue: 'transaction.duration',
         required: true,
       },
@@ -122,7 +132,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration', 'number'],
+        columnTypes: validateForNumericAggregate(['duration', 'number']),
         required: true,
       },
     ],
@@ -142,7 +152,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration', 'number'],
+        columnTypes: validateForNumericAggregate(['duration', 'number']),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -155,7 +165,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration', 'number'],
+        columnTypes: validateForNumericAggregate(['duration', 'number']),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -168,7 +178,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration', 'number'],
+        columnTypes: validateForNumericAggregate(['duration', 'number']),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -182,7 +192,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration', 'number'],
+        columnTypes: validateForNumericAggregate(['duration', 'number']),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -195,7 +205,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration', 'number'],
+        columnTypes: validateForNumericAggregate(['duration', 'number']),
         required: false,
       },
     ],
@@ -207,7 +217,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration', 'number'],
+        columnTypes: validateForNumericAggregate(['duration', 'number']),
         defaultValue: 'transaction.duration',
         required: true,
       },
@@ -645,4 +655,24 @@ export function aggregateMultiPlotType(field: string): PlotType {
     return 'area';
   }
   return AGGREGATIONS[funcName].multiPlotType;
+}
+
+function validateForNumericAggregate(
+  validColumnTypes: ColumnType[]
+): ValidateColumnValueFunction {
+  return function ({name, dataType}: {name: string; dataType: ColumnType}): boolean {
+    // these built-in columns cannot be applied to numeric aggregates such as percentile(...)
+    if (
+      [
+        FieldKey.DEVICE_BATTERY_LEVEL,
+        FieldKey.STACK_COLNO,
+        FieldKey.STACK_LINENO,
+        FieldKey.STACK_STACK_LEVEL,
+      ].includes(name as FieldKey)
+    ) {
+      return false;
+    }
+
+    return validColumnTypes.includes(dataType);
+  };
 }

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -411,7 +411,7 @@ export const FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
   [FieldKey.DEVICE_LOCALE]: 'string',
   [FieldKey.DEVICE_UUID]: 'string',
   [FieldKey.DEVICE_ARCH]: 'string',
-  [FieldKey.DEVICE_BATTERY_LEVEL]: 'number',
+  [FieldKey.DEVICE_BATTERY_LEVEL]: 'string',
   [FieldKey.DEVICE_ORIENTATION]: 'string',
   [FieldKey.DEVICE_SIMULATOR]: 'boolean',
   [FieldKey.DEVICE_ONLINE]: 'boolean',
@@ -430,9 +430,9 @@ export const FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
   [FieldKey.STACK_MODULE]: 'string',
   [FieldKey.STACK_FUNCTION]: 'string',
   [FieldKey.STACK_IN_APP]: 'boolean',
-  [FieldKey.STACK_COLNO]: 'number',
-  [FieldKey.STACK_LINENO]: 'number',
-  [FieldKey.STACK_STACK_LEVEL]: 'number',
+  [FieldKey.STACK_COLNO]: 'string',
+  [FieldKey.STACK_LINENO]: 'string',
+  [FieldKey.STACK_STACK_LEVEL]: 'string',
   // contexts.key and contexts.value omitted on purpose.
 
   // Transaction event fields.

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -105,7 +105,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration'],
+        columnTypes: ['duration', 'number'],
         defaultValue: 'transaction.duration',
         required: true,
       },
@@ -118,7 +118,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration'],
+        columnTypes: ['duration', 'number'],
         required: true,
       },
     ],
@@ -138,7 +138,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration'],
+        columnTypes: ['duration', 'number'],
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -151,7 +151,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration'],
+        columnTypes: ['duration', 'number'],
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -164,7 +164,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration'],
+        columnTypes: ['duration', 'number'],
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -178,7 +178,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration'],
+        columnTypes: ['duration', 'number'],
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -191,7 +191,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration'],
+        columnTypes: ['duration', 'number'],
         required: false,
       },
     ],
@@ -203,7 +203,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: ['duration'],
+        columnTypes: ['duration', 'number'],
         defaultValue: 'transaction.duration',
         required: true,
       },

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -24,10 +24,14 @@ export type ColumnType =
 
 export type ColumnValueType = ColumnType | 'never'; // Matches to nothing
 
+type ValidateColumnValueFunction = ({name: string, dataType: ColumnType}) => boolean;
+
+export type ValidateColumnTypes = ColumnType[] | ValidateColumnValueFunction;
+
 export type AggregateParameter =
   | {
       kind: 'column';
-      columnTypes: Readonly<ColumnType[]>;
+      columnTypes: Readonly<ValidateColumnTypes>;
       defaultValue?: string;
       required: boolean;
     }

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -411,7 +411,7 @@ export const FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
   [FieldKey.DEVICE_LOCALE]: 'string',
   [FieldKey.DEVICE_UUID]: 'string',
   [FieldKey.DEVICE_ARCH]: 'string',
-  [FieldKey.DEVICE_BATTERY_LEVEL]: 'string',
+  [FieldKey.DEVICE_BATTERY_LEVEL]: 'number',
   [FieldKey.DEVICE_ORIENTATION]: 'string',
   [FieldKey.DEVICE_SIMULATOR]: 'boolean',
   [FieldKey.DEVICE_ONLINE]: 'boolean',
@@ -430,9 +430,9 @@ export const FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
   [FieldKey.STACK_MODULE]: 'string',
   [FieldKey.STACK_FUNCTION]: 'string',
   [FieldKey.STACK_IN_APP]: 'boolean',
-  [FieldKey.STACK_COLNO]: 'string',
-  [FieldKey.STACK_LINENO]: 'string',
-  [FieldKey.STACK_STACK_LEVEL]: 'string',
+  [FieldKey.STACK_COLNO]: 'number',
+  [FieldKey.STACK_LINENO]: 'number',
+  [FieldKey.STACK_STACK_LEVEL]: 'number',
   // contexts.key and contexts.value omitted on purpose.
 
   // Transaction event fields.

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -11,9 +11,14 @@ import {SelectValue} from 'app/types';
 import {t} from 'app/locale';
 import Badge from 'app/components/badge';
 import space from 'app/styles/space';
-import {ColumnType, AggregateParameter, QueryFieldValue} from 'app/utils/discover/fields';
+import {
+  ColumnType,
+  AggregateParameter,
+  QueryFieldValue,
+  ValidateColumnTypes,
+} from 'app/utils/discover/fields';
 
-import {FieldValueKind, FieldValue} from './types';
+import {FieldValueKind, FieldValue, FieldValueColumns} from './types';
 
 type FieldOptions = Record<string, SelectValue<FieldValue>>;
 
@@ -96,7 +101,7 @@ class QueryField extends React.Component<Props> {
             fieldValue.function[i + 1] = param.defaultValue || '';
           } else if (
             (field.kind === FieldValueKind.FIELD || field.kind === FieldValueKind.TAG) &&
-            param.columnTypes.includes(field.meta.dataType)
+            validateColumnTypes(param.columnTypes as ValidateColumnTypes, field)
           ) {
             // New function accepts current field.
             fieldValue.function[i + 1] = field.meta.name;
@@ -233,7 +238,7 @@ class QueryField extends React.Component<Props> {
                   (value.kind === FieldValueKind.FIELD ||
                     value.kind === FieldValueKind.TAG ||
                     value.kind === FieldValueKind.MEASUREMENT) &&
-                  param.columnTypes.includes(value.meta.dataType)
+                  validateColumnTypes(param.columnTypes as ValidateColumnTypes, value)
               ),
             };
           }
@@ -410,6 +415,17 @@ class QueryField extends React.Component<Props> {
       </Container>
     );
   }
+}
+
+function validateColumnTypes(
+  columnTypes: ValidateColumnTypes,
+  input: FieldValueColumns
+): boolean {
+  if (typeof columnTypes === 'function') {
+    return columnTypes({name: input.meta.name, dataType: input.meta.dataType});
+  }
+
+  return columnTypes.includes(input.meta.dataType);
 }
 
 const Container = styled('div')<{gridColumns: number}>`

--- a/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
@@ -35,10 +35,7 @@ export enum FieldValueKind {
   FUNCTION = 'function',
 }
 
-// Payload of select options in the column editor.
-// The first column contains a union of tags, fields and functions,
-// and we need ways to disambiguate them.
-export type FieldValue =
+export type FieldValueColumns =
   | {
       kind: FieldValueKind.TAG;
       meta: {
@@ -61,7 +58,13 @@ export type FieldValue =
         name: string;
         dataType: ColumnType;
       };
-    }
+    };
+
+// Payload of select options in the column editor.
+// The first column contains a union of tags, fields and functions,
+// and we need ways to disambiguate them.
+export type FieldValue =
+  | FieldValueColumns
   | {
       kind: FieldValueKind.FUNCTION;
       meta: {


### PR DESCRIPTION
Add a validation function to functions/aggregate function that accept numeric columns as parameters. This function will be able to exclude certain built-in functions (such as `stack.colno`) that shouldn't be used as parameters.

<img width="833" alt="Screen Shot 2020-10-22 at 3 33 47 PM" src="https://user-images.githubusercontent.com/139499/96921409-74064400-147c-11eb-9a58-e7f3b0749724.png">
<img width="804" alt="Screen Shot 2020-10-22 at 3 33 34 PM" src="https://user-images.githubusercontent.com/139499/96921415-75d00780-147c-11eb-921d-5c5bac8d1e52.png">
