### PR TITLE
build(gha): Acceptance workflow must match filename for Visual Snapshots

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,6 +1,10 @@
 # TODO(billy): this workflow has not been re-named from `acceptance` because
 # Visual Snapshots compares against artifacts from the same workflow name (on main branch)
 # We should rename this when we have a more finalized naming scheme.
+#
+# Also note that this name *MUST* match the filename because GHA
+# only provides the workflow name (https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables)
+# and GH APIs only support querying by workflow *FILENAME* (https://developer.github.com/v3/actions/workflows/#get-a-workflow)
 name: acceptance
 on:
   push:


### PR DESCRIPTION
This fixes a regression due to https://github.com/getsentry/sentry/pull/21386 where snapshots are not comparing against the correct set of snapshots because the workflow name must match the filename.

This is because in our workflows, we only have the *workflow name* as part of [GHA Environment Variables](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables)
and the [GH API only accepts a workflow name as an argument](https://developer.github.com/v3/actions/workflows/#get-a-workflow).