### PR TITLE
fix(metric_alerts): Handle `None` values being returned in the subscription topic.

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -182,6 +182,12 @@ class SubscriptionProcessor(object):
                 },
             )
         aggregation_value = list(subscription_update["values"]["data"][0].values())[0]
+        # In some cases Snuba can return a None value for an aggregation. This means
+        # there were no rows present when we made the query, for certain types of
+        # aggregations like avg. Defaulting this to 0 for now. It might turn out that
+        # we'd prefer to skip the update in the future.
+        if aggregation_value is None:
+            aggregation_value = 0
         alert_operator, resolve_operator = self.THRESHOLD_TYPE_OPERATORS[
             AlertRuleThresholdType(self.alert_rule.threshold_type)
         ]

--- a/src/sentry/snuba/json_schemas.py
+++ b/src/sentry/snuba/json_schemas.py
@@ -48,7 +48,7 @@ SUBSCRIPTION_PAYLOAD_VERSIONS = {
                         "items": {
                             "type": "object",
                             "minProperties": 1,
-                            "additionalProperties": {"type": "number"},
+                            "additionalProperties": {"type": ["number", "null"]},
                         },
                     }
                 },

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -40,6 +40,9 @@ from sentry.utils.dates import to_timestamp
 from sentry.utils.compat import map
 
 
+EMPTY = object()
+
+
 @freeze_time()
 class ProcessUpdateTest(TestCase):
     metrics = patcher("sentry.incidents.subscription_processor.metrics")
@@ -102,7 +105,7 @@ class ProcessUpdateTest(TestCase):
     def action(self):
         return self.trigger.alertruletriggeraction_set.get()
 
-    def build_subscription_update(self, subscription, time_delta=None, value=None):
+    def build_subscription_update(self, subscription, time_delta=None, value=EMPTY):
         if time_delta is not None:
             timestamp = timezone.now() + time_delta
         else:
@@ -112,7 +115,7 @@ class ProcessUpdateTest(TestCase):
         data = {}
 
         if subscription:
-            data = {"some_col_name": randint(0, 100) if value is None else value}
+            data = {"some_col_name": randint(0, 100) if value is EMPTY else value}
         values = {"data": [data]}
         return {
             "subscription_id": subscription.subscription_id if subscription else uuid4().hex,
@@ -279,6 +282,15 @@ class ProcessUpdateTest(TestCase):
         )
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
         self.assert_actions_fired_for_incident(incident, [self.action])
+
+    def test_alert_nullable(self):
+        # Verify that an alert rule that only expects a single update to be over the
+        # alert threshold triggers correctly
+        rule = self.rule
+        self.trigger
+        processor = self.send_update(rule, None)
+        self.assert_trigger_counts(processor, self.trigger, 0, 0)
+        self.assert_no_active_incident(rule)
 
     def test_alert_multiple_threshold_periods(self):
         # Verify that a rule that expects two consecutive updates to be over the

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -152,6 +152,11 @@ class ParseMessageValueTest(BaseQuerySubscriptionTest, unittest.TestCase):
     def test_valid(self):
         self.run_test({"version": 2, "payload": self.valid_payload})
 
+    def test_valid_nan(self):
+        payload = deepcopy(self.valid_payload)
+        payload["result"]["data"][0]["hello"] = float("nan")
+        self.run_test({"version": 2, "payload": payload})
+
     def test_old_version(self):
         self.run_test({"version": 1, "payload": self.old_payload})
 


### PR DESCRIPTION
For some aggregates like `avg`, if no rows exist in the query period the value will end up being
`nan`, which is translated to `None` when parsing json. Changing our code to be able to handle this
correctly.

I've modified the existing json schema rather than adding a new version - this is something that
could have been sent through the entire time but hasn't happened yet, and we're just relaxing
restrictions so it should be safe.

This should also allow us to try out https://github.com/getsentry/sentry/pull/21498/ safely.