### PR TITLE
feat(projects) Add links to issues/transactions and update deploy visuals

### DIFF
--- a/src/sentry/static/sentry/app/views/projectsDashboard/deploys.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/deploys.tsx
@@ -108,7 +108,7 @@ const DeployRows = styled(DeployContainer)`
   line-height: 1.2;
 `;
 
-const Environment = styled('p')`
+const Environment = styled('div')`
   color: ${p => p.theme.textColor};
   margin: 0;
 `;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/deploys.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/deploys.tsx
@@ -10,6 +10,7 @@ import TimeSince from 'app/components/timeSince';
 import Version from 'app/components/version';
 import space from 'app/styles/space';
 import getDynamicText from 'app/utils/getDynamicText';
+import {IconReleases} from 'app/icons';
 
 const DEPLOY_COUNT = 2;
 
@@ -36,7 +37,7 @@ const Deploys = ({project}: Props) => {
   }
 
   return (
-    <DeployContainer>
+    <DeployRows>
       {deploys.map(deploy => (
         <Deploy
           key={`${deploy.environment}-${deploy.version}`}
@@ -44,7 +45,7 @@ const Deploys = ({project}: Props) => {
           project={project}
         />
       ))}
-    </DeployContainer>
+    </DeployRows>
   );
 };
 
@@ -59,25 +60,25 @@ type DeployProps = Props & {
 };
 
 const Deploy = ({deploy, project}: DeployProps) => (
-  <DeployRow>
-    <Environment>{deploy.environment}</Environment>
-
-    <StyledTextOverflow>
+  <React.Fragment>
+    <IconReleases size="sm" />
+    <TextOverflow>
+      <Environment>{deploy.environment}</Environment>
       <Version
         version={deploy.version}
         projectId={project.id}
         tooltipRawVersion
         truncate
       />
-    </StyledTextOverflow>
+    </TextOverflow>
 
-    <DeployTimeWrapper>
+    <DeployTime>
       {getDynamicText({
         fixed: '3 hours ago',
         value: <TimeSince date={deploy.dateFinished} />,
       })}
-    </DeployTimeWrapper>
-  </DeployRow>
+    </DeployTime>
+  </React.Fragment>
 );
 
 Deploy.propTypes = {
@@ -86,61 +87,41 @@ Deploy.propTypes = {
 };
 
 const NoDeploys = () => (
-  <DeployContainer>
-    <Background>
-      <Button size="xsmall" href="https://docs.sentry.io/learn/releases/" external>
-        {t('Track deploys')}
-      </Button>
-    </Background>
-  </DeployContainer>
+  <GetStarted>
+    <Button size="small" href="https://docs.sentry.io/learn/releases/" external>
+      {t('Track deploys')}
+    </Button>
+  </GetStarted>
 );
-
-const DeployRow = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  color: ${p => p.theme.gray500};
-  font-size: ${p => p.theme.fontSizeSmall};
-
-  &:not(:last-of-type) {
-    margin-top: ${space(1)};
-  }
-`;
-
-const Environment = styled(TextOverflow)`
-  font-size: ${p => p.theme.fontSizeExtraSmall};
-  text-transform: uppercase;
-  width: 80px;
-  border: 1px solid ${p => p.theme.borderLight};
-  margin-right: ${space(1)};
-  background-color: ${p => p.theme.gray100};
-  text-align: center;
-  border-radius: ${p => p.theme.borderRadius};
-  flex-shrink: 0;
-`;
-
-const StyledTextOverflow = styled(TextOverflow)`
-  margin-right: ${space(1)};
-`;
-
-const DeployTimeWrapper = styled('div')`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 90px;
-  flex-grow: 1;
-  flex-shrink: 0;
-  text-align: right;
-`;
-
 const DeployContainer = styled('div')`
-  height: 92px;
   padding: ${space(2)};
+  height: 115px;
 `;
 
-const Background = styled('div')`
+const DeployRows = styled(DeployContainer)`
+  display: grid;
+  grid-template-columns: 30px 1fr 1fr;
+  grid-template-rows: auto;
+  grid-column-gap: ${space(1)};
+  grid-row-gap: ${space(1)};
+  font-size: ${p => p.theme.fontSizeMedium};
+  line-height: 1.2;
+`;
+
+const Environment = styled('p')`
+  color: ${p => p.theme.textColor};
+  margin: 0;
+`;
+
+const DeployTime = styled('div')`
+  color: ${p => p.theme.gray500};
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+`;
+
+const GetStarted = styled(DeployContainer)`
   display: flex;
-  height: 100%;
-  background-color: ${p => p.theme.gray100};
   align-items: center;
   justify-content: center;
 `;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
@@ -8,6 +8,7 @@ import {Organization, Project} from 'app/types';
 import BookmarkStar from 'app/components/projects/bookmarkStar';
 import {Client} from 'app/api';
 import {loadStatsForProject} from 'app/actionCreators/projects';
+import {tn} from 'app/locale';
 import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
@@ -15,6 +16,7 @@ import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
 import withApi from 'app/utils/withApi';
+import {formatAbbreviatedNumber} from 'app/utils/formatters';
 
 import Chart from './chart';
 import Deploys from './deploys';
@@ -42,39 +44,73 @@ class ProjectCard extends React.Component<Props> {
       orgId: organization.slug,
       projectId: project.id,
       query: {
-        transactionStats: organization.features.includes('performance-view')
-          ? '1'
-          : undefined,
+        transactionStats: this.hasPerformance ? '1' : undefined,
       },
     });
+  }
+
+  get hasPerformance() {
+    return this.props.organization.features.includes('performance-view');
   }
 
   render() {
     const {organization, project, hasProjectAccess} = this.props;
     const {id, firstEvent, stats, slug, transactionStats} = project;
+    const totalErrors =
+      stats !== undefined
+        ? formatAbbreviatedNumber(stats.reduce((sum, [_, value]) => sum + value, 0))
+        : '\u2014';
+
+    const totalTransactions =
+      transactionStats !== undefined
+        ? formatAbbreviatedNumber(
+            transactionStats.reduce((sum, [_, value]) => sum + value, 0)
+          )
+        : '\u2014';
 
     return (
       <div data-test-id={slug}>
         {stats ? (
           <StyledProjectCard>
-            <StyledProjectCardHeader>
-              <StyledIdBadge
-                project={project}
-                avatarSize={18}
-                displayName={
-                  hasProjectAccess ? (
+            <CardHeader>
+              <HeaderRow>
+                <StyledIdBadge
+                  project={project}
+                  avatarSize={18}
+                  displayName={
+                    hasProjectAccess ? (
+                      <Link
+                        to={`/organizations/${organization.slug}/issues/?project=${id}`}
+                      >
+                        <strong>{slug}</strong>
+                      </Link>
+                    ) : (
+                      <span>{slug}</span>
+                    )
+                  }
+                />
+                <BookmarkStar organization={organization} project={project} />
+              </HeaderRow>
+              <SummaryLinks>
+                <Link
+                  data-test-id="project-errors"
+                  to={`/organizations/${organization.slug}/issues/?project=${project.id}`}
+                >
+                  {tn('%s error', '%s errors', totalErrors)}
+                </Link>
+                {this.hasPerformance && (
+                  <React.Fragment>
+                    <em>|</em>
                     <Link
-                      to={`/organizations/${organization.slug}/issues/?project=${id}`}
+                      data-test-id="project-transactions"
+                      to={`/organizations/${organization.slug}/performance/?project=${project.id}`}
                     >
-                      <strong>{slug}</strong>
+                      {tn('%s transaction', '%s transactions', totalTransactions)}
                     </Link>
-                  ) : (
-                    <span>{slug}</span>
-                  )
-                }
-              />
-              <BookmarkStar organization={organization} project={project} />
-            </StyledProjectCardHeader>
+                  </React.Fragment>
+                )}
+              </SummaryLinks>
+            </CardHeader>
             <ChartContainer>
               <Chart stats={stats} transactionStats={transactionStats} />
               {!firstEvent && <NoEvents />}
@@ -148,11 +184,14 @@ const ChartContainer = styled('div')`
   padding-top: ${space(1)};
 `;
 
-const StyledProjectCardHeader = styled('div')`
+const CardHeader = styled('div')`
+  margin: 12px ${space(2)};
+`;
+
+const HeaderRow = styled('div')`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 12px ${space(2)};
 `;
 
 const StyledProjectCard = styled('div')`
@@ -171,6 +210,25 @@ const LoadingCard = styled('div')`
 const StyledIdBadge = styled(IdBadge)`
   overflow: hidden;
   white-space: nowrap;
+`;
+
+const SummaryLinks = styled('div')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
+
+  /* Need to offset for the project icon and margin */
+  margin-left: 26px;
+
+  a {
+    color: ${p => p.theme.formText};
+    :hover {
+      color: ${p => p.theme.gray600};
+    }
+  }
+  em {
+    font-style: normal;
+    margin: 0 ${space(0.5)};
+  }
 `;
 
 export {ProjectCard};

--- a/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
@@ -185,7 +185,7 @@ const ChartContainer = styled('div')`
 `;
 
 const CardHeader = styled('div')`
-  margin: 12px ${space(2)};
+  margin: ${space(1.5)} ${space(2)};
 `;
 
 const HeaderRow = styled('div')`

--- a/tests/js/spec/views/projectsDashboard/projectCard.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/projectCard.spec.jsx
@@ -19,6 +19,10 @@ describe('ProjectCard', function () {
             [1525042800, 1],
             [1525046400, 2],
           ],
+          transactionStats: [
+            [1525042800, 4],
+            [1525046400, 8],
+          ],
           platform: 'javascript',
         })}
         params={{orgId: 'org-slug'}}
@@ -82,6 +86,59 @@ describe('ProjectCard', function () {
     expect(wrapper.find('PlatformList')).toHaveLength(1);
     const icons = wrapper.find('StyledPlatformIcon');
     expect(icons.first().prop('platform')).toBe('javascript');
+  });
+
+  it('renders header link for errors', function () {
+    wrapper = mountWithTheme(
+      <ProjectCard
+        organization={TestStubs.Organization()}
+        project={TestStubs.Project({
+          stats: [
+            [1525042800, 3],
+            [1525046400, 3],
+          ],
+          platform: 'javascript',
+        })}
+        params={{orgId: 'org-slug'}}
+      />,
+      TestStubs.routerContext()
+    );
+
+    const total = wrapper.find('a[data-test-id="project-errors"]');
+    expect(total).toHaveLength(1);
+    expect(total.text()).toContain('6 errors');
+
+    // No transacations as the feature isn't set.
+    const transactions = wrapper.find('a[data-test-id="project-transactions"]');
+    expect(transactions).toHaveLength(0);
+  });
+
+  it('renders header link for transactions', function () {
+    wrapper = mountWithTheme(
+      <ProjectCard
+        organization={TestStubs.Organization({features: ['performance-view']})}
+        project={TestStubs.Project({
+          stats: [
+            [1525042800, 3],
+            [1525046400, 3],
+          ],
+          transactionStats: [
+            [1525042800, 4],
+            [1525046400, 4],
+          ],
+          platform: 'javascript',
+        })}
+        params={{orgId: 'org-slug'}}
+      />,
+      TestStubs.routerContext()
+    );
+
+    const total = wrapper.find('a[data-test-id="project-errors"]');
+    expect(total).toHaveLength(1);
+
+    const transactions = wrapper.find('a[data-test-id="project-transactions"]');
+    expect(transactions).toHaveLength(1);
+    expect(transactions.text()).toContain('8 transactions');
   });
 
   it('renders loading placeholder card if there are no stats', function () {


### PR DESCRIPTION
Add links from the project dashboard to transactions and issues. Transactions will only be shown when an account has access to `performance-view`. Our hope is that this helps encourage existing users to use transactions and makes them feel more well integrated into the rest of the product.

![Screen Shot 2020-10-26 at 2 54 39 PM](https://user-images.githubusercontent.com/24086/97217183-43384e80-179d-11eb-81ff-2e37e5c1cc2b.png)
