### PR TITLE
ref(stacktrace-link): Add get_stacktrace_link for GH/GL

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -114,8 +114,10 @@ class GitHubClientMixin(ApiClient):
         )
 
     @transaction_start("GitHubClientMixin.check_file")
-    def check_file(self, repo, path):
-        return self.head_cached(path="/repos/{}/contents/{}".format(repo, path))
+    def check_file(self, repo, path, version):
+        return self.head_cached(
+            path="/repos/{}/contents/{}".format(repo, path), params={"ref": version}
+        )
 
 
 class GitHubAppsClient(GitHubClientMixin):

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -100,14 +100,17 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
 
     def get_stacktrace_link(self, repo, filepath, default_version):
         try:
-            resp = self.get_client().get_file_url(repo.name, filepath)
+            self.get_client().check_file(repo.name, filepath)
         except ApiError as e:
             if e.code != 404:
                 raise
             return None
 
-        # if it exists return the url
-        return resp["html_url"]
+        # Must format the url ourselves since `check_file` is a head request
+        # "https://github.com/octokit/octokit.rb/blob/master/README.md"
+        web_url = "https://github.com/{}/blob/{}/{}".format(repo, default_version, filepath)
+
+        return web_url
 
     def get_unmigratable_repositories(self):
         accessible_repos = self.get_repositories()

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -98,9 +98,9 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
     def search_issues(self, query):
         return self.get_client().search_issues(query)
 
-    def get_stacktrace_link(self, repo, filepath, default_version):
+    def get_stacktrace_link(self, repo, filepath, version):
         try:
-            self.get_client().check_file(repo.name, filepath)
+            self.get_client().check_file(repo.name, filepath, version)
         except ApiError as e:
             if e.code != 404:
                 raise
@@ -108,7 +108,7 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
 
         # Must format the url ourselves since `check_file` is a head request
         # "https://github.com/octokit/octokit.rb/blob/master/README.md"
-        web_url = "https://github.com/{}/blob/{}/{}".format(repo, default_version, filepath)
+        web_url = u"https://github.com/{}/blob/{}/{}".format(repo.name, version, filepath)
 
         return web_url
 

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -92,12 +92,12 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
         resp = self.get_client().search_group_projects(group, query)
         return [{"identifier": repo["id"], "name": repo["name_with_namespace"]} for repo in resp]
 
-    def get_stacktrace_link(self, repo, filepath, default_version):
+    def get_stacktrace_link(self, repo, filepath, version):
         project_id = repo.config["project_id"]
         try:
             # repos are projects in GL so the project_id is the repo id which
             # GL's API uses instead of slugs like GH
-            self.get_client().check_file(project_id, filepath, default_version)
+            self.get_client().check_file(project_id, filepath, version)
         except ApiError as e:
             if e.code != 404:
                 raise
@@ -107,7 +107,7 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
 
         # Must format the url ourselves since `check_file` is a head request
         # "https://gitlab.com/gitlab-org/gitlab/blob/master/README.md"
-        web_url = "{}/{}/blob/{}/{}".format(base_url, repo.name, default_version, filepath)
+        web_url = u"{}/{}/blob/{}/{}".format(base_url, repo.name, version, filepath)
 
         return web_url
 

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -94,6 +94,7 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
 
     def get_stacktrace_link(self, repo, filepath, version):
         project_id = repo.config["project_id"]
+        repo_name = repo.config["path"]
         try:
             # repos are projects in GL so the project_id is the repo id which
             # GL's API uses instead of slugs like GH
@@ -107,7 +108,7 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
 
         # Must format the url ourselves since `check_file` is a head request
         # "https://gitlab.com/gitlab-org/gitlab/blob/master/README.md"
-        web_url = u"{}/{}/blob/{}/{}".format(base_url, repo.name, version, filepath)
+        web_url = u"{}/{}/blob/{}/{}".format(base_url, repo_name, version, filepath)
 
         return web_url
 

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -55,13 +55,14 @@ class GitHubAppsClientTest(TestCase):
 
         repo = "getsentry/sentry"
         path = "/src/sentry/integrations/github/client.py"
-        url = "https://api.github.com/repos/{}/contents/{}".format(repo, path)
+        version = "master"
+        url = "https://api.github.com/repos/{}/contents/{}?ref={}".format(repo, path, version)
 
         responses.add(
             method=responses.HEAD, url=url, json={"text": 200},
         )
 
-        resp = self.client.check_file(repo, path)
+        resp = self.client.check_file(repo, path, version)
         assert resp.status_code == 200
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
@@ -76,10 +77,11 @@ class GitHubAppsClientTest(TestCase):
 
         repo = "getsentry/sentry"
         path = "/src/santry/integrations/github/client.py"
-        url = "https://api.github.com/repos/{}/contents/{}".format(repo, path)
+        version = "master"
+        url = u"https://api.github.com/repos/{}/contents/{}?ref={}".format(repo, path, version)
 
         responses.add(method=responses.HEAD, url=url, status=404)
 
         with self.assertRaises(ApiError):
-            self.client.check_file(repo, path)
+            self.client.check_file(repo, path, version)
         assert responses.calls[1].response.status_code == 404

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -237,6 +237,55 @@ class GitHubIntegrationTest(IntegrationTestCase):
         ]
 
     @responses.activate
+    def test_get_stacktrace_link_file_exists(self):
+        self.assert_setup_flow()
+
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="github",
+            external_id=123,
+            config={"name": "Test-Organization/foo"},
+        )
+        path = "README.md"
+        version = "master"
+        responses.add(
+            responses.HEAD,
+            self.base_url + u"/repos/{}/contents/{}?ref={}".format(repo.name, path, version),
+        )
+        integration = Integration.objects.get(provider=self.provider.key)
+        installation = integration.get_installation(self.organization)
+        result = installation.get_stacktrace_link(repo, path, version)
+
+        assert result == "https://github.com/Test-Organization/foo/blob/master/README.md"
+
+    @responses.activate
+    def test_get_stacktrace_link_file_doesnt_exists(self):
+        self.assert_setup_flow()
+
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="github",
+            external_id=123,
+            config={"name": "Test-Organization/foo"},
+        )
+        path = "README.md"
+        version = "master"
+        responses.add(
+            responses.HEAD,
+            self.base_url + u"/repos/{}/contents/{}?ref={}".format(repo.name, path, version),
+            status=404,
+        )
+        integration = Integration.objects.get(provider=self.provider.key)
+        installation = integration.get_installation(self.organization)
+        result = installation.get_stacktrace_link(repo, path, version)
+
+        assert not result
+
+    @responses.activate
     def test_get_message_from_error(self):
         self.assert_setup_flow()
         integration = Integration.objects.get(provider=self.provider.key)

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -239,22 +239,23 @@ class GitHubIntegrationTest(IntegrationTestCase):
     @responses.activate
     def test_get_stacktrace_link_file_exists(self):
         self.assert_setup_flow()
-
+        integration = Integration.objects.get(provider=self.provider.key)
         repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="Test-Organization/foo",
             url="https://github.com/Test-Organization/foo",
-            provider="github",
+            provider="integrations:github",
             external_id=123,
             config={"name": "Test-Organization/foo"},
+            integration_id=integration.id,
         )
+
         path = "README.md"
         version = "master"
         responses.add(
             responses.HEAD,
             self.base_url + u"/repos/{}/contents/{}?ref={}".format(repo.name, path, version),
         )
-        integration = Integration.objects.get(provider=self.provider.key)
         installation = integration.get_installation(self.organization)
         result = installation.get_stacktrace_link(repo, path, version)
 
@@ -263,14 +264,16 @@ class GitHubIntegrationTest(IntegrationTestCase):
     @responses.activate
     def test_get_stacktrace_link_file_doesnt_exists(self):
         self.assert_setup_flow()
+        integration = Integration.objects.get(provider=self.provider.key)
 
         repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="Test-Organization/foo",
             url="https://github.com/Test-Organization/foo",
-            provider="github",
+            provider="integrations:github",
             external_id=123,
             config={"name": "Test-Organization/foo"},
+            integration_id=integration.id,
         )
         path = "README.md"
         version = "master"
@@ -279,7 +282,6 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.base_url + u"/repos/{}/contents/{}?ref={}".format(repo.name, path, version),
             status=404,
         )
-        integration = Integration.objects.get(provider=self.provider.key)
         installation = integration.get_installation(self.organization)
         result = installation.get_stacktrace_link(repo, path, version)
 

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -13,6 +13,7 @@ from sentry.models import (
     IdentityStatus,
     Integration,
     OrganizationIntegration,
+    Repository,
 )
 from sentry.testutils import IntegrationTestCase
 
@@ -194,3 +195,62 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
         installation = integration.get_installation(self.organization.id)
         assert self.default_group_id == installation.get_group_id()
+
+    @responses.activate
+    def test_get_stacktrace_link(self):
+        self.assert_setup_flow()
+        external_id = 4
+        integration = Integration.objects.get(provider=self.provider.key)
+        instance = integration.metadata["instance"]
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Get Sentry / Example Repo",
+            external_id=u"{}:{}".format(instance, external_id),
+            url="https://gitlab.example.com/getsentry/projects/example-repo",
+            config={"project_id": external_id, "path": "getsentry/example-repo"},
+            provider="integrations:gitlab",
+            integration_id=integration.id,
+        )
+        installation = integration.get_installation(self.organization.id)
+
+        filepath = "README.md"
+        ref = "master"
+        responses.add(
+            responses.HEAD,
+            u"https://gitlab.example.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
+                external_id, filepath, ref
+            ),
+        )
+        source_url = installation.get_stacktrace_link(repo, "README.md", "master")
+        assert (
+            source_url == "https://gitlab.example.com/getsentry/example-repo/blob/master/README.md"
+        )
+
+    @responses.activate
+    def test_get_stacktrace_link_file_doesnt_exist(self):
+        self.assert_setup_flow()
+        external_id = 4
+        integration = Integration.objects.get(provider=self.provider.key)
+        instance = integration.metadata["instance"]
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Get Sentry / Example Repo",
+            external_id=u"{}:{}".format(instance, external_id),
+            url="https://gitlab.example.com/getsentry/projects/example-repo",
+            config={"project_id": external_id, "path": "getsentry/example-repo"},
+            provider="integrations:gitlab",
+            integration_id=integration.id,
+        )
+        installation = integration.get_installation(self.organization.id)
+
+        filepath = "README.md"
+        ref = "master"
+        responses.add(
+            responses.HEAD,
+            u"https://gitlab.example.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
+                external_id, filepath, ref
+            ),
+            status=404,
+        )
+        source_url = installation.get_stacktrace_link(repo, "README.md", "master")
+        assert not source_url


### PR DESCRIPTION
Follow ups for https://github.com/getsentry/sentry/pull/21449. 

Instead of `GET` requests, we're using `HEAD` requests to check whether or not the file exists. If the file does exist, we'll need to format the `source_url` ourselves. 

**Small Changes**
* using `version` consistently, I had `default_version` in some places which isn't quite accurate because it may not always be the default (it could be a specific commit)
* using the `version` in our request to GH, if we are going to link to a specific version, the `check_file` should probably be checking that version of the file, not what the latest is.

Todos
* [x] Moar Tests