### PR TITLE
feat(ui): Add ability to hide series on release chart

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -33,21 +33,6 @@ class HealthChart extends React.Component<Props> {
     }
   }
 
-  shouldUnselectHealthySeries(): boolean {
-    const {timeseriesData, location, shouldRecalculateVisibleSeries} = this.props;
-
-    const otherAreasThanHealthyArePositive = timeseriesData
-      .filter(s => s.seriesName !== 'Healthy')
-      .some(s => s.data.some(d => d.value > 0));
-    const alreadySomethingUnselected = !!decodeList(location.query.unselectedSeries);
-
-    return (
-      shouldRecalculateVisibleSeries &&
-      otherAreasThanHealthyArePositive &&
-      !alreadySomethingUnselected
-    );
-  }
-
   shouldComponentUpdate(nextProps: Props) {
     if (nextProps.reloading || !nextProps.timeseriesData) {
       return false;
@@ -65,6 +50,21 @@ class HealthChart extends React.Component<Props> {
     }
 
     return true;
+  }
+
+  shouldUnselectHealthySeries(): boolean {
+    const {timeseriesData, location, shouldRecalculateVisibleSeries} = this.props;
+
+    const otherAreasThanHealthyArePositive = timeseriesData
+      .filter(s => s.seriesName !== 'Healthy')
+      .some(s => s.data.some(d => d.value > 0));
+    const alreadySomethingUnselected = !!decodeList(location.query.unselectedSeries);
+
+    return (
+      shouldRecalculateVisibleSeries &&
+      otherAreasThanHealthyArePositive &&
+      !alreadySomethingUnselected
+    );
   }
 
   handleLegendSelectChanged = legendChange => {

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -54,8 +54,8 @@ class HealthChart extends React.Component<Props> {
     }
 
     if (
-      this.props.shouldRecalculateVisibleSeries !==
-      nextProps.shouldRecalculateVisibleSeries
+      this.props.location.query.unselectedSeries !==
+      nextProps.location.query.unselectedSeries
     ) {
       return true;
     }
@@ -79,7 +79,7 @@ class HealthChart extends React.Component<Props> {
       },
     };
 
-    browserHistory.push(to);
+    browserHistory.replace(to);
   };
 
   formatTooltipValue = (value: string | number | null) => {

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import isEqual from 'lodash/isEqual';
+import {browserHistory} from 'react-router';
+import {Location} from 'history';
 
 import LineChart from 'app/components/charts/lineChart';
 import AreaChart from 'app/components/charts/areaChart';
@@ -8,6 +10,7 @@ import {Series} from 'app/types/echarts';
 import theme from 'app/utils/theme';
 import {defined} from 'app/utils';
 import {getExactDuration} from 'app/utils/formatters';
+import {decodeList} from 'app/utils/queryString';
 
 import {YAxis} from './releaseChartControls';
 
@@ -17,12 +20,44 @@ type Props = {
   timeseriesData: Series[];
   zoomRenderProps: any;
   yAxis: YAxis;
+  location: Location;
+  shouldRecalculateVisibleSeries: boolean;
+  onVisibleSeriesRecalculated: () => void;
 };
 
 class HealthChart extends React.Component<Props> {
+  componentDidMount() {
+    if (this.shouldUnselectHealthySeries()) {
+      this.props.onVisibleSeriesRecalculated();
+      this.handleLegendSelectChanged({selected: {Healthy: false}});
+    }
+  }
+
+  shouldUnselectHealthySeries(): boolean {
+    const {timeseriesData, location, shouldRecalculateVisibleSeries} = this.props;
+
+    const otherAreasThanHealthyArePositive = timeseriesData
+      .filter(s => s.seriesName !== 'Healthy')
+      .some(s => s.data.some(d => d.value > 0));
+    const alreadySomethingUnselected = !!decodeList(location.query.unselectedSeries);
+
+    return (
+      shouldRecalculateVisibleSeries &&
+      otherAreasThanHealthyArePositive &&
+      !alreadySomethingUnselected
+    );
+  }
+
   shouldComponentUpdate(nextProps: Props) {
     if (nextProps.reloading || !nextProps.timeseriesData) {
       return false;
+    }
+
+    if (
+      this.props.shouldRecalculateVisibleSeries !==
+      nextProps.shouldRecalculateVisibleSeries
+    ) {
+      return true;
     }
 
     if (isEqual(this.props.timeseriesData, nextProps.timeseriesData)) {
@@ -31,6 +66,21 @@ class HealthChart extends React.Component<Props> {
 
     return true;
   }
+
+  handleLegendSelectChanged = legendChange => {
+    const {location} = this.props;
+    const {selected} = legendChange;
+
+    const to = {
+      ...location,
+      query: {
+        ...location.query,
+        unselectedSeries: Object.keys(selected).filter(key => !selected[key]),
+      },
+    };
+
+    browserHistory.push(to);
+  };
 
   formatTooltipValue = (value: string | number | null) => {
     const {yAxis} = this.props;
@@ -84,13 +134,21 @@ class HealthChart extends React.Component<Props> {
   };
 
   render() {
-    const {utc, timeseriesData, zoomRenderProps} = this.props;
+    const {utc, timeseriesData, zoomRenderProps, location} = this.props;
+
     const Chart = this.getChart();
 
+    const seriesSelection = (decodeList(location.query.unselectedSeries) ?? []).reduce(
+      (selection, metric) => {
+        selection[metric] = false;
+        return selection;
+      },
+      {}
+    );
+
     const legend = {
-      right: 16,
+      right: 22,
       top: 12,
-      selectedMode: false,
       icon: 'circle',
       itemHeight: 8,
       itemWidth: 8,
@@ -101,7 +159,8 @@ class HealthChart extends React.Component<Props> {
         fontSize: 11,
         fontFamily: 'Rubik',
       },
-      data: timeseriesData.map(d => d.seriesName),
+      data: timeseriesData.map(d => d.seriesName).reverse(),
+      selected: seriesSelection,
     };
 
     return (
@@ -122,6 +181,7 @@ class HealthChart extends React.Component<Props> {
         }}
         yAxis={this.configureYAxis()}
         tooltip={{valueFormatter: this.formatTooltipValue}}
+        onLegendSelectChanged={this.handleLegendSelectChanged}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChartContainer.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChartContainer.tsx
@@ -21,46 +21,57 @@ type Props = Omit<
   router: ReactRouter.InjectedRouter;
 };
 
-const ReleaseChartContainer = ({
-  loading,
-  errored,
-  reloading,
-  chartData,
-  selection,
-  yAxis,
-  router,
-}: Props) => {
-  const {datetime} = selection;
-  const {utc, period, start, end} = datetime;
-
-  return (
-    <React.Fragment>
-      <ChartZoom router={router} period={period} utc={utc} start={start} end={end}>
-        {zoomRenderProps => {
-          if (errored) {
-            return (
-              <ErrorPanel>
-                <IconWarning color="gray500" size="lg" />
-              </ErrorPanel>
-            );
-          }
-
-          return (
-            <TransitionChart loading={loading} reloading={reloading}>
-              <TransparentLoadingMask visible={reloading} />
-              <HealthChart
-                utc={utc}
-                timeseriesData={chartData}
-                zoomRenderProps={zoomRenderProps}
-                reloading={reloading}
-                yAxis={yAxis}
-              />
-            </TransitionChart>
-          );
-        }}
-      </ChartZoom>
-    </React.Fragment>
-  );
+type State = {
+  shouldRecalculateVisibleSeries: boolean;
 };
+
+class ReleaseChartContainer extends React.Component<Props, State> {
+  state = {
+    shouldRecalculateVisibleSeries: true,
+  };
+
+  handleVisibleSeriesRecalculated = () => {
+    this.setState({shouldRecalculateVisibleSeries: false});
+  };
+
+  render() {
+    const {loading, errored, reloading, chartData, selection, yAxis, router} = this.props;
+    const {shouldRecalculateVisibleSeries} = this.state;
+    const {datetime} = selection;
+    const {utc, period, start, end} = datetime;
+
+    return (
+      <React.Fragment>
+        <ChartZoom router={router} period={period} utc={utc} start={start} end={end}>
+          {zoomRenderProps => {
+            if (errored) {
+              return (
+                <ErrorPanel>
+                  <IconWarning color="gray500" size="lg" />
+                </ErrorPanel>
+              );
+            }
+
+            return (
+              <TransitionChart loading={loading} reloading={reloading}>
+                <TransparentLoadingMask visible={reloading} />
+                <HealthChart
+                  utc={utc}
+                  timeseriesData={chartData}
+                  zoomRenderProps={zoomRenderProps}
+                  reloading={reloading}
+                  yAxis={yAxis}
+                  location={router.location}
+                  shouldRecalculateVisibleSeries={shouldRecalculateVisibleSeries}
+                  onVisibleSeriesRecalculated={this.handleVisibleSeriesRecalculated}
+                />
+              </TransitionChart>
+            );
+          }}
+        </ChartZoom>
+      </React.Fragment>
+    );
+  }
+}
 
 export default ReleaseChartContainer;


### PR DESCRIPTION
This PR adds the ability to toggle individual series in the release chart.

By default, we hide Healthy sessions (unless there are no other data) as healthy numbers are usually much bigger and can mess up the scale for other series.

This also reflects in the URL so that it's easier to share correct views.

![Kapture 2020-10-23 at 13 17 17](https://user-images.githubusercontent.com/9060071/96997495-2cda8a80-1532-11eb-9030-6915b47cb8b7.gif)
