### PR TITLE
feat(ui): adds Sentry project selector field

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
@@ -18,6 +18,7 @@ import ChoiceMapperField from './choiceMapperField';
 import RichListField from './richListField';
 import FieldSeparator from './fieldSeparator';
 import ProjectMapperField from './projectMapperField';
+import SentryProjectSelectorField from './sentryProjectSelectorField';
 import {Field} from './type';
 
 type Props = {
@@ -60,6 +61,7 @@ export default class FieldFromConfig extends React.Component<Props> {
         'url',
         'table',
         'project_mapper',
+        'sentry_project_selector',
       ]),
       required: PropTypes.bool,
       multiline: PropTypes.bool,
@@ -142,6 +144,8 @@ export default class FieldFromConfig extends React.Component<Props> {
         return <TableField {...props} />;
       case 'project_mapper':
         return <ProjectMapperField {...props} />;
+      case 'sentry_project_selector':
+        return <SentryProjectSelectorField {...props} />;
       case 'custom':
         return field.Component(props);
       default:

--- a/src/sentry/static/sentry/app/views/settings/components/forms/sentryProjectSelectorField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/sentryProjectSelectorField.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {components} from 'react-select';
+
+import {t} from 'app/locale';
+import InputField from 'app/views/settings/components/forms/inputField';
+import IdBadge from 'app/components/idBadge';
+import SelectControl from 'app/components/forms/selectControl';
+import {Project} from 'app/types';
+
+const defaultProps = {
+  avatarSize: 20,
+  placeholder: t('Choose Sentry project\u2026'),
+};
+
+type Props = InputField['props'];
+
+type RenderProps = {
+  projects: Project[]; //can't use AvatarProject since we need the ID
+} & Omit<Partial<Readonly<typeof defaultProps>>, 'placeholder'> &
+  Props;
+
+class RenderField extends React.Component<RenderProps> {
+  static defaultProps = defaultProps;
+  render() {
+    const {projects, avatarSize, ...rest} = this.props;
+
+    const projectOptions = projects.map(({slug, id}) => [id, slug]);
+
+    const customOptionProject = projectProps => {
+      const project = projects.find(proj => proj.id === projectProps.value);
+      //shouldn't happen but need to account for it
+      if (!project) {
+        return <components.Option {...projectProps} />;
+      }
+      return (
+        <components.Option {...projectProps}>
+          <IdBadge
+            project={project}
+            avatarSize={avatarSize}
+            displayName={project.slug}
+            avatarProps={{consistentWidth: true}}
+          />
+        </components.Option>
+      );
+    };
+
+    const customValueContainer = containerProps => {
+      const selectedValue = containerProps.getValue()[0];
+      const project = projects.find(proj => proj.id === selectedValue?.value);
+      //shouldn't happen but need to account for it
+      if (!project) {
+        return <components.ValueContainer {...containerProps} />;
+      }
+      return (
+        <components.ValueContainer {...containerProps}>
+          <IdBadge
+            project={project}
+            avatarSize={avatarSize}
+            displayName={project.slug}
+            avatarProps={{consistentWidth: true}}
+          />
+        </components.ValueContainer>
+      );
+    };
+
+    return (
+      <SelectControl
+        choices={projectOptions}
+        components={{
+          Option: customOptionProject,
+          ValueContainer: customValueContainer,
+        }}
+        {...rest}
+      />
+    );
+  }
+}
+
+const SentryProjectSelectorField = (props: Props) => (
+  <InputField
+    {...props}
+    field={(renderProps: RenderProps) => <RenderField {...renderProps} />}
+  />
+);
+
+export default SentryProjectSelectorField;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/sentryProjectSelectorField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/sentryProjectSelectorField.tsx
@@ -27,7 +27,7 @@ class RenderField extends React.Component<RenderProps> {
     onBlur: Props['onBlur'],
     onChange: Props['onChange'],
     optionObj: {value: any},
-    event: any
+    event: React.MouseEvent
   ) => {
     const {value} = optionObj;
     onChange?.(value, event);

--- a/src/sentry/static/sentry/app/views/settings/components/forms/sentryProjectSelectorField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/sentryProjectSelectorField.tsx
@@ -21,10 +21,23 @@ type RenderProps = {
 
 class RenderField extends React.Component<RenderProps> {
   static defaultProps = defaultProps;
-  render() {
-    const {projects, avatarSize, ...rest} = this.props;
 
-    const projectOptions = projects.map(({slug, id}) => [id, slug]);
+  //need to map the option object to the value
+  handleChange = (
+    onBlur: Props['onBlur'],
+    onChange: Props['onChange'],
+    optionObj: {value: any},
+    event: any
+  ) => {
+    const {value} = optionObj;
+    onChange?.(value, event);
+    onBlur?.(value, event);
+  };
+
+  render() {
+    const {projects, avatarSize, onChange, onBlur, ...rest} = this.props;
+
+    const projectOptions = projects.map(({slug, id}) => ({value: id, label: slug}));
 
     const customOptionProject = projectProps => {
       const project = projects.find(proj => proj.id === projectProps.value);
@@ -65,12 +78,13 @@ class RenderField extends React.Component<RenderProps> {
 
     return (
       <SelectControl
-        choices={projectOptions}
+        options={projectOptions}
         components={{
           Option: customOptionProject,
           ValueContainer: customValueContainer,
         }}
         {...rest}
+        onChange={this.handleChange.bind(this, onBlur, onChange)}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -3,7 +3,7 @@ import {createFilter} from 'react-select';
 
 import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
 import Alert from 'app/components/alert';
-import {AvatarProject} from 'app/types';
+import {AvatarProject, Project} from 'app/types';
 
 export const FieldType = [
   'array',
@@ -23,6 +23,7 @@ export const FieldType = [
   'url',
   'table',
   'project_mapper',
+  'sentry_project_selector',
 ] as const;
 
 export type FieldValue = any;
@@ -137,6 +138,7 @@ export type TableType = {
   //TODO(TS): Should we have addButtonText and allowEmpty here as well?
 };
 
+//maps a sentry project to another field
 export type ProjectMapperType = {
   type: 'project_mapper';
   mappedDropdown: {
@@ -151,6 +153,13 @@ export type ProjectMapperType = {
   iconType: string;
 };
 
+//selects a sentry project with avatars
+export type SentryProjectSelectorType = {
+  type: 'sentry_project_selector';
+  projects: Project[];
+  avatarSize?: number;
+};
+
 export type Field = (
   | CustomType
   | SelectControlType
@@ -160,6 +169,7 @@ export type Field = (
   | {type: typeof FieldType[number]}
   | TableType
   | ProjectMapperType
+  | SentryProjectSelectorType
 ) &
   BaseField;
 


### PR DESCRIPTION
This PR adds a sentry project selector field (`sentry_project_selector`) where the user can pick a project from a select field that shows the project icon. This is going to be used in the upcoming stack trace mapping UI. Here's what it looks like in that form:

Empty state:
![Screen Shot 2020-10-23 at 11 25 17 AM](https://user-images.githubusercontent.com/8533851/97040204-7ae79200-1522-11eb-94f2-6150f3ad686b.png)

Dropdown state:
![Screen Shot 2020-10-23 at 11 25 24 AM](https://user-images.githubusercontent.com/8533851/97040208-7c18bf00-1522-11eb-828d-10bb831a4d5a.png)

Selected state:
![Screen Shot 2020-10-23 at 11 25 30 AM](https://user-images.githubusercontent.com/8533851/97040210-7cb15580-1522-11eb-8541-cc5e6baa2bff.png)

Note that I was thinking of using the `AvatarProject` project type since that's all that's needed to render the avatar. However, I want the selected value of the dropdown to be the id instead of the slug and the id field is missing there. I could use something like `AvatarProject & {id: string}` but I'm not sure how useful that would be.
