### PR TITLE
ref(vercel): Tighten up the configuration interface

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -67,9 +67,6 @@ external_install = {
 
 
 configure_integration = {"title": _("Connect Your Projects")}
-connect_project_instruction = _(
-    "To complete installation, please connect your Sentry and Vercel projects."
-)
 create_project_instruction = _("Don't have a project yet? Click [here]({}) to create one.")
 install_source_code_integration = _(
     "Install a [source code integration]({}) and configure your repositories."
@@ -120,7 +117,6 @@ class VercelIntegration(IntegrationInstallation):
         return {
             "configure_integration": {
                 "instructions": [
-                    connect_project_instruction,
                     create_project_instruction.format(add_project_link),
                     install_source_code_integration.format(source_code_link),
                 ]
@@ -195,7 +191,13 @@ class VercelIntegration(IntegrationInstallation):
                     "placeholder": _("Vercel project..."),
                 },
                 "sentryProjects": sentry_projects,
-                "nextButton": {"allowedDomain": "https://vercel.com", "text": _("To Vercel")},
+                "nextButton": {
+                    "allowedDomain": "https://vercel.com",
+                    "description": _(
+                        "Link your Sentry projects to complete your installation on Vercel"
+                    ),
+                    "text": _("Complete on Vercel"),
+                },
                 "iconType": "vercel",
                 "manageUrl": manage_url,
             }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -11,11 +11,19 @@ import {ProjectMapperType} from 'app/views/settings/components/forms/type';
 import SelectControl from 'app/components/forms/selectControl';
 import IdBadge from 'app/components/idBadge';
 import Button from 'app/components/button';
-import {IconVercel, IconGeneric, IconDelete, IconOpen, IconAdd} from 'app/icons';
+import {
+  IconVercel,
+  IconGeneric,
+  IconDelete,
+  IconOpen,
+  IconAdd,
+  IconArrow,
+} from 'app/icons';
 import ExternalLink from 'app/components/links/externalLink';
 import {t} from 'app/locale';
 import {removeAtArrayIndex} from 'app/utils/removeAtArrayIndex';
 import {safeGetQsParam} from 'app/utils/integrationUtil';
+import {PanelAlert} from 'app/components/panels';
 
 type MappedValue = string | number;
 
@@ -47,7 +55,7 @@ export class RenderField extends React.Component<RenderProps, State> {
       value: incomingValues,
       sentryProjects,
       mappedDropdown: {items: mappedDropdownItems, placeholder: mappedValuePlaceholder},
-      nextButton: {text: nextButtonText, allowedDomain},
+      nextButton: {text: nextButtonText, description: nextDescription, allowedDomain},
       iconType,
       model,
       id: formElementId,
@@ -120,35 +128,34 @@ export class RenderField extends React.Component<RenderProps, State> {
       const mappedItem = mappedItemsByValue[mappedValue];
       return (
         <Item key={index}>
-          <SentryProjectValue>
+          <MappedProjectWrapper>
             {project ? (
-              <StyledIdBadge
+              <IdBadge
                 project={project}
                 avatarSize={20}
                 displayName={project.slug}
                 avatarProps={{consistentWidth: true}}
               />
             ) : (
-              <ItemValue>{t('Deleted')}</ItemValue>
+              t('Deleted')
             )}
-          </SentryProjectValue>
+            <IconArrow size="xs" direction="right" />
+          </MappedProjectWrapper>
           <MappedItemValue>
             {mappedItem ? (
               <React.Fragment>
                 <IntegrationIconWrapper>{getIcon(iconType)}</IntegrationIconWrapper>
-                <MappedValueLabel>{mappedItem.label}</MappedValueLabel>
-                <ExternalLinkWrapper>
-                  <StyledExternalLink href={mappedItem.url}>
-                    <IconOpen />
-                  </StyledExternalLink>
-                </ExternalLinkWrapper>
+                {mappedItem.label}
+                <StyledExternalLink href={mappedItem.url}>
+                  <IconOpen size="xs" />
+                </StyledExternalLink>
               </React.Fragment>
             ) : (
               t('Deleted')
             )}
           </MappedItemValue>
           <DeleteButtonWrapper>
-            <DeleteButton
+            <Button
               onClick={() => handleDelete(index)}
               icon={<IconDelete color="gray500" />}
               size="small"
@@ -225,7 +232,7 @@ export class RenderField extends React.Component<RenderProps, State> {
       <React.Fragment>
         {existingValues.map(renderItem)}
         <Item>
-          <StyledProjectSelectControl
+          <SelectControl
             placeholder={t('Sentry project\u2026')}
             name="project"
             openMenuOnFocus
@@ -237,7 +244,7 @@ export class RenderField extends React.Component<RenderProps, State> {
             onChange={handleSelectProject}
             value={selectedSentryProjectId}
           />
-          <MappedValueSelectControl
+          <SelectControl
             placeholder={mappedValuePlaceholder}
             name="mappedDropdown"
             openMenuOnFocus
@@ -250,7 +257,7 @@ export class RenderField extends React.Component<RenderProps, State> {
             value={selectedMappedValue}
           />
           <AddProjectWrapper>
-            <StyledAddProjectButton
+            <Button
               type="button"
               disabled={!selectedSentryProjectId || !selectedMappedValue}
               size="small"
@@ -267,20 +274,23 @@ export class RenderField extends React.Component<RenderProps, State> {
               </div>
             )}
           </FieldControlWrapper>
-          {nextUrl && (
-            <StyledNextButtonWrapper>
-              <StyledNextButton
+        </Item>
+        {nextUrl && (
+          <NextButtonPanelAlert icon={false} type="muted">
+            <NextButtonWrapper>
+              {nextDescription ?? ''}
+              <Button
                 type="button"
                 size="small"
-                priority="default"
-                icon={<IconOpen />}
+                priority="primary"
+                icon={<IconOpen size="xs" color="white" />}
                 href={nextUrl}
               >
                 {nextButtonText}
-              </StyledNextButton>
-            </StyledNextButtonWrapper>
-          )}
-        </Item>
+              </Button>
+            </NextButtonWrapper>
+          </NextButtonPanelAlert>
+        )}
       </React.Fragment>
     );
   }
@@ -299,48 +309,40 @@ const ProjectMapperField = (props: Props) => (
 
 export default ProjectMapperField;
 
-const StyledProjectSelectControl = styled(SelectControl)`
-  grid-area: sentry-project;
-`;
-
-const MappedValueSelectControl = styled(SelectControl)`
-  grid-area: mapped-value;
+const MappedProjectWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-right: ${space(1)};
 `;
 
 const Item = styled('div')`
-  margin: -1px;
-  border: 1px solid ${p => p.theme.gray400};
   min-height: 60px;
-  padding: ${space(1)};
+  padding: ${space(2)};
+
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.borderLight};
+  }
 
   display: grid;
   grid-column-gap: ${space(1)};
   align-items: center;
-  grid-template-columns: 2.5fr 2.5fr 0.8fr 0.3fr 1.1fr;
-  grid-template-areas: 'sentry-project mapped-value add-project field-control right-button';
+  grid-template-columns: 2.5fr 2.5fr max-content 30px;
+  grid-template-areas: 'sentry-project mapped-value manage-project field-control';
 `;
 
-const ItemValue = styled('div')``;
-
 const MappedItemValue = styled('div')`
-  display: flex;
-  grid-area: mapped-value;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  align-items: center;
+  grid-gap: ${space(1)};
   width: 100%;
 `;
 
-const SentryProjectValue = styled('div')`
-  grid-area: sentry-project;
-`;
-
 const DeleteButtonWrapper = styled('div')`
-  grid-area: right-button;
+  grid-area: manage-project;
 `;
-
-const DeleteButton = styled(Button)`
-  float: right;
-`;
-
-const StyledIdBadge = styled(IdBadge)``;
 
 const IntegrationIconWrapper = styled('span')`
   display: flex;
@@ -348,40 +350,19 @@ const IntegrationIconWrapper = styled('span')`
 `;
 
 const AddProjectWrapper = styled('div')`
-  grid-area: add-project;
+  grid-area: manage-project;
 `;
 
 const OptionLabelWrapper = styled('div')`
   margin-left: ${space(0.5)};
 `;
 
-const StyledAddProjectButton = styled(Button)`
-  float: right;
-`;
-
-const StyledNextButtonWrapper = styled('div')`
-  grid-area: right-button;
-`;
-
-const StyledNextButton = styled(Button)`
-  grid-area: right-button;
-`;
-
 const StyledInputField = styled(InputField)`
   padding: 0;
 `;
 
-const ExternalLinkWrapper = styled('div')`
-  height: 100%;
+const StyledExternalLink = styled(ExternalLink)`
   display: flex;
-  align-items: center;
-  margin-left: ${space(0.5)};
-`;
-
-const StyledExternalLink = styled(ExternalLink)``;
-
-const MappedValueLabel = styled('span')`
-  margin-left: ${space(0.5)};
 `;
 
 const OptionWrapper = styled('div')`
@@ -392,6 +373,20 @@ const OptionWrapper = styled('div')`
 const FieldControlWrapper = styled('div')`
   position: relative;
   grid-area: field-control;
+`;
+
+const NextButtonPanelAlert = styled(PanelAlert)`
+  align-items: center;
+  margin-bottom: -1px;
+  border-bottom-left-radius: ${p => p.theme.borderRadius};
+  border-bottom-right-radius: ${p => p.theme.borderRadius};
+`;
+
+const NextButtonWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  grid-gap: ${space(1)};
+  align-items: center;
 `;
 
 const StyledFieldErrorReason = styled(FieldErrorReason)``;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -149,6 +149,7 @@ export type ProjectMapperType = {
   sentryProjects: Array<AvatarProject & {id: number; name: string}>;
   nextButton: {
     text: string; //url comes from the `next` parameter in the QS
+    description?: string;
     allowedDomain: string;
   };
   iconType: string;

--- a/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -7,7 +7,7 @@ import AsyncView from 'app/views/asyncView';
 import AddIntegration from 'app/views/organizationIntegrations/addIntegration';
 import BreadcrumbTitle from 'app/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import Button from 'app/components/button';
-import {IconAdd} from 'app/icons';
+import {IconAdd, IconArrow} from 'app/icons';
 import Form from 'app/views/settings/components/forms/form';
 import IntegrationAlertRules from 'app/views/organizationIntegrations/integrationAlertRules';
 import IntegrationItem from 'app/views/organizationIntegrations/integrationItem';
@@ -21,6 +21,8 @@ import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 import {singleLineRenderer} from 'app/utils/marked';
 import Alert from 'app/components/alert';
 import NavTabs from 'app/components/navTabs';
+import List from 'app/components/list';
+import ListItem from 'app/components/list/listItem';
 
 type RouteParams = {
   orgId: string;
@@ -114,6 +116,9 @@ class ConfigureIntegration extends AsyncView<Props, State> {
     const {orgId} = this.props.params;
     const {integration} = this.state;
 
+    const instructions =
+      integration.dynamicDisplayInformation?.configure_integration?.instructions;
+
     return (
       <React.Fragment>
         <BreadcrumbTitle routes={this.props.routes} title={integration.provider.name} />
@@ -137,12 +142,24 @@ class ConfigureIntegration extends AsyncView<Props, State> {
           </Form>
         )}
 
-        {integration.dynamicDisplayInformation?.configure_integration?.instructions.map(
-          (instruction, i) => (
-            <Alert type="info" key={i}>
-              <span dangerouslySetInnerHTML={{__html: singleLineRenderer(instruction)}} />
-            </Alert>
-          )
+        {instructions && instructions.length > 0 && (
+          <Alert type="info">
+            {instructions?.length === 1 ? (
+              <span
+                dangerouslySetInnerHTML={{__html: singleLineRenderer(instructions[0])}}
+              />
+            ) : (
+              <List symbol={<IconArrow size="xs" direction="right" />}>
+                {instructions?.map((instruction, i) => (
+                  <ListItem key={i}>
+                    <span
+                      dangerouslySetInnerHTML={{__html: singleLineRenderer(instruction)}}
+                    />
+                  </ListItem>
+                )) ?? []}
+              </List>
+            )}
+          </Alert>
         )}
 
         {provider.features.includes('alert-rule') && (

--- a/tests/js/spec/components/forms/projectMapperField.spec.jsx
+++ b/tests/js/spec/components/forms/projectMapperField.spec.jsx
@@ -44,7 +44,7 @@ describe('ProjectMapperField', () => {
     selectByValue(wrapper, '24', {control: true, name: 'project'});
     selectByValue(wrapper, '1', {control: true, name: 'mappedDropdown'});
 
-    wrapper.find('StyledAddProjectButton').simulate('click');
+    wrapper.find('AddProjectWrapper Button').simulate('click');
 
     expect(onBlur).toHaveBeenCalledWith(
       [
@@ -68,7 +68,7 @@ describe('ProjectMapperField', () => {
       ['24', '1'],
     ];
     wrapper = mountWithTheme(<RenderField {...props} value={existingValues} />);
-    wrapper.find('DeleteButton').first().simulate('click');
+    wrapper.find('Button[aria-label="Delete"]').first().simulate('click');
 
     expect(onBlur).toHaveBeenCalledWith([['24', '1']], []);
     expect(onChange).toHaveBeenCalledWith([['24', '1']], []);


### PR DESCRIPTION
Lots of minor tweaks to the vercel integration flow

 * Move's the "To vercel" button into a panel alert under the controls, including adding a new description text informing the user to continue back to vercel.

   This is an improvment since before it was unclear what the 'To Vercel' button was for or why you would need to click it.

 * Fixed various alignment and spacing / padding. The form and previous mapping entries will now line up on a grid

 * Merged the installation instructions into a single info box when there are multiple.

Before

![image](https://user-images.githubusercontent.com/1421724/97359935-c370b980-185a-11eb-922c-30817e39d5bd.png)

After

![image](https://user-images.githubusercontent.com/1421724/97359207-a12a6c00-1859-11eb-9294-300a07333434.png)
