### PR TITLE
feat(web-vitals): Add web vitals Discover pre-canned query

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -32,6 +32,27 @@ export const TRANSACTION_VIEWS: Readonly<Array<NewQuery>> = [
   },
 ];
 
+export const WEB_VITALS_VIEWS: Readonly<Array<NewQuery>> = [
+  {
+    id: undefined,
+    name: t('Web Vitals'),
+    fields: [
+      'transaction',
+      'epm()',
+      'p75(measurements.fp)',
+      'p75(measurements.fcp)',
+      'p75(measurements.lcp)',
+      'p75(measurements.fid)',
+      'p75(measurements.cls)',
+    ],
+    orderby: '-epm',
+    query: 'event.type:transaction transaction.op:pageload',
+    projects: [],
+    version: 2,
+    range: '24h',
+  },
+];
+
 export const ALL_VIEWS: Readonly<Array<NewQuery>> = [
   DEFAULT_EVENT_VIEW,
   {

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -27,7 +27,7 @@ import {
   measurementType,
 } from 'app/utils/discover/fields';
 
-import {ALL_VIEWS, TRANSACTION_VIEWS} from './data';
+import {ALL_VIEWS, TRANSACTION_VIEWS, WEB_VITALS_VIEWS} from './data';
 import {TableColumn, FieldValue, FieldValueKind} from './table/types';
 
 export type QueryWithColumnState =
@@ -130,12 +130,14 @@ export function generateTitle({
 }
 
 export function getPrebuiltQueries(organization: LightWeightOrganization) {
-  let views = ALL_VIEWS;
+  const views = [...ALL_VIEWS];
   if (organization.features.includes('performance-view')) {
     // insert transactions queries at index 2
-    const cloned = [...ALL_VIEWS];
-    cloned.splice(2, 0, ...TRANSACTION_VIEWS);
-    views = cloned;
+    views.splice(2, 0, ...TRANSACTION_VIEWS);
+  }
+
+  if (organization.features.includes('measurements')) {
+    views.push(...WEB_VITALS_VIEWS);
   }
 
   return views;


### PR DESCRIPTION
This pre-canned query will only be shown to orgs that have the `measurements` feature flag.

<img width="1671" alt="Screen Shot 2020-10-28 at 4 19 50 PM" src="https://user-images.githubusercontent.com/139499/97493210-01dda580-193b-11eb-9113-6da1346ddd91.png">
<img width="1658" alt="Screen Shot 2020-10-28 at 4 23 52 PM" src="https://user-images.githubusercontent.com/139499/97493219-03a76900-193b-11eb-8870-dbf1be744ed7.png">
