### PR TITLE
fix(vitals): The beta alert for vitals should take up the whole row

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/header.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/header.tsx
@@ -140,14 +140,14 @@ class TransactionHeader extends React.Component<Props> {
             return (
               <React.Fragment>
                 {currentTab === Tab.RealUserMonitoring && (
-                  <Alert type="info" icon={<IconInfo size="md" />}>
+                  <StyledAlert type="info" icon={<IconInfo size="md" />}>
                     {t(
                       "Web vitals is a new beta feature for organizations who have turned on Early Adopter in their account settings. We'd love to hear any feedback you have at"
                     )}{' '}
                     <ExternalLink href="mailto:performance-feedback@sentry.io">
                       performance-feedback@sentry.io
                     </ExternalLink>
-                  </Alert>
+                  </StyledAlert>
                 )}
                 <StyledNavTabs>
                   <ListLink
@@ -174,6 +174,11 @@ class TransactionHeader extends React.Component<Props> {
     );
   }
 }
+
+const StyledAlert = styled(Alert)`
+  /* Makes sure the alert is pushed into another row */
+  width: 100%;
+`;
 
 const StyledNavTabs = styled(NavTabs)`
   margin-bottom: 0;


### PR DESCRIPTION
The beta alert for vitals may move up to the same row as the title and header
actions on large viewports. This ensures that it stays in its own row.

# Before:
![image](https://user-images.githubusercontent.com/10239353/97340086-b99a8680-1859-11eb-9fe7-968b35611b5d.png)

# After:
![image](https://user-images.githubusercontent.com/10239353/97340156-ce771a00-1859-11eb-9d9d-c67c7f74d8ed.png)
