### PR TITLE
feat(linked-issues): Consolidate integration configurations in linked issues sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -159,6 +159,7 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
                 ))}
               </Container>
             }
+            onOpen={unlinked.length === 1 ? () => this.openModal(unlinked[0]) : undefined}
           />
         )}
         {selectedIntegration && (

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -162,10 +162,6 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
 
         {unlinked.length > 0 && (
           <IssueSyncListElement
-            externalIssueLink={null}
-            externalIssueId={null}
-            externalIssueKey={null}
-            externalIssueDisplayName={null}
             integrationType={unlinked[0].provider.key}
             hoverCardHeader={t('Linked %s Integration', unlinked[0].provider.name)}
             hoverCardBody={

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -16,6 +16,7 @@ import {Group, GroupIntegration, IntegrationExternalIssue} from 'app/types';
 
 type Props = AsyncComponent['props'] & {
   integration: GroupIntegration;
+  configurations: GroupIntegration[];
   group: Group;
 };
 
@@ -93,11 +94,11 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
 
   renderBody() {
     const {action, selectedIntegration, issue} = this.state;
-
+    console.log({issue});
     return (
       <React.Fragment>
         <IssueSyncListElement
-          onOpen={this.openModal}
+          // onOpen={this.openModal}
           externalIssueLink={issue ? issue.url : null}
           externalIssueId={issue ? issue.id : null}
           externalIssueKey={issue ? issue.key : null}
@@ -114,7 +115,13 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
                 )}
               </div>
             ) : (
-              <IntegrationItem integration={selectedIntegration} />
+              <React.Fragment>
+                {this.props.configurations.map(config => (
+                  <Wrapper onClick={this.openModal}>
+                    <IntegrationItem integration={config} />
+                  </Wrapper>
+                ))}
+              </React.Fragment>
             )
           }
         />
@@ -166,6 +173,11 @@ const IssueTitle = styled('div')`
 const IssueDescription = styled('div')`
   margin-top: ${space(1)};
   ${overflowEllipsis};
+`;
+
+const Wrapper = styled('div')`
+  margin-bottom: ${space(2)};
+  cursor: pointer;
 `;
 
 export default ExternalIssueActions;

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -26,6 +26,12 @@ type State = AsyncComponent['state'] & {
   unlinked: GroupIntegration[];
   linked: GroupIntegration[];
 };
+
+type LinkedIssues = {
+  linked: GroupIntegration[];
+  unlinked: GroupIntegration[];
+};
+
 class ExternalIssueActions extends AsyncComponent<Props, State> {
   static propTypes = {
     group: PropTypes.object.isRequired,
@@ -49,7 +55,7 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
 
   linkedIssuesFilter() {
     return this.props.configurations.reduce(
-      (acc, curr) => {
+      (acc: LinkedIssues, curr) => {
         if (curr.externalIssues.length) {
           acc.linked.push(curr);
         } else {
@@ -57,7 +63,7 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
         }
         return acc;
       },
-      {linked: [] as GroupIntegration[], unlinked: [] as GroupIntegration[]}
+      {linked: [], unlinked: []}
     );
   }
 

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import styled from '@emotion/styled';
+
 import {addSuccessMessage, addErrorMessage} from 'app/actionCreators/indicator';
 import AsyncComponent from 'app/components/asyncComponent';
 import IssueSyncListElement from 'app/components/issueSyncListElement';
@@ -66,8 +67,8 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
     const {externalIssues} = integration;
     // Currently we do not support a case where there is multiple external issues.
     // For example, we shouldn't have more than 1 jira ticket created for an issue for each jira configuration.
-    let issue = externalIssues[0];
-    let {id} = issue;
+    const issue = externalIssues[0];
+    const {id} = issue;
     const endpoint = `/groups/${group.id}/integrations/${integration.id}/?externalIssue=${id}`;
 
     this.api.request(endpoint, {
@@ -123,7 +124,7 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
         {linked.length > 0 &&
           linked.map(config => {
             const {provider, externalIssues} = config;
-            let issue = externalIssues[0];
+            const issue = externalIssues[0];
             return (
               <IssueSyncListElement
                 key={issue.id}

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -46,17 +46,19 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
   }
 
   linkedIssuesFilter() {
-    return this.props.configurations.reduce(
-      (acc: LinkedIssues, curr) => {
-        if (curr.externalIssues.length) {
-          acc.linked.push(curr);
-        } else {
-          acc.unlinked.push(curr);
-        }
-        return acc;
-      },
-      {linked: [], unlinked: []}
-    );
+    return this.props.configurations
+      .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
+      .reduce(
+        (acc: LinkedIssues, curr) => {
+          if (curr.externalIssues.length) {
+            acc.linked.push(curr);
+          } else {
+            acc.unlinked.push(curr);
+          }
+          return acc;
+        },
+        {linked: [], unlinked: []}
+      );
   }
 
   deleteIssue(integration: GroupIntegration) {
@@ -148,15 +150,11 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
             hoverCardHeader={t('Linked %s Integration', unlinked[0].provider.name)}
             hoverCardBody={
               <Container>
-                {unlinked
-                  .sort((a, b) =>
-                    a.name.toLowerCase().localeCompare(b.name.toLowerCase())
-                  )
-                  .map(config => (
-                    <Wrapper onClick={() => this.openModal(config)} key={config.id}>
-                      <IntegrationItem integration={config} />
-                    </Wrapper>
-                  ))}
+                {unlinked.map(config => (
+                  <Wrapper onClick={() => this.openModal(config)} key={config.id}>
+                    <IntegrationItem integration={config} />
+                  </Wrapper>
+                ))}
               </Container>
             }
           />

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'react-bootstrap/lib/Modal';
 import styled from '@emotion/styled';
-
+import cloneDeep from 'lodash/cloneDeep';
 import {addSuccessMessage, addErrorMessage} from 'app/actionCreators/indicator';
 import AsyncComponent from 'app/components/asyncComponent';
 import IssueSyncListElement from 'app/components/issueSyncListElement';
@@ -78,7 +78,7 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
       method: 'DELETE',
       success: () => {
         addSuccessMessage(t('Successfully unlinked issue.'));
-        let unlinked = JSON.parse(JSON.stringify(integration)) as GroupIntegration;
+        let unlinked = cloneDeep(integration);
         unlinked.externalIssues = [];
         this.setState({
           selectedIntegration: null,
@@ -119,7 +119,7 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
     integration: GroupIntegration,
     externalIssue: IntegrationExternalIssue
   ) => {
-    let linked = JSON.parse(JSON.stringify(integration)) as GroupIntegration;
+    let linked = cloneDeep(integration);
     linked.externalIssues = [externalIssue];
     this.setState(
       {

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -64,6 +64,8 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
   deleteIssue(integration: GroupIntegration) {
     const {group} = this.props;
     const {externalIssues} = integration;
+    // Currently we do not support a case where there is multiple external issues.
+    // For example, we shouldn't have more than 1 jira ticket created for an issue for each jira configuration.
     let issue = externalIssues[0];
     let {id} = issue;
     const endpoint = `/groups/${group.id}/integrations/${integration.id}/?externalIssue=${id}`;

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -33,7 +33,10 @@ type Props = {
   group: Group;
   integration: Integration;
   action: 'create' | 'link';
-  onSubmitSuccess: (externalIssue: IntegrationExternalIssue) => void;
+  onSubmitSuccess: (
+    externalIssue: IntegrationExternalIssue,
+    onSucess: () => void
+  ) => void;
 } & AsyncComponent['props'];
 
 type State = {
@@ -83,8 +86,9 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
   };
 
   onSubmitSuccess = (data: IntegrationExternalIssue) => {
-    addSuccessMessage(MESSAGES_BY_ACTION[this.props.action]);
-    this.props.onSubmitSuccess(data);
+    this.props.onSubmitSuccess(data, () =>
+      addSuccessMessage(MESSAGES_BY_ACTION[this.props.action])
+    );
     this.submitTransaction?.finish();
   };
 

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -14,7 +14,7 @@ import {t} from 'app/locale';
 import {
   Group,
   Integration,
-  PlatformExternalIssue,
+  IntegrationExternalIssue,
   IntegrationIssueConfig,
   IssueConfigField,
 } from 'app/types';
@@ -33,7 +33,7 @@ type Props = {
   group: Group;
   integration: Integration;
   action: 'create' | 'link';
-  onSubmitSuccess: (externalIssue: PlatformExternalIssue) => void;
+  onSubmitSuccess: (externalIssue: IntegrationExternalIssue) => void;
 } & AsyncComponent['props'];
 
 type State = {
@@ -82,7 +82,7 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
     this.submitTransaction = this.startTransaction('submit');
   };
 
-  onSubmitSuccess = (data: PlatformExternalIssue) => {
+  onSubmitSuccess = (data: IntegrationExternalIssue) => {
     addSuccessMessage(MESSAGES_BY_ACTION[this.props.action]);
     this.props.onSubmitSuccess(data);
     this.submitTransaction?.finish();
@@ -224,7 +224,6 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
       // TODO(jess): figure out why this is breaking and fix
       initialData[field.name] = field.multiple ? '' : field.default;
     });
-
     return (
       <Form
         apiEndpoint={`/groups/${group.id}/integrations/${integration.id}/`}

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
@@ -111,7 +111,7 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
   async updateIntegrations(onSuccess = () => {}, onError = () => {}) {
     try {
       const {group} = this.props;
-      let integrations = await this.api.requestPromise(
+      const integrations = await this.api.requestPromise(
         `/groups/${group.id}/integrations/`
       );
       this.setState({integrations}, () => onSuccess());
@@ -131,7 +131,7 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
       string,
       GroupIntegration[]
     > = activeIntegrations.reduce((acc, curr) => {
-      let items = acc.get(curr.provider.key);
+      const items = acc.get(curr.provider.key);
 
       if (!!items) {
         acc.set(curr.provider.key, [...items, curr]);

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
@@ -44,13 +44,6 @@ type State = AsyncComponent['state'] & {
 class ExternalIssueList extends AsyncComponent<Props, State> {
   unsubscribables: any[] = [];
 
-  static propTypes = {
-    group: SentryTypes.Group.isRequired,
-    project: SentryTypes.Project.isRequired,
-    organization: SentryTypes.Organization.isRequired,
-    event: SentryTypes.Event,
-  };
-
   getEndpoints(): [string, string][] {
     const {group} = this.props;
     return [['integrations', `/groups/${group.id}/integrations/`]];
@@ -134,14 +127,11 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
       return acc;
     }, {});
 
-    console.log({activeIntegrations, activeIntegrationsByProvider});
-
     return activeIntegrations.length
       ? Object.entries(activeIntegrationsByProvider).map(([provider, configurations]) => (
           <ExternalIssueActions
             key={provider}
             configurations={configurations}
-            integration={configurations[0]}
             group={group}
           />
         ))
@@ -209,7 +199,6 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
     const integrationIssues = this.renderIntegrationIssues(this.state.integrations);
     const pluginIssues = this.renderPluginIssues();
     const pluginActions = this.renderPluginActions();
-    console.log({integrationIssues});
     if (!sentryAppIssues && !integrationIssues && !pluginIssues && !pluginActions) {
       return (
         <React.Fragment>

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
@@ -139,14 +139,16 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
     }, {});
 
     return activeIntegrations.length
-      ? Object.entries(activeIntegrationsByProvider).map(([provider, configurations]) => (
-          <ExternalIssueActions
-            key={provider}
-            configurations={configurations}
-            group={group}
-            onChange={this.updateIntegrations.bind(this)}
-          />
-        ))
+      ? Object.keys(activeIntegrationsByProvider)
+          .sort((a, b) => a.localeCompare(b))
+          .map(provider => (
+            <ExternalIssueActions
+              key={provider}
+              configurations={activeIntegrationsByProvider[provider]}
+              group={group}
+              onChange={this.updateIntegrations.bind(this)}
+            />
+          ))
       : null;
   }
 

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
@@ -123,11 +123,25 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
       integration => integration.status === 'active'
     );
 
+    const activeIntegrationsByProvider: {
+      [key: string]: GroupIntegration[];
+    } = activeIntegrations.reduce((acc, curr) => {
+      if (acc[curr.provider.key]) {
+        acc[curr.provider.key].push(curr);
+      } else {
+        acc[curr.provider.key] = [curr];
+      }
+      return acc;
+    }, {});
+
+    console.log({activeIntegrations, activeIntegrationsByProvider});
+
     return activeIntegrations.length
-      ? activeIntegrations.map(integration => (
+      ? Object.entries(activeIntegrationsByProvider).map(([provider, configurations]) => (
           <ExternalIssueActions
-            key={integration.id}
-            integration={integration}
+            key={provider}
+            configurations={configurations}
+            integration={configurations[0]}
             group={group}
           />
         ))
@@ -195,7 +209,7 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
     const integrationIssues = this.renderIntegrationIssues(this.state.integrations);
     const pluginIssues = this.renderPluginIssues();
     const pluginActions = this.renderPluginActions();
-
+    console.log({integrationIssues});
     if (!sentryAppIssues && !integrationIssues && !pluginIssues && !pluginActions) {
       return (
         <React.Fragment>

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
@@ -127,28 +127,29 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
       integration => integration.status === 'active'
     );
 
-    const activeIntegrationsByProvider: {
-      [key: string]: GroupIntegration[];
-    } = activeIntegrations.reduce((acc, curr) => {
-      if (acc[curr.provider.key]) {
-        acc[curr.provider.key].push(curr);
+    const activeIntegrationsByProvider: Map<
+      string,
+      GroupIntegration[]
+    > = activeIntegrations.reduce((acc, curr) => {
+      let items = acc.get(curr.provider.key);
+
+      if (!!items) {
+        acc.set(curr.provider.key, [...items, curr]);
       } else {
-        acc[curr.provider.key] = [curr];
+        acc.set(curr.provider.key, [curr]);
       }
       return acc;
-    }, {});
+    }, new Map());
 
     return activeIntegrations.length
-      ? Object.keys(activeIntegrationsByProvider)
-          .sort((a, b) => a.localeCompare(b))
-          .map(provider => (
-            <ExternalIssueActions
-              key={provider}
-              configurations={activeIntegrationsByProvider[provider]}
-              group={group}
-              onChange={this.updateIntegrations.bind(this)}
-            />
-          ))
+      ? [...activeIntegrationsByProvider.entries()].map(([provider, configurations]) => (
+          <ExternalIssueActions
+            key={provider}
+            configurations={configurations}
+            group={group}
+            onChange={this.updateIntegrations.bind(this)}
+          />
+        ))
       : null;
   }
 

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
@@ -23,7 +23,6 @@ import {IconGeneric} from 'app/icons';
 import SentryAppComponentsStore from 'app/stores/sentryAppComponentsStore';
 import SentryAppExternalIssueActions from 'app/components/group/sentryAppExternalIssueActions';
 import SentryAppInstallationStore from 'app/stores/sentryAppInstallationsStore';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -109,6 +108,18 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
     }
   }
 
+  async updateIntegrations(onSuccess = () => {}, onError = () => {}) {
+    try {
+      const {group} = this.props;
+      let integrations = await this.api.requestPromise(
+        `/groups/${group.id}/integrations/`
+      );
+      this.setState({integrations}, () => onSuccess());
+    } catch (error) {
+      onError();
+    }
+  }
+
   renderIntegrationIssues(integrations: GroupIntegration[] = []) {
     const {group} = this.props;
 
@@ -133,6 +144,7 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
             key={provider}
             configurations={configurations}
             group={group}
+            onChange={this.updateIntegrations.bind(this)}
           />
         ))
       : null;

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
@@ -141,7 +141,7 @@ class IssueSyncListElement extends React.Component<Props> {
             </Hovercard>
           )}
         </ClassNames>
-        {this.props.onClose && (
+        {(this.props.onClose || this.props.onOpen) && (
           <StyledIcon onClick={this.handleIconClick}>
             {this.isLinked() ? <IconClose /> : this.props.onOpen ? <IconAdd /> : null}
           </StyledIcon>

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
@@ -51,6 +51,14 @@ class IssueSyncListElement extends React.Component<Props> {
     callIfFunction(this.props.onClose, this.props.externalIssueId);
   };
 
+  handleIconClick = () => {
+    if (this.isLinked()) {
+      this.handleDelete();
+    } else if (this.props.onOpen) {
+      this.props.onOpen();
+    }
+  };
+
   getIcon(): React.ReactNode {
     switch (this.props.integrationType) {
       case 'bitbucket':
@@ -133,9 +141,9 @@ class IssueSyncListElement extends React.Component<Props> {
             </Hovercard>
           )}
         </ClassNames>
-        {this.props.onOpen && this.props.onClose && (
-          <StyledIcon onClick={this.isLinked() ? this.handleDelete : this.props.onOpen}>
-            {this.isLinked() ? <IconClose /> : <IconAdd />}
+        {this.props.onClose && (
+          <StyledIcon onClick={this.handleIconClick}>
+            {this.isLinked() ? <IconClose /> : this.props.onOpen ? <IconAdd /> : null}
           </StyledIcon>
         )}
       </IssueSyncListElementContainer>

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
@@ -19,7 +19,7 @@ import Hovercard from 'app/components/hovercard';
 import {callIfFunction} from 'app/utils/callIfFunction';
 
 type Props = {
-  externalIssueLink: string | null;
+  externalIssueLink?: string | null;
   externalIssueId?: string | null;
   externalIssueKey?: string | null;
   externalIssueDisplayName?: string | null;

--- a/tests/js/spec/components/group/externalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueActions.spec.jsx
@@ -12,7 +12,7 @@ describe('ExternalIssueActions', function () {
     const configurations = [integration];
     const wrapper = mountWithTheme(
       <ExternalIssueActions
-        key={'github'}
+        key="github"
         group={group}
         configurations={configurations}
         onChange={() => {}}
@@ -31,7 +31,7 @@ describe('ExternalIssueActions', function () {
     });
 
     it('should not have `+` icon', function () {
-      let container = wrapper.find('IssueSyncListElementContainer').first();
+      const container = wrapper.find('IssueSyncListElementContainer').first();
       expect(container.contains('StyledIcon')).toBe(false);
     });
 

--- a/tests/js/spec/components/group/externalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueActions.spec.jsx
@@ -9,16 +9,30 @@ describe('ExternalIssueActions', function () {
 
   describe('with no external issues linked', function () {
     const integration = TestStubs.GitHubIntegration({externalIssues: []});
+    const configurations = [integration];
     const wrapper = mountWithTheme(
-      <ExternalIssueActions group={group} integration={integration} />,
+      <ExternalIssueActions
+        key={'github'}
+        group={group}
+        configurations={configurations}
+        onChange={() => {}}
+      />,
+
       TestStubs.routerContext()
     );
+
+    // console.log(configurations);
     it('renders', function () {
       expect(wrapper).toSnapshot();
     });
 
     it('renders Link GitHub Issue when no issues currently linked', function () {
       expect(wrapper.find('IntegrationLink a').text()).toEqual('Link GitHub Issue');
+    });
+
+    it('should not have `+` icon', function () {
+      let container = wrapper.find('IssueSyncListElementContainer').first();
+      expect(container.contains('StyledIcon')).toBe(false);
     });
 
     describe('opens modal', function () {
@@ -29,12 +43,9 @@ describe('ExternalIssueActions', function () {
 
       it('opens when clicking text', function () {
         wrapper.find('IntegrationLink a').simulate('click');
-        expect(wrapper.find('Modal').first().prop('show')).toBe(true);
-      });
-
-      it('opens when clicking +', function () {
-        wrapper.find('StyledIcon').simulate('click');
-        expect(wrapper.find('Modal').first().prop('show')).toBe(true);
+        expect(wrapper.find('Hovercard').first().prop('header')).toEqual(
+          'Linked GitHub Integration'
+        );
       });
     });
   });
@@ -48,8 +59,14 @@ describe('ExternalIssueActions', function () {
       },
     ];
     const integration = TestStubs.GitHubIntegration({externalIssues});
+    const configurations = [integration];
     const wrapper = mountWithTheme(
-      <ExternalIssueActions group={group} integration={integration} />,
+      <ExternalIssueActions
+        key="github"
+        group={group}
+        configurations={configurations}
+        onChange={() => {}}
+      />,
       TestStubs.routerContext()
     );
     it('renders', function () {
@@ -61,14 +78,14 @@ describe('ExternalIssueActions', function () {
     });
 
     describe('deletes linked issue', function () {
-      MockApiClient.addMockResponse({
+      const mockDelete = MockApiClient.addMockResponse({
         url: '/groups/1/integrations/1/?externalIssue=100',
         method: 'DELETE',
       });
 
       it('deletes when clicking x', function () {
         wrapper.find('StyledIcon').simulate('click');
-        expect(wrapper.find('IntegrationLink a').text()).toEqual('Link GitHub Issue');
+        expect(mockDelete).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## Objective
Issue detail page: When a user has multiple installations of the same project management integration, it is unclear to the user which installation is which unless they hover and view the tooltip. It can be frustrating to users to find which instance they are looking for.

In this PR, we will consolidate all the configurations inside the hovercard for each provider type.

SQL Query to check the prevalence of this scenario:
```
SELECT m.organization_id, ml.provider, COUNT(ml) as configurations
FROM getsentry.sentry_organizationintegration m ,getsentry.sentry_integration ml
WHERE m.integration_id=ml.id 
GROUP BY m.organization_id, ml.provider
HAVING configurations > 2
ORDER BY configurations DESC
```

## UI
**Before**
<img width="356" alt="Screen Shot 2020-10-26 at 6 42 54 PM" src="https://user-images.githubusercontent.com/10491193/97507981-ad86f580-193b-11eb-93cb-53cc7513be18.png">

**After**
<img width="409" alt="Screen Shot 2020-10-28 at 4 36 50 PM" src="https://user-images.githubusercontent.com/10491193/97508023-ce4f4b00-193b-11eb-80d5-d500c346d5df.png">
