### PR TITLE
fix(discover) Fix rendering and cell action for error.handled

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -164,6 +164,7 @@ type SpecialFields = {
   user: SpecialField;
   'user.display': SpecialField;
   'issue.id': SpecialField;
+  'error.handled': SpecialField;
   issue: SpecialField;
   release: SpecialField;
 };
@@ -296,6 +297,14 @@ const SPECIAL_FIELDS: SpecialFields = {
       ) : (
         <Container>{emptyValue}</Container>
       ),
+  },
+  'error.handled': {
+    sortField: 'error.handled',
+    renderFunc: data => {
+      const values = data['error.handled'];
+      const value = Array.isArray(values) ? values.slice(-1)[0] : values;
+      return <Container>{[1, null].includes(value) ? 'true' : 'false'}</Container>;
+    },
   },
 };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -160,10 +160,24 @@ class CellAction extends React.Component<Props, State> {
 
   renderMenuButtons() {
     const {dataRow, column, handleCellAction, allowActions} = this.props;
-
     const fieldAlias = getAggregateAlias(column.name);
-    const value = dataRow[fieldAlias];
 
+    // Slice out the last element from array values as that is the value
+    // we show. See utils/discover/fieldRenderers.tsx and how
+    // strings and error.handled are rendered.
+    let value = dataRow[fieldAlias];
+    if (Array.isArray(value)) {
+      value = value.slice(-1)[0];
+    }
+
+    // error.handled is a strange field where null = true.
+    if (
+      value === null &&
+      column.column.kind === 'field' &&
+      column.column.field === 'error.handled'
+    ) {
+      value = 1;
+    }
     const actions: React.ReactNode[] = [];
 
     function addMenuItem(action: Actions, menuItem: React.ReactNode) {
@@ -177,7 +191,9 @@ class CellAction extends React.Component<Props, State> {
 
     if (
       !['duration', 'number', 'percentage'].includes(column.type) ||
-      (value === null && column.column.kind === 'field')
+      (value === null &&
+        column.column.kind === 'field' &&
+        column.column.field !== 'error.handled')
     ) {
       addMenuItem(
         Actions.ADD,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -191,9 +191,7 @@ class CellAction extends React.Component<Props, State> {
 
     if (
       !['duration', 'number', 'percentage'].includes(column.type) ||
-      (value === null &&
-        column.column.kind === 'field' &&
-        column.column.field !== 'error.handled')
+      (value === null && column.column.kind === 'field')
     ) {
       addMenuItem(
         Actions.ADD,

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -14,6 +14,7 @@ const defaultData = {
   nullValue: null,
   'measurements.fcp': 1234,
   percentile_measurements_fcp_0_5: 1234,
+  'error.handled': [null],
 };
 
 function makeWrapper(eventView, handleCellAction, columnIndex = 0, data = defaultData) {
@@ -42,6 +43,7 @@ describe('Discover -> CellAction', function () {
         'nullValue',
         'measurements.fcp',
         'percentile(measurements.fcp, 0.5)',
+        'error.handled',
       ],
       widths: ['437', '647', '416', '905'],
       sort: ['title'],
@@ -168,6 +170,33 @@ describe('Discover -> CellAction', function () {
         'show_less_than',
         '2020-06-09T01:46:25+00:00'
       );
+    });
+
+    it('error.handled with null adds condition', function () {
+      wrapper = makeWrapper(view, handleCellAction, 7, defaultData);
+
+      // Show button and menu.
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+
+      wrapper.find('button[data-test-id="add-to-filter"]').simulate('click');
+
+      expect(handleCellAction).toHaveBeenCalledWith('add', 1);
+    });
+
+    it('error.handled with 0 adds condition', function () {
+      wrapper = makeWrapper(view, handleCellAction, 7, {
+        ...defaultData,
+        'error.handled': [0],
+      });
+
+      // Show button and menu.
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+
+      wrapper.find('button[data-test-id="add-to-filter"]').simulate('click');
+
+      expect(handleCellAction).toHaveBeenCalledWith('add', 0);
     });
 
     it('show appropriate actions for string cells', function () {


### PR DESCRIPTION
* Render the null values in error.handled correctly as 'true'
* Render the 1 / 0 as true/false so that the display matches error.unhandled.
* Fix cell action on error.handled to work with null values.

Fixes VIS-274
Fixes VIS-275