### PR TITLE
ref(trends): Remove medium confidence as an option

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -77,14 +77,9 @@ export const CONFIDENCE_LEVELS: ConfidenceLevel[] = [
     min: 6,
   },
   {
-    label: 'Medium',
-    min: 3,
-    max: 6,
-  },
-  {
     label: 'Low',
     min: 0,
-    max: 3,
+    max: 6,
   },
 ];
 


### PR DESCRIPTION
- High confidence should be a good default, and users shouldn't need to
  click through a few options to see other transactions