### PR TITLE
build(gha): Fix `visual-diff` job being skipped

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -169,7 +169,9 @@ jobs:
           snapshot-path: .artifacts/visual-snapshots
 
   visual-diff:
-    if: ${{ github.ref != 'refs/heads/master' }}
+    # Note: `github.ref` is always `master` for `pull_request_target` event
+    # `github.head/base_ref` == '' for `push` event, we want to skip it on pushes
+    if: github.head_ref != ''
     needs: [acceptance, frontend]
     runs-on: ubuntu-16.04
     timeout-minutes: 20


### PR DESCRIPTION
For the workflow event `pull_request_target`, `github.ref` is *always*
the main branch. Instead we can check `github.head_ref` being set to
determine that it is a PR (it is empty for `push` events).