### PR TITLE
ref(releases): adds transactions for releases

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -32,6 +32,8 @@ from sentry.snuba.sessions import (
 )
 from sentry.utils.cache import cache
 from sentry.utils.compat import zip as izip
+from sentry.utils.sdk import configure_scope, bind_organization_context
+from sentry.web.decorators import transaction_start
 
 
 ERR_INVALID_STATS_PERIOD = "Invalid %s. Valid choices are %s"
@@ -129,6 +131,7 @@ def debounce_update_release_health_data(organization, project_ids):
 
 
 class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
+    @transaction_start("ReleaseSerializerWithProjects.get")
     def get(self, request, organization):
         """
         List an Organization's Releases
@@ -245,6 +248,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
             **paginator_kwargs
         )
 
+    @transaction_start("ReleaseSerializerWithProjects.post")
     def post(self, request, organization):
         """
         Create a New Release for an Organization
@@ -285,106 +289,117 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
                            ``commit`` may contain a range in the form of ``previousCommit..commit``
         :auth: required
         """
+        bind_organization_context(organization)
         serializer = ReleaseSerializerWithProjects(data=request.data)
 
-        if serializer.is_valid():
-            result = serializer.validated_data
+        with configure_scope() as scope:
+            if serializer.is_valid():
+                result = serializer.validated_data
+                scope.set_tag("version", result["version"])
 
-            allowed_projects = {p.slug: p for p in self.get_projects(request, organization)}
+                allowed_projects = {p.slug: p for p in self.get_projects(request, organization)}
 
-            projects = []
-            for slug in result["projects"]:
-                if slug not in allowed_projects:
-                    return Response({"projects": ["Invalid project slugs"]}, status=400)
-                projects.append(allowed_projects[slug])
+                projects = []
+                for slug in result["projects"]:
+                    if slug not in allowed_projects:
+                        return Response({"projects": ["Invalid project slugs"]}, status=400)
+                    projects.append(allowed_projects[slug])
 
-            # release creation is idempotent to simplify user
-            # experiences
-            try:
-                with transaction.atomic():
-                    release, created = (
-                        Release.objects.create(
-                            organization_id=organization.id,
-                            version=result["version"],
-                            ref=result.get("ref"),
-                            url=result.get("url"),
-                            owner=result.get("owner"),
-                            date_released=result.get("dateReleased"),
-                        ),
-                        True,
-                    )
-            except IntegrityError:
-                release, created = (
-                    Release.objects.get(organization_id=organization.id, version=result["version"]),
-                    False,
-                )
-            else:
-                release_created.send_robust(release=release, sender=self.__class__)
-
-            new_projects = []
-            for project in projects:
-                created = release.add_project(project)
-                if created:
-                    new_projects.append(project)
-
-            if release.date_released:
-                for project in new_projects:
-                    Activity.objects.create(
-                        type=Activity.RELEASE,
-                        project=project,
-                        ident=Activity.get_version_ident(result["version"]),
-                        data={"version": result["version"]},
-                        datetime=release.date_released,
-                    )
-
-            commit_list = result.get("commits")
-            if commit_list:
-                release.set_commits(commit_list)
-
-            refs = result.get("refs")
-            if not refs:
-                refs = [
-                    {
-                        "repository": r["repository"],
-                        "previousCommit": r.get("previousId"),
-                        "commit": r["currentId"],
-                    }
-                    for r in result.get("headCommits", [])
-                ]
-            if refs:
-                if not request.user.is_authenticated():
-                    return Response(
-                        {"refs": ["You must use an authenticated API token to fetch refs"]},
-                        status=400,
-                    )
-                fetch_commits = not commit_list
+                # release creation is idempotent to simplify user
+                # experiences
                 try:
-                    release.set_refs(refs, request.user, fetch=fetch_commits)
-                except InvalidRepository as e:
-                    return Response({"refs": [six.text_type(e)]}, status=400)
+                    with transaction.atomic():
+                        release, created = (
+                            Release.objects.create(
+                                organization_id=organization.id,
+                                version=result["version"],
+                                ref=result.get("ref"),
+                                url=result.get("url"),
+                                owner=result.get("owner"),
+                                date_released=result.get("dateReleased"),
+                            ),
+                            True,
+                        )
+                except IntegrityError:
+                    release, created = (
+                        Release.objects.get(
+                            organization_id=organization.id, version=result["version"]
+                        ),
+                        False,
+                    )
+                else:
+                    release_created.send_robust(release=release, sender=self.__class__)
 
-            if not created and not new_projects:
-                # This is the closest status code that makes sense, and we want
-                # a unique 2xx response code so people can understand when
-                # behavior differs.
-                #   208 Already Reported (WebDAV; RFC 5842)
-                status = 208
-            else:
-                status = 201
+                new_projects = []
+                for project in projects:
+                    created = release.add_project(project)
+                    if created:
+                        new_projects.append(project)
 
-            analytics.record(
-                "release.created",
-                user_id=request.user.id if request.user and request.user.id else None,
-                organization_id=organization.id,
-                project_ids=[project.id for project in projects],
-                user_agent=request.META.get("HTTP_USER_AGENT", ""),
-                created_status=status,
-            )
-            return Response(serialize(release, request.user), status=status)
-        return Response(serializer.errors, status=400)
+                if release.date_released:
+                    for project in new_projects:
+                        Activity.objects.create(
+                            type=Activity.RELEASE,
+                            project=project,
+                            ident=Activity.get_version_ident(result["version"]),
+                            data={"version": result["version"]},
+                            datetime=release.date_released,
+                        )
+
+                commit_list = result.get("commits")
+                if commit_list:
+                    release.set_commits(commit_list)
+
+                refs = result.get("refs")
+                if not refs:
+                    refs = [
+                        {
+                            "repository": r["repository"],
+                            "previousCommit": r.get("previousId"),
+                            "commit": r["currentId"],
+                        }
+                        for r in result.get("headCommits", [])
+                    ]
+                scope.set_tag("has_refs", bool(refs))
+                if refs:
+                    if not request.user.is_authenticated():
+                        scope.set_tag("failure_reason", "user_not_authenticated")
+                        return Response(
+                            {"refs": ["You must use an authenticated API token to fetch refs"]},
+                            status=400,
+                        )
+                    fetch_commits = not commit_list
+                    try:
+                        release.set_refs(refs, request.user, fetch=fetch_commits)
+                    except InvalidRepository as e:
+                        scope.set_tag("failure_reason", "InvalidRepository")
+                        return Response({"refs": [six.text_type(e)]}, status=400)
+
+                if not created and not new_projects:
+                    # This is the closest status code that makes sense, and we want
+                    # a unique 2xx response code so people can understand when
+                    # behavior differs.
+                    #   208 Already Reported (WebDAV; RFC 5842)
+                    status = 208
+                else:
+                    status = 201
+
+                analytics.record(
+                    "release.created",
+                    user_id=request.user.id if request.user and request.user.id else None,
+                    organization_id=organization.id,
+                    project_ids=[project.id for project in projects],
+                    user_agent=request.META.get("HTTP_USER_AGENT", ""),
+                    created_status=status,
+                )
+                scope.set_tag("success_status", status)
+                return Response(serialize(release, request.user), status=status)
+            scope.set_tag("failure_reason", "serializer_error")
+            return Response(serializer.errors, status=400)
 
 
 class OrganizationReleasesStatsEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
+    @transaction_start("OrganizationReleasesStatsEndpoint.get")
     def get(self, request, organization):
         """
         List an Organization's Releases specifically for building timeseries

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function
 import logging
 import re
 import six
+import sentry_sdk
 import itertools
 
 from django.db import models, IntegrityError, transaction
@@ -330,54 +331,57 @@ class Release(Model):
                 ref["previousCommit"], ref["commit"] = ref["commit"].split(COMMIT_RANGE_DELIMITER)
 
     def set_refs(self, refs, user, fetch=False):
-        from sentry.api.exceptions import InvalidRepository
-        from sentry.models import Commit, ReleaseHeadCommit, Repository
-        from sentry.tasks.commits import fetch_commits
+        with sentry_sdk.start_span(op="set_refs"):
+            from sentry.api.exceptions import InvalidRepository
+            from sentry.models import Commit, ReleaseHeadCommit, Repository
+            from sentry.tasks.commits import fetch_commits
 
-        # TODO: this does the wrong thing unless you are on the most
-        # recent release.  Add a timestamp compare?
-        prev_release = (
-            type(self)
-            .objects.filter(organization_id=self.organization_id, projects__in=self.projects.all())
-            .extra(select={"sort": "COALESCE(date_released, date_added)"})
-            .exclude(version=self.version)
-            .order_by("-sort")
-            .first()
-        )
-
-        names = {r["repository"] for r in refs}
-        repos = list(
-            Repository.objects.filter(organization_id=self.organization_id, name__in=names)
-        )
-        repos_by_name = {r.name: r for r in repos}
-        invalid_repos = names - set(repos_by_name.keys())
-        if invalid_repos:
-            raise InvalidRepository("Invalid repository names: %s" % ",".join(invalid_repos))
-
-        self.handle_commit_ranges(refs)
-
-        for ref in refs:
-            repo = repos_by_name[ref["repository"]]
-
-            commit = Commit.objects.get_or_create(
-                organization_id=self.organization_id, repository_id=repo.id, key=ref["commit"]
-            )[0]
-            # update head commit for repo/release if exists
-            ReleaseHeadCommit.objects.create_or_update(
-                organization_id=self.organization_id,
-                repository_id=repo.id,
-                release=self,
-                values={"commit": commit},
+            # TODO: this does the wrong thing unless you are on the most
+            # recent release.  Add a timestamp compare?
+            prev_release = (
+                type(self)
+                .objects.filter(
+                    organization_id=self.organization_id, projects__in=self.projects.all()
+                )
+                .extra(select={"sort": "COALESCE(date_released, date_added)"})
+                .exclude(version=self.version)
+                .order_by("-sort")
+                .first()
             )
-        if fetch:
-            fetch_commits.apply_async(
-                kwargs={
-                    "release_id": self.id,
-                    "user_id": user.id,
-                    "refs": refs,
-                    "prev_release_id": prev_release and prev_release.id,
-                }
+
+            names = {r["repository"] for r in refs}
+            repos = list(
+                Repository.objects.filter(organization_id=self.organization_id, name__in=names)
             )
+            repos_by_name = {r.name: r for r in repos}
+            invalid_repos = names - set(repos_by_name.keys())
+            if invalid_repos:
+                raise InvalidRepository("Invalid repository names: %s" % ",".join(invalid_repos))
+
+            self.handle_commit_ranges(refs)
+
+            for ref in refs:
+                repo = repos_by_name[ref["repository"]]
+
+                commit = Commit.objects.get_or_create(
+                    organization_id=self.organization_id, repository_id=repo.id, key=ref["commit"]
+                )[0]
+                # update head commit for repo/release if exists
+                ReleaseHeadCommit.objects.create_or_update(
+                    organization_id=self.organization_id,
+                    repository_id=repo.id,
+                    release=self,
+                    values={"commit": commit},
+                )
+            if fetch:
+                fetch_commits.apply_async(
+                    kwargs={
+                        "release_id": self.id,
+                        "user_id": user.id,
+                        "refs": refs,
+                        "prev_release_id": prev_release and prev_release.id,
+                    }
+                )
 
     def set_commits(self, commit_list):
         """


### PR DESCRIPTION
We want to have a better idea why releases might fail for users. This PR adds transactions for the following release endpoints:
1. OrganizationReleaseDetailsEndpoint
2. OrganizationReleasesEndpoint
3. ProjectReleaseDetailsEndpoint
4. ProjectReleasesEndpoint

I've added the following tags:
1. version: The version of the release
2. success_status: Either 208 or 201 depending on if the release was created from a `POST` request (not applicable for `PUT`s)
3. failure_reason: why did the release fail
4. has_refs: a boolean for whether the release has refs we need to look-up with `release.set_refs`

I recommend ignoring white space changes for this PR so it's easier to read.