### PR TITLE
upgrade(urllib3): Upgrade urllib3 to latest

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -46,7 +46,7 @@ rb>=1.8.0,<2.0.0
 redis-py-cluster==2.1.0
 redis==3.3.11
 requests-oauthlib==1.2.0
-requests[security]>=2.20.0,<2.21.0
+requests[security]>=2.22.0,<2.23.0
 # [start] jsonschema format validators
 rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
@@ -62,7 +62,7 @@ symbolic>=7.3.5,<8.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.10.0,<0.11.0
 unidiff>=0.5.4
-urllib3>=1.24.2,<1.26.0
+urllib3>=1.24.2,!=1.25.0,!=1.25.1,<1.26.0
 uwsgi>2.0.0,<2.1.0
 
 # msgpack>=1.0.0 correctly encodes / decodes byte types in python3 as the

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,7 +62,7 @@ symbolic>=7.3.5,<8.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.10.0,<0.11.0
 unidiff>=0.5.4
-urllib3>=1.24.2,!=1.25.0,!=1.25.1,<1.26.0
+urllib3>=1.24.2,<1.26.0
 uwsgi>2.0.0,<2.1.0
 
 # msgpack>=1.0.0 correctly encodes / decodes byte types in python3 as the

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,7 +62,7 @@ symbolic>=7.3.5,<8.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.10.0,<0.11.0
 unidiff>=0.5.4
-urllib3==1.24.2
+urllib3>=1.24.2,<1.26.0
 uwsgi>2.0.0,<2.1.0
 
 # msgpack>=1.0.0 correctly encodes / decodes byte types in python3 as the


### PR DESCRIPTION
This is needed for #13777. It comes with a bunch of security and bug fixes, defaults to verified HTTPS certificates and using the system certificates when none passed explicitly. Full changelog: https://github.com/urllib3/urllib3/blob/master/CHANGES.rst
