### PR TITLE
fix(Jira): Handle case when issue has no description field

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -303,7 +303,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         return {
             "key": issue_id,
             "title": issue["fields"]["summary"],
-            "description": issue["fields"].get("description", None),
+            "description": issue["fields"].get("description"),
         }
 
     def create_comment(self, issue_id, user_id, group_note):

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -303,7 +303,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         return {
             "key": issue_id,
             "title": issue["fields"]["summary"],
-            "description": issue["fields"]["description"],
+            "description": issue["fields"].get("description", None),
         }
 
     def create_comment(self, issue_id, user_id, group_note):


### PR DESCRIPTION
If for some reason there is no description field for a Jira issue, just return None. I wasn't able to truly replicate this situation despite removing the description field as an option in my Jira instance, but I checked this when removing the key (`del issue["fields"]["description"]`) and it still works fine.


Fixes [SENTRY-H4R](https://sentry.io/organizations/sentry/issues/1790585705/?project=1&referrer=jira_integration)