### PR TITLE
ref(ui) Update release health sparklines to echarts

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/healthStatsChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/healthStatsChart.tsx
@@ -2,8 +2,10 @@
 import React from 'react';
 import LazyLoad from 'react-lazyload';
 
+import {Series} from 'app/types/echarts';
 import {t} from 'app/locale';
-import BarChart from 'app/components/barChart';
+import MiniBarChart from 'app/components/charts/miniBarChart';
+import theme from 'app/utils/theme';
 
 import {StatsSubject} from './healthStatsSubject';
 import {StatsPeriod} from './healthStatsPeriod';
@@ -36,31 +38,37 @@ class HealthStatsChart extends React.Component<Props> {
   getChartLabel() {
     const {subject} = this.props;
     if (subject === 'users') {
-      return t('users');
+      return t('Users');
     }
 
-    return t('sessions');
+    return t('Sessions');
   }
 
   render() {
     const {height, period, data} = this.props;
-
     const stats = period ? data[period] : null;
-
     if (!stats || !stats.length) {
       return null;
     }
 
-    const chartData = stats.map(point => ({x: point[0], y: point[1]}));
+    const colors = [theme.gray500];
+    const emphasisColors = [theme.purple400];
+    const series: Series[] = [
+      {
+        seriesName: this.getChartLabel(),
+        data: stats.map(point => ({name: point[0] * 1000, value: point[1]})),
+      },
+    ];
 
     return (
       <LazyLoad debounce={50} height={height}>
-        <BarChart
-          points={chartData}
+        <MiniBarChart
+          series={series}
           height={height}
-          label={this.getChartLabel()}
-          minHeights={[3]}
-          gap={1}
+          colors={colors}
+          emphasisColors={emphasisColors}
+          isGroupedByDate
+          showTimeInTooltip
         />
       </LazyLoad>
     );

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/content.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/content.tsx
@@ -240,6 +240,8 @@ const DailyUsersColumn = styled(Column)`
   grid-area: daily-users;
   display: flex;
   align-items: flex-end;
+  /* Chart tooltips need overflow */
+  overflow: visible;
   @media (max-width: ${p => p.theme.breakpoints[2]}) {
     display: none;
   }


### PR DESCRIPTION
Use MiniBarChart to render release health sparkline charts.

![Screen Shot 2020-10-23 at 11 00 29 AM](https://user-images.githubusercontent.com/24086/97020487-9b621d00-151f-11eb-8998-afef6ee0d598.png)
![Screen Shot 2020-10-23 at 11 00 48 AM](https://user-images.githubusercontent.com/24086/97020489-9b621d00-151f-11eb-8cb5-e594f9a1cf9c.png)
