### PR TITLE
build(gha): Create an explicit backend path filter

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -16,7 +16,7 @@ frontend:
 
 backend:
   - '**/*.py'
-  - 'src/sentry/templates'
+  - 'src/sentry/!(static)/**'
   - 'requirements-*.txt'
   - 'migrations_lockfile.txt'
   - '.python-version'

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -2,11 +2,6 @@
 
 # TODO: There are some meta files that we potentially could ignore for both front/backend,
 # as well as some configuration files that should trigger both
-
-# For now we can infer that "backend == !frontend"
-# We do this because frontend sources are a bit more well defined than backend and
-# the scope is a bit smaller. e.g. by simply doing a filter on python files (*.py)
-# would miss the django templates
 frontend:
   - '**/*.[tj]{s,sx}'
   - '**/*.less'
@@ -17,3 +12,12 @@ frontend:
   - 'docs-ui/**'
   - 'src/sentry/static/sentry/**'
   - 'tests/js/**'
+  - '.github/workflows/javascript*.yml'
+
+backend:
+  - '**/*.py'
+  - 'src/sentry/templates'
+  - 'requirements-*.txt'
+  - 'migrations_lockfile.txt'
+  - '.python-version'
+  - '.github/workflows/!(javascript*)'

--- a/.github/workflows/acceptance-py3.6.yml
+++ b/.github/workflows/acceptance-py3.6.yml
@@ -42,24 +42,24 @@ jobs:
 
       - name: Set python version output
         id: python-version
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           echo "::set-output name=python-version::$(awk 'FNR == 2' .python-version)"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python-version: ${{ steps.python-version.outputs.python-version }}
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
         id: pip
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
 
       - name: pip cache
         uses: actions/cache@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
@@ -69,7 +69,7 @@ jobs:
       - name: Setup sentry python env
         uses: ./.github/actions/setup-sentry
         id: setup
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python: 3
           snuba: true
@@ -77,7 +77,7 @@ jobs:
       - name: yarn cache
         uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           path: ${{ steps.setup.outputs.yarn-cache-dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -85,17 +85,17 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Javascript Dependencies
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           yarn install --frozen-lockfile
 
       - name: webpack
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           yarn webpack --display errors-only
 
       - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           mkdir -p ${{ steps.setup.outputs.acceptance-dir }}
           mkdir -p ${{ steps.setup.outputs.acceptance-dir }}-mobile

--- a/.github/workflows/backend-test-py2.7.yml
+++ b/.github/workflows/backend-test-py2.7.yml
@@ -38,18 +38,18 @@ jobs:
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python-version: 2.7.17
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
         id: pip
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
 
       - name: pip cache
         uses: actions/cache@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
@@ -59,13 +59,13 @@ jobs:
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python: 2
           snuba: true
 
       - name: Run backend test [py2.7] (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           # Note: `USE_SNUBA` is not used for backend tests because there are a few failing tests with Snuba enabled.
           unset USE_SNUBA

--- a/.github/workflows/backend-test-py3.6.yml
+++ b/.github/workflows/backend-test-py3.6.yml
@@ -38,24 +38,24 @@ jobs:
 
       - name: Set python version output
         id: python-version
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           echo "::set-output name=python-version::$(awk 'FNR == 2' .python-version)"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python-version: ${{ steps.python-version.outputs.python-version }}
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         id: pip
 
       - name: pip cache
         uses: actions/cache@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
@@ -64,14 +64,14 @@ jobs:
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         id: setup
         with:
           python: 3
           snuba: true
 
       - name: Run backend test [py3.6] (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           # Note: `USE_SNUBA` is not used for backend tests because there are a few failing tests with Snuba enabled.
           unset USE_SNUBA

--- a/.github/workflows/command-line-test.yml
+++ b/.github/workflows/command-line-test.yml
@@ -23,18 +23,18 @@ jobs:
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python-version: 2.7.17
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
         id: pip
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
 
       - name: pip cache
         uses: actions/cache@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
@@ -44,11 +44,11 @@ jobs:
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python: 2
 
       - name: Run test
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           make test-cli

--- a/.github/workflows/relay-integration-test.yml
+++ b/.github/workflows/relay-integration-test.yml
@@ -23,18 +23,18 @@ jobs:
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python-version: 2.7.17
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
         id: pip
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
 
       - name: pip cache
         uses: actions/cache@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
@@ -44,20 +44,20 @@ jobs:
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python: 2
           snuba: true
           kafka: true
 
       - name: Pull relay image
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           # pull relay we'll run and kill it for each test
           docker pull us.gcr.io/sentryio/relay:latest
           docker ps -a
 
       - name: Run test
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           make test-relay-integration

--- a/.github/workflows/snuba-integration-test-py2.7.yml
+++ b/.github/workflows/snuba-integration-test-py2.7.yml
@@ -39,18 +39,18 @@ jobs:
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python-version: 2.7.17
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
         id: pip
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
 
       - name: pip cache
         uses: actions/cache@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
@@ -60,13 +60,13 @@ jobs:
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python: 2
           snuba: true
           kafka: true
 
       - name: Run snuba test [py2.7] (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           make travis-test-snuba

--- a/.github/workflows/snuba-integration-test-py3.6.yml
+++ b/.github/workflows/snuba-integration-test-py3.6.yml
@@ -39,24 +39,24 @@ jobs:
 
       - name: Set python version output
         id: python-version
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           echo "::set-output name=python-version::$(awk 'FNR == 2' .python-version)"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python-version: ${{ steps.python-version.outputs.python-version }}
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         id: pip
 
       - name: pip cache
         uses: actions/cache@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         id: setup
         with:
           python: 3
@@ -73,6 +73,6 @@ jobs:
           kafka: true
 
       - name: Run snuba test [py3.6] (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           make travis-test-snuba

--- a/.github/workflows/symbolicator-integration-test.yml
+++ b/.github/workflows/symbolicator-integration-test.yml
@@ -23,18 +23,18 @@ jobs:
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python-version: 2.7.17
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
         id: pip
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
 
       - name: pip cache
         uses: actions/cache@v2
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
@@ -44,14 +44,14 @@ jobs:
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         with:
           python: 2
           snuba: true
           kafka: true
 
       - name: Start symbolicator
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           echo $PWD
           docker run \
@@ -64,6 +64,6 @@ jobs:
           docker ps -a
 
       - name: Run test
-        if: steps.changes.outputs.frontend == 'false'
+        if: steps.changes.outputs.backend == 'true'
         run: |
           make test-symbolicator


### PR DESCRIPTION
We had a bad assumption that matching frontend change means not a backend change. This does not work if there is both a frontend and backend change.