### PR TITLE
feat(metric_alerts): Add function to deduplicate a list of trigger actions. (WOR-134)

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -23,12 +23,14 @@ from sentry.incidents.logic import (
     create_alert_rule,
     create_alert_rule_trigger,
     create_alert_rule_trigger_action,
+    CRITICAL_TRIGGER_LABEL,
     delete_alert_rule_trigger,
     delete_alert_rule_trigger_action,
     translate_aggregate_field,
     update_alert_rule,
     update_alert_rule_trigger,
     update_alert_rule_trigger_action,
+    WARNING_TRIGGER_LABEL,
 )
 from sentry.incidents.models import (
     AlertRule,
@@ -65,9 +67,6 @@ dataset_valid_event_types = {
     ),
     QueryDatasets.TRANSACTIONS: set([SnubaQueryEventType.EventType.TRANSACTION]),
 }
-
-CRITICAL_TRIGGER_LABEL = "critical"
-WARNING_TRIGGER_LABEL = "warning"
 
 
 class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -59,6 +59,9 @@ from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
 WINDOWED_STATS_DATA_POINTS = 200
 NOT_SET = object()
 
+CRITICAL_TRIGGER_LABEL = "critical"
+WARNING_TRIGGER_LABEL = "warning"
+
 
 class AlreadyDeletedError(Exception):
     pass
@@ -1049,7 +1052,7 @@ def trigger_incident_triggers(incident):
                 method = "resolve"
                 for action in AlertRuleTriggerAction.objects.filter(
                     alert_rule_trigger=trigger.alert_rule_trigger
-                ):
+                ).select_related("alert_rule_trigger"):
                     for project in incident.projects.all():
                         transaction.on_commit(
                             handle_trigger_action.s(
@@ -1061,6 +1064,36 @@ def trigger_incident_triggers(incident):
                         )
                 trigger.status = TriggerStatus.RESOLVED.value
                 trigger.save()
+
+
+def deduplicate_trigger_actions(actions):
+    """
+    Given a list of trigger actions, this returns a list of actions that is unique on
+    (type, target_type, target_identifier, integration_id, sentry_app_id). If there are
+    duplicate actions, we'll prefer the action from a critical trigger over a warning
+    trigger. If there are duplicate actions on a critical trigger, we'll just choose
+    one arbitrarily.
+    :param actions: A list of `AlertRuleTriggerAction` instances from the same
+    `AlertRule`.
+    :return: A list of deduplicated `AlertRuleTriggerAction` instances.
+    """
+    # Make sure we process actions from the critical trigger first
+    actions.sort(
+        key=lambda action: 0 if action.alert_rule_trigger.label == CRITICAL_TRIGGER_LABEL else 1
+    )
+    deduped = {}
+    for action in actions:
+        deduped.setdefault(
+            (
+                action.type,
+                action.target_type,
+                action.target_identifier,
+                action.integration_id,
+                action.sentry_app_id,
+            ),
+            action,
+        )
+    return list(deduped.values())
 
 
 def get_subscriptions_from_alert_rule(alert_rule, projects):

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -10,8 +10,12 @@ from django.conf import settings
 from django.db import transaction
 
 from sentry import features
-from sentry.incidents.logic import create_incident, update_incident_status
-from sentry.incidents.endpoints.serializers import WARNING_TRIGGER_LABEL, CRITICAL_TRIGGER_LABEL
+from sentry.incidents.logic import (
+    create_incident,
+    CRITICAL_TRIGGER_LABEL,
+    update_incident_status,
+    WARNING_TRIGGER_LABEL,
+)
 from sentry.incidents.models import (
     AlertRule,
     AlertRuleThresholdType,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -22,15 +22,16 @@ from sentry.incidents.logic import (
     AlertRuleNameAlreadyUsedError,
     AlertRuleTriggerLabelAlreadyUsedError,
     InvalidTriggerActionError,
-    get_incident_stats,
+    calculate_incident_time_range,
     create_alert_rule,
     create_alert_rule_trigger,
     create_alert_rule_trigger_action,
     create_event_stat_snapshot,
-    calculate_incident_time_range,
     create_incident,
     create_incident_activity,
     create_incident_snapshot,
+    CRITICAL_TRIGGER_LABEL,
+    deduplicate_trigger_actions,
     delete_alert_rule,
     delete_alert_rule_trigger,
     delete_alert_rule_trigger_action,
@@ -42,6 +43,7 @@ from sentry.incidents.logic import (
     get_excluded_projects_for_alert_rule,
     get_incident_aggregates,
     get_incident_event_stats,
+    get_incident_stats,
     get_incident_subscribers,
     get_triggers_for_alert_rule,
     ProjectsNotAssociatedWithAlertRuleError,
@@ -51,6 +53,7 @@ from sentry.incidents.logic import (
     update_alert_rule_trigger_action,
     update_alert_rule_trigger,
     update_incident_status,
+    WARNING_TRIGGER_LABEL,
     WINDOWED_STATS_DATA_POINTS,
 )
 from sentry.incidents.models import (
@@ -1716,3 +1719,132 @@ class TriggerActionTest(TestCase):
         out = mail.outbox[0]
         assert out.to == [self.user.email]
         assert out.subject == u"[Resolved] {} - {}".format(incident.title, self.project.slug)
+
+
+class TestDeduplicateTriggerActions(TestCase):
+    @fixture
+    def critical(self):
+        return AlertRuleTrigger(label=CRITICAL_TRIGGER_LABEL)
+
+    @fixture
+    def warning(self):
+        return AlertRuleTrigger(label=WARNING_TRIGGER_LABEL)
+
+    def run_test(self, input, output):
+        assert sorted(deduplicate_trigger_actions(input)) == sorted(output)
+
+    def test_critical_only(self):
+        action = AlertRuleTriggerAction(
+            alert_rule_trigger=self.critical,
+            type=AlertRuleTriggerAction.Type.EMAIL.value,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier="1",
+        )
+        self.run_test([action], [action])
+        self.run_test([action, action], [action])
+
+        other_action = AlertRuleTriggerAction(
+            alert_rule_trigger=self.critical,
+            type=AlertRuleTriggerAction.Type.EMAIL.value,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier="2",
+        )
+        self.run_test([action, action, other_action], [action, other_action])
+        integration_action = AlertRuleTriggerAction(
+            alert_rule_trigger=self.critical,
+            type=AlertRuleTriggerAction.Type.SLACK.value,
+            integration_id=1,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            target_identifier="D12345",
+        )
+        app_action = AlertRuleTriggerAction(
+            alert_rule_trigger=self.critical,
+            type=AlertRuleTriggerAction.Type.MSTEAMS.value,
+            integration_id=1,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            target_identifier="D12345",
+        )
+        self.run_test(
+            [action, action, other_action, integration_action, app_action],
+            [action, other_action, integration_action, app_action],
+        )
+        self.run_test(
+            [
+                action,
+                action,
+                other_action,
+                other_action,
+                integration_action,
+                integration_action,
+                app_action,
+                app_action,
+            ],
+            [action, other_action, integration_action, app_action],
+        )
+
+    def test_critical_warning(self):
+        action_c = AlertRuleTriggerAction(
+            alert_rule_trigger=self.critical,
+            type=AlertRuleTriggerAction.Type.EMAIL.value,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier="1",
+        )
+        action_w = AlertRuleTriggerAction(
+            alert_rule_trigger=self.warning,
+            type=AlertRuleTriggerAction.Type.EMAIL.value,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier="1",
+        )
+        self.run_test([action_w, action_c, action_c], [action_c])
+        other_action_w = AlertRuleTriggerAction(
+            alert_rule_trigger=self.warning,
+            type=AlertRuleTriggerAction.Type.EMAIL.value,
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier="2",
+        )
+        self.run_test([action_w, action_c, action_c, other_action_w], [action_c, other_action_w])
+        integration_action_w = AlertRuleTriggerAction(
+            alert_rule_trigger=self.warning,
+            type=AlertRuleTriggerAction.Type.SLACK.value,
+            integration_id=1,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            target_identifier="D12345",
+        )
+        app_action_w = AlertRuleTriggerAction(
+            alert_rule_trigger=self.warning,
+            type=AlertRuleTriggerAction.Type.MSTEAMS.value,
+            integration_id=1,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            target_identifier="D12345",
+        )
+        self.run_test(
+            [action_w, action_c, action_c, other_action_w, integration_action_w, app_action_w],
+            [action_c, other_action_w, integration_action_w, app_action_w],
+        )
+        integration_action_c = AlertRuleTriggerAction(
+            alert_rule_trigger=self.critical,
+            type=AlertRuleTriggerAction.Type.SLACK.value,
+            integration_id=1,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            target_identifier="D12345",
+        )
+        app_action_c = AlertRuleTriggerAction(
+            alert_rule_trigger=self.critical,
+            type=AlertRuleTriggerAction.Type.MSTEAMS.value,
+            integration_id=1,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            target_identifier="D12345",
+        )
+        self.run_test(
+            [
+                action_w,
+                action_c,
+                action_c,
+                other_action_w,
+                integration_action_w,
+                app_action_w,
+                integration_action_c,
+                app_action_c,
+            ],
+            [action_c, other_action_w, integration_action_c, app_action_c],
+        )


### PR DESCRIPTION
We want to not spam users with multiple identical messages when they have the same action set up on
both their warning and critical triggers. This pr adds a function to deduplicate actions based on
where they'll send. Will make use of this in a later pr.