### PR TITLE
feat(vercel): update ui for vercel

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -165,15 +165,6 @@ class VercelIntegration(IntegrationInstallation):
             for p in vercel_client.get_projects()
         ]
 
-        next_url = None
-        configuration_id = self.get_configuration_id()
-        if configuration_id:
-            if self.metadata["installation_type"] == "team":
-                dashboard_url = u"https://vercel.com/dashboard/%s" % slug
-            else:
-                dashboard_url = "https://vercel.com/dashboard"
-            next_url = u"%s/integrations/%s/popup" % (dashboard_url, configuration_id)
-
         proj_fields = ["id", "platform", "name", "slug"]
         sentry_projects = map(
             lambda proj: {key: proj[key] for key in proj_fields},
@@ -195,7 +186,7 @@ class VercelIntegration(IntegrationInstallation):
                     "placeholder": _("Vercel project..."),
                 },
                 "sentryProjects": sentry_projects,
-                "nextButton": {"url": next_url, "text": _("To Vercel")},
+                "nextButton": {"allowedDomain": "https://vercel.com", "text": _("To Vercel")},
                 "iconType": "vercel",
             }
         ]

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -70,6 +70,7 @@ configure_integration = {"title": _("Connect Your Projects")}
 connect_project_instruction = _(
     "To complete installation, please connect your Sentry and Vercel projects."
 )
+create_project_instruction = _("Don't have a project yet? Click [here]({}) to create one.")
 install_source_code_integration = _(
     "Install a [source code integration]({}) and configure your repositories."
 )
@@ -115,10 +116,12 @@ class VercelIntegration(IntegrationInstallation):
             u"/settings/%s/integrations/?%s"
             % (organization.slug, urlencode({"category": "source code management"}))
         )
+        add_project_link = absolute_uri(u"/organizations/%s/projects/new/" % (organization.slug))
         return {
             "configure_integration": {
                 "instructions": [
                     connect_project_instruction,
+                    create_project_instruction.format(add_project_link),
                     install_source_code_integration.format(source_code_link),
                 ]
             }
@@ -166,10 +169,10 @@ class VercelIntegration(IntegrationInstallation):
         configuration_id = self.get_configuration_id()
         if configuration_id:
             if self.metadata["installation_type"] == "team":
-                dashboard_url = u"https://vercel.com/dashboard/%s/" % slug
+                dashboard_url = u"https://vercel.com/dashboard/%s" % slug
             else:
-                dashboard_url = "https://vercel.com/dashboard/"
-            next_url = u"%s/integrations/%s" % (dashboard_url, configuration_id)
+                dashboard_url = "https://vercel.com/dashboard"
+            next_url = u"%s/integrations/%s/popup" % (dashboard_url, configuration_id)
 
         proj_fields = ["id", "platform", "name", "slug"]
         sentry_projects = map(
@@ -189,10 +192,10 @@ class VercelIntegration(IntegrationInstallation):
                 "type": "project_mapper",
                 "mappedDropdown": {
                     "items": vercel_projects,
-                    "placeholder": _("Choose Vercel project..."),
+                    "placeholder": _("Vercel project..."),
                 },
                 "sentryProjects": sentry_projects,
-                "nextButton": {"url": next_url, "text": _("Return to Vercel")},
+                "nextButton": {"url": next_url, "text": _("To Vercel")},
                 "iconType": "vercel",
             }
         ]
@@ -206,7 +209,7 @@ class VercelIntegration(IntegrationInstallation):
         try:
             new_mappings = data["project_mappings"]
         except KeyError:
-            return ValidationError("Failed to update configuration.")
+            raise ValidationError("Failed to update configuration.")
 
         old_mappings = config.get("project_mappings") or []
 

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -165,6 +165,15 @@ class VercelIntegration(IntegrationInstallation):
             for p in vercel_client.get_projects()
         ]
 
+        manage_url = None
+        configuration_id = self.get_configuration_id()
+        if configuration_id:
+            if self.metadata["installation_type"] == "team":
+                dashboard_url = u"https://vercel.com/dashboard/%s/" % slug
+            else:
+                dashboard_url = "https://vercel.com/dashboard/"
+            manage_url = u"%s/integrations/%s" % (dashboard_url, configuration_id)
+
         proj_fields = ["id", "platform", "name", "slug"]
         sentry_projects = map(
             lambda proj: {key: proj[key] for key in proj_fields},
@@ -188,6 +197,7 @@ class VercelIntegration(IntegrationInstallation):
                 "sentryProjects": sentry_projects,
                 "nextButton": {"allowedDomain": "https://vercel.com", "text": _("To Vercel")},
                 "iconType": "vercel",
+                "manageUrl": manage_url,
             }
         ]
 

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -325,3 +325,12 @@ export const convertIntegrationTypeToSnakeCase = (
       return type;
   }
 };
+
+export const safeGetQsParam = (param: string) => {
+  try {
+    const query = qs.parse(window.location.search) || {};
+    return query[param];
+  } catch {
+    return undefined;
+  }
+};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -160,6 +160,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
 
       if (field) {
         const mappingField = field as ProjectMapperType;
+        url = mappingField.manageUrl || '';
         window.open(mappingField.manageUrl, '_blank');
       }
       return;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -11,7 +11,6 @@ import {IconFlag, IconOpen, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {IntegrationWithConfig, IntegrationProvider} from 'app/types';
-import {ProjectMapperType} from 'app/views/settings/components/forms/type';
 import {sortArray} from 'app/utils';
 import {isSlackWorkspaceApp, getReauthAlertText} from 'app/utils/integrationUtil';
 import withOrganization from 'app/utils/withOrganization';
@@ -149,6 +148,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
   onDisable = (integration: IntegrationWithConfig) => {
     let url: string;
 
+    //TODO: Clean up hack for Vercel
     if (integration.provider.key === 'vercel') {
       // kind of a hack since this isn't what the url was stored for
       // but it's exactly what we need and contains the configuration id
@@ -158,8 +158,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
       );
 
       if (field) {
-        const mappingField = field as ProjectMapperType;
-        url = mappingField.nextButton.url || '';
+        url = 'https://vercel.com/dashboard/integrations';
         window.open(url, '_blank');
       }
       return;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -11,6 +11,7 @@ import {IconFlag, IconOpen, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {IntegrationWithConfig, IntegrationProvider} from 'app/types';
+import {ProjectMapperType} from 'app/views/settings/components/forms/type';
 import {sortArray} from 'app/utils';
 import {isSlackWorkspaceApp, getReauthAlertText} from 'app/utils/integrationUtil';
 import withOrganization from 'app/utils/withOrganization';
@@ -158,8 +159,8 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
       );
 
       if (field) {
-        url = 'https://vercel.com/dashboard/integrations';
-        window.open(url, '_blank');
+        const mappingField = field as ProjectMapperType;
+        window.open(mappingField.manageUrl, '_blank');
       }
       return;
     }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -161,7 +161,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
       if (field) {
         const mappingField = field as ProjectMapperType;
         url = mappingField.manageUrl || '';
-        window.open(mappingField.manageUrl, '_blank');
+        window.open(url, '_blank');
       }
       return;
     }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -47,7 +47,7 @@ export class RenderField extends React.Component<RenderProps, State> {
       value: incomingValues,
       sentryProjects,
       mappedDropdown: {items: mappedDropdownItems, placeholder: mappedValuePlaceholder},
-      nextButton: {text: nextButtonText},
+      nextButton: {text: nextButtonText, allowedDomain},
       iconType,
       model,
       id: formElementId,
@@ -55,7 +55,13 @@ export class RenderField extends React.Component<RenderProps, State> {
     } = this.props;
     const existingValues: Array<[number, MappedValue]> = incomingValues || [];
     const nextUrlOrArray = safeGetQsParam('next');
-    const nextUrl = Array.isArray(nextUrlOrArray) ? nextUrlOrArray[0] : nextUrlOrArray;
+    let nextUrl = Array.isArray(nextUrlOrArray) ? nextUrlOrArray[0] : nextUrlOrArray;
+
+    if (nextUrl && !nextUrl.startsWith(allowedDomain)) {
+      // eslint-disable-next-line no-console
+      console.warn(`Got unexpected next url: ${nextUrl}`);
+      nextUrl = undefined;
+    }
 
     const {selectedSentryProjectId, selectedMappedValue} = this.state;
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -15,6 +15,7 @@ import {IconVercel, IconGeneric, IconDelete, IconOpen} from 'app/icons';
 import ExternalLink from 'app/components/links/externalLink';
 import {t} from 'app/locale';
 import {removeAtArrayIndex} from 'app/utils/removeAtArrayIndex';
+import {safeGetQsParam} from 'app/utils/integrationUtil';
 
 type MappedValue = string | number;
 
@@ -46,13 +47,15 @@ export class RenderField extends React.Component<RenderProps, State> {
       value: incomingValues,
       sentryProjects,
       mappedDropdown: {items: mappedDropdownItems, placeholder: mappedValuePlaceholder},
-      nextButton: {url: nextUrl, text: nextButtonText},
+      nextButton: {text: nextButtonText},
       iconType,
       model,
       id: formElementId,
       error,
     } = this.props;
     const existingValues: Array<[number, MappedValue]> = incomingValues || [];
+    const nextUrlOrArray = safeGetQsParam('next');
+    const nextUrl = Array.isArray(nextUrlOrArray) ? nextUrlOrArray[0] : nextUrlOrArray;
 
     const {selectedSentryProjectId, selectedMappedValue} = this.state;
 
@@ -111,36 +114,44 @@ export class RenderField extends React.Component<RenderProps, State> {
       const mappedItem = mappedItemsByValue[mappedValue];
       return (
         <Item key={index}>
-          {project ? (
-            <StyledIdBadge
-              project={project}
-              avatarSize={20}
-              displayName={project.slug}
-              avatarProps={{consistentWidth: true}}
-            />
-          ) : (
-            <ItemValue>{t('Deleted')}</ItemValue>
-          )}
+          <SentryProjectValue>
+            {project ? (
+              <StyledIdBadge
+                project={project}
+                avatarSize={20}
+                displayName={project.slug}
+                avatarProps={{consistentWidth: true}}
+              />
+            ) : (
+              <ItemValue>{t('Deleted')}</ItemValue>
+            )}
+          </SentryProjectValue>
           <MappedItemValue>
             {mappedItem ? (
               <React.Fragment>
                 <IntegrationIconWrapper>{getIcon(iconType)}</IntegrationIconWrapper>
-                {mappedItem.label}
-                <StyledExternalLink href={mappedItem.url}>
-                  <IconOpen />
-                </StyledExternalLink>
+                <MappedValueLabel>{mappedItem.label}</MappedValueLabel>
+                <ExternalLinkWrapper>
+                  <InnerLinkWrapper>
+                    <StyledExternalLink href={mappedItem.url}>
+                      <IconOpen />
+                    </StyledExternalLink>
+                  </InnerLinkWrapper>
+                </ExternalLinkWrapper>
               </React.Fragment>
             ) : (
               t('Deleted')
             )}
           </MappedItemValue>
-          <DeleteButton
-            onClick={() => handleDelete(index)}
-            icon={<IconDelete color="gray500" />}
-            size="small"
-            type="button"
-            aria-label={t('Delete')}
-          />
+          <DeleteButtonWrapper>
+            <DeleteButton
+              onClick={() => handleDelete(index)}
+              icon={<IconDelete color="gray500" />}
+              size="small"
+              type="button"
+              aria-label={t('Delete')}
+            />
+          </DeleteButtonWrapper>
         </Item>
       );
     };
@@ -207,11 +218,11 @@ export class RenderField extends React.Component<RenderProps, State> {
     };
 
     return (
-      <Wrapper>
+      <React.Fragment>
         {existingValues.map(renderItem)}
         <Item>
-          <StyledSelectControl
-            placeholder={t('Choose Sentry project\u2026')}
+          <StyledProjectSelectControl
+            placeholder={t('Sentry project\u2026')}
             name="project"
             openMenuOnFocus
             options={projectOptions}
@@ -222,7 +233,7 @@ export class RenderField extends React.Component<RenderProps, State> {
             onChange={handleSelectProject}
             value={selectedSentryProjectId}
           />
-          <StyledSelectControl
+          <MappedValueSelectControl
             placeholder={mappedValuePlaceholder}
             name="mappedDropdown"
             openMenuOnFocus
@@ -252,19 +263,20 @@ export class RenderField extends React.Component<RenderProps, State> {
             )}
           </FieldControlWrapper>
           {nextUrl && (
-            <StyledNextButton
-              type="button"
-              size="small"
-              priority="default"
-              icon={<IconOpen />}
-              href={nextUrl}
-              external
-            >
-              {nextButtonText}
-            </StyledNextButton>
+            <StyledNextButtonWrapper>
+              <StyledNextButton
+                type="button"
+                size="small"
+                priority="default"
+                icon={<IconOpen />}
+                href={nextUrl}
+              >
+                {nextButtonText}
+              </StyledNextButton>
+            </StyledNextButtonWrapper>
           )}
         </Item>
-      </Wrapper>
+      </React.Fragment>
     );
   }
 }
@@ -282,59 +294,84 @@ const ProjectMapperField = (props: Props) => (
 
 export default ProjectMapperField;
 
-const StyledSelectControl = styled(SelectControl)`
-  width: 272px;
-  margin-left: ${space(1.5)};
+const StyledProjectSelectControl = styled(SelectControl)`
+  grid-area: sentry-project;
+`;
+
+const MappedValueSelectControl = styled(SelectControl)`
+  grid-area: mapped-value;
 `;
 
 const Item = styled('div')`
   margin: -1px;
   border: 1px solid ${p => p.theme.gray400};
-  display: flex;
+  min-height: 60px;
+  padding: ${space(1)};
+
+  display: grid;
+  grid-column-gap: ${space(1)};
   align-items: center;
-  height: 60px;
+  grid-template-columns: 2.5fr 2.5fr 0.8fr 0.3fr 1.1fr;
+  grid-template-areas: 'sentry-project mapped-value add-project field-control right-button';
 `;
 
-const ItemValue = styled('div')`
-  padding: ${space(0.5)};
-  margin-left: ${space(2)};
-`;
+const ItemValue = styled('div')``;
 
 const MappedItemValue = styled('div')`
   display: flex;
-  padding: ${space(0.5)};
-  position: absolute;
-  left: 300px;
+  grid-area: mapped-value;
+  width: 100%;
+`;
+
+const SentryProjectValue = styled('div')`
+  grid-area: sentry-project;
+`;
+
+const DeleteButtonWrapper = styled('div')`
+  grid-area: right-button;
 `;
 
 const DeleteButton = styled(Button)`
-  position: absolute;
-  right: ${space(2)};
+  float: right;
 `;
 
-const StyledIdBadge = styled(IdBadge)`
-  margin-left: ${space(3)};
-`;
+const StyledIdBadge = styled(IdBadge)``;
 
 const IntegrationIconWrapper = styled('span')`
-  margin-right: ${space(0.5)};
   display: flex;
+  align-items: center;
 `;
 
 const StyledAddProjectButton = styled(Button)`
-  margin-left: ${space(2)};
+  float: right;
+`;
+
+const StyledNextButtonWrapper = styled('div')`
+  grid-area: right-button;
 `;
 
 const StyledNextButton = styled(Button)`
-  position: absolute;
-  right: ${space(2)};
+  grid-area: right-button;
 `;
 
 const StyledInputField = styled(InputField)`
   padding: 0;
 `;
 
-const StyledExternalLink = styled(ExternalLink)`
+const ExternalLinkWrapper = styled('div')`
+  width: 100%;
+`;
+
+const InnerLinkWrapper = styled('div')`
+  height: 100%;
+  float: right;
+  display: flex;
+  align-items: center;
+`;
+
+const StyledExternalLink = styled(ExternalLink)``;
+
+const MappedValueLabel = styled('span')`
   margin-left: ${space(0.5)};
 `;
 
@@ -343,13 +380,9 @@ const OptionWrapper = styled('div')`
   display: flex;
 `;
 
-const Wrapper = styled('div')``;
-
 const FieldControlWrapper = styled('div')`
   position: relative;
-  margin-left: ${space(2)};
+  grid-area: field-control;
 `;
 
-const StyledFieldErrorReason = styled(FieldErrorReason)`
-  width: 100px;
-`;
+const StyledFieldErrorReason = styled(FieldErrorReason)``;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -148,6 +148,7 @@ export type ProjectMapperType = {
   sentryProjects: Array<AvatarProject & {id: number; name: string}>;
   nextButton: {
     text: string; //url comes from the `next` parameter in the QS
+    allowedDomain: string;
   };
   iconType: string;
 };

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -151,6 +151,7 @@ export type ProjectMapperType = {
     allowedDomain: string;
   };
   iconType: string;
+  manageUrl?: string;
 };
 
 //selects a sentry project with avatars

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -147,8 +147,7 @@ export type ProjectMapperType = {
   };
   sentryProjects: Array<AvatarProject & {id: number; name: string}>;
   nextButton: {
-    url: string | null;
-    text: string;
+    text: string; //url comes from the `next` parameter in the QS
   };
   iconType: string;
 };

--- a/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -138,8 +138,8 @@ class ConfigureIntegration extends AsyncView<Props, State> {
         )}
 
         {integration.dynamicDisplayInformation?.configure_integration?.instructions.map(
-          instruction => (
-            <Alert type="info">
+          (instruction, i) => (
+            <Alert type="info" key={i}>
               <span dangerouslySetInnerHTML={{__html: singleLineRenderer(instruction)}} />
             </Alert>
           )


### PR DESCRIPTION
Because of recent changes for Vercel integrations, we had to make some changes in our integration:

1. Making the UI more friendly to be rendered in a popup in the new installation flow. To do this I switched to using a grid CSS and shortened some of the text to make it look better when smaller.
2. Use the value of `next` in the query string for the link. Previously, we would construct the URL based on the configuration ID so we could display the link even when you navigated to the page from Sentry (instead of during installation). The problem is that the URL can change and we don't want to have to update code every time that happens. The only downside is that we won't show the button if the user just navigates to the integration in Sentry.
3. Add an alert to create a new project at the bottom.

In a popup:

![Screen Shot 2020-10-26 at 4 25 22 PM](https://user-images.githubusercontent.com/8533851/97239399-c4491300-17a8-11eb-83d5-389cfdbb01a5.png)


In a large window navigating to the page without a `next` button

![Screen Shot 2020-10-26 at 4 36 27 PM](https://user-images.githubusercontent.com/8533851/97239668-6f59cc80-17a9-11eb-8433-9bafee258b03.png)
