### PR TITLE
Feat(trend) confidence selector

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -48,6 +48,7 @@ import {
   normalizeTrends,
   getSelectedQueryKey,
   getCurrentTrendFunction,
+  getCurrentConfidenceLevel,
   getTrendBaselinesForTransaction,
   getIntervalRatio,
   StyledIconArrow,
@@ -162,12 +163,26 @@ function handleFilterTransaction(location: Location, transaction: string) {
 
   const query = stringifyQueryObject(conditions);
 
+  trackAnalyticsEvent({
+    eventKey: 'performance_views.trends.hide_transaction',
+    eventName: 'Performance Views: Hide Transaction',
+    confidence_level: getCurrentConfidenceLevel(location).label,
+  });
+
   browserHistory.push({
     pathname: location.pathname,
     query: {
       ...location.query,
       query: String(query).trim(),
     },
+  });
+}
+
+function handleSummaryClick(confidenceLevel: string) {
+  trackAnalyticsEvent({
+    eventKey: 'performance_views.trends.summary',
+    eventName: 'Performance Views: Summary Navigation',
+    confidence_level: confidenceLevel,
   });
 }
 
@@ -566,7 +581,8 @@ const CompareDurations = (props: CompareLinkProps) => {
 type TransactionSummaryLinkProps = TrendsListItemProps & {};
 
 const TransactionSummaryLink = (props: TransactionSummaryLinkProps) => {
-  const {organization, trendView: eventView, transaction, projects} = props;
+  const {organization, trendView: eventView, transaction, projects, location} = props;
+  const confidenceLevel = getCurrentConfidenceLevel(location).label;
 
   const summaryView = eventView.clone();
   const projectID = getTrendProjectId(transaction, projects);
@@ -577,7 +593,11 @@ const TransactionSummaryLink = (props: TransactionSummaryLinkProps) => {
     projectID,
   });
 
-  return <ItemTransactionName to={target}>{transaction.transaction}</ItemTransactionName>;
+  return (
+    <ItemTransactionName to={target} onClick={() => handleSummaryClick(confidenceLevel)}>
+      {transaction.transaction}
+    </ItemTransactionName>
+  );
 };
 
 const TransactionsListContainer = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -26,6 +26,7 @@ import {
   DEFAULT_MAX_DURATION,
   TRENDS_FUNCTIONS,
   CONFIDENCE_LEVELS,
+  trendCursorNames,
   getCurrentTrendFunction,
   getCurrentConfidenceLevel,
   getSelectedQueryKey,

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -25,9 +25,10 @@ import {TrendChangeType, TrendView, TrendFunctionField} from './types';
 import {
   DEFAULT_MAX_DURATION,
   TRENDS_FUNCTIONS,
+  CONFIDENCE_LEVELS,
   getCurrentTrendFunction,
+  getCurrentConfidenceLevel,
   getSelectedQueryKey,
-  trendCursorNames,
 } from './utils';
 import ChangedTransactions from './changedTransactions';
 import ChangedProjects from './changedProjects';
@@ -104,6 +105,25 @@ class TrendsContent extends React.Component<Props, State> {
     });
   };
 
+  handleConfidenceChange = (label: string) => {
+    const {organization, location} = this.props;
+
+    trackAnalyticsEvent({
+      eventKey: 'performance_views.trends.change_confidence',
+      eventName: 'Performance Views: Change confidence',
+      organization_id: parseInt(organization.id, 10),
+      confidence_level: label,
+    });
+
+    browserHistory.push({
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        confidenceLevel: label,
+      },
+    });
+  };
+
   render() {
     const {organization, eventView, selection, location} = this.props;
     const {previousTrendFunction} = this.state;
@@ -115,6 +135,7 @@ class TrendsContent extends React.Component<Props, State> {
       },
     ]);
     const currentTrendFunction = getCurrentTrendFunction(location);
+    const currentConfidenceLevel = getCurrentConfidenceLevel(location);
     const query = getTransactionSearchQuery(location);
     const showChangedProjects = hasMultipleProjects(selection);
 
@@ -137,6 +158,24 @@ class TrendsContent extends React.Component<Props, State> {
               fields={fields}
               onSearch={this.handleSearch}
             />
+            <TrendsDropdown>
+              <DropdownControl
+                buttonProps={{prefix: t('Confidence')}}
+                label={currentConfidenceLevel.label}
+              >
+                {CONFIDENCE_LEVELS.map(({label}) => (
+                  <DropdownItem
+                    key={label}
+                    onSelect={this.handleConfidenceChange}
+                    eventKey={label}
+                    data-test-id={label}
+                    isActive={label === currentConfidenceLevel.label}
+                  >
+                    {label}
+                  </DropdownItem>
+                ))}
+              </DropdownControl>
+            </TrendsDropdown>
             <TrendsDropdown>
               <DropdownControl
                 buttonProps={{prefix: t('Display')}}
@@ -234,10 +273,10 @@ class DefaultTrends extends React.Component<DefaultTrendsProps> {
 const StyledSearchBar = styled(SearchBar)`
   flex-grow: 1;
   margin-bottom: ${space(2)};
-  margin-right: ${space(1)};
 `;
 
 const TrendsDropdown = styled('div')`
+  margin-left: ${space(1)};
   flex-grow: 0;
 `;
 

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -26,7 +26,7 @@ import {
   DEFAULT_MAX_DURATION,
   TRENDS_FUNCTIONS,
   CONFIDENCE_LEVELS,
-  trendCursorNames,
+  resetCursors,
   getCurrentTrendFunction,
   getCurrentConfidenceLevel,
   getSelectedQueryKey,
@@ -58,8 +58,7 @@ class TrendsContent extends React.Component<Props, State> {
   handleSearch = (searchQuery: string) => {
     const {location} = this.props;
 
-    const cursors = {};
-    Object.values(trendCursorNames).forEach(cursor => (cursors[cursor] = undefined)); // Resets both cursors
+    const cursors = resetCursors();
 
     browserHistory.push({
       pathname: location.pathname,
@@ -92,8 +91,7 @@ class TrendsContent extends React.Component<Props, State> {
       previousTrendFunction: getCurrentTrendFunction(location).field,
     });
 
-    const cursors = {};
-    Object.values(trendCursorNames).forEach(cursor => (cursors[cursor] = undefined)); // Resets both cursors
+    const cursors = resetCursors();
 
     browserHistory.push({
       pathname: location.pathname,
@@ -116,10 +114,13 @@ class TrendsContent extends React.Component<Props, State> {
       confidence_level: label,
     });
 
+    const cursors = resetCursors();
+
     browserHistory.push({
       pathname: location.pathname,
       query: {
         ...location.query,
+        ...cursors,
         confidenceLevel: label,
       },
     });

--- a/src/sentry/static/sentry/app/views/performance/trends/types.ts
+++ b/src/sentry/static/sentry/app/views/performance/trends/types.ts
@@ -24,6 +24,12 @@ export type TrendFunction = {
   legendLabel: string;
 };
 
+export type ConfidenceLevel = {
+  label: string;
+  min: number;
+  max?: number;
+};
+
 export enum TrendChangeType {
   IMPROVED = 'improved',
   REGRESSION = 'regression',

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -109,6 +109,12 @@ export const trendCursorNames = {
   [TrendChangeType.REGRESSION]: 'regressionCursor',
 };
 
+export function resetCursors() {
+  const cursors = {};
+  Object.values(trendCursorNames).forEach(cursor => (cursors[cursor] = undefined)); // Resets both cursors
+  return cursors;
+}
+
 export function getCurrentTrendFunction(location: Location): TrendFunction {
   const trendFunctionField = decodeScalar(location?.query?.trendFunction);
   const trendFunction = TRENDS_FUNCTIONS.find(({field}) => field === trendFunctionField);

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -9,6 +9,7 @@ import ProjectsStore from 'app/stores/projectsStore';
 import {
   DEFAULT_MAX_DURATION,
   TRENDS_FUNCTIONS,
+  CONFIDENCE_LEVELS,
   getTrendAliasedFieldPercentage,
   getTrendAliasedMinus,
 } from 'app/views/performance/trends/utils';
@@ -28,10 +29,22 @@ jest.mock('moment', () => {
 
 function selectTrendFunction(wrapper, field) {
   const menu = wrapper.find('TrendsDropdown DropdownMenu');
-  expect(menu).toHaveLength(1);
-  menu.find('DropdownButton').simulate('click');
+  expect(menu).toHaveLength(2);
+  menu.find('DropdownButton').at(1).simulate('click');
 
   const option = menu.find(`DropdownItem[data-test-id="${field}"] span`);
+  expect(option).toHaveLength(1);
+  option.simulate('click');
+
+  wrapper.update();
+}
+
+function selectConfidenceLevel(wrapper, label) {
+  const menu = wrapper.find('TrendsDropdown DropdownMenu');
+  expect(menu).toHaveLength(2);
+  menu.find('DropdownButton').first().simulate('click');
+
+  const option = menu.find(`DropdownItem[data-test-id="${label}"] span`);
   expect(option).toHaveLength(1);
   option.simulate('click');
 
@@ -211,7 +224,7 @@ describe('Performance > Trends', function () {
     wrapper.update();
 
     // Trends dropdown and transaction widgets should render.
-    expect(wrapper.find('TrendsDropdown')).toHaveLength(1);
+    expect(wrapper.find('TrendsDropdown')).toHaveLength(2);
     expect(wrapper.find('ChangedTransactions')).toHaveLength(2);
   });
 
@@ -516,6 +529,29 @@ describe('Performance > Trends', function () {
           regressionCursor: undefined,
           improvedCursor: undefined,
           trendFunction: trendFunction.field,
+        }),
+      });
+    }
+  });
+
+  it('choosing a confidence level changes location', async function () {
+    const projects = [TestStubs.Project()];
+    const data = initializeData(projects, {project: ['-1']});
+    const wrapper = mountWithTheme(
+      <PerformanceLanding
+        organization={data.organization}
+        location={data.router.location}
+      />,
+      data.routerContext
+    );
+
+    for (const confidenceLevel of CONFIDENCE_LEVELS) {
+      selectConfidenceLevel(wrapper, confidenceLevel.label);
+      await tick();
+
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        query: expect.objectContaining({
+          confidenceLevel: confidenceLevel.label,
         }),
       });
     }


### PR DESCRIPTION
- The confidence selector will default to High to show trends that we're most confident in
- reload PR: https://github.com/getsentry/reload/pull/183
<img width="735" alt="image" src="https://user-images.githubusercontent.com/4205004/97025026-88eae200-1525-11eb-89cf-85dd00425afe.png">
