### PR TITLE
fix: Allow `DEFAULT_QUEUED_MAX_MESSAGE_KBYTES` to be overriden in config

### DIFF
--- a/src/sentry/utils/batching_kafka_consumer.py
+++ b/src/sentry/utils/batching_kafka_consumer.py
@@ -113,7 +113,7 @@ class BatchingKafkaConsumer(object):
         dead_letter_topic=None,
         commit_log_topic=None,
         auto_offset_reset="error",
-        queued_max_messages_kbytes=DEFAULT_QUEUED_MAX_MESSAGE_KBYTES,
+        queued_max_messages_kbytes=None,
         queued_min_messages=DEFAULT_QUEUED_MIN_MESSAGES,
         metrics_sample_rates=None,
         metrics_default_tags=None,
@@ -145,6 +145,9 @@ class BatchingKafkaConsumer(object):
             topics = list(topics)
         elif not isinstance(topics, list):
             topics = [topics]
+
+        if queued_max_messages_kbytes is None:
+            queued_max_messages_kbytes = DEFAULT_QUEUED_MAX_MESSAGE_KBYTES
 
         self.consumer = self.create_consumer(
             topics,


### PR DESCRIPTION
Because we assign this in the function definition we can't override it later on. Changing this so we
always fetch this default dynamically.

Allows https://github.com/getsentry/getsentry/pull/4607 to work