### PR TITLE
fix(integrations): Merge project_issue_defaults updates instead of overwrite

### DIFF
--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -74,7 +74,7 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
         return comment
 
     def get_persisted_default_config_fields(self):
-        return ["project"]
+        return ["project", "issueType"]
 
     def get_create_issue_config(self, group, **kwargs):
         kwargs["link_referrer"] = "example_integration"

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -115,7 +115,9 @@ class IssueBasicMixin(object):
 
         defaults = {k: v for k, v in six.iteritems(data) if k in persisted_fields}
 
-        self.org_integration.config.update({"project_issue_defaults": {project_id: defaults}})
+        self.org_integration.config.setdefault("project_issue_defaults", {}).setdefault(
+            six.text_type(project_id), {}
+        ).update(defaults)
         self.org_integration.save()
 
     def get_project_defaults(self, project_id):

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -145,6 +145,25 @@ class IssueDefaultTest(TestCase):
         assert default_repo == "user/repo2"
         assert repo_choice == [("user/repo1", "repo1"), ("user/repo2", "repo2")]
 
+    def test_store_issue_last_defaults_partial_update(self):
+        assert "project" in self.installation.get_persisted_default_config_fields()
+        assert "issueType" in self.installation.get_persisted_default_config_fields()
+        self.installation.store_issue_last_defaults(1, {"project": "xyz", "issueType": "BUG"})
+        self.installation.store_issue_last_defaults(1, {"issueType": "FEATURE"})
+        # {} is commonly triggered by "link issue" flow
+        self.installation.store_issue_last_defaults(1, {})
+        assert self.installation.get_project_defaults(1) == {
+            "project": "xyz",
+            "issueType": "FEATURE",
+        }
+
+    def test_store_issue_last_defaults_multiple_projects(self):
+        assert "project" in self.installation.get_persisted_default_config_fields()
+        self.installation.store_issue_last_defaults(1, {"project": "xyz"})
+        self.installation.store_issue_last_defaults(2, {"project": "abc"})
+        assert self.installation.get_project_defaults(1) == {"project": "xyz"}
+        assert self.installation.get_project_defaults(2) == {"project": "abc"}
+
     def test_annotations(self):
         label = self.installation.get_issue_display_name(self.external_issue)
         link = self.installation.get_issue_url(self.external_issue.key)


### PR DESCRIPTION
When an external issue is either created or linked, `store_issue_last_defaults`
is called to persist the subset of field values that are configured for that
integration via `get_persisted_default_config_fields` for the next issue
created or linked. In common scenarios, "create" has a complete list of
defaults to persist while "link" has an empty list, as only the existing issue
id needs to be specified.

This is problematic in the old implementation, as linking an issue would unset
all default values captured via the "create" flow. Additionally, the old
implementation would effectively unset defaults for any other projects.

The new implementation avoids both of these issues by merging updates into both
levels of the config object's "project_issue_defaults".

Fixes #15720

----

## Test Plan
- I've added regression tests for both problematic scenarios
- I've tested both cases manually via the UI.

To illustrate the issue, I've recorded a GIF that demonstrates the first problematic behavior:
![old-behavior](https://user-images.githubusercontent.com/549473/97099713-59cd9100-1649-11eb-8c5f-50d1342974d7.gif)

With the fix applied, we see that the previous default values are preserved:
![new-behavior](https://user-images.githubusercontent.com/549473/97099884-30ae0000-164b-11eb-9342-61e562266a14.gif)

