### PR TITLE
feat(trends): Add the raw graph to the legend so it can be toggled

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/changedProjects.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedProjects.tsx
@@ -226,7 +226,7 @@ function getVisualization(
   trendChangeType: TrendChangeType,
   projectTrend: NormalizedProjectTrend
 ) {
-  const color = trendToColor[trendChangeType];
+  const color = trendToColor[trendChangeType].default;
 
   const trendPercent = formatPercentage(
     projectTrend.percentage_aggregate_range_2_aggregate_range_1 - 1,

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -346,7 +346,7 @@ function TrendsListItem(props: TrendsListItemProps) {
     projects,
     handleSelectTransaction,
   } = props;
-  const color = trendToColor[trendChangeType];
+  const color = trendToColor[trendChangeType].default;
 
   const selectedTransaction = getSelectedTransaction(
     location,

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -297,7 +297,7 @@ class Chart extends React.Component<Props> {
                   .map(values => {
                     return {
                       ...values,
-                      color: lineColor,
+                      color: lineColor.default,
                       lineStyle: {
                         opacity: 1,
                       },
@@ -311,7 +311,7 @@ class Chart extends React.Component<Props> {
                   .map(values => {
                     return {
                       ...values,
-                      color: lineColor,
+                      color: lineColor.lighter,
                       lineStyle: {
                         opacity: 0.25,
                       },

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -88,7 +88,7 @@ function transformEventStatsSmoothed(data: Series[], seriesName?: string): Serie
   ];
 }
 
-function getLegend() {
+function getLegend(trendFunction: string) {
   const legend = {
     right: 10,
     top: 0,
@@ -107,6 +107,10 @@ function getLegend() {
       },
       {
         name: 'Releases',
+        icon: 'line',
+      },
+      {
+        name: trendFunction,
         icon: 'line',
       },
     ],
@@ -259,7 +263,7 @@ class Chart extends React.Component<Props> {
     const utc = decodeScalar(router.location.query.utc);
 
     const intervalRatio = getIntervalRatio(router.location);
-    const legend = getLegend();
+    const legend = getLegend(trendFunction.chartLabel);
 
     const loading = isLoading;
     const reloading = isLoading;

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -70,8 +70,14 @@ export const TRENDS_FUNCTIONS: TrendFunction[] = [
 ];
 
 export const trendToColor = {
-  [TrendChangeType.IMPROVED]: theme.green400,
-  [TrendChangeType.REGRESSION]: theme.red400,
+  [TrendChangeType.IMPROVED]: {
+    lighter: theme.green300,
+    default: theme.green400,
+  },
+  [TrendChangeType.REGRESSION]: {
+    lighter: theme.red300,
+    default: theme.red400,
+  },
 };
 
 export const trendSelectedQueryKeys = {


### PR DESCRIPTION
- This should help make the graph more readable when the raw graph fluctuates wildly
- Not sure if this should be disabled by default, but for now the raw graph will still show by default
![graph toggle](https://user-images.githubusercontent.com/4205004/96900013-9c337a00-145f-11eb-86c3-dc33da30b080.gif)
