### PR TITLE
fix(ui): handle camel case nonFieldErrors

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.tsx
@@ -547,15 +547,16 @@ class FormModel {
         // 1) map of {[fieldName] => Array<ErrorMessages>}
         // 2) {'non_field_errors' => Array<ErrorMessages>}
         if (resp && resp.responseJSON) {
+          //non-field errors can be camelcase or snake case
+          const nonFieldErrors =
+            resp.responseJSON.non_field_errors || resp.responseJSON.nonFieldErrors;
+
           // Show resp msg from API endpoint if possible
           if (Array.isArray(resp.responseJSON[id]) && resp.responseJSON[id].length) {
             // Just take first resp for now
             this.setError(id, resp.responseJSON[id][0]);
-          } else if (
-            Array.isArray(resp.responseJSON.non_field_errors) &&
-            resp.responseJSON.non_field_errors.length
-          ) {
-            addErrorMessage(resp.responseJSON.non_field_errors[0], {duration: 10000});
+          } else if (Array.isArray(nonFieldErrors) && nonFieldErrors.length) {
+            addErrorMessage(nonFieldErrors[0], {duration: 10000});
             // Reset saving state
             this.setError(id, '');
           } else {
@@ -681,12 +682,14 @@ class FormModel {
 
     // Show resp msg from API endpoint if possible
     Object.keys(resp).forEach(id => {
+      //non-field errors can be camelcase or snake case
+      const nonFieldErrors = resp.non_field_errors || resp.nonFieldErrors;
       if (
-        id === 'non_field_errors' &&
-        Array.isArray(resp.non_field_errors) &&
-        resp.non_field_errors.length
+        (id === 'non_field_errors' || id === 'nonFieldErrors') &&
+        Array.isArray(nonFieldErrors) &&
+        nonFieldErrors.length
       ) {
-        addErrorMessage(resp.non_field_errors[0], {duration: 10000});
+        addErrorMessage(nonFieldErrors[0], {duration: 10000});
       } else if (Array.isArray(resp[id]) && resp[id].length) {
         // Just take first resp for now
         this.setError(id, resp[id][0]);


### PR DESCRIPTION
This PR adds support for handing the field `nonFieldErrors`. Previously, we just handled `non_field_errors`. However, this doesn't work with a new `CamelSnakeModelSerializer` which converts errors to camelcase:
https://github.com/getsentry/sentry/blob/cd0f78a95fbf19844a87775d7a7d0ac782a668ab/src/sentry/api/serializers/rest_framework/base.py#L75-L77