### PR TITLE
feat(vercel): more styling changes for popup

### DIFF
--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -325,7 +325,7 @@ const iconSizes = {
 };
 
 const theme = {
-  breakpoints: ['768px', '992px', '1200px', '1440px', '2560px'],
+  breakpoints: ['800px', '992px', '1200px', '1440px', '2560px'],
 
   ...colors,
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -11,7 +11,7 @@ import {ProjectMapperType} from 'app/views/settings/components/forms/type';
 import SelectControl from 'app/components/forms/selectControl';
 import IdBadge from 'app/components/idBadge';
 import Button from 'app/components/button';
-import {IconVercel, IconGeneric, IconDelete, IconOpen} from 'app/icons';
+import {IconVercel, IconGeneric, IconDelete, IconOpen, IconAdd} from 'app/icons';
 import ExternalLink from 'app/components/links/externalLink';
 import {t} from 'app/locale';
 import {removeAtArrayIndex} from 'app/utils/removeAtArrayIndex';
@@ -205,7 +205,7 @@ export class RenderField extends React.Component<RenderProps, State> {
       return (
         <components.ValueContainer {...containerProps}>
           <IntegrationIconWrapper>{getIcon(iconType)}</IntegrationIconWrapper>
-          {mappedValue.label}
+          <OptionLabelWrapper>{mappedValue.label}</OptionLabelWrapper>
         </components.ValueContainer>
       );
     };
@@ -215,7 +215,7 @@ export class RenderField extends React.Component<RenderProps, State> {
         <components.Option {...optionProps}>
           <OptionWrapper>
             <IntegrationIconWrapper>{getIcon(iconType)}</IntegrationIconWrapper>
-            {optionProps.label}
+            <OptionLabelWrapper>{optionProps.label}</OptionLabelWrapper>
           </OptionWrapper>
         </components.Option>
       );
@@ -249,15 +249,16 @@ export class RenderField extends React.Component<RenderProps, State> {
             onChange={handleSelectMappedValue}
             value={selectedMappedValue}
           />
-          <StyledAddProjectButton
-            type="button"
-            disabled={!selectedSentryProjectId || !selectedMappedValue}
-            size="small"
-            priority="primary"
-            onClick={handleAdd}
-          >
-            {t('Add Project')}
-          </StyledAddProjectButton>
+          <AddProjectWrapper>
+            <StyledAddProjectButton
+              type="button"
+              disabled={!selectedSentryProjectId || !selectedMappedValue}
+              size="small"
+              priority="primary"
+              onClick={handleAdd}
+              icon={<IconAdd />}
+            />
+          </AddProjectWrapper>
           <FieldControlWrapper>
             {formElementId && (
               <div>
@@ -344,6 +345,14 @@ const StyledIdBadge = styled(IdBadge)``;
 const IntegrationIconWrapper = styled('span')`
   display: flex;
   align-items: center;
+`;
+
+const AddProjectWrapper = styled('div')`
+  grid-area: add-project;
+`;
+
+const OptionLabelWrapper = styled('div')`
+  margin-left: ${space(0.5)};
 `;
 
 const StyledAddProjectButton = styled(Button)`


### PR DESCRIPTION
This PR is a followup from the one merged yesterday (https://github.com/getsentry/sentry/pull/21602) to clean up the UI for Vecel. The major change is the breakpoint change but I needed to make some other syling changes.

This PR does the following:
1. Increase the smallest breakpoint to `800px` so the left sidebar collapses for the default size of the Vercel installation popup.
2. Switch "add" button to an icon so that we don't have to worry about wrapping button text
3. Fix the spacing of the text and icon in the mapped value 

I would have split the changes up but time is limited before Cramer is up in the Nextjs conference.

Before:

![Screen Shot 2020-10-27 at 10 15 20 AM](https://user-images.githubusercontent.com/8533851/97337286-56026000-183d-11eb-86e6-c21e45701455.png)

After:

![Screen Shot 2020-10-27 at 10 09 51 AM](https://user-images.githubusercontent.com/8533851/97337225-3ec37280-183d-11eb-842f-33622bde84fc.png)

