### PR TITLE
Fix(similar-issues): Fix Scorebar for new algorithm 

### DIFF
--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -32,7 +32,7 @@ export class Request {
 }
 
 type ParamsType = {
-  itemIds?: Array<number>;
+  itemIds?: Array<number> | Array<string>;
   query?: string;
   environment?: string | null;
   project?: Array<number> | null;

--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -32,7 +32,7 @@ export class Request {
 }
 
 type ParamsType = {
-  itemIds?: Array<number> | Array<string>;
+  itemIds?: Array<number>;
   query?: string;
   environment?: string | null;
   project?: Array<number> | null;

--- a/src/sentry/static/sentry/app/components/similarScoreCard.tsx
+++ b/src/sentry/static/sentry/app/components/similarScoreCard.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
@@ -7,7 +6,6 @@ import space from 'app/styles/space';
 
 const scoreComponents = {
   'exception:message:character-shingles': t('Exception Message'),
-  'exception:stacktrace:application-chunks': t('Application Code'),
   'exception:stacktrace:pairs': t('Stacktrace Frames'),
   'message:message:character-shingles': t('Log Message'),
 };
@@ -25,7 +23,7 @@ const SimilarScoreCard = ({scoreList = []}: Props) => {
   }
 
   return (
-    <div>
+    <React.Fragment>
       {scoreList.map(([key, score]) => (
         <Wrapper key={key}>
           <div>{scoreComponents[key]}</div>
@@ -33,7 +31,7 @@ const SimilarScoreCard = ({scoreList = []}: Props) => {
           <Score score={score === null ? score : Math.round(score * 5)} />
         </Wrapper>
       ))}
-    </div>
+    </React.Fragment>
   );
 };
 
@@ -50,9 +48,5 @@ const Score = styled('div')<{score: Score}>`
   background-color: ${p =>
     p.score === null ? p.theme.similarity.empty : p.theme.similarity.colors[p.score]};
 `;
-
-SimilarScoreCard.propTypes = {
-  scoreList: PropTypes.arrayOf(PropTypes.array),
-};
 
 export default SimilarScoreCard;

--- a/src/sentry/static/sentry/app/stores/groupingStore.tsx
+++ b/src/sentry/static/sentry/app/stores/groupingStore.tsx
@@ -35,7 +35,7 @@ type State = {
   similarItems: [];
   filteredSimilarItems: [];
   similarLinks: string;
-  mergeState: Record<string, any>;
+  mergeState: Map<any, any>;
   mergeList: Array<string>;
   mergedLinks: string;
   mergeDisabled: boolean;
@@ -179,7 +179,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
       similarItems: [],
       filteredSimilarItems: [],
       similarLinks: '',
-      mergeState: {},
+      mergeState: new Map(),
       mergeList: [],
       mergedLinks: '',
       mergeDisabled: false,
@@ -363,7 +363,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
       return;
     }
 
-    if (this.mergedList.includes(id)) {
+    if (this.mergeList.includes(id)) {
       this.mergeList = this.mergeList.filter(item => item !== id);
     } else {
       this.mergeList = [...this.mergeList, id];

--- a/src/sentry/static/sentry/app/stores/groupingStore.tsx
+++ b/src/sentry/static/sentry/app/stores/groupingStore.tsx
@@ -440,7 +440,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
         {
           orgId,
           projectId: projectId || params.projectId,
-          itemIds: [...(ids as any), groupId] as Array<number>,
+          itemIds: [...ids, groupId] as Array<number>,
           query,
         },
         {

--- a/src/sentry/static/sentry/app/stores/groupingStore.tsx
+++ b/src/sentry/static/sentry/app/stores/groupingStore.tsx
@@ -35,8 +35,8 @@ type State = {
   similarItems: [];
   filteredSimilarItems: [];
   similarLinks: string;
-  mergeState: Map<any, any>;
-  mergeList: Set<any>;
+  mergeState: Record<string, any>;
+  mergeList: Array<string>;
   mergedLinks: string;
   mergeDisabled: boolean;
   loading: boolean;
@@ -158,7 +158,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
     });
   },
 
-  getInitialState() {
+  getInitialState(): State {
     return {
       // List of fingerprints that belong to issue
       mergedItems: [],
@@ -175,8 +175,8 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
       similarItems: [],
       filteredSimilarItems: [],
       similarLinks: '',
-      mergeState: new Map(),
-      mergeList: new Set(),
+      mergeState: {},
+      mergeList: [],
       mergedLinks: '',
       mergeDisabled: false,
       loading: true,
@@ -322,10 +322,10 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
       return;
     }
 
-    if (this.mergeList.has(id)) {
-      this.mergeList.delete(id);
+    if (this.mergedList.includes(id)) {
+      this.mergeList = this.mergeList.filter(item => item !== id);
     } else {
-      this.mergeList.add(id);
+      this.mergeList = [...this.mergeList, id];
       checked = true;
     }
 
@@ -422,7 +422,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
       return undefined;
     }
 
-    const ids = Array.from(this.mergeList.values()) as Array<string>;
+    const ids = this.mergeList;
 
     this.mergeDisabled = true;
 
@@ -456,7 +456,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
               checked: false,
               busy: true,
             });
-            this.mergeList.clear();
+            this.mergeList = [];
           },
           error: () => {
             this.setStateForId(this.mergeState, ids, {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -106,27 +106,24 @@ class SimilarStackTrace extends React.Component<Props, State> {
 
   listener = GroupingStore.listen(this.onGroupingChange, undefined);
 
-  getEndpoint(type = 'similar') {
+  fetchData() {
     const {params, location} = this.props;
 
-    const queryParams = {
-      ...location.query,
-      limit: 50,
-      version: this.state.v2 ? '2' : '1',
-    };
-
-    return `/issues/${params.groupId}/${type}/?${queryString.stringify(queryParams)}`;
-  }
-
-  fetchData() {
     this.setState({loading: true, error: false});
 
-    const reqs: Array<{endpoint: string; dataKey: string}> = [];
+    const reqs: Parameters<typeof GroupingStore.onFetch>[0] = [];
 
     if (this.hasSimilarityFeature()) {
+      const version = this.state.v2 ? '2' : '1';
+
       reqs.push({
-        endpoint: this.getEndpoint('similar'),
+        endpoint: `/issues/${params.groupId}/similar/?${queryString.stringify({
+          ...location.query,
+          limit: 50,
+          version,
+        })}`,
         dataKey: 'similar',
+        version: this.state.v2 ? '2' : '1',
       });
     }
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -123,7 +123,7 @@ class SimilarStackTrace extends React.Component<Props, State> {
           version,
         })}`,
         dataKey: 'similar',
-        version: this.state.v2 ? '2' : '1',
+        version,
       });
     }
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
@@ -30,12 +30,12 @@ class SimilarToolbar extends React.Component<Props, State> {
   }
 
   onGroupChange = ({mergeList}) => {
-    if (!mergeList?.size) {
+    if (!mergeList?.length) {
       return;
     }
 
-    if (mergeList.size !== this.state.mergeCount) {
-      this.setState({mergeCount: mergeList.size});
+    if (mergeList.length !== this.state.mergeCount) {
+      this.setState({mergeCount: mergeList.length});
     }
   };
 

--- a/tests/js/spec/stores/groupingStore.spec.jsx
+++ b/tests/js/spec/stores/groupingStore.spec.jsx
@@ -269,7 +269,7 @@ describe('Grouping Store', function () {
     let mergeState;
 
     beforeEach(function () {
-      mergeList = new Set();
+      mergeList = [];
       mergeState = new Map();
       return GroupingStore.onFetch([
         {dataKey: 'similar', endpoint: '/issues/groupId/similar/'},
@@ -281,14 +281,14 @@ describe('Grouping Store', function () {
       it('can check and uncheck item', function () {
         GroupingStore.onToggleMerge('1');
 
-        mergeList.add('1');
+        mergeList = ['1'];
         mergeState.set('1', {checked: true});
         expect(GroupingStore.mergeList).toEqual(mergeList);
         expect(GroupingStore.mergeState).toEqual(mergeState);
 
         // Uncheck
         GroupingStore.onToggleMerge('1');
-        mergeList.delete('1');
+        mergeList = mergeList.filter(item => item !== '1');
         mergeState.set('1', {checked: false});
 
         // Check all
@@ -296,9 +296,7 @@ describe('Grouping Store', function () {
         GroupingStore.onToggleMerge('2');
         GroupingStore.onToggleMerge('3');
 
-        mergeList.add('1');
-        mergeList.add('2');
-        mergeList.add('3');
+        mergeList = ['1', '2', '3'];
         mergeState.set('1', {checked: true});
         mergeState.set('2', {checked: true});
         mergeState.set('3', {checked: true});
@@ -327,7 +325,7 @@ describe('Grouping Store', function () {
       it('disables rows to be merged', async function () {
         trigger.mockReset();
         GroupingStore.onToggleMerge('1');
-        mergeList.add('1');
+        mergeList = ['1'];
         mergeState.set('1', {checked: true});
 
         expect(trigger).toHaveBeenLastCalledWith({
@@ -372,7 +370,7 @@ describe('Grouping Store', function () {
         );
 
         // Should be removed from mergeList after merged
-        mergeList.delete('1');
+        mergeList = mergeList.filter(item => item !== '1');
         mergeState.set('1', {checked: false, busy: true});
         expect(trigger).toHaveBeenLastCalledWith({
           mergeDisabled: false,
@@ -383,7 +381,7 @@ describe('Grouping Store', function () {
 
       it('keeps rows in "busy" state and unchecks after successfully adding to merge queue', async function () {
         GroupingStore.onToggleMerge('1');
-        mergeList.add('1');
+        mergeList = ['1'];
         mergeState.set('1', {checked: true});
 
         // Expect checked
@@ -420,7 +418,7 @@ describe('Grouping Store', function () {
         // After promise, reset checked to false, but keep busy
         expect(trigger).toHaveBeenLastCalledWith({
           mergeDisabled: false,
-          mergeList: new Set(),
+          mergeList: [],
           mergeState,
         });
       });
@@ -435,7 +433,7 @@ describe('Grouping Store', function () {
         });
 
         GroupingStore.onToggleMerge('1');
-        mergeList.add('1');
+        mergeList = ['1'];
         mergeState.set('1', {checked: true});
 
         const promise = GroupingStore.onMerge({

--- a/tests/js/spec/views/organizationGroupDetails/groupSimilarIssues.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupSimilarIssues.spec.jsx
@@ -26,7 +26,6 @@ describe('Issues Similar View', function () {
     {'exception:stacktrace:pairs': 0.01264},
     {'exception:stacktrace:pairs': 0.875},
     {
-      'exception:stacktrace:application-chunks': 0.000235,
       'exception:stacktrace:pairs': 0.001488,
     },
   ];


### PR DESCRIPTION
closes: https://app.asana.com/0/1182975495223914/1198878396381134

In the new algorithm, some keys of the event payload were renamed, breaking the scoreBar graph.

Example:

**Old Algorithm:**

```
exception:message:character-shingles: 0.125
exception:stacktrace:application-chunks: null
exception:stacktrace:pairs: null
message:message:character-shingles: 0.125
```

**New Algorithm:**

```
'similarity:2020-07-23:stacktrace:frames-pairs': 0,
'similarity:2020-07-23:lineno:ident-shingle': null,
'similarity:2020-07-23:frame:frame-ident': null,
'similarity:2020-07-23:function:ident-shingle': null,
'similarity:2020-07-23:symbol:ident-shingle': null,
'similarity:2020-07-23:filename:ident-shingle': null,
'similarity:2020-07-23:module:ident-shingle': null,
'similarity:2020-07-23:type:ident-shingle': 1.0,
'similarity:2020-07-23:stacktrace:frames-ident': null,
'similarity:2020-07-23:message:character-5-shingle': null,
'similarity:2020-07-23:context-line:ident-shingle': null,
'similarity:2020-07-23:fingerprint:ident-shingle': 0,
'similarity:2020-07-23:value:character-5-shingle': 0.0

```


This PR fixes the issue

#sync-getsentry