### PR TITLE
build(gha): Use `pull_request_target` for acceptance workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -23,6 +23,14 @@ jobs:
       VISUAL_HTML_ENABLE: 1
     steps:
       - uses: actions/checkout@v2
+        name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
+        if: github.event.pull_request.head.ref != ''
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - uses: actions/checkout@v2
+        if: github.event.pull_request.head.ref == ''
 
       - uses: volta-cli/action@v1
 
@@ -82,6 +90,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
+        if: github.event.pull_request.head.ref != ''
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - uses: actions/checkout@v2
+        if: github.event.pull_request.head.ref == ''
 
       - uses: volta-cli/action@v1
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -23,13 +23,16 @@ jobs:
       VISUAL_HTML_ENABLE: 1
     steps:
       - uses: actions/checkout@v2
-        name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
+        name: Checkout sentry (pull_request)
         if: github.event.pull_request.head.ref != ''
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          # Note this is required because of `pull_request_target`, which allows
+          # forks to access secrets safely by only running workflows from the main branch.
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - uses: actions/checkout@v2
+        name: Checkout sentry (push)
         if: github.event.pull_request.head.ref == ''
 
       - uses: volta-cli/action@v1
@@ -90,13 +93,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
+        name: Checkout sentry (pull_request)
         if: github.event.pull_request.head.ref != ''
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          # Note this is required because of `pull_request_target`, which allows
+          # forks to access secrets safely by only running workflows from the main branch.
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - uses: actions/checkout@v2
+        name: Checkout sentry (push)
         if: github.event.pull_request.head.ref == ''
 
       - uses: volta-cli/action@v1

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -11,7 +11,6 @@ on:
     branches:
       - master
       - releases/**
-  pull_request:
   pull_request_target:
 
 jobs:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -24,6 +24,13 @@ jobs:
       VISUAL_HTML_ENABLE: 1
     steps:
       - uses: actions/checkout@v2
+        if: ${{ github.event.pull_request.head.ref == "" }}
+
+      - uses: actions/checkout@v2
+        if: ${{ github.event.pull_request.head.ref != "" }}
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - uses: volta-cli/action@v1
 
@@ -81,6 +88,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        if: ${{ github.event.pull_request.head.ref == "" }}
+
+      - uses: actions/checkout@v2
+        if: ${{ github.event.pull_request.head.ref != "" }}
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - uses: volta-cli/action@v1
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -23,14 +23,6 @@ jobs:
       VISUAL_HTML_ENABLE: 1
     steps:
       - uses: actions/checkout@v2
-        name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
-        if: github.event.pull_request.head.ref != ''
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-
-      - uses: actions/checkout@v2
-        if: github.event.pull_request.head.ref == ''
 
       - uses: volta-cli/action@v1
 
@@ -88,14 +80,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
-        if: github.event.pull_request.head.ref != ''
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - uses: actions/checkout@v2
-        if: github.event.pull_request.head.ref == ''
       - uses: volta-cli/action@v1
 
       # Until GH composite actions can use `uses`, we need to setup python here

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - master
       - releases/**
+  pull_request:
   pull_request_target:
 
 jobs:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -39,6 +39,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - run: cat src/sentry/static/sentry/app/utils/theme.tsx
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -50,8 +50,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: cat src/sentry/static/sentry/app/utils/theme.tsx
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        name: Checkout sentry (pull_request)
+        name: Checkout sentry (pull_request_target)
         if: github.event.pull_request.head.ref != ''
         with:
           # Note this is required because of `pull_request_target`, which allows

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -26,6 +26,7 @@ jobs:
         if: ${{ github.event.pull_request.head.ref == "" }}
 
       - uses: actions/checkout@v2
+        name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.ref != "" }}
         with:
           ref: ${{github.event.pull_request.head.ref}}
@@ -90,6 +91,7 @@ jobs:
         if: ${{ github.event.pull_request.head.ref == "" }}
 
       - uses: actions/checkout@v2
+        name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.ref != "" }}
         with:
           ref: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -23,14 +23,14 @@ jobs:
       VISUAL_HTML_ENABLE: 1
     steps:
       - uses: actions/checkout@v2
-        if: ${{ github.event.pull_request.head.ref == "" }}
-
-      - uses: actions/checkout@v2
         name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.ref != "" }}
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      # - uses: actions/checkout@v2
+        # if: ${{ github.event.pull_request.head.ref == "" }}
 
       - uses: volta-cli/action@v1
 
@@ -88,14 +88,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        if: ${{ github.event.pull_request.head.ref == "" }}
-
-      - uses: actions/checkout@v2
         name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.ref != "" }}
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      # - uses: actions/checkout@v2
+        # if: ${{ github.event.pull_request.head.ref == "" }}
 
       - uses: volta-cli/action@v1
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -24,13 +24,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
-        if: ${{ github.event.pull_request.head.ref != "" }}
+        if: github.event.pull_request.head.ref != ''
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      # - uses: actions/checkout@v2
-        # if: ${{ github.event.pull_request.head.ref == "" }}
+      - uses: actions/checkout@v2
+        if: github.event.pull_request.head.ref == ''
 
       - uses: volta-cli/action@v1
 
@@ -89,14 +89,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout ${{github.event.pull_request.head.repo.full_name}} --> ${{github.event.pull_request.head.ref}}
-        if: ${{ github.event.pull_request.head.ref != "" }}
+        if: github.event.pull_request.head.ref != ''
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      # - uses: actions/checkout@v2
-        # if: ${{ github.event.pull_request.head.ref == "" }}
-
+      - uses: actions/checkout@v2
+        if: github.event.pull_request.head.ref == ''
       - uses: volta-cli/action@v1
 
       # Until GH composite actions can use `uses`, we need to setup python here

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - master
       - releases/**
+  # XXX: We are using `pull_request_target` instead of `pull_request` because we want
+  # Visual Snapshots to run on forks.  It allows forks to access secrets safely by
+  # only running workflows from the main branch. Prefer to use `pull_request` when possible.
+  #
+  # See https://github.com/getsentry/sentry/pull/21600 for more details
   pull_request_target:
 
 jobs:
@@ -23,7 +28,7 @@ jobs:
       VISUAL_HTML_ENABLE: 1
     steps:
       - uses: actions/checkout@v2
-        name: Checkout sentry (pull_request)
+        name: Checkout sentry (pull_request_target)
         if: github.event.pull_request.head.ref != ''
         with:
           # Note this is required because of `pull_request_target`, which allows

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - master
       - releases/**
-  pull_request:
+  pull_request_target:
 
 jobs:
   frontend:

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -17,11 +17,12 @@ on:
 
 jobs:
   getsentry:
-    if: ${{ github.ref != 'refs/heads/master' && secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY != ''}}
+    if: ${{ github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-16.04
     steps:
       - name: getsentry token
         id: getsentry
+        if: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY != '' }}
         uses: getsentry/action-github-app-token@v1
         with:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   getsentry:
-    if: ${{ github.ref != 'refs/heads/master' }}
+    if: ${{ github.ref != 'refs/heads/master' && secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY != ''}}
     runs-on: ubuntu-16.04
     steps:
       - name: getsentry token

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - name: getsentry token
         id: getsentry
-        if: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY != '' }}
         uses: getsentry/action-github-app-token@v1
         with:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    paths:
-      - '**.[tj]sx?'
-      - package.json
-      - yarn.lock
   pull_request_target:
     paths:
       - '**.[tj]sx?'

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
     paths:
       - '**.[tj]sx?'
       - package.json

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -9,6 +9,11 @@ on:
       - '**.[tj]sx?'
       - package.json
       - yarn.lock
+  pull_request_target:
+    paths:
+      - '**.[tj]sx?'
+      - package.json
+      - yarn.lock
 
 jobs:
   getsentry:


### PR DESCRIPTION
This changes our visual snapshots/acceptance workflow to use the `pull_request_target` event instead of `pull_request` so that we can have Visual Snapshots working on fork PRs. By default, forks do not have write access tokens, but when using `pull_request_target`, forked PRs will use the base repository workflows as the source. This ensures that secrets/apis do not get exposed from by the fork changing workflows. See https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target for more information.

Important notes about `pull_request_target`:

- Used to allow forks to have write-access tokens + secrets
- Ensures safety by only running workflow from the main branch
- You can test workflow changes by making your branch the base branch in a Pull Request
- Note that the workflow seems to be cached after opening the PR
    - e.g. if you make a pull request against a feature branch, the workflow that will be used is the workflow in the base branch at the point when you create the PR. From there on, you won't be able to change the workflow that is run
- You must specify the ref + repository when using the checkout action
