### PR TITLE
feat(search): Add support for `is:linked` and `is:unlinked` filters

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -42,6 +42,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         "bookmarked_by",
         "assigned_to",
         "unassigned",
+        "linked",
         "subscribed_by",
         "active_at",
         "first_release",

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -46,6 +46,8 @@ class IssueSearchVisitor(SearchVisitor):
             "assigned": (SearchKey("unassigned"), SearchValue(False)),
             "unassigned": (SearchKey("unassigned"), SearchValue(True)),
             "inbox": (SearchKey("inbox"), SearchValue(True)),
+            "linked": (SearchKey("linked"), SearchValue(True)),
+            "unlinked": (SearchKey("linked"), SearchValue(False)),
         }
         for status_key, status_value in STATUS_CHOICES.items():
             is_filter_translators[status_key] = (SearchKey("status"), SearchValue(status_value))

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -748,6 +748,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         "assigned_to",
         "inbox",
         "unassigned",
+        "linked",
         "subscribed_by",
         "active_at",
         "first_release",

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -230,6 +230,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             "bookmarked_by",
             "assigned_to",
             "unassigned",
+            "linked",
             "subscribed_by",
             "active_at",
             "first_release",

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -438,6 +438,10 @@ def parse_query(projects, query, user, environments):
                     results["unassigned"] = False
                 elif value == "inbox":
                     results["inbox"] = True
+                elif value == "linked":
+                    results["linked"] = True
+                elif value == "unlinked":
+                    results["linked"] = False
                 else:
                     try:
                         results["status"] = STATUS_CHOICES[value]

--- a/src/sentry/static/sentry/app/stores/tagStore.tsx
+++ b/src/sentry/static/sentry/app/stores/tagStore.tsx
@@ -77,7 +77,15 @@ const tagStoreConfig: Reflux.StoreDefinition & TagStoreInterface = {
       is: {
         key: 'is',
         name: 'Status',
-        values: ['resolved', 'unresolved', 'ignored', 'assigned', 'unassigned'],
+        values: [
+          'resolved',
+          'unresolved',
+          'ignored',
+          'assigned',
+          'unassigned',
+          'linked',
+          'unlinked',
+        ],
         predefined: true,
       },
       has: {

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -57,6 +57,21 @@ class ParseSearchQueryTest(TestCase):
             SearchFilter(key=SearchKey(name="unassigned"), operator="!=", value=SearchValue(False))
         ]
 
+    def test_is_query_linked(self):
+        assert parse_search_query("is:linked") == [
+            SearchFilter(key=SearchKey(name="linked"), operator="=", value=SearchValue(True))
+        ]
+        assert parse_search_query("is:unlinked") == [
+            SearchFilter(key=SearchKey(name="linked"), operator="=", value=SearchValue(False))
+        ]
+
+        assert parse_search_query("!is:linked") == [
+            SearchFilter(key=SearchKey(name="linked"), operator="!=", value=SearchValue(True))
+        ]
+        assert parse_search_query("!is:unlinked") == [
+            SearchFilter(key=SearchKey(name="linked"), operator="!=", value=SearchValue(False))
+        ]
+
     def test_is_query_status(self):
         for status_string, status_val in STATUS_CHOICES.items():
             assert parse_search_query("is:%s" % status_string) == [

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -408,6 +408,14 @@ class ParseQueryTest(TestCase):
         result = self.parse_query("is:inbox")
         assert result == {"inbox": True, "tags": {}, "query": ""}
 
+    def test_is_unlinked(self):
+        result = self.parse_query("is:unlinked")
+        assert result == {"linked": False, "tags": {}, "query": ""}
+
+    def test_is_linked(self):
+        result = self.parse_query("is:linked")
+        assert result == {"linked": True, "tags": {}, "query": ""}
+
     def test_age_from(self):
         result = self.parse_query("age:-24h")
         assert result["age_from"] > timezone.now() - timedelta(hours=25)


### PR DESCRIPTION
- "linked" means there is an issue linked to the group.
- "unlinked" means there isn't an issue linked to the group.

The implementation mirrors that of the `is:assigned`/`is:unassigned`
filters where it does a non-snuba, postgres filter for `Group`s
that are either linked to:
    - an `ExternalIssue` (via `GroupLink` with `LinkedType.issue`), or
    - a `PlatformExternalIssue`

Fixes #15725, fixes #8338, fixes #5413, fixes #15525.

## Screenshots
These are outdated as the keywords were changed to `linked` and `unlinked`

### Issue search
![image](https://user-images.githubusercontent.com/549473/97155023-f23f4080-1731-11eb-8a9b-24d77193da6e.png)
![image](https://user-images.githubusercontent.com/549473/97154045-ac35ad00-1730-11eb-99a1-b8b0fa9b81f1.png)
![image](https://user-images.githubusercontent.com/549473/97154087-b9529c00-1730-11eb-8acb-e0b21475ee2f.png)
