### PR TITLE
fix: py3 test regression in #21454

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -107,7 +107,7 @@ class GitHubClientMixin(ApiClient):
         return self.post(
             u"/app/installations/{}/access_tokens".format(self.integration.external_id),
             headers={
-                "Authorization": b"Bearer %s" % self.get_jwt(),
+                "Authorization": u"Bearer %s" % self.get_jwt(),
                 # TODO(jess): remove this whenever it's out of preview
                 "Accept": "application/vnd.github.machine-man-preview+json",
             },

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -107,7 +107,7 @@ class GitHubClientMixin(ApiClient):
         return self.post(
             u"/app/installations/{}/access_tokens".format(self.integration.external_id),
             headers={
-                "Authorization": u"Bearer %s" % self.get_jwt(),
+                "Authorization": b"Bearer %s" % self.get_jwt(),
                 # TODO(jess): remove this whenever it's out of preview
                 "Accept": "application/vnd.github.machine-man-preview+json",
             },

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -22,7 +22,7 @@ class GitHubAppsClientTest(TestCase):
         install = integration.get_installation(organization_id="123")
         self.client = install.get_client()
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
     def test_save_token(self, get_jwt):
 
@@ -43,7 +43,7 @@ class GitHubAppsClientTest(TestCase):
         assert token == "12345token"
         assert len(responses.calls) == 1
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
     def test_check_file(self, get_jwt):
         responses.add(
@@ -64,7 +64,7 @@ class GitHubAppsClientTest(TestCase):
         resp = self.client.check_file(repo, path)
         assert resp.status_code == 200
 
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
     def test_check_no_file(self, get_jwt):
         responses.add(


### PR DESCRIPTION
Patches a py3 test regression intro'd in https://github.com/getsentry/sentry/pull/21454. It was mergeable because repo settings were not updated following a GHA job rename.
