### PR TITLE
chore(trends): Rename t score to t test

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -2060,7 +2060,7 @@ FUNCTIONS = {
         ),
         # Calculate the Welch's t-test value, this is used to help identify which of our trends are significant or not
         Function(
-            "t_score",
+            "t_test",
             required_args=[
                 FunctionArg("avg_1"),
                 FunctionArg("avg_2"),
@@ -2072,7 +2072,7 @@ FUNCTIONS = {
             aggregate=[
                 u"divide(minus({avg_1},{avg_2}),sqrt(plus(divide({variance_1},{count_1}),divide({variance_2},{count_2}))))",
                 None,
-                "t_score",
+                "t_test",
             ],
             default_result_type="number",
         ),

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -418,11 +418,11 @@ function getLimitTransactionItems(
   trendChangeType: TrendChangeType,
   confidenceLevel: ConfidenceLevel
 ) {
-  let limitQuery = `trend_percentage():<1 t_score():>${confidenceLevel.min}`;
-  limitQuery += confidenceLevel.max ? ` t_score():<=${confidenceLevel.max}` : '';
+  let limitQuery = `trend_percentage():<1 t_test():>${confidenceLevel.min}`;
+  limitQuery += confidenceLevel.max ? ` t_test():<=${confidenceLevel.max}` : '';
   if (trendChangeType === TrendChangeType.REGRESSION) {
-    limitQuery = `trend_percentage():>1 t_score():<-${confidenceLevel.min}`;
-    limitQuery += confidenceLevel.max ? ` t_score():>=-${confidenceLevel.max}` : '';
+    limitQuery = `trend_percentage():>1 t_test():<-${confidenceLevel.min}`;
+    limitQuery += confidenceLevel.max ? ` t_test():>=-${confidenceLevel.max}` : '';
   }
   limitQuery +=
     ' percentage(count_range_2,count_range_1):>0.5 percentage(count_range_2,count_range_1):<2';


### PR DESCRIPTION
- This is to be more consistent with documentation
- t-score, t-test, t-stat etc. are all valid and there doesn't seem to be a consistent naming for this function. But t-test seems to be the most popular.