### PR TITLE
feat(alert): Reorganize metric alert builder components

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -7,9 +7,12 @@ import {Environment, Organization} from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 import {defined} from 'app/utils';
 >>>>>>> adding feature flag for gui filters and duplicated conditions form
+=======
+>>>>>>> use optional chaining
 import {getDisplayName} from 'app/utils/environment';
 import {t, tct} from 'app/locale';
 import FormField from 'app/views/settings/components/forms/formField';
@@ -83,6 +86,7 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
     const {environments} = this.state;
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     const environmentList: [IncidentRule['environment'], React.ReactNode][] =
       environments?.map((env: Environment) => [env.name, getDisplayName(env)]) ?? [];
 =======
@@ -92,6 +96,10 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
       ? environments.map((env: Environment) => [env.name, getDisplayName(env)])
       : [];
 >>>>>>> adding feature flag for gui filters and duplicated conditions form
+=======
+    const environmentList: [IncidentRule['environment'], React.ReactNode][] =
+      environments?.map((env: Environment) => [env.name, getDisplayName(env)]) ?? [];
+>>>>>>> use optional chaining
 
     const anyEnvironmentLabel = (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -6,6 +6,10 @@ import {DATA_SOURCE_LABELS} from 'app/views/alerts/utils';
 import {Environment, Organization} from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {addErrorMessage} from 'app/actionCreators/indicator';
+<<<<<<< HEAD
+=======
+import {defined} from 'app/utils';
+>>>>>>> adding feature flag for gui filters and duplicated conditions form
 import {getDisplayName} from 'app/utils/environment';
 import {t, tct} from 'app/locale';
 import FormField from 'app/views/settings/components/forms/formField';
@@ -78,8 +82,16 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
     const {organization, disabled, onFilterSearch} = this.props;
     const {environments} = this.state;
 
+<<<<<<< HEAD
     const environmentList: [IncidentRule['environment'], React.ReactNode][] =
       environments?.map((env: Environment) => [env.name, getDisplayName(env)]) ?? [];
+=======
+    const environmentList: [IncidentRule['environment'], React.ReactNode][] = defined(
+      environments
+    )
+      ? environments.map((env: Environment) => [env.name, getDisplayName(env)])
+      : [];
+>>>>>>> adding feature flag for gui filters and duplicated conditions form
 
     const anyEnvironmentLabel = (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -117,139 +117,137 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
     environmentList.unshift([null, anyEnvironmentLabel]);
 
     return (
-      <React.Fragment>
-        <StyledPanel>
-          <PanelHeader>{t('Alert Conditions')}</PanelHeader>
-          <PanelBody>
-            <Feature requireAll features={['organizations:performance-view']}>
-              <FormField required name="dataset" label="Data source">
-                {({onChange, onBlur, value, model, label}) => (
-                  <RadioGroup
-                    orientInline
-                    disabled={disabled}
-                    value={value}
-                    label={label}
-                    onChange={(id, e) => {
-                      onChange(id, e);
-                      onBlur(id, e);
-                      // Reset the aggregate to the default (which works across
-                      // datatypes), otherwise we may send snuba an invalid query
-                      // (transaction aggregate on events datasource = bad).
-                      model.setValue('aggregate', DEFAULT_AGGREGATE);
-                    }}
-                    choices={[
-                      [Dataset.ERRORS, DATA_SOURCE_LABELS[Dataset.ERRORS]],
-                      [Dataset.TRANSACTIONS, DATA_SOURCE_LABELS[Dataset.TRANSACTIONS]],
-                    ]}
-                  />
-                )}
-              </FormField>
-            </Feature>
-            <SelectField
-              name="environment"
-              label={t('Environment')}
-              placeholder={t('All Environments')}
-              help={t('Choose which environment events must match')}
-              styles={{
-                singleValue: (base: any) => ({
-                  ...base,
-                  '.all-environment-note': {display: 'none'},
-                }),
-                option: (base: any, state: any) => ({
-                  ...base,
-                  '.all-environment-note': {
-                    ...(!state.isSelected && !state.isFocused
-                      ? {color: theme.gray600}
-                      : {}),
-                    fontSize: theme.fontSizeSmall,
-                  },
-                }),
-              }}
-              choices={environmentList}
-              isDisabled={disabled || this.state.environments === null}
-              isClearable
-            />
-            <FormField name="query" inline={false}>
-              {({onChange, onBlur, onKeyDown, initialData, model}) => (
-                <SearchContainer>
-                  <SearchLabel>{t('Filter')}</SearchLabel>
-                  <StyledSearchBar
-                    defaultQuery={initialData?.query ?? ''}
-                    inlineLabel={
-                      <Tooltip
-                        title={t(
-                          'Metric alerts are automatically filtered to your data source'
-                        )}
-                      >
-                        <SearchEventTypeNote>
-                          {DATASET_EVENT_TYPE_FILTERS[model.getValue('dataset')]}
-                        </SearchEventTypeNote>
-                      </Tooltip>
-                    }
-                    omitTags={['event.type']}
-                    disabled={disabled}
-                    useFormWrapper={false}
-                    organization={organization}
-                    placeholder={
-                      model.getValue('dataset') === 'events'
-                        ? t('Filter events by level, message, or other properties...')
-                        : t('Filter transactions by URL, tags, and other properties...')
-                    }
-                    onChange={onChange}
-                    onKeyDown={e => {
-                      /**
-                       * Do not allow enter key to submit the alerts form since it is unlikely
-                       * users will be ready to create the rule as this sits above required fields.
-                       */
-                      if (e.key === 'Enter') {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }
-
-                      onKeyDown?.(e);
-                    }}
-                    onBlur={query => {
-                      onFilterSearch(query);
-                      onBlur(query);
-                    }}
-                    onSearch={query => {
-                      onFilterSearch(query);
-                      onChange(query, {});
-                    }}
-                  />
-                </SearchContainer>
+      <StyledPanel>
+        <PanelHeader>{t('Alert Conditions')}</PanelHeader>
+        <PanelBody>
+          <Feature requireAll features={['organizations:performance-view']}>
+            <FormField required name="dataset" label="Data source">
+              {({onChange, onBlur, value, model, label}) => (
+                <RadioGroup
+                  orientInline
+                  disabled={disabled}
+                  value={value}
+                  label={label}
+                  onChange={(id, e) => {
+                    onChange(id, e);
+                    onBlur(id, e);
+                    // Reset the aggregate to the default (which works across
+                    // datatypes), otherwise we may send snuba an invalid query
+                    // (transaction aggregate on events datasource = bad).
+                    model.setValue('aggregate', DEFAULT_AGGREGATE);
+                  }}
+                  choices={[
+                    [Dataset.ERRORS, DATA_SOURCE_LABELS[Dataset.ERRORS]],
+                    [Dataset.TRANSACTIONS, DATA_SOURCE_LABELS[Dataset.TRANSACTIONS]],
+                  ]}
+                />
               )}
             </FormField>
-            <MetricField
-              name="aggregate"
-              label={t('Metric')}
-              organization={organization}
-              disabled={disabled}
-              required
-            />
-            <SelectField
-              name="timeWindow"
-              label={t('Time Window')}
-              help={
-                <React.Fragment>
-                  <div>{t('The time window over which the Metric is evaluated')}</div>
-                  <div>
-                    {t(
-                      'Note: Triggers are evaluated every minute regardless of this value.'
-                    )}
-                  </div>
-                </React.Fragment>
-              }
-              choices={Object.entries(TIME_WINDOW_MAP)}
-              required
-              isDisabled={disabled}
-              getValue={value => Number(value)}
-              setValue={value => `${value}`}
-            />
-            {this.props.thresholdChart}
-          </PanelBody>
-        </StyledPanel>
-      </React.Fragment>
+          </Feature>
+          <SelectField
+            name="environment"
+            label={t('Environment')}
+            placeholder={t('All Environments')}
+            help={t('Choose which environment events must match')}
+            styles={{
+              singleValue: (base: any) => ({
+                ...base,
+                '.all-environment-note': {display: 'none'},
+              }),
+              option: (base: any, state: any) => ({
+                ...base,
+                '.all-environment-note': {
+                  ...(!state.isSelected && !state.isFocused
+                    ? {color: theme.gray600}
+                    : {}),
+                  fontSize: theme.fontSizeSmall,
+                },
+              }),
+            }}
+            choices={environmentList}
+            isDisabled={disabled || this.state.environments === null}
+            isClearable
+          />
+          <FormField name="query" inline={false}>
+            {({onChange, onBlur, onKeyDown, initialData, model}) => (
+              <SearchContainer>
+                <SearchLabel>{t('Filter')}</SearchLabel>
+                <StyledSearchBar
+                  defaultQuery={initialData?.query ?? ''}
+                  inlineLabel={
+                    <Tooltip
+                      title={t(
+                        'Metric alerts are automatically filtered to your data source'
+                      )}
+                    >
+                      <SearchEventTypeNote>
+                        {DATASET_EVENT_TYPE_FILTERS[model.getValue('dataset')]}
+                      </SearchEventTypeNote>
+                    </Tooltip>
+                  }
+                  omitTags={['event.type']}
+                  disabled={disabled}
+                  useFormWrapper={false}
+                  organization={organization}
+                  placeholder={
+                    model.getValue('dataset') === 'events'
+                      ? t('Filter events by level, message, or other properties...')
+                      : t('Filter transactions by URL, tags, and other properties...')
+                  }
+                  onChange={onChange}
+                  onKeyDown={e => {
+                    /**
+                     * Do not allow enter key to submit the alerts form since it is unlikely
+                     * users will be ready to create the rule as this sits above required fields.
+                     */
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }
+
+                    onKeyDown?.(e);
+                  }}
+                  onBlur={query => {
+                    onFilterSearch(query);
+                    onBlur(query);
+                  }}
+                  onSearch={query => {
+                    onFilterSearch(query);
+                    onChange(query, {});
+                  }}
+                />
+              </SearchContainer>
+            )}
+          </FormField>
+          <MetricField
+            name="aggregate"
+            label={t('Metric')}
+            organization={organization}
+            disabled={disabled}
+            required
+          />
+          <SelectField
+            name="timeWindow"
+            label={t('Time Window')}
+            help={
+              <React.Fragment>
+                <div>{t('The time window over which the Metric is evaluated')}</div>
+                <div>
+                  {t(
+                    'Note: Triggers are evaluated every minute regardless of this value.'
+                  )}
+                </div>
+              </React.Fragment>
+            }
+            choices={Object.entries(TIME_WINDOW_MAP)}
+            required
+            isDisabled={disabled}
+            getValue={value => Number(value)}
+            setValue={value => `${value}`}
+          />
+          {this.props.thresholdChart}
+        </PanelBody>
+      </StyledPanel>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -6,13 +6,6 @@ import {DATA_SOURCE_LABELS} from 'app/views/alerts/utils';
 import {Environment, Organization} from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {addErrorMessage} from 'app/actionCreators/indicator';
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-import {defined} from 'app/utils';
->>>>>>> adding feature flag for gui filters and duplicated conditions form
-=======
->>>>>>> use optional chaining
 import {getDisplayName} from 'app/utils/environment';
 import {t, tct} from 'app/locale';
 import FormField from 'app/views/settings/components/forms/formField';
@@ -85,21 +78,8 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
     const {organization, disabled, onFilterSearch} = this.props;
     const {environments} = this.state;
 
-<<<<<<< HEAD
-<<<<<<< HEAD
     const environmentList: [IncidentRule['environment'], React.ReactNode][] =
       environments?.map((env: Environment) => [env.name, getDisplayName(env)]) ?? [];
-=======
-    const environmentList: [IncidentRule['environment'], React.ReactNode][] = defined(
-      environments
-    )
-      ? environments.map((env: Environment) => [env.name, getDisplayName(env)])
-      : [];
->>>>>>> adding feature flag for gui filters and duplicated conditions form
-=======
-    const environmentList: [IncidentRule['environment'], React.ReactNode][] =
-      environments?.map((env: Environment) => [env.name, getDisplayName(env)]) ?? [];
->>>>>>> use optional chaining
 
     const anyEnvironmentLabel = (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -118,10 +118,10 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
 
     return (
       <React.Fragment>
-        <Feature requireAll features={['organizations:performance-view']}>
-          <StyledPanel>
-            <PanelHeader>{t('Alert Conditions')}</PanelHeader>
-            <PanelBody>
+        <StyledPanel>
+          <PanelHeader>{t('Alert Conditions')}</PanelHeader>
+          <PanelBody>
+            <Feature requireAll features={['organizations:performance-view']}>
               <FormField required name="dataset" label="Data source">
                 {({onChange, onBlur, value, model, label}) => (
                   <RadioGroup
@@ -144,115 +144,111 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
                   />
                 )}
               </FormField>
-            </PanelBody>
-          </StyledPanel>
-        </Feature>
-
-        <div>
-          {/* Contained in the same div for the css sticky overlay */}
-          {this.props.thresholdChart}
-          <StyledPanel>
-            <PanelHeader>{t('Alert Conditions')}</PanelHeader>
-            <PanelBody>
-              <FormField name="query" inline={false}>
-                {({onChange, onBlur, onKeyDown, initialData, model}) => (
-                  <SearchContainer>
-                    <SearchLabel>{t('Filter')}</SearchLabel>
-                    <StyledSearchBar
-                      defaultQuery={initialData?.query ?? ''}
-                      inlineLabel={
-                        <Tooltip
-                          title={t(
-                            'Metric alerts are automatically filtered to your data source'
-                          )}
-                        >
-                          <SearchEventTypeNote>
-                            {DATASET_EVENT_TYPE_FILTERS[model.getValue('dataset')]}
-                          </SearchEventTypeNote>
-                        </Tooltip>
+            </Feature>
+            <SelectField
+              name="environment"
+              label={t('Environment')}
+              placeholder={t('All Environments')}
+              help={t('Choose which environment events must match')}
+              styles={{
+                singleValue: (base: any) => ({
+                  ...base,
+                  '.all-environment-note': {display: 'none'},
+                }),
+                option: (base: any, state: any) => ({
+                  ...base,
+                  '.all-environment-note': {
+                    ...(!state.isSelected && !state.isFocused
+                      ? {color: theme.gray600}
+                      : {}),
+                    fontSize: theme.fontSizeSmall,
+                  },
+                }),
+              }}
+              choices={environmentList}
+              isDisabled={disabled || this.state.environments === null}
+              isClearable
+            />
+            <FormField name="query" inline={false}>
+              {({onChange, onBlur, onKeyDown, initialData, model}) => (
+                <SearchContainer>
+                  <SearchLabel>{t('Filter')}</SearchLabel>
+                  <StyledSearchBar
+                    defaultQuery={initialData?.query ?? ''}
+                    inlineLabel={
+                      <Tooltip
+                        title={t(
+                          'Metric alerts are automatically filtered to your data source'
+                        )}
+                      >
+                        <SearchEventTypeNote>
+                          {DATASET_EVENT_TYPE_FILTERS[model.getValue('dataset')]}
+                        </SearchEventTypeNote>
+                      </Tooltip>
+                    }
+                    omitTags={['event.type']}
+                    disabled={disabled}
+                    useFormWrapper={false}
+                    organization={organization}
+                    placeholder={
+                      model.getValue('dataset') === 'events'
+                        ? t('Filter events by level, message, or other properties...')
+                        : t('Filter transactions by URL, tags, and other properties...')
+                    }
+                    onChange={onChange}
+                    onKeyDown={e => {
+                      /**
+                       * Do not allow enter key to submit the alerts form since it is unlikely
+                       * users will be ready to create the rule as this sits above required fields.
+                       */
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        e.stopPropagation();
                       }
-                      omitTags={['event.type']}
-                      disabled={disabled}
-                      useFormWrapper={false}
-                      organization={organization}
-                      onChange={onChange}
-                      onKeyDown={e => {
-                        /**
-                         * Do not allow enter key to submit the alerts form since it is unlikely
-                         * users will be ready to create the rule as this sits above required fields.
-                         */
-                        if (e.key === 'Enter') {
-                          e.preventDefault();
-                          e.stopPropagation();
-                        }
 
-                        onKeyDown?.(e);
-                      }}
-                      onBlur={query => {
-                        onFilterSearch(query);
-                        onBlur(query);
-                      }}
-                      onSearch={query => {
-                        onFilterSearch(query);
-                        onChange(query, {});
-                      }}
-                    />
-                  </SearchContainer>
-                )}
-              </FormField>
-              <MetricField
-                name="aggregate"
-                label={t('Metric')}
-                organization={organization}
-                disabled={disabled}
-                required
-              />
-              <SelectField
-                name="timeWindow"
-                label={t('Time Window')}
-                help={
-                  <React.Fragment>
-                    <div>{t('The time window over which the Metric is evaluated')}</div>
-                    <div>
-                      {t(
-                        'Note: Triggers are evaluated every minute regardless of this value.'
-                      )}
-                    </div>
-                  </React.Fragment>
-                }
-                choices={Object.entries(TIME_WINDOW_MAP)}
-                required
-                isDisabled={disabled}
-                getValue={value => Number(value)}
-                setValue={value => `${value}`}
-              />
-              <SelectField
-                name="environment"
-                label={t('Environment')}
-                placeholder={t('All Environments')}
-                help={t('Choose which environment events must match')}
-                styles={{
-                  singleValue: (base: any) => ({
-                    ...base,
-                    '.all-environment-note': {display: 'none'},
-                  }),
-                  option: (base: any, state: any) => ({
-                    ...base,
-                    '.all-environment-note': {
-                      ...(!state.isSelected && !state.isFocused
-                        ? {color: theme.gray600}
-                        : {}),
-                      fontSize: theme.fontSizeSmall,
-                    },
-                  }),
-                }}
-                choices={environmentList}
-                isDisabled={disabled || this.state.environments === null}
-                isClearable
-              />
-            </PanelBody>
-          </StyledPanel>
-        </div>
+                      onKeyDown?.(e);
+                    }}
+                    onBlur={query => {
+                      onFilterSearch(query);
+                      onBlur(query);
+                    }}
+                    onSearch={query => {
+                      onFilterSearch(query);
+                      onChange(query, {});
+                    }}
+                  />
+                </SearchContainer>
+              )}
+            </FormField>
+            <MetricField
+              name="aggregate"
+              label={t('Metric')}
+              organization={organization}
+              disabled={disabled}
+              required
+            />
+            <SelectField
+              name="timeWindow"
+              label={t('Time Window')}
+              help={
+                <React.Fragment>
+                  <div>{t('The time window over which the Metric is evaluated')}</div>
+                  <div>
+                    {t(
+                      'Note: Triggers are evaluated every minute regardless of this value.'
+                    )}
+                  </div>
+                </React.Fragment>
+              }
+              choices={Object.entries(TIME_WINDOW_MAP)}
+              required
+              isDisabled={disabled}
+              getValue={value => Number(value)}
+              setValue={value => `${value}`}
+            />
+            {this.props.thresholdChart}
+          </PanelBody>
+        </StyledPanel>
       </React.Fragment>
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -200,51 +200,66 @@ class TriggersChart extends React.PureComponent<Props, State> {
                   }
                 }
 
-                return (
-                  <StickyWrapper>
-                    <StyledPanel>
-                      <PanelBody withPadding>
-                        <ControlsContainer>
-                          <PeriodSelectControl
-                            inline={false}
-                            styles={{
-                              control: provided => ({
-                                ...provided,
-                                minHeight: '25px',
-                                height: '25px',
-                              }),
-                            }}
-                            isSearchable={false}
-                            isClearable={false}
-                            disabled={loading || reloading}
-                            name="statsPeriod"
-                            value={period}
-                            choices={statsPeriodOptions.map(timePeriod => [
-                              timePeriod,
-                              TIME_PERIOD_MAP[timePeriod],
-                            ])}
-                            onChange={this.handleStatsPeriodChange}
-                          />
-                        </ControlsContainer>
+                const chart = (
+                  <React.Fragment>
+                    <ControlsContainer>
+                      <PeriodSelectControl
+                        inline={false}
+                        styles={{
+                          control: provided => ({
+                            ...provided,
+                            minHeight: '25px',
+                            height: '25px',
+                          }),
+                        }}
+                        isSearchable={false}
+                        isClearable={false}
+                        disabled={loading || reloading}
+                        name="statsPeriod"
+                        value={period}
+                        choices={statsPeriodOptions.map(timePeriod => [
+                          timePeriod,
+                          TIME_PERIOD_MAP[timePeriod],
+                        ])}
+                        onChange={this.handleStatsPeriodChange}
+                      />
+                    </ControlsContainer>
 
-                        {loading || reloading ? (
-                          <ChartPlaceholder />
-                        ) : (
-                          <React.Fragment>
-                            <TransparentLoadingMask visible={reloading} />
-                            <ThresholdsChart
-                              period={statsPeriod}
-                              maxValue={maxValue ? maxValue.value : maxValue}
-                              data={timeseriesData}
-                              triggers={triggers}
-                              resolveThreshold={resolveThreshold}
-                              thresholdType={thresholdType}
-                            />
-                          </React.Fragment>
-                        )}
-                      </PanelBody>
-                    </StyledPanel>
-                  </StickyWrapper>
+                    {loading || reloading ? (
+                      <ChartPlaceholder />
+                    ) : (
+                      <React.Fragment>
+                        <TransparentLoadingMask visible={reloading} />
+                        <ThresholdsChart
+                          period={statsPeriod}
+                          maxValue={maxValue ? maxValue.value : maxValue}
+                          data={timeseriesData}
+                          triggers={triggers}
+                          resolveThreshold={resolveThreshold}
+                          thresholdType={thresholdType}
+                        />
+                      </React.Fragment>
+                    )}
+                  </React.Fragment>
+                );
+
+                return (
+                  <Feature
+                    organization={organization}
+                    features={['metric-alert-gui-filters']}
+                  >
+                    {({hasFeature: hasGuiFilters}) =>
+                      hasGuiFilters ? (
+                        <ChartWrapper>{chart}</ChartWrapper>
+                      ) : (
+                        <StickyWrapper>
+                          <StyledPanel>
+                            <PanelBody withPadding>{chart}</PanelBody>
+                          </StyledPanel>
+                        </StickyWrapper>
+                      )
+                    }
+                  </Feature>
                 );
               }}
             </EventsRequest>
@@ -292,4 +307,8 @@ const PeriodSelectControl = styled(SelectControl)`
   font-weight: normal;
   text-transform: none;
   border: 0;
+`;
+
+const ChartWrapper = styled('div')`
+  padding: ${space(2)};
 `;


### PR DESCRIPTION
Continuing on in the process of implementing metric alert gui filters this PR has combined all the alert condition form components into one panel to more closely resemble the final product. It also changed the placeholder text for the filter bar.

**Before:**
<img width="1217" alt="Screen Shot 2020-10-23 at 3 54 41 PM" src="https://user-images.githubusercontent.com/9372512/97056007-f31b7b00-1555-11eb-9b46-f40b8ccffd6a.png">

**After:**
<img width="1182" alt="Screen Shot 2020-10-23 at 5 26 59 PM" src="https://user-images.githubusercontent.com/9372512/97055998-edbe3080-1555-11eb-9952-58e030b993e4.png">

Note: These changes are only visible to organizations with the flag `metric-alert-gui-filters` which is currently none, but will change as more meaningful changes are made.