### PR TITLE
feat(metric_alerts): Dedupe actions in the subscription processor. (WOR-134)

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1079,7 +1079,10 @@ def deduplicate_trigger_actions(actions):
     """
     # Make sure we process actions from the critical trigger first
     actions.sort(
-        key=lambda action: 0 if action.alert_rule_trigger.label == CRITICAL_TRIGGER_LABEL else 1
+        key=lambda action: (
+            0 if action.alert_rule_trigger.label == CRITICAL_TRIGGER_LABEL else 1,
+            action.id,
+        )
     )
     deduped = {}
     for action in actions:

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -13,6 +13,7 @@ from sentry import features
 from sentry.incidents.logic import (
     create_incident,
     CRITICAL_TRIGGER_LABEL,
+    deduplicate_trigger_actions,
     update_incident_status,
     WARNING_TRIGGER_LABEL,
 )
@@ -20,6 +21,7 @@ from sentry.incidents.models import (
     AlertRule,
     AlertRuleThresholdType,
     AlertRuleTrigger,
+    AlertRuleTriggerAction,
     Incident,
     IncidentStatus,
     IncidentStatusMethod,
@@ -195,42 +197,49 @@ class SubscriptionProcessor(object):
         alert_operator, resolve_operator = self.THRESHOLD_TYPE_OPERATORS[
             AlertRuleThresholdType(self.alert_rule.threshold_type)
         ]
-        for trigger in self.triggers:
-            if alert_operator(
-                aggregation_value, trigger.alert_threshold
-            ) and not self.check_trigger_status(trigger, TriggerStatus.ACTIVE):
-                metrics.incr("incidents.alert_rules.threshold", tags={"type": "alert"})
-                with transaction.atomic():
-                    self.trigger_alert_threshold(trigger, aggregation_value)
+        fired_incident_triggers = []
+        with transaction.atomic():
+            for trigger in self.triggers:
+                if alert_operator(
+                    aggregation_value, trigger.alert_threshold
+                ) and not self.check_trigger_status(trigger, TriggerStatus.ACTIVE):
+                    metrics.incr("incidents.alert_rules.threshold", tags={"type": "alert"})
+                    incident_trigger = self.trigger_alert_threshold(trigger, aggregation_value)
+                    if incident_trigger is not None:
+                        fired_incident_triggers.append(incident_trigger)
+                else:
+                    self.trigger_alert_counts[trigger.id] = 0
+
+            if (
+                resolve_operator(aggregation_value, self.calculate_resolve_threshold())
+                and self.active_incident
+            ):
+                self.rule_resolve_counts += 1
+                if self.rule_resolve_counts >= self.alert_rule.threshold_period:
+                    # TODO: Make sure we iterate over critical then warning in order.
+                    metrics.incr("incidents.alert_rules.threshold", tags={"type": "resolve"})
+                    for trigger in self.triggers:
+                        if self.check_trigger_status(trigger, TriggerStatus.ACTIVE):
+                            incident_trigger = self.trigger_resolve_threshold(
+                                trigger, aggregation_value
+                            )
+                            if incident_trigger is not None:
+                                fired_incident_triggers.append(incident_trigger)
+
+                    update_incident_status(
+                        self.active_incident,
+                        IncidentStatus.CLOSED,
+                        status_method=IncidentStatusMethod.RULE_TRIGGERED,
+                        date_closed=self.calculate_event_date_from_update_date(self.last_update),
+                    )
+                    self.active_incident = None
+                    self.incident_triggers.clear()
+                    self.rule_resolve_counts = 0
             else:
-                self.trigger_alert_counts[trigger.id] = 0
-
-        if (
-            resolve_operator(aggregation_value, self.calculate_resolve_threshold())
-            and self.active_incident
-        ):
-            self.rule_resolve_counts += 1
-            if self.rule_resolve_counts >= self.alert_rule.threshold_period:
-                # TODO: Make sure we iterate over critical then warning in order.
-                # Potentially also de-dupe actions that are identical. Maybe just
-                # collect all actions, de-dupe and resolve all at once
-                metrics.incr("incidents.alert_rules.threshold", tags={"type": "resolve"})
-                for trigger in self.triggers:
-                    if self.check_trigger_status(trigger, TriggerStatus.ACTIVE):
-                        with transaction.atomic():
-                            self.trigger_resolve_threshold(trigger, aggregation_value)
-
-                update_incident_status(
-                    self.active_incident,
-                    IncidentStatus.CLOSED,
-                    status_method=IncidentStatusMethod.RULE_TRIGGERED,
-                    date_closed=self.calculate_event_date_from_update_date(self.last_update),
-                )
-                self.active_incident = None
-                self.incident_triggers.clear()
                 self.rule_resolve_counts = 0
-        else:
-            self.rule_resolve_counts = 0
+
+            if fired_incident_triggers:
+                self.handle_trigger_actions(fired_incident_triggers, aggregation_value)
 
         # We update the rule stats here after we commit the transaction. This guarantees
         # that we'll never miss an update, since we'll never roll back if the process
@@ -296,7 +305,6 @@ class SubscriptionProcessor(object):
                     status=TriggerStatus.ACTIVE.value,
                 )
             self.handle_incident_severity_update()
-            self.handle_trigger_actions(incident_trigger, metric_value)
             self.incident_triggers[trigger.id] = incident_trigger
 
             # TODO: We should create an audit log, and maybe something that keeps
@@ -306,6 +314,7 @@ class SubscriptionProcessor(object):
             # We now set this threshold to 0. We don't need to count it anymore
             # once we've triggered an incident.
             self.trigger_alert_counts[trigger.id] = 0
+            return incident_trigger
 
     def trigger_resolve_threshold(self, trigger, metric_value):
         """
@@ -317,21 +326,29 @@ class SubscriptionProcessor(object):
         incident_trigger = self.incident_triggers[trigger.id]
         incident_trigger.status = TriggerStatus.RESOLVED.value
         incident_trigger.save()
-        self.handle_trigger_actions(incident_trigger, metric_value)
+        return incident_trigger
 
-    def handle_trigger_actions(self, incident_trigger, metric_value):
+    def handle_trigger_actions(self, incident_triggers, metric_value):
+        # These will all be for the same incident and status, so just grab the first one
+        incident_trigger = incident_triggers[0]
         method = "fire" if incident_trigger.status == TriggerStatus.ACTIVE.value else "resolve"
+        actions = deduplicate_trigger_actions(
+            list(
+                AlertRuleTriggerAction.objects.filter(
+                    alert_rule_trigger__in=[it.alert_rule_trigger for it in incident_triggers]
+                ).select_related("alert_rule_trigger")
+            )
+        )
 
-        for action in incident_trigger.alert_rule_trigger.alertruletriggeraction_set.all():
-            handle_trigger_action.apply_async(
-                kwargs={
-                    "action_id": action.id,
-                    "incident_id": incident_trigger.incident_id,
-                    "project_id": self.subscription.project_id,
-                    "metric_value": metric_value,
-                    "method": method,
-                },
-                countdown=5,
+        for action in actions:
+            transaction.on_commit(
+                handle_trigger_action.s(
+                    action_id=action.id,
+                    incident_id=incident_trigger.incident_id,
+                    project_id=self.subscription.project_id,
+                    metric_value=metric_value,
+                    method=method,
+                ).delay
             )
 
     def handle_incident_severity_update(self):

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -125,7 +125,7 @@ class HandleSnubaQueryUpdateTest(TestCase):
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             with self.assertChanges(
                 lambda: active_incident().exists(), before=False, after=True
-            ), self.tasks():
+            ), self.tasks(), self.capture_on_commit_callbacks(execute=True):
                 consumer.run()
 
         assert len(mail.outbox) == 1


### PR DESCRIPTION
This uses `deduplicate_trigger_actions` from https://github.com/getsentry/sentry/pull/21579 to
dedupe actions in the subscription processor. We'll still need to apply this for manual resolving as
well.

Also fixed an issue with the transactions we use in here - previously we were doing these per
trigger, which seemed unsafe. Moved it out to cover all the triggers at once. I may have done it
like this to avoid starting a transaction when we don't need one, but it shouldn't be a big
performance concern.

Switched the calls to `handle_trigger_action` to use `transaction.on_commit` so that they're more
reliable. Using an arbitrary countdown was never a great solution, and `on_commit` is generally a
better option to use.