### PR TITLE
fix(slack): Fix unfurled issue url to have color that matches last event's level

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -197,10 +197,6 @@ def build_group_attachment(group, event=None, tags=None, identity=None, actions=
     teams = get_team_assignees(group)
 
     logo_url = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
-    color = (
-        LEVEL_TO_COLOR.get(event.get_tag("level"), "error") if event else LEVEL_TO_COLOR["error"]
-    )
-
     text = build_attachment_text(group, event) or ""
 
     if actions is None:
@@ -257,11 +253,19 @@ def build_group_attachment(group, event=None, tags=None, identity=None, actions=
         },
     ]
 
+    # If an event is unspecified, use the tags of the latest event (if one exists).
+    event_for_tags = event if event else group.get_latest_event()
+
+    fallback_color = LEVEL_TO_COLOR["error"]
+    color = (
+        LEVEL_TO_COLOR.get(event_for_tags.get_tag("level"), fallback_color)
+        if event_for_tags
+        else fallback_color
+    )
+
     fields = []
-
     if tags:
-        event_tags = event.tags if event else group.get_latest_event().tags
-
+        event_tags = event_for_tags.tags if event_for_tags else []
         for key, value in event_tags:
             std_key = tagstore.get_standardized_key(key)
             if std_key not in tags:

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -283,3 +283,18 @@ class BuildIncidentAttachmentTest(TestCase):
             "fallback": u"[{}] {}".format(self.project.slug, event.title),
             "footer_icon": u"http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
         }
+
+    def test_build_group_attachment_color_no_event_error_fallback(self):
+        group_with_no_events = self.create_group(project=self.project)
+        assert build_group_attachment(group_with_no_events)["color"] == "#E03E2F"
+
+    def test_build_group_attachment_color_unxpected_level_error_fallback(self):
+        unexpected_level_event = self.store_event(
+            data={"level": "trace"}, project_id=self.project.id, assert_no_errors=False
+        )
+        assert build_group_attachment(unexpected_level_event.group)["color"] == "#E03E2F"
+
+    def test_build_group_attachment_color_warning(self):
+        warning_event = self.store_event(data={"level": "warning"}, project_id=self.project.id)
+        assert build_group_attachment(warning_event.group)["color"] == "#FFC227"
+        assert build_group_attachment(warning_event.group, warning_event)["color"] == "#FFC227"


### PR DESCRIPTION
When unfurling an issue url, the "color" would fallback to the color
corresponding to the "error" level due to there being no event present. However,
the more sensical behavior is to do as tags are handled and to use the issue's
last event to determine the level / color to use.

Also fix "color" fallback for unexpected "level" value to be "#E03E2F" instead
of the literal string "error".

Fixes #21590

-----

### Warning in Sentry
![image](https://user-images.githubusercontent.com/549473/97139255-59033080-1717-11eb-8e58-c0f8e0507fca.png)

### Unfurl in Slack Before: Wrong Color 👎 
![image](https://user-images.githubusercontent.com/549473/97139088-f27e1280-1716-11eb-81d5-1692e569e3e9.png)


### Unfurl in Slack After: Correct Color 👍 
![image](https://user-images.githubusercontent.com/549473/97139112-03c71f00-1717-11eb-893d-a9ae85397a9e.png)
