### PR TITLE
fix(trends): Adjust precision for low duration trends

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -391,11 +391,11 @@ function TrendsListItem(props: TrendsListItemProps) {
 
   const previousDuration = getDuration(
     previousPeriodValue / 1000,
-    previousPeriodValue < 1000 ? 0 : 2
+    previousPeriodValue < 1000 && previousPeriodValue > 10 ? 0 : 2
   );
   const currentDuration = getDuration(
     currentPeriodValue / 1000,
-    currentPeriodValue < 1000 ? 0 : 2
+    currentPeriodValue < 1000 && previousPeriodValue > 10 ? 0 : 2
   );
 
   const percentChangeExplanation = t(

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -395,7 +395,7 @@ function TrendsListItem(props: TrendsListItemProps) {
   );
   const currentDuration = getDuration(
     currentPeriodValue / 1000,
-    currentPeriodValue < 1000 && previousPeriodValue > 10 ? 0 : 2
+    currentPeriodValue < 1000 && currentPeriodValue > 10 ? 0 : 2
   );
 
   const percentChangeExplanation = t(

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -136,8 +136,8 @@ export function transformDeltaSpread(
 ) {
   const fromSeconds = from / 1000;
   const toSeconds = to / 1000;
-  const fromSubSecond = fromSeconds < 1;
-  const toSubSecond = toSeconds < 1;
+
+  const showDigits = from > 1000 || to > 1000 || from < 10 || to < 10; // Show digits consistently if either has them
 
   if (trendFunctionField === TrendFunctionField.USER_MISERY) {
     return (
@@ -151,9 +151,9 @@ export function transformDeltaSpread(
 
   return (
     <span>
-      <Duration seconds={fromSeconds} fixedDigits={fromSubSecond ? 0 : 1} abbreviation />
+      <Duration seconds={fromSeconds} fixedDigits={showDigits ? 1 : 0} abbreviation />
       <StyledIconArrow direction="right" size="xs" />
-      <Duration seconds={toSeconds} fixedDigits={toSubSecond ? 0 : 1} abbreviation />
+      <Duration seconds={toSeconds} fixedDigits={showDigits ? 1 : 0} abbreviation />
     </span>
   );
 }
@@ -322,11 +322,10 @@ export function transformValueDelta(
 
   const seconds = absoluteValue / 1000;
 
-  const isSubSecond = seconds < 1;
+  const fixedDigits = absoluteValue > 1000 || absoluteValue < 10 ? 1 : 0;
   return (
     <span>
-      <Duration seconds={seconds} fixedDigits={isSubSecond ? 0 : 1} abbreviation />{' '}
-      {changeLabel}
+      <Duration seconds={seconds} fixedDigits={fixedDigits} abbreviation /> {changeLabel}
     </span>
   );
 }


### PR DESCRIPTION
### Summary
Trends that are closer to 0ms weren't showing enough precision to make sense. This increases precision on the duration's when 10ms and below, so as to not show too much precision in the very common hundreds of millisecond range (and crowd the page).

### Screenshot
![Screen Shot 2020-10-27 at 7 27 08 PM](https://user-images.githubusercontent.com/6111995/97383330-950ad280-188a-11eb-8dcf-f3a20f83e88a.png)
