### PR TITLE
fix(tests): Decrease accuracy of mark.xxx measurements

### DIFF
--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -207,7 +207,7 @@ def load_data(
             for key, entry in measurements.items():
                 if key in ["fp", "fcp", "lcp", "fid"]:
                     measurement_markers["mark.{}".format(key)] = {
-                        "value": data["start_timestamp"] + entry["value"] / 1000
+                        "value": round(data["start_timestamp"] + entry["value"] / 1000)
                     }
             measurements.update(measurement_markers)
 

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -207,7 +207,7 @@ def load_data(
             for key, entry in measurements.items():
                 if key in ["fp", "fcp", "lcp", "fid"]:
                     measurement_markers["mark.{}".format(key)] = {
-                        "value": round(data["start_timestamp"] + entry["value"] / 1000)
+                        "value": round(data["start_timestamp"] + entry["value"] / 1000, 3)
                     }
             measurements.update(measurement_markers)
 


### PR DESCRIPTION
The calculation to populate mark.xxx measurements in tests is subject to
floating point errors. This makes for possibly flaky tests. Reduce the accuracy
of these measurements to improve the stability of tests.