### PR TITLE
fix(integrations): adds justify-content center for integration logo

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.tsx
@@ -52,6 +52,7 @@ const Labels = styled('div')<StyledProps>`
   flex-direction: ${p => (p.compact ? 'row' : 'column')};
   padding-left: ${space(1)};
   min-width: 0;
+  justify-content: center;
 `;
 
 const IntegrationName = styled('div')`


### PR DESCRIPTION
Before:
![Screen Shot 2020-10-27 at 10 29 03 AM](https://user-images.githubusercontent.com/8533851/97339280-9e228200-183f-11eb-81ed-df563b83ad2e.png)

After:
![Screen Shot 2020-10-27 at 10 32 24 AM](https://user-images.githubusercontent.com/8533851/97339443-d2963e00-183f-11eb-857e-30e30c782322.png)
