### PR TITLE
fix: "Create project" on UI truncates long project names

### DIFF
--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -15,7 +15,7 @@ ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '
 
 
 class ProjectSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=64, required=True)
+    name = serializers.CharField(max_length=50, required=True)
     slug = serializers.RegexField(r"^[a-z0-9_\-]+$", max_length=50, required=False, allow_null=True)
     platform = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     default_rules = serializers.BooleanField(required=False, initial=True)

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -54,7 +54,7 @@ ExpressionNode = CombinedExpression
 resolve_expression_node = resolve_combined_expression
 
 
-def slugify_instance(inst, label, reserved=(), max_length=50, field_name="slug", *args, **kwargs):
+def slugify_instance(inst, label, reserved=(), max_length=30, field_name="slug", *args, **kwargs):
     base_value = slugify(label)[:max_length]
 
     if base_value is not None:

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -54,7 +54,7 @@ ExpressionNode = CombinedExpression
 resolve_expression_node = resolve_combined_expression
 
 
-def slugify_instance(inst, label, reserved=(), max_length=30, field_name="slug", *args, **kwargs):
+def slugify_instance(inst, label, reserved=(), max_length=50, field_name="slug", *args, **kwargs):
     base_value = slugify(label)[:max_length]
 
     if base_value is not None:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -138,7 +138,11 @@ class Project(Model, PendingDeletionMixin):
             lock = locks.get("slug:project", duration=5)
             with TimedRetryPolicy(10)(lock.acquire):
                 slugify_instance(
-                    self, self.name, organization=self.organization, reserved=RESERVED_PROJECT_SLUGS
+                    self,
+                    self.name,
+                    organization=self.organization,
+                    reserved=RESERVED_PROJECT_SLUGS,
+                    max_length=50,
                 )
             super(Project, self).save(*args, **kwargs)
         else:
@@ -344,7 +348,7 @@ class Project(Model, PendingDeletionMixin):
             with transaction.atomic():
                 self.update(organization=organization)
         except IntegrityError:
-            slugify_instance(self, self.name, organization=organization)
+            slugify_instance(self, self.name, organization=organization, max_length=50)
             self.update(slug=self.slug, organization=organization)
 
         # Both environments and releases are bound at an organization level.


### PR DESCRIPTION
Pass `max_length=50` to `slugify_instance()` when called for `Project` model: max length now matches `django.db.models.SlugField`'s `max_length`.

~Partially solves #16616: user still can submit *project name* with max length 64 via project setup wizard (serializer max length; model's max length is even bigger - 200), but later in project settings they can only modify *project slug* which has max length of 50. Not sure if project name is used anywhere and why it's a required field and why frontend sends slug as a name.. but at least there is now a matching max length for slugified value and slug field in the backend.~

**EDIT:** Fixes #16616. A user can submit *project name* with max length 50 (which is already slugified by frontend) via project setup wizard and later in project settings they can modify *project slug* with the same max length of 50. Error is shown if max length is greater than 50, no unexpected truncation to 30 chars.