### PR TITLE
fix(jira): reset form state when changing projects

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -95,18 +95,9 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
 
   onRequestSuccess({stateKey, data}) {
     if (stateKey === 'integrationDetails' && !this.state.dynamicFieldValues) {
-      this.setState(
-        {
-          dynamicFieldValues: this.getDynamicFields(data),
-        },
-        () => {
-          // we need to reset the form model if fields change to/from
-          // required but we want to maintain the data as well
-          const existingData = this.model.getData();
-          this.model.reset();
-          this.model.setInitialData(existingData);
-        }
-      );
+      this.setState({
+        dynamicFieldValues: this.getDynamicFields(data),
+      });
     }
   }
 
@@ -251,7 +242,7 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
       >
         {config.map(field => (
           <FieldFromConfig
-            key={`${field.name}-${field.default}`}
+            key={`${field.name}-${field.default}-${field.required}`}
             field={field}
             inline={false}
             stacked

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -8,7 +8,7 @@ import {addSuccessMessage} from 'app/actionCreators/indicator';
 import AsyncComponent from 'app/components/asyncComponent';
 import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
 import Form from 'app/views/settings/components/forms/form';
-import FormModel, {FieldValue} from 'app/views/settings/components/forms/model';
+import {FieldValue} from 'app/views/settings/components/forms/model';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
 import {
@@ -42,7 +42,6 @@ type State = {
 } & AsyncComponent['state'];
 
 class ExternalIssueForm extends AsyncComponent<Props, State> {
-  model = new FormModel();
   static propTypes = {
     group: SentryTypes.Group.isRequired,
     integration: PropTypes.object.isRequired,
@@ -228,7 +227,6 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
 
     return (
       <Form
-        model={this.model}
         apiEndpoint={`/groups/${group.id}/integrations/${integration.id}/`}
         apiMethod={action === 'create' ? 'POST' : 'PUT'}
         onSubmitSuccess={this.onSubmitSuccess}


### PR DESCRIPTION
This PR fixes a bug where the user cannot submit the form for creating a Jira issue after changing projects if a field that was required is no longer required. This is happening because we don't reset the field when we reload the config. This PR fixes it by adding `field.required` to the key of the field so that when if it changes, the field re-mounts and we properly mark it is required/not required.