### PR TITLE
fix(jira): Fix submitting forms for Jira plugin (legacy integration)

### DIFF
--- a/src/sentry/static/sentry/app/plugins/jira/components/settings.jsx
+++ b/src/sentry/static/sentry/app/plugins/jira/components/settings.jsx
@@ -73,7 +73,7 @@ class Settings extends DefaultSettings {
       this.onSaveSuccess(this.onSaveComplete);
       return;
     }
-    const body = Object.assign({}, this.state.data);
+    const body = Object.assign({}, this.state.formData);
     // if the project has changed, it's likely these values aren't valid anymore
     if (body.default_project !== this.state.initialData.default_project) {
       body.default_issue_type = null;


### PR DESCRIPTION
This fixes a regression introduced in #15766 which referenced a
non-existent `this.state.data` when it should have remained
`this.state.formData`.

Fixes #21463

------
### Investigation
Breakpoint before the save happens shows that state.data is undefined, while state.formData is the expected vaue.
![image](https://user-images.githubusercontent.com/549473/97114794-e3b04500-16af-11eb-9645-3a8e778b2dfb.png)

Tracing the change reveals that it looks like an accidental change:
https://github.com/getsentry/sentry/pull/15766/files#diff-1ef5b383a036417bfcea5af934b4a3926017f0188f419ca6b58b506e8cacd778L72-L80

![image](https://user-images.githubusercontent.com/549473/97114705-45bc7a80-16af-11eb-9926-46ca77bb0aae.png)

## Manual regression test:
### Before 💥 
![image](https://user-images.githubusercontent.com/549473/97114726-7a303680-16af-11eb-8ec6-74c572db07cc.png)

### After 💚 
![image](https://user-images.githubusercontent.com/549473/97114625-dd6d9900-16ae-11eb-9d21-d31993d623b4.png)
