### PR TITLE
ref(stacktrace): Update Stacktrace exception logic

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/getThreadException.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/getThreadException.tsx
@@ -10,6 +10,11 @@ function getThreadException(thread: Thread, event: Event): EntryTypeData | undef
     if (entry.type !== 'exception') {
       continue;
     }
+
+    if (entry.data.values.length === 1 && !entry.data.values[0].threadId) {
+      return entry.data;
+    }
+
     for (const exc of entry.data.values) {
       if (exc.threadId === thread.id) {
         return entry.data;


### PR DESCRIPTION
closes: https://app.asana.com/0/1158284503473033/1198885927872565/f

**Description:**
In React-Native we send an error that contains threads and exceptions, both of them contain a stack trace. 
The problem now in the UI is that it only renders the one Thread that is contained in threads and completely ignores the stack trace from the exception

This was happening because we usually try to match the id of a thread and the thread id of a stack trace exception.


**Solution:**
The `getThreadException` logic has been updated and now in case entry.data.values.length is length 1 and ThreadId is null, we return the data

Since no ThreadID is provided, it doesn't make sense to display the ThreadSelector. 