### PR TITLE
feat(alert): Add stacktrace.package as an alerting option

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -49,6 +49,7 @@ ATTR_CHOICES = [
     "stacktrace.module",
     "stacktrace.filename",
     "stacktrace.abs_path",
+    "stacktrace.package",
 ]
 
 
@@ -69,7 +70,7 @@ class EventAttributeCondition(EventCondition):
     - exception.{type,value}
     - user.{id,ip_address,email,FIELD}
     - http.{method,url}
-    - stacktrace.{code,module,filename,abs_path}
+    - stacktrace.{code,module,filename,abs_path,package}
     - extra.{FIELD}
     """
 
@@ -154,7 +155,7 @@ class EventAttributeCondition(EventCondition):
             result = []
             for st in stacks:
                 for frame in st.frames:
-                    if path[1] in ("filename", "module", "abs_path"):
+                    if path[1] in ("filename", "module", "abs_path", "package"):
                         result.append(getattr(frame, path[1]))
                     elif path[1] == "code":
                         if frame.pre_context:


### PR DESCRIPTION
Some customers wrote in with a problem that sentry-native doesn't populate `stacktrace.module`, but instead populates `stacktrace.package` in the event data. Therefore, added this new alerting option to the `event_attribute` condition.

**Dropdown:**
<img width="1132" alt="Screen Shot 2020-10-22 at 3 04 22 PM" src="https://user-images.githubusercontent.com/9372512/96924920-5e474d80-1481-11eb-8436-ca443f04e2f3.png">

**Option Selected:**
<img width="1152" alt="Screen Shot 2020-10-22 at 3 04 12 PM" src="https://user-images.githubusercontent.com/9372512/96924914-5be4f380-1481-11eb-8af4-68ed82067cb6.png">

Very similar to https://github.com/getsentry/sentry/pull/20814
