### PR TITLE
ref(ui): Switch ts-ignore to ts-expect-error

### DIFF
--- a/src/sentry/static/sentry/app/__mocks__/api.tsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.tsx
@@ -82,7 +82,7 @@ class Client {
 
   wrapCallback(_id, error) {
     return (...args) => {
-      // @ts-ignore
+      // @ts-expect-error
       if (this.hasProjectBeenRenamed(...args)) {
         return;
       }

--- a/src/sentry/static/sentry/app/actionCreators/indicator.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/indicator.tsx
@@ -50,11 +50,11 @@ export function addMessage(
 
   // XXX: Debug for https://sentry.io/organizations/sentry/issues/1595204979/
   if (
-    // @ts-ignore
+    // @ts-expect-error
     typeof msg?.message !== 'undefined' &&
-    // @ts-ignore
+    // @ts-expect-error
     typeof msg?.code !== 'undefined' &&
-    // @ts-ignore
+    // @ts-expect-error
     typeof msg?.extra !== 'undefined'
   ) {
     Sentry.captureException(new Error('Attempt to XHR response to Indicators'));

--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -151,7 +151,7 @@ export class Client {
       if (req && req.alive) {
         // Check if API response is a 302 -- means project slug was renamed and user
         // needs to be redirected
-        // @ts-ignore
+        // @ts-expect-error
         if (this.hasProjectBeenRenamed(...args)) {
           return;
         }

--- a/src/sentry/static/sentry/app/components/charts/baseChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.tsx
@@ -362,11 +362,10 @@ class BaseChart extends React.Component<Props, State> {
 
     // Maybe changing the series type to types/echarts Series[] would be a better solution
     // and can't use ignore for multiline blocks
-    // @ts-ignore
+    // @ts-expect-error
     const seriesValid = series && series[0]?.data && series[0].data.length > 1;
-    // @ts-ignore
+    // @ts-expect-error
     const seriesData = seriesValid ? series[0].data : undefined;
-    // @ts-ignore
     const bucketSize = seriesData ? seriesData[1][0] - seriesData[0][0] : undefined;
 
     return (

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -305,20 +305,20 @@ export const setBodyUserSelect = (nextValues: UserSelectValues): UserSelectValue
   const previousValues = {
     userSelect: document.body.style.userSelect,
     // MozUserSelect is not typed in TS
-    // @ts-ignore
+    // @ts-expect-error
     MozUserSelect: document.body.style.MozUserSelect,
     // msUserSelect is not typed in TS
-    // @ts-ignore
+    // @ts-expect-error
     msUserSelect: document.body.style.msUserSelect,
     webkitUserSelect: document.body.style.webkitUserSelect,
   };
 
   document.body.style.userSelect = nextValues.userSelect || '';
   // MozUserSelect is not typed in TS
-  // @ts-ignore
+  // @ts-expect-error
   document.body.style.MozUserSelect = nextValues.MozUserSelect || '';
   // msUserSelect is not typed in TS
-  // @ts-ignore
+  // @ts-expect-error
   document.body.style.msUserSelect = nextValues.msUserSelect || '';
   document.body.style.webkitUserSelect = nextValues.webkitUserSelect || '';
 

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueActions.tsx
@@ -199,7 +199,6 @@ class SentryAppExternalIssueActions extends React.Component<Props, State> {
   }
 }
 
-// @ts-ignore ; TS2589: Type instantiation is excessively deep and possibly infinite.
 const StyledSentryAppIcon = styled(SentryAppIcon)`
   color: ${p => p.theme.gray700};
   width: ${space(3)};

--- a/src/sentry/static/sentry/app/icons/svgIcon.tsx
+++ b/src/sentry/static/sentry/app/icons/svgIcon.tsx
@@ -28,7 +28,7 @@ const SvgIcon = React.forwardRef<SVGSVGElement, Props>(function SvgIcon(
 });
 
 SvgIcon.propTypes = {
-  // @ts-ignore
+  // @ts-expect-error
   color: PropTypes.string,
   size: PropTypes.string,
   viewBox: PropTypes.string,

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarTraceID/list.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarTraceID/list.tsx
@@ -83,7 +83,6 @@ class List extends React.Component<Props, State> {
       const convertedGroups = this.convertGroupsIntoEventFormat(groups);
 
       // this is necessary, because the AssigneeSelector component fetches the group from the GroupStore
-      // @ts-ignore Property 'add' does not exist on type 'Store'
       GroupStore.add(convertedGroups);
       this.setState({groups: convertedGroups, isLoading: false});
     } catch (error) {

--- a/tests/js/spec/components/forms/jsonForm.spec.tsx
+++ b/tests/js/spec/components/forms/jsonForm.spec.tsx
@@ -6,7 +6,7 @@ import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import accountDetailsFields from 'app/data/forms/accountDetails';
 import {fields} from 'app/data/forms/projectGeneralSettings';
 
-// @ts-ignore
+// @ts-expect-error
 const user = TestStubs.User({});
 
 describe('JsonForm', function () {

--- a/tests/js/spec/views/settings/components/dataScrubbing/addModal.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/addModal.spec.tsx
@@ -13,7 +13,7 @@ import {
   getRuleLabel,
 } from 'app/views/settings/components/dataScrubbing/utils';
 
-// @ts-ignore
+// @ts-expect-error
 const relayPiiConfig = TestStubs.DataScrubbingRelayPiiConfig();
 const stringRelayPiiConfig = JSON.stringify(relayPiiConfig);
 const organizationSlug = 'sentry';
@@ -22,7 +22,7 @@ const rules = convertedRules;
 const successfullySaved = jest.fn();
 const projectId = 'foo';
 const endpoint = `/projects/${organizationSlug}/${projectId}/`;
-// @ts-ignore
+// @ts-expect-error
 const api = new MockApiClient();
 
 async function renderComponent() {
@@ -40,7 +40,7 @@ async function renderComponent() {
     />
   ));
 
-  // @ts-ignore
+  // @ts-expect-error
   await tick();
   wrapper.update();
 
@@ -111,7 +111,7 @@ describe('Add Modal', () => {
     expect(cancelButton.exists()).toBe(true);
     cancelButton.simulate('click');
 
-    // @ts-ignore
+    // @ts-expect-error
     await tick();
     wrapper.update();
 
@@ -253,7 +253,7 @@ describe('Add Modal', () => {
   it('Display Event Id', async () => {
     const eventId = '12345678901234567890123456789012';
 
-    // @ts-ignore
+    // @ts-expect-error
     MockApiClient.addMockResponse({
       url: `/organizations/${organizationSlug}/data-scrubbing-selector-suggestions/`,
       body: {
@@ -275,7 +275,7 @@ describe('Add Modal', () => {
 
     eventIdFieldInput.simulate('blur');
 
-    // @ts-ignore
+    // @ts-expect-error
     await tick();
 
     // Loading

--- a/tests/js/spec/views/settings/components/dataScrubbing/content.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/content.spec.tsx
@@ -5,7 +5,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import Content from 'app/views/settings/components/dataScrubbing/content';
 import convertRelayPiiConfig from 'app/views/settings/components/dataScrubbing/convertRelayPiiConfig';
 
-// @ts-ignore
+// @ts-expect-error
 const relayPiiConfig = TestStubs.DataScrubbingRelayPiiConfig();
 const stringRelayPiiConfig = JSON.stringify(relayPiiConfig);
 const convertedRules = convertRelayPiiConfig(stringRelayPiiConfig);

--- a/tests/js/spec/views/settings/components/dataScrubbing/dataScrubbing.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/dataScrubbing.spec.tsx
@@ -9,7 +9,7 @@ import {openModal} from 'app/actionCreators/modal';
 
 jest.mock('app/actionCreators/modal');
 
-// @ts-ignore
+// @ts-expect-error
 const relayPiiConfig = TestStubs.DataScrubbingRelayPiiConfig();
 const stringRelayPiiConfig = JSON.stringify(relayPiiConfig);
 const organizationSlug = 'sentry';
@@ -19,7 +19,7 @@ const additionalContext = 'These rules can be configured for each project.';
 jest.mock('app/actionCreators/indicator');
 
 function getOrganization(piiConfig?: string) {
-  // @ts-ignore
+  // @ts-expect-error
   return TestStubs.Organization(
     piiConfig ? {id: '123', relayPiiConfig: piiConfig} : {id: '123'}
   );
@@ -192,7 +192,7 @@ describe('Data Scrubbing', () => {
     });
 
     it('Delete rule successfully', async () => {
-      // @ts-ignore
+      // @ts-expect-error
       const mockDelete = MockApiClient.addMockResponse({
         url: endpoint,
         method: 'PUT',
@@ -213,7 +213,7 @@ describe('Data Scrubbing', () => {
       deleteButton.simulate('click');
       expect(mockDelete).toHaveBeenCalled();
 
-      // @ts-ignore
+      // @ts-expect-error
       await tick();
       wrapper.update();
 

--- a/tests/js/spec/views/settings/components/dataScrubbing/editModal.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/editModal.spec.tsx
@@ -15,7 +15,7 @@ import {
 } from 'app/views/settings/components/dataScrubbing/utils';
 import submitRules from 'app/views/settings/components/dataScrubbing/submitRules';
 
-// @ts-ignore
+// @ts-expect-error
 const relayPiiConfig = TestStubs.DataScrubbingRelayPiiConfig();
 const stringRelayPiiConfig = JSON.stringify(relayPiiConfig);
 const organizationSlug = 'sentry';
@@ -25,7 +25,7 @@ const rule = rules[2];
 const successfullySaved = jest.fn();
 const projectId = 'foo';
 const endpoint = `/projects/${organizationSlug}/${projectId}/`;
-// @ts-ignore
+// @ts-expect-error
 const api = new MockApiClient();
 
 jest.mock('app/views/settings/components/dataScrubbing/submitRules');
@@ -46,7 +46,7 @@ async function renderComponent() {
     />
   ));
 
-  // @ts-ignore
+  // @ts-expect-error
   await tick();
   wrapper.update();
 
@@ -149,7 +149,7 @@ describe('Edit Modal', () => {
     expect(cancelButton.exists()).toBe(true);
     cancelButton.simulate('click');
 
-    // @ts-ignore
+    // @ts-expect-error
     await tick();
     wrapper.update();
 

--- a/tests/js/spec/views/settings/components/dataScrubbing/rules.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/rules.spec.tsx
@@ -5,7 +5,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import Rules from 'app/views/settings/components/dataScrubbing/rules';
 import convertRelayPiiConfig from 'app/views/settings/components/dataScrubbing/convertRelayPiiConfig';
 
-// @ts-ignore
+// @ts-expect-error
 const relayPiiConfig = TestStubs.DataScrubbingRelayPiiConfig();
 const stringRelayPiiConfig = JSON.stringify(relayPiiConfig);
 const convertedRules = convertRelayPiiConfig(stringRelayPiiConfig);

--- a/tests/js/spec/views/settings/projectSecurityAndPrivacy.spec.tsx
+++ b/tests/js/spec/views/settings/projectSecurityAndPrivacy.spec.tsx
@@ -6,14 +6,14 @@ import ProjectSecurityAndPrivacy, {
   ProjectSecurityAndPrivacyProps,
 } from 'app/views/settings/projectSecurityAndPrivacy';
 
-// @ts-ignore
+// @ts-expect-error
 const org = TestStubs.Organization();
-// @ts-ignore
+// @ts-expect-error
 const project = TestStubs.ProjectDetails();
-// @ts-ignore
+// @ts-expect-error
 const routerContext = TestStubs.routerContext([
   {
-    // @ts-ignore
+    // @ts-expect-error
     router: TestStubs.router({
       params: {
         projectId: project.slug,
@@ -25,7 +25,7 @@ const routerContext = TestStubs.routerContext([
 
 function renderComponent(props: Partial<ProjectSecurityAndPrivacyProps>) {
   const organization = props?.organization ?? org;
-  // @ts-ignore
+  // @ts-expect-error
   MockApiClient.addMockResponse({
     url: `/projects/${organization.slug}/${project.slug}/`,
     method: 'GET',


### PR DESCRIPTION
ts-expect-error was added in typescript 3.9

They're almost the same, but I like that ts-expect-error tells you when it is no longer needed and can be cleaned up.

see the docs for more info - https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#ts-ignore-or-ts-expect-error