### PR TITLE
fix(vercel): line wrap for mapped value

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -138,11 +138,9 @@ export class RenderField extends React.Component<RenderProps, State> {
                 <IntegrationIconWrapper>{getIcon(iconType)}</IntegrationIconWrapper>
                 <MappedValueLabel>{mappedItem.label}</MappedValueLabel>
                 <ExternalLinkWrapper>
-                  <InnerLinkWrapper>
-                    <StyledExternalLink href={mappedItem.url}>
-                      <IconOpen />
-                    </StyledExternalLink>
-                  </InnerLinkWrapper>
+                  <StyledExternalLink href={mappedItem.url}>
+                    <IconOpen />
+                  </StyledExternalLink>
                 </ExternalLinkWrapper>
               </React.Fragment>
             ) : (
@@ -365,14 +363,10 @@ const StyledInputField = styled(InputField)`
 `;
 
 const ExternalLinkWrapper = styled('div')`
-  width: 100%;
-`;
-
-const InnerLinkWrapper = styled('div')`
   height: 100%;
-  float: right;
   display: flex;
   align-items: center;
+  margin-left: ${space(0.5)};
 `;
 
 const StyledExternalLink = styled(ExternalLink)``;


### PR DESCRIPTION
I realize some of the styling changes I merged yesterday (https://github.com/getsentry/sentry/pull/21602) look bad in a large view. The mapped value wraps when it doesn't need to. So I tweaked some of the stylings. The external link arrow is no longer right aligned but I think that's OK:

Before:
![Screen Shot 2020-10-27 at 9 28 06 AM](https://user-images.githubusercontent.com/8533851/97331942-294b4a00-1837-11eb-8b9d-5250d0688ac4.png)

After:
![Screen Shot 2020-10-27 at 9 30 21 AM](https://user-images.githubusercontent.com/8533851/97331953-2b150d80-1837-11eb-8b5d-00936607c861.png)
