### PR TITLE
fix(trends): Reset trend pages on query change

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -22,7 +22,12 @@ import ExternalLink from 'app/components/links/externalLink';
 
 import {getTransactionSearchQuery} from '../utils';
 import {TrendChangeType, TrendView, TrendFunctionField} from './types';
-import {TRENDS_FUNCTIONS, getCurrentTrendFunction, getSelectedQueryKey} from './utils';
+import {
+  TRENDS_FUNCTIONS,
+  getCurrentTrendFunction,
+  getSelectedQueryKey,
+  trendCursorNames,
+} from './utils';
 import ChangedTransactions from './changedTransactions';
 import ChangedProjects from './changedProjects';
 import {FilterViews} from '../landing';
@@ -50,11 +55,14 @@ class TrendsContent extends React.Component<Props, State> {
   handleSearch = (searchQuery: string) => {
     const {location} = this.props;
 
+    const cursors = {};
+    Object.values(trendCursorNames).forEach(cursor => (cursors[cursor] = undefined)); // Resets both cursors
+
     browserHistory.push({
       pathname: location.pathname,
       query: {
         ...location.query,
-        cursor: undefined,
+        ...cursors,
         query: String(searchQuery).trim() || undefined,
       },
     });

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -89,11 +89,15 @@ class TrendsContent extends React.Component<Props, State> {
       previousTrendFunction: getCurrentTrendFunction(location).field,
     });
 
+    const cursors = {};
+    Object.values(trendCursorNames).forEach(cursor => (cursors[cursor] = undefined)); // Resets both cursors
+
     browserHistory.push({
       pathname: location.pathname,
       query: {
         ...location.query,
         ...offsets,
+        ...cursors,
         trendFunction: field,
       },
     });

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -514,6 +514,8 @@ describe('Performance > Trends', function () {
 
       expect(browserHistory.push).toHaveBeenCalledWith({
         query: expect.objectContaining({
+          regressionCursor: undefined,
+          improvedCursor: undefined,
           trendFunction: trendFunction.field,
         }),
       });


### PR DESCRIPTION
### Summary
This will reset pagination when changing the query. Added a test to ensure browser history continues to be pushed correctly.