### PR TITLE
feat: reserve org slugs to avoid conflict with legal pages

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -175,6 +175,8 @@ RESERVED_PROJECT_SLUGS = frozenset(
         "integrations",
         "developer-settings",
         "usage",
+        "trust",
+        "legal",
     )
 )
 


### PR DESCRIPTION
Legal has requested pages at /legal and /trust so I'm reserving these.