### PR TITLE
build(gha): Change frontend workflows to always run

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -12,7 +12,7 @@ frontend:
   - 'docs-ui/**'
   - 'src/sentry/static/sentry/**'
   - 'tests/js/**'
-  # - '.github/workflows/js-*.yml'
+  - '.github/workflows/js-*.yml'
 
 backend:
   - '**/*.py'
@@ -20,4 +20,4 @@ backend:
   - 'requirements-*.txt'
   - 'migrations_lockfile.txt'
   - '.python-version'
-  # - '.github/workflows/!(js-*)'
+  - '.github/workflows/!(js-*)'

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -20,4 +20,4 @@ backend:
   - 'requirements-*.txt'
   - 'migrations_lockfile.txt'
   - '.python-version'
-  - '.github/workflows/!(js-*)'
+  # - '.github/workflows/!(js-*)'

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -12,7 +12,7 @@ frontend:
   - 'docs-ui/**'
   - 'src/sentry/static/sentry/**'
   - 'tests/js/**'
-  - '.github/workflows/javascript*.yml'
+  # - '.github/workflows/js-*.yml'
 
 backend:
   - '**/*.py'
@@ -20,4 +20,4 @@ backend:
   - 'requirements-*.txt'
   - 'migrations_lockfile.txt'
   - '.python-version'
-  - '.github/workflows/!(javascript*)'
+  - '.github/workflows/!(js-*)'

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -1,45 +1,16 @@
-name: javascript
+name: js build and lint
 
 on:
+  # Only runs webpack on master to save bundle size info into artifacts
+  # which are then used on PRs to compare against
   push:
     branches:
       - master
   pull_request:
-    paths:
-      - '**.[tj]sx?'
-      - package.json
-      - yarn.lock
 
 jobs:
-  getsentry:
-    if: ${{ github.ref != 'refs/heads/master' }}
-    runs-on: ubuntu-16.04
-    steps:
-      - name: getsentry token
-        id: getsentry
-        uses: getsentry/action-github-app-token@v1
-        with:
-          app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
-          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
-
-      # Notify getsentry
-      - name: Dispatch getsentry tests
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ steps.getsentry.outputs.token }}
-          script: |
-            github.actions.createWorkflowDispatch({
-              owner: 'getsentry',
-              repo: 'getsentry',
-              workflow_id: 'javascript.yml',
-              ref: 'master',
-              inputs: {
-                'sentry-sha': '${{ github.event.pull_request.head.sha }}',
-              }
-            })
-
-  build:
-    name: lint and typescript
+  ts-and-lint:
+    name: typescript and lint
     if: ${{ github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-16.04
     steps:

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -62,7 +62,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: tsc
-        if: steps.changes.outputs.frontend == 'true' && always()
+        if: steps.changes.outputs.frontend == 'true'
         run: |
           yarn tsc -p config/tsconfig.build.json
 

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 jobs:
-  ts-and-lint:
+  typescript-and-lint:
     name: typescript and lint
     if: ${{ github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-16.04

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -16,15 +16,26 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Check for frontend file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+
       - uses: volta-cli/action@v1
+        if: steps.changes.outputs.frontend == 'true'
 
       # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
+        if: steps.changes.outputs.frontend == 'true'
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        if: steps.changes.outputs.frontend == 'true'
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -32,11 +43,13 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install dependencies
+        if: steps.changes.outputs.frontend == 'true'
         run: yarn install --frozen-lockfile
 
       # Setup custom tsc matcher, see https://github.com/actions/setup-node/issues/97
       - name: setup matchers
         id: matchers
+        if: steps.changes.outputs.frontend == 'true'
         run: |
           echo "::remove-matcher owner=masters::"
           echo "::add-matcher::.github/tsc.json"
@@ -44,11 +57,12 @@ jobs:
 
       - name: eslint + fix
         uses: getsentry/action-eslint-fix@v2
+        if: steps.changes.outputs.frontend == 'true'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: tsc
-        if: always()
+        if: steps.changes.outputs.frontend == 'true' && always()
         run: |
           yarn tsc -p config/tsconfig.build.json
 
@@ -57,15 +71,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Check for frontend file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
       - uses: volta-cli/action@v1
+        if: steps.changes.outputs.frontend == 'true'
 
       # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
+        if: steps.changes.outputs.frontend == 'true'
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        if: steps.changes.outputs.frontend == 'true'
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -73,9 +97,11 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install dependencies
+        if: steps.changes.outputs.frontend == 'true'
         run: yarn install --frozen-lockfile
 
       - uses: getsentry/size-limit-action@v1-dev
+        if: steps.changes.outputs.frontend == 'true'
         with:
           main_branch: master
           skip_step: install

--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -9,6 +9,8 @@ jobs:
     name: frontend dispatch
     runs-on: ubuntu-16.04
     steps:
+      - use: actions/checkout@v2
+
       - name: Check for frontend file changes
         uses: getsentry/paths-filter@v2
         id: changes

--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -21,7 +21,6 @@ jobs:
       - name: getsentry token
         uses: getsentry/action-github-app-token@v1
         id: getsentry
-        if: steps.changes.outputs.frontend == 'true'
         with:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
@@ -29,7 +28,6 @@ jobs:
       # Notify getsentry only if there were frontend files changed
       - name: Dispatch getsentry frontend tests
         uses: actions/github-script@v3
-        if: steps.changes.outputs.frontend == 'true'
         with:
           github-token: ${{ steps.getsentry.outputs.token }}
           script: |

--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -37,7 +37,7 @@ jobs:
               workflow_id: 'javascript.yml',
               ref: 'build/gha/allow-javascript-tests-to-be-skipped',
               inputs: {
-                'skip': "${{ steps.changes.outputs.frontend == 'true' }}",
+                'skip': "${{ steps.changes.outputs.frontend != 'true' }}",
                 'sentry-sha': '${{ github.event.pull_request.head.sha }}',
               }
             })

--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -1,0 +1,43 @@
+# If frontend files change, dispatch a request to getsentry to run its javascript test suites
+name: getsentry dispatcher
+
+on:
+  pull_request:
+
+jobs:
+  frontend:
+    name: frontend dispatch
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Check for frontend file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+      - name: getsentry token
+        id: getsentry
+        if: steps.changes.outputs.frontend == 'true'
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
+          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
+      # Notify getsentry only if there were frontend files changed
+      - name: Dispatch getsentry frontend tests
+        uses: actions/github-script@v3
+        if: steps.changes.outputs.frontend == 'true'
+        with:
+          github-token: ${{ steps.getsentry.outputs.token }}
+          script: |
+            github.actions.createWorkflowDispatch({
+              owner: 'getsentry',
+              repo: 'getsentry',
+              workflow_id: 'javascript.yml',
+              ref: 'build/gha/allow-javascript-tests-to-be-skipped',
+              inputs: {
+                'skip': "${{ steps.changes.outputs.frontend == 'true' }}",
+                'sentry-sha': '${{ github.event.pull_request.head.sha }}',
+              }
+            })

--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -9,7 +9,7 @@ jobs:
     name: frontend dispatch
     runs-on: ubuntu-16.04
     steps:
-      - use: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       - name: Check for frontend file changes
         uses: getsentry/paths-filter@v2

--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -2,13 +2,21 @@
 name: getsentry dispatcher
 
 on:
-  pull_request:
+  # XXX: We are using `pull_request_target` instead of `pull_request` because we want
+  # this to run on forks.  It allows forks to access secrets safely by
+  # only running workflows from the main branch. Prefer to use `pull_request` when possible.
+  #
+  # See https://github.com/getsentry/sentry/pull/21600 for more details
+  pull_request_target:
 
 jobs:
   frontend:
     name: frontend dispatch
     runs-on: ubuntu-16.04
     steps:
+      # This workflow only uses `.github/file-filters.yml`, so we do not need to checkout
+      # the head ref from potential forked repo. Instead, we are ok with the base branch
+      # (i.e. getsentry master)
       - uses: actions/checkout@v2
 
       - name: Check for frontend file changes

--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -35,7 +35,7 @@ jobs:
               owner: 'getsentry',
               repo: 'getsentry',
               workflow_id: 'javascript.yml',
-              ref: 'build/gha/allow-javascript-tests-to-be-skipped',
+              ref: 'master',
               inputs: {
                 'skip': "${{ steps.changes.outputs.frontend != 'true' }}",
                 'sentry-sha': '${{ github.event.pull_request.head.sha }}',

--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -19,9 +19,9 @@ jobs:
           filters: .github/file-filters.yml
 
       - name: getsentry token
+        uses: getsentry/action-github-app-token@v1
         id: getsentry
         if: steps.changes.outputs.frontend == 'true'
-        uses: getsentry/action-github-app-token@v1
         with:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}


### PR DESCRIPTION
This changes the frontend workflows to always run (similar to what we did with the backend path filters).